### PR TITLE
Fix font preview double-click functionality

### DIFF
--- a/src/components/fontPreview/fontPreview.view.yaml
+++ b/src/components/fontPreview/fontPreview.view.yaml
@@ -1,6 +1,6 @@
 elementName: rvn-font-preview
 
-handleBeforeMountviewDataSchema:
+viewDataSchema:
   type: object
   properties:
     previewText:

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -168,7 +168,7 @@ export const handleDragDropFileSelected = async (e, deps) => {
 };
 
 export const handleFontItemDoubleClick = async (e, deps) => {
-  const { store, render, repository, httpClient, fontManager } = deps;
+  const { store, render, repository, getFileContent, fontManager } = deps;
   const { itemId } = e.detail;
 
   // Find the font item
@@ -183,7 +183,7 @@ export const handleFontItemDoubleClick = async (e, deps) => {
 
   // Extract font information
   const fontInfoExtractor = createFontInfoExtractor({
-    httpClient,
+    getFileContent,
     fontManager,
   });
   const fontInfo = await fontInfoExtractor.extractFontInfo(fontItem);

--- a/src/pages/fonts/fonts.store.js
+++ b/src/pages/fonts/fonts.store.js
@@ -81,31 +81,33 @@ const fontInfoForm = {
       inputType: "read-only-text",
       description: "Format",
     },
-    {
-      name: "weightClass",
-      inputType: "read-only-text",
-      description: "Weight Class",
-    },
-    {
-      name: "isVariableFont",
-      inputType: "read-only-text",
-      description: "Variable Font",
-    },
-    {
-      name: "supportsItalics",
-      inputType: "read-only-text",
-      description: "Italic Support",
-    },
-    {
-      name: "glyphCount",
-      inputType: "read-only-text",
-      description: "Glyph Count",
-    },
-    {
-      name: "languageSupport",
-      inputType: "read-only-text",
-      description: "Languages",
-    },
+    // NOTE: The following fields are commented out because the current implementation
+    // does not accurately extract this information from font files
+    // {
+    //   name: "weightClass",
+    //   inputType: "read-only-text",
+    //   description: "Weight Class",
+    // },
+    // {
+    //   name: "isVariableFont",
+    //   inputType: "read-only-text",
+    //   description: "Variable Font",
+    // },
+    // {
+    //   name: "supportsItalics",
+    //   inputType: "read-only-text",
+    //   description: "Italic Support",
+    // },
+    // {
+    //   name: "glyphCount",
+    //   inputType: "read-only-text",
+    //   description: "Glyph Count",
+    // },
+    // {
+    //   name: "languageSupport",
+    //   inputType: "read-only-text",
+    //   description: "Languages",
+    // },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Fixed font preview modal not opening when double-clicking font items
- Resolved JavaScript errors that were preventing the modal from displaying

## Changes
- Fixed incorrect dependency injection in `handleFontItemDoubleClick` - was passing `httpClient` instead of `getFileContent` to `createFontInfoExtractor`
- Fixed YAML syntax error in `fontPreview.view.yaml` where schema property name was malformed
- Commented out inaccurate font metadata fields (weight class, variable font support, italic support, glyph count, languages) with explanatory note as the current implementation doesn't accurately extract this information

## Test plan
- [x] Double-click on any font item in the fonts page
- [x] Verify the font details modal opens without errors
- [x] Confirm font preview and basic metadata (family, filename, size, format) are displayed correctly
- [x] Check browser console for any JavaScript errors