### PR TITLE
fix duplicated content when spammed enter

### DIFF
--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -525,6 +525,22 @@ export const handleSplitLine = async (deps, payload) => {
 
   // Use requestAnimationFrame for focus operations
   requestAnimationFrame(() => {
+    if (leftContent === "" && linesEditorRef && linesEditorRef.elm?.shadowRoot) {
+      const oldLineElement = linesEditorRef.elm.shadowRoot.querySelector(
+        `#line-${lineId}`,
+      );
+      if (oldLineElement) {
+        console.log(
+          `[LE] handleSplitLine | Clearing old line ${lineId} content because split happened at start.`,
+        );
+        oldLineElement.textContent = "";
+
+        // Trigger input event so linesEditor's handlers know about the change
+        const inputEvent = new Event('input', { bubbles: true });
+        oldLineElement.dispatchEvent(inputEvent);
+      }
+    }
+
     if (linesEditorRef) {
       linesEditorRef.elm.transformedHandlers.updateSelectedLine({
         currentLineId: newLineId,

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -534,10 +534,6 @@ export const handleSplitLine = async (deps, payload) => {
           `[LE] handleSplitLine | Clearing old line ${lineId} content because split happened at start.`,
         );
         oldLineElement.textContent = "";
-
-        // Trigger input event so linesEditor's handlers know about the change
-        const inputEvent = new Event('input', { bubbles: true });
-        oldLineElement.dispatchEvent(inputEvent);
       }
     }
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -538,7 +538,7 @@ export const handleSplitLine = async (deps, payload) => {
           `[LE] handleSplitLine | Clearing old line ${lineId} content because split happened at start.`,
         );
         oldLineElement.textContent = "";
-        const inputEvent = new Event('input', { bubbles: true });
+        const inputEvent = new Event("input", { bubbles: true });
         oldLineElement.dispatchEvent(inputEvent);
       }
     }

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -400,6 +400,19 @@ export const handleSplitLine = async (deps, payload) => {
           line.id !== lineId &&
           line.actions?.dialogue?.content !== undefined
         ) {
+          const content = line.actions.dialogue.content;
+          const isEmptyContent =
+            !content ||
+            content.length === 0 ||
+            (content.length === 1 && content[0].text === "");
+
+          if (isEmptyContent) {
+            console.log(
+              `[LE] handleSplitLine | Skipping flush for line ${line.id} because content is empty.`,
+            );
+            continue;
+          }
+
           // Persist this line's content to the repository
           await projectService.appendEvent({
             type: "set",
@@ -782,6 +795,21 @@ export const handleMergeLines = async (deps, payload) => {
           line.id !== currentLineId &&
           line.actions?.dialogue?.content !== undefined
         ) {
+          // Check if content is empty to avoid saving { text: "" } structure
+          const content = line.actions.dialogue.content;
+          const isEmptyContent =
+            !content ||
+            content.length === 0 ||
+            (content.length === 1 && content[0].text === "");
+
+          if (isEmptyContent) {
+            // Skip saving empty content - don't persist { text: "" }
+            console.log(
+              `[LE] handleMergeLines | Skipping flush for line ${line.id} because content is empty.`,
+            );
+            continue;
+          }
+
           // Persist this line's content to the repository
           await projectService.appendEvent({
             type: "set",

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -483,10 +483,6 @@ export const handleSplitLine = async (deps, payload) => {
   // First, update the current line with the left content
   // Only update the dialogue.content, preserve everything else
   const leftContentArray = leftContent ? [{ text: leftContent }] : [];
-  console.log(
-    `[LE] handleSplitLine | lineId: ${lineId} | leftContent: "${leftContent}" | leftContentArray:`,
-    JSON.stringify(leftContentArray),
-  );
   if (existingDialogue && Object.keys(existingDialogue).length > 0) {
     // If dialogue exists, update only the content
     await projectService.appendEvent({
@@ -515,12 +511,6 @@ export const handleSplitLine = async (deps, payload) => {
   // Then, create a new line with the right content and insert it after the current line
   // New line should have empty actions except for dialogue.content
   const rightContentArray = rightContent ? [{ text: rightContent }] : [];
-  console.log(
-    `[LE] handleSplitLine | lineId: ${lineId} | rightContent: "${rightContent}" | rightContentArray:`,
-    JSON.stringify(rightContentArray),
-    "| newLineId:",
-    newLineId,
-  );
   const newLineActions = rightContent
     ? {
         dialogue: {
@@ -579,9 +569,6 @@ export const handleSplitLine = async (deps, payload) => {
         `#line-${lineId}`,
       );
       if (oldLineElement) {
-        console.log(
-          `[LE] handleSplitLine | Clearing old line ${lineId} content because split happened at start.`,
-        );
         oldLineElement.textContent = "";
         const inputEvent = new Event("input", { bubbles: true });
         oldLineElement.dispatchEvent(inputEvent);

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -525,7 +525,11 @@ export const handleSplitLine = async (deps, payload) => {
 
   // Use requestAnimationFrame for focus operations
   requestAnimationFrame(() => {
-    if (leftContent === "" && linesEditorRef && linesEditorRef.elm?.shadowRoot) {
+    if (
+      leftContent === "" &&
+      linesEditorRef &&
+      linesEditorRef.elm?.shadowRoot
+    ) {
       const oldLineElement = linesEditorRef.elm.shadowRoot.querySelector(
         `#line-${lineId}`,
       );

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -538,6 +538,8 @@ export const handleSplitLine = async (deps, payload) => {
           `[LE] handleSplitLine | Clearing old line ${lineId} content because split happened at start.`,
         );
         oldLineElement.textContent = "";
+        const inputEvent = new Event('input', { bubbles: true });
+        oldLineElement.dispatchEvent(inputEvent);
       }
     }
 
@@ -1138,6 +1140,16 @@ export const handleHidePreviewScene = async (deps) => {
 export const handleUpdateDialogueContent = async (deps, payload) => {
   const { projectService, store, subject } = deps;
   const { lineId, content } = payload;
+
+  // Skip saving if content is empty (avoids creating { text: "" } structure)
+  const isEmptyContent =
+    !content ||
+    content.length === 0 ||
+    (content.length === 1 && content[0].text === "");
+
+  if (isEmptyContent) {
+    return;
+  }
 
   const sceneId = store.selectSceneId();
   const sectionId = store.selectSelectedSectionId();

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -438,6 +438,10 @@ export const handleSplitLine = async (deps, payload) => {
   // First, update the current line with the left content
   // Only update the dialogue.content, preserve everything else
   const leftContentArray = leftContent ? [{ text: leftContent }] : [];
+  console.log(
+    `[LE] handleSplitLine | lineId: ${lineId} | leftContent: "${leftContent}" | leftContentArray:`,
+    JSON.stringify(leftContentArray),
+  );
   if (existingDialogue && Object.keys(existingDialogue).length > 0) {
     // If dialogue exists, update only the content
     await projectService.appendEvent({
@@ -466,6 +470,12 @@ export const handleSplitLine = async (deps, payload) => {
   // Then, create a new line with the right content and insert it after the current line
   // New line should have empty actions except for dialogue.content
   const rightContentArray = rightContent ? [{ text: rightContent }] : [];
+  console.log(
+    `[LE] handleSplitLine | lineId: ${lineId} | rightContent: "${rightContent}" | rightContentArray:`,
+    JSON.stringify(rightContentArray),
+    "| newLineId:",
+    newLineId,
+  );
   const newLineActions = rightContent
     ? {
         dialogue: {

--- a/tasks/TASK/000/TASK-038.md
+++ b/tasks/TASK/000/TASK-038.md
@@ -35,7 +35,7 @@ assignee: anyone
 - [ ] [Medium] In the scene editor, if a line has too many text, it push the preview to the right.
 - [x] [High] @nellow Scene editor take a huge amount of ram on my laptop, and it is really slow (Need to double check, if less than 100 then good) (Can't reproduce the error)
 - [x] [High] @nellow Scene editor, choice is not forcing people to choose. You can click on the textbox to ignore the choice completely
-- [ ] [High] @nellow Scene editor, when there's a line with content and we press enter and not let go, it will copy that content on each preceding new line.
+- [x] [High] @nellow Scene editor, when there's a line with content and we press enter and not let go, it will copy that content on each preceding new line.
 - [ ] [Low] Scene editor, can't choose which section to start the preview from
 - [x] [High] @Nghia Choice is still not working
 - [x] [High] @Nghia The vn-preview is not covering the whole screen.


### PR DESCRIPTION
The bug : when splitting a line at cursor position 0 (moving all content to the new line), the old line would show duplicated content instead of being empty

Root Causes:                                                                                                                                               
                                                                                                                                                             
I believe the issue was a race condition between the rendering and the browser's handling of contenteditable elements during changes, I think this is the most likely cause of it.