### PR TITLE
Fix actor context error and upgrade Rettangoli stack to 1.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,9 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rettangoli/fe": "1.0.0-rc3",
-        "@rettangoli/ui": "1.0.0-rc16",
+        "@rettangoli/fe": "1.0.1",
+        "@rettangoli/ui": "1.0.1",
+        "@rettangoli/vt": "1.0.1",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -35,7 +36,7 @@
         "lint-staged": "^16.1.2",
         "oxlint": "^1.19.0",
         "prettier": "3.6.2",
-        "rtgl": "1.0.0-rc15",
+        "rtgl": "1.0.1",
       },
     },
   },
@@ -54,7 +55,11 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
+    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -166,6 +171,50 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.112.0", "", { "os": "android", "cpu": "arm" }, "sha512-retxBzJ39Da7Lh/eZTn9+HJgTeDUxZIpuI0urOsmcFsBKXAth3lc1jIvwseQ9qbAI/VrsoFOXiGIzgclARbAHg=="],
+
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.112.0", "", { "os": "android", "cpu": "arm64" }, "sha512-pRkbBRbuIIsufUWpOJ+JHWfJFNupkidy4sbjfcm37e6xwYrn9LSKMLubPHvNaL1Zf92ZRhGiwaYkEcmaFg2VcA=="],
+
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.112.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fh6/KQL/cbH5DukT3VkdCqnULLuvVnszVKySD5IgSE0WZb32YZo/cPsPdEv052kk6w3N4agu+NTiMnZjcvhUIg=="],
+
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.112.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-vUBOOY1E30vlu/DoTGDoT1UbLlwu5Yv9tqeBabAwRzwNDz8Skho16VKhsBDUiyqddtpsR3//v6vNk38w4c+6IA=="],
+
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.112.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hnEtO/9AVnYWzrgnp6L+oPs/6UqlFeteUL6n7magkd2tttgmx1C01hyNNh6nTpZfLzEVJSNJ0S+4NTsK2q2CxA=="],
+
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.112.0", "", { "os": "linux", "cpu": "arm" }, "sha512-WxJrUz3pcIc2hp4lvJbvt/sTL33oX9NPvkD3vDDybE6tc0V++rS+hNOJxwXdD2FDIFPkHs/IEn5asEZFVH+VKw=="],
+
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.112.0", "", { "os": "linux", "cpu": "arm" }, "sha512-jj8A8WWySaJQqM9XKAIG8U2Q3qxhFQKrXPWv98d1oC35at+L1h+C+V4M3l8BAKhpHKCu3dYlloaAbHd5q1Hw6A=="],
+
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.112.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-G2F8H6FcAExVK5vvhpSh61tqWx5QoaXXUnSsj5FyuDiFT/K7AMMVSQVqnZREDc+YxhrjB0vnKjCcuobXK63kIw=="],
+
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.112.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3R0iqjM3xYOZCnwgcxOQXH7hrz64/USDIuLbNTM1kZqQzRqaR4w7SwoWKU934zABo8d0op2oSwOp+CV3hZnM7A=="],
+
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.112.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-lAQf8PQxfgy7h0bmcfSVE3hg3qMueshPYULFsCrHM+8KefGZ9W+ZMvRyU33gLrB4w1O3Fz1orR0hmKMCRxXNrQ=="],
+
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.112.0", "", { "os": "linux", "cpu": "none" }, "sha512-2QlvQBUhHuAE3ezD4X3CAEKMXdfgInggQ5Bj/7gb5NcYP3GyfLTj7c+mMu+BRwfC9B3AXBNyqHWbqEuuUvZyRQ=="],
+
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.112.0", "", { "os": "linux", "cpu": "none" }, "sha512-v06iu0osHszgqJ1dLQRb6leWFU1sjG/UQk4MoVBtE6ZPewgfTkby6G9II1SpEAf2onnAuQceVYxQH9iuU3NJqw=="],
+
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.112.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-+5HhNHtxsdcd7+ljXFnn9FOoCNXJX3UPgIfIE6vdwS1HqdGNH6eAcVobuqGOp54l8pvcxDQA6F4cPswCgLrQfQ=="],
+
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.112.0", "", { "os": "linux", "cpu": "x64" }, "sha512-jKwO7ZLNkjxwg7FoCLw+fJszooL9yXRZsDN0AQ1AQUTWq1l8GH/2e44k68N3fcP19jl8O8jGpqLAZcQTYk6skA=="],
+
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.112.0", "", { "os": "linux", "cpu": "x64" }, "sha512-TYqnuKV/p3eOc+N61E0961nA7DC+gaCeJ3+V2LcjJdTwFMdikqWL6uVk1jlrpUCBrozHDATVUKDZYH7r4FQYjQ=="],
+
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.112.0", "", { "os": "none", "cpu": "arm64" }, "sha512-ZhrVmWFifVEFQX4XPwLoVFDHw9tAWH9p9vHsHFH+5uCKdfVR+jje4WxVo6YrokWCboGckoOzHq5KKMOcPZfkRg=="],
+
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.112.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-Gr8X2PUU3hX1g3F5oLWIZB8DhzDmjr5TfOrmn5tlBOo9l8ojPGdKjnIBfObM7X15928vza8QRKW25RTR7jfivg=="],
+
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.112.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-t5CDLbU70Ea88bGRhvU/dLJTc/Wcrtf2Jp534E8P3cgjAvHDjdKsfDDqBZrhybJ8Jv9v9vW5ngE40EK51BluDA=="],
+
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.112.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-rZH0JynCCwnhe2HfRoyNOl/Kfd9pudoWxgpC5OZhj7j77pMK0UOAa35hYDfrtSOUk2HLzrikV5dPUOY2DpSBSA=="],
+
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.112.0", "", { "os": "win32", "cpu": "x64" }, "sha512-oGHluohzmVFAuQrkEnl1OXAxMz2aYmimxUqIgKXpBgbr7PvFv0doELB273sX+5V3fKeggohKg1A2Qq21W9Z9cQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
+
     "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.39.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lT3hNhIa02xCujI6YGgjmYGg3Ht/X9ag5ipUVETaMpx5Rd4BbTNWUPif1WN1YZHxt3KLCIqaAe7zVhatv83HOQ=="],
 
     "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.39.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-UT+rfTWd+Yr7iJeSLd/7nF8X4gTYssKh+n77hxl6Oilp3NnG1CKRHxZDy3o3lIBnwgzJkdyUAiYWO1bTMXQ1lA=="],
