### PR TITLE
Initialize route-engine when hiding preview scene

### DIFF
--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1040,6 +1040,10 @@ export const handleHidePreviewScene = async (deps) => {
 
   const { canvas } = getRefIds();
   await graphicsService.init({ canvas: canvas.elm });
+
+  const projectData = store.selectProjectData();
+  graphicsService.initRouteEngine(projectData);
+
   await renderSceneState(store, graphicsService);
 };
 


### PR DESCRIPTION
Solving bug discussed in https://discord.com/channels/1233660682419834920/1461203575123480707/1461203575123480707


https://github.com/user-attachments/assets/cef8c66d-c982-455f-bf99-860c82ce7e6a

