### PR TITLE
Update Scene editor and Presentation State panel to use events

### DIFF
--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -1,3 +1,4 @@
+import { filter, tap } from "rxjs";
 export const open = (deps, payload) => {
   const { store, render } = deps;
   const { mode } = payload;
@@ -116,4 +117,17 @@ export const handleDropdownMenuClose = (deps) => {
   const { store, render } = deps;
   store.hideDropdownMenu();
   render();
+};
+
+export const subscriptions = (deps) => {
+  const { subject, store, render } = deps;
+  return [
+    subject.pipe(
+      filter(({ action }) => action === "updatePresentationState"),
+      tap(({ payload }) => {
+        store.setLocalPresentationState(payload);
+        render();
+      }),
+    ),
+  ];
 };

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -86,7 +86,6 @@ export const setLocalPresentationState = (state, presentationState) => {
   state.localPresentationState = presentationState;
 };
 
-
 export const selectRepositoryState = ({ state }) => {
   return state.repositoryState;
 };
@@ -132,7 +131,8 @@ export const setMode = (state, payload) => {
 // Moved from sceneEditor.store.js - now returns object instead of array
 export const selectActionsData = ({ props, state }) => {
   const { actions } = props;
-  const presentationState = state.localPresentationState ?? props.presentationState ?? {};
+  const presentationState =
+    state.localPresentationState ?? props.presentationState ?? {};
 
   if (!actions) {
     return {};

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -14,6 +14,7 @@ export const createInitialState = () => ({
     ],
   },
   repositoryState: {}, // Add this - default to empty object
+  localPresentationState: null,
 });
 
 export const selectViewData = ({ state, props, attrs }) => {
@@ -81,6 +82,11 @@ export const selectViewData = ({ state, props, attrs }) => {
   };
 };
 
+export const setLocalPresentationState = (state, presentationState) => {
+  state.localPresentationState = presentationState;
+};
+
+
 export const selectRepositoryState = ({ state }) => {
   return state.repositoryState;
 };
@@ -125,7 +131,8 @@ export const setMode = (state, payload) => {
 
 // Moved from sceneEditor.store.js - now returns object instead of array
 export const selectActionsData = ({ props, state }) => {
-  const { actions, presentationState = {} } = props;
+  const { actions } = props;
+  const presentationState = state.localPresentationState ?? props.presentationState ?? {};
 
   if (!actions) {
     return {};

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -131,8 +131,7 @@ export const setMode = (state, payload) => {
 // Moved from sceneEditor.store.js - now returns object instead of array
 export const selectActionsData = ({ props, state }) => {
   const { actions } = props;
-  const presentationState =
-    state.localPresentationState ?? props.presentationState ?? {};
+  const presentationState = state.localPresentationState;
 
   if (!actions) {
     return {};

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -244,10 +244,7 @@ export const handleEditorDataChanged = async (deps, payload) => {
     content,
   });
 
-  // Trigger debounced canvas render with skipRender flag.
-  // skipRender prevents full UI re-render which would reset cursor position while typing.
-  // Typing only updates dialogue content, not presentationState, so State panel doesn't need to update.
-  subject.dispatch("sceneEditor.renderCanvas", { skipRender: true });
+  subject.dispatch("sceneEditor.renderCanvas", {});
 };
 
 export const handleAddActionsButtonClick = (deps) => {
@@ -1070,12 +1067,9 @@ export const handleUpdateDialogueContent = async (deps, payload) => {
 };
 
 // Handler for debounced canvas rendering
-async function handleRenderCanvas(deps, payload) {
-  const { store, graphicsService, render } = deps;
+async function handleRenderCanvas(deps) {
+  const { store, graphicsService } = deps;
   await renderSceneState(store, graphicsService);
-  if (!payload?.skipRender) {
-    render();
-  }
 }
 
 // RxJS subscriptions for handling events with throttling/debouncing

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1068,7 +1068,7 @@ export const handleUpdateDialogueContent = async (deps, payload) => {
 
 // Handler for debounced canvas rendering
 async function handleRenderCanvas(deps) {
-  const { store, graphicsService, subject  } = deps;
+  const { store, graphicsService, subject } = deps;
   await renderSceneState(store, graphicsService);
   const presentationState = store.selectPresentationState();
   subject.dispatch("updatePresentationState", presentationState);

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1068,8 +1068,10 @@ export const handleUpdateDialogueContent = async (deps, payload) => {
 
 // Handler for debounced canvas rendering
 async function handleRenderCanvas(deps) {
-  const { store, graphicsService } = deps;
+  const { store, graphicsService, subject  } = deps;
   await renderSceneState(store, graphicsService);
+  const presentationState = store.selectPresentationState();
+  subject.dispatch("updatePresentationState", presentationState);
 }
 
 // RxJS subscriptions for handling events with throttling/debouncing

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -43,6 +43,10 @@ export const hidePreviewScene = (state) => {
   state.previewVisible = false;
 };
 
+export const selectPresentationState = ({ state }) => {
+  return state.presentationState;
+};
+
 export const setPresentationState = (state, presentationState) => {
   state.presentationState = presentationState;
 };


### PR DESCRIPTION
#### Previous Attempt and Why It Was Removed

Calling render() on the parent sceneEditor was not ok because:
  1. It re-renders all child components including linesEditor
  2. The contenteditable DOM gets recreated, losing cursor position
  3. This happens asynchronously (50ms debounce), making it impossible to preserve cursor state ( I did not notice this yesterday)

Using the event approach because it's already used in the project 