@@ -204,13 +253,17 @@
 
     "@pixi/utils": ["@pixi/utils@7.4.3", "", { "dependencies": { "@pixi/color": "7.4.3", "@pixi/constants": "7.4.3", "@pixi/settings": "7.4.3", "@types/earcut": "^2.1.0", "earcut": "^2.2.4", "eventemitter3": "^4.0.0", "url": "^0.11.0" } }, "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA=="],
 
-    "@rettangoli/fe": ["@rettangoli/fe@1.0.0-rc3", "", { "dependencies": { "esbuild": "^0.25.5", "immer": "^10.1.1", "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "rxjs": "^7.8.2", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-KWykgf8liQfIF4tqpS9bZJE3rGGukYXi7YMqxlYhv7hnPmdAq6JX+Ep5WzGebR7lzw8CSaJSRNZAEjBFQLXXLA=="],
+    "@rettangoli/be": ["@rettangoli/be@1.0.0-rc1", "", { "dependencies": { "ajv": "^8.17.1", "chokidar": "^4.0.3", "js-yaml": "^4.1.0" } }, "sha512-oFTPnVJhftLyM60oYCI2UfNpXu9xgw7HAjL7Nr3dn9/GnBupO96oKpsRDIPAvCetN0SdBVfcpYf0L/RAMJUV8Q=="],
 
-    "@rettangoli/sites": ["@rettangoli/sites@1.0.0-rc4", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-RU71qTTjYxzHUjMRssERM3ohbuZIhU8aqGcX1pSNk08PpGAP223dIYljR1pBmhujoSmTx9hgNgle8bW3NoGzng=="],
+    "@rettangoli/check": ["@rettangoli/check@0.1.2", "", { "dependencies": { "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "oxc-parser": "^0.112.0", "yahtml": "0.0.5" }, "bin": { "rtgl-check": "src/cli/bin.js" } }, "sha512-m/iepT/8o7l9DvSSxqK2Y65C0+qdjnB6S7i+3d1W/43kW4nH2wjYVd4sdS4FN1ohIzygP1iIFcVYcisDB9ObTg=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.0.0-rc16", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@rettangoli/fe": "1.0.0-rc3", "commander": "^13.1.0", "jempl": "1.0.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "snabbdom": "^3.6.2" } }, "sha512-ZNHHv8g+LxmUnrBvI2c2QuvWXM205X4yEDye8sQMjrpLRaff9DjXE/C8zcqE3lXMpMgxKjaxZNSAeWlFmCJlwg=="],
+    "@rettangoli/fe": ["@rettangoli/fe@1.0.1", "", { "dependencies": { "esbuild": "^0.25.5", "immer": "^10.1.1", "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "rxjs": "^7.8.2", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-YOYj0+mpCcGuuNj8d4HfsKlvw+nYHAQBW6WnEazqW6mR2R0IzrupVHusNAF5L3aIC60zwkOYIgXBVVYN2MMMCg=="],
 
-    "@rettangoli/vt": ["@rettangoli/vt@1.0.0-rc13", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-3g+WFQyBjvbEqIVpSSvbTxW/Kc1AtJ/mkU6+nbwSAYIe53O7v1tZeR87BIzci+O53smCW+TzvNivdVvyhi2+jQ=="],
+    "@rettangoli/sites": ["@rettangoli/sites@1.0.0-rc13", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-5FeX83zGckIYL6EnzC8Y/eTuOEg6NMHhNextyRrZ8hNZmabS2tNSTJrAaPcxnKrUs4hY+a5J6wEu5ruDUzPgDQ=="],
+
+    "@rettangoli/ui": ["@rettangoli/ui@1.0.1", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@rettangoli/fe": "1.0.1", "commander": "^13.1.0", "jempl": "1.0.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "snabbdom": "^3.6.2" } }, "sha512-6UDpEDefNCZKQhN99LgX82oWtHU46OwqN1kBuMqjmYAMusasS93QyeOq9NmN++6Y66xC8P/5gWMLsAg7hIWbWw=="],
+
+    "@rettangoli/vt": ["@rettangoli/vt@1.0.1", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-Tis1JkOjP9EDZ0hxyafmKG5BvwzNOnEgiA6NnsoBHBrKHh6f3R902sfhgWydTuOm0lpiurWmC0l7P/5RBtimwQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.55.1", "", { "os": "android", "cpu": "arm" }, "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg=="],
 
@@ -320,6 +373,8 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/css-font-loading-module": ["@types/css-font-loading-module@0.0.12", "", {}, "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="],
@@ -358,6 +413,8 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
     "ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -383,6 +440,8 @@
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -439,6 +498,10 @@
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -514,6 +577,8 @@
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
@@ -586,6 +651,8 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
+    "oxc-parser": ["oxc-parser@0.112.0", "", { "dependencies": { "@oxc-project/types": "^0.112.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.112.0", "@oxc-parser/binding-android-arm64": "0.112.0", "@oxc-parser/binding-darwin-arm64": "0.112.0", "@oxc-parser/binding-darwin-x64": "0.112.0", "@oxc-parser/binding-freebsd-x64": "0.112.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.112.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.112.0", "@oxc-parser/binding-linux-arm64-gnu": "0.112.0", "@oxc-parser/binding-linux-arm64-musl": "0.112.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.112.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.112.0", "@oxc-parser/binding-linux-riscv64-musl": "0.112.0", "@oxc-parser/binding-linux-s390x-gnu": "0.112.0", "@oxc-parser/binding-linux-x64-gnu": "0.112.0", "@oxc-parser/binding-linux-x64-musl": "0.112.0", "@oxc-parser/binding-openharmony-arm64": "0.112.0", "@oxc-parser/binding-wasm32-wasi": "0.112.0", "@oxc-parser/binding-win32-arm64-msvc": "0.112.0", "@oxc-parser/binding-win32-ia32-msvc": "0.112.0", "@oxc-parser/binding-win32-x64-msvc": "0.112.0" } }, "sha512-7rQ3QdJwobMQLMZwQaPuPYMEF2fDRZwf51lZ//V+bA37nejjKW5ifMHbbCwvA889Y4RLhT+/wLJpPRhAoBaZYw=="],
+
     "oxlint": ["oxlint@1.39.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.39.0", "@oxlint/darwin-x64": "1.39.0", "@oxlint/linux-arm64-gnu": "1.39.0", "@oxlint/linux-arm64-musl": "1.39.0", "@oxlint/linux-x64-gnu": "1.39.0", "@oxlint/linux-x64-musl": "1.39.0", "@oxlint/win32-arm64": "1.39.0", "@oxlint/win32-x64": "1.39.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.10.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-wSiLr0wjG+KTU6c1LpVoQk7JZ7l8HCKlAkVDVTJKWmCGazsNxexxnOXl7dsar92mQcRnzko5g077ggP3RINSjA=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
@@ -632,11 +699,15 @@
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
@@ -650,7 +721,7 @@
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
-    "rtgl": ["rtgl@1.0.0-rc15", "", { "dependencies": { "@rettangoli/fe": "1.0.0-rc3", "@rettangoli/sites": "1.0.0-rc4", "@rettangoli/ui": "1.0.0-rc7", "@rettangoli/vt": "1.0.0-rc13", "commander": "^14.0.0", "js-yaml": "^4.1.0" }, "bin": { "rtgl": "cli.js" } }, "sha512-shVOGow2gEnJBTX8UhL0ixQ8n29lDaqfo2vGt5xVAAjZo39PrqO/Gm2ns4umcCXG1OVa5UwtzC0a2k1IxRCsRw=="],
+    "rtgl": ["rtgl@1.0.1", "", { "dependencies": { "@rettangoli/be": "1.0.0-rc1", "@rettangoli/check": "0.1.2", "@rettangoli/fe": "1.0.1", "@rettangoli/sites": "1.0.0-rc13", "@rettangoli/ui": "1.0.1", "@rettangoli/vt": "1.0.1", "commander": "^14.0.0", "js-yaml": "^4.1.0" }, "bin": { "rtgl": "cli.js" } }, "sha512-RS+W1nZ3c3Xe1T8OQXHhuI+cvBUARZUSxl1c+UqomSo05HuMVmAe7/NYIgUVjZRlRLz8ByQJqnq0ex9OqNW0ZQ=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -786,7 +857,7 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
-    "yahtml": ["yahtml@0.0.4", "", {}, "sha512-9QuyogoLkvpq1ETyiETeHtcFVqUUI0pl3RjgfJ8mlpeAvkP8f1risDDJ0s9rZ8H8TwAA9hegw3mzr2eTsdRT3g=="],
+    "yahtml": ["yahtml@0.0.5", "", {}, "sha512-JH4JUr11KszQ5HdIislKXjODiO++DbLJXQeNflRzv769LqgyLVXedz1wcn2KGw0yvJyk84voR2ZESKzqBONCFQ=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -798,9 +869,13 @@
 
     "@pixi/utils/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "@rettangoli/check/jempl": ["jempl@0.3.2-rc2", "", {}, "sha512-8t6P7vO46Er0cpG00nYlmBIZw/5MhKCNnE0WBm+ZWMaGqi/MCexe1/Bl7SlbFQjgKsFXVC3cdT/K+4PD0XHUVg=="],
+
     "@rettangoli/fe/jempl": ["jempl@0.3.2-rc2", "", {}, "sha512-8t6P7vO46Er0cpG00nYlmBIZw/5MhKCNnE0WBm+ZWMaGqi/MCexe1/Bl7SlbFQjgKsFXVC3cdT/K+4PD0XHUVg=="],
 
     "@rettangoli/sites/jempl": ["jempl@0.3.2", "", {}, "sha512-k8+u4mElt1TavcUptro3/g8rXC/Y1c19szO162pVq2GzcbHsnThszRKev39B9dS2hExIbA0MvyEjFLuGb1aGIg=="],
+
+    "@rettangoli/sites/yahtml": ["yahtml@0.0.4", "", {}, "sha512-9QuyogoLkvpq1ETyiETeHtcFVqUUI0pl3RjgfJ8mlpeAvkP8f1risDDJ0s9rZ8H8TwAA9hegw3mzr2eTsdRT3g=="],
 
     "@rettangoli/ui/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
@@ -820,18 +895,10 @@
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "rtgl/@rettangoli/ui": ["@rettangoli/ui@1.0.0-rc7", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@rettangoli/fe": "1.0.0-rc1", "commander": "^13.1.0", "jempl": "1.0.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "snabbdom": "^3.6.2" } }, "sha512-h9GVYKSWuOCqInbieETY3+tQ+hdNfGH9917CcFbHjKRa+vkPRQGafJlVT8PZqVSc5auRyKli7OeimvHzPfRW4A=="],
-
     "url/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "rtgl/@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.0.0-rc1", "", { "dependencies": { "esbuild": "^0.25.5", "immer": "^10.1.1", "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "rxjs": "^7.8.2", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-lxbR8xEfAIZrUNoKYtNeeoqH/DGnlHlq9AelSrrkr75Rhn5WimzvBtrM59BkqEfUWntE/1ysVltdT7A+gOeDFg=="],
-
-    "rtgl/@rettangoli/ui/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
-
-    "rtgl/@rettangoli/ui/@rettangoli/fe/jempl": ["jempl@0.3.2-rc2", "", {}, "sha512-8t6P7vO46Er0cpG00nYlmBIZw/5MhKCNnE0WBm+ZWMaGqi/MCexe1/Bl7SlbFQjgKsFXVC3cdT/K+4PD0XHUVg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   ],
   "type": "module",
   "dependencies": {
-    "@rettangoli/fe": "1.0.0-rc3",
-    "@rettangoli/ui": "1.0.0-rc16",
+    "@rettangoli/fe": "1.0.1",
+    "@rettangoli/ui": "1.0.1",
+    "@rettangoli/vt": "1.0.1",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",
@@ -71,7 +72,7 @@
     "lint-staged": "^16.1.2",
     "oxlint": "^1.19.0",
     "prettier": "3.6.2",
-    "rtgl": "1.0.0-rc15"
+    "rtgl": "1.0.1"
   },
   "lint-staged": {
     "src/**/*.{js}": [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ set -e
 
 BUILD_TYPE=${1:-web}
 SETUP_FILE="src/setup.${BUILD_TYPE}.js"
-RETTANGOLI_VERSION="1.0.0-rc16"
+RETTANGOLI_VERSION="1.0.1"
 RETTANGOLI_URL="https://cdn.jsdelivr.net/npm/@rettangoli/ui@${RETTANGOLI_VERSION}/dist/rettangoli-iife-ui.min.js"
 RETTANGOLI_DIR="static/public/@rettangoli/ui@${RETTANGOLI_VERSION}/dist"
 RETTANGOLI_FILE="${RETTANGOLI_DIR}/rettangoli-iife-ui.min.js"

--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -236,7 +236,10 @@ export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
         projectId: resolvedProjectId,
       }),
       token,
-      actor,
+      actor: {
+        userId,
+        clientId,
+      },
       partitions: resolvedPartitions,
       clientStore,
       logger: (entry) => {

--- a/static/index.html
+++ b/static/index.html
@@ -8,7 +8,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/components/index.html
+++ b/static/project/resources/components/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -6,7 +6,7 @@
     <title>VT E2E Runner</title>
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.0-rc16/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">


### PR DESCRIPTION
## Summary
- fix web collab session initialization to pass an explicit actor object (`{ userId, clientId }`) instead of an undefined shorthand variable
- upgrade `@rettangoli/fe`, `@rettangoli/ui`, `@rettangoli/vt`, and `rtgl` to `1.0.1`
- update build/static template references to load `/public/@rettangoli/ui@1.0.1/...`
- refresh `bun.lock` with resolved `1.0.1` packages

## Validation
- `bun install`
- `bun run build:web`

## Notes
- excluded unrelated local edits in `src/pages/projects/*` from this PR
