### PR TITLE
fix the 'No selection' text

### DIFF
--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -70,7 +70,7 @@ template:
                       - rtgl-form#detail-form key=${selectedItemId} w=f h=f .form=form .defaultValues=defaultValues:
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
-                      - rtgl-text s=md c=mu-fg: "No selection"
+                          - rtgl-text s=md c=mu-fg: "No selection"
   - "rtgl-dialog#transform-dialog ?open=${isDialogOpen} s=lg":
       - 'rtgl-view slot="content" d=h ah=c g=lg w=f':
           - "$if isDialogOpen":


### PR DESCRIPTION
The transform panel had it's text anchored to bottom left when nothing was selected

<img width="671" height="541" alt="image" src="https://github.com/user-attachments/assets/707e542f-0144-4f0d-a5a7-90f0a3b50b27" />

Fixed it and now looks like 

<img width="799" height="652" alt="image" src="https://github.com/user-attachments/assets/ed5e9f24-b964-4e46-b35a-fcb033b9edeb" />
