### PR TITLE
Add unified zoom controls for media resources

### DIFF
--- a/src/components/groupResourcesView/groupResourcesView.handlers.js
+++ b/src/components/groupResourcesView/groupResourcesView.handlers.js
@@ -203,3 +203,48 @@ export const handleAddAnimationClick = (e, deps) => {
     }),
   );
 };
+
+export const handleZoomChange = async (e, deps) => {
+  const { store, render, userConfig } = deps;
+  const zoomLevel = parseFloat(e.detail?.value || e.target?.value);
+
+  // Update internal state
+  store.setZoomLevel(zoomLevel);
+  await userConfig.set("images.zoomLevel", zoomLevel);
+  render();
+};
+
+export const handleZoomIn = async (_, deps) => {
+  const { store, render, userConfig } = deps;
+
+  // Increase zoom by 0.1, max 4.0
+  const currentZoom = store.state.zoomLevel || 1.0;
+  const newZoom = Math.min(4.0, currentZoom + 0.1);
+
+  // Update internal state
+  store.setZoomLevel(newZoom);
+  await userConfig.set("images.zoomLevel", newZoom);
+  render();
+};
+
+export const handleZoomOut = async (_, deps) => {
+  const { store, render, userConfig } = deps;
+
+  // Decrease zoom by 0.1, min 0.5
+  const currentZoom = store.state.zoomLevel || 1.0;
+  const newZoom = Math.max(0.5, currentZoom - 0.1);
+
+  // Update internal state
+  store.setZoomLevel(newZoom);
+  await userConfig.set("images.zoomLevel", newZoom);
+  render();
+};
+
+export const handleAfterMount = async (deps) => {
+  const { store, render, userConfig } = deps;
+  const savedZoom = await userConfig.get("images.zoomLevel");
+  if (savedZoom !== null && savedZoom !== undefined) {
+    store.setZoomLevel(savedZoom);
+    render();
+  }
+};

