### PR TITLE
feat/right pannel details

### DIFF
--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -240,8 +240,8 @@ export const handleAfterMount = async (deps) => {
   // Ensure repository is loaded for sync access
   await projectService.ensureRepository();
 
-  // Get sceneId from router payload
-  const { sceneId } = appService.getPayload();
+  // Get sceneId and optional sectionId from router payload
+  const { sceneId, sectionId: requestedSectionId } = appService.getPayload();
   const state = projectService.getState();
 
   if (state.fonts && state.fonts.items) {
@@ -258,16 +258,22 @@ export const handleAfterMount = async (deps) => {
   store.setSceneId(sceneId);
   store.setRepositoryState(state);
 
-  // Get scene to set first section and first line
+  // Get scene to set requested section (fallback: first section) and first line
   const scene = store.selectScene();
   if (scene && scene.sections && scene.sections.length > 0) {
-    const firstSection = scene.sections[0];
-    store.setSelectedSectionId(firstSection.id);
+    const selectedSection =
+      scene.sections.find((section) => section.id === requestedSectionId) ||
+      scene.sections[0];
+    store.setSelectedSectionId(selectedSection.id);
 
-    // Also select the first line in the first section
-    if (firstSection.lines && firstSection.lines.length > 0) {
-      store.setSelectedLineId(firstSection.lines[0].id);
+    // Select first line from selected section
+    if (selectedSection.lines && selectedSection.lines.length > 0) {
+      store.setSelectedLineId(selectedSection.lines[0].id);
+    } else {
+      store.setSelectedLineId(undefined);
     }
+  } else {
+    store.setSelectedLineId(undefined);
   }
 
   const { canvas } = getRefIds();

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -218,6 +218,23 @@ export const showSectionDropdownMenu = (state, { position, sectionId }) => {
   };
 };
 
+export const showSectionsOverviewDropdownMenu = (state, { position }) => {
+  const scene = selectScene({ state });
+  const items = (scene?.sections || []).map((section, index) => ({
+    label: `${index + 1}. ${section.name || `Section ${index + 1}`}`,
+    type: "item",
+    value: `go-to-section:${section.id}`,
+  }));
+
+  state.dropdownMenu = {
+    isOpen: true,
+    position,
+    items,
+    sectionId: null,
+    actionsType: null,
+  };
+};
+
 export const showActionsDropdownMenu = (state, { position, actionsType }) => {
   state.dropdownMenu = {
     isOpen: true,

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -36,6 +36,10 @@ refs:
     eventListeners:
       click:
         handler: handleSectionAddClick
+  sections-overview:
+    eventListeners:
+      click:
+        handler: handleSectionsOverviewClick
   dropdown-menu:
     eventListeners:
       close:
@@ -116,6 +120,8 @@ template:
                                       - rtgl-text s=sm: ${section.name}
                       - rtgl-view#section-add h=32 av=c ph=lg ah=c cur=p bgc=mu:
                           - rtgl-text s=sm: +
+                      - rtgl-view#sections-overview h=32 av=c ph=lg ah=c cur=p bgc=mu:
+                          - rtgl-text s=sm: ...
 
                       - rtgl-view flex=1:
                       # Toggle graph view button - commented out for now

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -123,6 +123,7 @@ export const handleAfterMount = async (deps) => {
 
   // Set the scenes data
   store.setItems(scenesData);
+  store.setLayouts(layouts);
 
   // Transform only scene items (not folders) into whiteboard items
   const initialSceneId = story?.initialSceneId;
@@ -200,6 +201,7 @@ export const handleDataChanged = async (deps) => {
 
   // Update both scenes data and whiteboard items
   store.setItems(sceneData);
+  store.setLayouts(layouts);
   store.setWhiteboardItems(sceneItems);
   render();
 };
@@ -249,6 +251,30 @@ export const handleWhiteboardItemSelected = (deps, payload) => {
   // Update selected item for detail panel
   store.setSelectedItemId(itemId);
   render();
+};
+
+export const handleSectionsPanelToggle = (deps) => {
+  const { store, render } = deps;
+  store.toggleSectionsPanelExpanded();
+  render();
+};
+
+export const handleSectionRowClick = (deps, payload) => {
+  const { store, appService } = deps;
+  const rowId = payload._event.currentTarget.id;
+  const sectionId = rowId.replace("section-row-", "");
+  const sceneId = store.selectSelectedItemId();
+
+  if (!sceneId || !sectionId) {
+    return;
+  }
+
+  const currentPayload = appService.getPayload();
+  appService.navigate("/project/scene-editor", {
+    ...currentPayload,
+    sceneId,
+    sectionId,
+  });
 };
 
 export const handleWhiteboardItemDoubleClick = (deps, payload) => {
@@ -436,6 +462,7 @@ export const handleSceneFormAction = async (deps, payload) => {
           type: "scene",
           name: formData.name || `Scene ${new Date().toLocaleTimeString()}`,
           createdAt: new Date().toISOString(),
+          initialSectionId: sectionId,
           position: {
             x: sceneWhiteboardPosition.x,
             y: sceneWhiteboardPosition.y,

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -56,7 +56,6 @@ const getSectionPresentation = (
       returnsToMenuScene = true;
     }
     const sectionTransitionKey = createTransitionKey(sectionTransition);
-
     if (sectionTransitionKey) {
       transitions.add(sectionTransitionKey);
     }
@@ -72,7 +71,6 @@ const getSectionPresentation = (
         returnsToMenuScene = true;
       }
       const choiceTransitionKey = createTransitionKey(choiceTransition);
-
       if (choiceTransitionKey) {
         transitions.add(choiceTransitionKey);
       }
@@ -94,7 +92,6 @@ const getSectionPresentation = (
           returnsToMenuScene = true;
         }
         const layoutTransitionKey = createTransitionKey(layoutTransition);
-
         if (layoutTransitionKey) {
           transitions.add(layoutTransitionKey);
         }

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -89,27 +89,25 @@ template:
                           - 'rtgl-view w=f flex=1 d=v bw=xs br=md bgc=bg style="min-height: 0px;"':
                               - rtgl-view#sections-panel-toggle w=f d=v g=md p=lg cur=p h-bgc=mu bw=xs br=sm bgc=bg:
                                   - rtgl-view w=f d=h av=c:
-                                      - rtgl-text s=sm fw=500: Sections Overview
+                                      - rtgl-text s=md fw=600: Sections Overview
                                       - rtgl-view flex=1:
                                       - rtgl-view ph=md pv=xs bgc=ac bw=xs bc=ac br=full:
                                           - rtgl-text s=xs fw=600 c=bg: ${sectionsPanelToggleLabel}
                                   - rtgl-view w=f d=h g=md:
-                                      - 'rtgl-view flex=1 h=88 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
-                                          - rtgl-text s=xs c=mu-fg: Sections
+                                      - 'rtgl-view flex=1 h=72 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
+                                          - rtgl-text s=sm c=mu-fg: Sections
                                           - rtgl-text s=lg: ${sectionCount}
-                                      - 'rtgl-view flex=1 h=88 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
-                                          - rtgl-text s=xs c=mu-fg: Dead Ends
+                                      - 'rtgl-view flex=1 h=72 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
+                                          - rtgl-text s=sm c=mu-fg: Dead Ends
                                           - rtgl-text s=lg: ${deadEndCount}
-                                      - 'rtgl-view flex=1 h=88 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
-                                          - rtgl-text s=xs c=mu-fg: Initial
+                                      - 'rtgl-view flex=1 h=72 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
+                                          - rtgl-text s=sm c=mu-fg: Initial
                                           - $if initialSectionName:
-                                              - 'rtgl-text s=sm style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"': ${initialSectionName}
+                                              - 'rtgl-text s=md style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"': ${initialSectionName}
                                             $else:
-                                              - rtgl-text s=sm c=mu-fg: None
-                                  - rtgl-view w=f d=h av=c:
-                                      - rtgl-text s=xs c=mu-fg: ${sectionCount} total, ${deadEndCount} dead ends
+                                              - rtgl-text s=md c=mu-fg: None
                               - $if sectionsPanelExpanded:
-                                  - 'rtgl-view w=f flex=1 d=v p=md g=md style="min-height: 0px;"':
+                                  - 'rtgl-view w=f flex=1 d=v p=sm g=sm style="min-height: 0px;"':
                                       - $if sectionCount == 0:
                                           - rtgl-view flex=1 av=c ah=c bw=xs br=sm bgc=mu:
                                               - rtgl-text s=sm c=mu-fg: No sections
@@ -117,29 +115,27 @@ template:
                                           - 'rtgl-view w=f flex=1 sv d=v p=sm g=md bgc=bg bw=xs br=sm style="min-height: 0px;"':
                                               - $for section in sectionCards:
                                                   - rtgl-view#section-row-${section.id} w=f d=v g=md p=lg cur=p bw=xs bc=mu br=sm bgc=bg h-bgc=mu:
-                                                      - rtgl-view d=h av=c jc=sb g=xs:
-                                                          - rtgl-view d=h av=c g=xs:
-                                                              - rtgl-text s=md fw=500: ${section.name}
-                                                              - $if section.isInitial:
-                                                                  - rtgl-view ph=xs pv=xxs bgc=ac br=sm:
-                                                                      - rtgl-text s=xs: Initial
+                                                      - rtgl-view d=h w=f av=c g=sm:
+                                                          - 'rtgl-view d=h av=c g=sm flex=1 style="min-width: 0px;"':
+                                                              - rtgl-text s=md fw=600: ${section.name}
                                                               - $if section.isMenuReturn:
                                                                   - rtgl-view ph=xs pv=xxs bgc=mu br=sm:
                                                                       - rtgl-text s=xs c=mu-fg: Menu End
+                                                          - rtgl-view d=h av=c g=sm:
+                                                              - rtgl-text s=xxs c=mu-fg: #${section.order}
                                                               - $if section.isDeadEnd:
                                                                   - rtgl-view ph=xs pv=xxs bgc=er br=sm:
                                                                       - rtgl-text s=xs c=bg: Dead End
-                                                          - rtgl-text s=xs c=mu-fg: #${section.order}
-                                                      - rtgl-view d=h g=sm jc=c av=c:
-                                                          - rtgl-view w=92 d=v g=xs p=sm bgc=mu bw=xs bc=bg br=sm:
-                                                              - rtgl-text s=xxs c=mu-fg: Lines
-                                                              - rtgl-text s=sm: ${section.lineCount}
-                                                          - rtgl-view w=92 d=v g=xs p=sm bgc=mu bw=xs bc=bg br=sm:
-                                                              - rtgl-text s=xxs c=mu-fg: Choices
-                                                              - rtgl-text s=sm: ${section.choiceCount}
-                                                          - rtgl-view w=92 d=v g=xs p=sm bgc=mu bw=xs bc=bg br=sm:
-                                                              - rtgl-text s=xxs c=mu-fg: Outgoing
-                                                              - rtgl-text s=sm: ${section.outgoingCount}
+                                                      - rtgl-view d=h g=md jc=c av=c:
+                                                          - rtgl-view w=98 h=72 d=v jc=sb p=md bgc=mu bw=xs bc=mu br=sm:
+                                                              - rtgl-text s=xs c=mu-fg: Lines
+                                                              - rtgl-text s=md: ${section.lineCount}
+                                                          - rtgl-view w=98 h=72 d=v jc=sb p=md bgc=mu bw=xs bc=mu br=sm:
+                                                              - rtgl-text s=xs c=mu-fg: Choices
+                                                              - rtgl-text s=md: ${section.choiceCount}
+                                                          - rtgl-view w=98 h=72 d=v jc=sb p=md bgc=mu bw=xs bc=mu br=sm:
+                                                              - rtgl-text s=xs c=mu-fg: Outgoing
+                                                              - rtgl-text s=md: ${section.outgoingCount}
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -39,6 +39,14 @@ refs:
     eventListeners:
       form-change:
         handler: handleFormChange
+  sections-panel-toggle:
+    eventListeners:
+      click:
+        handler: handleSectionsPanelToggle
+  section-row-*:
+    eventListeners:
+      click:
+        handler: handleSectionRowClick
   scene-form:
     eventListeners:
       action-click:
@@ -72,11 +80,66 @@ template:
                   - rvn-file-explorer#fileexplorer .items=flatItems .repositoryTarget=repositoryTarget:
           - rtgl-view flex=1 h=f:
               - rvn-whiteboard#whiteboard .items=whiteboardItems .cursor=whiteboardCursor .selectedItemId=selectedItemId:
-          - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
-              - rtgl-view wh=f slot="content":
+          - rvn-resizable-panel panel-type=detail-panel w=400 min-w=320 max-w=620 resize-side="left":
+              - rtgl-view wh=f d=v slot="content":
                   - $if selectedItemId:
-                      - rtgl-form#detail-form key=${selectedItemId} w=f h=f .form=form .defaultValues=defaultValues:
-                          - rtgl-button#preview-button slot="preview" data-scene-id="${selectedItemId}": Preview
+                      - 'rtgl-view w=f h=f d=v g=sm style="min-height: 0px;"':
+                          - rtgl-form#detail-form key=${selectedItemId} w=f .form=form .defaultValues=defaultValues:
+                              - rtgl-button#preview-button slot="preview" data-scene-id="${selectedItemId}": Preview
+                          - 'rtgl-view w=f flex=1 d=v bw=xs br=md bgc=bg style="min-height: 0px;"':
+                              - rtgl-view#sections-panel-toggle w=f d=v g=md p=lg cur=p h-bgc=mu bw=xs br=sm bgc=bg:
+                                  - rtgl-view w=f d=h av=c:
+                                      - rtgl-text s=sm fw=500: Sections Overview
+                                      - rtgl-view flex=1:
+                                      - rtgl-view ph=md pv=xs bgc=ac bw=xs bc=ac br=full:
+                                          - rtgl-text s=xs fw=600 c=bg: ${sectionsPanelToggleLabel}
+                                  - rtgl-view w=f d=h g=md:
+                                      - 'rtgl-view flex=1 h=88 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
+                                          - rtgl-text s=xs c=mu-fg: Sections
+                                          - rtgl-text s=lg: ${sectionCount}
+                                      - 'rtgl-view flex=1 h=88 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
+                                          - rtgl-text s=xs c=mu-fg: Dead Ends
+                                          - rtgl-text s=lg: ${deadEndCount}
+                                      - 'rtgl-view flex=1 h=88 d=v jc=sb p=md bw=xs bc=mu br=sm bgc=mu style="min-width: 0px;"':
+                                          - rtgl-text s=xs c=mu-fg: Initial
+                                          - $if initialSectionName:
+                                              - 'rtgl-text s=sm style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"': ${initialSectionName}
+                                            $else:
+                                              - rtgl-text s=sm c=mu-fg: None
+                                  - rtgl-view w=f d=h av=c:
+                                      - rtgl-text s=xs c=mu-fg: ${sectionCount} total, ${deadEndCount} dead ends
+                              - $if sectionsPanelExpanded:
+                                  - 'rtgl-view w=f flex=1 d=v p=md g=md style="min-height: 0px;"':
+                                      - $if sectionCount == 0:
+                                          - rtgl-view flex=1 av=c ah=c bw=xs br=sm bgc=mu:
+                                              - rtgl-text s=sm c=mu-fg: No sections
+                                        $else:
+                                          - 'rtgl-view w=f flex=1 sv d=v p=sm g=md bgc=bg bw=xs br=sm style="min-height: 0px;"':
+                                              - $for section in sectionCards:
+                                                  - rtgl-view#section-row-${section.id} w=f d=v g=md p=lg cur=p bw=xs bc=mu br=sm bgc=bg h-bgc=mu:
+                                                      - rtgl-view d=h av=c jc=sb g=xs:
+                                                          - rtgl-view d=h av=c g=xs:
+                                                              - rtgl-text s=md fw=500: ${section.name}
+                                                              - $if section.isInitial:
+                                                                  - rtgl-view ph=xs pv=xxs bgc=ac br=sm:
+                                                                      - rtgl-text s=xs: Initial
+                                                              - $if section.isMenuReturn:
+                                                                  - rtgl-view ph=xs pv=xxs bgc=mu br=sm:
+                                                                      - rtgl-text s=xs c=mu-fg: Menu End
+                                                              - $if section.isDeadEnd:
+                                                                  - rtgl-view ph=xs pv=xxs bgc=er br=sm:
+                                                                      - rtgl-text s=xs c=bg: Dead End
+                                                          - rtgl-text s=xs c=mu-fg: #${section.order}
+                                                      - rtgl-view d=h g=sm jc=c av=c:
+                                                          - rtgl-view w=92 d=v g=xs p=sm bgc=mu bw=xs bc=bg br=sm:
+                                                              - rtgl-text s=xxs c=mu-fg: Lines
+                                                              - rtgl-text s=sm: ${section.lineCount}
+                                                          - rtgl-view w=92 d=v g=xs p=sm bgc=mu bw=xs bc=bg br=sm:
+                                                              - rtgl-text s=xxs c=mu-fg: Choices
+                                                              - rtgl-text s=sm: ${section.choiceCount}
+                                                          - rtgl-view w=92 d=v g=xs p=sm bgc=mu bw=xs bc=bg br=sm:
+                                                              - rtgl-text s=xxs c=mu-fg: Outgoing
+                                                              - rtgl-text s=sm: ${section.outgoingCount}
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -128,14 +128,14 @@ template:
                                                                       - rtgl-text s=xs c=bg: Dead End
                                                       - rtgl-view d=h g=md jc=c av=c:
                                                           - rtgl-view w=98 h=72 d=v jc=sb p=md bgc=mu bw=xs bc=mu br=sm:
-                                                              - rtgl-text s=xs c=mu-fg: Lines
-                                                              - rtgl-text s=md: ${section.lineCount}
+                                                              - rtgl-text s=sm c=mu-fg: Lines
+                                                              - rtgl-text s=lg: ${section.lineCount}
                                                           - rtgl-view w=98 h=72 d=v jc=sb p=md bgc=mu bw=xs bc=mu br=sm:
-                                                              - rtgl-text s=xs c=mu-fg: Choices
-                                                              - rtgl-text s=md: ${section.choiceCount}
+                                                              - rtgl-text s=sm c=mu-fg: Choices
+                                                              - rtgl-text s=lg: ${section.choiceCount}
                                                           - rtgl-view w=98 h=72 d=v jc=sb p=md bgc=mu bw=xs bc=mu br=sm:
-                                                              - rtgl-text s=xs c=mu-fg: Outgoing
-                                                              - rtgl-text s=md: ${section.outgoingCount}
+                                                              - rtgl-text s=sm c=mu-fg: Outgoing
+                                                              - rtgl-text s=lg: ${section.outgoingCount}
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection


### PR DESCRIPTION
- **Add sections overview menu in scene editor**
- **feat(scenes): distinguish menu-return endings from dead ends in sections overview**


https://github.com/user-attachments/assets/4c9f1596-889f-42ed-afcc-d0eaae738101

This also shows dead end, if there's no transition within a section.

