### PR TITLE
feat scenes arrows update

### DIFF
--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -249,6 +249,7 @@ export const handleItemContextMenu = (deps, payload) => {
 
 export const handleWindowMouseMove = (deps, payload) => {
   const { store, getRefIds, render } = deps;
+  console.log(store.selectIsDragging());
 
   if (store.selectIsPanning()) {
     // Handle panning
@@ -300,12 +301,17 @@ export const handleWindowMouseMove = (deps, payload) => {
     const snappedX = Math.round(constrainedX / 5) * 5;
     const snappedY = Math.round(constrainedY / 5) * 5;
 
-    // Update the element position directly for immediate visual feedback
-    const itemElement = getRefIds()[`item-${dragItemId}`];
-    if (itemElement && itemElement.elm) {
-      itemElement.elm.style.left = snappedX + "px";
-      itemElement.elm.style.top = snappedY + "px";
-    }
+    // Dispatch real-time position update to parent (scenes page)
+    console.log(snappedX, snappedY);
+    dispatchEvent(
+      new CustomEvent("item-position-updating", {
+        detail: {
+          itemId: dragItemId,
+          x: snappedX,
+          y: snappedY,
+        },
+      }),
+    );
   }
 };
 

--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -248,8 +248,7 @@ export const handleItemContextMenu = (deps, payload) => {
 };
 
 export const handleWindowMouseMove = (deps, payload) => {
-  const { store, getRefIds, render } = deps;
-  console.log(store.selectIsDragging());
+  const { store, getRefIds, render, dispatchEvent } = deps;
 
   if (store.selectIsPanning()) {
     // Handle panning
@@ -302,7 +301,6 @@ export const handleWindowMouseMove = (deps, payload) => {
     const snappedY = Math.round(constrainedY / 5) * 5;
 
     // Dispatch real-time position update to parent (scenes page)
-    console.log(snappedX, snappedY);
     dispatchEvent(
       new CustomEvent("item-position-updating", {
         detail: {

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -1,4 +1,4 @@
-import { drawArrowBetwweenScenes } from "../../utils/arrowUtils";
+import { drawArrowBetweenScenes } from "../../utils/arrowUtils";
 
 // Natural zoom levels
 const ZOOM_LEVELS = [0.2, 0.3, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
@@ -196,7 +196,7 @@ export const selectViewData = ({ state, props }) => {
       sourceItem.transitions.forEach((targetSceneId) => {
         const targetItem = items.find((item) => item.id === targetSceneId);
         if (targetItem) {
-          const arrowData = drawArrowBetwweenScenes(sourceItem, targetItem);
+          const arrowData = drawArrowBetweenScenes(sourceItem, targetItem);
           // Add unique identifier for DOM reference
           arrowData.id = `arrow-${sourceItem.id}-to-${targetSceneId}`;
           arrowsList.push(arrowData);

--- a/src/components/whiteboard/whiteboard.view.yaml
+++ b/src/components/whiteboard/whiteboard.view.yaml
@@ -34,21 +34,6 @@ viewDataSchema:
       type: string
     itemCursor:
       type: string
-    arrowsList:
-      type: array
-      items:
-        type: object
-        properties:
-          id:
-            type: string
-          path:
-            type: string
-          svgWidth:
-            type: number
-          svgHeight:
-            type: number
-          style:
-            type: string
 
 propsSchema:
   type: object

--- a/src/components/whiteboard/whiteboard.view.yaml
+++ b/src/components/whiteboard/whiteboard.view.yaml
@@ -34,6 +34,21 @@ viewDataSchema:
       type: string
     itemCursor:
       type: string
+    arrowsList:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          path:
+            type: string
+          svgWidth:
+            type: number
+          svgHeight:
+            type: number
+          style:
+            type: string
 
 propsSchema:
   type: object

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -148,21 +148,12 @@ export const selectSelectedItemId = ({ state }) => {
 };
 
 export const handleWhiteboardItemPositionUpdating = async (deps, payload) => {
-  console.log("handleWhiteboardItemPositionChanged called!");
   const { store, render } = deps;
   const { itemId, x, y } = payload._event.detail;
-
-  console.log("Updating item position:", { itemId, x, y });
 
   // Only update local whiteboard state for real-time feedback
   // Don't update repository during drag (too expensive)
   store.updateItemPosition({ itemId, x, y });
-
-  // Check if the update was applied
-  const updatedItems = store.selectWhiteboardItems();
-  const updatedItem = updatedItems.find((item) => item.id === itemId);
-  console.log("Updated item:", updatedItem);
-
   render();
 };
 

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -147,6 +147,25 @@ export const selectSelectedItemId = ({ state }) => {
   return state.selectedItemId;
 };
 
+export const handleWhiteboardItemPositionUpdating = async (deps, payload) => {
+  console.log("handleWhiteboardItemPositionChanged called!");
+  const { store, render } = deps;
+  const { itemId, x, y } = payload._event.detail;
+
+  console.log("Updating item position:", { itemId, x, y });
+
+  // Only update local whiteboard state for real-time feedback
+  // Don't update repository during drag (too expensive)
+  store.updateItemPosition({ itemId, x, y });
+
+  // Check if the update was applied
+  const updatedItems = store.selectWhiteboardItems();
+  const updatedItem = updatedItems.find((item) => item.id === itemId);
+  console.log("Updated item:", updatedItem);
+
+  render();
+};
+
 export const handleWhiteboardItemPositionChanged = async (deps, payload) => {
   const { store, render, repositoryFactory, router } = deps;
   const { p } = router.getPayload();
@@ -160,7 +179,7 @@ export const handleWhiteboardItemPositionChanged = async (deps, payload) => {
     value: { x, y },
   });
 
-  // Update local whiteboard state
+  // Update local whiteboard state (already updated by position-updating, but keeping for consistency)
   store.updateItemPosition({ itemId, x, y });
   render();
 };

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -13,6 +13,8 @@ refs:
     eventListeners:
       item-position-changed:
         handler: handleWhiteboardItemPositionChanged
+      item-position-updating:
+        handler: handleWhiteboardItemPositionUpdating
       item-selected:
         handler: handleWhiteboardItemSelected
       item-double-click:

--- a/src/utils/arrowUtils.js
+++ b/src/utils/arrowUtils.js
@@ -34,7 +34,7 @@ export const drawArrowBetweenPoints = (sourceX, sourceY, targetX, targetY) => {
   return { path, labelX, labelY, offsetX, offsetY, svgWidth, svgHeight, style };
 };
 
-export const drawArrowBetwweenScenes = (sourceScene, targetScene) => {
+export const drawArrowBetweenScenes = (sourceScene, targetScene) => {
   return drawArrowBetweenPoints(
     sourceScene.x + 120,
     sourceScene.y + 30,


### PR DESCRIPTION
The origin implement is directly change the item dom data, but it seems hard for arrows. My plan is to dispatchEvent when dragging and scenes page listening that, then update the whiteboard props and force re-render, however, the `item-position-updating` cannot be listened