### PR TITLE
Fix detail pannel

### DIFF
--- a/src/components/fileExplorer/fileExplorer.handlers.js
+++ b/src/components/fileExplorer/fileExplorer.handlers.js
@@ -30,7 +30,8 @@ export const handleClickItem = async (deps, payload) => {
 
   const repositoryState = repository.getState();
   const targetData = lodashGet(repositoryState, repositoryTarget);
-  const selectedItem = targetData && targetData.items ? targetData.items[id] : null;
+  const selectedItem =
+    targetData && targetData.items ? targetData.items[id] : null;
 
   // Forward the event with enhanced detail containing item data
   dispatchEvent(
@@ -39,6 +40,7 @@ export const handleClickItem = async (deps, payload) => {
         ...payload._event.detail,
         item: selectedItem,
         repositoryTarget,
+        isFolder: selectedItem && selectedItem.type === "folder",
       },
       bubbles: true,
       composed: true,

--- a/src/pages/audio/audio.handlers.js
+++ b/src/pages/audio/audio.handlers.js
@@ -20,11 +20,28 @@ export const handleDataChanged = async (deps) => {
   render();
 };
 
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id } = payload._event.detail;
+export const handleFileExplorerSelectionChanged = async (deps, payload) => {
+  const { store, render, fileManagerFactory, router } = deps;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  // If we have item data with waveformDataFileId, set up media context for preview
+  if (item && item.waveformDataFileId) {
+    const { p: projectId } = router.getPayload();
+    const fileManager = await fileManagerFactory.getByProject(projectId);
+
+    const waveformData = await fileManager.downloadMetadata({
+      fileId: item.waveformDataFileId,
+    });
+
+    store.setContext({
+      fileId: {
+        waveformData,
+      },
+    });
+  }
+
   render();
 };
 

--- a/src/pages/audio/audio.handlers.js
+++ b/src/pages/audio/audio.handlers.js
@@ -22,7 +22,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   const { store, render, fileManagerFactory, router } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      fileId: {
+        waveformData: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -47,7 +47,8 @@ export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   }
 
   // Check if this is a folder (either from BaseFileExplorer or from our own data)
-  const actualIsFolder = isFolder || (actualItem && actualItem.type === "folder");
+  const actualIsFolder =
+    isFolder || (actualItem && actualItem.type === "folder");
 
   // If this is a folder, clear selection and context
   if (actualIsFolder) {

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -34,7 +34,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   const { store, render, fileManagerFactory, router } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      fileId: {
+        src: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -32,11 +32,26 @@ export const handleDataChanged = async (deps) => {
   render();
 };
 
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id } = payload._event.detail;
+export const handleFileExplorerSelectionChanged = async (deps, payload) => {
+  const { store, render, fileManagerFactory, router } = deps;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  // If we have item data with fileId, set up media context for preview
+  if (item && item.fileId) {
+    const { p: projectId } = router.getPayload();
+    const fileManager = await fileManagerFactory.getByProject(projectId);
+    const { url } = await fileManager.getFileContent({
+      fileId: item.fileId,
+    });
+    store.setContext({
+      fileId: {
+        src: url,
+      },
+    });
+  }
+
   render();
 };
 

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -63,6 +63,10 @@ export const selectCharacterId = ({ state }) => {
   return state.characterId;
 };
 
+export const selectFlatItems = ({ state }) => {
+  return toFlatItems(state.spritesData);
+};
+
 export const showFullImagePreview = (state, { itemId }) => {
   const flatItems = toFlatItems(state.spritesData);
   const item = flatItems.find((item) => item.id === itemId);
@@ -146,7 +150,7 @@ export const selectViewData = ({ state }) => {
     resourceCategory: "assets",
     selectedResourceId: "characterSprites",
     selectedItemId: state.selectedItemId,
-    repositoryTarget: "characterSprites",
+    repositoryTarget: "character.sprites",
     form,
     context: state.context,
     defaultValues,

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -18,11 +18,26 @@ export const handleDataChanged = async (deps) => {
   render();
 };
 
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id } = payload._event.detail;
+export const handleFileExplorerSelectionChanged = async (deps, payload) => {
+  const { store, render, fileManagerFactory, router } = deps;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  // If we have item data with fileId, set up media context for preview
+  if (item && item.fileId) {
+    const { p: projectId } = router.getPayload();
+    const fileManager = await fileManagerFactory.getByProject(projectId);
+    const { url } = await fileManager.getFileContent({
+      fileId: item.fileId,
+    });
+    store.setContext({
+      fileId: {
+        src: url,
+      },
+    });
+  }
+
   render();
 };
 

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -20,7 +20,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   const { store, render, fileManagerFactory, router } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      fileId: {
+        src: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 

--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -39,9 +39,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = (deps, payload) => {
   const { store, render } = deps;
-  const { id } = payload._event.detail;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  // If we have item data with hex value, set up color context for preview
+  if (item && item.hex) {
+    store.setContext({
+      colorImage: {
+        src: hexToBase64Image(item.hex),
+      },
+    });
+  }
+
   render();
 };
 

--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -39,7 +39,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = (deps, payload) => {
   const { store, render } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      colorImage: {
+        src: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -9,11 +9,27 @@ export const handleAfterMount = async (deps) => {
   render();
 };
 
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id } = payload._event.detail;
+export const handleFileExplorerSelectionChanged = async (deps, payload) => {
+  const { store, render, fileManagerFactory, router } = deps;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  // If we have item data with fileId, set up media context for preview
+  if (item && item.fileId) {
+    const { p: projectId } = router.getPayload();
+    const fileManager = await fileManagerFactory.getByProject(projectId);
+    const { url } = await fileManager.getFileContent({
+      fileId: item.fileId,
+    });
+
+    store.setContext({
+      fileId: {
+        src: url,
+      },
+    });
+  }
+
   render();
 };
 

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -11,7 +11,19 @@ export const handleAfterMount = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   const { store, render, fileManagerFactory, router } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      fileId: {
+        src: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -11,6 +11,11 @@ const form = {
     },
     { name: "name", inputType: "popover-input", description: "Name" },
     {
+      name: "fileType",
+      inputType: "read-only-text",
+      description: "File Type",
+    },
+    {
       name: "fileSize",
       inputType: "read-only-text",
       description: "File Size",

--- a/src/pages/typography/typography.handlers.js
+++ b/src/pages/typography/typography.handlers.js
@@ -28,9 +28,36 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = (deps, payload) => {
   const { store, render } = deps;
-  const { id } = payload._event.detail;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  if (item) {
+    try {
+      const colorsData = store.selectColorsData();
+      const fontsData = store.selectFontsData();
+
+      const previewImage = generateTypographyPreview(
+        item,
+        colorsData,
+        fontsData,
+      );
+
+      store.setContext({
+        typographyPreview: {
+          src: previewImage,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to generate typography preview:", error);
+      store.setContext({
+        typographyPreview: {
+          src: null,
+        },
+      });
+    }
+  }
+
   render();
 };
 

--- a/src/pages/typography/typography.handlers.js
+++ b/src/pages/typography/typography.handlers.js
@@ -28,7 +28,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = (deps, payload) => {
   const { store, render } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      typographyPreview: {
+        src: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -19,11 +19,26 @@ export const handleDataChanged = async (deps) => {
   render();
 };
 
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id } = payload._event.detail;
+export const handleFileExplorerSelectionChanged = async (deps, payload) => {
+  const { store, render, fileManagerFactory, router } = deps;
+  const { id, item } = payload._event.detail;
 
   store.setSelectedItemId(id);
+
+  // If we have item data with thumbnailFileId, set up media context for preview
+  if (item && item.thumbnailFileId) {
+    const { p: projectId } = router.getPayload();
+    const fileManager = await fileManagerFactory.getByProject(projectId);
+    const { url } = await fileManager.getFileContent({
+      fileId: item.thumbnailFileId,
+    });
+    store.setContext({
+      thumbnailFileId: {
+        src: url,
+      },
+    });
+  }
+
   render();
 };
 

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -21,7 +21,19 @@ export const handleDataChanged = async (deps) => {
 
 export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   const { store, render, fileManagerFactory, router } = deps;
-  const { id, item } = payload._event.detail;
+  const { id, item, isFolder } = payload._event.detail;
+
+  // If this is a folder, clear selection and context
+  if (isFolder) {
+    store.setSelectedItemId(null);
+    store.setContext({
+      thumbnailFileId: {
+        src: null,
+      },
+    });
+    render();
+    return;
+  }
 
   store.setSelectedItemId(id);
 


### PR DESCRIPTION
Note: 

In fact only in file explorer can select the folder, in group resources view cannot do that. So the simplest way to implement it is just set **No selection** in detail pannel when file explorer selected a folder. Maybe show folder data is also ok, but should need double-check the form structure, so haven't done for now.

<img width="1602" height="932" alt="image" src="https://github.com/user-attachments/assets/18700ee2-99e4-48d9-a74d-90d5055b61ed" />
