### PR TITLE
chore: simplify auth and repository bootstrap

### DIFF
--- a/src/deps/infra/tauri/tauriRepositoryAdapter.js
+++ b/src/deps/infra/tauri/tauriRepositoryAdapter.js
@@ -4,50 +4,12 @@ import Database from "@tauri-apps/plugin-sql";
 const REPOSITORY_EVENTS_TABLE = "events";
 const MATERIALIZED_VIEW_TABLE = "materialized_view_state";
 
-const hasTable = async (db, tableName) => {
-  const rows = await db.select(
-    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $1",
-    [tableName],
-  );
-  return Array.isArray(rows) && rows.length > 0;
-};
-
-const getTableColumns = async (db, tableName) => {
-  if (!(await hasTable(db, tableName))) {
-    return [];
-  }
-  return (await db.select(`PRAGMA table_info(${tableName})`)) || [];
-};
-
 const ensureRepositorySchema = async (db) => {
-  const eventColumns = await getTableColumns(db, REPOSITORY_EVENTS_TABLE);
-  const hasLegacyTypeColumn = eventColumns.some(
-    (column) => column?.name === "type",
-  );
-
-  if (eventColumns.length === 0) {
-    await db.execute(`CREATE TABLE IF NOT EXISTS ${REPOSITORY_EVENTS_TABLE} (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      payload TEXT NOT NULL,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )`);
-  } else if (hasLegacyTypeColumn) {
-    await db.execute(
-      `ALTER TABLE ${REPOSITORY_EVENTS_TABLE} RENAME TO ${REPOSITORY_EVENTS_TABLE}_legacy`,
-    );
-    await db.execute(`CREATE TABLE ${REPOSITORY_EVENTS_TABLE} (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      payload TEXT NOT NULL,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )`);
-    await db.execute(
-      `INSERT INTO ${REPOSITORY_EVENTS_TABLE} (id, payload, created_at)
-       SELECT id, payload, created_at
-       FROM ${REPOSITORY_EVENTS_TABLE}_legacy
-       ORDER BY id`,
-    );
-    await db.execute(`DROP TABLE ${REPOSITORY_EVENTS_TABLE}_legacy`);
-  }
+  await db.execute(`CREATE TABLE IF NOT EXISTS ${REPOSITORY_EVENTS_TABLE} (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    payload TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`);
 
   await db.execute(`CREATE TABLE IF NOT EXISTS app (
     key TEXT PRIMARY KEY,

--- a/src/deps/services/projectService.js
+++ b/src/deps/services/projectService.js
@@ -26,6 +26,7 @@ import {
   createProjectRepository,
   initialProjectData,
 } from "./shared/projectRepository.js";
+import { getOrCreateLocked } from "./shared/getOrCreateLocked.js";
 
 // Font loading helper
 const loadFont = async (fontName, fontUrl) => {
@@ -166,21 +167,13 @@ export const createProjectService = ({ router, db, filePicker }) => {
 
   // Get or create repository by path
   const getRepositoryByPath = async (projectPath) => {
-    // Check cache first
-    if (repositoriesByPath.has(projectPath)) {
-      return repositoriesByPath.get(projectPath);
-    }
-
-    // Check if initialization is already in progress
-    if (initLocksByPath.has(projectPath)) {
-      return initLocksByPath.get(projectPath);
-    }
-
-    // Create init promise and store lock
-    const initPromise = (async () => {
-      try {
+    return getOrCreateLocked({
+      cache: repositoriesByPath,
+      locks: initLocksByPath,
+      key: projectPath,
+      create: async () => {
         const store = await createInsiemeTauriStoreAdapter(projectPath);
-        let existingEvents = (await store.getEvents()) || [];
+        const existingEvents = (await store.getEvents()) || [];
         const repository = await createProjectRepository({
           projectId: projectPath,
           store,
@@ -190,31 +183,17 @@ export const createProjectService = ({ router, db, filePicker }) => {
         repositoriesByPath.set(projectPath, repository);
         adaptersByPath.set(projectPath, store);
         return repository;
-      } finally {
-        // Always remove the lock when done (success or failure)
-        initLocksByPath.delete(projectPath);
-      }
-    })();
-
-    initLocksByPath.set(projectPath, initPromise);
-    return initPromise;
+      },
+    });
   };
 
   // Get or create repository by projectId
   const getRepositoryByProject = async (projectId) => {
-    // Check cache first
-    if (repositoriesByProject.has(projectId)) {
-      return repositoriesByProject.get(projectId);
-    }
-
-    // Check if initialization is already in progress
-    if (initLocksByProject.has(projectId)) {
-      return initLocksByProject.get(projectId);
-    }
-
-    // Create init promise and store lock
-    const initPromise = (async () => {
-      try {
+    return getOrCreateLocked({
+      cache: repositoriesByProject,
+      locks: initLocksByProject,
+      key: projectId,
+      create: async () => {
         const projects = (await db.get("projectEntries")) || [];
         const project = projects.find((p) => p.id === projectId);
         if (!project) {
@@ -226,14 +205,8 @@ export const createProjectService = ({ router, db, filePicker }) => {
         repositoriesByProject.set(projectId, repository);
         adaptersByProject.set(projectId, adapter);
         return repository;
-      } finally {
-        // Always remove the lock when done (success or failure)
-        initLocksByProject.delete(projectId);
-      }
-    })();
-
-    initLocksByProject.set(projectId, initPromise);
-    return initPromise;
+      },
+    });
   };
 
   // Get current project's repository (updates cache)

--- a/src/deps/services/shared/authSession.js
+++ b/src/deps/services/shared/authSession.js
@@ -1,0 +1,69 @@
+export const mapApiUserToAuthUser = (user) => {
+  const email = typeof user?.email === "string" ? user.email : "";
+  const name =
+    typeof user?.creatorDisplayName === "string" ? user.creatorDisplayName : "";
+  const displayColor =
+    typeof user?.creatorDisplayColor === "string" && user.creatorDisplayColor
+      ? user.creatorDisplayColor
+      : "#E2E8F0";
+  const avatar =
+    typeof user?.creatorDisplayAvatar === "string"
+      ? user.creatorDisplayAvatar
+      : "";
+  const id = typeof user?.id === "string" ? user.id : "";
+
+  return {
+    id,
+    email,
+    name,
+    displayColor,
+    avatar,
+    registered: true,
+  };
+};
+
+export const getSessionAuthToken = (appService) => {
+  const authSession = appService.getUserConfig("auth.session");
+  return authSession?.authToken?.trim?.() ?? "";
+};
+
+export const getStoredAuthUser = (appService) => {
+  const authUser = appService.getUserConfig("auth.user");
+  return authUser && typeof authUser === "object" ? authUser : undefined;
+};
+
+export const getPersistedAuthenticatedUser = (appService) => {
+  return getSessionAuthToken(appService)
+    ? getStoredAuthUser(appService)
+    : undefined;
+};
+
+export const getAuthenticatedSession = (appService) => {
+  const authToken = getSessionAuthToken(appService);
+  if (!authToken) {
+    return;
+  }
+
+  return {
+    authToken,
+    authUser: getStoredAuthUser(appService),
+  };
+};
+
+export const persistAuthenticatedSession = (appService, authResult) => {
+  const authToken =
+    typeof authResult?.authToken === "string" ? authResult.authToken : "";
+  const refreshToken =
+    typeof authResult?.refreshToken === "string" ? authResult.refreshToken : "";
+
+  appService.setUserConfig("auth.session", {
+    authToken,
+    refreshToken,
+  });
+  appService.setUserConfig("auth.user", mapApiUserToAuthUser(authResult?.user));
+};
+
+export const clearAuthenticatedSession = (appService) => {
+  appService.setUserConfig("auth.session", null);
+  appService.setUserConfig("auth.user", null);
+};

--- a/src/deps/services/shared/getOrCreateLocked.js
+++ b/src/deps/services/shared/getOrCreateLocked.js
@@ -1,0 +1,18 @@
+export const getOrCreateLocked = ({ cache, locks, key, create }) => {
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+
+  if (locks.has(key)) {
+    return locks.get(key);
+  }
+
+  const pending = Promise.resolve()
+    .then(create)
+    .finally(() => {
+      locks.delete(key);
+    });
+
+  locks.set(key, pending);
+  return pending;
+};

--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -31,6 +31,7 @@ import {
   createProjectRepository,
   repositoryEventToCommand,
 } from "../shared/projectRepository.js";
+import { getOrCreateLocked } from "../shared/getOrCreateLocked.js";
 
 // Font loading helper
 const loadFont = async (fontName, fontUrl) => {
@@ -519,21 +520,13 @@ export const createProjectService = ({
 
   // Get or create repository by projectId
   const getRepositoryByProject = async (projectId) => {
-    // Check cache first
-    if (repositoriesByProject.has(projectId)) {
-      return repositoriesByProject.get(projectId);
-    }
-
-    // Check if initialization is already in progress
-    if (initLocksByProject.has(projectId)) {
-      return initLocksByProject.get(projectId);
-    }
-
-    // Create init promise and store lock
-    const initPromise = (async () => {
-      try {
+    return getOrCreateLocked({
+      cache: repositoriesByProject,
+      locks: initLocksByProject,
+      key: projectId,
+      create: async () => {
         const store = await getAdapterByProject(projectId);
-        let existingEvents = (await store.getEvents()) || [];
+        const existingEvents = (await store.getEvents()) || [];
 
         // Recover from stale sync cursor state: a project can have a persisted
         // cursor while local repository events are empty/minimal (e.g. cleared IDB events).
@@ -566,14 +559,8 @@ export const createProjectService = ({
         assertV2State(repository.getState());
         repositoriesByProject.set(projectId, repository);
         return repository;
-      } finally {
-        // Always remove the lock when done (success or failure)
-        initLocksByProject.delete(projectId);
-      }
-    })();
-
-    initLocksByProject.set(projectId, initPromise);
-    return initPromise;
+      },
+    });
   };
 
   // Get current project's repository (updates cache)

--- a/src/pages/authenticate/authenticate.handlers.js
+++ b/src/pages/authenticate/authenticate.handlers.js
@@ -1,3 +1,5 @@
+import { persistAuthenticatedSession } from "../../deps/services/shared/authSession.js";
+
 export const handleBackButtonClick = (deps) => {
   const { appService } = deps;
   appService.navigate("/projects");
@@ -67,44 +69,6 @@ const extractRegisterCode = (result) => {
   }
 
   return "";
-};
-
-const mapApiUserToAuthUser = (user) => {
-  const email = typeof user?.email === "string" ? user.email : "";
-  const name =
-    typeof user?.creatorDisplayName === "string" ? user.creatorDisplayName : "";
-  const displayColor =
-    typeof user?.creatorDisplayColor === "string" && user.creatorDisplayColor
-      ? user.creatorDisplayColor
-      : "#E2E8F0";
-  const avatar =
-    typeof user?.creatorDisplayAvatar === "string"
-      ? user.creatorDisplayAvatar
-      : "";
-  const id = typeof user?.id === "string" ? user.id : "";
-
-  return {
-    id,
-    email,
-    name,
-    displayColor,
-    avatar,
-    registered: true,
-  };
-};
-
-const persistAuthenticatedSession = (appService, authResult) => {
-  const authToken =
-    typeof authResult?.authToken === "string" ? authResult.authToken : "";
-  const refreshToken =
-    typeof authResult?.refreshToken === "string" ? authResult.refreshToken : "";
-  const mappedUser = mapApiUserToAuthUser(authResult?.user);
-
-  appService.setUserConfig("auth.session", {
-    authToken,
-    refreshToken,
-  });
-  appService.setUserConfig("auth.user", mappedUser);
 };
 
 export const handleFormAction = async (deps, payload) => {

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -1,43 +1,9 @@
-const getSessionAuthToken = (appService) => {
-  const authSession = appService.getUserConfig("auth.session");
-  const authToken = authSession?.authToken?.trim?.() ?? "";
-  return authToken;
-};
-
-const getAuthenticatedCloudSession = (appService) => {
-  const authToken = getSessionAuthToken(appService);
-  if (!authToken) {
-    return;
-  }
-
-  const authUser = appService.getUserConfig("auth.user");
-  const email = authUser?.email?.trim?.() ?? "";
-  if (!email) {
-    return;
-  }
-
-  return {
-    authToken,
-    authUser,
-  };
-};
-
-const mapApiUserToAuthUser = (user) => {
-  const id = user?.id;
-  const email = user?.email;
-  const name = user?.creatorDisplayName;
-  const displayColor = user?.creatorDisplayColor ?? "#E2E8F0";
-  const avatar = user?.creatorDisplayAvatar;
-
-  return {
-    id,
-    email,
-    name,
-    displayColor,
-    avatar,
-    registered: true,
-  };
-};
+import {
+  clearAuthenticatedSession,
+  getAuthenticatedSession,
+  getPersistedAuthenticatedUser,
+  mapApiUserToAuthUser,
+} from "../../deps/services/shared/authSession.js";
 
 const mapCloudProject = (project) => {
   const projectId = project?.id;
@@ -86,28 +52,12 @@ const loadCloudProjects = async ({
 };
 
 export const handleAfterMount = async (deps) => {
-  const { appService, apiService, store, render } = deps;
+  const { appService, store, render } = deps;
   const platform = appService.getPlatform();
   store.setPlatform({ platform: platform });
-  const cloudSession = getAuthenticatedCloudSession(appService);
-  const authUser = cloudSession?.authUser;
+  const authUser = getPersistedAuthenticatedUser(appService);
   store.setAuthUser({ user: authUser });
-
-  if (cloudSession) {
-    try {
-      await loadCloudProjects({
-        appService,
-        apiService,
-        store,
-        authToken: cloudSession.authToken,
-      });
-    } catch (error) {
-      console.error("Failed to load cloud profile:", error);
-      store.setCloudProjects({ projects: [] });
-    }
-  } else {
-    store.setCloudProjects({ projects: [] });
-  }
+  store.setCloudProjects({ projects: [] });
 
   const projects = await appService.loadAllProjects();
   store.setProjects({ projects: projects });
@@ -131,7 +81,7 @@ export const handleCreateButtonClick = async (deps) => {
 
 export const handleCloudCreateButtonClick = (deps) => {
   const { appService, store, render } = deps;
-  const cloudSession = getAuthenticatedCloudSession(appService);
+  const cloudSession = getAuthenticatedSession(appService);
   if (!cloudSession) {
     appService.showToast("Please login to create a cloud project.");
     return;
@@ -165,7 +115,7 @@ export const handleCloudCreateFormAction = async (deps, payload) => {
     return;
   }
 
-  const cloudSession = getAuthenticatedCloudSession(appService);
+  const cloudSession = getAuthenticatedSession(appService);
   if (!cloudSession) {
     appService.showToast("Please login to create a cloud project.");
     return;
@@ -370,8 +320,7 @@ export const handleProfileDropdownClickItem = async (deps, payload) => {
       return;
     }
 
-    appService.setUserConfig("auth.session", null);
-    appService.setUserConfig("auth.user", null);
+    clearAuthenticatedSession(appService);
     store.setAuthUser({ user: null });
     store.setCloudProjects({ projects: [] });
     render();
@@ -568,7 +517,7 @@ export const handleAddMemberFormAction = async (deps, payload) => {
     return;
   }
 
-  const cloudSession = getAuthenticatedCloudSession(appService);
+  const cloudSession = getAuthenticatedSession(appService);
   if (!cloudSession) {
     appService.showToast("Please login to add a member.");
     return;

--- a/static/index.html
+++ b/static/index.html
@@ -3,9 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>
-      console.warn("[routevn.boot] static/index.html loaded");
-    </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
     <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>


### PR DESCRIPTION
## Summary
- centralize auth/session normalization used by authentication and projects flows
- remove unsupported legacy repository schema migration logic from the Tauri adapter
- deduplicate repository bootstrap cache/lock flow across web and Tauri services
- remove the stray static boot log

## Notes
- the hidden cloud feature is preserved; this PR does not remove it
- `/projects` still avoids mount-time cloud RPC while logged out
- no build was run

## Validation
- `bun run lint`
- `bun run test:v2-smoke`
- `bun run test:v2-convergence`
- `bun run test:v2-command-only`
