### PR TITLE
Fix commandline default item

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -13,7 +13,7 @@ const form = {
 
 export const INITIAL_STATE = Object.freeze({
   mode: "current",
-  items: [],
+  items: { items: {}, tree: [] },
   selectedResourceId: undefined,
   tempSelectedResourceId: undefined,
 });

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -2,7 +2,7 @@ import { toFlatGroups, toFlatItems } from "../../deps/repository";
 
 export const INITIAL_STATE = Object.freeze({
   mode: "current",
-  items: [],
+  items: { items: {}, tree: [] },
   transforms: { tree: [], items: {} },
   /**
    * Array of raw character objects with the following structure (same as props):

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.store.js
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.store.js
@@ -58,7 +58,7 @@ const form = {
 
 export const INITIAL_STATE = Object.freeze({
   mode: "current",
-  items: [],
+  items: { items: {}, tree: [] },
 
   defaultValues: {
     sameScene: "this_scene",

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
@@ -2,7 +2,7 @@ import { toFlatGroups, toFlatItems } from "../../deps/repository";
 
 export const INITIAL_STATE = Object.freeze({
   mode: "current",
-  items: [],
+  items: { items: {}, tree: [] },
   /**
    * Array of sound effect objects with the following structure:
    * {

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -99,14 +99,16 @@ export const handleCharacterCreated = async (e, deps) => {
 };
 
 export const handleSpritesButtonClick = (e, deps) => {
-  const { subject, render } = deps;
+  const { subject, render, router } = deps;
   const { itemId } = e.detail;
+  const { p } = router.getPayload();
 
   // Dispatch redirect with path and payload for query params
   subject.dispatch("redirect", {
     path: "/project/resources/character-sprites",
     payload: {
       characterId: itemId,
+      p: p,
     },
   });
 


### PR DESCRIPTION
### Fixes
- character payload pass miss, lead to cannot get character sprites
- commandLine items default value reset to `{ items: {}, tree: [] }` in many files.

### Problems

layout position wrong when firstly rendered, then correct

<img width="1602" height="932" alt="image" src="https://github.com/user-attachments/assets/3059e48f-87ec-439e-8653-0b461655db5b" />

character sprite cannot show

<img width="1602" height="932" alt="image" src="https://github.com/user-attachments/assets/afee53d3-0e9b-4dbb-aa20-8b61e1e3e42c" />

dialogue still have problems after selected character

<img width="620" height="95" alt="image" src="https://github.com/user-attachments/assets/c8113428-a9d3-4532-a7f5-61a66491b5e0" />
