### PR TITLE
update template dialogue y

### DIFF
--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -332,7 +332,7 @@
               "type": "container",
               "name": "Dialogue Container",
               "x": 35,
-              "y": 640,
+              "y": 695,
               "width": 1850,
               "height": 350,
               "anchorX": 0,


### PR DESCRIPTION
The origin y 640 is smaller so the distance to the bottom is too long

now set 695, it's screen height - container height - left/right margin (1080-350-35)

Old:

<img width="1602" height="932" alt="image" src="https://github.com/user-attachments/assets/5f874e5a-8b4d-4e11-8156-fce0a8abb15f" />

New:

<img width="723" height="413" alt="image" src="https://github.com/user-attachments/assets/228a0e80-e088-4532-9318-eb8013562f6d" />