### PR TITLE
Fix/problem with scene editor loading

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "jszip": "^3.10.1",
         "nanoid": "^5.1.5",
         "route-engine-js": "^0.1.15",
-        "route-graphics": "0.0.26",
+        "route-graphics": "0.0.28",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
         "snabbdom-to-html": "^7.1.0",
@@ -508,7 +508,7 @@
 
     "route-engine-js": ["route-engine-js@0.1.15", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-TQ06CVyd1Uje2HRLlJjZVhq4n4XF/i9CDuAGnNZPCXgeKL37Ntrj2e0Ymv943dHVRrihfSbvIg7n2IT+c1nyiw=="],
 
-    "route-graphics": ["route-graphics@0.0.26", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-67C84tKAW2RTMVOAMpz36hijkscasuJweJ49lJ5bJ0t5F/0dogk2mxfClvlErI02ThdaSUa6y94MivTyQvwl6Q=="],
+    "route-graphics": ["route-graphics@0.0.28", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-PdS30JsL1aNk9SEl/6lEvPNcDhshleYbiiO6UXAEr1YdbCWlQhwQ5Kpg7l6HpqU1H0TXhfV6pOT2kW3RFiPZSQ=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jszip": "^3.10.1",
     "nanoid": "^5.1.5",
     "route-engine-js": "^0.1.15",
-    "route-graphics": "0.0.26",
+    "route-graphics": "0.0.28",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",
     "snabbdom-to-html": "^7.1.0",

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -9,6 +9,11 @@ async function createAssetsFromFileIds(
   projectService,
   resources,
 ) {
+  console.log("CREATE ASSETS FROM FILE IDS");
+  console.log("File references: ", fileReferences);
+  console.log("Project service: ", projectService);
+  console.log("Project resources: ", resources);
+  console.log("-----");
   const { sounds, images, fonts = {} } = resources;
   const allItems = Object.entries({
     ...sounds,
@@ -82,29 +87,6 @@ export const handleBeforeMount = (deps) => {
   };
 };
 
-// Seperate for asyn operation
-const initializeRouteGraphics = async (
-  canvas,
-  store,
-  projectService,
-  graphicsService,
-) => {
-  await graphicsService.init({ canvas: canvas.elm });
-  const projectData = store.selectProjectData();
-
-  graphicsService.initRouteEngine(projectData);
-  // TODO don't load all data... only ones necessary for this scene
-  const fileReferences = extractFileIdsFromRenderState(projectData);
-  const assets = await createAssetsFromFileIds(
-    fileReferences,
-    projectService,
-    projectData.resources,
-  );
-  await graphicsService.loadAssets(assets);
-  // don't know why but it needs to be called twice the first time to work...
-  renderSceneState(store, graphicsService);
-};
-
 export const handleAfterMount = async (deps) => {
   const {
     getRefIds,
@@ -139,7 +121,21 @@ export const handleAfterMount = async (deps) => {
 
   const { canvas } = getRefIds();
 
-  initializeRouteGraphics(canvas, store, projectService, graphicsService);
+  await graphicsService.init({ canvas: canvas.elm });
+  const projectData = store.selectProjectData();
+
+
+  graphicsService.initRouteEngine(projectData);
+  // TODO don't load all data... only ones necessary for this scene
+  const fileReferences = extractFileIdsFromRenderState(projectData);
+  const assets = await createAssetsFromFileIds(
+    fileReferences,
+    projectService,
+    projectData.resources,
+  );
+  await graphicsService.loadAssets(assets);
+  // don't know why but it needs to be called twice the first time to work...
+  renderSceneState(store, graphicsService);
   render();
 };
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -9,11 +9,6 @@ async function createAssetsFromFileIds(
   projectService,
   resources,
 ) {
-  console.log("CREATE ASSETS FROM FILE IDS");
-  console.log("File references: ", fileReferences);
-  console.log("Project service: ", projectService);
-  console.log("Project resources: ", resources);
-  console.log("-----");
   const { sounds, images, fonts = {} } = resources;
   const allItems = Object.entries({
     ...sounds,

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -82,6 +82,25 @@ export const handleBeforeMount = (deps) => {
   };
 };
 
+// Seperate for asyn operation
+const initializeRouteGraphics = async (canvas, store, projectService, graphicsService) => {
+  await graphicsService.init({ canvas: canvas.elm });
+  const projectData = store.selectProjectData();
+
+
+  graphicsService.initRouteEngine(projectData);
+  // TODO don't load all data... only ones necessary for this scene
+  const fileReferences = extractFileIdsFromRenderState(projectData);
+  const assets = await createAssetsFromFileIds(
+    fileReferences,
+    projectService,
+    projectData.resources,
+  );
+  await graphicsService.loadAssets(assets);
+  // don't know why but it needs to be called twice the first time to work...
+  renderSceneState(store, graphicsService);
+}
+
 export const handleAfterMount = async (deps) => {
   const {
     getRefIds,
@@ -115,21 +134,8 @@ export const handleAfterMount = async (deps) => {
   }
 
   const { canvas } = getRefIds();
-  await graphicsService.init({ canvas: canvas.elm });
 
-  const projectData = store.selectProjectData();
-
-  graphicsService.initRouteEngine(projectData);
-  // TODO don't load all data... only ones necessary for this scene
-  const fileReferences = extractFileIdsFromRenderState(projectData);
-  const assets = await createAssetsFromFileIds(
-    fileReferences,
-    projectService,
-    projectData.resources,
-  );
-  await graphicsService.loadAssets(assets);
-  // don't know why but it needs to be called twice the first time to work...
-  renderSceneState(store, graphicsService);
+  initializeRouteGraphics(canvas, store, projectService, graphicsService);
   render();
 };
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -83,10 +83,14 @@ export const handleBeforeMount = (deps) => {
 };
 
 // Seperate for asyn operation
-const initializeRouteGraphics = async (canvas, store, projectService, graphicsService) => {
+const initializeRouteGraphics = async (
+  canvas,
+  store,
+  projectService,
+  graphicsService,
+) => {
   await graphicsService.init({ canvas: canvas.elm });
   const projectData = store.selectProjectData();
-
 
   graphicsService.initRouteEngine(projectData);
   // TODO don't load all data... only ones necessary for this scene
@@ -99,7 +103,7 @@ const initializeRouteGraphics = async (canvas, store, projectService, graphicsSe
   await graphicsService.loadAssets(assets);
   // don't know why but it needs to be called twice the first time to work...
   renderSceneState(store, graphicsService);
-}
+};
 
 export const handleAfterMount = async (deps) => {
   const {

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -124,7 +124,6 @@ export const handleAfterMount = async (deps) => {
   await graphicsService.init({ canvas: canvas.elm });
   const projectData = store.selectProjectData();
 
-
   graphicsService.initRouteEngine(projectData);
   // TODO don't load all data... only ones necessary for this scene
   const fileReferences = extractFileIdsFromRenderState(projectData);

--- a/tasks/TASK/000/TASK-038.md
+++ b/tasks/TASK/000/TASK-038.md
@@ -31,7 +31,7 @@ assignee: anyone
 
 ## Scene Editor Issues
 
-- [ ] [Critical] @Nghia Scene Editor, when first create a new scene, it give me a black screen with only a plus symbol on the left, I can't click on the tabs at the top, because there were none, so I click on the plus symbol and it create another tab
+- [x] [Critical] @Nghia Scene Editor, when first create a new scene, it give me a black screen with only a plus symbol on the left, I can't click on the tabs at the top, because there were none, so I click on the plus symbol and it create another tab
 - [ ] [Medium] In the scene editor, if a line has too many text, it push the preview to the right.
 - [ ] [High] @nellow Scene editor take a huge amount of ram on my laptop, and it is really slow (Need to double check, if less than 100 then good)
 - [ ] [High] @nellow Scene editor, choice is not forcing people to choose. You can click on the textbox to ignore the choice completely


### PR DESCRIPTION
Problem: The scene editor sometime have problem when first loading in. After investigating, I have found out that it was because of loading async operation with route-graphics. I have seperated that part of the code to a different async function. Now the scene editor can load immediately, save for the preview which will have a black screen for a bit before fully loading. 

Note: I'm having problem with using `ctrl  + r` to reload the scene editor page, which cause the line editor to have a black screen. Also, because the core problem is because the graphic loadAssets, we may encounter an error with the preview having a black screen for a while in the future. Which mean we should probably change the loading to only load the nedded assets when changing into a section/scene.