### PR TITLE
Fix Presentation state and character ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jsdom": "^26.1.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.5",
-    "route-engine-js": "0.1.14",
+    "route-engine-js": "^0.1.15",
     "route-graphics": "0.0.24",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -244,8 +244,9 @@ export const handleEditorDataChanged = async (deps, payload) => {
     content,
   });
 
-  // Render the scene immediately with the updated content
-  // Trigger debounced canvas render
+  // Trigger debounced canvas render with skipRender flag.
+  // skipRender prevents full UI re-render which would reset cursor position while typing.
+  // Typing only updates dialogue content, not presentationState, so State panel doesn't need to update.
   subject.dispatch("sceneEditor.renderCanvas", { skipRender: true });
 };
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -246,7 +246,7 @@ export const handleEditorDataChanged = async (deps, payload) => {
 
   // Render the scene immediately with the updated content
   // Trigger debounced canvas render
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  subject.dispatch("sceneEditor.renderCanvas", { skipRender: true });
 };
 
 export const handleAddActionsButtonClick = (deps) => {
@@ -1069,9 +1069,12 @@ export const handleUpdateDialogueContent = async (deps, payload) => {
 };
 
 // Handler for debounced canvas rendering
-async function handleRenderCanvas(deps) {
-  const { store, graphicsService } = deps;
+async function handleRenderCanvas(deps, payload) {
+  const { store, graphicsService, render } = deps;
   await renderSceneState(store, graphicsService);
+  if (!payload?.skipRender) {
+    render();
+  }
 }
 
 // RxJS subscriptions for handling events with throttling/debouncing


### PR DESCRIPTION
- Fix Presentation State panel not updating after changes (adding/removing characters, navigating lines)
 - Add skipRender flag to prevent cursor reset while typing in line editor
 - Update route engine for character id duplication
 

 ### Presentation State UI fix:

 The State panel was showing stale/inconsistent data because handleRenderCanvas wasn't calling render() after updating presentationState in the store. Added render() call to sync the UI.

### To verify this

  - Add a character on line 2, verify it appears in State panel
  - Go to line 3-4, verify character persists in State panel
  - Delete character on line 5, verify it disappears from State panel
  - Go back to line 2-4, verify character shows correctly

Or any line, they are just for reference
