### PR TITLE
Fix selected border not scaled with text element

### DIFF
--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -226,7 +226,7 @@ const renderLayoutPreview = async (deps) => {
   const finalElements = parseAndRender(elementsToRender, data);
 
   const parsedState = graphicsService.parse({
-    elements: renderStateElements,
+    elements: finalElements,
   });
 
   if (!selectedItem) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -104,6 +104,7 @@ export const layoutTreeStructureToRenderState = (
           fontWeight: typography.fontWeight || "normal",
           fill: colorItem?.hex || "white",
           lineHeight: typography.lineHeight || 1.2,
+          breakWords: true,
         };
       } else {
         // Use default settings


### PR DESCRIPTION
The reason why it didn't scale is because the text is still using the template text like ${layout.element[0]} and not the actual text to do the calculation for the border rect. So I changed to use the actual text and change breakWords to true so that it doesn't need a space to break a line.