### PR TITLE
fix tauri csp

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,8 +22,8 @@
       }
     ],
     "security": {
-      "csp": null,
-      "dangerousDisableAssetCspModification": true,
+      "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost; media-src 'self' asset: http://asset.localhost; font-src 'self' asset: http://asset.localhost",
+      "dangerousDisableAssetCspModification": false,
       "devCsp": null,
       "assetProtocol": {
         "enable": true,


### PR DESCRIPTION
When csp is null, Tauri doesn't enforce a Content Security Policy, but the browser's default security still applies， doesn't allow everything such as 'unsafe-inline' 'unsafe-eval' allows

For more safety, the current csp removed all unsafe words and keep the basic need