### PR TITLE
fix custom text fonts not working in the preview in scene editor

### DIFF
--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -109,6 +109,17 @@ export const handleAfterMount = async (deps) => {
   const { sceneId } = appService.getPayload();
   const state = projectService.getState();
 
+  if (state.fonts && state.fonts.items) {
+    for (const font of Object.values(state.fonts.items)) {
+      if (font.type === "font" && font.fileId && font.fontFamily) {
+        await projectService.loadFontFile({
+          fontName: font.fontFamily,
+          fileId: font.fileId,
+        });
+      }
+    }
+  }
+
   store.setSceneId(sceneId);
   store.setRepositoryState(state);
 

--- a/src/utils/projectDataConstructor.js
+++ b/src/utils/projectDataConstructor.js
@@ -136,7 +136,7 @@ export function constructProjectData(state, options = {}) {
     const layouts = repositoryState.layouts?.items || {};
     const typography = repositoryState.typography || { items: {}, tree: [] };
     const colors = repositoryState.colors || { items: {}, tree: [] };
-    const fonts = repositoryState.fonts?.items || {};
+    const fonts = repositoryState.fonts || { items: {}, tree: [] };
 
     const processedCharacters = constructCharacters(characters);
     const characterImages = extractCharacterImages(characters);
@@ -146,7 +146,7 @@ export function constructProjectData(state, options = {}) {
       transforms: constructTransforms(transforms),
       characters: processedCharacters,
       sounds: constructSounds(sounds),
-      fonts: constructFonts(fonts),
+      fonts: constructFonts(fonts.items || {}),
       layouts: constructLayouts(layouts, images, typography, colors, fonts),
       tweens: constructTweens(tweens),
     };


### PR DESCRIPTION
The constructResources function was passing the entire fonts object to constructFonts. The fonts object from the repository has this structure

```js
{
  items: { /* actual font data here */ },
  tree: [ /* folder structure here */ ]
}
```
but the constructFonts function expected to receive only the items object, like this:

```js
{
  "-hpZD817Q_lRDt-vjl4UN": { "type": "font", ... },
  "QYuWaM2V5aJO9ajqAsR2S": { "type": "font", ... }
}
```

 It received the wrong structure, it was trying to loop over the keys "items" and "tree", not the actual font items inside items.
This resulted in constructFonts returning an empty object, so the final projectData sent to the renderer had no font information in it.

fixed by correctly passing only the object containing the actual font data to the constructFonts function