### PR TITLE
Fix cursor jumping to beginning on input

### DIFF
--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1067,9 +1067,8 @@ export const handleUpdateDialogueContent = async (deps, payload) => {
 
 // Handler for debounced canvas rendering
 async function handleRenderCanvas(deps) {
-  const { store, graphicsService, render } = deps;
+  const { store, graphicsService } = deps;
   await renderSceneState(store, graphicsService);
-  render();
 }
 
 // RxJS subscriptions for handling events with throttling/debouncing


### PR DESCRIPTION
Remove unnecessary render() call in handleRenderCanvas that was causing cursor reset while typing.