### PR TITLE
fix: stabilize scene editor panel and scoped asset loading

### DIFF
--- a/src/components/vnPreview/vnPreview.store.js
+++ b/src/components/vnPreview/vnPreview.store.js
@@ -1,9 +1,16 @@
-export const createInitialState = () => ({});
+export const createInitialState = () => ({
+  isAssetLoading: false,
+});
 
-export const selectViewData = ({ attrs }) => {
+export const setAssetLoading = (state, isLoading) => {
+  state.isAssetLoading = isLoading;
+};
+
+export const selectViewData = ({ attrs, state }) => {
   return {
     sceneId: attrs.sceneId,
     sectionId: attrs.sectionId,
     lineId: attrs.lineId,
+    isAssetLoading: state.isAssetLoading,
   };
 };

--- a/src/components/vnPreview/vnPreview.view.yaml
+++ b/src/components/vnPreview/vnPreview.view.yaml
@@ -19,3 +19,6 @@ template:
     - 'rtgl-view w=f pos=rel bwb=xs style="aspect-ratio: 16/9; max-width: 100%; max-height: 100%"':
       - rtgl-view pos=abs cor=full:
         - 'div#canvas id=canvas style="width: 100%; height: 100%;display: flex; justify-content: center"':
+      - $if isAssetLoading:
+          - rtgl-view pos=abs cor=full bgc=bg op=0.6 av=c ah=c:
+              - rtgl-text s=sm: Loading assets...

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -27,6 +27,7 @@ export const createInitialState = () => ({
   presentationState: {},
   sectionLineChanges: {},
   isMuted: false,
+  isSceneAssetLoading: false,
   lockingLineId: null, // Lock to prevent duplicate split/merge operations
 });
 
@@ -58,6 +59,14 @@ export const setPresentationState = (state, presentationState) => {
 
 export const setSectionLineChanges = (state, changes) => {
   state.sectionLineChanges = changes;
+};
+
+export const setSceneAssetLoading = (state, isLoading) => {
+  state.isSceneAssetLoading = isLoading;
+};
+
+export const selectIsSceneAssetLoading = ({ state }) => {
+  return state.isSceneAssetLoading;
 };
 
 export const selectSectionLineChanges = ({ state }) => {
@@ -306,6 +315,7 @@ export const selectViewData = ({ state }) => {
         null,
         2,
       ),
+      isSceneAssetLoading: state.isSceneAssetLoading,
     };
   }
 
@@ -352,15 +362,6 @@ export const selectViewData = ({ state }) => {
     (line) => line.id === state.selectedLineId,
   );
 
-  // Debug logging
-  if (!selectedLine && state.selectedLineId) {
-    console.warn("Selected line not found:", {
-      selectedLineId: state.selectedLineId,
-      availableLineIds: currentSection?.lines?.map((line) => line.id) || [],
-      currentSectionId: state.selectedSectionId,
-    });
-  }
-
   const repositoryState = selectRepositoryState({ state });
 
   return {
@@ -400,6 +401,7 @@ export const selectViewData = ({ state }) => {
     sectionLineChanges: state.sectionLineChanges,
     isMuted: state.isMuted,
     muteIcon: state.isMuted ? "mute" : "unmute",
+    isSceneAssetLoading: state.isSceneAssetLoading,
   };
 };
 

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -127,8 +127,11 @@ template:
           - rtgl-view w=1 h=f bgc=mu:
           - rtgl-view w=f:
               - rtgl-view:
-                  - rtgl-view w=700 h=400 bgc=fg:
+                  - rtgl-view w=700 h=400 bgc=fg pos=rel:
                       - 'div#canvas id=canvas style="width: 100%; height: 100%;display: flex;"':
+                      - $if isSceneAssetLoading:
+                          - rtgl-view pos=abs cor=full bgc=bg op=0.7 av=c ah=c:
+                              - rtgl-text s=sm: Loading assets...
               - rtgl-view w=f h=1 bgc=mu:
               - rtgl-view w=f m=md:
                   - rtgl-view d=h av=c:


### PR DESCRIPTION
  - Load only assets needed for the current scene.
  - Keep a cache so already-loaded files aren’t fetched again.
  - Before a transition action runs, preload target-scene assets.
  - Re-check scenes for newly added references (so edits don’t require remount).
  - Show a loading overlay when needed to avoid blank/black render states.