### PR TITLE
When item is clicked on layout editor make it interactable instead of selecting from file panel

### DIFF
--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -56,6 +56,11 @@ export const createGraphicsService = async ({ subject }) => {
           } else if (eventName === "drag-end") {
             if (payload._event.id === "selected-border")
               subject.dispatch("border-drag-end");
+          } else if (eventName === "click") {
+            console.log("Dispatching canvas-element-clicked for id:", payload._event.id);
+            subject.dispatch("canvas-element-clicked", {
+              id: payload._event.id,
+            });
           }
 
           if (!engine) {

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -57,7 +57,10 @@ export const createGraphicsService = async ({ subject }) => {
             if (payload._event.id === "selected-border")
               subject.dispatch("border-drag-end");
           } else if (eventName === "click") {
-            console.log("Dispatching canvas-element-clicked for id:", payload._event.id);
+            console.log(
+              "Dispatching canvas-element-clicked for id:",
+              payload._event.id,
+            );
             subject.dispatch("canvas-element-clicked", {
               id: payload._event.id,
             });

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -223,6 +223,26 @@ const renderLayoutPreview = async (deps) => {
   };
 
   const finalElements = parseAndRender(elementsToRender, data);
+  const addInteractivity = (elements) => {
+    elements.forEach((el) => {
+      if (el.id !== "bg") {
+        el.hover = {
+          cursor: "pointer",
+        };
+        el.click = {
+          actionPayload: {
+            type: "select",
+          },
+        };
+      }
+
+      if (el.children && el.children.length > 0) {
+        addInteractivity(el.children);
+      }
+    });
+  };
+
+  addInteractivity(finalElements);
 
   console.log("Final elements for rendering:", finalElements);
   const parsedState = graphicsService.parse({

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -224,20 +224,7 @@ const renderLayoutPreview = async (deps) => {
 
   const finalElements = parseAndRender(elementsToRender, data);
 
-  // Add drag and hover properties to all elements to make them interactive
-  finalElements.forEach((el) => {
-    if (el.id !== "bg") {
-      el.drag = {
-        move: {},
-        start: {},
-        end: {},
-      };
-      el.hover = {
-        cursor: "pointer",
-      };
-    }
-  });
-
+  console.log("Final elements for rendering:", finalElements);
   const parsedState = graphicsService.parse({
     elements: finalElements,
   });


### PR DESCRIPTION

https://github.com/user-attachments/assets/060313fc-6153-4f5b-ae98-7b4480ef70b8

currently attempting to select any element will result in the container getting selected, but when selected from file preview, it will work and attempt to click on background will also lead to container getting selected.

- i think in route-graphics, when you click an element, the event fires for that element and then bubbles up to its parents so this might be the cause but I'm not sure 