--- a/src/components/groupResourcesView/groupResourcesView.store.js
+++ b/src/components/groupResourcesView/groupResourcesView.store.js
@@ -1,6 +1,22 @@
-export const INITIAL_STATE = Object.freeze({});
+export const INITIAL_STATE = Object.freeze({
+  zoomLevel: 1.0,
+});
+
+export const setZoomLevel = (state, zoomLevel) => {
+  state.zoomLevel = zoomLevel;
+};
 
 export const toViewData = ({ state, props, attrs }) => {
+  // Calculate dimensions based on zoom level for all media types
+  const baseHeight = props.imageHeight || 150;
+  const baseWidth = props.maxWidth || 400;
+  const baseMediaWidth = 225; // Base width for media items (audio, video, etc.)
+  const baseMediaHeight = 150; // Base height for media items (audio, video, etc.)
+  const imageHeight = Math.round(baseHeight * state.zoomLevel);
+  const maxWidth = Math.round(baseWidth * state.zoomLevel);
+  const mediaWidth = Math.round(baseMediaWidth * state.zoomLevel);
+  const mediaHeight = Math.round(baseMediaHeight * state.zoomLevel);
+
   return {
     fullWidthAttr: attrs["full-width-item"] === true ? "w=f" : "",
     resourceType: props.resourceType || "default",
@@ -13,8 +29,12 @@ export const toViewData = ({ state, props, attrs }) => {
     emptyMessage:
       props.emptyMessage ||
       `No ${props.resourceType || "items"} found matching "${props.searchQuery || ""}"`,
-    imageHeight: props.imageHeight,
-    maxWidth: props.maxWidth,
+    imageHeight,
+    maxWidth,
+    mediaWidth,
+    mediaHeight,
+    zoomLevel: state.zoomLevel,
+    showZoomControls: attrs["show-zoom-controls"] !== "false", // Default to true unless explicitly set to "false"
     itemProperties: props.itemProperties || {},
     items: props.items || {},
   };

--- a/src/components/groupResourcesView/groupResourcesView.view.yaml
+++ b/src/components/groupResourcesView/groupResourcesView.view.yaml
@@ -48,12 +48,32 @@ propsSchema:
     maxWidth:
       type: number
       description: Max width for image items (for zoom control)
+    zoomLevel:
+      type: number
+      description: Current zoom level for zoom controls
+    showZoomControls:
+      type: boolean
+      description: Whether to show zoom controls
 
 refs:
   search-input:
     eventListeners:
       input-change:
         handler: handleSearchInput
+  zoom-slider:
+    eventListeners:
+      change:
+        handler: handleZoomChange
+      input-change:
+        handler: handleZoomChange
+  zoom-out:
+    eventListeners:
+      click:
+        handler: handleZoomOut
+  zoom-in:
+    eventListeners:
+      click:
+        handler: handleZoomIn
   drag-drop-item-*:
     eventListeners:
       file-selected:
@@ -105,7 +125,14 @@ template:
   - 'rtgl-view w=f h=100vh g=lg style="overflow-y: scroll;"':
       - rtgl-view g=lg w=f h=f:
           - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
-              - rtgl-input#search-input s=sm placeholder="${searchPlaceholder}" value=${searchQuery}:
+              - rtgl-view w=f d=h av=c g=md fw=w:
+                  - rtgl-view av=c g=md:
+                      - rtgl-input#search-input s=sm placeholder="${searchPlaceholder}" value=${searchQuery} flex=1:
+                  - $if showZoomControls:
+                      - rtgl-view d=h av=e g=sm:
+                          - rtgl-button#zoom-out w=10 v="gh" s=sm: "-"
+                          - input#zoom-slider type="range" w=120 min="0.5" max="4.0" step="0.1" value="${zoomLevel}":
+                          - rtgl-button#zoom-in w=10 v="gh" s=sm: "+"
           - $if flatGroups.length > 0:
               - $for group in flatGroups:
                   - rtgl-view w=f ph=md:
@@ -124,18 +151,18 @@ template:
                                       - $for item in group.children:
                                           - 'rtgl-view#item-${item.id} ${fullWidthAttr} cur=p style="${item.selectedStyle}"':
                                               - $if resourceType == 'fonts':
-                                                  - rtgl-view w=200 d=v p=md bw=xs br=md:
-                                                      - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fileId} fontSize=60 width=200 height=150 av=c ah=c:
-                                                      - rtgl-text s=xs c=mu-fg m=sm ellipsis w="calc(200px - 2 * var(--spacing-md))": ${item.name}
+                                                  - rtgl-view w=${mediaWidth} d=v p=md bw=xs br=md:
+                                                      - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fileId} fontSize=60 width=${mediaWidth} height=${mediaHeight} av=c ah=c:
+                                                      - rtgl-text s=xs c=mu-fg m=sm ellipsis: ${item.name}
                                                 $elif resourceType == 'videos':
-                                                  - rvn-file-image br=md w=200 h=150 fileId=${item.thumbnailFileId}:
+                                                  - rvn-file-image br=md w=${mediaWidth} h=${mediaHeight} fileId=${item.thumbnailFileId}:
                                                 $elif resourceType == 'audio':
                                                   - $if item.waveformDataFileId:
                                                       - rtgl-view:
-                                                          - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} width=225 height=150:
-                                                          - rtgl-text w=225 ellipsis=true mt=sm: ${item.name}
+                                                          - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=${mediaWidth} h=${mediaHeight}:
+                                                          - rtgl-text w=${mediaWidth} ellipsis=true mt=sm: ${item.name}
                                                     $else:
-                                                      - rtgl-image br=md w=225 h=150 src=/public/project_logo_placeholder.png:
+                                                      - rtgl-image br=md w=${mediaWidth} h=${mediaHeight} src=/public/project_logo_placeholder.png:
                                                 $elif resourceType == 'images':
                                                   - rvn-file-image br=md mw=${maxWidth} h=${imageHeight} fileId=${item.fileId} key=${item.fileId}-${imageHeight}x${maxWidth}:
                                                 $elif resourceType == 'characters':
@@ -148,13 +175,13 @@ template:
                                                           - rtgl-button#sprites-button-${item.id}: Sprites
                                                 $elif resourceType == 'colors':
                                                   - 'rtgl-view br=md g=sm bw=xs style="overflow: hidden;"':
