### PR TITLE
Line editor render

### DIFF
--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -671,13 +671,6 @@ export const handleLineNavigation = (deps, payload) => {
 
     // Force a render to update line colors after navigation
     setTimeout(() => {
-      render();
-      // Also render the linesEditor to update line colors
-      if (linesEditorRef) {
-        linesEditorRef.elm.render();
-      }
-
-      // Trigger debounced canvas render
       subject.dispatch("sceneEditor.renderCanvas", {});
     }, 0);
   } else if (direction === "up" && currentLineId === targetLineId) {
@@ -1071,11 +1064,20 @@ export const handleUpdateDialogueContent = async (deps, payload) => {
 
 // Handler for debounced canvas rendering
 async function handleRenderCanvas(deps, payload) {
-  const { store, graphicsService, render } = deps;
+  const { store, graphicsService, render, getRefIds } = deps;
   await renderSceneState(store, graphicsService);
-  if (!payload?.skipRender) {
-    render();
+
+  if (payload?.skipRender) {
+    return;
   }
+
+  const refIds = getRefIds();
+  const linesEditorRef = refIds?.["lines-editor"];
+  if (linesEditorRef?.elm?.store?.selectMode?.() === "text-editor") {
+    return;
+  }
+
+  render();
 }
 
 // RxJS subscriptions for handling events with throttling/debouncing


### PR DESCRIPTION
Previously, handleRenderCanvas was calling render() without checking if the linesEditor was in text-editor mode. Since the linesEditor tracks its mode ("block" vs "text-editor"), we needed to respect that state before triggering a full UI re-render

I forgot to check the linesEditor's mode state before deciding whether to render