### PR TITLE
refactor: centralize project metadata and file selection flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Read the links from the following files to familiarize with the code before star
 
 - Prefer direct property access or nullish coalescing (`??`) for defaults.
 - Avoid defensive `typeof x === "string" ? x : ""` patterns unless runtime type narrowing is truly required.
+- Prefer `undefined` over `null`.
+- Avoid explicit `= null` initialization; use `let value;` when a later assignment is expected.
 
 ## Layering
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,8 @@ Read the links from the following files to familiarize with the code before star
 
 - Prefer direct property access or nullish coalescing (`??`) for defaults.
 - Avoid defensive `typeof x === "string" ? x : ""` patterns unless runtime type narrowing is truly required.
+
+## Layering
+
+- Keep page/component handlers simple and orchestration-focused.
+- Push domain logic, validation, and async complexity into services.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,17 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Commands
 
 Build the project:
+
 ```bash
 bun run build
 ```
 
 This command:
+
 1. Removes the existing `_site` directory
 2. Copies static files from `static/` to `_site/`
 3. Runs the Rettangoli CLI to build the frontend bundle to `_site/public/main.js`
@@ -24,3 +26,8 @@ Read the links from the following files to familiarize with the code before star
 - [View](https://raw.githubusercontent.com/yuusoft-org/rettangoli/refs/heads/main/packages/rettangoli-fe/docs/view.md)
 - [State Management](https://raw.githubusercontent.com/yuusoft-org/rettangoli/refs/heads/main/packages/rettangoli-fe/docs/store.md)
 - [Handlers](https://raw.githubusercontent.com/yuusoft-org/rettangoli/refs/heads/main/packages/rettangoli-fe/docs/handlers.md)
+
+## JavaScript Style
+
+- Prefer direct property access or nullish coalescing (`??`) for defaults.
+- Avoid defensive `typeof x === "string" ? x : ""` patterns unless runtime type narrowing is truly required.

--- a/src/deps/infra/web/webRepositoryAdapter.js
+++ b/src/deps/infra/web/webRepositoryAdapter.js
@@ -39,12 +39,7 @@ async function copyTemplateFiles(templateId, adapter) {
 /**
  * Initialize a new project with IndexedDB.
  */
-export const initializeProject = async ({
-  name,
-  description,
-  projectId,
-  template,
-}) => {
+export const initializeProject = async ({ projectId, template }) => {
   if (!template) {
     throw new Error("Template is required for project initialization");
   }
@@ -64,8 +59,6 @@ export const initializeProject = async ({
     model_version: 2,
     project: {
       id: projectId,
-      name,
-      description,
     },
   };
 

--- a/src/deps/services/appService.js
+++ b/src/deps/services/appService.js
@@ -2,6 +2,7 @@ import { readDir, exists } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { nanoid } from "nanoid";
+import { validateIconDimensions } from "../../utils/fileProcessors";
 
 const DEFAULT_USER_CONFIG = {
   groupImagesView: {
@@ -15,6 +16,53 @@ const DEFAULT_USER_CONFIG = {
 };
 
 const USER_CONFIG_KEY = "routevn-user-config";
+const FILE_VALIDATION_ERROR_TITLE = "Error";
+
+const runFileValidation = async ({ file, validation } = {}) => {
+  if (!file || !validation || typeof validation !== "object") {
+    return { isValid: true, message: null };
+  }
+
+  if (validation.type === "square") {
+    return validateIconDimensions(file);
+  }
+
+  return { isValid: true, message: null };
+};
+
+const validatePickedFiles = async ({ files, validations } = {}) => {
+  const fileList = Array.isArray(files) ? files : [];
+  const validationList = Array.isArray(validations) ? validations : [];
+
+  for (const file of fileList) {
+    for (const validation of validationList) {
+      const result = await runFileValidation({ file, validation });
+      if (!result?.isValid) {
+        return {
+          isValid: false,
+          message: result?.message || "Invalid file selected.",
+        };
+      }
+    }
+  }
+
+  return { isValid: true, message: null };
+};
+
+const attachUploadState = ({ file, uploadResult } = {}) => {
+  if (!file) {
+    return file;
+  }
+  const isSuccessful = !!uploadResult;
+  try {
+    file.uploadSucessful = isSuccessful;
+    file.uploadSuccessful = isSuccessful;
+    file.uploadResult = uploadResult || null;
+  } catch {
+    // Ignore if File object cannot be extended in this runtime.
+  }
+  return file;
+};
 
 /**
  * Check whether the currently focused element is an actionable element within the provided root.
@@ -79,10 +127,13 @@ export const createAppService = ({
     ? JSON.parse(storedConfig)
     : { ...DEFAULT_USER_CONFIG };
 
-  const loadProjectDataFromDatabase = async (projectPath) => {
-    const repository = await projectService.getRepositoryByPath(projectPath);
-    const { project } = repository.getState();
-    return project;
+  const deriveProjectNameFromPath = (projectPath) => {
+    if (typeof projectPath !== "string" || projectPath.length === 0) {
+      return "Untitled Project";
+    }
+    const normalizedPath = projectPath.replace(/[\\/]+$/, "");
+    const segments = normalizedPath.split(/[\\/]/).filter(Boolean);
+    return segments[segments.length - 1] || "Untitled Project";
   };
 
   const loadProjectIcon = async (projectPath, iconFileId) => {
@@ -96,6 +147,60 @@ export const createAppService = ({
       console.error("Failed to load project icon:", error);
       return null;
     }
+  };
+
+  const createEmptyProjectEntry = ({ id = "", source = "local" } = {}) => {
+    return {
+      id,
+      source,
+      name: "",
+      description: "",
+      iconFileId: null,
+    };
+  };
+
+  const normalizeLocalProjectEntry = (entry) => {
+    return {
+      ...entry,
+      source: "local",
+      name: entry?.name || "",
+      description: entry?.description || "",
+      iconFileId: entry?.iconFileId || null,
+    };
+  };
+
+  let currentProjectEntry = createEmptyProjectEntry();
+
+  const getCurrentProjectId = () => {
+    return router.getPayload()?.p ?? "";
+  };
+
+  const resolveCurrentProjectEntry = async () => {
+    const projectId = getCurrentProjectId();
+    if (!projectId) {
+      return createEmptyProjectEntry();
+    }
+
+    try {
+      const entries = (await db.get("projectEntries")) || [];
+      if (!Array.isArray(entries)) {
+        return createEmptyProjectEntry({ id: projectId, source: "local" });
+      }
+
+      const localEntry = entries.find((entry) => entry?.id === projectId);
+      if (localEntry) {
+        return normalizeLocalProjectEntry(localEntry);
+      }
+
+      return createEmptyProjectEntry({ id: projectId, source: "cloud" });
+    } catch {
+      return createEmptyProjectEntry({ id: projectId, source: "local" });
+    }
+  };
+
+  const refreshCurrentProjectEntry = async () => {
+    currentProjectEntry = await resolveCurrentProjectEntry();
+    return currentProjectEntry;
   };
 
   return {
@@ -118,6 +223,9 @@ export const createAppService = ({
 
       entries.push(entry);
       await db.set("projectEntries", entries);
+      if (entry?.id === getCurrentProjectId()) {
+        currentProjectEntry = normalizeLocalProjectEntry(entry);
+      }
       return entries;
     },
 
@@ -125,6 +233,12 @@ export const createAppService = ({
       const entries = await this.getProjectEntries();
       const filtered = entries.filter((e) => e.id !== projectId);
       await db.set("projectEntries", filtered);
+      if (currentProjectEntry.id === projectId) {
+        const routeProjectId = getCurrentProjectId();
+        currentProjectEntry = routeProjectId
+          ? createEmptyProjectEntry({ id: routeProjectId, source: "cloud" })
+          : createEmptyProjectEntry();
+      }
       return filtered;
     },
 
@@ -134,6 +248,12 @@ export const createAppService = ({
       if (index !== -1) {
         entries[index] = { ...entries[index], ...updates };
         await db.set("projectEntries", entries);
+        if (
+          currentProjectEntry.id === projectId &&
+          currentProjectEntry.source === "local"
+        ) {
+          currentProjectEntry = normalizeLocalProjectEntry(entries[index]);
+        }
       }
       return entries;
     },
@@ -143,44 +263,25 @@ export const createAppService = ({
 
       const projectsWithFullData = await Promise.all(
         projectEntries.map(async (entry) => {
-          try {
-            const projectState = await loadProjectDataFromDatabase(
-              entry.projectPath,
-            );
+          const project = {
+            id: entry.id,
+            name: entry.name || "Untitled Project",
+            description: entry.description || "",
+            iconFileId: entry.iconFileId || null,
+            projectPath: entry.projectPath,
+            createdAt: entry.createdAt,
+            lastOpenedAt: entry.lastOpenedAt,
+          };
 
-            const project = {
-              id: entry.id,
-              name: projectState.name || "Untitled Project",
-              description: projectState.description || "",
-              iconFileId: projectState.iconFileId || null,
-              projectPath: entry.projectPath,
-              createdAt: entry.createdAt,
-              lastOpenedAt: entry.lastOpenedAt,
-            };
-
-            const iconUrl = await loadProjectIcon(
-              entry.projectPath,
-              project.iconFileId,
-            );
-            if (iconUrl) {
-              project.iconUrl = iconUrl;
-            }
-
-            return project;
-          } catch (error) {
-            console.error(
-              `Failed to load project data for ${entry.id}:`,
-              error,
-            );
-            return {
-              id: entry.id,
-              name: "Error loading project",
-              description: "Unable to read project data",
-              projectPath: entry.projectPath,
-              createdAt: entry.createdAt,
-              lastOpenedAt: entry.lastOpenedAt,
-            };
+          const iconUrl = await loadProjectIcon(
+            entry.projectPath,
+            project.iconFileId,
+          );
+          if (iconUrl) {
+            project.iconUrl = iconUrl;
           }
+
+          return project;
         }),
       );
 
@@ -216,18 +317,10 @@ export const createAppService = ({
     },
 
     async importProject(projectPath) {
-      const projectState = await loadProjectDataFromDatabase(projectPath);
-
-      if (!projectState.name || !projectState.description) {
-        throw new Error(
-          "Project database is missing required project information (name or description)",
-        );
-      }
-
       return {
-        name: projectState.name,
-        description: projectState.description,
-        iconFileId: projectState.iconFileId || null,
+        name: deriveProjectNameFromPath(projectPath),
+        description: "",
+        iconFileId: null,
       };
     },
 
@@ -244,6 +337,9 @@ export const createAppService = ({
       const projectEntry = {
         id: deviceProjectId,
         projectPath: folderPath,
+        name: projectData.name,
+        description: projectData.description,
+        iconFileId: projectData.iconFileId || null,
         createdAt: Date.now(),
         lastOpenedAt: null,
       };
@@ -252,9 +348,6 @@ export const createAppService = ({
 
       const fullProject = {
         ...projectEntry,
-        name: projectData.name,
-        description: projectData.description,
-        iconFileId: projectData.iconFileId,
       };
 
       if (projectData.iconFileId) {
@@ -283,13 +376,14 @@ export const createAppService = ({
       const projectEntry = {
         id: deviceProjectId,
         projectPath,
+        name,
+        description,
+        iconFileId: null,
         createdAt: Date.now(),
         lastOpenedAt: null,
       };
 
       await projectService.initializeProject({
-        name,
-        description,
         projectPath,
         template,
       });
@@ -298,9 +392,6 @@ export const createAppService = ({
 
       return {
         ...projectEntry,
-        name,
-        description,
-        iconFileId: null,
       };
     },
 
@@ -332,6 +423,18 @@ export const createAppService = ({
 
     getPayload() {
       return router.getPayload();
+    },
+
+    getCurrentProjectId() {
+      return getCurrentProjectId();
+    },
+
+    getCurrentProjectEntry() {
+      return currentProjectEntry;
+    },
+
+    async refreshCurrentProjectEntry() {
+      return refreshCurrentProjectEntry();
     },
 
     setPayload(payload) {
@@ -377,7 +480,12 @@ export const createAppService = ({
     // Browser-style file picker that returns File objects (for uploads)
     pickFiles(options = {}) {
       return new Promise((resolve) => {
-        const { accept = "*/*", multiple = false } = options;
+        const {
+          accept = "*/*",
+          multiple = false,
+          validations = [],
+          upload = false,
+        } = options;
 
         const input = document.createElement("input");
         input.type = "file";
@@ -385,15 +493,60 @@ export const createAppService = ({
         input.multiple = multiple;
         input.style.display = "none";
 
-        input.onchange = (event) => {
+        const cleanup = () => {
+          if (document.body.contains(input)) {
+            document.body.removeChild(input);
+          }
+        };
+
+        input.onchange = async (event) => {
           const files = Array.from(event.target.files || []);
-          document.body.removeChild(input);
-          resolve(files);
+          const filesToValidate = multiple ? files : files.slice(0, 1);
+          const validationResult = await validatePickedFiles({
+            files: filesToValidate,
+            validations,
+          });
+
+          cleanup();
+
+          if (!validationResult.isValid) {
+            globalUI.showAlert({
+              message: validationResult.message,
+              title: FILE_VALIDATION_ERROR_TITLE,
+            });
+            resolve(multiple ? [] : null);
+            return;
+          }
+
+          if (!upload) {
+            resolve(multiple ? files : files[0] || null);
+            return;
+          }
+
+          const uploadResults =
+            await projectService.uploadFiles(filesToValidate);
+          if (multiple) {
+            const enrichedFiles = files.map((file) => {
+              const uploadResult =
+                uploadResults.find((item) => item.file === file) || null;
+              return attachUploadState({ file, uploadResult });
+            });
+            resolve(enrichedFiles);
+            return;
+          }
+
+          const file = files[0] || null;
+          const uploadResult =
+            uploadResults.find((item) => item.file === file) ||
+            uploadResults[0] ||
+            null;
+          resolve(attachUploadState({ file, uploadResult }));
+          return;
         };
 
         input.oncancel = () => {
-          document.body.removeChild(input);
-          resolve([]);
+          cleanup();
+          resolve(multiple ? [] : null);
         };
 
         document.body.appendChild(input);

--- a/src/deps/services/projectService.js
+++ b/src/deps/services/projectService.js
@@ -73,6 +73,17 @@ export const createProjectService = ({ router, db, filePicker }) => {
     return p;
   };
 
+  const getProjectMetadataFromEntries = async (projectId) => {
+    const entries = (await db.get("projectEntries")) || [];
+    const entry = Array.isArray(entries)
+      ? entries.find((item) => item?.id === projectId)
+      : null;
+    return {
+      name: entry?.name || "",
+      description: entry?.description || "",
+    };
+  };
+
   const createSessionForProject = async ({
     projectId,
     token,
@@ -101,10 +112,11 @@ export const createProjectService = ({ router, db, filePicker }) => {
       resolvedProjectId,
       partitions,
     );
+    const projectMetadata = await getProjectMetadataFromEntries(projectId);
     const collabSession = createProjectCollabService({
       projectId: resolvedProjectId,
-      projectName: state.project?.name || "",
-      projectDescription: state.project?.description || "",
+      projectName: projectMetadata.name,
+      projectDescription: projectMetadata.description,
       initialState: projectRepositoryStateToDomainState({
         repositoryState: state,
         projectId: resolvedProjectId,
@@ -468,7 +480,7 @@ export const createProjectService = ({ router, db, filePicker }) => {
     deleteVersionFromProject: serviceCore.deleteVersionFromProject,
 
     // Initialize a new project at a given path
-    async initializeProject({ name, description, projectPath, template }) {
+    async initializeProject({ projectPath, template }) {
       if (!template) {
         throw new Error("Template is required for project initialization");
       }
@@ -485,7 +497,7 @@ export const createProjectService = ({ router, db, filePicker }) => {
         ...initialProjectData,
         ...templateData,
         model_version: 2,
-        project: { name, description },
+        project: { id: projectPath },
       };
 
       const bootstrapDomainState = projectRepositoryStateToDomainState({

--- a/src/deps/services/web/appService.js
+++ b/src/deps/services/web/appService.js
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { validateIconDimensions } from "../../../utils/fileProcessors";
 
 const DEFAULT_USER_CONFIG = {
   groupImagesView: {
@@ -12,6 +13,53 @@ const DEFAULT_USER_CONFIG = {
 };
 
 const USER_CONFIG_KEY = "routevn-user-config";
+const FILE_VALIDATION_ERROR_TITLE = "Error";
+
+const runFileValidation = async ({ file, validation } = {}) => {
+  if (!file || !validation || typeof validation !== "object") {
+    return { isValid: true, message: null };
+  }
+
+  if (validation.type === "square") {
+    return validateIconDimensions(file);
+  }
+
+  return { isValid: true, message: null };
+};
+
+const validatePickedFiles = async ({ files, validations } = {}) => {
+  const fileList = Array.isArray(files) ? files : [];
+  const validationList = Array.isArray(validations) ? validations : [];
+
+  for (const file of fileList) {
+    for (const validation of validationList) {
+      const result = await runFileValidation({ file, validation });
+      if (!result?.isValid) {
+        return {
+          isValid: false,
+          message: result?.message || "Invalid file selected.",
+        };
+      }
+    }
+  }
+
+  return { isValid: true, message: null };
+};
+
+const attachUploadState = ({ file, uploadResult } = {}) => {
+  if (!file) {
+    return file;
+  }
+  const isSuccessful = !!uploadResult;
+  try {
+    file.uploadSucessful = isSuccessful;
+    file.uploadSuccessful = isSuccessful;
+    file.uploadResult = uploadResult || null;
+  } catch {
+    // Ignore if File object cannot be extended in this runtime.
+  }
+  return file;
+};
 
 const isInputFocused = (root = document) => {
   let active = root.activeElement;
@@ -68,16 +116,14 @@ export const createAppService = ({
     isUpdateAvailable: () => false,
   };
 
-  const loadProjectDataFromDatabase = async (projectId) => {
-    const repository = await projectService.getRepositoryById(projectId);
-    const { project } = repository.getState();
-    return project;
-  };
-
   const loadProjectIcon = async (projectId, iconFileId) => {
     if (!iconFileId) return null;
     try {
+      await projectService.getRepositoryById(projectId);
       const adapter = projectService.getAdapterById(projectId);
+      if (!adapter) {
+        return null;
+      }
       const blob = await adapter.getFile(iconFileId);
       if (blob) {
         return URL.createObjectURL(blob);
@@ -87,6 +133,60 @@ export const createAppService = ({
       console.error("Failed to load project icon:", error);
       return null;
     }
+  };
+
+  const createEmptyProjectEntry = ({ id = "", source = "local" } = {}) => {
+    return {
+      id,
+      source,
+      name: "",
+      description: "",
+      iconFileId: null,
+    };
+  };
+
+  const normalizeLocalProjectEntry = (entry) => {
+    return {
+      ...entry,
+      source: "local",
+      name: entry?.name || "",
+      description: entry?.description || "",
+      iconFileId: entry?.iconFileId || null,
+    };
+  };
+
+  let currentProjectEntry = createEmptyProjectEntry();
+
+  const getCurrentProjectId = () => {
+    return router.getPayload()?.p ?? "";
+  };
+
+  const resolveCurrentProjectEntry = async () => {
+    const projectId = getCurrentProjectId();
+    if (!projectId) {
+      return createEmptyProjectEntry();
+    }
+
+    try {
+      const entries = (await db.get("projectEntries")) || [];
+      if (!Array.isArray(entries)) {
+        return createEmptyProjectEntry({ id: projectId, source: "local" });
+      }
+
+      const localEntry = entries.find((entry) => entry?.id === projectId);
+      if (localEntry) {
+        return normalizeLocalProjectEntry(localEntry);
+      }
+
+      return createEmptyProjectEntry({ id: projectId, source: "cloud" });
+    } catch {
+      return createEmptyProjectEntry({ id: projectId, source: "local" });
+    }
+  };
+
+  const refreshCurrentProjectEntry = async () => {
+    currentProjectEntry = await resolveCurrentProjectEntry();
+    return currentProjectEntry;
   };
 
   return {
@@ -102,12 +202,21 @@ export const createAppService = ({
       }
       entries.push(entry);
       await db.set("projectEntries", entries);
+      if (entry?.id === getCurrentProjectId()) {
+        currentProjectEntry = normalizeLocalProjectEntry(entry);
+      }
       return entries;
     },
     async removeProjectEntry(projectId) {
       const entries = await this.getProjectEntries();
       const filtered = entries.filter((e) => e.id !== projectId);
       await db.set("projectEntries", filtered);
+      if (currentProjectEntry.id === projectId) {
+        const routeProjectId = getCurrentProjectId();
+        currentProjectEntry = routeProjectId
+          ? createEmptyProjectEntry({ id: routeProjectId, source: "cloud" })
+          : createEmptyProjectEntry();
+      }
       return filtered;
     },
     async updateProjectEntry(projectId, updates) {
@@ -116,6 +225,12 @@ export const createAppService = ({
       if (index !== -1) {
         entries[index] = { ...entries[index], ...updates };
         await db.set("projectEntries", entries);
+        if (
+          currentProjectEntry.id === projectId &&
+          currentProjectEntry.source === "local"
+        ) {
+          currentProjectEntry = normalizeLocalProjectEntry(entries[index]);
+        }
       }
       return entries;
     },
@@ -123,34 +238,19 @@ export const createAppService = ({
       const projectEntries = await this.getProjectEntries();
       const projectsWithFullData = await Promise.all(
         projectEntries.map(async (entry) => {
-          try {
-            const projectState = await loadProjectDataFromDatabase(entry.id);
-            const project = {
-              id: entry.id,
-              name: projectState.name || "Untitled Project",
-              description: projectState.description || "",
-              iconFileId: projectState.iconFileId || null,
-              createdAt: entry.createdAt,
-              lastOpenedAt: entry.lastOpenedAt,
-            };
-            const iconUrl = await loadProjectIcon(entry.id, project.iconFileId);
-            if (iconUrl) {
-              project.iconUrl = iconUrl;
-            }
-            return project;
-          } catch (error) {
-            console.error(
-              `Failed to load project data for ${entry.id}:`,
-              error,
-            );
-            return {
-              id: entry.id,
-              name: "Error loading project",
-              description: "Unable to read project data",
-              createdAt: entry.createdAt,
-              lastOpenedAt: entry.lastOpenedAt,
-            };
+          const project = {
+            id: entry.id,
+            name: entry.name || "Untitled Project",
+            description: entry.description || "",
+            iconFileId: entry.iconFileId || null,
+            createdAt: entry.createdAt,
+            lastOpenedAt: entry.lastOpenedAt,
+          };
+          const iconUrl = await loadProjectIcon(entry.id, project.iconFileId);
+          if (iconUrl) {
+            project.iconUrl = iconUrl;
           }
+          return project;
         }),
       );
       return projectsWithFullData;
@@ -168,17 +268,18 @@ export const createAppService = ({
       const projectId = nanoid();
       const projectEntry = {
         id: projectId,
+        name,
+        description,
+        iconFileId: null,
         createdAt: Date.now(),
         lastOpenedAt: null,
       };
       await projectService.initializeProject({
-        name,
-        description,
         projectId,
         template,
       });
       await this.addProjectEntry(projectEntry);
-      return { ...projectEntry, name, description, iconFileId: null };
+      return { ...projectEntry };
     },
     async getSetting(key) {
       return await db.get(`setting:${key}`);
@@ -200,6 +301,15 @@ export const createAppService = ({
     },
     getPayload() {
       return router.getPayload();
+    },
+    getCurrentProjectId() {
+      return getCurrentProjectId();
+    },
+    getCurrentProjectEntry() {
+      return currentProjectEntry;
+    },
+    async refreshCurrentProjectEntry() {
+      return refreshCurrentProjectEntry();
     },
     setPayload(payload) {
       router.setPayload(payload);
@@ -230,7 +340,58 @@ export const createAppService = ({
       return filePicker.saveFilePicker(blob, filename);
     },
     async pickFiles(options = {}) {
-      return filePicker.openFilePicker({ ...options, multiple: true });
+      const multiple = options.multiple ?? false;
+      const upload = options.upload ?? false;
+      const validations = Array.isArray(options.validations)
+        ? options.validations
+        : [];
+      const selection = await filePicker.openFilePicker({
+        ...options,
+        multiple,
+      });
+
+      const files = Array.isArray(selection)
+        ? selection
+        : selection
+          ? [selection]
+          : [];
+      if (files.length === 0) {
+        return multiple ? [] : null;
+      }
+
+      const validationResult = await validatePickedFiles({
+        files: multiple ? files : files.slice(0, 1),
+        validations,
+      });
+      if (!validationResult.isValid) {
+        globalUI.showAlert({
+          message: validationResult.message,
+          title: FILE_VALIDATION_ERROR_TITLE,
+        });
+        return multiple ? [] : null;
+      }
+
+      if (!upload) {
+        return multiple ? files : files[0] || null;
+      }
+
+      const filesToUpload = multiple ? files : files.slice(0, 1);
+      const uploadResults = await projectService.uploadFiles(filesToUpload);
+
+      if (multiple) {
+        return files.map((file) => {
+          const uploadResult =
+            uploadResults.find((item) => item.file === file) || null;
+          return attachUploadState({ file, uploadResult });
+        });
+      }
+
+      const file = files[0] || null;
+      const uploadResult =
+        uploadResults.find((item) => item.file === file) ||
+        uploadResults[0] ||
+        null;
+      return attachUploadState({ file, uploadResult });
     },
     isInputFocused,
     getAppVersion() {

--- a/src/deps/services/web/collabBootstrapService.js
+++ b/src/deps/services/web/collabBootstrapService.js
@@ -685,6 +685,7 @@ export const createWebProjectServiceWithCollab = async ({
   router,
   filePicker,
   subject,
+  db,
 }) => {
   const collabDebugEnabled = resolveCollabDebugEnabled();
   const collabDebugLog = createCollabDebugLogger({
@@ -700,6 +701,7 @@ export const createWebProjectServiceWithCollab = async ({
     router,
     filePicker,
     onRemoteEvent,
+    db,
   });
 
   const collabRuntimeBootstrap = createCollabRuntimeBootstrap({

--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -128,7 +128,12 @@ const summarizeRepositoryEventsForSync = (events = []) => {
 
 const INITIAL_REMOTE_SYNC_TIMEOUT_MS = 5_000;
 
-export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
+export const createProjectService = ({
+  router,
+  filePicker,
+  onRemoteEvent,
+  db,
+}) => {
   const collabLog = (level, message, meta = {}) => {
     const fn =
       level === "error"
@@ -158,6 +163,24 @@ export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
   const getCurrentProjectId = () => {
     const { p } = router.getPayload();
     return p;
+  };
+
+  const getProjectMetadataFromEntries = async (projectId) => {
+    if (!db || typeof db.get !== "function") {
+      return {
+        name: "",
+        description: "",
+      };
+    }
+
+    const entries = (await db.get("projectEntries")) || [];
+    const entry = Array.isArray(entries)
+      ? entries.find((item) => item?.id === projectId)
+      : null;
+    return {
+      name: entry?.name || "",
+      description: entry?.description || "",
+    };
   };
 
   const ensureCommittedIdLoaded = async (projectId) => {
@@ -268,6 +291,7 @@ export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
       resolvedProjectId,
       partitions,
     );
+    const projectMetadata = await getProjectMetadataFromEntries(projectId);
     const clientStore = await createPersistedInMemoryClientStore({
       projectId,
       adapter,
@@ -280,8 +304,8 @@ export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
     await ensureCommittedIdLoaded(projectId);
     const collabSession = createProjectCollabService({
       projectId: resolvedProjectId,
-      projectName: state.project?.name || "",
-      projectDescription: state.project?.description || "",
+      projectName: projectMetadata.name,
+      projectDescription: projectMetadata.description,
       initialState: projectRepositoryStateToDomainState({
         repositoryState: state,
         projectId: resolvedProjectId,
@@ -776,10 +800,9 @@ export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
         },
       );
     },
-    onSessionCleared: ({ projectId, reason }) => {
+    onSessionCleared: ({ projectId }) => {
       collabApplyQueueByProject.delete(projectId);
       collabAppliedCommittedIdsByProject.delete(projectId);
-      void reason;
     },
     onSessionTransportUpdated: () => {},
   });
@@ -801,10 +824,8 @@ export const createProjectService = ({ router, filePicker, onRemoteEvent }) => {
     ...serviceCore.typedCommandApi,
     addVersionToProject: serviceCore.addVersionToProject,
     deleteVersionFromProject: serviceCore.deleteVersionFromProject,
-    async initializeProject({ name, description, projectId, template }) {
+    async initializeProject({ projectId, template }) {
       return initializeWebProject({
-        name,
-        description,
         projectId,
         template,
       });

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -4,6 +4,8 @@ const GLOBAL_NAV_TIMEOUT_MS = 1500;
 
 let awaitingGlobalNavigationTarget = false;
 let globalNavigationTimerId = null;
+let routeTransitionToken = 0;
+let lastEnsuredProjectId = "";
 
 const isProjectRoute = (path) => {
   return path === "/project" || path.startsWith("/project/");
@@ -12,6 +14,17 @@ const isProjectRoute = (path) => {
 const getCurrentQueryPayload = (appService) => {
   const payload = appService.getPayload() || {};
   return Object.keys(payload).length > 0 ? payload : undefined;
+};
+
+const normalizePayload = (payload) => {
+  if (payload && typeof payload === "object") {
+    return payload;
+  }
+  return undefined;
+};
+
+const routeNeedsRepository = (path, projectId) => {
+  return isProjectRoute(path) && !!projectId;
 };
 
 const clearGlobalNavigationState = () => {
@@ -106,20 +119,73 @@ const mountSubscriptions = (deps) => {
   return () => active.forEach((subscription) => subscription?.unsubscribe?.());
 };
 
+const runRouteTransition = async (
+  deps,
+  { path, payload, shouldUpdateHistory = false } = {},
+) => {
+  const { appService, projectService, store, render } = deps;
+  const transitionToken = ++routeTransitionToken;
+  const nextPayload = normalizePayload(payload);
+
+  if (shouldUpdateHistory) {
+    appService.redirect(path, nextPayload);
+  }
+
+  const currentProject = await appService.refreshCurrentProjectEntry();
+  const currentProjectId = currentProject.id || "";
+  const needsRepository = routeNeedsRepository(path, currentProjectId);
+  const isAlreadyEnsured = currentProjectId === lastEnsuredProjectId;
+
+  store.setCurrentRoute({ route: path });
+  store.setRepositoryLoading({
+    isLoading: needsRepository && !isAlreadyEnsured,
+  });
+  render();
+
+  if (!needsRepository || isAlreadyEnsured) {
+    if (transitionToken !== routeTransitionToken) {
+      return;
+    }
+    store.setRepositoryLoading({ isLoading: false });
+    render();
+    return;
+  }
+
+  try {
+    await projectService.ensureRepository();
+    if (transitionToken !== routeTransitionToken) {
+      return;
+    }
+    lastEnsuredProjectId = currentProjectId;
+    store.setRepositoryLoading({ isLoading: false });
+    render();
+  } catch (error) {
+    if (transitionToken !== routeTransitionToken) {
+      return;
+    }
+    store.setRepositoryLoading({ isLoading: false });
+    appService.showToast(error?.message || "Failed to load project.");
+    appService.redirect("/projects");
+    store.setCurrentRoute({ route: "/projects" });
+    render();
+  }
+};
+
 export const handleBeforeMount = (deps) => {
   const cleanupSubscriptions = mountSubscriptions(deps);
   const { appService } = deps;
   const currentPath = appService.getPath();
   clearGlobalNavigationState();
 
-  if (currentPath === "/") {
-    appService.navigate("/projects");
-    deps.store.setCurrentRoute({ route: "/projects" });
-  } else {
-    deps.store.setCurrentRoute({ route: currentPath });
-  }
+  const initialPath = currentPath === "/" ? "/projects" : currentPath;
+  runRouteTransition(deps, {
+    path: initialPath,
+    payload: appService.getPayload(),
+    shouldUpdateHistory: currentPath === "/",
+  }).catch((error) => {
+    console.error("Failed to resolve initial route:", error);
+  });
 
-  deps.render();
   return () => {
     clearGlobalNavigationState();
     cleanupSubscriptions();
@@ -134,17 +200,25 @@ export const handleAfterMount = (deps) => {
 };
 
 export const handleRedirect = (deps, payload) => {
-  const { appService } = deps;
-  deps.store.setCurrentRoute({ route: payload.path });
-  appService.redirect(payload.path, payload.payload);
-  deps.render();
+  runRouteTransition(deps, {
+    path: payload.path,
+    payload: payload.payload,
+    shouldUpdateHistory: true,
+  }).catch((error) => {
+    console.error("Failed to navigate:", error);
+  });
 };
 
 export const handleWindowPop = (deps) => {
   const { appService } = deps;
-  deps.store.setCurrentRoute({ route: appService.getPath() });
   clearGlobalNavigationState();
-  deps.render();
+  runRouteTransition(deps, {
+    path: appService.getPath(),
+    payload: appService.getPayload(),
+    shouldUpdateHistory: false,
+  }).catch((error) => {
+    console.error("Failed to apply browser navigation:", error);
+  });
 };
 
 export const handleGlobalKeyDown = (deps, payload) => {

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -1,5 +1,6 @@
 export const createInitialState = () => ({
   currentRoute: "/projects",
+  isRepositoryLoading: false,
 });
 
 const SIDEBAR_WIDTH_PX = 64;
@@ -73,6 +74,10 @@ export const selectCurrentRoutePattern = ({ state }) => {
 
 export const setCurrentRoute = ({ state }, { route } = {}) => {
   state.currentRoute = route;
+};
+
+export const setRepositoryLoading = ({ state }, { isLoading } = {}) => {
+  state.isRepositoryLoading = !!isLoading;
 };
 
 export const selectViewData = ({ state }) => {

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -7,57 +7,61 @@ template:
       - $if showSidebar:
           - rvn-sidebar: []
       - 'rtgl-view h=f style="width: ${contentWidth}; min-width: 0;"':
-          - $if currentRoutePattern == "/projects":
-              - rvn-projects: []
-            $elif currentRoutePattern == "/authenticate":
-              - rvn-authenticate: []
-            $elif currentRoutePattern == "/project":
-              - rvn-project: []
-            $elif currentRoutePattern == "/project/resources":
-              - rvn-resources: []
-            $elif currentRoutePattern == "/project/cgs":
-              - rvn-cgs: []
-            $elif currentRoutePattern == "/project/resources/images":
-              - rvn-images: []
-            $elif currentRoutePattern == "/project/resources/backgrounds":
-              - rvn-backgrounds: []
-            $elif currentRoutePattern == "/project/resources/characters":
-              - rvn-characters: []
-            $elif currentRoutePattern == "/project/resources/character-sprites":
-              - rvn-character-sprites: []
-            $elif currentRoutePattern == "/project/resources/sounds":
-              - rvn-sound: []
-            $elif currentRoutePattern == "/project/resources/tweens":
-              - rvn-tweens: []
-            $elif currentRoutePattern == "/project/resources/transforms":
-              - rvn-transforms: []
-            $elif currentRoutePattern == "/project/resources/visuals":
-              - rvn-visuals: []
-            $elif currentRoutePattern == "/project/resources/videos":
-              - rvn-videos: []
-            $elif currentRoutePattern == "/project/resources/typography":
-              - rvn-typography: []
-            $elif currentRoutePattern == "/project/resources/choices":
-              - rvn-choices: []
-            $elif currentRoutePattern == "/project/resources/variables":
-              - rvn-variables: []
-            $elif currentRoutePattern == "/project/scenes":
-              - rvn-scenes: []
-            $elif currentRoutePattern == "/project/scene-editor":
-              - rvn-scene-editor: []
-            $elif currentRoutePattern == "/project/settings/about":
-              - rvn-about: []
-            $elif currentRoutePattern == "/project/settings/user":
-              - rvn-settings-user: []
-            $elif currentRoutePattern == "/project/resources/colors":
-              - rvn-colors: []
-            $elif currentRoutePattern == "/project/resources/fonts":
-              - rvn-fonts: []
-            $elif currentRoutePattern == "/project/resources/layouts":
-              - rvn-layouts: []
-            $elif currentRoutePattern == "/project/resources/layout-editor":
-              - rvn-layout-editor: []
-            $elif currentRoutePattern == "/project/releases":
-              - rvn-versions: []
-            $elif currentRoutePattern == "/project/releases/versions":
-              - rvn-versions: []
+          - $if isRepositoryLoading:
+              - rtgl-view w=f h=f d=v ah=c av=c g=sm:
+                  - rtgl-text s=sm c=mu-fg: Loading project...
+            $else:
+              - $if currentRoutePattern == "/projects":
+                  - rvn-projects: []
+                $elif currentRoutePattern == "/authenticate":
+                  - rvn-authenticate: []
+                $elif currentRoutePattern == "/project":
+                  - rvn-project: []
+                $elif currentRoutePattern == "/project/resources":
+                  - rvn-resources: []
+                $elif currentRoutePattern == "/project/cgs":
+                  - rvn-cgs: []
+                $elif currentRoutePattern == "/project/resources/images":
+                  - rvn-images: []
+                $elif currentRoutePattern == "/project/resources/backgrounds":
+                  - rvn-backgrounds: []
+                $elif currentRoutePattern == "/project/resources/characters":
+                  - rvn-characters: []
+                $elif currentRoutePattern == "/project/resources/character-sprites":
+                  - rvn-character-sprites: []
+                $elif currentRoutePattern == "/project/resources/sounds":
+                  - rvn-sound: []
+                $elif currentRoutePattern == "/project/resources/tweens":
+                  - rvn-tweens: []
+                $elif currentRoutePattern == "/project/resources/transforms":
+                  - rvn-transforms: []
+                $elif currentRoutePattern == "/project/resources/visuals":
+                  - rvn-visuals: []
+                $elif currentRoutePattern == "/project/resources/videos":
+                  - rvn-videos: []
+                $elif currentRoutePattern == "/project/resources/typography":
+                  - rvn-typography: []
+                $elif currentRoutePattern == "/project/resources/choices":
+                  - rvn-choices: []
+                $elif currentRoutePattern == "/project/resources/variables":
+                  - rvn-variables: []
+                $elif currentRoutePattern == "/project/scenes":
+                  - rvn-scenes: []
+                $elif currentRoutePattern == "/project/scene-editor":
+                  - rvn-scene-editor: []
+                $elif currentRoutePattern == "/project/settings/about":
+                  - rvn-about: []
+                $elif currentRoutePattern == "/project/settings/user":
+                  - rvn-settings-user: []
+                $elif currentRoutePattern == "/project/resources/colors":
+                  - rvn-colors: []
+                $elif currentRoutePattern == "/project/resources/fonts":
+                  - rvn-fonts: []
+                $elif currentRoutePattern == "/project/resources/layouts":
+                  - rvn-layouts: []
+                $elif currentRoutePattern == "/project/resources/layout-editor":
+                  - rvn-layout-editor: []
+                $elif currentRoutePattern == "/project/releases":
+                  - rvn-versions: []
+                $elif currentRoutePattern == "/project/releases/versions":
+                  - rvn-versions: []

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -392,16 +392,16 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  const files = await appService.pickFiles({
+  const file = await appService.pickFiles({
     accept: "image/*",
     multiple: false,
   });
 
-  if (files.length === 0) {
+  if (!file) {
     return; // User cancelled
   }
 
-  const uploadedFiles = await projectService.uploadFiles(files);
+  const uploadedFiles = await projectService.uploadFiles([file]);
 
   if (uploadedFiles.length === 0) {
     console.error("File upload failed, no files uploaded");

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -1,5 +1,4 @@
 import { nanoid } from "nanoid";
-import { validateIconDimensions } from "../../utils/fileProcessors";
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
 
 const getCharacterItemById = ({ store, itemId } = {}) => {
@@ -324,21 +323,14 @@ export const handleDetailPanelAvatarClick = async (deps) => {
     return;
   }
 
-  const files = await appService.pickFiles({
+  const file = await appService.pickFiles({
     accept: "image/*",
     multiple: false,
+    validations: [{ type: "square" }],
   });
 
-  if (files.length === 0) {
+  if (!file) {
     return; // User cancelled
-  }
-
-  const file = files[0];
-
-  const { isValid, message } = await validateIconDimensions(file);
-  if (!isValid) {
-    appService.showToast(message, { title: "Error" });
-    return;
   }
 
   try {
@@ -480,19 +472,13 @@ export const handleDialogAvatarClick = async (deps) => {
   const { store, render, appService, projectService } = deps;
 
   try {
-    const files = await appService.pickFiles({
+    const file = await appService.pickFiles({
       accept: "image/*",
       multiple: false,
+      validations: [{ type: "square" }],
     });
 
-    if (files.length > 0) {
-      const file = files[0];
-      const { isValid, message } = await validateIconDimensions(file);
-      if (!isValid) {
-        appService.showToast(message, { title: "Error" });
-        return;
-      }
-
+    if (file) {
       const uploadResults = await projectService.uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {
@@ -559,19 +545,13 @@ export const handleEditDialogAvatarClick = async (deps) => {
   const { store, render, appService, projectService } = deps;
 
   try {
-    const files = await appService.pickFiles({
+    const file = await appService.pickFiles({
       accept: "image/*",
       multiple: false,
+      validations: [{ type: "square" }],
     });
 
-    if (files.length > 0) {
-      const file = files[0];
-      const { isValid, message } = await validateIconDimensions(file);
-      if (!isValid) {
-        appService.showToast(message, { title: "Error" });
-        return;
-      }
-
+    if (file) {
       const uploadResults = await projectService.uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -218,16 +218,14 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  const files = await appService.pickFiles({
+  const file = await appService.pickFiles({
     accept: ".ttf,.otf,.woff,.woff2,.ttc",
     multiple: false,
   });
 
-  if (files.length === 0) {
+  if (!file) {
     return; // User cancelled
   }
-
-  const file = files[0];
 
   // Validate file format
   if (!file.name.match(/\.(ttf|otf|woff|woff2|ttc)$/i)) {

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -206,16 +206,14 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  const files = await appService.pickFiles({
+  const file = await appService.pickFiles({
     accept: "image/*",
     multiple: false,
   });
 
-  if (files.length === 0) {
+  if (!file) {
     return; // User cancelled
   }
-
-  const file = files[0];
 
   const uploadedFiles = await projectService.uploadFiles([file]);
 

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -18,33 +18,44 @@ export const handleFormChange = async (deps, payload) => {
 
 export const handleFormExtraEvent = async (deps) => {
   const { appService, subject, render, store } = deps;
+  let file;
 
   try {
-    const file = await appService.pickFiles({
+    file = await appService.pickFiles({
       accept: "image/*",
       multiple: false,
       validations: [{ type: "square" }],
       upload: true,
     });
-
-    if (!file || !file.uploadSucessful || !file.uploadResult) {
-      return; // User cancelled
-    }
-
-    const result = file.uploadResult;
-    const currentProject = appService.getCurrentProjectEntry();
-    if (currentProject.id && currentProject.source === "local") {
-      await appService.updateProjectEntry(currentProject.id, {
-        iconFileId: result.fileId,
-      });
-    }
-
-    store.setIconFileId({ iconFileId: result.fileId });
-    subject.dispatch("project-image-update");
-    render();
-  } catch (error) {
-    console.error("Project image upload failed:", error);
+  } catch {
+    appService.showToast("Failed to select file.", {
+      title: "Error",
+    });
+    return;
   }
+
+  if (!file) {
+    return; // User cancelled
+  }
+
+  if (!file.uploadSucessful || !file.uploadResult) {
+    appService.showToast("Failed to upload project icon.", {
+      title: "Error",
+    });
+    return;
+  }
+
+  const result = file.uploadResult;
+  const currentProject = appService.getCurrentProjectEntry();
+  if (currentProject.id && currentProject.source === "local") {
+    await appService.updateProjectEntry(currentProject.id, {
+      iconFileId: result.fileId,
+    });
+  }
+
+  store.setIconFileId({ iconFileId: result.fileId });
+  subject.dispatch("project-image-update");
+  render();
 };
 
 export const handleBackToProjects = async (deps) => {

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -1,91 +1,47 @@
-import { validateIconDimensions } from "../../utils/fileProcessors";
-
-const resolveProjectSource = async (appService) => {
-  const payload = appService.getPayload() || {};
-  const projectId = typeof payload?.p === "string" ? payload.p : "";
-  if (!projectId) {
-    return "local";
-  }
-
-  try {
-    const entries = await appService.getProjectEntries();
-    const isLocalProject =
-      Array.isArray(entries) &&
-      entries.some(
-        (entry) => typeof entry?.id === "string" && entry.id === projectId,
-      );
-    return isLocalProject ? "local" : "cloud";
-  } catch {
-    return "local";
-  }
-};
-
-export const handleAfterMount = async (deps) => {
-  await handleDataChanged(deps);
-};
-
-export const handleDataChanged = async (deps) => {
-  const { appService, projectService, store, render } = deps;
-  const source = await resolveProjectSource(appService);
-  store.setProjectSource({ source });
-  render();
-
-  try {
-    await projectService.ensureRepository();
-    const state = projectService.getState();
-    const { project } = state;
-    store.setProject({ project: project });
-    render();
-  } catch (error) {
-    console.error("Failed to load project data:", error);
-    appService.showToast(error?.message || "Failed to load project.");
-  }
+export const handleBeforeMount = (deps) => {
+  const { appService, store } = deps;
+  const project = appService.getCurrentProjectEntry();
+  store.setCurrentProject({ project });
 };
 
 export const handleFormChange = async (deps, payload) => {
-  const { projectService } = deps;
-  await projectService.updateProjectFields({
-    patch: {
-      [payload._event.detail.name]: payload._event.detail.value,
-    },
+  const { appService } = deps;
+  const currentProject = appService.getCurrentProjectEntry();
+  if (!currentProject.id || currentProject.source !== "local") {
+    return;
+  }
+
+  await appService.updateProjectEntry(currentProject.id, {
+    [payload._event.detail.name]: payload._event.detail.value,
   });
 };
 
 export const handleFormExtraEvent = async (deps) => {
-  const { appService, projectService, subject, render, store } = deps;
+  const { appService, subject, render, store } = deps;
 
   try {
-    const files = await appService.pickFiles({
+    const file = await appService.pickFiles({
       accept: "image/*",
       multiple: false,
+      validations: [{ type: "square" }],
+      upload: true,
     });
 
-    if (!files || files.length === 0) {
+    if (!file || !file.uploadSucessful || !file.uploadResult) {
       return; // User cancelled
     }
 
-    const file = files[0];
-
-    const { isValid, message } = await validateIconDimensions(file);
-    if (!isValid) {
-      appService.showToast(message, { title: "Error" });
-      return;
-    }
-
-    const successfulUploads = await projectService.uploadFiles([file]);
-
-    if (successfulUploads.length > 0) {
-      const result = successfulUploads[0];
-      await projectService.updateProjectFields({
-        patch: {
-          iconFileId: result.fileId,
-        },
+    const result = file.uploadResult;
+    const currentProject = appService.getCurrentProjectEntry();
+    if (currentProject.id && currentProject.source === "local") {
+      await appService.updateProjectEntry(currentProject.id, {
+        iconFileId: result.fileId,
       });
-
-      store.setIconFileId({ iconFileId: result.fileId });
-      subject.dispatch("project-image-update");
-      render();
     }
+
+    store.setIconFileId({ iconFileId: result.fileId });
+    subject.dispatch("project-image-update");
+    render();
   } catch (error) {
     console.error("Project image upload failed:", error);
   }

--- a/src/pages/project/project.store.js
+++ b/src/pages/project/project.store.js
@@ -30,17 +30,18 @@ export const createInitialState = () => ({
   dataLoaded: false,
 });
 
-export const setProject = ({ state }, { project } = {}) => {
-  state.project = project;
+export const setCurrentProject = ({ state }, { project } = {}) => {
+  state.project = {
+    name: project?.name || "",
+    description: project?.description || "",
+    iconFileId: project?.iconFileId || null,
+  };
+  state.projectSource = project?.source === "cloud" ? "cloud" : "local";
   state.dataLoaded = true;
 };
 
 export const setIconFileId = ({ state }, { iconFileId } = {}) => {
   state.project.iconFileId = iconFileId;
-};
-
-export const setProjectSource = ({ state }, { source } = {}) => {
-  state.projectSource = source === "cloud" ? "cloud" : "local";
 };
 
 export const selectViewData = ({ state }) => {

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -1,25 +1,15 @@
 const getSessionAuthToken = (appService) => {
   const authSession = appService.getUserConfig("auth.session");
-  const authToken =
-    typeof authSession?.authToken === "string"
-      ? authSession.authToken.trim()
-      : "";
+  const authToken = authSession?.authToken?.trim?.() ?? "";
   return authToken;
 };
 
 const mapApiUserToAuthUser = (user) => {
-  const id = typeof user?.id === "string" ? user.id : "";
-  const email = typeof user?.email === "string" ? user.email : "";
-  const name =
-    typeof user?.creatorDisplayName === "string" ? user.creatorDisplayName : "";
-  const displayColor =
-    typeof user?.creatorDisplayColor === "string" && user.creatorDisplayColor
-      ? user.creatorDisplayColor
-      : "#E2E8F0";
-  const avatar =
-    typeof user?.creatorDisplayAvatar === "string"
-      ? user.creatorDisplayAvatar
-      : "";
+  const id = user?.id;
+  const email = user?.email;
+  const name = user?.creatorDisplayName;
+  const displayColor = user?.creatorDisplayColor ?? "#E2E8F0";
+  const avatar = user?.creatorDisplayAvatar;
 
   return {
     id,
@@ -32,13 +22,10 @@ const mapApiUserToAuthUser = (user) => {
 };
 
 const mapCloudProject = (project) => {
-  const projectId = typeof project?.id === "string" ? project.id : "";
-  const name = typeof project?.name === "string" ? project.name : "Untitled";
-  const role = typeof project?.role === "string" ? project.role : "member";
-  const data =
-    project?.data && typeof project.data === "object" ? project.data : {};
-  const description =
-    typeof data.description === "string" ? data.description : "";
+  const projectId = project?.id;
+  const name = project?.name ?? "Untitled";
+  const role = project?.role ?? "member";
+  const description = project?.data?.description ?? "";
   const memberCount = Array.isArray(project?.members)
     ? project.members.length
     : 0;
@@ -106,11 +93,7 @@ export const handleAfterMount = async (deps) => {
 };
 
 const getProjectIdFromEvent = (event) => {
-  return (
-    event?.currentTarget?.getAttribute?.("data-project-id") ||
-    event?.currentTarget?.id?.replace("project", "") ||
-    ""
-  );
+  return event?.currentTarget?.dataset?.projectId ?? "";
 };
 
 const buildProjectPageUrl = (projectId) => {

--- a/src/pages/sidebar/sidebar.handlers.js
+++ b/src/pages/sidebar/sidebar.handlers.js
@@ -11,12 +11,11 @@ export const handleBeforeMount = (deps) => {
 };
 
 export const handleAfterMount = async (deps) => {
-  const { projectService, store, render } = deps;
+  const { projectService, appService, store, render } = deps;
   await projectService.ensureRepository();
-  const state = projectService.getState();
-  const project = state.project;
+  const project = appService.getCurrentProjectEntry();
 
-  if (!project.iconFileId) {
+  if (!project?.iconFileId) {
     return;
   }
 
@@ -44,11 +43,10 @@ export const handleHeaderClick = (deps) => {
 };
 
 export const handleProjectImageUpdate = async (deps) => {
-  const { projectService, store, render } = deps;
-  const state = projectService.getState();
-  const project = state.project;
+  const { projectService, appService, store, render } = deps;
+  const project = appService.getCurrentProjectEntry();
 
-  if (!project.iconFileId) {
+  if (!project?.iconFileId) {
     return;
   }
 

--- a/src/pages/sound/sound.handlers.js
+++ b/src/pages/sound/sound.handlers.js
@@ -332,16 +332,14 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  const files = await appService.pickFiles({
+  const file = await appService.pickFiles({
     accept: "audio/*",
     multiple: false,
   });
 
-  if (files.length === 0) {
+  if (!file) {
     return; // User cancelled
   }
-
-  const file = files[0];
 
   let uploadedFiles;
   try {

--- a/src/pages/versions/versions.handlers.js
+++ b/src/pages/versions/versions.handlers.js
@@ -130,7 +130,21 @@ export const handleDownloadZipClick = async (deps, payload) => {
     projectData: constructedProjectData,
   };
   const fileIds = usage.fileIds;
-  const zipName = `${projectData.project.name}_${version.name}`;
+  const currentPayload = appService.getPayload?.() || {};
+  const projectId =
+    typeof currentPayload?.p === "string" ? currentPayload.p : "";
+  let projectName = "project";
+  if (projectId && typeof appService.getProjectEntries === "function") {
+    const entries = await appService.getProjectEntries();
+    const projectEntry = Array.isArray(entries)
+      ? entries.find((entry) => entry?.id === projectId)
+      : null;
+    const entryName = projectEntry?.name?.trim?.();
+    if (entryName) {
+      projectName = entryName;
+    }
+  }
+  const zipName = `${projectName}_${version.name}`;
 
   // Create and download ZIP with streamed bundle creation
   try {

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -275,16 +275,14 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  const files = await appService.pickFiles({
+  const file = await appService.pickFiles({
     accept: "video/*",
     multiple: false,
   });
 
-  if (files.length === 0) {
+  if (!file) {
     return; // User cancelled
   }
-
-  const file = files[0];
 
   const uploadedFiles = await projectService.uploadFiles([file]);
 

--- a/src/setup.web.js
+++ b/src/setup.web.js
@@ -46,6 +46,7 @@ const projectService = await createWebProjectServiceWithCollab({
   router,
   filePicker,
   subject,
+  db: appDb,
 });
 
 // Create app service (web version)


### PR DESCRIPTION
## Summary
- move project header metadata (name/description/icon) to app DB entries and stop writing it into repository bootstrap payload
- add app-level route guard/loading for `/project*` to centralize `ensureRepository()` behavior and remove page-local ensure in project page
- add appService current-project in-memory cache (`refreshCurrentProjectEntry` + sync getter) and simplify project/sidebar handlers
- standardize projects handler mapping style to direct access/`??` defaults and dataset-based project id lookup
- extend `appService.pickFiles` to support
  - single-file return when `multiple: false`
  - `validations` (currently `[{ type: "square" }]`)
  - `upload: true` with upload metadata attached on selected file(s)
- update avatar/icon replacement call sites to use new picker behavior

## Testing
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`
- targeted checks run during implementation for touched files with `oxlint` and `prettier --check`