-                                                      - 'rtgl-view w=200 h=150 style="background-color: ${item.hex}"':
-                                                      - rtgl-text s=sm c=mu-fg m=md ellipsis w="calc(200px - 2 * var(--spacing-md))": ${item.name}
+                                                      - 'rtgl-view w=${mediaWidth} h=${mediaHeight} style="background-color: ${item.hex}"':
+                                                      - rtgl-text s=sm c=mu-fg m=md ellipsis w="calc(${mediaWidth}px - 2 * var(--spacing-md))": ${item.name}
                                                 $elif resourceType == 'typography':
                                                   - rtgl-view w=f br=md p=md bw=xs:
                                                       - rvn-font-preview fontFamily=${item.fontStyle} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=${item.fontSize} lineHeight=${item.lineHeight} color=${item.color} fontWeight=${item.fontWeight} width=700 height=80 showBorder=false:
                                                 $elif resourceType == 'layouts':
-                                                  - rtgl-view w=200 h=150 ah=c av=c bw=xs br=sm cur=p style="${item.selectedStyle}":
+                                                  - rtgl-view w=${mediaWidth} h=${mediaHeight} ah=c av=c bw=xs br=sm cur=p style="${item.selectedStyle}":
                                                       - rtgl-view av=c ah=c:
                                                           - rtgl-text s=md: ${item.name}
                                                           - rtgl-text s=sm c=mu-fg: ${item.layoutTypeDisplay}
@@ -168,7 +195,7 @@ template:
                                                       - rtgl-view h=12:
                                                       - rvn-keyframe-timeline .properties=#{item.properties}:
                                                 $else:
-                                                  - rtgl-view w=200 d=v p=md bw=xs br=md:
+                                                  - rtgl-view w=${mediaWidth} d=v p=md bw=xs br=md:
                                                       - rtgl-text s=xs c=mu-fg: ${item.name}
                                       - $if resourceType == 'characters':
                                           - rtgl-view mt=lg w=f:
@@ -176,7 +203,7 @@ template:
                                                   - rtgl-svg wh=24 svg=plus c=pr:
                                                   - rtgl-text s=md c=pr fw=500: Add Character
                                         $elif resourceType == 'colors':
-                                          - "rtgl-view#add-color-button-${group.id} w=200 h=150 av=c ah=c g=md bw=xs bc=bo br=md cur=p":
+                                          - "rtgl-view#add-color-button-${group.id} w=${mediaWidth} h=${mediaHeight} av=c ah=c g=md bw=xs bc=bo br=md cur=p":
                                               - rtgl-svg svg=plus wh=24:
                                               - rtgl-text: Add Color
                                         $elif resourceType == 'typography':
@@ -184,11 +211,11 @@ template:
                                               - rtgl-svg svg=plus wh=24 c=pr:
                                               - rtgl-text s=md c=pr fw=500: Add Typography
                                         $elif resourceType == 'layouts':
-                                          - "rtgl-view#add-layout-button-${group.id} w=200 h=150 av=c ah=c g=md bw=xs bc=bo br=md cur=p":
+                                          - "rtgl-view#add-layout-button-${group.id} w=${mediaWidth} h=${mediaHeight} av=c ah=c g=md bw=xs bc=bo br=md cur=p":
                                               - rtgl-svg svg=plus wh=24:
                                               - rtgl-text: Add Layout
                                         $elif resourceType == 'transforms':
-                                          - rtgl-view#add-transform-button-${group.id} w=200 h=150 av=c ah=c bw=xs br=md g=md cur=p:
+                                          - rtgl-view#add-transform-button-${group.id} w=${mediaWidth} h=${mediaHeight} av=c ah=c bw=xs br=md g=md cur=p:
                                               - rtgl-svg svg=plus wh=24:
                                               - rtgl-text: Add Transform
                                         $elif resourceType == 'animations':
@@ -205,7 +232,7 @@ template:
                                                   - rtgl-svg wh=24 svg=plus c=pr:
                                                   - rtgl-text s=md c=pr fw=500: Add Character
                                         $elif resourceType == 'colors':
