### PR TITLE
fix(collab): replay uncommitted local events on connect

### DIFF
--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -76,9 +76,7 @@ const toSyncSubmissionEvents = (repositoryEvents = []) =>
       if (partitions.length === 0) return null;
 
       const projectId =
-        command?.projectId ||
-        repositoryEvent?.payload?.projectId ||
-        undefined;
+        command?.projectId || repositoryEvent?.payload?.projectId || undefined;
       return {
         partitions,
         event: commandToSyncEvent({
@@ -93,7 +91,9 @@ const toUncommittedSyncSubmissionEvents = ({
   repositoryEvents = [],
   committedCursor = 0,
 }) => {
-  const normalizedEvents = Array.isArray(repositoryEvents) ? repositoryEvents : [];
+  const normalizedEvents = Array.isArray(repositoryEvents)
+    ? repositoryEvents
+    : [];
   const cursor = Number.isFinite(Number(committedCursor))
     ? Math.max(0, Math.floor(Number(committedCursor)))
     : 0;


### PR DESCRIPTION
## Summary
- replace initializer-only seed path with uncommitted local event replay on connect
- convert local typed repository events into sync submit events (including `project.created`)
- submit and flush replayed events, then run sync to advance persisted cursor
- add logs to confirm local event snapshot and replay details

## Validation
- bun run build:web
