### PR TITLE
fix line editor overflow

### DIFF
--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -56,6 +56,7 @@ styles:
     font-size: 16px
     font-family: inherit
     line-height: 1.5
+    word-break: break-word
   'div[contenteditable]:focus':
     outline: none
 

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -107,8 +107,8 @@ template:
                   - rtgl-view:
                       - rtgl-text: ${sectionsGraph}
             $else:
-              - 'rtgl-view w=h h=f style="min-height: 0px"':
-                  - 'rtgl-view d=h g=xs w="calc((100vw - 64px) / 2)"':
+              - 'rtgl-view w="calc((100vw - 64px) / 2)" d=v h=f style="min-height: 0px"':
+                  - 'rtgl-view d=h g=xs w=f':
                       - rtgl-view d=h sh:
                           - rtgl-view d=h g=xs:
                               - $for section in sections:
@@ -121,7 +121,7 @@ template:
                       # Toggle graph view button - commented out for now
                       # - rtgl-view#toggle-sections-graph-view h=32 av=c ph=lg ah=c bw=sm cur=p:
                       #     - rtgl-text s=sm: "<>"
-                  - "rtgl-view w=f p=md sv":
+                  - "rtgl-view w=f p=md sv flex=1":
                       - rvn-lines-editor#lines-editor .lines=currentLines .selectedLineId=selectedLineId .sectionLineChanges=sectionLineChanges:
                       - rtgl-view h=30vh:
           - rtgl-view w=1 h=f bgc=mu:


### PR DESCRIPTION
My headphones pressed key for long text and i noticed that it pushed the preview more to right.

<img width="1746" height="961" alt="image" src="https://github.com/user-attachments/assets/cfbf415f-1ffb-4a27-98fe-4e3af5c91a64" />


now it looks like

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/4c1ce57c-1ea1-4a28-9fad-d3df323981fa" />