-                                          - "rtgl-view#add-color-button-${group.id} w=200 h=150 av=c ah=c g=md bw=xs bc=bo br=md cur=p":
+                                          - "rtgl-view#add-color-button-${group.id} w=${mediaWidth} h=${mediaHeight} av=c ah=c g=md bw=xs bc=bo br=md cur=p":
                                               - rtgl-svg svg=plus wh=24:
                                               - rtgl-text: Add Color
                                         $elif resourceType == 'typography':
@@ -213,11 +240,11 @@ template:
                                               - rtgl-svg svg=plus wh=24 c=pr:
                                               - rtgl-text s=md c=pr fw=500: Add Typography
                                         $elif resourceType == 'layouts':
-                                          - "rtgl-view#add-layout-button-${group.id} w=200 h=150 av=c ah=c g=md bw=xs bc=bo br=md cur=p":
+                                          - "rtgl-view#add-layout-button-${group.id} w=${mediaWidth} h=${mediaHeight} av=c ah=c g=md bw=xs bc=bo br=md cur=p":
                                               - rtgl-svg svg=plus wh=24:
                                               - rtgl-text: Add Layout
                                         $elif resourceType == 'transforms':
-                                          - rtgl-view#add-transform-button-${group.id} w=200 h=150 av=c ah=c bw=xs br=md g=md cur=p:
+                                          - rtgl-view#add-transform-button-${group.id} w=${mediaWidth} h=${mediaHeight} av=c ah=c bw=xs br=md g=md cur=p:
                                               - rtgl-svg svg=plus wh=24:
                                               - rtgl-text: Add Transform
                                         $elif resourceType == 'animations':

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -94,7 +94,7 @@ template:
                   - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
                   - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget .contextMenuItems=contextMenuItems .emptyContextMenuItems=emptyContextMenuItems:
           - rtgl-view flex=1 h=f:
-              - rvn-group-resources-view#groupview full-width-item .resourceType=resourceType searchPlaceholder="Search animations..." .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery:
+              - rvn-group-resources-view#groupview full-width-item .resourceType=resourceType searchPlaceholder="Search animations..." .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery show-zoom-controls=false:
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/audio/audio.view.yaml
+++ b/src/pages/audio/audio.view.yaml
@@ -45,21 +45,21 @@ refs:
         handler: handleFormChange
 
 template:
-  - rtgl-view d=h w=f h=f: 
-    - rtgl-view d=h h=f w=f:
-      - rvn-resizable-panel#file-explorer w=300 min-w=200 max-w=500 resize-side="right":
-        - rtgl-view slot="content" w=f h=f:
-          - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
-          - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget:
-      - rtgl-view flex=1 h=f:
-        - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder .uploadText=uploadText .acceptedFileTypes=acceptedFileTypes:
-      - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
-        - rtgl-view wh=f slot="content":
-          - $if selectedItemId:
-            - rtgl-form#detail-form key=${selectedItemId} w=f h=f .form=form .context=context .defaultValues=defaultValues:
-            $else:
-              - rtgl-view wh=f av=c ah=c bgc=mu-fg:
-                  - rtgl-text s=md c=mu-fg: No selection
-    - $if showAudioPlayer:
-        - 'rtgl-view h=72 pos=fix cor=bottom z=1001 style="left: ${audioPlayerLeft}px; right: ${audioPlayerRight}px;"':
-            - rvn-audio-player fileId=${playingAudio.fileId} autoPlay=true .title=playingAudio.title:
+  - rtgl-view d=h w=f h=f:
+      - rtgl-view d=h h=f w=f:
+          - rvn-resizable-panel#file-explorer w=300 min-w=200 max-w=500 resize-side="right":
+              - rtgl-view slot="content" w=f h=f:
+                  - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
+                  - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget:
+          - rtgl-view flex=1 h=f:
+              - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder .uploadText=uploadText .acceptedFileTypes=acceptedFileTypes:
+          - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
+              - rtgl-view wh=f slot="content":
+                  - $if selectedItemId:
+                      - rtgl-form#detail-form key=${selectedItemId} w=f h=f .form=form .context=context .defaultValues=defaultValues:
+                    $else:
+                      - rtgl-view wh=f av=c ah=c bgc=mu-fg:
+                          - rtgl-text s=md c=mu-fg: No selection
+      - $if showAudioPlayer:
+          - 'rtgl-view h=72 pos=fix cor=bottom z=1001 style="left: ${audioPlayerLeft}px; right: ${audioPlayerRight}px;"':
+              - rvn-audio-player fileId=${playingAudio.fileId} autoPlay=true .title=playingAudio.title:

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -224,47 +224,6 @@ export const handleGroupToggle = (e, deps) => {
   render();
 };
 
