### PR TITLE
Line editor content duplication bug when held enter

### DIFF
--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -603,7 +603,18 @@ export const handleLineKeyDown = (deps, payload) => {
         const leftContent = fullText.substring(0, cursorPos);
         const rightContent = fullText.substring(cursorPos);
 
-        // Dispatch immediately, not in requestAnimationFrame
+        // Update store immediately with the left content to prevent stale display
+        dispatchEvent(
+          new CustomEvent("editor-data-changed", {
+            detail: {
+              lineId: id,
+              content: leftContent,
+            },
+            bubbles: true,
+          }),
+        );
+
+        // Dispatch split event
         dispatchEvent(
           new CustomEvent("splitLine", {
             detail: {

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -603,6 +603,7 @@ export const handleLineKeyDown = (deps, payload) => {
         const leftContent = fullText.substring(0, cursorPos);
         const rightContent = fullText.substring(cursorPos);
 
+        //payload._event.currentTarget.textContent = leftContent;
         // Update store immediately with the left content to prevent stale display
         dispatchEvent(
           new CustomEvent("editor-data-changed", {

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -1030,7 +1030,7 @@ export const handleOnFocus = (deps, payload) => {
 export const handleLineBlur = (deps, payload) => {
   const { store, render, getRefIds } = deps;
 
-   store.setIsSplitting(false);
+  store.setIsSplitting(false);
   // Capture element references before the timeout
   const blurredElement = payload._event.currentTarget;
   const shadowRoot = blurredElement.getRootNode();

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -570,6 +570,7 @@ export const handleLineKeyDown = (deps, payload) => {
       }
       break;
     case "Escape":
+      store.setIsSplitting(false);
       payload._event.preventDefault();
       // Switch to block mode and blur the current element
       store.setMode("block");
@@ -1029,6 +1030,7 @@ export const handleOnFocus = (deps, payload) => {
 export const handleLineBlur = (deps, payload) => {
   const { store, render, getRefIds } = deps;
 
+   store.setIsSplitting(false);
   // Capture element references before the timeout
   const blurredElement = payload._event.currentTarget;
   const shadowRoot = blurredElement.getRootNode();

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -583,9 +583,18 @@ export const handleLineKeyDown = (deps, payload) => {
       break;
     case "Enter":
       if (mode === "text-editor") {
+        // Always prevent default first
         payload._event.preventDefault();
 
-        // Get current cursor position and text content
+        // Prevent concurrent split operations
+        if (store.selectIsSplitting()) {
+          return;
+        }
+
+        // Set splitting flag immediately to prevent concurrent operations
+        store.setIsSplitting(true);
+
+        // Get current cursor position and text content immediately
         const cursorPos = getCursorPosition(payload._event.currentTarget);
         const fullText = payload._event.currentTarget.textContent;
 
@@ -593,17 +602,16 @@ export const handleLineKeyDown = (deps, payload) => {
         const leftContent = fullText.substring(0, cursorPos);
         const rightContent = fullText.substring(cursorPos);
 
-        requestAnimationFrame(() => {
-          dispatchEvent(
-            new CustomEvent("splitLine", {
-              detail: {
-                lineId: id,
-                leftContent: leftContent,
-                rightContent: rightContent,
-              },
-            }),
-          );
-        });
+        // Dispatch immediately, not in requestAnimationFrame
+        dispatchEvent(
+          new CustomEvent("splitLine", {
+            detail: {
+              lineId: id,
+              leftContent: leftContent,
+              rightContent: rightContent,
+            },
+          }),
+        );
       }
       break;
     case "ArrowUp":

--- a/src/components/linesEditor/linesEditor.store.js
+++ b/src/components/linesEditor/linesEditor.store.js
@@ -7,6 +7,7 @@ export const createInitialState = () => ({
   goalColumn: 0, // Remember the desired column when moving vertically
   isNavigating: false, // Flag to prevent cursor reset during navigation
   navigationDirection: null, // 'up', 'down', 'end', or null - for proper cursor positioning
+  isSplitting: false, // Flag to prevent concurrent split operations
   repositoryState: {},
 });
 
@@ -38,6 +39,10 @@ export const setNavigationDirection = (state, direction) => {
   state.navigationDirection = direction;
 };
 
+export const setIsSplitting = (state, isSplitting) => {
+  state.isSplitting = isSplitting;
+};
+
 export const selectMode = ({ state }) => {
   return state.mode;
 };
@@ -56,6 +61,10 @@ export const selectGoalColumn = ({ state }) => {
 
 export const selectNavigationDirection = ({ state }) => {
   return state.navigationDirection;
+};
+
+export const selectIsSplitting = ({ state }) => {
+  return state.isSplitting;
 };
 
 export const selectViewData = ({ state, props }) => {

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -384,11 +384,9 @@ export const handleSplitLine = async (deps, payload) => {
   if (storeScene) {
     for (const section of toFlatItems(storeScene.sections)) {
       for (const line of toFlatItems(section.lines)) {
-        // Skip the line being split
-        if (
-          line.id !== lineId &&
-          line.actions?.dialogue?.content !== undefined
-        ) {
+        // Persist all lines including the one being split
+        // This flushes any pending debounced updates from store to repository
+        if (line.actions?.dialogue?.content !== undefined) {
           // Persist this line's content to the repository
           await projectService.appendEvent({
             type: "set",

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -511,6 +511,9 @@ export const handleSplitLine = async (deps, payload) => {
 
       // Also render the linesEditor
       linesEditorRef.elm.render();
+
+      // Reset splitting flag after all operations complete
+      linesEditorRef.elm.store.setIsSplitting(false);
     }
   });
 


### PR DESCRIPTION
WIP does not occur but there's one case that I cant figure out right now that being

i type

| hehe and enter enters then i move up type haha and move the | to 0 and enter haha gets duplicated just once, probably need to validate moving with arrow keys but will check later