-export const handleZoomChange = (e, deps) => {
-  const { store, render, userConfig } = deps;
-  const zoomLevel = parseFloat(e.detail?.value || e.target?.value);
-
-  store.setZoomLevel(zoomLevel);
-
-  if (userConfig) {
-    userConfig.set("characterSprites.zoomLevel", zoomLevel);
-  }
-
-  render();
-};
-
-export const handleZoomIn = (_, deps) => {
-  const { store, render, userConfig } = deps;
-  const currentZoom = store.selectCurrentZoomLevel();
-  const newZoom = Math.min(4.0, currentZoom + 0.1);
-
-  store.setZoomLevel(newZoom);
-
-  if (userConfig) {
-    userConfig.set("characterSprites.zoomLevel", newZoom);
-  }
-
-  render();
-};
-
-export const handleZoomOut = (_, deps) => {
-  const { store, render, userConfig } = deps;
-  const currentZoom = store.selectCurrentZoomLevel();
-  const newZoom = Math.max(0.5, currentZoom - 0.1);
-
-  store.setZoomLevel(newZoom);
-
-  if (userConfig) {
-    userConfig.set("characterSprites.zoomLevel", newZoom);
-  }
-
-  render();
-};
-
 export const handleImageDoubleClick = (e, deps) => {
   const { store, render } = deps;
   const { itemId } = e.detail;
@@ -286,12 +245,5 @@ export const handlePreviewOverlayClick = (_, deps) => {
 
 export const handleOnMount = async (deps) => {
   const { store, render, userConfig } = deps;
-
-  if (userConfig) {
-    const savedZoom = await userConfig.get("characterSprites.zoomLevel");
-    if (savedZoom !== null && savedZoom !== undefined) {
-      store.setZoomLevel(savedZoom);
-      render();
-    }
-  }
+  // No zoom initialization needed - handled by groupResourcesView
 };

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -155,8 +155,6 @@ export const toViewData = ({ state, props }, payload) => {
       ? []
       : (group.children || []).map((item) => ({
           ...item,
-          height: imageHeight,
-          maxWidth: maxWidth,
           selectedStyle:
             item.id === state.selectedItemId
               ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -35,7 +35,6 @@ export const INITIAL_STATE = Object.freeze({
   },
   searchQuery: "",
   collapsedIds: [],
-  zoomLevel: 1.0,
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
 });
@@ -69,12 +68,6 @@ export const toggleGroupCollapse = (state, groupId) => {
   }
 };
 
-export const setZoomLevel = (state, zoomLevel) => {
-  const newZoomLevel = Math.max(0.5, Math.min(4.0, zoomLevel));
-  if (Math.abs(state.zoomLevel - newZoomLevel) < 0.001) return;
-  state.zoomLevel = newZoomLevel;
-};
-
 export const showFullImagePreview = (state, fileId) => {
   state.fullImagePreviewVisible = true;
   state.fullImagePreviewFileId = fileId;
@@ -84,8 +77,6 @@ export const hideFullImagePreview = (state) => {
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
 };
-
-export const selectCurrentZoomLevel = ({ state }) => state.zoomLevel;
 
 export const selectCharacterId = ({ state }) => {
   return state.characterId;
@@ -156,11 +147,6 @@ export const toViewData = ({ state, props }, payload) => {
       .filter(Boolean);
   }
 
-  // Calculate zoom-based dimensions
-  const baseHeight = 150;
-  const imageHeight = Math.round(baseHeight * state.zoomLevel);
-  const maxWidth = Math.round(400 * state.zoomLevel);
-
   // Apply collapsed state and selection styling
   const flatGroups = filteredGroups.map((group) => ({
     ...group,
@@ -193,9 +179,6 @@ export const toViewData = ({ state, props }, payload) => {
     searchPlaceholder: "Search sprites...",
     uploadText: "Upload Sprite",
     acceptedFileTypes: [".png", ".jpg", ".jpeg", ".gif", ".webp"],
-    zoomLevel: state.zoomLevel,
-    imageHeight,
-    maxWidth,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
   };

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -31,9 +31,9 @@ refs:
       group-toggle:
         handler: handleGroupToggle
     preview-overlay:
-    eventListeners:
-      click:
-        handler: handlePreviewOverlayClick
+      eventListeners:
+        click:
+          handler: handlePreviewOverlayClick
   detail-form:
     eventListeners:
       extra-event:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -8,12 +8,6 @@ viewDataSchema:
   properties:
     searchQuery:
       type: string
-    zoomLevel:
-      type: number
-    imageHeight:
-      type: number
-    maxWidth:
-      type: number
     fullImagePreviewVisible:
       type: boolean
     fullImagePreviewFileId:
@@ -36,21 +30,7 @@ refs:
         handler: handleSearchInput
       group-toggle:
         handler: handleGroupToggle
-  zoom-slider:
-    eventListeners:
-      change:
-        handler: handleZoomChange
-      input-change:
-        handler: handleZoomChange
-  zoom-out:
-    eventListeners:
-      click:
-        handler: handleZoomOut
-  zoom-in:
-    eventListeners:
-      click:
-        handler: handleZoomIn
-  preview-overlay:
+    preview-overlay:
     eventListeners:
       click:
         handler: handlePreviewOverlayClick
@@ -68,14 +48,8 @@ template:
         - rtgl-view slot="content" w=f h=f:
           - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
           - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget:
-      - rtgl-view flex=1 h=f d=v:
-        - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="z-index: 100;"':
-          - rtgl-view d=h av=c g=sm:
-            - rtgl-button#zoom-out w=10 v="gh" s=sm: "-"
-            - input#zoom-slider type="range" w=120 min="0.5" max="4.0" step="0.1" value="${zoomLevel}":
-            - rtgl-button#zoom-in w=10 v="gh" s=sm: "+"
-        - rtgl-view flex=1 h=f:
-          - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder .uploadText=uploadText .acceptedFileTypes=acceptedFileTypes .imageHeight=imageHeight .maxWidth=maxWidth:
+      - rtgl-view flex=1 h=f:
+          - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder .uploadText=uploadText .acceptedFileTypes=acceptedFileTypes:
       - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
         - rtgl-view wh=f slot="content":
           - $if selectedItemId:

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -58,7 +58,7 @@ template:
                   - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
                   - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget:
           - rtgl-view flex=1 h=f:
-              - rvn-group-resources-view#groupview full-width-item .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder:
+              - rvn-group-resources-view#groupview full-width-item .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder show-zoom-controls=false:
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -181,77 +181,15 @@ export const handleGroupToggle = (e, deps) => {
   render();
 };
 
-export const handleZoomChange = (e, deps) => {
-  const { store, render, userConfig } = deps;
-  const zoomLevel = parseFloat(e.detail?.value || e.target?.value);
-
-  store.setZoomLevel(zoomLevel);
-
-  // Save zoom level to user config
-  if (userConfig) {
-    userConfig.set("images.zoomLevel", zoomLevel);
-  }
-
-  render();
-};
-
-export const handleZoomIn = (_, deps) => {
-  const { store, render, userConfig } = deps;
-  const currentZoom = store.selectCurrentZoomLevel();
-  const newZoom = Math.min(4.0, currentZoom + 0.1);
-
-  store.setZoomLevel(newZoom);
-
-  // Save zoom level to user config
-  if (userConfig) {
-    userConfig.set("images.zoomLevel", newZoom);
-  }
-
-  render();
-};
-
-export const handleZoomOut = (_, deps) => {
-  const { store, render, userConfig } = deps;
-  const currentZoom = store.selectCurrentZoomLevel();
-  const newZoom = Math.max(0.5, currentZoom - 0.1);
-
-  store.setZoomLevel(newZoom);
-
-  // Save zoom level to user config
-  if (userConfig) {
-    userConfig.set("images.zoomLevel", newZoom);
-  }
-
-  render();
-};
-
 export const handleImageDoubleClick = (e, deps) => {
   const { store, render } = deps;
   const { itemId } = e.detail;
-
-  const selectedItem = store.selectSelectedItem();
-  if (selectedItem && selectedItem.id === itemId) {
-    store.showFullImagePreview(selectedItem.fileId);
-    render();
-  }
+  store.showFullImagePreview(itemId);
+  render();
 };
 
 export const handlePreviewOverlayClick = (_, deps) => {
   const { store, render } = deps;
-
   store.hideFullImagePreview();
   render();
-};
-
-export const handleOnMount = async (deps) => {
-  const { store, render, userConfig } = deps;
-
-  // Load saved zoom level from user config
-  if (userConfig) {
-    const savedZoom = await userConfig.get("images.zoomLevel");
-    if (savedZoom !== null && savedZoom !== undefined) {
-      store.setZoomLevel(savedZoom);
-      render();
-    }
-  }
 };

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -33,7 +33,6 @@ export const INITIAL_STATE = Object.freeze({
   },
   searchQuery: "",
   collapsedIds: [],
-  zoomLevel: 1.0,
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
 });
@@ -74,29 +73,20 @@ export const toggleGroupCollapse = (state, groupId) => {
   }
 };
 
-export const setZoomLevel = (state, zoomLevel) => {
-  const newZoomLevel = Math.max(0.5, Math.min(4.0, zoomLevel));
+export const showFullImagePreview = (state, itemId) => {
+  // Find the item by itemId and extract its fileId
+  const flatItems = toFlatItems(state.imagesData);
+  const item = flatItems.find((item) => item.id === itemId);
 
-  // Only update if the value actually changed (avoid infinite loops)
-  if (Math.abs(state.zoomLevel - newZoomLevel) < 0.001) {
-    return; // No change needed
+  if (item && item.fileId) {
+    state.fullImagePreviewVisible = true;
+    state.fullImagePreviewFileId = item.fileId;
   }
-
-  state.zoomLevel = newZoomLevel;
-};
-
-export const showFullImagePreview = (state, fileId) => {
-  state.fullImagePreviewVisible = true;
-  state.fullImagePreviewFileId = fileId;
 };
 
 export const hideFullImagePreview = (state) => {
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
-};
-
-export const selectCurrentZoomLevel = ({ state }) => {
-  return state.zoomLevel || 1.0;
 };
 
 export const toViewData = ({ state }) => {
@@ -114,10 +104,11 @@ export const toViewData = ({ state }) => {
     return name.includes(searchQuery) || description.includes(searchQuery);
   };
 
-  // Calculate zoom-based dimensions
+  // Fixed base dimensions - zoom is handled by groupResourcesView
   const baseHeight = 150;
-  const imageHeight = Math.round(baseHeight * state.zoomLevel);
-  const maxWidth = Math.round(400 * state.zoomLevel);
+  const baseWidth = 400;
+  const imageHeight = baseHeight;
+  const maxWidth = baseWidth;
 
   // Apply collapsed state and search filtering to flatGroups
   const flatGroups = rawFlatGroups
@@ -219,7 +210,6 @@ export const toViewData = ({ state }) => {
       ".webp",
       ".svg",
     ],
-    zoomLevel: state.zoomLevel,
     imageHeight,
     maxWidth,
     fullImagePreviewVisible: state.fullImagePreviewVisible,

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -1,16 +1,10 @@
 elementName: rvn-images
 
-onMount:
-  handler: handleOnMount
-
-
 viewDataSchema:
   type: object
   properties:
     searchQuery:
       type: string
-    zoomLevel:
-      type: number
     imageHeight:
       type: number
     maxWidth:
@@ -37,20 +31,6 @@ refs:
         handler: handleSearchInput
       group-toggle:
         handler: handleGroupToggle
-  zoom-slider:
-    eventListeners:
-      change:
-        handler: handleZoomChange
-      input-change:
-        handler: handleZoomChange
-  zoom-out:
-    eventListeners:
-      click:
-        handler: handleZoomOut
-  zoom-in:
-    eventListeners:
-      click:
-        handler: handleZoomIn
   preview-overlay:
     eventListeners:
       click:
@@ -64,28 +44,23 @@ refs:
 
 template:
   - rtgl-view d=h w=f h=f:
-    - rtgl-view d=h h=f w=f:
-      - rvn-resizable-panel#file-explorer w=300 min-w=200 max-w=500 resize-side="right":
-        - rtgl-view slot="content" w=f h=f:
-          - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
-          - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget:
-      - rtgl-view flex=1 h=f d=v:
-        - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="z-index: 100;"':
-          - rtgl-view d=h av=c g=sm:
-            - rtgl-button#zoom-out w=10 v="gh" s=sm: "-"
-            - input#zoom-slider type="range" w=120 min="0.5" max="4.0" step="0.1" value="${zoomLevel}":
-            - rtgl-button#zoom-in w=10 v="gh" s=sm: "+"
-        - rtgl-view flex=1 h=f:
-          - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder .uploadText=uploadText .acceptedFileTypes=acceptedFileTypes .imageHeight=imageHeight .maxWidth=maxWidth:
-      - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
-        - rtgl-view wh=f slot="content":
-          - $if selectedItemId:
-            - rtgl-form#detail-form key=${selectedItemId} w=f h=f .form=form .context=context .defaultValues=defaultValues:
-            $else:
-              - rtgl-view wh=f av=c ah=c bgc=mu-fg:
-                  - rtgl-text s=md c=mu-fg: No selection
-    - $if fullImagePreviewVisible:
-        - rtgl-view#preview-overlay pos=fix cor=full ah=c av=c z=3000 cur=p:
-          - rtgl-view w=f h=f pos=fix cor=full ah=c av=c bgc=bg op="0.5":
-          - $if fullImagePreviewFileId:
-              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% z=3001:
+      - rtgl-view d=h h=f w=f:
+          - rvn-resizable-panel#file-explorer w=300 min-w=200 max-w=500 resize-side="right":
+              - rtgl-view slot="content" w=f h=f:
+                  - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
+                  - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget:
+          - rtgl-view flex=1 h=f d=v:
+              - rtgl-view flex=1 h=f:
+                  - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder .uploadText=uploadText .acceptedFileTypes=acceptedFileTypes .imageHeight=imageHeight .maxWidth=maxWidth:
+          - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
+              - rtgl-view wh=f slot="content":
+                  - $if selectedItemId:
+                      - rtgl-form#detail-form key=${selectedItemId} w=f h=f .form=form .context=context .defaultValues=defaultValues:
+                    $else:
+                      - rtgl-view wh=f av=c ah=c bgc=mu-fg:
+                          - rtgl-text s=md c=mu-fg: No selection
+      - $if fullImagePreviewVisible:
+          - rtgl-view#preview-overlay pos=fix cor=full ah=c av=c z=3000 cur=p:
+              - rtgl-view w=f h=f pos=fix cor=full ah=c av=c bgc=bg op="0.5":
+              - $if fullImagePreviewFileId:
+                  - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% z=3001:

--- a/src/pages/typography/typography.view.yaml
+++ b/src/pages/typography/typography.view.yaml
@@ -70,7 +70,7 @@ template:
           - rvn-resource-types .resourceCategory=resourceCategory .selectedResourceId=selectedResourceId:
           - rvn-file-explorer .items=flatItems .repositoryTarget=repositoryTarget .contextMenuItems=contextMenuItems .emptyContextMenuItems=emptyContextMenuItems:
       - rtgl-view flex=1 h=f:
-        - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder:
+        - rvn-group-resources-view#groupview .resourceType=resourceType .flatGroups=flatGroups .selectedItemId=selectedItemId .searchQuery=searchQuery .searchPlaceholder=searchPlaceholder show-zoom-controls=false:
       - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
         - rtgl-view wh=f slot="content":
           - $if selectedItemId:


### PR DESCRIPTION
## Summary
- Add unified zoom functionality for all media resource types (images, audio, video, colors, layouts, fonts)
- Add configurable zoom controls that can be disabled for specific resource types
- Disable zoom controls for typography, animations, and characters pages where they're not needed

## Test plan
- [ ] Test zoom controls work correctly for images, audio, and video resources
- [ ] Verify zoom controls are hidden for typography, animations, and characters
- [ ] Test zoom slider and zoom in/out buttons function properly
- [ ] Verify media dimensions scale correctly with zoom level