### PR TITLE
Refactor media resource pages

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -202,6 +202,10 @@ Current family pattern:
   UI-only center-pane component for media-style resource pages
 - `src/deps/features/resourcePages/media/`
   shared store/handler helpers for media-family pages
+- `src/components/catalogResourcesView/`
+  UI-only center-pane component for catalog-style resource pages
+- `src/deps/features/resourcePages/catalog/`
+  shared store/handler helpers for catalog-family pages
 
 Page-family helpers should own:
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -184,6 +184,56 @@ Handlers must stay thin.
 Stores must not absorb domain logic.
 Views must stay declarative.
 
+## Resource Page Pattern
+
+Resource pages should stay explicit at the page level.
+
+Do not hide an entire resource page behind one large page factory or one generic layout abstraction.
+
+The preferred structure is:
+
+- page YAML stays in `src/pages/<page>/`
+- reusable center-pane UI lives in `src/components/`
+- shared page-family orchestration lives in `src/deps/features/resourcePages/`
+
+Current family pattern:
+
+- `src/components/mediaResourcesView/`
+  UI-only center-pane component for media-style resource pages
+- `src/deps/features/resourcePages/media/`
+  shared store/handler helpers for media-family pages
+
+Page-family helpers should own:
+
+- repeated page-store shape
+- repeated page handler wiring
+- shared selection/search/edit orchestration
+
+They should not absorb:
+
+- route structure
+- page-specific dialogs and overlays
+- page-specific upload payload mapping
+- domain rules that belong in services or `src/domain/`
+
+Resource center components must stay presentational.
+
+They may own:
+
+- local UI state such as hover, collapse, zoom, and context menu display
+- rendering normalized item cards
+- emitting generic events such as `item-click`, `item-preview`, `upload-click`
+
+They must not own:
+
+- file picking
+- uploads
+- repository mutations
+- resource-type-specific service orchestration
+
+When a set of resource pages shares the same interaction model, add a family-specific component and shared feature helpers.
+Do not force unrelated resource pages into one universal resource-page system.
+
 ## Public Service Facades
 
 UI handlers should normally talk to only:

--- a/src/components/catalogResourcesView/catalogResourcesView.handlers.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.handlers.js
@@ -1,0 +1,132 @@
+const getDataAttribute = (event, name) => {
+  return event?.currentTarget?.getAttribute?.(name) ?? undefined;
+};
+
+export const handleSearchInput = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const value = payload._event.detail.value ?? "";
+
+  dispatchEvent(
+    new CustomEvent("search-input", {
+      detail: { value },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleGroupClick = (deps, payload) => {
+  const { store, render } = deps;
+  const groupId = getDataAttribute(payload._event, "data-group-id");
+  if (!groupId) {
+    return;
+  }
+
+  store.toggleGroupCollapse({ groupId });
+  render();
+};
+
+export const handleItemClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: { itemId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleItemDoubleClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("item-dblclick", {
+      detail: { itemId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleAddButtonClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  payload._event.stopPropagation();
+
+  dispatchEvent(
+    new CustomEvent("add-click", {
+      detail: {
+        groupId: getDataAttribute(payload._event, "data-group-id"),
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleItemContextMenu = (deps, payload) => {
+  const { store, render } = deps;
+  payload._event.preventDefault();
+
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  store.showContextMenu({
+    itemId,
+    x: payload._event.clientX,
+    y: payload._event.clientY,
+  });
+  render();
+};
+
+export const handleCloseContextMenu = (deps) => {
+  const { store, render } = deps;
+  store.hideContextMenu();
+  render();
+};
+
+export const handleContextMenuClickItem = (deps, payload) => {
+  const { store, render, dispatchEvent } = deps;
+  const action = payload._event.detail.item?.value;
+  const itemId = store.selectDropdownMenu().targetItemId;
+
+  if (!itemId) {
+    store.hideContextMenu();
+    render();
+    return;
+  }
+
+  if (action === "edit-item") {
+    dispatchEvent(
+      new CustomEvent("item-edit", {
+        detail: { itemId },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  if (action === "delete-item") {
+    dispatchEvent(
+      new CustomEvent("item-delete", {
+        detail: { itemId },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  store.hideContextMenu();
+  render();
+};

--- a/src/components/catalogResourcesView/catalogResourcesView.schema.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.schema.yaml
@@ -1,0 +1,31 @@
+componentName: rvn-catalog-resources-view
+propsSchema:
+  type: object
+  properties:
+    navTitle:
+      type: string
+      description: Optional title to display in the header
+    groups:
+      type: array
+      description: Array of normalized catalog groups to display
+    selectedItemId:
+      type: string
+      description: ID of the currently selected item
+    searchQuery:
+      type: string
+      description: Current search query
+    searchPlaceholder:
+      type: string
+      description: Placeholder text for search input
+    emptyMessage:
+      type: string
+      description: Message to show when no items match
+    addText:
+      type: string
+      description: Text to display in add affordances
+    canAdd:
+      type: boolean
+      description: Whether add actions should be shown
+    itemContextMenuItems:
+      type: array
+      description: Context menu items for catalog cards

--- a/src/components/catalogResourcesView/catalogResourcesView.store.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.store.js
@@ -1,0 +1,99 @@
+export const createInitialState = () => ({
+  collapsedIds: [],
+  dropdownMenu: {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    targetItemId: undefined,
+    items: [],
+  },
+});
+
+export const toggleGroupCollapse = ({ state }, { groupId } = {}) => {
+  const index = state.collapsedIds.indexOf(groupId);
+  if (index > -1) {
+    state.collapsedIds.splice(index, 1);
+    return;
+  }
+
+  state.collapsedIds.push(groupId);
+};
+
+export const showContextMenu = ({ state, props }, { itemId, x, y } = {}) => {
+  state.dropdownMenu.isOpen = true;
+  state.dropdownMenu.x = x;
+  state.dropdownMenu.y = y;
+  state.dropdownMenu.targetItemId = itemId;
+  state.dropdownMenu.items = props.itemContextMenuItems ?? [
+    { label: "Delete", type: "item", value: "delete-item" },
+  ];
+};
+
+export const hideContextMenu = ({ state }, _payload = {}) => {
+  state.dropdownMenu.isOpen = false;
+  state.dropdownMenu.x = 0;
+  state.dropdownMenu.y = 0;
+  state.dropdownMenu.targetItemId = undefined;
+  state.dropdownMenu.items = [];
+};
+
+export const selectDropdownMenu = ({ state }) => state.dropdownMenu;
+
+const parseBooleanProp = (value, fallback = false) => {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  if (value === true || value === "") {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1") {
+      return true;
+    }
+    if (normalized === "false" || normalized === "0") {
+      return false;
+    }
+  }
+
+  return Boolean(value);
+};
+
+export const selectViewData = ({ state, props, props: attrs }) => {
+  const canAddAttr = attrs.canAdd ?? attrs["can-add"];
+
+  const groups = (props.groups ?? []).map((group) => {
+    const isCollapsed = state.collapsedIds.includes(group.id);
+    const children = isCollapsed ? [] : (group.children ?? []);
+
+    return {
+      ...group,
+      isCollapsed,
+      children: children.map((item) => {
+        const isSelected = item.id === props.selectedItemId;
+
+        return {
+          ...item,
+          itemBorderColor: isSelected ? "pr" : "bo",
+          itemHoverBorderColor: isSelected ? "pr" : "ac",
+        };
+      }),
+    };
+  });
+
+  return {
+    navTitle: props.navTitle,
+    groups,
+    selectedItemId: props.selectedItemId,
+    searchQuery: props.searchQuery ?? "",
+    searchPlaceholder: props.searchPlaceholder ?? "Search...",
+    emptyMessage:
+      props.emptyMessage ??
+      `No items found matching "${props.searchQuery ?? ""}"`,
+    addText: props.addText ?? "Add",
+    canAdd: parseBooleanProp(canAddAttr, true),
+    dropdownMenu: state.dropdownMenu,
+  };
+};

--- a/src/components/catalogResourcesView/catalogResourcesView.store.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.store.js
@@ -76,6 +76,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
 
         return {
           ...item,
+          itemWidth: item.itemWidth ?? 225,
           itemBorderColor: isSelected ? "pr" : "bo",
           itemHoverBorderColor: isSelected ? "pr" : "ac",
         };

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -62,6 +62,10 @@ template:
                                                   - rtgl-text s=md ellipsis w=f: ${item.name}
                                                   - $if item.subtitle:
                                                       - rtgl-text s=sm c=mu-fg ellipsis w=f: ${item.subtitle}
+                                            $elif item.cardKind == 'transform':
+                                              - rtgl-view w=225 p=md g=md br=md:
+                                                  - rvn-transform-thumbnail :item=#{item} w=193 h=120: null
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=193: ${item.name}
                                             $else:
                                               - rtgl-view w=225 h=152 d=v ah=c av=c br=md p=md g=sm:
                                                   - rtgl-text s=md ellipsis w=f: ${item.name}

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -1,0 +1,81 @@
+refs:
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
+  contextMenu:
+    eventListeners:
+      close:
+        handler: handleCloseContextMenu
+      item-click:
+        handler: handleContextMenuClickItem
+  addBtn*:
+    eventListeners:
+      click:
+        handler: handleAddButtonClick
+  groupToggle*:
+    eventListeners:
+      click:
+        handler: handleGroupClick
+  item*:
+    eventListeners:
+      click:
+        handler: handleItemClick
+      dblclick:
+        handler: handleItemDoubleClick
+      contextmenu:
+        handler: handleItemContextMenu
+template:
+  - 'rtgl-view w=f h=100vh g=lg style="min-width: 0;"':
+      - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
+          - rtgl-view w=f d=h av=c g=md wrap:
+              - rtgl-view av=c g=sm d=h w=1fg:
+                  - $if navTitle:
+                      - rtgl-text c=mu-fg: ${navTitle}
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
+      - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
+          - $if groups.length > 0:
+              - $for group, gIndex in groups:
+                  - rtgl-view w=f ph=md:
+                      - 'rtgl-view d=h w=f av=c style="position: sticky; top: 0px;"':
+                          - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
+                              - $if group.isCollapsed:
+                                  - rtgl-svg wh=16 svg=folderArrowRight: null
+                                $else:
+                                  - rtgl-svg wh=16 svg=folderArrowDown: null
+                              - rtgl-svg wh=16 svg=folder: null
+                              - rtgl-text: ${group.fullLabel}
+                          - rtgl-view w=1fg: null
+                          - $if canAdd:
+                              - rtgl-button#addBtnHeaderRef${gIndex} data-group-id=${group.id} s=sm w=1fg pre=plus: ${addText}
+                      - $if !group.isCollapsed:
+                          - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
+                              - $if group.hasChildren:
+                                  - $for item, itemIndex in group.children:
+                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} w=225 cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                          - $if item.cardKind == 'color':
+                                              - 'rtgl-view p=md g=md br=md style="overflow: hidden;"':
+                                                  - 'rtgl-view w=193 h=120 br=sm style="background-color: ${item.swatchHex};"': null
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=193: ${item.name}
+                                            $elif item.cardKind == 'layout':
+                                              - rtgl-view w=225 h=152 d=v ah=c av=c br=md p=md g=sm:
+                                                  - rtgl-text s=md ellipsis w=f: ${item.name}
+                                                  - $if item.subtitle:
+                                                      - rtgl-text s=sm c=mu-fg ellipsis w=f: ${item.subtitle}
+                                            $else:
+                                              - rtgl-view w=225 h=152 d=v ah=c av=c br=md p=md g=sm:
+                                                  - rtgl-text s=md ellipsis w=f: ${item.name}
+                                                  - $if item.subtitle:
+                                                      - rtgl-text s=sm c=mu-fg ellipsis w=f: ${item.subtitle}
+                                $else:
+                                  - $if canAdd:
+                                      - rtgl-view#addBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 av=c ah=c g=md bw=xs bc=bo br=md cur=pointer:
+                                          - rtgl-svg svg=plus wh=24: null
+                                          - rtgl-text: ${addText}
+            $elif searchQuery:
+              - rtgl-view w=f h=400 av=c ah=c:
+                  - rtgl-text s=lg c=mu-fg: ${emptyMessage}
+            $else:
+              - rtgl-view w=f h=f av=c ah=c:
+                  - rtgl-text s=lg c=mu-fg: No data
+  - rtgl-dropdown-menu#contextMenu :items=dropdownMenu.items ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -52,7 +52,7 @@ template:
                           - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
                               - $if group.hasChildren:
                                   - $for item, itemIndex in group.children:
-                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} w=225 cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} w=${item.itemWidth} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
                                           - $if item.cardKind == 'color':
                                               - 'rtgl-view p=md g=md br=md style="overflow: hidden;"':
                                                   - 'rtgl-view w=193 h=120 br=sm style="background-color: ${item.swatchHex};"': null
@@ -66,6 +66,10 @@ template:
                                               - rtgl-view w=225 p=md g=md br=md:
                                                   - rvn-transform-thumbnail :item=#{item} w=193 h=120: null
                                                   - rtgl-text s=xs c=mu-fg ellipsis w=193: ${item.name}
+                                            $elif item.cardKind == 'tween':
+                                              - rtgl-view w=f h=1fg bgc=bg br=md p=md:
+                                                  - rtgl-text s=h4 mb=md: ${item.name}
+                                                  - rvn-keyframe-timeline :properties=#{item.properties}: null
                                             $else:
                                               - rtgl-view w=225 h=152 d=v ah=c av=c br=md p=md g=sm:
                                                   - rtgl-text s=md ellipsis w=f: ${item.name}

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -1,0 +1,281 @@
+import {
+  getAcceptAttribute,
+  isFileTypeAccepted,
+} from "../../utils/fileTypeUtils.js";
+
+const getDataAttribute = (event, name) => {
+  return event?.currentTarget?.getAttribute?.(name) ?? undefined;
+};
+
+export const handleSearchInput = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const value = payload._event.detail.value ?? "";
+
+  dispatchEvent(
+    new CustomEvent("search-input", {
+      detail: { value },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleDragEnter = (deps, payload) => {
+  const { store, render, props } = deps;
+  if (props.canUpload === false) {
+    return;
+  }
+
+  payload._event.preventDefault();
+  payload._event.stopPropagation();
+
+  const groupId = getDataAttribute(payload._event, "data-group-id");
+  if (!groupId) {
+    return;
+  }
+
+  store.setDraggingGroupId({ groupId });
+  render();
+};
+
+export const handleDragOver = (deps, payload) => {
+  payload._event.preventDefault();
+  payload._event.stopPropagation();
+};
+
+export const handleDragLeave = (deps, payload) => {
+  const { store, render } = deps;
+  payload._event.preventDefault();
+  payload._event.stopPropagation();
+
+  const relatedTarget = payload._event.relatedTarget;
+  const currentTarget = payload._event.currentTarget;
+
+  if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+    store.setDraggingGroupId({ groupId: undefined });
+    render();
+  }
+};
+
+export const handleDrop = (deps, payload) => {
+  const { dispatchEvent, store, render, props } = deps;
+  if (props.canUpload === false) {
+    return;
+  }
+
+  payload._event.preventDefault();
+  payload._event.stopPropagation();
+
+  const targetGroupId = store.selectDraggingGroupId();
+  store.setDraggingGroupId({ groupId: undefined });
+  render();
+
+  const files = Array.from(payload._event.dataTransfer?.files ?? []).filter(
+    (file) => isFileTypeAccepted(file, props.acceptedFileTypes),
+  );
+
+  if (!files.length) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("files-dropped", {
+      detail: {
+        files,
+        targetGroupId,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleGroupClick = (deps, payload) => {
+  const { store, render } = deps;
+  const groupId = getDataAttribute(payload._event, "data-group-id");
+  if (!groupId) {
+    return;
+  }
+
+  store.toggleGroupCollapse({ groupId });
+  render();
+};
+
+export const handleItemClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: { itemId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleItemMouseEnter = (deps, payload) => {
+  const { store, render } = deps;
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId || store.selectHoveredItemId() === itemId) {
+    return;
+  }
+
+  store.setHoveredItemId({ itemId });
+  render();
+};
+
+export const handleItemMouseLeave = (deps) => {
+  const { store, render } = deps;
+  if (store.selectHoveredItemId() === undefined) {
+    return;
+  }
+
+  store.setHoveredItemId({ itemId: undefined });
+  render();
+};
+
+export const handleItemDoubleClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("item-dblclick", {
+      detail: { itemId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handlePreviewActionClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  payload._event.stopPropagation();
+
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("item-preview", {
+      detail: { itemId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleUploadButtonClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  payload._event.stopPropagation();
+
+  dispatchEvent(
+    new CustomEvent("upload-click", {
+      detail: {
+        groupId: getDataAttribute(payload._event, "data-group-id"),
+        accept: getAcceptAttribute(deps.props.acceptedFileTypes),
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleZoomChange = (deps, payload) => {
+  const { store, render } = deps;
+  const zoomLevel = parseFloat(
+    payload._event.detail?.value ?? payload._event.target?.value ?? 1,
+  );
+
+  store.setZoomLevel({ zoomLevel });
+  render();
+};
+
+export const handleZoomIn = (deps) => {
+  const { store, render } = deps;
+  const zoomLevel = Math.min(4, store.selectZoomLevel() + 0.1);
+  store.setZoomLevel({ zoomLevel });
+  render();
+};
+
+export const handleZoomOut = (deps) => {
+  const { store, render } = deps;
+  const zoomLevel = Math.max(0.5, store.selectZoomLevel() - 0.1);
+  store.setZoomLevel({ zoomLevel });
+  render();
+};
+
+export const handleItemContextMenu = (deps, payload) => {
+  const { store, render } = deps;
+  payload._event.preventDefault();
+
+  const itemId = getDataAttribute(payload._event, "data-item-id");
+  if (!itemId) {
+    return;
+  }
+
+  store.showContextMenu({
+    itemId,
+    x: payload._event.clientX,
+    y: payload._event.clientY,
+  });
+  render();
+};
+
+export const handleCloseContextMenu = (deps) => {
+  const { store, render } = deps;
+  store.hideContextMenu();
+  render();
+};
+
+export const handleContextMenuClickItem = (deps, payload) => {
+  const { store, render, dispatchEvent } = deps;
+  const action = payload._event.detail.item?.value;
+  const itemId = store.selectDropdownMenu().targetItemId;
+
+  if (!itemId) {
+    store.hideContextMenu();
+    render();
+    return;
+  }
+
+  if (action === "edit-item") {
+    dispatchEvent(
+      new CustomEvent("item-edit", {
+        detail: { itemId },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  if (action === "preview-item") {
+    dispatchEvent(
+      new CustomEvent("item-preview", {
+        detail: { itemId },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  if (action === "delete-item") {
+    dispatchEvent(
+      new CustomEvent("item-delete", {
+        detail: { itemId },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  store.hideContextMenu();
+  render();
+};

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -20,6 +20,17 @@ export const handleSearchInput = (deps, payload) => {
   );
 };
 
+export const handleBackClick = (deps) => {
+  const { dispatchEvent } = deps;
+
+  dispatchEvent(
+    new CustomEvent("back-click", {
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
 export const handleDragEnter = (deps, payload) => {
   const { store, render, props } = deps;
   if (props.canUpload === false) {

--- a/src/components/mediaResourcesView/mediaResourcesView.schema.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.schema.yaml
@@ -35,6 +35,9 @@ propsSchema:
     showZoomControls:
       type: boolean
       description: Whether to show zoom controls
+    showBackButton:
+      type: boolean
+      description: Whether to show a back button in the header
     canUpload:
       type: boolean
       description: Whether upload actions should be shown

--- a/src/components/mediaResourcesView/mediaResourcesView.schema.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.schema.yaml
@@ -1,0 +1,43 @@
+componentName: rvn-media-resources-view
+propsSchema:
+  type: object
+  properties:
+    navTitle:
+      type: string
+      description: Optional title to display in the header
+    groups:
+      type: array
+      description: Array of normalized media groups to display
+    selectedItemId:
+      type: string
+      description: ID of the currently selected item
+    searchQuery:
+      type: string
+      description: Current search query
+    uploadText:
+      type: string
+      description: Text to display in upload affordances
+    acceptedFileTypes:
+      type: array
+      description: Array of accepted file extensions
+    searchPlaceholder:
+      type: string
+      description: Placeholder text for search input
+    emptyMessage:
+      type: string
+      description: Message to show when no items match
+    imageHeight:
+      type: number
+      description: Base height for image cards
+    maxWidth:
+      type: number
+      description: Base width for image cards
+    showZoomControls:
+      type: boolean
+      description: Whether to show zoom controls
+    canUpload:
+      type: boolean
+      description: Whether upload actions should be shown
+    itemContextMenuItems:
+      type: array
+      description: Context menu items for media cards

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -101,6 +101,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
   const mediaHeight = Math.round(baseMediaHeight * state.zoomLevel);
   const showZoomControlsAttr =
     attrs.showZoomControls ?? attrs["show-zoom-controls"];
+  const showBackButtonAttr = attrs.showBackButton ?? attrs["show-back-button"];
   const canUploadAttr = attrs.canUpload ?? attrs["can-upload"];
 
   const groups = (props.groups ?? []).map((group) => {
@@ -143,6 +144,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     mediaHeight,
     zoomLevel: state.zoomLevel,
     showZoomControls: parseBooleanProp(showZoomControlsAttr),
+    showBackButton: parseBooleanProp(showBackButtonAttr),
     canUpload: parseBooleanProp(canUploadAttr, true),
     draggingGroupId: state.draggingGroupId,
     dropdownMenu: state.dropdownMenu,

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -1,0 +1,150 @@
+export const createInitialState = () => ({
+  zoomLevel: 1,
+  collapsedIds: [],
+  hoveredItemId: undefined,
+  dropdownMenu: {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    targetItemId: undefined,
+    items: [],
+  },
+  draggingGroupId: undefined,
+});
+
+export const setZoomLevel = ({ state }, { zoomLevel } = {}) => {
+  state.zoomLevel = zoomLevel;
+};
+
+export const selectZoomLevel = ({ state }) => state.zoomLevel;
+
+export const setDraggingGroupId = ({ state }, { groupId } = {}) => {
+  state.draggingGroupId = groupId;
+};
+
+export const selectDraggingGroupId = ({ state }) => state.draggingGroupId;
+
+export const setHoveredItemId = ({ state }, { itemId } = {}) => {
+  state.hoveredItemId = itemId;
+};
+
+export const selectHoveredItemId = ({ state }) => state.hoveredItemId;
+
+export const toggleGroupCollapse = ({ state }, { groupId } = {}) => {
+  const index = state.collapsedIds.indexOf(groupId);
+  if (index > -1) {
+    state.collapsedIds.splice(index, 1);
+    return;
+  }
+
+  state.collapsedIds.push(groupId);
+};
+
+export const showContextMenu = ({ state, props }, { itemId, x, y } = {}) => {
+  state.dropdownMenu.isOpen = true;
+  state.dropdownMenu.x = x;
+  state.dropdownMenu.y = y;
+  state.dropdownMenu.targetItemId = itemId;
+  state.dropdownMenu.items = props.itemContextMenuItems ?? [
+    { label: "Delete", type: "item", value: "delete-item" },
+  ];
+};
+
+export const hideContextMenu = ({ state }, _payload = {}) => {
+  state.dropdownMenu.isOpen = false;
+  state.dropdownMenu.x = 0;
+  state.dropdownMenu.y = 0;
+  state.dropdownMenu.targetItemId = undefined;
+  state.dropdownMenu.items = [];
+};
+
+export const selectDropdownMenu = ({ state }) => state.dropdownMenu;
+
+const parseBooleanProp = (value, fallback = false) => {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  if (value === true || value === "") {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1") {
+      return true;
+    }
+    if (normalized === "false" || normalized === "0") {
+      return false;
+    }
+  }
+
+  return Boolean(value);
+};
+
+const resolveDefaultBorderColor = (cardKind) => {
+  if (cardKind === "sound" || cardKind === "video") {
+    return "tr";
+  }
+
+  return "bo";
+};
+
+export const selectViewData = ({ state, props, props: attrs }) => {
+  const baseHeight = props.imageHeight ?? 150;
+  const baseWidth = props.maxWidth ?? 400;
+  const baseMediaWidth = 225;
+  const baseMediaHeight = 150;
+  const imageHeight = Math.round(baseHeight * state.zoomLevel);
+  const maxWidth = Math.round(baseWidth * state.zoomLevel);
+  const mediaWidth = Math.round(baseMediaWidth * state.zoomLevel);
+  const mediaHeight = Math.round(baseMediaHeight * state.zoomLevel);
+  const showZoomControlsAttr =
+    attrs.showZoomControls ?? attrs["show-zoom-controls"];
+  const canUploadAttr = attrs.canUpload ?? attrs["can-upload"];
+
+  const groups = (props.groups ?? []).map((group) => {
+    const isCollapsed = state.collapsedIds.includes(group.id);
+    const children = isCollapsed ? [] : (group.children ?? []);
+
+    return {
+      ...group,
+      isCollapsed,
+      children: children.map((item) => {
+        const isSelected = item.id === props.selectedItemId;
+        const defaultBorderColor = resolveDefaultBorderColor(item.cardKind);
+
+        return {
+          ...item,
+          itemBorderColor: isSelected ? "pr" : defaultBorderColor,
+          itemHoverBorderColor: isSelected ? "pr" : "ac",
+          showPreviewIcon: Boolean(
+            item.canPreview && item.id === state.hoveredItemId,
+          ),
+        };
+      }),
+    };
+  });
+
+  return {
+    navTitle: props.navTitle,
+    groups,
+    selectedItemId: props.selectedItemId,
+    searchQuery: props.searchQuery ?? "",
+    searchPlaceholder: props.searchPlaceholder ?? "Search...",
+    uploadText: props.uploadText ?? "Upload Files",
+    emptyMessage:
+      props.emptyMessage ??
+      `No items found matching "${props.searchQuery ?? ""}"`,
+    acceptedFileTypes: props.acceptedFileTypes ?? [],
+    imageHeight,
+    maxWidth,
+    mediaWidth,
+    mediaHeight,
+    zoomLevel: state.zoomLevel,
+    showZoomControls: parseBooleanProp(showZoomControlsAttr),
+    canUpload: parseBooleanProp(canUploadAttr, true),
+    draggingGroupId: state.draggingGroupId,
+    dropdownMenu: state.dropdownMenu,
+  };
+};

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -3,6 +3,10 @@ refs:
     eventListeners:
       value-input:
         handler: handleSearchInput
+  backButton:
+    eventListeners:
+      click:
+        handler: handleBackClick
   contextMenu:
     eventListeners:
       close:
@@ -62,6 +66,8 @@ template:
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
+                  - $if showBackButton:
+                      - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
                   - $if navTitle:
                       - rtgl-text c=mu-fg: ${navTitle}
               - rtgl-view d=h av=c g=md:

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -1,0 +1,151 @@
+refs:
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
+  contextMenu:
+    eventListeners:
+      close:
+        handler: handleCloseContextMenu
+      item-click:
+        handler: handleContextMenuClickItem
+  zoomSlider:
+    eventListeners:
+      change:
+        handler: handleZoomChange
+      input:
+        handler: handleZoomChange
+  zoomOut:
+    eventListeners:
+      click:
+        handler: handleZoomOut
+  zoomIn:
+    eventListeners:
+      click:
+        handler: handleZoomIn
+  uploadBtn*:
+    eventListeners:
+      click:
+        handler: handleUploadButtonClick
+  groupToggle*:
+    eventListeners:
+      click:
+        handler: handleGroupClick
+  item*:
+    eventListeners:
+      click:
+        handler: handleItemClick
+      dblclick:
+        handler: handleItemDoubleClick
+      mouseenter:
+        handler: handleItemMouseEnter
+      mouseleave:
+        handler: handleItemMouseLeave
+      contextmenu:
+        handler: handleItemContextMenu
+  groupDrop*:
+    eventListeners:
+      dragenter:
+        handler: handleDragEnter
+      dragover:
+        handler: handleDragOver
+      dragleave:
+        handler: handleDragLeave
+      drop:
+        handler: handleDrop
+  previewAction*:
+    eventListeners:
+      click:
+        handler: handlePreviewActionClick
+template:
+  - 'rtgl-view w=f h=100vh g=lg style="min-width: 0;"':
+      - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
+          - rtgl-view w=f d=h av=c g=md wrap:
+              - rtgl-view av=c g=sm d=h w=1fg:
+                  - $if navTitle:
+                      - rtgl-text c=mu-fg: ${navTitle}
+              - rtgl-view d=h av=c g=md:
+                  - $if showZoomControls:
+                      - rtgl-view d=h av=c g=sm:
+                          - rtgl-button#zoomOut sq v="gh" s=sm: '-'
+                          - input#zoomSlider type="range" w=120 min="0.5" max="4.0" step="0.1" value="${zoomLevel}": null
+                          - rtgl-button#zoomIn sq v="gh" s=sm: +
+                  - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
+      - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
+          - $if groups.length > 0:
+              - $for group, gIndex in groups:
+                  - rtgl-view#groupDropRef${gIndex} data-group-id=${group.id} w=f ph=md pos=rel:
+                      - $if draggingGroupId == group.id:
+                          - 'rtgl-view d=h av=c pos=abs w=f h=f bw=md bc=pr bgc=se op="0.5" style="top: 0; bottom: 0; left: 0; right: 0;"':
+                              - rtgl-view w=f h=f av=c ah=c:
+                                  - rtgl-text s=lg: Drag file to this area to upload
+                      - 'rtgl-view d=h w=f av=c style="position: sticky; top: 0px;"':
+                          - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
+                              - $if group.isCollapsed:
+                                  - rtgl-svg wh=16 svg=folderArrowRight: null
+                                $else:
+                                  - rtgl-svg wh=16 svg=folderArrowDown: null
+                              - rtgl-svg wh=16 svg=folder: null
+                              - rtgl-text: ${group.fullLabel}
+                          - rtgl-view w=1fg: null
+                          - $if canUpload:
+                              - rtgl-button#uploadBtnHeaderRef${gIndex} data-group-id=${group.id} s=sm w=1fg pre=upload: ${uploadText}
+                      - $if !group.isCollapsed:
+                          - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
+                              - $if group.hasChildren:
+                                  - $for item, itemIndex in group.children:
+                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                          - $if item.cardKind == 'image':
+                                              - 'rtgl-view p=md g=md br=md w=${maxWidth} pos=rel style="max-width: 100%;"':
+                                                  - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.imageFileId} key=${item.imageFileId}-${imageHeight}x${maxWidth}: null
+                                                  - $if item.showPreviewIcon:
+                                                      - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} bw=xs bc=ac bgc=bg br=f w=24 h=24 ah=c av=c pos=abs cur=pointer style="top: 8px; right: 8px; z-index: 2;"':
+                                                          - rtgl-svg svg=zoomIn wh=12 c=ac: null
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
+                                            $elif item.cardKind == 'video':
+                                              - 'rtgl-view p=md g=md br=md pos=rel':
+                                                  - $if item.thumbnailFileId:
+                                                      - rvn-file-image br=md w=${mediaWidth} h=${mediaHeight} fileId=${item.thumbnailFileId}: null
+                                                    $else:
+                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-text s=xs c=mu-fg: No thumbnail
+                                                  - $if item.showPreviewIcon:
+                                                      - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} bw=xs bc=ac bgc=bg br=f w=24 h=24 ah=c av=c pos=abs cur=pointer style="top: 8px; right: 8px; z-index: 2;"':
+                                                          - rtgl-svg svg=play wh=12 c=ac: null
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                            $elif item.cardKind == 'sound':
+                                              - 'rtgl-view p=md g=md br=md pos=rel':
+                                                  - $if item.waveformDataFileId:
+                                                      - rtgl-view g=md:
+                                                          - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=${mediaWidth} h=${mediaHeight}: null
+                                                          - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                    $else:
+                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-text s=xs c=mu-fg: No waveform
+                                                  - $if item.showPreviewIcon:
+                                                      - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} bw=xs bc=ac bgc=bg br=f w=24 h=24 ah=c av=c pos=abs cur=pointer style="top: 8px; right: 8px; z-index: 2;"':
+                                                          - rtgl-svg svg=play wh=12 c=ac: null
+                                            $elif item.cardKind == 'font':
+                                              - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
+                                                  - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=${mediaWidth} height=${mediaHeight} av=c ah=c: null
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                            $else:
+                                              - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                $else:
+                                  - $if canUpload:
+                                      - rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=sm cur=pointer:
+                                          - rtgl-svg svg=upload wh=32: null
+                                          - rtgl-text: ${uploadText}
+            $elif searchQuery:
+              - rtgl-view w=f h=400 av=c ah=c:
+                  - rtgl-text s=lg c=mu-fg: ${emptyMessage}
+            $else:
+              - rtgl-view w=f h=f av=c ah=c g=lg:
+                  - $if canUpload:
+                      - rtgl-view#uploadBtnRoot w=300 h=200 bw=xs bc=bo br=md ah=c av=c g=sm cur=pointer:
+                          - rtgl-svg svg=upload wh=32: null
+                          - rtgl-text: ${uploadText}
+                    $else:
+                      - rtgl-text s=lg c=mu-fg: No data
+  - rtgl-dropdown-menu#contextMenu :items=dropdownMenu.items ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null

--- a/src/deps/features/resourcePages/catalog/createCatalogPageHandlers.js
+++ b/src/deps/features/resourcePages/catalog/createCatalogPageHandlers.js
@@ -1,0 +1,74 @@
+import { createResourceFileExplorerHandlers } from "../../fileExplorerHandlers.js";
+
+const EMPTY_TREE = { tree: [], items: {} };
+
+export const createCatalogPageHandlers = ({
+  resourceType,
+  createExplorerHandlers = ({ refresh }) =>
+    createResourceFileExplorerHandlers({
+      resourceType,
+      refresh,
+    }),
+}) => {
+  const refreshData = async (deps) => {
+    const { store, render, projectService } = deps;
+    const data = projectService.getState()[resourceType] ?? EMPTY_TREE;
+    store.setItems({ data });
+    render();
+  };
+
+  const handleAfterMount = async (deps) => {
+    const { projectService } = deps;
+    await projectService.ensureRepository();
+    await refreshData(deps);
+  };
+
+  const handleFileExplorerSelectionChanged = (deps, payload) => {
+    const { store, render } = deps;
+    const { itemId, isFolder } = payload._event.detail;
+
+    if (isFolder) {
+      store.setSelectedItemId({ itemId: undefined });
+      render();
+      return;
+    }
+
+    if (!itemId) {
+      return;
+    }
+
+    store.setSelectedItemId({ itemId });
+    render();
+  };
+
+  const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
+    createExplorerHandlers({ refresh: refreshData });
+
+  const handleItemClick = (deps, payload) => {
+    const { store, render, refs } = deps;
+    const { itemId } = payload._event.detail;
+    if (!itemId) {
+      return;
+    }
+
+    store.setSelectedItemId({ itemId });
+    refs.fileExplorer.selectItem({ itemId });
+    render();
+  };
+
+  const handleSearchInput = (deps, payload) => {
+    const { store, render } = deps;
+    store.setSearchQuery({ value: payload._event.detail.value ?? "" });
+    render();
+  };
+
+  return {
+    refreshData,
+    handleAfterMount,
+    handleFileExplorerSelectionChanged,
+    handleFileExplorerAction,
+    handleFileExplorerTargetChanged,
+    handleItemClick,
+    handleSearchInput,
+  };
+};

--- a/src/deps/features/resourcePages/catalog/createCatalogPageStore.js
+++ b/src/deps/features/resourcePages/catalog/createCatalogPageStore.js
@@ -1,0 +1,152 @@
+import { toFlatGroups, toFlatItems } from "../../../../domain/treeHelpers.js";
+
+const EMPTY_TREE = { tree: [], items: {} };
+
+const folderContextMenuItems = [
+  { label: "New Folder", type: "item", value: "new-child-folder" },
+  { label: "Duplicate", type: "item", value: "duplicate-item" },
+  { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const itemContextMenuItems = [
+  { label: "Duplicate", type: "item", value: "duplicate-item" },
+  { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const emptyContextMenuItems = [
+  { label: "New Folder", type: "item", value: "new-item" },
+];
+
+const defaultCenterItemContextMenuItems = [
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const defaultMatchesSearch = (item, searchQuery) => {
+  if (!searchQuery) {
+    return true;
+  }
+
+  const name = (item.name ?? "").toLowerCase();
+  return name.includes(searchQuery);
+};
+
+export const createCatalogPageStore = ({
+  itemType,
+  resourceType,
+  title,
+  selectedResourceId = resourceType,
+  resourceCategory = "userInterface",
+  addText = "Add",
+  searchPlaceholder = "Search...",
+  emptyMessage,
+  centerItemContextMenuItems = defaultCenterItemContextMenuItems,
+  matchesSearch = defaultMatchesSearch,
+  buildDetailFields = () => [],
+  buildCatalogItem = (item) => item,
+  extendViewData,
+}) => {
+  const selectDataItem = (state, itemId) => {
+    const item = state.data?.items?.[itemId];
+    return item?.type === itemType ? item : undefined;
+  };
+
+  const createInitialState = () => ({
+    data: EMPTY_TREE,
+    selectedItemId: undefined,
+    searchQuery: "",
+  });
+
+  const setItems = ({ state }, { data } = {}) => {
+    state.data = data ?? EMPTY_TREE;
+  };
+
+  const setSelectedItemId = ({ state }, { itemId } = {}) => {
+    state.selectedItemId = itemId;
+  };
+
+  const selectSelectedItem = ({ state }) => {
+    return selectDataItem(state, state.selectedItemId);
+  };
+
+  const selectItemById = ({ state }, { itemId } = {}) => {
+    return selectDataItem(state, itemId);
+  };
+
+  const selectSelectedItemId = ({ state }) => state.selectedItemId;
+
+  const setSearchQuery = ({ state }, { value } = {}) => {
+    state.searchQuery = value ?? "";
+  };
+
+  const selectViewData = ({ state }) => {
+    const flatItems = toFlatItems(state.data);
+    const rawFlatGroups = toFlatGroups(state.data);
+    const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+
+    const catalogGroups = rawFlatGroups
+      .map((group) => {
+        const filteredChildren = (group.children ?? []).filter((item) =>
+          matchesSearch(item, searchQuery),
+        );
+        const groupName = (group.name ?? "").toLowerCase();
+        const shouldShowGroup =
+          !searchQuery ||
+          filteredChildren.length > 0 ||
+          groupName.includes(searchQuery);
+
+        return {
+          ...group,
+          children: filteredChildren.map(buildCatalogItem),
+          hasChildren: filteredChildren.length > 0,
+          shouldDisplay: shouldShowGroup,
+        };
+      })
+      .filter((group) => group.shouldDisplay);
+
+    const selectedItem = selectDataItem(state, state.selectedItemId);
+
+    const baseViewData = {
+      flatItems,
+      catalogGroups,
+      resourceCategory,
+      selectedResourceId,
+      selectedItemId: state.selectedItemId,
+      selectedItemName: selectedItem?.name ?? "",
+      detailFields: buildDetailFields(selectedItem),
+      searchQuery: state.searchQuery,
+      searchPlaceholder,
+      title,
+      addText,
+      emptyMessage,
+      folderContextMenuItems,
+      itemContextMenuItems,
+      emptyContextMenuItems,
+      centerItemContextMenuItems,
+    };
+
+    if (!extendViewData) {
+      return baseViewData;
+    }
+
+    return extendViewData({
+      state,
+      flatItems,
+      selectedItem,
+      catalogGroups,
+      baseViewData,
+    });
+  };
+
+  return {
+    createInitialState,
+    setItems,
+    setSelectedItemId,
+    selectSelectedItem,
+    selectItemById,
+    selectSelectedItemId,
+    setSearchQuery,
+    selectViewData,
+  };
+};

--- a/src/deps/features/resourcePages/media/createMediaPageHandlers.js
+++ b/src/deps/features/resourcePages/media/createMediaPageHandlers.js
@@ -1,0 +1,146 @@
+import { createResourceFileExplorerHandlers } from "../../fileExplorerHandlers.js";
+import { syncMediaPageData } from "./mediaPageShared.js";
+
+export const createMediaPageHandlers = ({
+  resourceType,
+  subscriptions,
+  selectItemById = (store, { itemId }) => store.selectItemById({ itemId }),
+  getEditValues = (item) => ({
+    name: item?.name ?? "",
+    description: item?.description ?? "",
+  }),
+  getEditPreviewFileId = () => undefined,
+}) => {
+  const refreshData = async (deps) => {
+    const { store, render, projectService } = deps;
+    syncMediaPageData({
+      store,
+      projectService,
+      resourceType,
+    });
+    render();
+  };
+
+  const openEditDialogWithValues = ({ deps, itemId } = {}) => {
+    const { store, refs, render } = deps;
+    const { fileExplorer, editForm } = refs;
+
+    if (!itemId) {
+      return;
+    }
+
+    const item = selectItemById(store, { itemId });
+    if (!item) {
+      return;
+    }
+
+    const editValues = getEditValues(item);
+
+    store.setSelectedItemId({ itemId });
+    fileExplorer.selectItem({ itemId });
+    store.openEditDialog({
+      itemId,
+      defaultValues: editValues,
+      previewFileId: getEditPreviewFileId(item),
+    });
+    render();
+    editForm.reset();
+    editForm.setValues({ values: editValues });
+  };
+
+  const mountSubscriptions = (deps) => {
+    const streams = subscriptions?.(deps) ?? [];
+    if (!streams.length) {
+      return undefined;
+    }
+
+    const active = streams.map((stream) => stream.subscribe());
+    return () =>
+      active.forEach((subscription) => subscription?.unsubscribe?.());
+  };
+
+  const handleBeforeMount = (deps) => {
+    const { store, projectService } = deps;
+    syncMediaPageData({
+      store,
+      projectService,
+      resourceType,
+    });
+    return mountSubscriptions(deps);
+  };
+
+  const handleFileExplorerSelectionChanged = (deps, payload) => {
+    const { store, render } = deps;
+    const { itemId, isFolder } = payload._event.detail;
+
+    if (isFolder) {
+      store.setSelectedItemId({ itemId: undefined });
+      render();
+      return;
+    }
+
+    if (!itemId) {
+      return;
+    }
+
+    store.setSelectedItemId({ itemId });
+    render();
+  };
+
+  const handleFileExplorerDoubleClick = (deps, payload) => {
+    const { itemId, isFolder } = payload._event.detail;
+    if (isFolder) {
+      return;
+    }
+
+    openEditDialogWithValues({ deps, itemId });
+  };
+
+  const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
+    createResourceFileExplorerHandlers({
+      resourceType,
+      refresh: refreshData,
+    });
+
+  const handleItemClick = (deps, payload) => {
+    const { store, render, refs } = deps;
+    const { itemId } = payload._event.detail;
+    if (!itemId) {
+      return;
+    }
+
+    store.setSelectedItemId({ itemId });
+    refs.fileExplorer.selectItem({ itemId });
+    render();
+  };
+
+  const handleItemDoubleClick = (deps, payload) => {
+    const { itemId } = payload._event.detail;
+    openEditDialogWithValues({ deps, itemId });
+  };
+
+  const handleItemEdit = (deps, payload) => {
+    const { itemId } = payload._event.detail;
+    openEditDialogWithValues({ deps, itemId });
+  };
+
+  const handleSearchInput = (deps, payload) => {
+    const { store, render } = deps;
+    store.setSearchQuery({ value: payload._event.detail.value ?? "" });
+    render();
+  };
+
+  return {
+    refreshData,
+    openEditDialogWithValues,
+    handleBeforeMount,
+    handleFileExplorerSelectionChanged,
+    handleFileExplorerDoubleClick,
+    handleFileExplorerAction,
+    handleFileExplorerTargetChanged,
+    handleItemClick,
+    handleItemDoubleClick,
+    handleItemEdit,
+    handleSearchInput,
+  };
+};

--- a/src/deps/features/resourcePages/media/createMediaPageStore.js
+++ b/src/deps/features/resourcePages/media/createMediaPageStore.js
@@ -1,0 +1,222 @@
+import { toFlatGroups, toFlatItems } from "../../../../domain/treeHelpers.js";
+
+const EMPTY_TREE = { tree: [], items: {} };
+
+const folderContextMenuItems = [
+  { label: "New Folder", type: "item", value: "new-child-folder" },
+  { label: "Duplicate", type: "item", value: "duplicate-item" },
+  { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const itemContextMenuItems = [
+  { label: "Duplicate", type: "item", value: "duplicate-item" },
+  { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const emptyContextMenuItems = [
+  { label: "New Folder", type: "item", value: "new-item" },
+];
+
+const createCenterItemContextMenuItems = (previewMenuLabel) => {
+  const items = [{ label: "Edit", type: "item", value: "edit-item" }];
+
+  if (previewMenuLabel) {
+    items.push({
+      label: previewMenuLabel,
+      type: "item",
+      value: "preview-item",
+    });
+  }
+
+  items.push({ label: "Delete", type: "item", value: "delete-item" });
+  return items;
+};
+
+const defaultMatchesSearch = (item, searchQuery) => {
+  if (!searchQuery) {
+    return true;
+  }
+
+  const name = (item.name ?? "").toLowerCase();
+  const description = (item.description ?? "").toLowerCase();
+
+  return name.includes(searchQuery) || description.includes(searchQuery);
+};
+
+export const createMediaPageStore = ({
+  itemType,
+  resourceType,
+  title,
+  selectedResourceId = resourceType,
+  resourceCategory = "assets",
+  uploadText,
+  acceptedFileTypes,
+  imageHeight = 150,
+  maxWidth = 400,
+  showZoomControls = false,
+  searchPlaceholder = "Search...",
+  previewMenuLabel = "Preview",
+  centerItemContextMenuItems,
+  matchesSearch = defaultMatchesSearch,
+  buildDetailFields = () => [],
+  buildMediaItem = (item) => item,
+  createEditForm = () => undefined,
+  getSelectedPreviewFileId = () => undefined,
+  extendViewData,
+}) => {
+  const editForm = createEditForm();
+  const resolvedCenterItemContextMenuItems =
+    centerItemContextMenuItems ??
+    createCenterItemContextMenuItems(previewMenuLabel);
+  const selectDataItem = (state, itemId) => {
+    const item = state.data?.items?.[itemId];
+    return item?.type === itemType ? item : undefined;
+  };
+
+  const createInitialState = () => ({
+    data: EMPTY_TREE,
+    selectedItemId: undefined,
+    searchQuery: "",
+    isEditDialogOpen: false,
+    editItemId: undefined,
+    editDefaultValues: {
+      name: "",
+      description: "",
+    },
+    editPreviewFileId: undefined,
+    editUploadResult: undefined,
+  });
+
+  const setItems = ({ state }, { data } = {}) => {
+    state.data = data ?? EMPTY_TREE;
+  };
+
+  const setSelectedItemId = ({ state }, { itemId } = {}) => {
+    state.selectedItemId = itemId;
+  };
+
+  const openEditDialog = (
+    { state },
+    { itemId, defaultValues, previewFileId } = {},
+  ) => {
+    state.isEditDialogOpen = true;
+    state.editItemId = itemId;
+    state.editDefaultValues = {
+      name: defaultValues?.name ?? "",
+      description: defaultValues?.description ?? "",
+    };
+    state.editPreviewFileId = previewFileId;
+    state.editUploadResult = undefined;
+  };
+
+  const closeEditDialog = ({ state }, _payload = {}) => {
+    state.isEditDialogOpen = false;
+    state.editItemId = undefined;
+    state.editDefaultValues = {
+      name: "",
+      description: "",
+    };
+    state.editPreviewFileId = undefined;
+    state.editUploadResult = undefined;
+  };
+
+  const setEditUpload = ({ state }, { uploadResult, previewFileId } = {}) => {
+    state.editUploadResult = uploadResult;
+    state.editPreviewFileId = previewFileId;
+  };
+
+  const selectSelectedItem = ({ state }) => {
+    return selectDataItem(state, state.selectedItemId);
+  };
+
+  const selectItemById = ({ state }, { itemId } = {}) => {
+    return selectDataItem(state, itemId);
+  };
+
+  const selectSelectedItemId = ({ state }) => state.selectedItemId;
+
+  const setSearchQuery = ({ state }, { value } = {}) => {
+    state.searchQuery = value ?? "";
+  };
+
+  const selectViewData = ({ state }) => {
+    const flatItems = toFlatItems(state.data);
+    const rawFlatGroups = toFlatGroups(state.data);
+    const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+
+    const mediaGroups = rawFlatGroups
+      .map((group) => {
+        const filteredChildren = (group.children ?? []).filter((item) =>
+          matchesSearch(item, searchQuery),
+        );
+        const shouldShowGroup = !searchQuery || filteredChildren.length > 0;
+
+        return {
+          ...group,
+          children: filteredChildren.map(buildMediaItem),
+          hasChildren: filteredChildren.length > 0,
+          shouldDisplay: shouldShowGroup,
+        };
+      })
+      .filter((group) => group.shouldDisplay);
+
+    const selectedItem = selectDataItem(state, state.selectedItemId);
+
+    const baseViewData = {
+      flatItems,
+      mediaGroups,
+      resourceCategory,
+      selectedResourceId,
+      selectedItemId: state.selectedItemId,
+      selectedItemName: selectedItem?.name ?? "",
+      detailFields: buildDetailFields(selectedItem),
+      searchQuery: state.searchQuery,
+      searchPlaceholder,
+      resourceType,
+      title,
+      uploadText,
+      acceptedFileTypes,
+      imageHeight,
+      maxWidth,
+      showZoomControls,
+      selectedPreviewFileId: getSelectedPreviewFileId(selectedItem),
+      folderContextMenuItems,
+      itemContextMenuItems,
+      emptyContextMenuItems,
+      centerItemContextMenuItems: resolvedCenterItemContextMenuItems,
+      isEditDialogOpen: state.isEditDialogOpen,
+      editItemId: state.editItemId,
+      editForm,
+      editDefaultValues: state.editDefaultValues,
+      editPreviewFileId: state.editPreviewFileId,
+    };
+
+    if (!extendViewData) {
+      return baseViewData;
+    }
+
+    return extendViewData({
+      state,
+      flatItems,
+      selectedItem,
+      mediaGroups,
+      baseViewData,
+    });
+  };
+
+  return {
+    createInitialState,
+    setItems,
+    setSelectedItemId,
+    openEditDialog,
+    closeEditDialog,
+    setEditUpload,
+    selectSelectedItem,
+    selectItemById,
+    selectSelectedItemId,
+    setSearchQuery,
+    selectViewData,
+  };
+};

--- a/src/deps/features/resourcePages/media/mediaPageShared.js
+++ b/src/deps/features/resourcePages/media/mediaPageShared.js
@@ -1,0 +1,23 @@
+const EMPTY_TREE = { tree: [], items: {} };
+
+export const getMediaPageData = ({ projectService, resourceType } = {}) => {
+  return projectService.getState()[resourceType] ?? EMPTY_TREE;
+};
+
+export const syncMediaPageData = ({
+  store,
+  projectService,
+  resourceType,
+} = {}) => {
+  store.setItems({
+    data: getMediaPageData({ projectService, resourceType }),
+  });
+};
+
+export const resolveResourceParentId = (groupId) => {
+  if (!groupId || groupId === "_root") {
+    return undefined;
+  }
+
+  return groupId;
+};

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -8,6 +8,9 @@ import {
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
 import { createCharacterSpritesFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
 
+const EMPTY_TREE = { items: {}, tree: [] };
+const ACCEPTED_FILE_TYPES = ".jpg,.jpeg,.png,.webp";
+
 const applyCharacterSpritesPatch = async ({
   projectService,
   characterId,
@@ -15,11 +18,11 @@ const applyCharacterSpritesPatch = async ({
 }) => {
   const { characters } = projectService.getState();
   const character = characters.items?.[characterId];
-  if (!character) return;
+  if (!character) {
+    return;
+  }
 
-  const spritesState = structuredClone(
-    character.sprites || { items: {}, tree: [] },
-  );
+  const spritesState = structuredClone(character.sprites ?? EMPTY_TREE);
   const nextSprites = patchFactory(spritesState);
 
   await projectService.updateResourceItem({
@@ -31,128 +34,72 @@ const applyCharacterSpritesPatch = async ({
   });
 };
 
-const resolveDetailItemId = (detail = {}) => {
-  return detail.itemId || detail.id || detail.item?.id || "";
+const getCharacterIdFromPayload = ({ appService }) => {
+  return appService.getPayload().characterId;
 };
 
-const callFormMethod = ({ formRef, methodName, payload } = {}) => {
-  if (!formRef || !methodName) return false;
-
-  if (typeof formRef[methodName] === "function") {
-    formRef[methodName](payload);
-    return true;
-  }
-
-  if (typeof formRef.transformedMethods?.[methodName] === "function") {
-    formRef.transformedMethods[methodName](payload);
-    return true;
-  }
-
-  return false;
+const getCharacter = ({ projectService, characterId }) => {
+  return projectService.getState().characters.items?.[characterId];
 };
 
-const createDetailFormValues = (item, imageSrc) => {
-  if (!item) {
-    return {
-      fileId: null,
-      name: "",
-      description: "",
-    };
-  }
+const createDetailFormValues = (item, imageSrc) => ({
+  fileId: imageSrc,
+  name: item?.name ?? "",
+  description: item?.description ?? "",
+});
 
-  return {
-    fileId: imageSrc || null,
-    name: item.name || "",
-    description: item.description || "No description provided",
-  };
-};
-
-const syncDetailFormValues = ({
-  deps,
-  values,
-  selectedItemId,
-  attempt = 0,
-} = {}) => {
-  const formRef = deps?.refs?.detailForm;
-  const currentSelectedItemId = deps?.store?.selectSelectedItemId?.();
-
-  if (!selectedItemId || selectedItemId !== currentSelectedItemId) {
+const syncDetailForm = ({ refs, values } = {}) => {
+  const { detailForm } = refs;
+  if (!detailForm) {
     return;
   }
 
-  if (!formRef) {
-    if (attempt < 6) {
-      setTimeout(() => {
-        syncDetailFormValues({
-          deps,
-          values,
-          selectedItemId,
-          attempt: attempt + 1,
-        });
-      }, 0);
-    }
-    return;
+  detailForm.reset();
+  detailForm.setValues({ values });
+};
+
+const getPreviewImageSrc = async ({ projectService, item } = {}) => {
+  if (!item?.fileId) {
+    return undefined;
   }
 
-  callFormMethod({ formRef, methodName: "reset" });
+  const { url } = await projectService.getFileContent(item.fileId);
+  return url;
+};
 
-  const didSet = callFormMethod({
-    formRef,
-    methodName: "setValues",
-    payload: { values },
+const syncCharacterSpritesData = async (deps) => {
+  const { appService, projectService, store } = deps;
+  const characterId =
+    store.selectCharacterId() ?? getCharacterIdFromPayload(deps);
+
+  if (!characterId) {
+    appService.showToast("Character is missing.", { title: "Error" });
+    return {};
+  }
+
+  const character = getCharacter({
+    projectService,
+    characterId,
   });
 
-  if (!didSet && attempt < 6) {
-    setTimeout(() => {
-      syncDetailFormValues({
-        deps,
-        values,
-        selectedItemId,
-        attempt: attempt + 1,
-      });
-    }, 0);
-  }
-};
-
-export const handleAfterMount = async (deps) => {
-  const { appService, store, projectService, render, globalUI } = deps;
-  const { characterId } = appService.getPayload();
-  await projectService.ensureRepository();
-  const { characters } = projectService.getState();
-  const character = characters.items[characterId];
-
   if (!character) {
-    globalUI.showAlert({ message: "Character not found", title: "Error" });
+    appService.showToast("Character not found.", { title: "Error" });
+    return {};
   }
 
-  store.setCharacterId({ characterId: characterId });
+  store.setCharacterId({ characterId });
   store.setCharacterName({ characterName: character.name });
-  store.setItems({ spritesData: character.sprites });
-  render();
-};
+  store.setItems({ spritesData: character.sprites ?? EMPTY_TREE });
 
-const refreshCharacterSpritesData = async (deps) => {
-  const { appService, render, store, projectService, globalUI } = deps;
-  const { characterId } = appService.getPayload();
-  await projectService.ensureRepository();
-  const { characters } = projectService.getState();
-  const character = characters.items[characterId];
-
-  if (!character) {
-    globalUI.showAlert({ message: "Character not found", title: "Error" });
-    return;
+  if (store.selectSelectedItemId() && !store.selectSelectedItem()) {
+    store.setSelectedItemId({ itemId: undefined });
   }
 
-  store.setCharacterName({ characterName: character.name });
-  store.setItems({ spritesData: character.sprites });
-  const selectedItemId = store.selectSelectedItemId();
   const selectedItem = store.selectSelectedItem();
-  let imageSrc = null;
-
-  if (selectedItem?.fileId) {
-    const { url } = await projectService.getFileContent(selectedItem.fileId);
-    imageSrc = url;
-  }
+  const imageSrc = await getPreviewImageSrc({
+    projectService,
+    item: selectedItem,
+  });
 
   store.setContext({
     context: {
@@ -161,21 +108,128 @@ const refreshCharacterSpritesData = async (deps) => {
       },
     },
   });
-  const detailValues = createDetailFormValues(selectedItem, imageSrc);
+
+  return {
+    characterId,
+    selectedItem,
+    imageSrc,
+  };
+};
+
+const refreshCharacterSpritesData = async (deps) => {
+  const { render, refs } = deps;
+  const { selectedItem, imageSrc } = await syncCharacterSpritesData(deps);
   render();
 
   if (selectedItem) {
-    syncDetailFormValues({
-      deps,
-      values: detailValues,
-      selectedItemId,
+    syncDetailForm({
+      refs,
+      values: createDetailFormValues(selectedItem, imageSrc),
     });
   }
 };
 
+const selectSprite = async ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { projectService, refs, render, store } = deps;
+  const item = store.selectSpriteItemById({ itemId });
+
+  if (!itemId || !item) {
+    return;
+  }
+
+  store.setSelectedItemId({ itemId });
+
+  if (syncExplorer) {
+    refs.fileExplorer.selectItem({ itemId });
+  }
+
+  const imageSrc = await getPreviewImageSrc({
+    projectService,
+    item,
+  });
+
+  store.setContext({
+    context: {
+      fileId: {
+        src: imageSrc,
+      },
+    },
+  });
+
+  render();
+  syncDetailForm({
+    refs,
+    values: createDetailFormValues(item, imageSrc),
+  });
+};
+
+const createSpritesFromFiles = async ({
+  deps,
+  files,
+  parentId = ROOT_TREE_PARENT_ID,
+} = {}) => {
+  const { appService, projectService, store } = deps;
+  let successfulUploads;
+
+  try {
+    successfulUploads = await projectService.uploadFiles(files);
+  } catch {
+    appService.showToast("Failed to upload sprites.", { title: "Error" });
+    return;
+  }
+
+  if (!successfulUploads.length) {
+    appService.showToast("Failed to upload sprites.", { title: "Error" });
+    return;
+  }
+
+  const characterId = store.selectCharacterId();
+  if (!characterId) {
+    appService.showToast("Character is missing.", { title: "Error" });
+    return;
+  }
+
+  await applyCharacterSpritesPatch({
+    projectService,
+    characterId,
+    patchFactory: (spritesState) => {
+      let nextSprites = spritesState;
+
+      for (const result of successfulUploads) {
+        nextSprites = insertTreeItem({
+          treeCollection: nextSprites,
+          value: {
+            id: nanoid(),
+            type: "image",
+            fileId: result.fileId,
+            name: result.displayName,
+            fileType: result.file.type,
+            fileSize: result.file.size,
+            width: result.dimensions.width,
+            height: result.dimensions.height,
+          },
+          parentId,
+          position: "last",
+        });
+      }
+
+      return nextSprites;
+    },
+  });
+
+  await refreshCharacterSpritesData(deps);
+};
+
+export const handleAfterMount = async (deps) => {
+  const { projectService } = deps;
+  await projectService.ensureRepository();
+  await refreshCharacterSpritesData(deps);
+};
+
 const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
   createCharacterSpritesFileExplorerHandlers({
-    getCharacterId: (deps) => deps.store.selectCharacterId(),
+    getCharacterId: (deps) =>
+      deps.store.selectCharacterId() ?? getCharacterIdFromPayload(deps),
     refresh: refreshCharacterSpritesData,
   });
 
@@ -184,31 +238,15 @@ export { handleFileExplorerAction, handleFileExplorerTargetChanged };
 export const handleDataChanged = refreshCharacterSpritesData;
 
 export const handleFileExplorerSelectionChanged = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const detail = payload?._event?.detail || {};
-  const id = resolveDetailItemId(detail);
-  const { item, isFolder } = detail;
+  const { render, store } = deps;
+  const { itemId, isFolder } = payload._event.detail;
 
-  // For characterSprites, get item data from our own store since BaseFileExplorer
-  // can't access the nested character.sprites data structure
-  let actualItem = item;
-  if (!actualItem) {
-    // Get the item from our store's spritesData
-    const flatItems = store.selectFlatItems();
-    actualItem = flatItems.find((item) => item.id === id) || null;
-  }
-
-  // Check if this is a folder (either from BaseFileExplorer or from our own data)
-  const actualIsFolder =
-    isFolder || (actualItem && actualItem.type === "folder");
-
-  // If this is a folder, clear selection and context
-  if (actualIsFolder) {
-    store.setSelectedItemId({ itemId: null });
+  if (isFolder) {
+    store.setSelectedItemId({ itemId: undefined });
     store.setContext({
       context: {
         fileId: {
-          src: null,
+          src: undefined,
         },
       },
     });
@@ -216,145 +254,90 @@ export const handleFileExplorerSelectionChanged = async (deps, payload) => {
     return;
   }
 
-  if (!id) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: id });
-  const selectedItem = actualItem || store.selectSelectedItem();
-  let imageSrc = null;
-
-  // If we have item data with fileId, set up media context for preview
-  if (selectedItem?.fileId) {
-    const { url } = await projectService.getFileContent(selectedItem.fileId);
-    imageSrc = url;
-  }
-
-  store.setContext({
-    context: {
-      fileId: {
-        src: imageSrc,
-      },
-    },
+  await selectSprite({
+    deps,
+    itemId,
   });
-
-  const detailValues = createDetailFormValues(selectedItem, imageSrc);
-  render();
-  if (selectedItem) {
-    syncDetailFormValues({
-      deps,
-      values: detailValues,
-      selectedItemId: id,
-    });
-  }
 };
 
 export const handleFileExplorerDoubleClick = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) return;
+
+  if (isFolder || !itemId) {
+    return;
+  }
 
   store.showFullImagePreview({ itemId });
   render();
 };
 
-export const handleImageItemClick = async (deps, payload) => {
-  const { store, render, projectService, refs } = deps;
-  const detail = payload?._event?.detail || {};
-  const itemId = resolveDetailItemId(detail);
+export const handleSpriteItemClick = async (deps, payload) => {
+  const { itemId } = payload._event.detail;
+
+  await selectSprite({
+    deps,
+    itemId,
+    syncExplorer: true,
+  });
+};
+
+export const handleSpriteItemDoubleClick = (deps, payload) => {
+  const { render, store } = deps;
+  const { itemId } = payload._event.detail;
+
   if (!itemId) {
     return;
   }
 
-  store.setSelectedItemId({ itemId: itemId });
-
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  const selectedItem = detail.item || store.selectSelectedItem();
-  let imageSrc = null;
-
-  if (selectedItem?.fileId) {
-    const { url } = await projectService.getFileContent(selectedItem.fileId);
-    imageSrc = url;
-  }
-
-  store.setContext({
-    context: {
-      fileId: {
-        src: imageSrc,
-      },
-    },
-  });
-  const detailValues = createDetailFormValues(selectedItem, imageSrc);
+  store.showFullImagePreview({ itemId });
   render();
-  if (selectedItem) {
-    syncDetailFormValues({
-      deps,
-      values: detailValues,
-      selectedItemId: itemId,
-    });
-  }
 };
 
-export const handleDragDropFileSelected = async (deps, payload) => {
-  const { store, render, projectService, globalUI } = deps;
-  const { files, targetGroupId } = payload._event.detail; // Extract from forwarded event
-  const id = targetGroupId;
+export const handleUploadClick = async (deps, payload) => {
+  const { appService } = deps;
+  const { groupId } = payload._event.detail;
+  let files;
 
-  const characterId = store.selectCharacterId();
-  const { characters } = projectService.getState();
-  const character = characters.items[characterId];
-
-  if (!character) {
-    globalUI.showAlert({ message: "Character not found", title: "Error" });
+  try {
+    files = await appService.pickFiles({
+      accept: ACCEPTED_FILE_TYPES,
+      multiple: true,
+    });
+  } catch {
+    appService.showToast("Failed to select files.", { title: "Error" });
     return;
   }
 
-  // Upload all files
-  const uploadResults = await projectService.uploadFiles(files);
-
-  // uploadResults already contains only successful uploads
-  const successfulUploads = uploadResults;
-
-  if (successfulUploads.length > 0) {
-    for (const result of successfulUploads) {
-      await applyCharacterSpritesPatch({
-        projectService,
-        characterId,
-        patchFactory: (spritesState) =>
-          insertTreeItem({
-            treeCollection: spritesState,
-            value: {
-              id: nanoid(),
-              type: "image",
-              fileId: result.fileId,
-              name: result.displayName,
-              fileType: result.file.type,
-              fileSize: result.file.size,
-              width: result.dimensions.width,
-              height: result.dimensions.height,
-            },
-            parentId: id || ROOT_TREE_PARENT_ID,
-            position: "last",
-          }),
-      });
-    }
-
-    // Update store with the latest repository state
-    const { characters } = projectService.getState();
-    const character = characters.items[characterId];
-    store.setItems({ spritesData: character.sprites });
+  if (!files?.length) {
+    return;
   }
 
-  render();
+  await createSpritesFromFiles({
+    deps,
+    files,
+    parentId: groupId ?? ROOT_TREE_PARENT_ID,
+  });
+};
+
+export const handleFilesDropped = async (deps, payload) => {
+  const { files, targetGroupId } = payload._event.detail;
+
+  await createSpritesFromFiles({
+    deps,
+    files,
+    parentId: targetGroupId ?? ROOT_TREE_PARENT_ID,
+  });
 };
 
 export const handleFormChange = async (deps, payload) => {
   const { projectService, render, store } = deps;
-
   const characterId = store.selectCharacterId();
   const selectedItemId = store.selectSelectedItemId();
+
+  if (!characterId || !selectedItemId) {
+    return;
+  }
 
   await applyCharacterSpritesPatch({
     projectService,
@@ -370,56 +353,53 @@ export const handleFormChange = async (deps, payload) => {
       }),
   });
 
-  const { characters } = projectService.getState();
-  const character = characters.items[characterId];
-  store.setItems({
-    spritesData: character?.sprites || { items: {}, tree: [] },
+  const character = getCharacter({
+    projectService,
+    characterId,
   });
-  const selectedItem = store.selectSelectedItem();
-  const detailValues = createDetailFormValues(
-    selectedItem,
-    store.getState()?.context?.fileId?.src || null,
-  );
-  render();
 
-  if (selectedItem) {
-    syncDetailFormValues({
-      deps,
-      values: detailValues,
-      selectedItemId,
-    });
-  }
+  store.setItems({
+    spritesData: character?.sprites ?? EMPTY_TREE,
+  });
+  render();
 };
 
 export const handleFormExtraEvent = async (deps) => {
-  const { projectService, appService, store, render } = deps;
-
-  // Get the currently selected item
+  const { appService, projectService, store } = deps;
   const selectedItem = store.selectSelectedItem();
+
   if (!selectedItem) {
-    console.warn("No item selected for image replacement");
     return;
   }
 
-  const file = await appService.pickFiles({
-    accept: "image/*",
-    multiple: false,
-  });
+  let file;
+
+  try {
+    file = await appService.pickFiles({
+      accept: ACCEPTED_FILE_TYPES,
+      multiple: false,
+      upload: true,
+    });
+  } catch {
+    appService.showToast("Failed to select file.", { title: "Error" });
+    return;
+  }
 
   if (!file) {
-    return; // User cancelled
-  }
-
-  const uploadedFiles = await projectService.uploadFiles([file]);
-
-  if (uploadedFiles.length === 0) {
-    console.error("File upload failed, no files uploaded");
     return;
   }
 
-  const uploadResult = uploadedFiles[0];
+  if (!(file.uploadSucessful && file.uploadResult)) {
+    appService.showToast("Failed to upload sprite.", { title: "Error" });
+    return;
+  }
+
+  const uploadResult = file.uploadResult;
   const characterId = store.selectCharacterId();
-  const selectedItemId = store.selectSelectedItemId();
+  if (!characterId) {
+    appService.showToast("Character is missing.", { title: "Error" });
+    return;
+  }
 
   await applyCharacterSpritesPatch({
     projectService,
@@ -430,7 +410,7 @@ export const handleFormExtraEvent = async (deps) => {
         id: selectedItem.id,
         value: {
           fileId: uploadResult.fileId,
-          name: uploadResult.file.name,
+          name: uploadResult.displayName,
           fileType: uploadResult.file.type,
           fileSize: uploadResult.file.size,
           width: uploadResult.dimensions.width,
@@ -440,62 +420,35 @@ export const handleFormExtraEvent = async (deps) => {
       }),
   });
 
-  // Update the store with the new repository state
-  const { characters } = projectService.getState();
-  const character = characters.items[characterId];
-  store.setContext({
-    context: {
-      fileId: {
-        src: uploadResult.downloadUrl,
-      },
-    },
-  });
-  store.setItems({
-    spritesData: character?.sprites || { items: {}, tree: [] },
-  });
-  const updatedSelectedItem = store.selectSelectedItem();
-  const detailValues = createDetailFormValues(
-    updatedSelectedItem,
-    uploadResult.downloadUrl,
-  );
-  render();
-
-  if (updatedSelectedItem) {
-    syncDetailFormValues({
-      deps,
-      values: detailValues,
-      selectedItemId,
-    });
-  }
+  await refreshCharacterSpritesData(deps);
 };
 
 export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail?.value || "";
-  store.setSearchQuery({ query: searchQuery });
+  const { render, store } = deps;
+  store.setSearchQuery({ query: payload._event.detail.value ?? "" });
   render();
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
+  const { appService, projectService, store } = deps;
   const { itemId } = payload._event.detail;
-
   const characterId = store.selectCharacterId();
-  const state = projectService.getState();
+
+  if (!characterId || !itemId) {
+    return;
+  }
 
   const usage = recursivelyCheckResource({
-    state,
+    state: projectService.getState(),
     itemId,
     checkTargets: ["scenes", "layouts"],
   });
 
   if (usage.isUsed) {
     appService.showToast("Cannot delete resource, it is currently in use.");
-    render();
     return;
   }
 
-  // Perform the delete operation
   await applyCharacterSpritesPatch({
     projectService,
     characterId,
@@ -506,11 +459,10 @@ export const handleItemDelete = async (deps, payload) => {
       }),
   });
 
-  // Refresh data and update store
-  const { characters } = projectService.getState();
-  const character = characters.items[characterId];
-  store.setItems({
-    spritesData: character?.sprites || { items: {}, tree: [] },
-  });
-  render();
+  await refreshCharacterSpritesData(deps);
+};
+
+export const handleBackClick = (deps) => {
+  const { appService } = deps;
+  appService.navigate("/project/resources/characters", appService.getPayload());
 };

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -1,5 +1,7 @@
 import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
 
+const EMPTY_TREE = { tree: [], items: {} };
+
 const folderContextMenuItems = [
   { label: "New Folder", type: "item", value: "new-child-folder" },
   { label: "Duplicate", type: "item", value: "duplicate-item" },
@@ -15,6 +17,10 @@ const itemContextMenuItems = [
 
 const emptyContextMenuItems = [
   { label: "New Folder", type: "item", value: "new-item" },
+];
+
+const centerItemContextMenuItems = [
+  { label: "Delete", type: "item", value: "delete-item" },
 ];
 
 const form = {
@@ -35,14 +41,31 @@ const form = {
   ],
 };
 
+const createDetailValues = (item, imageSrc) => ({
+  fileId: imageSrc,
+  name: item?.name ?? "",
+  description: item?.description ?? "",
+});
+
+const matchesSearch = (item, searchQuery) => {
+  if (!searchQuery) {
+    return true;
+  }
+
+  const name = (item.name ?? "").toLowerCase();
+  const description = (item.description ?? "").toLowerCase();
+
+  return name.includes(searchQuery) || description.includes(searchQuery);
+};
+
 export const createInitialState = () => ({
-  spritesData: { tree: [], items: {} },
+  spritesData: EMPTY_TREE,
   selectedItemId: undefined,
   characterId: undefined,
   characterName: undefined,
   context: {
     fileId: {
-      src: "",
+      src: undefined,
     },
   },
   searchQuery: "",
@@ -55,7 +78,7 @@ export const setContext = ({ state }, { context } = {}) => {
 };
 
 export const setItems = ({ state }, { spritesData } = {}) => {
-  state.spritesData = spritesData;
+  state.spritesData = spritesData ?? EMPTY_TREE;
 };
 
 export const setCharacterId = ({ state }, { characterId } = {}) => {
@@ -71,13 +94,17 @@ export const setSelectedItemId = ({ state }, { itemId } = {}) => {
 };
 
 export const setSearchQuery = ({ state }, { query } = {}) => {
-  state.searchQuery = query;
+  state.searchQuery = query ?? "";
 };
 
 export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) return null;
-  const flatItems = toFlatItems(state.spritesData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
+  const item = state.spritesData.items?.[state.selectedItemId];
+  return item?.type === "image" ? item : undefined;
+};
+
+export const selectSpriteItemById = ({ state }, { itemId } = {}) => {
+  const item = state.spritesData.items?.[itemId];
+  return item?.type === "image" ? item : undefined;
 };
 
 export const selectSelectedItemId = ({ state }) => {
@@ -88,15 +115,10 @@ export const selectCharacterId = ({ state }) => {
   return state.characterId;
 };
 
-export const selectFlatItems = ({ state }) => {
-  return toFlatItems(state.spritesData);
-};
-
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {
-  const flatItems = toFlatItems(state.spritesData);
-  const item = flatItems.find((item) => item.id === itemId);
+  const item = state.spritesData.items?.[itemId];
 
-  if (item && item.fileId) {
+  if (item?.fileId) {
     state.fullImagePreviewVisible = true;
     state.fullImagePreviewFileId = item.fileId;
   }
@@ -110,83 +132,51 @@ export const hideFullImagePreview = ({ state }, _payload = {}) => {
 export const selectViewData = ({ state }) => {
   const flatItems = toFlatItems(state.spritesData);
   const rawFlatGroups = toFlatGroups(state.spritesData);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : null;
-
-  // Transform selectedItem into form defaults
-  let defaultValues = {};
-
-  if (selectedItem) {
-    defaultValues = {
-      fileId: state.context?.fileId?.src || null,
-      name: selectedItem.name,
-      description: selectedItem.description || "No description provided",
-    };
-  }
-
-  // Apply search filter
   const searchQuery = state.searchQuery.toLowerCase().trim();
-  let filteredGroups = rawFlatGroups;
 
-  if (searchQuery) {
-    filteredGroups = rawFlatGroups
-      .map((group) => {
-        const filteredChildren = (group.children || []).filter((item) => {
-          const name = (item.name || "").toLowerCase();
-          const description = (item.description || "").toLowerCase();
-          return (
-            name.includes(searchQuery) || description.includes(searchQuery)
-          );
-        });
+  const mediaGroups = rawFlatGroups
+    .map((group) => {
+      const children = (group.children ?? []).filter((item) =>
+        matchesSearch(item, searchQuery),
+      );
+      const shouldDisplay = !searchQuery || children.length > 0;
 
-        const groupName = (group.name || "").toLowerCase();
-        const shouldIncludeGroup =
-          filteredChildren.length > 0 || groupName.includes(searchQuery);
+      return {
+        ...group,
+        children: children.map((item) => ({
+          ...item,
+          cardKind: "image",
+          imageFileId: item.fileId,
+        })),
+        hasChildren: children.length > 0,
+        shouldDisplay,
+      };
+    })
+    .filter((group) => group.shouldDisplay);
 
-        return shouldIncludeGroup
-          ? {
-              ...group,
-              children: filteredChildren,
-              hasChildren: filteredChildren.length > 0,
-            }
-          : null;
-      })
-      .filter(Boolean);
-  }
-
-  // Apply collapsed state and selection styling
-  const flatGroups = filteredGroups.map((group) => ({
-    ...group,
-    children: (group.children || []).map((item) => ({
-      ...item,
-      selectedStyle:
-        item.id === state.selectedItemId
-          ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-          : "",
-    })),
-  }));
+  const selectedItem = state.spritesData.items?.[state.selectedItemId];
 
   return {
     flatItems,
-    flatGroups,
+    mediaGroups,
     resourceCategory: "assets",
     selectedResourceId: "characterSprites",
     selectedItemId: state.selectedItemId,
     form,
     context: state.context,
-    defaultValues,
+    defaultValues: createDetailValues(
+      selectedItem?.type === "image" ? selectedItem : undefined,
+      state.context.fileId.src,
+    ),
     searchQuery: state.searchQuery,
-    resourceType: "characterSprites",
+    uploadText: "Upload Sprite",
     acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
     folderContextMenuItems,
     itemContextMenuItems,
     emptyContextMenuItems,
+    centerItemContextMenuItems,
     title: state.characterName,
-    backUrl: "/project/resources/characters",
   };
 };

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -12,17 +12,19 @@ refs:
   groupview:
     eventListeners:
       item-click:
-        handler: handleImageItemClick
+        handler: handleSpriteItemClick
       item-dblclick:
-        action: showFullImagePreview
-        payload:
-          itemId: ${_event.detail.itemId}
-      files-uploaded:
-        handler: handleDragDropFileSelected
+        handler: handleSpriteItemDoubleClick
+      files-dropped:
+        handler: handleFilesDropped
+      upload-click:
+        handler: handleUploadClick
       search-input:
         handler: handleSearchInput
       item-delete:
         handler: handleItemDelete
+      back-click:
+        handler: handleBackClick
   previewOverlay:
     eventListeners:
       click:
@@ -41,7 +43,7 @@ template:
                   - rvn-resource-types :resourceCategory=resourceCategory  :selectedResourceId=selectedResourceId: null
                   - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - rtgl-view w=1fg h=f:
-              - rvn-group-resources-view#groupview :backUrl=backUrl show-zoom-controls :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes: null
+              - rvn-media-resources-view#groupview w=f h=f show-back-button show-zoom-controls :navTitle=title :groups=mediaGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -1,32 +1,27 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
-
-const getColorItemById = ({ store, itemId } = {}) => {
-  if (!itemId) return undefined;
-  const item = store.getState().colorsData?.items?.[itemId];
-  if (!item || item.type !== "color") return undefined;
-  return item;
-};
+import { createCatalogPageHandlers } from "../../deps/features/resourcePages/catalog/createCatalogPageHandlers.js";
 
 const syncEditFormValues = ({ deps, values } = {}) => {
-  const formRef = deps?.refs?.editForm;
-  if (!formRef) {
-    return;
-  }
-  formRef.reset();
-  formRef.setValues({ values });
+  const { editForm } = deps.refs;
+  editForm.reset();
+  editForm.setValues({ values });
 };
 
 const openEditDialogWithValues = ({ deps, itemId } = {}) => {
-  if (!itemId) return;
+  if (!itemId) {
+    return;
+  }
 
-  const { store, render } = deps;
-  const colorItem = getColorItemById({ store, itemId });
-  if (!colorItem) return;
+  const { store, render, refs } = deps;
+  const colorItem = store.selectColorItemById({ itemId });
+  if (!colorItem) {
+    return;
+  }
 
-  store.setSelectedItemId({ itemId: itemId });
-  store.openEditDialog({ itemId: itemId });
+  store.setSelectedItemId({ itemId });
+  refs.fileExplorer.selectItem({ itemId });
+  store.openEditDialog({ itemId });
   render();
 
   syncEditFormValues({
@@ -38,111 +33,41 @@ const openEditDialogWithValues = ({ deps, itemId } = {}) => {
   });
 };
 
-export const handleAfterMount = async (deps) => {
-  const { store, projectService, render } = deps;
-  await projectService.ensureRepository();
-  const { colors } = projectService.getState();
-  store.setItems({ colorsData: colors });
-  render();
-};
+const {
+  handleAfterMount,
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleItemClick: handleColorItemClick,
+  handleSearchInput,
+} = createCatalogPageHandlers({
+  resourceType: "colors",
+});
 
-const refreshColorsData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const { colors } = projectService.getState();
-  store.setItems({ colorsData: colors });
-  render();
-};
-
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "colors",
-    refresh: refreshColorsData,
-  });
-
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleDataChanged = refreshColorsData;
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id, isFolder } = payload._event.detail;
-
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: id });
-  render();
-};
-
-export const handleColorItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const { itemId } = payload._event.detail;
-  store.setSelectedItemId({ itemId: itemId });
-
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  render();
-};
-
-export const handleColorCreated = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { groupId, name, hex } = payload._event.detail;
-
-  await projectService.createResourceItem({
-    resourceType: "colors",
-    resourceId: nanoid(),
-    data: {
-      type: "color",
-      name,
-      hex,
-    },
-    parentId: groupId,
-    position: "last",
-  });
-
-  const { colors } = projectService.getState();
-  store.setItems({ colorsData: colors });
-  render();
-};
-
-export const handleColorEdited = (deps, payload) => {
-  const { subject } = deps;
-  const { itemId, name, hex } = payload._event.detail;
-
-  // Dispatch to app handlers for repository update
-  subject.dispatch("update-color", {
-    itemId,
-    updates: {
-      name,
-      hex,
-    },
-  });
+export {
+  handleAfterMount,
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleColorItemClick,
+  handleSearchInput,
 };
 
 export const handleColorItemDoubleClick = (deps, payload) => {
-  const { store } = deps;
-  const detail = payload?._event?.detail || {};
-  const isFolder = detail.isFolder === true;
+  const { itemId, isFolder } = payload._event.detail;
+  if (isFolder) {
+    return;
+  }
 
-  if (isFolder) return;
-
-  const candidateIds = [detail.itemId, detail.id, store.selectSelectedItemId()];
-  const itemId = candidateIds.find((candidateId) =>
-    getColorItemById({ store, itemId: candidateId }),
-  );
-  if (!itemId) return;
-
-  openEditDialogWithValues({ deps, itemId: itemId });
+  openEditDialogWithValues({ deps, itemId });
 };
 
 export const handleAddColorClick = (deps, payload) => {
   const { store, render } = deps;
   const { groupId } = payload._event.detail;
-  store.openAddDialog({ groupId: groupId });
+  store.openAddDialog({ groupId });
   render();
 };
 
@@ -153,40 +78,41 @@ export const handleEditDialogClose = (deps) => {
 };
 
 export const handleEditFormAction = async (deps, payload) => {
-  const { store, render, projectService, appService } = deps;
+  const { store, projectService, appService, render } = deps;
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
+    return;
+  }
 
-  if (payload._event.detail.actionId === "submit") {
-    const formData = payload._event.detail.values;
-    const editItemId = store.getState().editItemId;
+  const name = values?.name?.trim();
+  if (!name) {
+    appService.showToast("Color name is required.", { title: "Warning" });
+    return;
+  }
 
-    if (!formData.name || !formData.name.trim()) {
-      appService.showToast("Color name is required.", { title: "Warning" });
-      return;
-    }
-    // Update the color in the repository
-    await projectService.updateResourceItem({
-      resourceType: "colors",
-      resourceId: editItemId,
-      patch: {
-        name: formData.name,
-        hex: formData.hex,
-      },
-    });
-
-    const { colors } = projectService.getState();
-    store.setItems({ colorsData: colors });
-
+  const editItemId = store.getState().editItemId;
+  if (!editItemId) {
     store.closeEditDialog();
     render();
+    return;
   }
+
+  await projectService.updateResourceItem({
+    resourceType: "colors",
+    resourceId: editItemId,
+    patch: {
+      name,
+      hex: values?.hex ?? "#ffffff",
+    },
+  });
+
+  store.closeEditDialog();
+  await handleDataChanged(deps);
 };
 
 export const handleFormFieldClick = (deps) => {
-  const { store } = deps;
-  const selectedItemId = store.selectSelectedItemId();
-  if (selectedItemId) {
-    openEditDialogWithValues({ deps, itemId: selectedItemId });
-  }
+  const selectedItemId = deps.store.selectSelectedItemId();
+  openEditDialogWithValues({ deps, itemId: selectedItemId });
 };
 
 export const handleAddDialogClose = (deps) => {
@@ -196,60 +122,40 @@ export const handleAddDialogClose = (deps) => {
 };
 
 export const handleAddFormAction = async (deps, payload) => {
-  const { store, render, projectService, appService } = deps;
-
-  if (payload._event.detail.actionId === "submit") {
-    const formData = payload._event.detail.values;
-
-    if (!formData.name || !formData.name.trim()) {
-      appService.showToast("Color name cannot be empty.", { title: "Warning" });
-      return;
-    }
-
-    const targetGroupId = store.getState().targetGroupId;
-    const newColorId = nanoid();
-
-    // Create the color in the repository
-    await projectService.createResourceItem({
-      resourceType: "colors",
-      resourceId: newColorId,
-      data: {
-        type: "color",
-        name: formData.name,
-        hex: formData.hex,
-      },
-      parentId: targetGroupId,
-      position: "last",
-    });
-
-    const { colors } = projectService.getState();
-    store.setItems({ colorsData: colors });
-    store.closeAddDialog();
-    render();
+  const { store, projectService, appService } = deps;
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
+    return;
   }
-};
 
-export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail?.value ?? "";
-  store.setSearchQuery({ query: searchQuery });
-  render();
-};
+  const name = values?.name?.trim();
+  if (!name) {
+    appService.showToast("Color name cannot be empty.", { title: "Warning" });
+    return;
+  }
 
-export const handleGroupToggle = (deps, payload) => {
-  const { store, render } = deps;
-  const { groupId } = payload._event.detail;
-  store.toggleGroupCollapse({ groupId: groupId });
-  render();
+  await projectService.createResourceItem({
+    resourceType: "colors",
+    resourceId: nanoid(),
+    data: {
+      type: "color",
+      name,
+      hex: values?.hex ?? "#ffffff",
+    },
+    parentId: store.getState().targetGroupId,
+    position: "last",
+  });
+
+  store.closeAddDialog();
+  await handleDataChanged(deps);
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { projectService, appService, render } = deps;
+  const { itemId } = payload._event.detail;
 
-  const state = projectService.getState();
   const usage = recursivelyCheckResource({
-    state,
+    state: projectService.getState(),
     itemId,
     checkTargets: ["typography"],
   });
@@ -260,14 +166,10 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  // Perform the delete operation
   await projectService.deleteResourceItem({
-    resourceType,
+    resourceType: "colors",
     resourceId: itemId,
   });
 
-  // Refresh data and update store (reuse existing logic from handleDataChanged)
-  const data = projectService.getState()[resourceType];
-  store.setItems({ colorsData: data });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/colors/colors.store.js
+++ b/src/pages/colors/colors.store.js
@@ -1,46 +1,182 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
+import { createCatalogPageStore } from "../../deps/features/resourcePages/catalog/createCatalogPageStore.js";
 
 const hexToRgb = (hex) => {
-  if (!hex) return "";
+  if (!hex) {
+    return "";
+  }
+
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  if (!result) return "";
+  if (!result) {
+    return "";
+  }
+
   const r = parseInt(result[1], 16);
   const g = parseInt(result[2], 16);
   const b = parseInt(result[3], 16);
   return `rgb(${r}, ${g}, ${b})`;
 };
 
+const editForm = {
+  title: "Edit Color",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "hex",
+      type: "color-picker",
+      label: "Hex Value",
+      required: true,
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Update Color",
+      },
+    ],
+  },
+};
+
+const addForm = {
+  title: "Add Color",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Color Name",
+      required: true,
+    },
+    {
+      name: "hex",
+      type: "color-picker",
+      label: "Hex Value",
+      required: true,
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Add Color",
+      },
+    ],
+  },
+};
+
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
+  }
+
+  return [
+    {
+      type: "slot",
+      slot: "color-preview",
+      label: "",
+    },
+    {
+      type: "text",
+      label: "Hex Value",
+      value: item.hex ?? "",
+    },
+    {
+      type: "text",
+      label: "RGB Value",
+      value: hexToRgb(item.hex ?? ""),
+    },
+  ];
+};
+
+const buildCatalogItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "color",
+  swatchHex: item.hex ?? "#ffffff",
+});
+
+const matchesSearch = (item, searchQuery) => {
+  if (!searchQuery) {
+    return true;
+  }
+
+  const name = (item.name ?? "").toLowerCase();
+  const hex = (item.hex ?? "").toLowerCase();
+  return name.includes(searchQuery) || hex.includes(searchQuery);
+};
+
+const selectColorDataItem = (state, itemId) => {
+  const item = state.data?.items?.[itemId];
+  return item?.type === "color" ? item : undefined;
+};
+
+const {
+  createInitialState: createCatalogInitialState,
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectCatalogViewData,
+} = createCatalogPageStore({
+  itemType: "color",
+  resourceType: "colors",
+  title: "Colors",
+  selectedResourceId: "colors",
+  resourceCategory: "userInterface",
+  addText: "Add Color",
+  matchesSearch,
+  buildDetailFields,
+  buildCatalogItem,
+  extendViewData: ({ state, selectedItem, baseViewData }) => {
+    const editItem = selectColorDataItem(state, state.editItemId);
+
+    return {
+      ...baseViewData,
+      selectedColorHex: selectedItem?.hex ?? "",
+      isEditDialogOpen: state.isEditDialogOpen,
+      editDefaultValues: {
+        name: editItem?.name ?? "",
+        hex: editItem?.hex ?? "",
+      },
+      editForm,
+      isAddDialogOpen: state.isAddDialogOpen,
+      addDefaultValues: state.addDefaultValues,
+      addForm,
+    };
+  },
+});
+
 export const createInitialState = () => ({
-  colorsData: { tree: [], items: {} },
-  selectedItemId: null,
+  ...createCatalogInitialState(),
   isEditDialogOpen: false,
-  editItemId: null,
+  editItemId: undefined,
   isAddDialogOpen: false,
-  targetGroupId: null,
-  searchQuery: "",
-  collapsedIds: [],
+  targetGroupId: undefined,
   addDefaultValues: {
     name: "",
     hex: "#ffffff",
   },
-  contextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-    { label: "Duplicate", type: "item", value: "duplicate-item" },
-    { label: "Rename", type: "item", value: "rename-item" },
-    { label: "Delete", type: "item", value: "delete-item" },
-  ],
-  emptyContextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-  ],
 });
 
-export const setItems = ({ state }, { colorsData } = {}) => {
-  state.colorsData = colorsData;
+export {
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
 };
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
+export const selectColorItemById = selectItemById;
 
 export const openEditDialog = ({ state }, { itemId } = {}) => {
   state.isEditDialogOpen = true;
@@ -49,206 +185,23 @@ export const openEditDialog = ({ state }, { itemId } = {}) => {
 
 export const closeEditDialog = ({ state }, _payload = {}) => {
   state.isEditDialogOpen = false;
-  state.editItemId = null;
+  state.editItemId = undefined;
 };
 
 export const openAddDialog = ({ state }, { groupId } = {}) => {
   state.isAddDialogOpen = true;
-  state.targetGroupId = groupId;
+  state.targetGroupId = groupId === "_root" ? undefined : groupId;
 };
 
 export const closeAddDialog = ({ state }, _payload = {}) => {
   state.isAddDialogOpen = false;
-  state.targetGroupId = null;
+  state.targetGroupId = undefined;
   state.addDefaultValues = {
     name: "",
     hex: "#ffffff",
   };
 };
 
-export const setSearchQuery = ({ state }, { query } = {}) => {
-  state.searchQuery = query;
-};
-
-export const toggleGroupCollapse = ({ state }, { groupId } = {}) => {
-  const index = state.collapsedIds.indexOf(groupId);
-  if (index > -1) {
-    state.collapsedIds.splice(index, 1);
-  } else {
-    state.collapsedIds.push(groupId);
-  }
-};
-
-export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) return null;
-  const flatItems = toFlatItems(state.colorsData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
-};
-
-export const selectSelectedItemId = ({ state }) => state.selectedItemId;
-
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.colorsData);
-  const rawFlatGroups = toFlatGroups(state.colorsData);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  const selectedColorHex = selectedItem?.hex ?? "";
-  const detailFields = selectedItem
-    ? [
-        {
-          type: "slot",
-          slot: "color-preview",
-          label: "",
-        },
-        {
-          type: "text",
-          label: "Hex Value",
-          value: selectedColorHex,
-        },
-        {
-          type: "text",
-          label: "RGB Value",
-          value: hexToRgb(selectedColorHex),
-        },
-      ]
-    : [];
-
-  // Apply search filter
-  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
-  let filteredGroups = rawFlatGroups;
-
-  if (searchQuery) {
-    filteredGroups = rawFlatGroups
-      .map((group) => {
-        const filteredChildren = (group.children ?? []).filter((item) => {
-          const name = (item.name ?? "").toLowerCase();
-          const hex = (item.hex ?? "").toLowerCase();
-          return name.includes(searchQuery) || hex.includes(searchQuery);
-        });
-
-        const groupName = (group.name ?? "").toLowerCase();
-        const shouldIncludeGroup =
-          filteredChildren.length > 0 || groupName.includes(searchQuery);
-
-        return shouldIncludeGroup
-          ? {
-              ...group,
-              children: filteredChildren,
-              hasChildren: filteredChildren.length > 0,
-            }
-          : null;
-      })
-      .filter(Boolean);
-  }
-
-  // Apply collapsed state and selection styling
-  const flatGroups = filteredGroups.map((group) => ({
-    ...group,
-    isCollapsed: state.collapsedIds.includes(group.id),
-    children: state.collapsedIds.includes(group.id)
-      ? []
-      : (group.children ?? []).map((item) => ({
-          ...item,
-          selectedStyle:
-            item.id === state.selectedItemId
-              ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-              : "",
-        })),
-  }));
-
-  // Get edit item details
-  const editItem = state.editItemId
-    ? flatItems.find((item) => item.id === state.editItemId)
-    : undefined;
-
-  let editDefaultValues = {};
-  let editForm = {
-    title: "Edit Color",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Name",
-        required: true,
-      },
-      {
-        name: "hex",
-        type: "color-picker",
-        label: "Hex Value",
-        required: true,
-      },
-    ],
-    actions: {
-      layout: "",
-      buttons: [
-        {
-          id: "submit",
-          variant: "pr",
-          label: "Update Color",
-        },
-      ],
-    },
-  };
-
-  if (editItem) {
-    editDefaultValues = {
-      name: editItem.name ?? "",
-      hex: editItem.hex ?? "",
-    };
-  }
-
-  // Add form configuration
-  const addForm = {
-    title: "Add Color",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Color Name",
-        required: true,
-      },
-      {
-        name: "hex",
-        type: "color-picker",
-        label: "Hex Value",
-        required: true,
-      },
-    ],
-    actions: {
-      layout: "",
-      buttons: [
-        {
-          id: "submit",
-          variant: "pr",
-          label: "Add Color",
-        },
-      ],
-    },
-  };
-
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "userInterface",
-    selectedResourceId: "colors",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    selectedColorHex,
-    detailFields,
-    title: "Colors",
-    contextMenuItems: state.contextMenuItems,
-    emptyContextMenuItems: state.emptyContextMenuItems,
-    isEditDialogOpen: state.isEditDialogOpen,
-    editDefaultValues,
-    editForm,
-    isAddDialogOpen: state.isAddDialogOpen,
-    addDefaultValues: state.addDefaultValues,
-    addForm,
-    searchQuery: state.searchQuery,
-    resourceType: "colors",
-  };
+export const selectViewData = (context) => {
+  return selectCatalogViewData(context);
 };

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -42,14 +42,14 @@ refs:
       form-action:
         handler: handleAddFormAction
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
-                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :contextMenuItems=contextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
-          - rtgl-view w=1fg h=f:
-              - rvn-group-resources-view#groupview :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery: null
+                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+              - rvn-catalog-resources-view#groupview w=f h=f :navTitle=title :groups=catalogGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :addText=addText :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -1,96 +1,176 @@
 import { nanoid } from "nanoid";
 import { createFontInfoExtractor } from "../../deps/fontInfoExtractor.js";
-import { toFlatItems } from "../../domain/treeHelpers.js";
 import { getFileType } from "../../utils/fileTypeUtils";
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
+import { createMediaPageHandlers } from "../../deps/features/resourcePages/media/createMediaPageHandlers.js";
+import { resolveResourceParentId } from "../../deps/features/resourcePages/media/mediaPageShared.js";
 
-export const handleAfterMount = async (deps) => {
-  const { store, projectService, render } = deps;
-  await projectService.ensureRepository();
-  const { fonts } = projectService.getState();
-  store.setItems({ fontsData: fonts });
-  render();
+const FONT_FILE_PATTERN = /\.(ttf|otf|woff|woff2|ttc|eot)$/i;
+
+const showInvalidFormatToast = (appService) => {
+  appService.showToast(
+    "Invalid file format. Please upload a font file (.ttf, .otf, .woff, .woff2, .ttc, or .eot)",
+    { title: "Warning" },
+  );
 };
 
-const refreshFontsData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const { fonts } = projectService.getState();
-  store.setItems({ fontsData: fonts });
-  render();
+const validateFontFiles = ({ appService, files } = {}) => {
+  const invalidFiles = Array.from(files ?? []).filter(
+    (file) => !file.name.match(FONT_FILE_PATTERN),
+  );
+
+  if (invalidFiles.length > 0) {
+    showInvalidFormatToast(appService);
+    return false;
+  }
+
+  return true;
 };
 
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "fonts",
-    refresh: refreshFontsData,
-  });
+const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
+  const { appService, projectService } = deps;
+  if (!validateFontFiles({ appService, files })) {
+    return;
+  }
+
+  let successfulUploads;
+  try {
+    successfulUploads = await projectService.uploadFiles(files);
+  } catch {
+    appService.showToast("Failed to upload font.", { title: "Error" });
+    return;
+  }
+
+  if (!successfulUploads.length) {
+    appService.showToast("Failed to upload font.", { title: "Error" });
+    return;
+  }
+
+  for (const result of successfulUploads) {
+    await projectService.createResourceItem({
+      resourceType: "fonts",
+      resourceId: nanoid(),
+      data: {
+        type: "font",
+        fileId: result.fileId,
+        name: result.displayName,
+        fontFamily: result.fontName,
+        fileType: getFileType(result),
+        fileSize: result.file.size,
+      },
+      parentId,
+      position: "last",
+    });
+  }
+
+  await handleDataChanged(deps);
+};
+
+const {
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleSearchInput,
+  handleItemClick: handleFontItemClick,
+} = createMediaPageHandlers({
+  resourceType: "fonts",
+  selectItemById: (store, { itemId }) => store.selectFontItemById({ itemId }),
+});
 
 export { handleFileExplorerAction, handleFileExplorerTargetChanged };
 
-export const handleDataChanged = refreshFontsData;
+export const handleAfterMount = async (deps) => {
+  const { projectService } = deps;
+  await projectService.ensureRepository();
+  await handleDataChanged(deps);
+};
 
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id, isFolder } = payload._event.detail;
+export {
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleSearchInput,
+  handleFontItemClick,
+};
 
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
+export const handleUploadClick = async (deps, payload) => {
+  const { appService } = deps;
+  const { groupId } = payload._event.detail;
+  let files;
+
+  try {
+    files = await appService.pickFiles({
+      accept: ".ttf,.otf,.woff,.woff2,.ttc,.eot",
+      multiple: true,
+    });
+  } catch {
+    appService.showToast("Failed to select files.", { title: "Error" });
     return;
   }
 
-  store.setSelectedItemId({ itemId: id });
-  render();
+  if (!files?.length) {
+    return;
+  }
+
+  await createFontsFromFiles({
+    deps,
+    files,
+    parentId: resolveResourceParentId(groupId),
+  });
 };
 
-export const handleFontItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const { itemId } = payload._event.detail;
-  store.setSelectedItemId({ itemId: itemId });
+export const handleFilesDropped = async (deps, payload) => {
+  const { files, targetGroupId } = payload._event.detail;
 
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  render();
+  await createFontsFromFiles({
+    deps,
+    files,
+    parentId: targetGroupId ?? undefined,
+  });
 };
 
 export const handleFormExtraEvent = async (deps) => {
-  const { appService, projectService, store, render } = deps;
-
-  // Get the currently selected item
+  const { appService, projectService, store } = deps;
   const selectedItem = store.selectSelectedItem();
+
   if (!selectedItem) {
-    console.warn("No item selected for font replacement");
     return;
   }
 
-  const file = await appService.pickFiles({
-    accept: ".ttf,.otf,.woff,.woff2,.ttc",
-    multiple: false,
-  });
+  let file;
+  try {
+    file = await appService.pickFiles({
+      accept: ".ttf,.otf,.woff,.woff2,.ttc,.eot",
+      multiple: false,
+    });
+  } catch {
+    appService.showToast("Failed to select file.", { title: "Error" });
+    return;
+  }
 
   if (!file) {
-    return; // User cancelled
-  }
-
-  // Validate file format
-  if (!file.name.match(/\.(ttf|otf|woff|woff2|ttc)$/i)) {
-    appService.showToast(
-      "Invalid file format. Please upload a font file (.ttf, .otf, .woff, .woff2, or .ttc)",
-      { title: "Warning" },
-    );
     return;
   }
 
-  const uploadedFiles = await projectService.uploadFiles([file]);
-
-  if (uploadedFiles.length === 0) {
-    console.error("File upload failed, no files uploaded");
+  if (!validateFontFiles({ appService, files: [file] })) {
     return;
   }
 
-  const uploadResult = uploadedFiles[0];
+  let uploadedFiles;
+  try {
+    uploadedFiles = await projectService.uploadFiles([file]);
+  } catch {
+    appService.showToast("Failed to upload font.", { title: "Error" });
+    return;
+  }
+
+  const uploadResult = uploadedFiles?.[0];
+
+  if (!uploadResult) {
+    appService.showToast("Failed to upload font.", { title: "Error" });
+    return;
+  }
+
   await projectService.updateResourceItem({
     resourceType: "fonts",
     resourceId: selectedItem.id,
@@ -103,132 +183,45 @@ export const handleFormExtraEvent = async (deps) => {
     },
   });
 
-  // Update the store with the new repository state
-  const { fonts } = projectService.getState();
-  store.setItems({ fontsData: fonts });
-  render();
-};
-
-export const handleDragDropFileSelected = async (deps, payload) => {
-  const { store, render, projectService, appService } = deps;
-  const { files, targetGroupId } = payload._event.detail; // Extract from forwarded event
-  const id = targetGroupId;
-
-  // Validate all files first
-  const invalidFiles = Array.from(files).filter(
-    (file) => !file.name.match(/\.(ttf|otf|woff|woff2|ttc)$/i),
-  );
-  if (invalidFiles.length > 0) {
-    appService.showToast(
-      "Invalid file format. Please upload only font files (.ttf, .otf, .woff, .woff2, or .ttc)",
-      { title: "Warning" },
-    );
-    return;
-  }
-
-  // Upload files
-  const successfulUploads = await projectService.uploadFiles(files);
-
-  // Add successfully uploaded files to repository and collect new font items
-  const newFontItems = [];
-  for (const result of successfulUploads) {
-    const fontItem = {
-      id: nanoid(),
-      type: "font",
-      fileId: result.fileId,
-      name: result.displayName,
-      fontFamily: result.fontName,
-      fileType: getFileType(result),
-      fileSize: result.file.size,
-    };
-
-    await projectService.createResourceItem({
-      resourceType: "fonts",
-      resourceId: fontItem.id,
-      data: fontItem,
-      parentId: id,
-      position: "last",
-    });
-
-    newFontItems.push(fontItem);
-  }
-
-  if (successfulUploads.length > 0) {
-    const { fonts } = projectService.getState();
-    store.setItems({ fontsData: fonts });
-
-    // Load the newly uploaded fonts to ensure they're available
-    const loadPromises = newFontItems.map((item) =>
-      projectService.loadFontFile({
-        fontName: item.fontFamily,
-        fileId: item.fileId,
-      }),
-    );
-    await Promise.all(loadPromises);
-  }
-
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleFontItemDoubleClick = async (deps, payload) => {
   const { store, render, projectService, appService } = deps;
   const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) return;
-
-  // Find the font item
-  const { fonts } = projectService.getState();
-  const flatItems = toFlatItems(fonts);
-  const fontItem = flatItems.find((item) => item.id === itemId);
-
-  if (!fontItem) {
-    console.warn("Font item not found:", itemId);
+  if (isFolder || !itemId) {
     return;
   }
 
-  // Extract font information
+  const fontItem = store.selectFontItemById({ itemId });
+  if (!fontItem) {
+    return;
+  }
+
   const fontInfoExtractor = createFontInfoExtractor({
     getFileContent: (fileId) => projectService.getFileContent(fileId),
     loadFont: (fontName, fontUrl) => appService.loadFont(fontName, fontUrl),
   });
   const fontInfo = await fontInfoExtractor.extractFontInfo(fontItem);
 
-  // Open modal with font info
-  store.setSelectedFontInfo({ fontInfo: fontInfo });
+  store.setSelectedFontInfo({ fontInfo });
   store.setModalOpen({ isOpen: true });
   render();
 };
 
 export const handleCloseModal = (deps) => {
   const { store, render } = deps;
-
   store.setModalOpen({ isOpen: false });
-  store.setSelectedFontInfo({ fontInfo: null });
-  render();
-};
-
-export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail.value ?? "";
-
-  store.setSearchQuery({ query: searchQuery });
-  render();
-};
-
-export const handleGroupToggle = (deps, payload) => {
-  const { store, render } = deps;
-  const groupId = payload._event.detail.groupId;
-
-  store.toggleGroupCollapse({ groupId: groupId });
+  store.setSelectedFontInfo({ fontInfo: undefined });
   render();
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { projectService, appService, render } = deps;
+  const { itemId } = payload._event.detail;
 
-  const state = projectService.getState();
   const usage = recursivelyCheckResource({
-    state,
+    state: projectService.getState(),
     itemId,
     checkTargets: ["typography"],
   });
@@ -239,14 +232,10 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  // Perform the delete operation
   await projectService.deleteResourceItem({
-    resourceType,
+    resourceType: "fonts",
     resourceId: itemId,
   });
 
-  // Refresh data and update store (reuse existing logic from handleDataChanged)
-  const data = projectService.getState()[resourceType];
-  store.setItems({ fontsData: data });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/fonts/fonts.store.js
+++ b/src/pages/fonts/fonts.store.js
@@ -1,52 +1,5 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
 import { formatFileSize } from "../../utils/index.js";
-
-const folderContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-child-folder" },
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const itemContextMenuItems = [
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const emptyContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-item" },
-];
-
-const fontToBase64Image = (fontFamily, text = "Aa") => {
-  if (!fontFamily) return "";
-
-  // Create a canvas element
-  const canvas = document.createElement("canvas");
-  const ctx = canvas.getContext("2d");
-
-  // Set canvas size
-  canvas.width = 200;
-  canvas.height = 100;
-
-  // Use dark mode colors as default
-  const backgroundColor = "#1a1a1a"; // Dark background
-  const foregroundColor = "#ffffff"; // Light text
-
-  // Fill with background color
-  ctx.fillStyle = backgroundColor;
-  ctx.fillRect(0, 0, 200, 100);
-
-  // Set font and draw text
-  ctx.fillStyle = foregroundColor;
-  ctx.font = `48px "${fontFamily}", sans-serif`;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  ctx.fillText(text, 100, 50);
-
-  // Convert to base64
-  return canvas.toDataURL("image/png");
-};
+import { createMediaPageStore } from "../../deps/features/resourcePages/media/createMediaPageStore.js";
 
 const fontInfoForm = {
   title: "Font Details",
@@ -75,83 +28,10 @@ const fontInfoForm = {
       label: "Format",
       content: "${format}",
     },
-    // NOTE: The following fields are commented out because the current implementation
-    // does not accurately extract this information from font files
-    // {
-    //   name: "weightClass",
-    //   type: "read-only-text",
-    //   description: "Weight Class",
-    // },
-    // {
-    //   name: "isVariableFont",
-    //   type: "read-only-text",
-    //   description: "Variable Font",
-    // },
-    // {
-    //   name: "supportsItalics",
-    //   type: "read-only-text",
-    //   description: "Italic Support",
-    // },
-    // {
-    //   name: "glyphCount",
-    //   type: "read-only-text",
-    //   description: "Glyph Count",
-    // },
-    // {
-    //   name: "languageSupport",
-    //   type: "read-only-text",
-    //   description: "Languages",
-    // },
   ],
 };
 
-export const createInitialState = () => ({
-  fontsData: { tree: [], items: {} },
-  selectedItemId: null,
-  isModalOpen: false,
-  selectedFontInfo: null,
-  searchQuery: "",
-  collapsedIds: [],
-});
-
-export const setItems = ({ state }, { fontsData } = {}) => {
-  state.fontsData = fontsData;
-};
-
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
-
-export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) return null;
-  const flatItems = toFlatItems(state.fontsData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
-};
-
-export const selectSelectedItemId = ({ state }) => state.selectedItemId;
-
-export const setModalOpen = ({ state }, { isOpen } = {}) => {
-  state.isModalOpen = isOpen;
-};
-
-export const setSelectedFontInfo = ({ state }, { fontInfo } = {}) => {
-  state.selectedFontInfo = fontInfo;
-};
-
-export const setSearchQuery = ({ state }, { query } = {}) => {
-  state.searchQuery = query;
-};
-
-export const toggleGroupCollapse = ({ state }, { groupId } = {}) => {
-  const index = state.collapsedIds.indexOf(groupId);
-  if (index > -1) {
-    state.collapsedIds.splice(index, 1);
-  } else {
-    state.collapsedIds.push(groupId);
-  }
-};
-
-export const getGlyphList = (_context = {}, _payload = {}) => {
+const getGlyphList = () => {
   const glyphs = [];
 
   const addGlyph = (char) => {
@@ -160,7 +40,6 @@ export const getGlyphList = (_context = {}, _payload = {}) => {
     glyphs.push({ char, unicode });
   };
 
-  // Basic Latin (A-Z, a-z, 0-9)
   for (let i = 65; i <= 90; i++) {
     addGlyph(String.fromCharCode(i));
   }
@@ -171,13 +50,11 @@ export const getGlyphList = (_context = {}, _payload = {}) => {
     addGlyph(String.fromCharCode(i));
   }
 
-  // Common punctuation
   const punctuation = " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
   for (const char of punctuation) {
     addGlyph(char);
   }
 
-  // Extended Latin characters (common accented characters)
   const extendedLatin =
     "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ";
   for (const char of extendedLatin) {
@@ -187,148 +64,136 @@ export const getGlyphList = (_context = {}, _payload = {}) => {
   return glyphs;
 };
 
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.fontsData);
-  const rawFlatGroups = toFlatGroups(state.fontsData);
-  const searchQuery = (state.searchQuery ?? "").toLowerCase();
-
-  // Helper function to check if an item matches the search query
-  const matchesSearch = (item) => {
-    if (!searchQuery) return true;
-
-    const name = (item.name ?? "").toLowerCase();
-    const description = (item.description ?? "").toLowerCase();
-
-    return name.includes(searchQuery) || description.includes(searchQuery);
-  };
-
-  // Apply collapsed state and search filtering to flatGroups
-  const flatGroups = rawFlatGroups
-    .map((group) => {
-      // Filter children based on search query
-      const filteredChildren = (group.children ?? []).filter(matchesSearch);
-
-      // Only show groups that have matching children or if there's no search query
-      const hasMatchingChildren = filteredChildren.length > 0;
-      const shouldShowGroup = !searchQuery || hasMatchingChildren;
-
-      return {
-        ...group,
-        isCollapsed: state.collapsedIds.includes(group.id),
-        children: state.collapsedIds.includes(group.id)
-          ? []
-          : filteredChildren.map((item) => ({
-              ...item,
-              fontFamily: item.fontFamily ?? "sans-serif",
-              previewText: "Aa",
-              selectedStyle:
-                item.id === state.selectedItemId
-                  ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-                  : "",
-            })),
-        hasChildren: filteredChildren.length > 0,
-        shouldDisplay: shouldShowGroup,
-      };
-    })
-    .filter((group) => group.shouldDisplay);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  // Get file type from extension if browser MIME type is empty
-  const getFileTypeFromName = (fileName) => {
-    if (!fileName) return "";
-    const extension = fileName.toLowerCase().split(".").pop();
-    const extensionMap = {
-      ttf: "font/ttf",
-      otf: "font/otf",
-      woff: "font/woff",
-      woff2: "font/woff2",
-      ttc: "font/ttc",
-      eot: "font/eot",
-    };
-    return extensionMap[extension] || `font/${extension}`;
-  };
-
-  const selectedFontFamily = selectedItem?.fontFamily ?? "";
-  const selectedFileType = selectedItem?.fileType
-    ? selectedItem.fileType
-    : getFileTypeFromName(selectedItem?.name ?? "");
-  const selectedFileSize = selectedItem?.fileSize
-    ? formatFileSize(selectedItem.fileSize)
-    : "";
-  const selectedFontPreview = selectedItem
-    ? fontToBase64Image(selectedFontFamily, "Aa")
-    : "";
-  const detailFields = selectedItem
-    ? [
-        {
-          type: "slot",
-          slot: "font-preview",
-          label: "",
-        },
-        {
-          type: "text",
-          label: "Font Family",
-          value: selectedFontFamily,
-        },
-        {
-          type: "text",
-          label: "File Type",
-          value: selectedFileType,
-        },
-        {
-          type: "text",
-          label: "File Size",
-          value: selectedFileSize,
-        },
-      ]
-    : [];
-
-  // Font info form values
-  let fontInfoValues = {};
-  if (state.selectedFontInfo) {
-    fontInfoValues = {
-      fontFamily: state.selectedFontInfo.fontFamily || "",
-      fileName: state.selectedFontInfo.fileName || "",
-      fileSize: state.selectedFontInfo.fileSize || "",
-      format: state.selectedFontInfo.format || "Unknown",
-      weightClass: state.selectedFontInfo.weightClass || "Unknown",
-      isVariableFont: state.selectedFontInfo.isVariableFont || "Unknown",
-      supportsItalics: state.selectedFontInfo.supportsItalics || "Unknown",
-      glyphCount: state.selectedFontInfo.glyphCount?.toString() || "0",
-      languageSupport: state.selectedFontInfo.languageSupport || "Unknown",
-    };
+const getFileTypeFromName = (fileName) => {
+  if (!fileName) {
+    return "";
   }
 
-  const viewData = {
-    flatItems,
-    flatGroups,
-    resourceCategory: "userInterface",
-    selectedResourceId: "fonts",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    detailFields,
-    title: "Fonts",
-    selectedFontFamily,
-    selectedFontFileId: selectedItem?.fileId,
-    selectedFontPreview,
-    isModalOpen: state.isModalOpen,
-    selectedFontInfo: state.selectedFontInfo,
-    glyphList: state.selectedFontInfo?.glyphs || getGlyphList(),
-    fontInfoForm,
-    fontInfoValues,
-    searchQuery: state.searchQuery,
-    collapsedIds: state.collapsedIds,
-    uploadText: "Upload Font",
-    acceptedFileTypes: [".ttf", ".otf", ".woff", ".woff2", ".ttc", ".eot"],
-    folderContextMenuItems,
-    itemContextMenuItems,
-    emptyContextMenuItems,
-    resourceType: "fonts",
+  const extension = fileName.toLowerCase().split(".").pop();
+  const extensionMap = {
+    ttf: "font/ttf",
+    otf: "font/otf",
+    woff: "font/woff",
+    woff2: "font/woff2",
+    ttc: "font/ttc",
+    eot: "font/eot",
   };
 
-  return viewData;
+  return extensionMap[extension] ?? `font/${extension}`;
+};
+
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
+  }
+
+  return [
+    {
+      type: "slot",
+      slot: "font-preview",
+      label: "",
+    },
+    {
+      type: "text",
+      label: "Font Family",
+      value: item.fontFamily ?? "",
+    },
+    {
+      type: "text",
+      label: "File Type",
+      value: item.fileType ?? getFileTypeFromName(item.name ?? ""),
+    },
+    {
+      type: "text",
+      label: "File Size",
+      value: item.fileSize ? formatFileSize(item.fileSize) : "",
+    },
+  ];
+};
+
+const buildMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "font",
+  fontFamily: item.fontFamily ?? "sans-serif",
+  previewText: "Aa",
+  fontFileId: item.fileId,
+});
+
+const {
+  createInitialState: createMediaInitialState,
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectMediaViewData,
+} = createMediaPageStore({
+  itemType: "font",
+  resourceType: "fonts",
+  title: "Fonts",
+  selectedResourceId: "fonts",
+  resourceCategory: "userInterface",
+  uploadText: "Upload Font",
+  acceptedFileTypes: [".ttf", ".otf", ".woff", ".woff2", ".ttc", ".eot"],
+  centerItemContextMenuItems: [
+    { label: "Delete", type: "item", value: "delete-item" },
+  ],
+  buildDetailFields,
+  buildMediaItem,
+  getSelectedPreviewFileId: (item) => item?.fileId,
+  extendViewData: ({ state, selectedItem, baseViewData }) => {
+    const selectedFontInfo = state.selectedFontInfo;
+
+    return {
+      ...baseViewData,
+      isModalOpen: state.isModalOpen,
+      selectedFontInfo,
+      selectedFontFamily: selectedItem?.fontFamily ?? "",
+      fontInfoForm,
+      fontInfoValues: selectedFontInfo
+        ? {
+            fontFamily: selectedFontInfo.fontFamily ?? "",
+            fileName: selectedFontInfo.fileName ?? "",
+            fileSize: selectedFontInfo.fileSize ?? "",
+            format: selectedFontInfo.format ?? "Unknown",
+            weightClass: selectedFontInfo.weightClass ?? "Unknown",
+            isVariableFont: selectedFontInfo.isVariableFont ?? "Unknown",
+            supportsItalics: selectedFontInfo.supportsItalics ?? "Unknown",
+            glyphCount: selectedFontInfo.glyphCount?.toString() ?? "0",
+            languageSupport: selectedFontInfo.languageSupport ?? "Unknown",
+          }
+        : {},
+      glyphList: selectedFontInfo?.glyphs ?? getGlyphList(),
+    };
+  },
+});
+
+export const createInitialState = () => ({
+  ...createMediaInitialState(),
+  isModalOpen: false,
+  selectedFontInfo: undefined,
+});
+
+export {
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
+};
+
+export const selectFontItemById = selectItemById;
+
+export const setModalOpen = ({ state }, { isOpen } = {}) => {
+  state.isModalOpen = isOpen;
+};
+
+export const setSelectedFontInfo = ({ state }, { fontInfo } = {}) => {
+  state.selectedFontInfo = fontInfo;
+};
+
+export const selectViewData = (context) => {
+  return selectMediaViewData(context);
 };

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -15,8 +15,10 @@ refs:
         handler: handleFontItemClick
       item-dblclick:
         handler: handleFontItemDoubleClick
-      files-uploaded:
-        handler: handleDragDropFileSelected
+      files-dropped:
+        handler: handleFilesDropped
+      upload-click:
+        handler: handleUploadClick
       search-input:
         handler: handleSearchInput
       item-delete:
@@ -41,7 +43,7 @@ template:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
                   - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - rtgl-view w=1fg h=f:
-              - rvn-group-resources-view#groupview :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes: null
+              - rvn-media-resources-view#groupview :navTitle=title :groups=mediaGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
@@ -49,9 +51,9 @@ template:
                           - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
                               - rtgl-text c=mu-fg: ${selectedItemName}
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
-                              - $if selectedFontFileId:
+                              - $if selectedPreviewFileId:
                                   - rtgl-view#detailFontPreview slot="font-preview" bw=xs bc=bo br=md p=md cur=pointer:
-                                      - rvn-font-preview fileId=${selectedFontFileId} fontFamily=${selectedFontFamily} previewText="Aa" fontSize=60 width=220 height=110 av=c ah=c: null
+                                      - rvn-font-preview fileId=${selectedPreviewFileId} fontFamily=${selectedFontFamily} previewText="Aa" fontSize=60 width=220 height=110 av=c ah=c: null
                                 $else:
                                   - rtgl-view#detailFontPreview slot="font-preview" h=110 bw=xs bc=bo br=md av=c ah=c cur=pointer:
                                       - rtgl-text c=mu-fg s=sm: No Preview

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -1,109 +1,125 @@
 import { nanoid } from "nanoid";
 import { filter, tap } from "rxjs";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
+import { createMediaPageHandlers } from "../../deps/features/resourcePages/media/createMediaPageHandlers.js";
+import { resolveResourceParentId } from "../../deps/features/resourcePages/media/mediaPageShared.js";
 
 const COLLAB_IMAGES_REFRESH_ACTION = "collab.images.refresh";
 
-const openEditDialogWithValues = ({ deps, itemId } = {}) => {
-  const { store, render, refs } = deps;
-  const { fileExplorer, editForm } = refs;
-  if (!itemId) {
+const {
+  refreshData: handleDataChanged,
+  handleBeforeMount,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerDoubleClick,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleSearchInput,
+  handleItemClick: handleImageItemClick,
+  handleItemDoubleClick: handleImageItemDoubleClick,
+  handleItemEdit: handleImageItemEdit,
+} = createMediaPageHandlers({
+  resourceType: "images",
+  subscriptions: (deps) => {
+    const { subject } = deps;
+    return [
+      subject.pipe(
+        filter(({ action }) => action === COLLAB_IMAGES_REFRESH_ACTION),
+        tap(() => {
+          deps.handlers.handleDataChanged(deps);
+        }),
+      ),
+    ];
+  },
+  selectItemById: (store, { itemId }) => store.selectImageItemById({ itemId }),
+  getEditPreviewFileId: (item) => item?.fileId,
+});
+
+export {
+  handleBeforeMount,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerDoubleClick,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleDataChanged,
+  handleSearchInput,
+  handleImageItemClick,
+  handleImageItemDoubleClick,
+  handleImageItemEdit,
+};
+
+const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
+  const { appService, projectService } = deps;
+  let successfulUploads;
+
+  try {
+    successfulUploads = await projectService.uploadFiles(files);
+  } catch {
+    appService.showToast("Failed to upload images.", { title: "Error" });
     return;
   }
 
-  const imageItem = store.selectImageItemById({ itemId });
-  if (!imageItem) {
+  if (!successfulUploads.length) {
+    appService.showToast("Failed to upload images.", { title: "Error" });
     return;
   }
 
-  const editValues = {
-    name: imageItem.name ?? "",
-    description: imageItem.description ?? "",
-  };
+  for (const result of successfulUploads) {
+    await projectService.createResourceItem({
+      resourceType: "images",
+      resourceId: nanoid(),
+      data: {
+        type: "image",
+        fileId: result.fileId,
+        name: result.displayName,
+        fileType: result.file.type,
+        fileSize: result.file.size,
+        width: result.dimensions.width,
+        height: result.dimensions.height,
+      },
+      parentId,
+      position: "last",
+    });
+  }
 
-  store.setSelectedItemId({ itemId });
-  fileExplorer.selectItem({ itemId });
-  store.openEditDialog({
-    itemId,
-    defaultValues: editValues,
-    fileId: imageItem.fileId,
+  await handleDataChanged(deps);
+};
+
+export const handleUploadClick = async (deps, payload) => {
+  const { appService } = deps;
+  const { groupId } = payload._event.detail;
+  let files;
+
+  try {
+    files = await appService.pickFiles({
+      accept: ".jpg,.jpeg,.png,.webp",
+      multiple: true,
+    });
+  } catch {
+    appService.showToast("Failed to select files.", { title: "Error" });
+    return;
+  }
+
+  if (!files?.length) {
+    return;
+  }
+
+  await createImagesFromFiles({
+    deps,
+    files,
+    parentId: resolveResourceParentId(groupId),
   });
-  render();
-  editForm.reset();
-  editForm.setValues({ values: editValues });
 };
 
-const mountSubscriptions = (deps) => {
-  const streams = subscriptions(deps) ?? [];
-  const active = streams.map((stream) => stream.subscribe());
-  return () => active.forEach((subscription) => subscription?.unsubscribe?.());
-};
-
-export const handleBeforeMount = (deps) => {
-  const { store, projectService } = deps;
-  const { images } = projectService.getState();
-  store.setItems({ imagesData: images });
-  return mountSubscriptions(deps);
-};
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const detail = payload._event.detail;
-  const { itemId: id } = detail;
-  const { isFolder } = detail;
-
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: null });
-    render();
-    return;
-  }
-
-  if (!id) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: id });
-  render();
-};
-
-export const handleFileExplorerDoubleClick = (deps, payload) => {
-  const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) return;
-  openEditDialogWithValues({ deps, itemId });
-};
-
-const refreshImagesData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const repository = await projectService.getRepository();
-  const state = repository.getState();
-  store.setItems({ imagesData: state.images });
-  render();
-};
-
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "images",
-    refresh: refreshImagesData,
+export const handleFilesDropped = async (deps, payload) => {
+  const { files, targetGroupId } = payload._event.detail;
+  await createImagesFromFiles({
+    deps,
+    files,
+    parentId: targetGroupId ?? undefined,
   });
-
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleFileExplorerDataChanged = refreshImagesData;
-
-const subscriptions = (deps) => {
-  const { subject } = deps;
-  return [
-    subject.pipe(
-      filter(({ action }) => action === COLLAB_IMAGES_REFRESH_ACTION),
-      tap(() => {
-        deps.handlers.handleFileExplorerDataChanged(deps);
-      }),
-    ),
-  ];
 };
 
 export const handleFormExtraEvent = async (deps) => {
-  const { appService, projectService, store, render } = deps;
+  const { appService, projectService, store } = deps;
   let file;
 
   const selectedItem = store.selectSelectedItem();
@@ -113,7 +129,7 @@ export const handleFormExtraEvent = async (deps) => {
 
   try {
     file = await appService.pickFiles({
-      accept: "image/*",
+      accept: ".jpg,.jpeg,.png,.webp",
       multiple: false,
       upload: true,
     });
@@ -123,7 +139,7 @@ export const handleFormExtraEvent = async (deps) => {
   }
 
   if (!file) {
-    return; // User cancelled
+    return;
   }
 
   if (!(file.uploadSucessful && file.uploadResult)) {
@@ -145,31 +161,7 @@ export const handleFormExtraEvent = async (deps) => {
     },
   });
 
-  // Update the store with the new repository state
-  const { images } = projectService.getState();
-  store.setItems({ imagesData: images });
-  render();
-};
-
-export const handleImageItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const { itemId } = payload._event.detail;
-
-  if (!itemId) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: itemId });
-
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  render();
-};
-
-export const handleImageItemDoubleClick = (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  openEditDialogWithValues({ deps, itemId });
+  await handleDataChanged(deps);
 };
 
 export const handleImageItemPreview = (deps, payload) => {
@@ -177,11 +169,6 @@ export const handleImageItemPreview = (deps, payload) => {
   const { itemId } = payload._event.detail;
   store.showFullImagePreview({ itemId });
   render();
-};
-
-export const handleImageItemEdit = (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  openEditDialogWithValues({ deps, itemId });
 };
 
 export const handleEditDialogClose = (deps) => {
@@ -196,7 +183,7 @@ export const handleEditDialogImageClick = async (deps) => {
 
   try {
     file = await appService.pickFiles({
-      accept: "image/*",
+      accept: ".jpg,.jpeg,.png,.webp",
       multiple: false,
       upload: true,
     });
@@ -214,7 +201,10 @@ export const handleEditDialogImageClick = async (deps) => {
     return;
   }
 
-  store.setEditImageUpload({ uploadResult: file.uploadResult });
+  store.setEditUpload({
+    uploadResult: file.uploadResult,
+    previewFileId: file.uploadResult.fileId,
+  });
   render();
 };
 
@@ -238,14 +228,14 @@ export const handleEditFormAction = async (deps, payload) => {
     return;
   }
 
-  const editImageUploadResult = store.getState().editImageUploadResult;
-  const imagePatch = editImageUploadResult
+  const editUploadResult = store.getState().editUploadResult;
+  const imagePatch = editUploadResult
     ? {
-        fileId: editImageUploadResult.fileId,
-        fileType: editImageUploadResult.file.type,
-        fileSize: editImageUploadResult.file.size,
-        width: editImageUploadResult.dimensions.width,
-        height: editImageUploadResult.dimensions.height,
+        fileId: editUploadResult.fileId,
+        fileType: editUploadResult.file.type,
+        fileSize: editUploadResult.file.size,
+        width: editUploadResult.dimensions.width,
+        height: editUploadResult.dimensions.height,
       }
     : {};
 
@@ -259,49 +249,15 @@ export const handleEditFormAction = async (deps, payload) => {
     },
   });
 
-  const { images } = projectService.getState();
-  store.setItems({ imagesData: images });
   store.closeEditDialog();
-  render();
-};
-
-export const handleDragDropFileSelected = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { files, targetGroupId } = payload._event.detail;
-  const id = targetGroupId;
-
-  const successfulUploads = await projectService.uploadFiles(files);
-  for (const result of successfulUploads) {
-    await projectService.createResourceItem({
-      resourceType: "images",
-      resourceId: nanoid(),
-      data: {
-        type: "image",
-        fileId: result.fileId,
-        name: result.displayName,
-        fileType: result.file.type,
-        fileSize: result.file.size,
-        width: result.dimensions.width,
-        height: result.dimensions.height,
-      },
-      parentId: id,
-      position: "last",
-    });
-  }
-
-  if (successfulUploads.length > 0) {
-    const { images } = projectService.getState();
-    store.setItems({ imagesData: images });
-  }
-
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { projectService, appService, render } = deps;
+  const { itemId } = payload._event.detail;
   const result = await projectService.deleteResourceItemIfUnused({
-    resourceType,
+    resourceType: "images",
     resourceId: itemId,
     checkTargets: ["scenes", "layouts"],
   });
@@ -312,8 +268,5 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  // Refresh data and update store (reuse existing logic from handleDataChanged)
-  const data = projectService.getState()[resourceType];
-  store.setItems({ imagesData: data });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -1,126 +1,138 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
 import { formatFileSize } from "../../utils/index.js";
+import { createMediaPageStore } from "../../deps/features/resourcePages/media/createMediaPageStore.js";
 
-const folderContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-child-folder" },
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
+  }
 
-const itemContextMenuItems = [
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
+  return [
+    {
+      type: "slot",
+      slot: "image-file-id",
+      label: "",
+    },
+    {
+      type: "description",
+      value: item.description ?? "",
+    },
+    {
+      type: "text",
+      label: "File Type",
+      value: item.fileType ?? "",
+    },
+    {
+      type: "text",
+      label: "File Size",
+      value: formatFileSize(item.fileSize),
+    },
+    {
+      type: "text",
+      label: "Dimensions",
+      value: item.width && item.height ? `${item.width} × ${item.height}` : "",
+    },
+  ];
+};
 
-const emptyContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-item" },
-];
+const buildMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "image",
+  imageFileId: item.fileId,
+  canPreview: true,
+});
+
+const createEditForm = () => ({
+  title: "Edit Image",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "description",
+      type: "input-textarea",
+      label: "Description",
+      required: false,
+    },
+    {
+      type: "slot",
+      slot: "image-slot",
+      label: "Image",
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Update Image",
+      },
+    ],
+  },
+});
+
+const {
+  createInitialState: createMediaInitialState,
+  setItems,
+  setSelectedItemId,
+  openEditDialog,
+  closeEditDialog,
+  setEditUpload,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectMediaViewData,
+} = createMediaPageStore({
+  itemType: "image",
+  resourceType: "images",
+  title: "Images",
+  selectedResourceId: "images",
+  uploadText: "Upload Image",
+  acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
+  showZoomControls: true,
+  buildDetailFields,
+  buildMediaItem,
+  createEditForm,
+  getSelectedPreviewFileId: (item) => item?.fileId,
+  extendViewData: ({ state, baseViewData }) => ({
+    ...baseViewData,
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewFileId: state.fullImagePreviewFileId,
+  }),
+});
 
 export const createInitialState = () => ({
-  imagesData: { tree: [], items: {} },
-  selectedItemId: null,
-  isEditDialogOpen: false,
-  editItemId: undefined,
-  editDefaultValues: {
-    name: "",
-    description: "",
-  },
-  editImageFileId: undefined,
-  editImageUploadResult: undefined,
-  searchQuery: "",
+  ...createMediaInitialState(),
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
 });
 
-export const setItems = ({ state }, { imagesData } = {}) => {
-  state.imagesData = imagesData;
+export {
+  setItems,
+  setSelectedItemId,
+  openEditDialog,
+  closeEditDialog,
+  setEditUpload,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
 };
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
-
-export const openEditDialog = (
-  { state },
-  { itemId, defaultValues, fileId } = {},
-) => {
-  state.isEditDialogOpen = true;
-  state.editItemId = itemId;
-  state.editDefaultValues = {
-    name: defaultValues?.name ?? "",
-    description: defaultValues?.description ?? "",
-  };
-  state.editImageFileId = fileId;
-  state.editImageUploadResult = undefined;
-};
-
-export const closeEditDialog = ({ state }, _payload = {}) => {
-  state.isEditDialogOpen = false;
-  state.editItemId = undefined;
-  state.editDefaultValues = {
-    name: "",
-    description: "",
-  };
-  state.editImageFileId = undefined;
-  state.editImageUploadResult = undefined;
-};
-
-export const setEditImageUpload = ({ state }, { uploadResult } = {}) => {
-  state.editImageUploadResult = uploadResult;
-  state.editImageFileId = uploadResult?.fileId;
-};
-
-const getSelectedItemFromState = (state) => {
-  if (!state.selectedItemId) {
-    return null;
-  }
-  const flatItems = toFlatItems(state.imagesData);
-  return flatItems.find((item) => item.id === state.selectedItemId) ?? null;
-};
-
-const createDetailFormValues = (item) => {
-  if (!item) {
-    return {
-      fileType: "",
-      fileSize: "",
-      dimensions: "",
-    };
-  }
-
-  return {
-    fileType: item.fileType ?? "",
-    fileSize: formatFileSize(item.fileSize),
-    dimensions: `${item.width} × ${item.height}`,
-  };
-};
-
-export const selectSelectedItem = ({ state }) => {
-  return getSelectedItemFromState(state);
-};
-
-export const selectImageItemById = ({ state }, { itemId } = {}) => {
-  const item = state.imagesData?.items?.[itemId];
-  return item?.type === "image" ? item : undefined;
-};
-
-export const selectSelectedItemId = ({ state }) => {
-  return state.selectedItemId;
-};
-
-export const setSearchQuery = ({ state }, { value } = {}) => {
-  state.searchQuery = value ?? "";
-};
+export const selectImageItemById = selectItemById;
 
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {
-  const flatItems = toFlatItems(state.imagesData);
-  const item = flatItems.find((item) => item.id === itemId);
-
-  if (item && item.fileId) {
-    state.fullImagePreviewVisible = true;
-    state.fullImagePreviewFileId = item.fileId;
+  const item = state.data?.items?.[itemId];
+  if (!(item?.type === "image") || !item.fileId) {
+    return;
   }
+
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewFileId = item.fileId;
 };
 
 export const hideFullImagePreview = ({ state }, _payload = {}) => {
@@ -128,137 +140,6 @@ export const hideFullImagePreview = ({ state }, _payload = {}) => {
   state.fullImagePreviewFileId = undefined;
 };
 
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.imagesData);
-  const rawFlatGroups = toFlatGroups(state.imagesData);
-  const searchQuery = (state.searchQuery ?? "").toLowerCase();
-
-  // Helper function to check if an item matches the search query
-  const matchesSearch = (item) => {
-    if (!searchQuery) return true;
-
-    const name = (item.name ?? "").toLowerCase();
-    const description = (item.description ?? "").toLowerCase();
-
-    return name.includes(searchQuery) || description.includes(searchQuery);
-  };
-
-  // Fixed base dimensions - zoom is handled by groupResourcesView
-  const baseHeight = 150;
-  const baseWidth = 400;
-  const imageHeight = baseHeight;
-  const maxWidth = baseWidth;
-
-  // Apply search filtering to flatGroups (collapse state is now handled by groupResourcesView)
-  const flatGroups = rawFlatGroups
-    .map((group) => {
-      // Filter children based on search query
-      const filteredChildren = (group.children ?? []).filter(matchesSearch);
-
-      // Only show groups that have matching children or if there's no search query
-      const hasMatchingChildren = filteredChildren.length > 0;
-      const shouldShowGroup = !searchQuery || hasMatchingChildren;
-
-      return {
-        ...group,
-        children: filteredChildren.map((item) => ({
-          ...item,
-          height: imageHeight,
-          maxWidth: maxWidth,
-          selectedStyle:
-            item.id === state.selectedItemId
-              ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-              : "",
-        })),
-        hasChildren: filteredChildren.length > 0,
-        shouldDisplay: shouldShowGroup,
-      };
-    })
-    .filter((group) => group.shouldDisplay);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  let detailFields = [];
-  const selectedItemName = selectedItem?.name ?? "";
-
-  if (selectedItem) {
-    const detailFormValues = createDetailFormValues(selectedItem);
-    const { fileType, fileSize, dimensions } = detailFormValues;
-
-    detailFields = [
-      {
-        type: "slot",
-        slot: "image-file-id",
-        label: "",
-      },
-      { type: "description", value: selectedItem.description ?? "" },
-      { type: "text", label: "File Type", value: fileType },
-      { type: "text", label: "File Size", value: fileSize },
-      { type: "text", label: "Dimensions", value: dimensions },
-    ];
-  }
-
-  const editForm = {
-    title: "Edit Image",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Name",
-        required: true,
-      },
-      {
-        name: "description",
-        type: "input-textarea",
-        label: "Description",
-        required: false,
-      },
-      {
-        type: "slot",
-        slot: "image-slot",
-        label: "Image",
-      },
-    ],
-    actions: {
-      layout: "",
-      buttons: [
-        {
-          id: "submit",
-          variant: "pr",
-          label: "Update Image",
-        },
-      ],
-    },
-  };
-
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "assets",
-    selectedResourceId: "images",
-    selectedItemId: state.selectedItemId,
-    selectedItemName,
-    detailFields,
-    searchQuery: state.searchQuery,
-    resourceType: "images",
-    title: "Images",
-    uploadText: "Upload Image",
-    acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
-    imageHeight,
-    maxWidth,
-    selectedImageFileId: selectedItem?.fileId,
-    fullImagePreviewVisible: state.fullImagePreviewVisible,
-    fullImagePreviewFileId: state.fullImagePreviewFileId,
-    folderContextMenuItems,
-    itemContextMenuItems,
-    emptyContextMenuItems,
-    isEditDialogOpen: state.isEditDialogOpen,
-    editItemId: state.editItemId,
-    editForm,
-    editDefaultValues: state.editDefaultValues,
-    editImageFileId: state.editImageFileId,
-  };
+export const selectViewData = (context) => {
+  return selectMediaViewData(context);
 };

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -19,12 +19,12 @@ refs:
         handler: handleImageItemPreview
       item-edit:
         handler: handleImageItemEdit
-      files-uploaded:
-        handler: handleDragDropFileSelected
+      files-dropped:
+        handler: handleFilesDropped
+      upload-click:
+        handler: handleUploadClick
       search-input:
-        action: setSearchQuery
-        payload:
-          value: ${_event.detail.value}
+        handler: handleSearchInput
       item-delete:
         handler: handleItemDelete
   previewOverlay:
@@ -59,7 +59,7 @@ template:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
                   - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
-              - rvn-group-resources-view#groupview w=f h=f :navTitle=title show-zoom-controls :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :imageHeight=imageHeight :maxWidth=maxWidth: null
+              - rvn-media-resources-view#groupview w=f h=f :navTitle=title show-zoom-controls :groups=mediaGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :imageHeight=imageHeight :maxWidth=maxWidth :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
@@ -67,17 +67,17 @@ template:
                           - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
                               - rtgl-text c=mu-fg: ${selectedItemName}
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
-                              - $if selectedImageFileId:
-                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedImageFileId} h=160 bw=xs bc=bo br=md cur=pointer: null
+                              - $if selectedPreviewFileId:
+                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} h=160 bw=xs bc=bo br=md cur=pointer: null
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=editDefaultValues :form=editForm w=f:
-              - $if editImageFileId:
+              - $if editPreviewFileId:
                   - rtgl-view slot=image-slot av=c ah=c:
-                      - rvn-file-image#editDialogImage fileId=${editImageFileId} h=120 bw=xs bc=bo br=md cur=pointer key=${editImageFileId}: null
+                      - rvn-file-image#editDialogImage fileId=${editPreviewFileId} h=120 bw=xs bc=bo br=md cur=pointer key=${editPreviewFileId}: null
                 $else:
                   - rtgl-view slot=image-slot av=c ah=c:
                       - rtgl-view#editDialogImagePlaceholder w=120 h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -1,66 +1,44 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
+import { createCatalogPageHandlers } from "../../deps/features/resourcePages/catalog/createCatalogPageHandlers.js";
 import { createLayoutsFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
 
-export const handleAfterMount = async (deps) => {
-  const { store, projectService, render } = deps;
-  await projectService.ensureRepository();
-  const { layouts } = projectService.getState();
-  store.setItems({ layoutsData: layouts });
-  render();
-};
+const {
+  handleAfterMount,
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleItemClick: handleLayoutItemClick,
+  handleSearchInput,
+} = createCatalogPageHandlers({
+  resourceType: "layouts",
+  createExplorerHandlers: ({ refresh }) =>
+    createLayoutsFileExplorerHandlers({
+      refresh,
+    }),
+});
 
-const refreshLayoutsData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const { layouts } = projectService.getState();
-  store.setItems({ layoutsData: layouts });
-  render();
-};
-
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createLayoutsFileExplorerHandlers({
-    refresh: refreshLayoutsData,
-  });
-
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleDataChanged = refreshLayoutsData;
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { id, isFolder } = payload._event.detail;
-
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: id });
-  render();
-};
-
-export const handleImageItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const { itemId } = payload._event.detail;
-
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  store.setSelectedItemId({ itemId: itemId });
-  render();
+export {
+  handleAfterMount,
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleLayoutItemClick,
+  handleSearchInput,
 };
 
 export const handleItemDoubleClick = (deps, payload) => {
   const { appService } = deps;
   const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) return;
+  if (isFolder) {
+    return;
+  }
 
-  // Get current payload to preserve projectId
   const currentPayload = appService.getPayload();
-
   appService.navigate("/project/resources/layout-editor", {
-    ...currentPayload, // Preserve existing payload (including p for projectId)
+    ...currentPayload,
     layoutId: itemId,
   });
 };
@@ -68,50 +46,7 @@ export const handleItemDoubleClick = (deps, payload) => {
 export const handleAddLayoutClick = (deps, payload) => {
   const { store, render } = deps;
   const { groupId } = payload._event.detail;
-
-  store.openAddDialog({ groupId: groupId });
-  render();
-};
-
-export const handleDragDropFileSelected = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { files, targetGroupId } = payload._event.detail; // Extract from forwarded event
-  const id = targetGroupId;
-
-  // Upload all files
-  const successfulUploads = await projectService.uploadFiles(files);
-
-  for (const result of successfulUploads) {
-    await projectService.createLayoutItem({
-      layoutId: nanoid(),
-      name: result.displayName,
-      layoutType: "normal",
-      elements: {
-        items: {},
-        tree: [],
-      },
-      parentId: id,
-      position: "last",
-      data: {
-        fileId: result.fileId,
-        fileType: result.file.type,
-        fileSize: result.file.size,
-      },
-    });
-  }
-
-  if (successfulUploads.length > 0) {
-    const { layouts } = projectService.getState();
-    store.setItems({ layoutsData: layouts });
-  }
-
-  render();
-};
-
-export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail?.value ?? "";
-  store.setSearchQuery({ query: searchQuery });
+  store.openAddDialog({ groupId });
   render();
 };
 
@@ -193,7 +128,9 @@ const createLayoutTemplate = (layoutType) => {
         },
       ],
     };
-  } else if (layoutType === "nvl") {
+  }
+
+  if (layoutType === "nvl") {
     const nvlContainerId = nanoid();
     const nvlBackgroundId = nanoid();
     const nvlLinesId = nanoid();
@@ -322,7 +259,9 @@ const createLayoutTemplate = (layoutType) => {
         },
       ],
     };
-  } else if (layoutType === "normal") {
+  }
+
+  if (layoutType === "normal") {
     const rootId = nanoid();
     const textId = nanoid();
 
@@ -372,7 +311,9 @@ const createLayoutTemplate = (layoutType) => {
         },
       ],
     };
-  } else if (layoutType === "base") {
+  }
+
+  if (layoutType === "base") {
     const spriteId = nanoid();
 
     return {
@@ -412,44 +353,43 @@ const createLayoutTemplate = (layoutType) => {
 };
 
 export const handleLayoutFormActionClick = async (deps, payload) => {
-  const { store, render, projectService, appService } = deps;
+  const { store, projectService, appService } = deps;
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
+    return;
+  }
 
-  const formData = payload._event.detail.values;
-  const targetGroupId = store.getState().targetGroupId;
-
-  // Validate required fields
-  if (!formData.name) {
+  const name = values?.name?.trim();
+  if (!name) {
     appService.showToast("Please enter a layout name", { title: "Warning" });
     return;
   }
-  if (!formData.layoutType) {
+
+  const layoutType = values?.layoutType;
+  if (!layoutType) {
     appService.showToast("Please select a layout type", { title: "Warning" });
     return;
   }
 
-  // Create the layout directly in the repository (like colors page does)
   await projectService.createLayoutItem({
     layoutId: nanoid(),
-    name: formData.name,
-    layoutType: formData.layoutType,
-    elements: createLayoutTemplate(formData.layoutType),
-    parentId: targetGroupId,
+    name,
+    layoutType,
+    elements: createLayoutTemplate(layoutType),
+    parentId: store.getState().targetGroupId,
     position: "last",
   });
 
-  const { layouts } = projectService.getState();
-  store.setItems({ layoutsData: layouts });
   store.closeAddDialog();
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { projectService, appService, render } = deps;
+  const { itemId } = payload._event.detail;
 
-  const state = projectService.getState();
   const usage = recursivelyCheckResource({
-    state,
+    state: projectService.getState(),
     itemId,
     checkTargets: ["scenes"],
   });
@@ -460,11 +400,6 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  // Perform the delete operation
   await projectService.deleteLayoutItem({ layoutId: itemId });
-
-  // Refresh data and update store (reuse existing logic from handleDataChanged)
-  const data = projectService.getState()[resourceType];
-  store.setItems({ layoutsData: data });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/layouts/layouts.store.js
+++ b/src/pages/layouts/layouts.store.js
@@ -1,4 +1,4 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
+import { createCatalogPageStore } from "../../deps/features/resourcePages/catalog/createCatalogPageStore.js";
 
 const layoutForm = {
   title: "Add Layout",
@@ -39,139 +39,90 @@ const layoutForm = {
   },
 };
 
-export const createInitialState = () => ({
-  layoutsData: { tree: [], items: {} },
-  selectedItemId: null,
-  searchQuery: "",
-  isAddDialogOpen: false,
-  targetGroupId: null,
-  contextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-    { label: "Duplicate", type: "item", value: "duplicate-item" },
-    { label: "Rename", type: "item", value: "rename-item" },
-    { label: "Delete", type: "item", value: "delete-item" },
-  ],
-  emptyContextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-  ],
-});
-
-export const setItems = ({ state }, { layoutsData } = {}) => {
-  state.layoutsData = layoutsData;
+const layoutTypeLabels = {
+  normal: "Normal",
+  dialogue: "Dialogue",
+  nvl: "NVL",
+  choice: "Choice",
+  base: "Base",
 };
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
-
-export const setSearchQuery = ({ state }, { query } = {}) => {
-  state.searchQuery = query;
-};
-
-export const openAddDialog = ({ state }, { groupId } = {}) => {
-  state.isAddDialogOpen = true;
-  state.targetGroupId = groupId;
-};
-
-export const closeAddDialog = ({ state }, _payload = {}) => {
-  state.isAddDialogOpen = false;
-  state.targetGroupId = null;
-};
-
-export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) return null;
-  const flatItems = toFlatItems(state.layoutsData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
-};
-
-export const selectSelectedItemId = ({ state }) => state.selectedItemId;
-
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.layoutsData);
-  const rawFlatGroups = toFlatGroups(state.layoutsData);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  const layoutTypeLabels = {
-    normal: "Normal",
-    dialogue: "Dialogue",
-    nvl: "NVL",
-    choice: "Choice",
-    base: "Base",
-  };
-  const selectedLayoutTypeLabel = selectedItem?.layoutType
-    ? (layoutTypeLabels[selectedItem.layoutType] ?? selectedItem.layoutType)
-    : "";
-  const detailFields = selectedItem
-    ? [
-        {
-          type: "text",
-          label: "Layout Type",
-          value: selectedLayoutTypeLabel,
-        },
-      ]
-    : [];
-
-  // Apply search filter
-  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
-  let filteredGroups = rawFlatGroups;
-
-  if (searchQuery) {
-    filteredGroups = rawFlatGroups
-      .map((group) => {
-        const filteredChildren = (group.children ?? []).filter((item) => {
-          const name = (item.name ?? "").toLowerCase();
-          return name.includes(searchQuery);
-        });
-
-        const groupName = (group.name ?? "").toLowerCase();
-        const shouldIncludeGroup =
-          filteredChildren.length > 0 || groupName.includes(searchQuery);
-
-        return shouldIncludeGroup
-          ? {
-              ...group,
-              children: filteredChildren,
-              hasChildren: filteredChildren.length > 0,
-            }
-          : null;
-      })
-      .filter(Boolean);
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
   }
 
-  // Apply selection styling (collapse state is now handled by groupResourcesView)
-  const flatGroups = filteredGroups.map((group) => ({
-    ...group,
-    children: (group.children ?? []).map((item) => ({
-      ...item,
-      selectedStyle:
-        item.id === state.selectedItemId
-          ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-          : "",
-    })),
-  }));
+  return [
+    {
+      type: "text",
+      label: "Layout Type",
+      value: layoutTypeLabels[item.layoutType] ?? item.layoutType ?? "",
+    },
+  ];
+};
 
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "userInterface",
-    selectedResourceId: "layouts",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    detailFields,
-    contextMenuItems: state.contextMenuItems,
-    emptyContextMenuItems: state.emptyContextMenuItems,
-    searchQuery: state.searchQuery,
-    resourceType: "layouts",
-    title: "Layouts",
+const buildCatalogItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "layout",
+  subtitle: layoutTypeLabels[item.layoutType] ?? item.layoutType ?? "",
+});
+
+const {
+  createInitialState: createCatalogInitialState,
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectCatalogViewData,
+} = createCatalogPageStore({
+  itemType: "layout",
+  resourceType: "layouts",
+  title: "Layouts",
+  selectedResourceId: "layouts",
+  resourceCategory: "userInterface",
+  addText: "Add Layout",
+  buildDetailFields,
+  buildCatalogItem,
+  extendViewData: ({ state, baseViewData }) => ({
+    ...baseViewData,
     isAddDialogOpen: state.isAddDialogOpen,
-    layoutForm: layoutForm,
+    layoutForm,
     layoutFormDefaults: {
       name: "",
       layoutType: "dialogue",
     },
-  };
+  }),
+});
+
+export const createInitialState = () => ({
+  ...createCatalogInitialState(),
+  isAddDialogOpen: false,
+  targetGroupId: undefined,
+});
+
+export {
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
+};
+
+export const selectLayoutItemById = selectItemById;
+
+export const openAddDialog = ({ state }, { groupId } = {}) => {
+  state.isAddDialogOpen = true;
+  state.targetGroupId = groupId === "_root" ? undefined : groupId;
+};
+
+export const closeAddDialog = ({ state }, _payload = {}) => {
+  state.isAddDialogOpen = false;
+  state.targetGroupId = undefined;
+};
+
+export const selectViewData = (context) => {
+  return selectCatalogViewData(context);
 };

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -12,11 +12,9 @@ refs:
   groupview:
     eventListeners:
       item-click:
-        handler: handleImageItemClick
+        handler: handleLayoutItemClick
       item-dblclick:
         handler: handleItemDoubleClick
-      files-uploaded:
-        handler: handleDragDropFileSelected
       add-click:
         handler: handleAddLayoutClick
       search-input:
@@ -32,14 +30,14 @@ refs:
       form-action:
         handler: handleLayoutFormActionClick
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
-                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :contextMenuItems=contextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
-          - rtgl-view w=1fg h=f:
-              - rvn-group-resources-view#groupview :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery: null
+                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+              - rvn-catalog-resources-view#groupview w=f h=f :navTitle=title :groups=catalogGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :addText=addText :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -1,16 +1,11 @@
 import { nanoid } from "nanoid";
 import { filter, tap } from "rxjs";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
+import { createMediaPageHandlers } from "../../deps/features/resourcePages/media/createMediaPageHandlers.js";
+import { resolveResourceParentId } from "../../deps/features/resourcePages/media/mediaPageShared.js";
 
 const UNSUPPORTED_FORMAT_TITLE = "Unsupported Format";
 const UNSUPPORTED_FORMAT_MESSAGE =
   "The audio file format is not supported. Please use MP3, WAV, or OGG (Windows only) files.";
-
-const mountSubscriptions = (deps) => {
-  const streams = subscriptions(deps) ?? [];
-  const active = streams.map((stream) => stream.subscribe());
-  return () => active.forEach((subscription) => subscription?.unsubscribe?.());
-};
 
 const showUnsupportedFormatDialog = async (appService) => {
   await appService.showDialog({
@@ -20,41 +15,12 @@ const showUnsupportedFormatDialog = async (appService) => {
   });
 };
 
-const openEditDialogWithValues = ({ deps, itemId } = {}) => {
-  const { store, refs, render } = deps;
-  const { fileExplorer, editForm } = refs;
-  if (!itemId) {
-    return;
-  }
-
-  const soundItem = store.selectSoundItemById({ itemId });
-  if (!soundItem) {
-    return;
-  }
-
-  const editValues = {
-    name: soundItem.name ?? "",
-    description: soundItem.description ?? "",
-  };
-
-  store.setSelectedItemId({ itemId });
-  fileExplorer.selectItem({ itemId });
-  store.openEditDialog({
-    itemId,
-    defaultValues: editValues,
-    waveformDataFileId: soundItem.waveformDataFileId,
-  });
-
-  render();
-  editForm.reset();
-  editForm.setValues({ values: editValues });
-};
-
 const pickAndUploadSound = async ({ appService, projectService } = {}) => {
   let file;
+
   try {
     file = await appService.pickFiles({
-      accept: "audio/*",
+      accept: ".mp3,.wav,.ogg",
       multiple: false,
     });
   } catch {
@@ -80,10 +46,91 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
   return { uploadResult };
 };
 
+const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
+  const { appService, projectService } = deps;
+  let successfulUploads;
+
+  try {
+    successfulUploads = await projectService.uploadFiles(files);
+  } catch {
+    await showUnsupportedFormatDialog(appService);
+    return;
+  }
+
+  if (!successfulUploads.length) {
+    appService.showToast("Failed to upload sound.", { title: "Error" });
+    return;
+  }
+
+  for (const result of successfulUploads) {
+    await projectService.createResourceItem({
+      resourceType: "sounds",
+      resourceId: nanoid(),
+      data: {
+        type: "sound",
+        fileId: result.fileId,
+        name: result.displayName,
+        description: "",
+        fileType: result.file.type,
+        fileSize: result.file.size,
+        waveformDataFileId: result.waveformDataFileId,
+        duration: result.duration,
+      },
+      parentId,
+      position: "last",
+    });
+  }
+
+  await handleDataChanged(deps);
+};
+
+const handlePanelResize = (deps, payload) => {
+  const { store, render } = deps;
+  const { panelType, width } = payload;
+
+  if (panelType === "file-explorer") {
+    store.updateAudioPlayerLeft({ width });
+    render();
+  }
+
+  if (panelType === "detail-panel") {
+    store.updateAudioPlayerRight({ width });
+    render();
+  }
+};
+
+const {
+  handleBeforeMount: handleMediaBeforeMount,
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerDoubleClick,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleSearchInput,
+  handleItemClick: handleSoundItemClick,
+  handleItemDoubleClick: handleSoundItemDoubleClick,
+  handleItemEdit: handleSoundItemEdit,
+} = createMediaPageHandlers({
+  resourceType: "sounds",
+  subscriptions: (deps) => {
+    const { subject } = deps;
+
+    return [
+      subject.pipe(
+        filter(({ action }) => action === "panel-resize"),
+        tap(({ payload }) => {
+          handlePanelResize(deps, payload);
+        }),
+      ),
+    ];
+  },
+  selectItemById: (store, { itemId }) => store.selectSoundItemById({ itemId }),
+  getEditPreviewFileId: (item) => item?.waveformDataFileId,
+});
+
 export const handleBeforeMount = (deps) => {
-  const { store, projectService, appService } = deps;
-  const { sounds } = projectService.getState();
-  store.setItems({ soundData: sounds ?? { tree: [], items: {} } });
+  const { appService, store } = deps;
+  const cleanup = handleMediaBeforeMount(deps);
 
   const defaultLeft = parseInt(
     appService.getUserConfig("resizablePanel.file-explorerWidth"),
@@ -91,75 +138,22 @@ export const handleBeforeMount = (deps) => {
   const defaultRight = parseInt(
     appService.getUserConfig("resizablePanel.detail-panelWidth"),
   );
-  store.updateAudioPlayerLeft({ width: defaultLeft, appService });
-  store.updateAudioPlayerRight({ width: defaultRight, appService });
+  store.updateAudioPlayerLeft({ width: defaultLeft });
+  store.updateAudioPlayerRight({ width: defaultRight });
 
-  return mountSubscriptions(deps);
+  return cleanup;
 };
 
-const refreshSoundsData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const { sounds } = projectService.getState();
-  store.setItems({ soundData: sounds ?? { tree: [], items: {} } });
-  render();
-};
-
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "sounds",
-    refresh: refreshSoundsData,
-  });
-
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleDataChanged = refreshSoundsData;
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { itemId, isFolder } = payload._event.detail;
-
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
-    return;
-  }
-
-  if (!itemId) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId });
-  render();
-};
-
-export const handleFileExplorerDoubleClick = (deps, payload) => {
-  const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) {
-    return;
-  }
-
-  openEditDialogWithValues({ deps, itemId });
-};
-
-export const handleSoundItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const { itemId } = payload._event.detail;
-
-  if (!itemId) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId });
-
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  render();
-};
-
-export const handleSoundItemDoubleClick = (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  openEditDialogWithValues({ deps, itemId });
+export {
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerDoubleClick,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleSearchInput,
+  handleSoundItemClick,
+  handleSoundItemDoubleClick,
+  handleSoundItemEdit,
 };
 
 export const handleSoundItemPreview = (deps, payload) => {
@@ -181,53 +175,44 @@ export const handleSoundItemPreview = (deps, payload) => {
   render();
 };
 
-export const handleSoundItemEdit = (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  openEditDialogWithValues({ deps, itemId });
-};
+export const handleUploadClick = async (deps, payload) => {
+  const { appService } = deps;
+  const { groupId } = payload._event.detail;
+  let files;
 
-export const handleDragDropFileSelected = async (deps, payload) => {
-  const { store, render, projectService, appService } = deps;
-  const { files, targetGroupId } = payload._event.detail;
-
-  let successfulUploads;
   try {
-    successfulUploads = await projectService.uploadFiles(files);
+    files = await appService.pickFiles({
+      accept: ".mp3,.wav,.ogg",
+      multiple: true,
+    });
   } catch {
-    await showUnsupportedFormatDialog(appService);
+    appService.showToast("Failed to select files.", { title: "Error" });
     return;
   }
 
-  for (const result of successfulUploads) {
-    await projectService.createResourceItem({
-      resourceType: "sounds",
-      resourceId: nanoid(),
-      data: {
-        type: "sound",
-        fileId: result.fileId,
-        name: result.displayName,
-        description: "",
-        fileType: result.file.type,
-        fileSize: result.file.size,
-        waveformDataFileId: result.waveformDataFileId,
-        duration: result.duration,
-      },
-      parentId: targetGroupId,
-      position: "last",
-    });
+  if (!files?.length) {
+    return;
   }
 
-  if (successfulUploads.length > 0) {
-    const { sounds } = projectService.getState();
-    store.setItems({ soundData: sounds ?? { tree: [], items: {} } });
-  }
+  await createSoundsFromFiles({
+    deps,
+    files,
+    parentId: resolveResourceParentId(groupId),
+  });
+};
 
-  render();
+export const handleFilesDropped = async (deps, payload) => {
+  const { files, targetGroupId } = payload._event.detail;
+
+  await createSoundsFromFiles({
+    deps,
+    files,
+    parentId: targetGroupId ?? undefined,
+  });
 };
 
 export const handleFormExtraEvent = async (deps) => {
-  const { appService, projectService, store, render } = deps;
-
+  const { appService, projectService, store } = deps;
   const selectedItem = store.selectSelectedItem();
   if (!selectedItem) {
     return;
@@ -266,9 +251,7 @@ export const handleFormExtraEvent = async (deps) => {
     },
   });
 
-  const { sounds } = projectService.getState();
-  store.setItems({ soundData: sounds ?? { tree: [], items: {} } });
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleEditDialogClose = (deps) => {
@@ -300,7 +283,10 @@ export const handleEditDialogSoundClick = async (deps) => {
     return;
   }
 
-  store.setEditSoundUpload({ uploadResult: result.uploadResult });
+  store.setEditUpload({
+    uploadResult: result.uploadResult,
+    previewFileId: result.uploadResult.waveformDataFileId,
+  });
   render();
 };
 
@@ -317,21 +303,20 @@ export const handleEditFormAction = async (deps, payload) => {
     return;
   }
 
-  const editItemId = store.getState().editItemId;
+  const { editItemId, editUploadResult } = store.getState();
   if (!editItemId) {
     store.closeEditDialog();
     render();
     return;
   }
 
-  const editSoundUploadResult = store.getState().editSoundUploadResult;
-  const soundPatch = editSoundUploadResult
+  const soundPatch = editUploadResult
     ? {
-        fileId: editSoundUploadResult.fileId,
-        fileType: editSoundUploadResult.file.type,
-        fileSize: editSoundUploadResult.file.size,
-        waveformDataFileId: editSoundUploadResult.waveformDataFileId,
-        duration: editSoundUploadResult.duration,
+        fileId: editUploadResult.fileId,
+        fileType: editUploadResult.file.type,
+        fileSize: editUploadResult.file.size,
+        waveformDataFileId: editUploadResult.waveformDataFileId,
+        duration: editUploadResult.duration,
       }
     : {};
 
@@ -345,25 +330,22 @@ export const handleEditFormAction = async (deps, payload) => {
     },
   });
 
-  const { sounds } = projectService.getState();
-  store.setItems({ soundData: sounds ?? { tree: [], items: {} } });
   store.closeEditDialog();
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleAudioPlayerClose = (deps) => {
   const { store, render } = deps;
-
   store.closeAudioPlayer();
   render();
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { projectService, appService, render } = deps;
+  const { itemId } = payload._event.detail;
 
   const result = await projectService.deleteResourceItemIfUnused({
-    resourceType,
+    resourceType: "sounds",
     resourceId: itemId,
     checkTargets: ["scenes", "layouts"],
   });
@@ -374,33 +356,5 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  const data = projectService.getState()[resourceType];
-  store.setItems({ soundData: data ?? { tree: [], items: {} } });
-  render();
-};
-
-export const handlePanelResize = (deps, payload) => {
-  const { store, render } = deps;
-  const { panelType, width } = payload;
-  if (panelType === "file-explorer") {
-    store.updateAudioPlayerLeft({ width });
-    render();
-  }
-
-  if (panelType === "detail-panel") {
-    store.updateAudioPlayerRight({ width });
-    render();
-  }
-};
-
-const subscriptions = (deps) => {
-  const { subject } = deps;
-  return [
-    subject.pipe(
-      filter(({ action }) => action === "panel-resize"),
-      tap(({ payload }) => {
-        handlePanelResize(deps, payload);
-      }),
-    ),
-  ];
+  await handleDataChanged(deps);
 };

--- a/src/pages/sounds/sounds.store.js
+++ b/src/pages/sounds/sounds.store.js
@@ -1,22 +1,5 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
 import { formatFileSize } from "../../utils/index.js";
-
-const folderContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-child-folder" },
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const itemContextMenuItems = [
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const emptyContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-item" },
-];
+import { createMediaPageStore } from "../../deps/features/resourcePages/media/createMediaPageStore.js";
 
 const formatDuration = (duration) => {
   if (duration === undefined || duration === null) {
@@ -28,18 +11,115 @@ const formatDuration = (duration) => {
     .padStart(2, "0")}`;
 };
 
-export const createInitialState = () => ({
-  soundData: { tree: [], items: {} },
-  selectedItemId: undefined,
-  searchQuery: "",
-  isEditDialogOpen: false,
-  editItemId: undefined,
-  editDefaultValues: {
-    name: "",
-    description: "",
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
+  }
+
+  return [
+    {
+      type: "slot",
+      slot: "sound-waveform",
+      label: "",
+    },
+    {
+      type: "description",
+      value: item.description ?? "",
+    },
+    {
+      type: "text",
+      label: "File Type",
+      value: item.fileType ?? "",
+    },
+    {
+      type: "text",
+      label: "File Size",
+      value: formatFileSize(item.fileSize),
+    },
+    {
+      type: "text",
+      label: "Duration",
+      value: formatDuration(item.duration),
+    },
+  ];
+};
+
+const buildMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "sound",
+  waveformDataFileId: item.waveformDataFileId,
+  canPreview: true,
+});
+
+const createEditForm = () => ({
+  title: "Edit Sound",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "description",
+      type: "input-textarea",
+      label: "Description",
+      required: false,
+    },
+    {
+      type: "slot",
+      slot: "sound-slot",
+      label: "Sound",
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Update Sound",
+      },
+    ],
   },
-  editWaveformDataFileId: undefined,
-  editSoundUploadResult: undefined,
+});
+
+const {
+  createInitialState: createMediaInitialState,
+  setItems,
+  setSelectedItemId,
+  openEditDialog,
+  closeEditDialog,
+  setEditUpload,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectMediaViewData,
+} = createMediaPageStore({
+  itemType: "sound",
+  resourceType: "sounds",
+  title: "Sounds",
+  selectedResourceId: "sounds",
+  uploadText: "Upload Sound",
+  acceptedFileTypes: [".mp3", ".wav", ".ogg"],
+  previewMenuLabel: "Play",
+  buildDetailFields,
+  buildMediaItem,
+  createEditForm,
+  getSelectedPreviewFileId: (item) => item?.waveformDataFileId,
+  extendViewData: ({ state, baseViewData }) => ({
+    ...baseViewData,
+    playingSound: state.playingSound,
+    showAudioPlayer: state.showAudioPlayer,
+    audioPlayerLeft: state.audioPlayerLeft,
+    audioPlayerRight: state.audioPlayerRight,
+  }),
+});
+
+export const createInitialState = () => ({
+  ...createMediaInitialState(),
   playingSound: {
     title: "",
     fileId: undefined,
@@ -49,47 +129,18 @@ export const createInitialState = () => ({
   audioPlayerRight: 0,
 });
 
-export const setItems = ({ state }, { soundData } = {}) => {
-  state.soundData = soundData;
+export {
+  setItems,
+  setSelectedItemId,
+  openEditDialog,
+  closeEditDialog,
+  setEditUpload,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
 };
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
-
-export const setSearchQuery = ({ state }, { value } = {}) => {
-  state.searchQuery = value ?? "";
-};
-
-export const openEditDialog = (
-  { state },
-  { itemId, defaultValues, waveformDataFileId } = {},
-) => {
-  state.isEditDialogOpen = true;
-  state.editItemId = itemId;
-  state.editDefaultValues = {
-    name: defaultValues?.name ?? "",
-    description: defaultValues?.description ?? "",
-  };
-  state.editWaveformDataFileId = waveformDataFileId;
-  state.editSoundUploadResult = undefined;
-};
-
-export const closeEditDialog = ({ state }, _payload = {}) => {
-  state.isEditDialogOpen = false;
-  state.editItemId = undefined;
-  state.editDefaultValues = {
-    name: "",
-    description: "",
-  };
-  state.editWaveformDataFileId = undefined;
-  state.editSoundUploadResult = undefined;
-};
-
-export const setEditSoundUpload = ({ state }, { uploadResult } = {}) => {
-  state.editSoundUploadResult = uploadResult;
-  state.editWaveformDataFileId = uploadResult?.waveformDataFileId;
-};
+export const selectSoundItemById = selectItemById;
 
 export const openAudioPlayer = ({ state }, { fileId, fileName } = {}) => {
   state.playingSound.fileId = fileId;
@@ -120,154 +171,6 @@ export const updateAudioPlayerRight = ({ state }, payload = {}) => {
   state.audioPlayerRight = resolveAudioPlayerWidth(payload);
 };
 
-export const selectAudioPlayerLeft = ({ state }) => {
-  return state.audioPlayerLeft;
-};
-
-export const selectAudioPlayerRight = ({ state }) => {
-  return state.audioPlayerRight;
-};
-
-export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) {
-    return undefined;
-  }
-
-  const flatItems = toFlatItems(state.soundData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
-};
-
-export const selectSoundItemById = ({ state }, { itemId } = {}) => {
-  const item = state.soundData?.items?.[itemId];
-  return item?.type === "sound" ? item : undefined;
-};
-
-export const selectSelectedItemId = ({ state }) => {
-  return state.selectedItemId;
-};
-
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.soundData);
-  const rawFlatGroups = toFlatGroups(state.soundData);
-  const searchQuery = (state.searchQuery ?? "").toLowerCase();
-
-  const matchesSearch = (item) => {
-    if (!searchQuery) {
-      return true;
-    }
-
-    const name = (item.name ?? "").toLowerCase();
-    const description = (item.description ?? "").toLowerCase();
-
-    return name.includes(searchQuery) || description.includes(searchQuery);
-  };
-
-  const flatGroups = rawFlatGroups
-    .map((group) => {
-      const filteredChildren = (group.children ?? []).filter(matchesSearch);
-      const hasMatchingChildren = filteredChildren.length > 0;
-      const shouldShowGroup = !searchQuery || hasMatchingChildren;
-
-      return {
-        ...group,
-        children: filteredChildren,
-        hasChildren: filteredChildren.length > 0,
-        shouldDisplay: shouldShowGroup,
-      };
-    })
-    .filter((group) => group.shouldDisplay);
-
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  const detailFields = selectedItem
-    ? [
-        {
-          type: "slot",
-          slot: "sound-waveform",
-          label: "",
-        },
-        {
-          type: "description",
-          value: selectedItem.description ?? "",
-        },
-        {
-          type: "text",
-          label: "File Type",
-          value: selectedItem.fileType ?? "",
-        },
-        {
-          type: "text",
-          label: "File Size",
-          value: formatFileSize(selectedItem.fileSize),
-        },
-        {
-          type: "text",
-          label: "Duration",
-          value: formatDuration(selectedItem.duration),
-        },
-      ]
-    : [];
-
-  const editForm = {
-    title: "Edit Sound",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Name",
-        required: true,
-      },
-      {
-        name: "description",
-        type: "input-textarea",
-        label: "Description",
-        required: false,
-      },
-      {
-        type: "slot",
-        slot: "sound-slot",
-        label: "Sound",
-      },
-    ],
-    actions: {
-      layout: "",
-      buttons: [
-        {
-          id: "submit",
-          variant: "pr",
-          label: "Update Sound",
-        },
-      ],
-    },
-  };
-
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "assets",
-    selectedResourceId: "sounds",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    detailFields,
-    searchQuery: state.searchQuery,
-    resourceType: "sounds",
-    title: "Sound",
-    uploadText: "Upload Sound",
-    acceptedFileTypes: [".mp3", ".wav", ".ogg"],
-    folderContextMenuItems,
-    itemContextMenuItems,
-    emptyContextMenuItems,
-    selectedSoundWaveformDataFileId: selectedItem?.waveformDataFileId,
-    isEditDialogOpen: state.isEditDialogOpen,
-    editItemId: state.editItemId,
-    editForm,
-    editDefaultValues: state.editDefaultValues,
-    editWaveformDataFileId: state.editWaveformDataFileId,
-    playingSound: state.playingSound,
-    showAudioPlayer: state.showAudioPlayer,
-    audioPlayerLeft: state.audioPlayerLeft,
-    audioPlayerRight: state.audioPlayerRight,
-  };
+export const selectViewData = (context) => {
+  return selectMediaViewData(context);
 };

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -19,12 +19,12 @@ refs:
         handler: handleSoundItemPreview
       item-edit:
         handler: handleSoundItemEdit
-      files-uploaded:
-        handler: handleDragDropFileSelected
+      files-dropped:
+        handler: handleFilesDropped
+      upload-click:
+        handler: handleUploadClick
       search-input:
-        action: setSearchQuery
-        payload:
-          value: ${_event.detail.value}
+        handler: handleSearchInput
       item-delete:
         handler: handleItemDelete
   rvnAudioPlayer:
@@ -63,7 +63,7 @@ template:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
                   - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
-              - rvn-group-resources-view#groupview w=f h=f :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes: null
+              - rvn-media-resources-view#groupview w=f h=f :navTitle=title :groups=mediaGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
@@ -71,9 +71,9 @@ template:
                           - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
                               - rtgl-text c=mu-fg: ${selectedItemName}
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
-                              - $if selectedSoundWaveformDataFileId:
+                              - $if selectedPreviewFileId:
                                   - rtgl-view slot="sound-waveform" p=sm bw=xs bc=bo br=md cur=pointer:
-                                      - rvn-waveform-visualizer#detailWaveform waveformDataFileId=${selectedSoundWaveformDataFileId} w=220 h=100: null
+                                      - rvn-waveform-visualizer#detailWaveform waveformDataFileId=${selectedPreviewFileId} w=220 h=100: null
                                 $else:
                                   - rtgl-view#detailWaveformPlaceholder slot="sound-waveform" w=f h=100 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                                       - rtgl-text c=mu-fg s=sm: Click to Upload
@@ -83,9 +83,9 @@ template:
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=editDefaultValues :form=editForm w=f:
-              - $if editWaveformDataFileId:
+              - $if editPreviewFileId:
                   - rtgl-view slot="sound-slot" p=sm bw=xs bc=bo br=md cur=pointer:
-                      - rvn-waveform-visualizer#editDialogWaveform waveformDataFileId=${editWaveformDataFileId} w=400 h=110: null
+                      - rvn-waveform-visualizer#editDialogWaveform waveformDataFileId=${editPreviewFileId} w=400 h=110: null
                 $else:
                   - rtgl-view#editDialogWaveformPlaceholder slot="sound-slot" w=f h=110 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                       - rtgl-text c=mu-fg s=sm: Click to Upload

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -1,9 +1,7 @@
 import { nanoid } from "nanoid";
-import { toFlatItems } from "../../domain/treeHelpers.js";
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
+import { createCatalogPageHandlers } from "../../deps/features/resourcePages/catalog/createCatalogPageHandlers.js";
 
-// Constants for graphicsService integration (moved from groupTransformsView)
 const MARKER_SIZE = 30;
 const CANVAS_WIDTH = 1920;
 const CANVAS_HEIGHT = 1080;
@@ -57,362 +55,211 @@ const createRenderState = ({
   };
 };
 
-const resolveDetailItemId = (detail = {}) => {
-  return detail.itemId ?? detail.id ?? detail.item?.id ?? "";
+const createTransformPayload = (values = {}) => {
+  const anchor = values.anchor ?? {
+    anchorX: values.anchorX,
+    anchorY: values.anchorY,
+  };
+
+  return {
+    name: values.name?.trim() ?? "",
+    x: parseInt(values.x ?? 0, 10),
+    y: parseInt(values.y ?? 0, 10),
+    scaleX: parseFloat(values.scaleX ?? 1),
+    scaleY: parseFloat(values.scaleY ?? 1),
+    anchorX: parseFloat(anchor.anchorX ?? 0),
+    anchorY: parseFloat(anchor.anchorY ?? 0),
+    rotation: parseInt(values.rotation ?? 0, 10) || 0,
+  };
 };
 
-export const handleAfterMount = async (deps) => {
-  const { store, projectService, render } = deps;
-  await projectService.ensureRepository();
-  const { transforms } = projectService.getState();
-  store.setItems({ transformData: transforms ?? { tree: [], items: {} } });
+const renderTransformPreview = ({ graphicsService, values } = {}) => {
+  if (!graphicsService) {
+    return;
+  }
+
+  const transformData = createTransformPayload(values);
+  graphicsService.render(
+    createRenderState({
+      x: transformData.x,
+      y: transformData.y,
+      rotation: transformData.rotation,
+      scaleX: transformData.scaleX,
+      scaleY: transformData.scaleY,
+      anchorX: transformData.anchorX,
+      anchorY: transformData.anchorY,
+    }),
+  );
+};
+
+const openTransformDialog = async ({
+  deps,
+  editMode = false,
+  itemId,
+  itemData,
+  targetGroupId,
+} = {}) => {
+  const { graphicsService, refs, render, store } = deps;
+
+  store.openTransformFormDialog({
+    editMode,
+    itemId,
+    itemData,
+    targetGroupId,
+  });
   render();
-};
 
-const refreshTransformsData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const { transforms } = projectService.getState();
-  store.setItems({ transformData: transforms ?? { tree: [], items: {} } });
-  render();
-};
+  const { canvas } = refs;
+  if (!canvas || !graphicsService) {
+    return;
+  }
 
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "transforms",
-    refresh: refreshTransformsData,
+  await graphicsService.init({
+    canvas,
   });
 
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleDataChanged = refreshTransformsData;
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const detail = payload?._event?.detail ?? {};
-  const { isFolder } = detail;
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
-    return;
-  }
-
-  const id = resolveDetailItemId(detail);
-  if (!id) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: id });
-  render();
+  renderTransformPreview({
+    graphicsService,
+    values: createTransformPayload(
+      itemData ?? {
+        x: 0,
+        y: 0,
+        scaleX: 1,
+        scaleY: 1,
+        anchor: { anchorX: 0, anchorY: 0 },
+      },
+    ),
+  });
 };
 
-export const handleTransformItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const detail = payload?._event?.detail ?? {};
-  const itemId = resolveDetailItemId(detail);
-  if (!itemId) {
-    return;
-  }
+const {
+  handleAfterMount,
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleItemClick: handleTransformItemClick,
+  handleSearchInput,
+} = createCatalogPageHandlers({
+  resourceType: "transforms",
+});
 
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  store.setSelectedItemId({ itemId });
-  render();
+export {
+  handleAfterMount,
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleTransformItemClick,
+  handleSearchInput,
 };
 
 export const handleTransformItemDoubleClick = async (deps, payload) => {
-  const { store, render, graphicsService, refs } = deps;
   const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) return;
-
-  // Find the item data using the same approach as fonts page
-  const state = store.getState();
-  const flatItems = toFlatItems(state.transformData);
-  const itemData = flatItems.find((item) => item.id === itemId);
-
-  if (!itemData) {
-    console.warn("Transform item not found:", itemId);
+  if (isFolder || !itemId) {
     return;
   }
 
-  // Open dialog in edit mode with item data
-  store.openTransformFormDialog({
+  const itemData = deps.store.selectTransformItemById({ itemId });
+  if (!itemData) {
+    return;
+  }
+
+  await openTransformDialog({
+    deps,
     editMode: true,
     itemId,
     itemData,
   });
-  render();
-
-  // Initialize graphicsService after dialog is opened and canvas is in DOM
-  const { canvas } = refs;
-  if (canvas) {
-    await graphicsService.init({
-      canvas: canvas,
-    });
-  }
-
-  // Render initial state with item's current position
-  const x = parseInt(itemData.x || 0);
-  const y = parseInt(itemData.y || 0);
-  const rotation = parseInt(itemData.rotation || 0);
-  const scaleX = parseFloat(itemData.scaleX || 1);
-  const scaleY = parseFloat(itemData.scaleY || 1);
-  const anchor = { anchorX: itemData.anchorX, anchorY: itemData.anchorY };
-
-  const renderState = createRenderState({
-    x,
-    y,
-    rotation,
-    scaleY,
-    scaleX,
-    anchorX: anchor.anchorX,
-    anchorY: anchor.anchorY,
-  });
-  graphicsService.render(renderState);
 };
 
 export const handleAddTransformClick = async (deps, payload) => {
-  const { store, render, graphicsService, refs } = deps;
-  payload._event.stopPropagation(); // Prevent group click
+  const { groupId } = payload._event.detail;
 
-  // Extract group ID from the clicked button
-  const groupId = payload._event.detail.groupId;
-
-  // Open dialog in add mode
-  store.openTransformFormDialog({
-    editMode: false,
+  await openTransformDialog({
+    deps,
     targetGroupId: groupId,
   });
-  render();
-
-  const { canvas } = refs;
-  if (canvas) {
-    await graphicsService.init({
-      canvas: canvas,
-    });
-  }
-
-  // Render initial state with default values (scale=1, anchor=center-center)
-  const renderState = createRenderState({
-    x: 0,
-    y: 0,
-    rotation: 0,
-    scaleY: 1,
-    scaleX: 1,
-    anchorX: 0,
-    anchorY: 0,
-  });
-  graphicsService.render(renderState);
 };
 
-export const handleGroupClick = (deps, payload) => {
-  const { store, render } = deps;
-  const groupId = payload._event.currentTarget.id.replace("group", "");
-
-  // Handle group collapse internally
-  store.toggleGroupCollapse({ groupId: groupId });
-  render();
-};
-
-export const handleTransformCreated = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { groupId, name, x, y, scaleX, scaleY, anchorX, anchorY, rotation } =
-    payload._event.detail;
-
-  await projectService.createResourceItem({
-    resourceType: "transforms",
-    resourceId: nanoid(),
-    data: {
-      type: "transform",
-      name,
-      x,
-      y,
-      scaleX,
-      scaleY,
-      anchorX,
-      anchorY,
-      rotation,
-    },
-    parentId: groupId,
-    position: "last",
-  });
-
-  const { transforms } = projectService.getState();
-  store.setItems({ transformData: transforms });
-  render();
-};
-
-export const handleTransformEdited = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { itemId, name, x, y, scaleX, scaleY, anchorX, anchorY, rotation } =
-    payload._event.detail;
-
-  // Update repository directly
-  await projectService.updateResourceItem({
-    resourceType: "transforms",
-    resourceId: itemId,
-    patch: {
-      name,
-      x,
-      y,
-      scaleX,
-      scaleY,
-      anchorX,
-      anchorY,
-      rotation,
-    },
-  });
-
-  // Update local state and render immediately
-  const { transforms } = projectService.getState();
-  store.setItems({ transformData: transforms });
-  render();
-};
-
-export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail?.value ?? "";
-  store.setSearchQuery({ query: searchQuery });
-  render();
-};
-
-export const handleGroupToggle = (deps, payload) => {
-  const { store, render } = deps;
-  const { groupId } = payload._event.detail;
-  store.toggleGroupCollapse({ groupId: groupId });
-  render();
-};
-
-// Transform dialog and canvas handlers (moved from groupTransformsView)
 export const handleTransformDialogClose = (deps) => {
-  const { store, render } = deps;
-
-  // Close dialog and reset all state
+  const { render, store } = deps;
   store.closeTransformFormDialog();
   render();
 };
 
-export const handleTransformFormActionClick = (deps, payload) => {
-  const { store, render, appService } = deps;
-
-  // Check which button was clicked
-  const actionId = payload._event.detail.actionId;
-
-  if (actionId === "submit") {
-    // Get form values from the event detail - it's in formValues
-    const formData = payload._event.detail.values;
-
-    if (!formData.name || !formData.name.trim()) {
-      appService.showToast("Transform name is required", { title: "Warning" });
-      return;
-    }
-    // Get state values using selector functions
-    const targetGroupId = store.selectTargetGroupId();
-    const editMode = store.selectEditMode();
-    const editItemId = store.selectEditItemId();
-
-    if (editMode && editItemId) {
-      // Call the existing transform edit handler directly
-      const editEvent = {
-        detail: {
-          itemId: editItemId,
-          name: formData.name,
-          x: parseInt(formData.x),
-          y: parseInt(formData.y),
-          scaleY: parseFloat(formData.scaleY),
-          scaleX: parseFloat(formData.scaleX),
-          anchorY: parseFloat(formData.anchor.anchorY),
-          anchorX: parseFloat(formData.anchor.anchorX),
-          rotation: parseInt(formData.rotation) || 0, //quick fix for now have to remove when we add implemetataion in graphics
-        },
-      };
-      handleTransformEdited(deps, { _event: editEvent });
-
-      // Force immediate render to update thumbnails
-      render();
-    } else {
-      // Call the existing transform creation handler directly
-      const createEvent = {
-        detail: {
-          groupId: targetGroupId,
-          name: formData.name,
-          x: parseInt(formData.x),
-          y: parseInt(formData.y),
-          scaleX: parseFloat(formData.scaleX),
-          scaleY: parseFloat(formData.scaleY),
-          anchorX: parseFloat(formData.anchor.anchorX),
-          anchorY: parseFloat(formData.anchor.anchorY),
-          rotation: parseInt(formData.rotation) || 0,
-        },
-      };
-      handleTransformCreated(deps, { _event: createEvent });
-    }
-
-    // Close dialog and reset all state
-    store.closeTransformFormDialog();
-
-    // Force a render after the event dispatch completes
-    render();
+export const handleTransformFormActionClick = async (deps, payload) => {
+  const { appService, projectService, store } = deps;
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
+    return;
   }
+
+  const transformData = createTransformPayload(values);
+  if (!transformData.name) {
+    appService.showToast("Transform name is required.", { title: "Warning" });
+    return;
+  }
+
+  const editMode = store.selectEditMode();
+  const editItemId = store.selectEditItemId();
+  const targetGroupId = store.selectTargetGroupId();
+
+  if (editMode && editItemId) {
+    await projectService.updateResourceItem({
+      resourceType: "transforms",
+      resourceId: editItemId,
+      patch: transformData,
+    });
+  } else {
+    await projectService.createResourceItem({
+      resourceType: "transforms",
+      resourceId: nanoid(),
+      data: {
+        type: "transform",
+        ...transformData,
+      },
+      parentId: targetGroupId,
+      position: "last",
+    });
+  }
+
+  store.closeTransformFormDialog();
+  await handleDataChanged(deps);
 };
 
-export const handleTransformFormChange = async (deps, payload) => {
-  const { render, graphicsService } = deps;
+export const handleTransformFormChange = (deps, payload) => {
+  const { graphicsService, render } = deps;
 
-  const formValues = payload._event.detail.values;
-
-  const x = parseInt(formValues.x || 0);
-  const y = parseInt(formValues.y || 0);
-  const rotation = parseInt(formValues.rotation || 0);
-  const scaleX = parseFloat(
-    formValues.scaleX === undefined ? 1 : formValues.scaleX,
-  );
-  const scaleY = parseFloat(
-    formValues.scaleY === undefined ? 1 : formValues.scaleY,
-  );
-  const anchorX = formValues.anchor.anchorX;
-  const anchorY = formValues.anchor.anchorY;
-
-  const renderState = createRenderState({
-    x,
-    y,
-    rotation,
-    scaleX,
-    scaleY,
-    anchorX,
-    anchorY,
+  renderTransformPreview({
+    graphicsService,
+    values: createTransformPayload(payload._event.detail.values),
   });
-
-  graphicsService.render(renderState);
-
   render();
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { appService, projectService } = deps;
+  const { itemId } = payload._event.detail;
+  if (!itemId) {
+    return;
+  }
 
-  const state = projectService.getState();
   const usage = recursivelyCheckResource({
-    state,
+    state: projectService.getState(),
     itemId,
     checkTargets: ["scenes", "layouts"],
   });
 
   if (usage.isUsed) {
     appService.showToast("Cannot delete resource, it is currently in use.");
-    render();
     return;
   }
 
-  // Perform the delete operation
   await projectService.deleteResourceItem({
-    resourceType,
+    resourceType: "transforms",
     resourceId: itemId,
   });
 
-  // Refresh data and update store (reuse existing logic from handleDataChanged)
-  const data = projectService.getState()[resourceType];
-  store.setItems({ transformData: data });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/transforms/transforms.store.js
+++ b/src/pages/transforms/transforms.store.js
@@ -1,167 +1,218 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
+import { createCatalogPageStore } from "../../deps/features/resourcePages/catalog/createCatalogPageStore.js";
 
-export const createInitialState = () => ({
-  transformData: { tree: [], items: {} },
-  selectedItemId: null,
-  searchQuery: "",
-  collapsedIds: [],
-  contextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-    { label: "Rename", type: "item", value: "rename-item" },
-    { label: "Delete", type: "item", value: "delete-item" },
-  ],
-  emptyContextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-  ],
-  // Transform dialog state (moved from groupTransformsView)
-  isDialogOpen: false,
-  targetGroupId: null,
-  editMode: false,
-  editItemId: null,
-  defaultValues: {
-    name: "",
-    x: "0",
-    y: "0",
-    scaleX: "1",
-    scaleY: "1",
-    anchor: { anchorX: 0, anchorY: 0 },
-    rotation: "0",
-  },
-  transformForm: {
-    title: "Add Transform",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Name",
-        required: true,
-      },
-      {
-        name: "x",
-        type: "slider-with-input",
-        min: 0,
-        max: 1920,
-        step: 1,
-        label: "Position X",
-        required: true,
-      },
-      {
-        name: "y",
-        type: "slider-with-input",
-        min: 0,
-        max: 1080,
-        step: 1,
-        label: "Position Y",
-        required: true,
-      },
-      {
-        name: "scaleX",
-        type: "slider-with-input",
-        min: 0.1,
-        max: 3,
-        step: 0.1,
-        label: "Scale X",
-        required: true,
-      },
-      {
-        name: "scaleY",
-        type: "slider-with-input",
-        min: 0.1,
-        max: 3,
-        step: 0.1,
-        label: "Scale Y",
-        required: true,
-      },
-      {
-        name: "anchor",
-        type: "select",
-        label: "Anchor",
-        placeholder: "Choose a anchor",
-        options: [
-          { id: "tl", label: "Top Left", value: { anchorX: 0, anchorY: 0 } },
-          {
-            id: "tc",
-            label: "Top Center",
-            value: { anchorX: 0.5, anchorY: 0 },
-          },
-          { id: "tr", label: "Top Right", value: { anchorX: 1, anchorY: 0 } },
-          {
-            id: "cl",
-            label: "Center Left",
-            value: { anchorX: 0, anchorY: 0.5 },
-          },
-          {
-            id: "cc",
-            label: "Center Center",
-            value: { anchorX: 0.5, anchorY: 0.5 },
-          },
-          {
-            id: "cr",
-            label: "Center Right",
-            value: { anchorX: 1, anchorY: 0.5 },
-          },
-          { id: "bl", label: "Bottom Left", value: { anchorX: 0, anchorY: 1 } },
-          {
-            id: "bc",
-            label: "Bottom Center",
-            value: { anchorX: 0.5, anchorY: 1 },
-          },
-          {
-            id: "br",
-            label: "Bottom Right",
-            value: { anchorX: 1, anchorY: 1 },
-          },
-        ],
-        required: true,
-      },
-      // {
-      //   name: "rotation",
-      //   type: "slider-input",
-      //   min: -360,
-      //   max: 360,
-      //   step: 1,
-      //   label: "Rotation",
-      //   tooltip: {
-      //     content: "In degrees. 360 is a full rotation",
-      //   },
-      //   required: true,
-      // },
-    ],
-    actions: {
-      layout: "",
-      buttons: [
+const createTransformForm = ({ editMode = false } = {}) => ({
+  title: editMode ? "Edit Transform" : "Add Transform",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "x",
+      type: "slider-with-input",
+      min: 0,
+      max: 1920,
+      step: 1,
+      label: "Position X",
+      required: true,
+    },
+    {
+      name: "y",
+      type: "slider-with-input",
+      min: 0,
+      max: 1080,
+      step: 1,
+      label: "Position Y",
+      required: true,
+    },
+    {
+      name: "scaleX",
+      type: "slider-with-input",
+      min: 0.1,
+      max: 3,
+      step: 0.1,
+      label: "Scale X",
+      required: true,
+    },
+    {
+      name: "scaleY",
+      type: "slider-with-input",
+      min: 0.1,
+      max: 3,
+      step: 0.1,
+      label: "Scale Y",
+      required: true,
+    },
+    {
+      name: "anchor",
+      type: "select",
+      label: "Anchor",
+      placeholder: "Choose an anchor",
+      options: [
+        { id: "tl", label: "Top Left", value: { anchorX: 0, anchorY: 0 } },
         {
-          id: "submit",
-          variant: "pr",
-          label: "Add Transform",
+          id: "tc",
+          label: "Top Center",
+          value: { anchorX: 0.5, anchorY: 0 },
+        },
+        { id: "tr", label: "Top Right", value: { anchorX: 1, anchorY: 0 } },
+        {
+          id: "cl",
+          label: "Center Left",
+          value: { anchorX: 0, anchorY: 0.5 },
+        },
+        {
+          id: "cc",
+          label: "Center Center",
+          value: { anchorX: 0.5, anchorY: 0.5 },
+        },
+        {
+          id: "cr",
+          label: "Center Right",
+          value: { anchorX: 1, anchorY: 0.5 },
+        },
+        {
+          id: "bl",
+          label: "Bottom Left",
+          value: { anchorX: 0, anchorY: 1 },
+        },
+        {
+          id: "bc",
+          label: "Bottom Center",
+          value: { anchorX: 0.5, anchorY: 1 },
+        },
+        {
+          id: "br",
+          label: "Bottom Right",
+          value: { anchorX: 1, anchorY: 1 },
         },
       ],
+      required: true,
     },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: editMode ? "Update Transform" : "Add Transform",
+      },
+    ],
   },
 });
 
-export const setItems = ({ state }, { transformData } = {}) => {
-  state.transformData = transformData;
-};
+const createDialogDefaultValues = (item) => ({
+  name: item?.name ?? "",
+  x: String(item?.x ?? 0),
+  y: String(item?.y ?? 0),
+  scaleX: String(item?.scaleX ?? 1),
+  scaleY: String(item?.scaleY ?? 1),
+  anchor: {
+    anchorX: item?.anchorX ?? 0,
+    anchorY: item?.anchorY ?? 0,
+  },
+});
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
-
-export const setSearchQuery = ({ state }, { query } = {}) => {
-  state.searchQuery = query;
-};
-
-export const toggleGroupCollapse = ({ state }, { groupId } = {}) => {
-  const index = state.collapsedIds.indexOf(groupId);
-  if (index > -1) {
-    state.collapsedIds.splice(index, 1);
-  } else {
-    state.collapsedIds.push(groupId);
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
   }
+
+  return [
+    {
+      type: "slot",
+      slot: "transform-preview",
+      label: "",
+    },
+    {
+      type: "text",
+      label: "Position X",
+      value: String(item.x ?? 0),
+    },
+    {
+      type: "text",
+      label: "Position Y",
+      value: String(item.y ?? 0),
+    },
+    {
+      type: "text",
+      label: "Scale X",
+      value: String(item.scaleX ?? 1),
+    },
+    {
+      type: "text",
+      label: "Scale Y",
+      value: String(item.scaleY ?? 1),
+    },
+    {
+      type: "text",
+      label: "Anchor X",
+      value: String(item.anchorX ?? 0),
+    },
+    {
+      type: "text",
+      label: "Anchor Y",
+      value: String(item.anchorY ?? 0),
+    },
+  ];
 };
 
-// Transform dialog management (moved from groupTransformsView)
+const buildCatalogItem = (item) => ({
+  ...item,
+  cardKind: "transform",
+});
+
+const {
+  createInitialState: createCatalogInitialState,
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectCatalogViewData,
+} = createCatalogPageStore({
+  itemType: "transform",
+  resourceType: "transforms",
+  title: "Transforms",
+  selectedResourceId: "transforms",
+  resourceCategory: "assets",
+  addText: "Add Transform",
+  emptyMessage: "No transforms found",
+  buildDetailFields,
+  buildCatalogItem,
+  extendViewData: ({ state, selectedItem, baseViewData }) => ({
+    ...baseViewData,
+    isDialogOpen: state.isDialogOpen,
+    transformForm: state.transformForm,
+    dialogDefaultValues: state.dialogDefaultValues,
+    selectedItem,
+  }),
+});
+
+export const createInitialState = () => ({
+  ...createCatalogInitialState(),
+  isDialogOpen: false,
+  targetGroupId: undefined,
+  editMode: false,
+  editItemId: undefined,
+  dialogDefaultValues: createDialogDefaultValues(),
+  transformForm: createTransformForm(),
+});
+
+export {
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
+};
+
+export const selectTransformItemById = selectItemById;
+
 export const openTransformFormDialog = ({ state }, options = {}) => {
   const {
     editMode = false,
@@ -170,70 +221,21 @@ export const openTransformFormDialog = ({ state }, options = {}) => {
     targetGroupId = undefined,
   } = options;
 
-  // Set edit mode and update form accordingly
+  state.isDialogOpen = true;
   state.editMode = editMode;
   state.editItemId = itemId;
-  state.targetGroupId = targetGroupId;
-
-  // Update form based on edit mode
-  if (editMode) {
-    state.transformForm.title = "Edit Transform";
-    state.transformForm.actions.buttons[0].content = "Update Transform";
-  } else {
-    state.transformForm.title = "Add Transform";
-    state.transformForm.actions.buttons[0].content = "Add Transform";
-  }
-
-  // Set default values based on item data
-  if (itemData) {
-    state.defaultValues = {
-      name: itemData.name ?? "",
-      x: String(itemData.x ?? "0"),
-      y: String(itemData.y ?? "0"),
-      scaleX: String(itemData.scaleX ?? "1"),
-      scaleY: String(itemData.scaleY ?? "1"),
-      anchor: { anchorX: itemData.anchorX, anchorY: itemData.anchorY },
-      //rotation: String(itemData.rotation || "0"),
-    };
-  } else {
-    state.defaultValues = {
-      name: "",
-      x: "0",
-      y: "0",
-      scaleX: "1",
-      scaleY: "1",
-      anchor: { anchorX: 0, anchorY: 0 },
-      //rotation: "0",
-    };
-  }
-
-  // Open dialog
-  state.isDialogOpen = true;
+  state.targetGroupId = targetGroupId === "_root" ? undefined : targetGroupId;
+  state.dialogDefaultValues = createDialogDefaultValues(itemData);
+  state.transformForm = createTransformForm({ editMode });
 };
 
 export const closeTransformFormDialog = ({ state }, _payload = {}) => {
-  // Close dialog
   state.isDialogOpen = false;
-
-  // Reset all form state
+  state.targetGroupId = undefined;
   state.editMode = false;
-  state.editItemId = null;
-  state.targetGroupId = null;
-
-  // Reset default values
-  state.defaultValues = {
-    name: "",
-    x: "0",
-    y: "0",
-    scaleX: "1",
-    scaleY: "1",
-    anchor: { anchorX: 0, anchorY: 0 },
-    //rotation: "0",
-  };
-
-  // Reset form to add mode
-  state.transformForm.title = "Add Transform";
-  state.transformForm.actions.buttons[0].content = "Add Transform";
+  state.editItemId = undefined;
+  state.dialogDefaultValues = createDialogDefaultValues();
+  state.transformForm = createTransformForm();
 };
 
 export const selectTargetGroupId = ({ state }) => {
@@ -248,138 +250,6 @@ export const selectEditItemId = ({ state }) => {
   return state.editItemId;
 };
 
-export const selectSelectedItemId = ({ state }) => {
-  return state.selectedItemId;
-};
-
-export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) {
-    return undefined;
-  }
-
-  const flatItems = toFlatItems(state.transformData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
-};
-
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.transformData);
-  const rawFlatGroups = toFlatGroups(state.transformData);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  const detailFields = selectedItem
-    ? [
-        {
-          type: "slot",
-          slot: "transform-preview",
-          label: "",
-        },
-        {
-          type: "text",
-          label: "Position X",
-          value: String(selectedItem.x ?? 0),
-        },
-        {
-          type: "text",
-          label: "Position Y",
-          value: String(selectedItem.y ?? 0),
-        },
-        {
-          type: "text",
-          label: "Scale X",
-          value: String(selectedItem.scaleX ?? 1),
-        },
-        {
-          type: "text",
-          label: "Scale Y",
-          value: String(selectedItem.scaleY ?? 1),
-        },
-        {
-          type: "text",
-          label: "Anchor X",
-          value: String(selectedItem.anchorX ?? 0),
-        },
-        {
-          type: "text",
-          label: "Anchor Y",
-          value: String(selectedItem.anchorY ?? 0),
-        },
-      ]
-    : [];
-
-  // Apply search filter
-  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
-  let filteredGroups = rawFlatGroups;
-
-  if (searchQuery) {
-    filteredGroups = rawFlatGroups
-      .map((group) => {
-        const filteredChildren = (group.children ?? []).filter((item) => {
-          const name = (item.name ?? "").toLowerCase();
-          return name.includes(searchQuery);
-        });
-
-        const groupName = (group.name ?? "").toLowerCase();
-        const shouldIncludeGroup =
-          filteredChildren.length > 0 || groupName.includes(searchQuery);
-
-        return shouldIncludeGroup
-          ? {
-              ...group,
-              children: filteredChildren,
-              hasChildren: filteredChildren.length > 0,
-            }
-          : null;
-      })
-      .filter(Boolean);
-  }
-
-  // Apply collapsed state and selection styling
-  const flatGroups = filteredGroups.map((group) => ({
-    ...group,
-    isCollapsed: state.collapsedIds.includes(group.id),
-    children: state.collapsedIds.includes(group.id)
-      ? []
-      : (group.children ?? []).map((item) => ({
-          ...item,
-          selectedStyle:
-            item.id === state.selectedItemId
-              ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-              : "",
-        })),
-  }));
-
-  // TODO this is hacky way to work around limitation of passing props
-  const items = {};
-  flatGroups.forEach((group) => {
-    group.children.forEach((child) => {
-      items[child.id] = child;
-    });
-  });
-
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "assets",
-    selectedResourceId: "transforms",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    detailFields,
-    contextMenuItems: state.contextMenuItems,
-    emptyContextMenuItems: state.emptyContextMenuItems,
-    searchQuery: state.searchQuery,
-    resourceType: "transforms",
-    title: "Transforms",
-    // Dialog state for transforms (moved from groupTransformsView)
-    isDialogOpen: state.isDialogOpen,
-    editMode: state.editMode,
-    editItemId: state.editItemId,
-    transformForm: state.transformForm,
-    dialogDefaultValues: state.defaultValues,
-    items,
-    selectedItem,
-  };
+export const selectViewData = (context) => {
+  return selectCatalogViewData(context);
 };

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -38,9 +38,9 @@ template:
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
-                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :contextMenuItems=contextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
+                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - rtgl-view w=1fg h=f:
-              - rvn-group-resources-view#groupview :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :collapsedIds=collapsedIds :emptyMessage="No transforms found" :uploadText="Upload Files" :acceptedFileTypes=[] :items=items: null
+              - rvn-catalog-resources-view#groupview w=f h=f :navTitle=title :groups=catalogGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :emptyMessage=emptyMessage :addText=addText :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/tweens/tweens.handlers.js
+++ b/src/pages/tweens/tweens.handlers.js
@@ -1,278 +1,181 @@
 import { nanoid } from "nanoid";
-import { resetState } from "./tweens.constants";
 import { recursivelyCheckResource } from "../../utils/resourceUsageChecker.js";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
+import { createCatalogPageHandlers } from "../../deps/features/resourcePages/catalog/createCatalogPageHandlers.js";
+import { resetState } from "./tweens.constants";
 
-const resolveDetailItemId = (detail = {}) => {
-  return detail.itemId ?? detail.id ?? detail.item?.id ?? "";
+const defaultInitialValues = {
+  x: 960,
+  y: 540,
+  alpha: 1,
+  scaleX: 1,
+  scaleY: 1,
+  rotation: 0,
 };
 
-export const handleAfterMount = async (deps) => {
-  const { store, projectService, render, graphicsService, refs } = deps;
-  await projectService.ensureRepository();
-  const { tweens } = projectService.getState();
-  store.setItems({ tweensData: tweens ?? { tree: [], items: {} } });
+const openTweenDialog = async ({
+  deps,
+  editMode = false,
+  itemId,
+  itemData,
+  targetGroupId,
+} = {}) => {
+  const { graphicsService, refs, render, store } = deps;
 
-  // Initialize graphicsService if canvas is present
-  const { canvas } = refs;
-  if (
-    graphicsService &&
-    canvas &&
-    !store.selectIsGraphicsServiceInitialized()
-  ) {
-    await graphicsService.init({
-      canvas: canvas,
-    });
-    store.setGraphicsServiceInitialized({ initialized: true });
-  }
-
-  render();
-};
-
-const refreshTweensData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const { tweens } = projectService.getState();
-  store.setItems({ tweensData: tweens ?? { tree: [], items: {} } });
-  render();
-};
-
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "tweens",
-    refresh: refreshTweensData,
+  store.openDialog({
+    editMode,
+    itemId,
+    itemData,
+    targetGroupId,
   });
-
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleDataChanged = refreshTweensData;
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const detail = payload?._event?.detail ?? {};
-  const { isFolder } = detail;
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
-    return;
-  }
-
-  const id = resolveDetailItemId(detail);
-  if (!id) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId: id });
-  render();
-};
-
-export const handleAnimationItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const detail = payload?._event?.detail ?? {};
-  const itemId = resolveDetailItemId(detail);
-  if (!itemId) {
-    return;
-  }
-
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-
-  store.setSelectedItemId({ itemId });
-  render();
-};
-
-export const handleAnimationCreated = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { groupId, name, properties } = payload._event.detail;
-
-  await projectService.createResourceItem({
-    resourceType: "tweens",
-    resourceId: nanoid(),
-    data: {
-      type: "tween",
-      name,
-      duration: "4s",
-      keyframes: 3,
-      properties,
-    },
-    parentId: groupId,
-    position: "last",
-  });
-
-  const { tweens } = projectService.getState();
-  store.setItems({ tweensData: tweens });
-  render();
-};
-
-export const handleAnimationUpdated = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { itemId, name, properties } = payload._event.detail;
-
-  await projectService.updateResourceItem({
-    resourceType: "tweens",
-    resourceId: itemId,
-    patch: {
-      name,
-      properties,
-    },
-  });
-
-  const { tweens } = projectService.getState();
-  store.setItems({ tweensData: tweens });
-  render();
-};
-
-// Handlers forwarded from groupResourcesView
-export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail.value ?? "";
-  store.setSearchQuery({ query: searchQuery });
-  render();
-};
-
-export const handleAddAnimationClick = async (deps, payload) => {
-  const { store, render, graphicsService, refs } = deps;
-  const { groupId } = payload._event.detail;
-  store.setTargetGroupId({ groupId: groupId });
-  store.openDialog();
   render();
 
-  const { canvas } = refs;
-  if (canvas && graphicsService) {
-    await graphicsService.init({ canvas });
-    graphicsService.render(resetState);
-  }
-};
-
-export const handleAnimationItemDoubleClick = async (deps, payload) => {
-  const { store, render, graphicsService, refs } = deps;
-  const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) return;
-
-  const tweensData = store.selectTweensData();
-
-  if (!tweensData || !tweensData.items) {
-    return;
-  }
-
-  const itemData = tweensData.items[itemId];
-
-  if (itemData) {
-    // Find parent group
-    let parent = null;
-    for (const [key, value] of Object.entries(tweensData.items)) {
-      if (value.children && value.children.includes(itemId)) {
-        parent = key;
-        break;
-      }
-    }
-
-    store.openDialog({
-      editMode: true,
-      itemId,
-      itemData: { ...itemData, parent },
-    });
-    render();
-    const { animationForm } = refs;
-    animationForm.reset();
-    animationForm.setValues({
+  if (editMode && itemData) {
+    refs.animationForm.reset();
+    refs.animationForm.setValues({
       values: {
         name: itemData.name ?? "",
       },
     });
-
-    const { canvas } = refs;
-    if (canvas && graphicsService) {
-      await graphicsService.init({ canvas });
-      graphicsService.render(resetState);
-    }
   }
+
+  const { canvas } = refs;
+  if (!canvas || !graphicsService) {
+    return;
+  }
+
+  await graphicsService.init({ canvas });
+  graphicsService.render(resetState);
 };
 
-// Dialog handlers
+const {
+  handleAfterMount,
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleItemClick: handleAnimationItemClick,
+  handleSearchInput,
+} = createCatalogPageHandlers({
+  resourceType: "tweens",
+});
+
+export {
+  handleAfterMount,
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleAnimationItemClick,
+  handleSearchInput,
+};
+
+export const handleAddAnimationClick = async (deps, payload) => {
+  const { groupId } = payload._event.detail;
+
+  await openTweenDialog({
+    deps,
+    targetGroupId: groupId,
+  });
+};
+
+export const handleAnimationItemDoubleClick = async (deps, payload) => {
+  const { itemId, isFolder } = payload._event.detail;
+  if (isFolder || !itemId) {
+    return;
+  }
+
+  const itemData = deps.store.selectTweenDisplayItemById({ itemId });
+  if (!itemData) {
+    return;
+  }
+
+  await openTweenDialog({
+    deps,
+    editMode: true,
+    itemId,
+    itemData,
+  });
+};
+
 export const handleCloseDialog = (deps) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   store.closeDialog();
   render();
 };
 
 export const handleClosePopover = (deps) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   store.closePopover();
   render();
 };
 
-export const handleFormActionClick = (deps, payload) => {
-  const { store, render } = deps;
-
-  const actionId = payload._event.detail.actionId;
-
-  if (actionId === "submit") {
-    const formData = payload._event.detail.values;
-    const formState = store.selectFormState();
-    const { targetGroupId, editItemId, editMode, properties } = formState;
-
-    if (editMode && editItemId) {
-      handleAnimationUpdated(deps, {
-        _event: {
-          detail: {
-            itemId: editItemId,
-            name: formData.name,
-            properties,
-          },
-        },
-      });
-    } else {
-      handleAnimationCreated(deps, {
-        _event: {
-          detail: {
-            groupId: targetGroupId,
-            name: formData.name,
-            properties,
-          },
-        },
-      });
-    }
-
-    store.closeDialog();
-    render();
+export const handleFormActionClick = async (deps, payload) => {
+  const { appService, projectService, store } = deps;
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
+    return;
   }
+
+  const name = values?.name?.trim();
+  if (!name) {
+    appService.showToast("Tween name is required.", { title: "Warning" });
+    return;
+  }
+
+  const properties = structuredClone(store.selectProperties());
+  const editMode = store.selectEditMode();
+  const editItemId = store.selectEditItemId();
+
+  if (editMode && editItemId) {
+    await projectService.updateResourceItem({
+      resourceType: "tweens",
+      resourceId: editItemId,
+      patch: {
+        name,
+        properties,
+      },
+    });
+  } else {
+    await projectService.createResourceItem({
+      resourceType: "tweens",
+      resourceId: nanoid(),
+      data: {
+        type: "tween",
+        name,
+        duration: "4s",
+        keyframes: 3,
+        properties,
+      },
+      parentId: store.selectTargetGroupId(),
+      position: "last",
+    });
+  }
+
+  store.closeDialog();
+  await handleDataChanged(deps);
 };
 
 export const handleAddPropertiesClick = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
 
   store.setPopover({
     mode: "addProperty",
     x: payload._event.clientX,
     y: payload._event.clientY,
   });
-
   render();
 };
 
 export const handleAddPropertyFormSubmit = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   const { property, initialValue, useInitialValue } =
     payload._event.detail.values;
-
-  const defaultValues = {
-    x: 960,
-    y: 540,
-    alpha: 1,
-    scaleX: 1,
-    scaleY: 1,
-    rotation: 0,
-  };
 
   const finalInitialValue = useInitialValue
     ? initialValue !== undefined
       ? initialValue
-      : defaultValues[property] !== undefined
-        ? defaultValues[property]
-        : 0
-    : defaultValues[property] !== undefined
-      ? defaultValues[property]
-      : 0;
+      : (defaultInitialValues[property] ?? 0)
+    : (defaultInitialValues[property] ?? 0);
 
   store.addProperty({ property, initialValue: finalInitialValue });
   store.closePopover();
@@ -280,7 +183,7 @@ export const handleAddPropertyFormSubmit = (deps, payload) => {
 };
 
 export const handleAddKeyframeInDialog = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
 
   store.setPopover({
     mode: "addKeyframe",
@@ -290,18 +193,16 @@ export const handleAddKeyframeInDialog = (deps, payload) => {
       property: payload._event.detail.property,
     },
   });
-
   render();
 };
 
 export const handleAddKeyframeFormSubmit = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   const {
     payload: { property, index },
   } = store.selectPopover();
 
   const formValues = payload._event.detail.values;
-
   if (formValues.duration < 1) {
     formValues.duration = 1;
   }
@@ -347,47 +248,48 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
   const popover = store.selectPopover();
   const { property, index } = popover.payload;
   const { x, y } = popover;
+  const value = payload._event.detail.item.value;
 
-  if (payload._event.detail.item.value === "edit") {
+  if (value === "edit") {
     store.setPopover({
       mode: "editKeyframe",
-      x: x,
-      y: y,
+      x,
+      y,
       payload: {
         property,
         index,
       },
     });
-  } else if (payload._event.detail.item.value === "delete-property") {
+  } else if (value === "delete-property") {
     store.deleteProperty({ property });
     store.closePopover();
-  } else if (payload._event.detail.item.value === "delete-keyframe") {
+  } else if (value === "delete-keyframe") {
     store.deleteKeyframe({ property, index });
     store.closePopover();
-  } else if (payload._event.detail.item.value === "add-right") {
+  } else if (value === "add-right") {
     store.setPopover({
       mode: "addKeyframe",
-      x: x,
-      y: y,
+      x,
+      y,
       payload: {
         property,
         index: index + 1,
       },
     });
-  } else if (payload._event.detail.item.value === "add-left") {
+  } else if (value === "add-left") {
     store.setPopover({
       mode: "addKeyframe",
-      x: x,
-      y: y,
+      x,
+      y,
       payload: {
         property,
         index,
       },
     });
-  } else if (payload._event.detail.item.value === "move-right") {
+  } else if (value === "move-right") {
     store.moveKeyframeRight({ property, index });
     store.closePopover();
-  } else if (payload._event.detail.item.value === "move-left") {
+  } else if (value === "move-left") {
     store.moveKeyframeLeft({ property, index });
     store.closePopover();
   }
@@ -396,13 +298,12 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
 };
 
 export const handleEditKeyframeFormSubmit = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   const {
     payload: { property, index },
   } = store.selectPopover();
 
   const formValues = payload._event.detail.values;
-
   if (formValues.duration < 1) {
     formValues.duration = 1;
   }
@@ -429,72 +330,58 @@ export const handleInitialValueClick = (deps, payload) => {
   render();
 };
 
+const updatePopoverFieldValue = ({ store, detail } = {}) => {
+  const { name, value } = detail;
+  const currentFormValues = store.selectPopover().formValues ?? {};
+  store.updatePopoverFormValues({
+    formValues: {
+      ...currentFormValues,
+      [name]: value,
+    },
+  });
+};
+
 export const handleAddPropertyFormChange = (deps, payload) => {
-  const { store, render } = deps;
-
-  const { name, value: fieldValue } = payload._event.detail;
-
-  const currentFormValues = store.selectPopover().formValues || {};
-  const updatedFormValues = {
-    ...currentFormValues,
-    [name]: fieldValue,
-  };
-  store.updatePopoverFormValues({ formValues: updatedFormValues });
+  const { render, store } = deps;
+  updatePopoverFieldValue({
+    store,
+    detail: payload._event.detail,
+  });
   render();
 };
 
 export const handleEditInitialValueFormChange = (deps, payload) => {
-  const { store, render } = deps;
-
-  const { name, value: fieldValue } = payload._event.detail;
-
-  const currentFormValues = store.selectPopover().formValues || {};
-  const updatedFormValues = {
-    ...currentFormValues,
-    [name]: fieldValue,
-  };
-
-  store.updatePopoverFormValues({ formValues: updatedFormValues });
+  const { render, store } = deps;
+  updatePopoverFieldValue({
+    store,
+    detail: payload._event.detail,
+  });
   render();
 };
 
 export const handleReplayAnimation = async (deps) => {
-  const { store, graphicsService } = deps;
-
-  if (!graphicsService || !store.selectIsGraphicsServiceInitialized()) {
+  const { graphicsService, store } = deps;
+  if (!graphicsService) {
     return;
   }
 
   await graphicsService.render(resetState);
 
   setTimeout(() => {
-    const renderState = store.selectAnimationRenderStateWithAnimations();
-    graphicsService.render(renderState);
+    graphicsService.render(store.selectAnimationRenderStateWithAnimations());
   }, 100);
 };
 
 export const handleEditInitialValueFormSubmit = (deps, payload) => {
-  const { store, render } = deps;
+  const { render, store } = deps;
   const {
     payload: { property },
   } = store.selectPopover();
 
   const { initialValue, valueSource } = payload._event.detail.values;
-
-  const defaultValues = {
-    x: 960,
-    y: 540,
-    alpha: 1,
-    scaleX: 1,
-    scaleY: 1,
-    rotation: 0,
-  };
-
   const finalInitialValue =
     valueSource === "default" || initialValue === undefined
-      ? defaultValues[property] !== undefined
-        ? defaultValues[property]
-        : 0
+      ? (defaultInitialValues[property] ?? 0)
       : initialValue;
 
   store.updateInitialValue({
@@ -506,30 +393,27 @@ export const handleEditInitialValueFormSubmit = (deps, payload) => {
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { appService, projectService } = deps;
+  const { itemId } = payload._event.detail;
+  if (!itemId) {
+    return;
+  }
 
-  const state = projectService.getState();
   const usage = recursivelyCheckResource({
-    state,
+    state: projectService.getState(),
     itemId,
     checkTargets: ["scenes", "layouts"],
   });
 
   if (usage.isUsed) {
     appService.showToast("Cannot delete resource, it is currently in use.");
-    render();
     return;
   }
 
-  // Perform the delete operation
   await projectService.deleteResourceItem({
-    resourceType,
+    resourceType: "tweens",
     resourceId: itemId,
   });
 
-  // Refresh data and update store (reuse existing logic from handleDataChanged)
-  const data = projectService.getState()[resourceType];
-  store.setItems({ tweensData: data });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/tweens/tweens.store.js
+++ b/src/pages/tweens/tweens.store.js
@@ -1,10 +1,12 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
+import { toFlatItems } from "../../domain/treeHelpers.js";
+import { createCatalogPageStore } from "../../deps/features/resourcePages/catalog/createCatalogPageStore.js";
 import { resetState } from "./tweens.constants";
 
 const createAddKeyframeForm = (property) => {
   if (!property) {
     return {};
   }
+
   const sliderConfig = {
     x: {
       min: 0,
@@ -29,11 +31,8 @@ const createAddKeyframeForm = (property) => {
       max: 5,
       step: 0.1,
     },
-    // rotation: {
-    //   min: -360,
-    //   max: 360,
-    // },
   };
+
   return {
     title: "Add Keyframe",
     fields: [
@@ -157,10 +156,9 @@ const propertyOptions = [
   { label: "Position Y", value: "y" },
   { label: "Scale X", value: "scaleX" },
   { label: "Scale Y", value: "scaleY" },
-  // { label: "Rotation", value: "rotation" },
 ];
 
-const createAddPropertyForm = (propertyOptions) => {
+const createAddPropertyForm = (availableProperties) => {
   return {
     title: "Add tween property",
     fields: [
@@ -168,7 +166,7 @@ const createAddPropertyForm = (propertyOptions) => {
         name: "property",
         type: "select",
         label: "Property",
-        options: propertyOptions,
+        options: availableProperties,
         required: true,
       },
       {
@@ -226,15 +224,6 @@ const createAddPropertyForm = (propertyOptions) => {
             step: 0.1,
             label: "Initial value",
           },
-          // {
-          //   $when: 'property == "rotation"',
-          //   name: "initialValue",
-          //   type: "slider-with-input",
-          //   min: -360,
-          //   max: 360,
-          //   step: 1,
-          //   label: "Initial value",
-          // },
         ],
       },
     ],
@@ -348,32 +337,171 @@ const editTweenForm = {
   },
 };
 
+const defaultInitialValuesByProperty = {
+  x: 960,
+  y: 540,
+  alpha: 1,
+  scaleX: 1,
+  scaleY: 1,
+  rotation: 0,
+};
+
+const buildCatalogItem = (item) => ({
+  ...item,
+  cardKind: "tween",
+  itemWidth: "f",
+});
+
+const matchesSearch = (item, searchQuery) => {
+  if (!searchQuery) {
+    return true;
+  }
+
+  const name = (item.name ?? "").toLowerCase();
+  const description = (item.description ?? "").toLowerCase();
+  return name.includes(searchQuery) || description.includes(searchQuery);
+};
+
+const {
+  createInitialState: createCatalogInitialState,
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectCatalogViewData,
+} = createCatalogPageStore({
+  itemType: "tween",
+  resourceType: "tweens",
+  title: "Tweens",
+  selectedResourceId: "tweens",
+  resourceCategory: "assets",
+  addText: "Add Tween Animation",
+  buildCatalogItem,
+  matchesSearch,
+  extendViewData: ({ state, selectedItem, baseViewData }) => {
+    const selectedTweenPropertyCount = Object.keys(
+      selectedItem?.properties ?? {},
+    ).length;
+
+    const availableProperties = propertyOptions.filter(
+      (item) => !Object.keys(state.properties).includes(item.value),
+    );
+
+    const keyframeDropdownItems = (() => {
+      if (state.popover.mode !== "keyframeMenu") {
+        return propertyNameDropdownItems;
+      }
+
+      const { property, index } = state.popover.payload;
+      const keyframes = state.properties[property]?.keyframes ?? [];
+      const currentIndex = Number(index);
+      const isFirstKeyframe = currentIndex === 0;
+      const isLastKeyframe = currentIndex === keyframes.length - 1;
+
+      return baseKeyframeDropdownItems.filter((item) => {
+        if (item.value === "move-left" && isFirstKeyframe) {
+          return false;
+        }
+        if (item.value === "move-right" && isLastKeyframe) {
+          return false;
+        }
+        return true;
+      });
+    })();
+
+    let addPropertyContext = {};
+    let editKeyframeDefaultValues = {};
+    let editInitialValueDefaultValues = {};
+    let editInitialValueContext = {};
+
+    if (state.popover.mode === "addProperty") {
+      addPropertyContext = { ...state.popover.formValues };
+    }
+
+    if (state.popover.mode === "editKeyframe") {
+      const { property, index } = state.popover.payload;
+      const currentKeyframe = state.properties[property]?.keyframes?.[index];
+
+      if (currentKeyframe) {
+        editKeyframeDefaultValues = {
+          duration: currentKeyframe.duration,
+          value: currentKeyframe.value,
+          easing: currentKeyframe.easing,
+          relative: currentKeyframe.relative,
+        };
+      }
+    }
+
+    if (state.popover.mode === "editInitialValue") {
+      const { property } = state.popover.payload;
+      const currentInitialValue = state.properties[property]?.initialValue;
+      const defaultValue = defaultInitialValuesByProperty[property] ?? 0;
+      const isUsingDefault = currentInitialValue === defaultValue;
+
+      editInitialValueDefaultValues = {
+        initialValue: currentInitialValue,
+        valueSource: isUsingDefault ? "default" : "custom",
+      };
+
+      editInitialValueContext = {
+        ...editInitialValueDefaultValues,
+        ...state.popover.formValues,
+      };
+    }
+
+    return {
+      ...baseViewData,
+      selectedItemDuration: String(selectedItem?.duration ?? ""),
+      selectedTweenPropertyCount,
+      isDialogOpen: state.isDialogOpen,
+      dialogDefaultValues: state.dialogDefaultValues,
+      dialogForm: state.dialogForm,
+      properties: state.properties,
+      addPropertyForm: createAddPropertyForm(availableProperties),
+      addPropertyContext,
+      addKeyframeForm: createAddKeyframeForm(state.popover.payload?.property),
+      addKeyframeDefaultValues,
+      updateKeyframeForm: createUpdateKeyframeForm(
+        state.popover.payload?.property,
+      ),
+      editInitialValueForm,
+      editInitialValueContext,
+      editKeyframeDefaultValues,
+      editInitialValueDefaultValues,
+      keyframeDropdownItems,
+      addPropertyButtonVisible: availableProperties.length > 0,
+      popover: {
+        ...state.popover,
+        popoverIsOpen: [
+          "addProperty",
+          "addKeyframe",
+          "editKeyframe",
+          "editInitialValue",
+        ].includes(state.popover.mode),
+        dropdownMenuIsOpen: ["keyframeMenu", "propertyNameMenu"].includes(
+          state.popover.mode,
+        ),
+      },
+      addPropertyFormDefaultValues: {
+        useInitialValue: false,
+      },
+    };
+  },
+});
+
 export const createInitialState = () => ({
-  tweensData: { tree: [], items: {} },
-  selectedItemId: null,
-  contextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-    { label: "Duplicate", type: "item", value: "duplicate-item" },
-    { label: "Rename", type: "item", value: "rename-item" },
-    { label: "Delete", type: "item", value: "delete-item" },
-  ],
-  emptyContextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-  ],
-  // Animation dialog state
-  searchQuery: "",
+  ...createCatalogInitialState(),
   isDialogOpen: false,
-  isGraphicsServiceInitialized: false,
-  targetGroupId: null,
-  selectedProperties: [],
-  initialValue: 0,
+  targetGroupId: undefined,
   properties: {},
   dialogDefaultValues: {
     name: "",
   },
   dialogForm: addTweenForm,
   editMode: false,
-  editItemId: null,
+  editItemId: undefined,
   popover: {
     mode: "none",
     x: undefined,
@@ -383,27 +511,88 @@ export const createInitialState = () => ({
   },
 });
 
-export const setItems = ({ state }, { tweensData } = {}) => {
-  state.tweensData = tweensData;
+export {
+  setItems,
+  setSelectedItemId,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
 };
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
+export const selectTweenItemById = selectItemById;
+
+export const selectTweenDisplayItemById = ({ state }, { itemId } = {}) => {
+  return toFlatItems(state.data).find(
+    (item) => item.id === itemId && item.type === "tween",
+  );
 };
 
-export const selectSelectedItemId = ({ state }) => state.selectedItemId;
+export const openDialog = (
+  { state },
+  { editMode, itemId, itemData, targetGroupId } = {},
+) => {
+  state.isDialogOpen = true;
+  state.editMode = Boolean(editMode);
+  state.editItemId = itemId;
 
-export const selectTweensData = ({ state }) => state.tweensData;
+  if (editMode && itemData) {
+    state.targetGroupId = itemData.parentId ?? undefined;
+    state.dialogForm = editTweenForm;
+    state.dialogDefaultValues = {
+      name: itemData.name ?? "",
+    };
+    state.properties = structuredClone(itemData.properties ?? {});
+    return;
+  }
 
-export const setSearchQuery = ({ state }, { query } = {}) => {
-  state.searchQuery = query;
+  state.targetGroupId =
+    targetGroupId === "_root"
+      ? undefined
+      : (targetGroupId ?? itemData?.parentId ?? undefined);
+  state.dialogForm = addTweenForm;
+  state.dialogDefaultValues = {
+    name: "",
+  };
+  state.properties = {};
+};
+
+export const closeDialog = ({ state }, _payload = {}) => {
+  state.isDialogOpen = false;
+  state.targetGroupId = undefined;
+  state.editMode = false;
+  state.editItemId = undefined;
+  state.dialogDefaultValues = {
+    name: "",
+  };
+  state.dialogForm = addTweenForm;
+  state.properties = {};
+};
+
+export const setTargetGroupId = ({ state }, { groupId } = {}) => {
+  state.targetGroupId = groupId === "_root" ? undefined : groupId;
+};
+
+export const selectTargetGroupId = ({ state }) => {
+  return state.targetGroupId;
+};
+
+export const selectEditMode = ({ state }) => {
+  return state.editMode;
+};
+
+export const selectEditItemId = ({ state }) => {
+  return state.editItemId;
+};
+
+export const selectProperties = ({ state }) => {
+  return state.properties;
 };
 
 export const setPopover = ({ state }, { mode, x, y, payload } = {}) => {
   state.popover.mode = mode;
   state.popover.x = x;
   state.popover.y = y;
-  state.popover.payload = payload;
+  state.popover.payload = payload ?? {};
 };
 
 export const closePopover = ({ state }, _payload = {}) => {
@@ -415,119 +604,60 @@ export const closePopover = ({ state }, _payload = {}) => {
 };
 
 export const updatePopoverFormValues = ({ state }, { formValues } = {}) => {
-  state.popover.formValues = formValues;
+  state.popover.formValues = formValues ?? {};
 };
 
 export const selectPopover = ({ state }) => {
   return state.popover;
 };
 
-export const selectFormState = ({ state }) => {
-  return {
-    targetGroupId: state.targetGroupId,
-    editItemId: state.editItemId,
-    editMode: state.editMode,
-    properties: state.properties,
-  };
-};
-
-export const openDialog = ({ state }, { editMode, itemId, itemData } = {}) => {
-  state.isDialogOpen = true;
-  state.editMode = editMode;
-  state.editItemId = itemId;
-
-  if (editMode && itemData) {
-    state.targetGroupId = itemData.parent || null;
-    state.dialogForm = editTweenForm;
-    state.dialogDefaultValues = {
-      name: itemData.name,
-    };
-    state.properties = itemData.properties || {};
-  } else {
-    state.dialogForm = addTweenForm;
-    state.dialogDefaultValues = {};
-    state.properties = {};
-  }
-};
-
-export const closeDialog = ({ state }, _payload = {}) => {
-  state.isDialogOpen = false;
-  state.editMode = false;
-  state.editItemId = null;
-  state.dialogForm = addTweenForm;
-  state.dialogDefaultValues = {
-    name: "",
-  };
-  state.properties = {};
-};
-
-export const setTargetGroupId = ({ state }, { groupId } = {}) => {
-  state.targetGroupId = groupId;
-};
-
-export const setGraphicsServiceInitialized = (
-  { state },
-  { initialized } = {},
-) => {
-  state.isGraphicsServiceInitialized = initialized;
-};
-
-export const selectIsGraphicsServiceInitialized = ({ state }) => {
-  return state.isGraphicsServiceInitialized;
-};
-
-// Helper function to create render state with animations
 const createAnimationRenderState = (properties, includeAnimations = true) => {
   const animations = [];
+
   if (includeAnimations && properties && Object.keys(properties).length > 0) {
     for (const [property, config] of Object.entries(properties)) {
-      if (config.keyframes && config.keyframes.length > 0) {
-        let propName = property;
-
-        let defaultValue = 0;
-        if (property === "x") defaultValue = 960;
-        else if (property === "y") defaultValue = 540;
-        else if (property === "rotation") defaultValue = 0;
-        else if (property === "alpha") defaultValue = 1;
-        else if (property === "scaleX" || property === "scaleY")
-          defaultValue = 1;
-
-        const initialValue =
-          config.initialValue !== undefined && config.initialValue !== ""
-            ? parseFloat(config.initialValue)
-            : defaultValue;
-
-        let processedInitialValue = isNaN(initialValue)
-          ? defaultValue
-          : initialValue;
-        if (property === "rotation") {
-          processedInitialValue = (processedInitialValue * Math.PI) / 180;
-        }
-
-        const animationProperties = {};
-        animationProperties[propName] = {
-          initialValue: processedInitialValue,
-          keyframes: config.keyframes.map((kf) => {
-            let value = parseFloat(kf.value) ?? 0;
-            if (property === "rotation") {
-              value = (value * Math.PI) / 180;
-            }
-            return {
-              duration: kf.duration,
-              value: value,
-              easing: kf.easing ?? "linear",
-              relative: kf.relative ?? false,
-            };
-          }),
-        };
-
-        animations.push({
-          id: `animation-${property}`,
-          targetId: "preview-element",
-          type: "tween",
-          properties: animationProperties,
-        });
+      if (!config.keyframes?.length) {
+        continue;
       }
+
+      let propName = property;
+      const defaultValue = defaultInitialValuesByProperty[property] ?? 0;
+      const initialValue =
+        config.initialValue !== undefined && config.initialValue !== ""
+          ? parseFloat(config.initialValue)
+          : defaultValue;
+
+      let processedInitialValue = Number.isNaN(initialValue)
+        ? defaultValue
+        : initialValue;
+      if (property === "rotation") {
+        processedInitialValue = (processedInitialValue * Math.PI) / 180;
+      }
+
+      const animationProperties = {};
+      animationProperties[propName] = {
+        initialValue: processedInitialValue,
+        keyframes: config.keyframes.map((keyframe) => {
+          let value = parseFloat(keyframe.value) ?? 0;
+          if (property === "rotation") {
+            value = (value * Math.PI) / 180;
+          }
+
+          return {
+            duration: keyframe.duration,
+            value,
+            easing: keyframe.easing ?? "linear",
+            relative: keyframe.relative ?? false,
+          };
+        }),
+      };
+
+      animations.push({
+        id: `animation-${property}`,
+        targetId: "preview-element",
+        type: "tween",
+        properties: animationProperties,
+      });
     }
   }
 
@@ -546,9 +676,10 @@ export const selectAnimationRenderStateWithAnimations = ({ state }) => {
 };
 
 export const addProperty = ({ state }, { property, initialValue } = {}) => {
-  if (state.properties[property]) {
+  if (!property || state.properties[property]) {
     return;
   }
+
   state.properties[property] = {
     initialValue,
     keyframes: [],
@@ -559,77 +690,68 @@ export const addKeyframe = ({ state }, keyframe = {}) => {
   if (!keyframe.property) {
     return;
   }
+
   const keyframes = state.properties[keyframe.property]?.keyframes;
   if (!Array.isArray(keyframes)) {
     return;
   }
-  let index = keyframe.index;
-  if (keyframe.index === undefined) {
-    index = keyframes.length;
-  }
+
+  const index =
+    keyframe.index === undefined ? keyframes.length : keyframe.index;
 
   keyframes.splice(index, 0, {
-    duration: parseInt(keyframe.duration),
+    duration: parseInt(keyframe.duration, 10),
     easing: keyframe.easing,
     value: parseFloat(keyframe.value),
     relative: keyframe.relative,
   });
 };
 
-export const deleteKeyframe = ({ state }, payload = {}) => {
-  const { property, index } = payload;
+export const deleteKeyframe = ({ state }, { property, index } = {}) => {
   const keyframes = state.properties[property]?.keyframes;
   if (!Array.isArray(keyframes)) {
     return;
   }
+
   keyframes.splice(index, 1);
 };
 
-export const deleteProperty = ({ state }, payload = {}) => {
-  const { property } = payload;
+export const deleteProperty = ({ state }, { property } = {}) => {
   if (!property) {
     return;
   }
 
-  state.selectedProperties = state.selectedProperties.filter(
-    (p) => p.name !== property,
-  );
-
   delete state.properties[property];
 };
 
-export const moveKeyframeRight = ({ state }, payload = {}) => {
-  const { property, index } = payload;
+export const moveKeyframeRight = ({ state }, { property, index } = {}) => {
   const numIndex = Number(index);
   const keyframes = state.properties[property]?.keyframes;
-  if (!Array.isArray(keyframes)) {
+  if (!Array.isArray(keyframes) || numIndex >= keyframes.length - 1) {
     return;
   }
 
-  if (numIndex < keyframes.length - 1) {
-    const temp = keyframes[numIndex];
-    keyframes[numIndex] = keyframes[numIndex + 1];
-    keyframes[numIndex + 1] = temp;
-  }
+  const current = keyframes[numIndex];
+  keyframes[numIndex] = keyframes[numIndex + 1];
+  keyframes[numIndex + 1] = current;
 };
 
-export const moveKeyframeLeft = ({ state }, payload = {}) => {
-  const { property, index } = payload;
+export const moveKeyframeLeft = ({ state }, { property, index } = {}) => {
   const numIndex = Number(index);
   const keyframes = state.properties[property]?.keyframes;
-  if (!Array.isArray(keyframes)) {
+  if (!Array.isArray(keyframes) || numIndex <= 0) {
     return;
   }
 
-  if (numIndex > 0) {
-    const temp = keyframes[numIndex];
-    keyframes[numIndex] = keyframes[numIndex - 1];
-    keyframes[numIndex - 1] = temp;
-  }
+  const current = keyframes[numIndex];
+  keyframes[numIndex] = keyframes[numIndex - 1];
+  keyframes[numIndex - 1] = current;
 };
 
-export const updateKeyframe = ({ state }, payload = {}) => {
-  const { property, index, keyframe } = payload;
+export const updateKeyframe = (
+  { state },
+  { property, index, keyframe } = {},
+) => {
   const keyframes = state.properties[property]?.keyframes;
   if (!Array.isArray(keyframes) || !keyframe) {
     return;
@@ -637,188 +759,23 @@ export const updateKeyframe = ({ state }, payload = {}) => {
 
   keyframes[index] = {
     ...keyframe,
-    duration: parseInt(keyframe.duration),
+    duration: parseInt(keyframe.duration, 10),
     value: parseFloat(keyframe.value),
     relative: keyframe.relative,
   };
 };
 
-export const updateInitialValue = ({ state }, payload = {}) => {
-  const { property, initialValue } = payload;
+export const updateInitialValue = (
+  { state },
+  { property, initialValue } = {},
+) => {
   if (!property || !state.properties[property]) {
     return;
   }
+
   state.properties[property].initialValue = initialValue;
 };
 
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.tweensData);
-  const rawFlatGroups = toFlatGroups(state.tweensData);
-
-  // Get selected item details
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  const selectedTweenPropertyCount = Object.keys(
-    selectedItem?.properties ?? {},
-  ).length;
-  const selectedItemDuration = String(selectedItem?.duration ?? "");
-
-  // Apply search filtering to flatGroups (collapse state is now handled by groupResourcesView)
-  const searchQuery = (state.searchQuery ?? "").toLowerCase();
-  const matchesSearch = (item) => {
-    if (!searchQuery) return true;
-    const name = (item.name ?? "").toLowerCase();
-    const description = (item.description ?? "").toLowerCase();
-    return name.includes(searchQuery) || description.includes(searchQuery);
-  };
-
-  const flatGroups = rawFlatGroups
-    .map((group) => {
-      // Filter children based on search query
-      const filteredChildren = (group.children || []).filter(matchesSearch);
-
-      // Only show groups that have matching children or if there's no search query
-      const hasMatchingChildren = filteredChildren.length > 0;
-      const shouldShowGroup = !searchQuery || hasMatchingChildren;
-
-      return {
-        ...group,
-        children: filteredChildren.map((item) => ({
-          ...item,
-          selectedStyle:
-            item.id === state.selectedItemId
-              ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-              : "",
-        })),
-        hasChildren: filteredChildren.length > 0,
-        shouldDisplay: shouldShowGroup,
-      };
-    })
-    .filter((group) => group.shouldDisplay);
-
-  // Build dialog-specific view data
-  const toAddProperties = propertyOptions.filter(
-    (item) => !Object.keys(state.properties).includes(item.value),
-  );
-
-  const keyframeDropdownItems = (() => {
-    if (state.popover.mode !== "keyframeMenu") {
-      return propertyNameDropdownItems;
-    }
-
-    const { property, index } = state.popover.payload;
-    const keyframes = state.properties[property].keyframes;
-    const currentIndex = Number(index);
-    const isFirstKeyframe = currentIndex === 0;
-    const isLastKeyframe = currentIndex === keyframes.length - 1;
-
-    return baseKeyframeDropdownItems.filter((item) => {
-      if (item.value === "move-left" && isFirstKeyframe) return false;
-      if (item.value === "move-right" && isLastKeyframe) return false;
-      return true;
-    });
-  })();
-
-  const addPropertyForm = createAddPropertyForm(toAddProperties);
-
-  let addPropertyDefaultValues = {};
-  let editKeyframeDefaultValues = {};
-  let editInitialValueDefaultValues = {};
-  let addPropertyContext = {};
-  let editInitialValueContext = {};
-
-  if (state.popover.mode === "addProperty") {
-    addPropertyDefaultValues = state.popover.formValues || {};
-    addPropertyContext = { ...addPropertyDefaultValues };
-  }
-
-  if (state.popover.mode === "editKeyframe") {
-    const { property, index } = state.popover.payload;
-    const currentKeyframe = state.properties[property].keyframes[index];
-
-    editKeyframeDefaultValues = {
-      duration: currentKeyframe.duration,
-      value: currentKeyframe.value,
-      easing: currentKeyframe.easing,
-      relative: currentKeyframe.relative,
-    };
-  }
-
-  if (state.popover.mode === "editInitialValue") {
-    const { property } = state.popover.payload;
-    const currentInitialValue = state.properties[property].initialValue;
-
-    const defaultValues = {
-      x: 0,
-      y: 0,
-      alpha: 1,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    };
-
-    const isUsingDefault = currentInitialValue === defaultValues[property];
-
-    editInitialValueDefaultValues = {
-      initialValue: currentInitialValue,
-      valueSource: isUsingDefault ? "default" : "custom",
-    };
-
-    editInitialValueContext = {
-      ...editInitialValueDefaultValues,
-      ...state.popover.formValues,
-    };
-  }
-
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "assets",
-    selectedResourceId: "tweens",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    selectedItemDuration,
-    selectedTweenPropertyCount,
-    searchQuery: state.searchQuery,
-    contextMenuItems: state.contextMenuItems,
-    emptyContextMenuItems: state.emptyContextMenuItems,
-    // Dialog state
-    isDialogOpen: state.isDialogOpen,
-    dialogDefaultValues: state.dialogDefaultValues,
-    dialogForm: state.dialogForm,
-    properties: state.properties,
-    initialValue: state.initialValue,
-    addPropertyForm,
-    addPropertyContext,
-    addKeyframeForm: createAddKeyframeForm(state?.popover?.payload?.property),
-    addKeyframeDefaultValues,
-    updateKeyframeForm: createUpdateKeyframeForm(
-      state?.popover?.payload?.property,
-    ),
-    editInitialValueForm,
-    editInitialValueContext,
-    editKeyframeDefaultValues,
-    editInitialValueDefaultValues,
-    keyframeDropdownItems,
-    addPropertyButtonVisible: toAddProperties.length !== 0,
-    popover: {
-      ...state.popover,
-      popoverIsOpen: [
-        "addProperty",
-        "addKeyframe",
-        "editKeyframe",
-        "editInitialValue",
-      ].includes(state.popover.mode),
-      dropdownMenuIsOpen: ["keyframeMenu", "propertyNameMenu"].includes(
-        state.popover.mode,
-      ),
-    },
-    addPropertyFormDefaultValues: {
-      useInitialValue: false,
-    },
-    resourceType: "tweens",
-    title: "Tweens",
-  };
+export const selectViewData = (context) => {
+  return selectCatalogViewData(context);
 };

--- a/src/pages/tweens/tweens.view.yaml
+++ b/src/pages/tweens/tweens.view.yaml
@@ -88,9 +88,9 @@ template:
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
-                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :contextMenuItems=contextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
+                  - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - rtgl-view w=1fg h=f:
-              - rvn-group-resources-view#groupview full-width-item :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery show-zoom-controls=false: null
+              - rvn-catalog-resources-view#groupview w=f h=f :navTitle=title :groups=catalogGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :addText=addText :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -1,62 +1,13 @@
 import { nanoid } from "nanoid";
-import { createResourceFileExplorerHandlers } from "../../deps/features/fileExplorerHandlers.js";
-
-const openEditDialogWithValues = ({ deps, itemId } = {}) => {
-  const { store, refs, render } = deps;
-  const { fileExplorer, editForm } = refs;
-  if (!itemId) {
-    return;
-  }
-
-  const videoItem = store.selectVideoItemById({ itemId });
-  if (!videoItem) {
-    return;
-  }
-
-  const editValues = {
-    name: videoItem.name ?? "",
-    description: videoItem.description ?? "",
-  };
-
-  store.setSelectedItemId({ itemId });
-  fileExplorer.selectItem({ itemId });
-  store.openEditDialog({
-    itemId,
-    defaultValues: editValues,
-    thumbnailFileId: videoItem.thumbnailFileId,
-  });
-
-  render();
-  editForm.reset();
-  editForm.setValues({ values: editValues });
-};
-
-const openVideoPreviewById = async ({ deps, itemId } = {}) => {
-  const { store, render, projectService } = deps;
-  if (!itemId) {
-    return;
-  }
-
-  const videoItem = store.selectVideoItemById({ itemId });
-  if (!videoItem?.fileId) {
-    return;
-  }
-
-  const { url } = await projectService.getFileContent(videoItem.fileId);
-  store.setVideoVisible({
-    video: {
-      url,
-      fileType: videoItem.fileType,
-    },
-  });
-  render();
-};
+import { createMediaPageHandlers } from "../../deps/features/resourcePages/media/createMediaPageHandlers.js";
+import { resolveResourceParentId } from "../../deps/features/resourcePages/media/mediaPageShared.js";
 
 const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
   let file;
+
   try {
     file = await appService.pickFiles({
-      accept: "video/*",
+      accept: ".mp4",
       multiple: false,
     });
   } catch {
@@ -82,91 +33,21 @@ const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
   return { uploadResult };
 };
 
-export const handleBeforeMount = (deps) => {
-  const { store, projectService } = deps;
-  const { videos } = projectService.getState();
-  store.setItems({ videosData: videos ?? { tree: [], items: {} } });
-};
+const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
+  const { appService, projectService } = deps;
+  let successfulUploads;
 
-const refreshVideosData = async (deps) => {
-  const { store, render, projectService } = deps;
-  const repository = await projectService.getRepository();
-  const state = repository.getState();
-  store.setItems({ videosData: state.videos ?? { tree: [], items: {} } });
-  render();
-};
-
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createResourceFileExplorerHandlers({
-    resourceType: "videos",
-    refresh: refreshVideosData,
-  });
-
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
-
-export const handleDataChanged = refreshVideosData;
-
-export const handleFileExplorerSelectionChanged = (deps, payload) => {
-  const { store, render } = deps;
-  const { itemId, isFolder } = payload._event.detail;
-
-  if (isFolder) {
-    store.setSelectedItemId({ itemId: undefined });
-    render();
+  try {
+    successfulUploads = await projectService.uploadFiles(files);
+  } catch {
+    appService.showToast("Failed to upload video.", { title: "Error" });
     return;
   }
 
-  if (!itemId) {
+  if (!successfulUploads.length) {
+    appService.showToast("Failed to upload video.", { title: "Error" });
     return;
   }
-
-  store.setSelectedItemId({ itemId });
-  render();
-};
-
-export const handleFileExplorerDoubleClick = (deps, payload) => {
-  const { itemId, isFolder } = payload._event.detail;
-  if (isFolder) {
-    return;
-  }
-
-  openEditDialogWithValues({ deps, itemId });
-};
-
-export const handleVideoItemClick = (deps, payload) => {
-  const { store, render, refs } = deps;
-  const { itemId } = payload._event.detail;
-  if (!itemId) {
-    return;
-  }
-
-  store.setSelectedItemId({ itemId });
-  const { fileExplorer } = refs;
-  fileExplorer.selectItem({ itemId });
-  render();
-};
-
-export const handleVideoItemDoubleClick = (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  openEditDialogWithValues({ deps, itemId });
-};
-
-export const handleVideoItemPreview = async (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  await openVideoPreviewById({ deps, itemId });
-};
-
-export const handleVideoItemEdit = (deps, payload) => {
-  const { itemId } = payload._event.detail;
-  openEditDialogWithValues({ deps, itemId });
-};
-
-export const handleDragDropFileSelected = async (deps, payload) => {
-  const { store, render, projectService } = deps;
-  const { files, targetGroupId } = payload._event.detail;
-  const id = targetGroupId === "root" ? undefined : targetGroupId;
-
-  const successfulUploads = await projectService.uploadFiles(files);
 
   for (const result of successfulUploads) {
     await projectService.createResourceItem({
@@ -183,22 +64,108 @@ export const handleDragDropFileSelected = async (deps, payload) => {
         width: result.dimensions?.width,
         height: result.dimensions?.height,
       },
-      parentId: id,
+      parentId,
       position: "last",
     });
   }
 
-  if (successfulUploads.length > 0) {
-    const { videos } = projectService.getState();
-    store.setItems({ videosData: videos ?? { tree: [], items: {} } });
+  await handleDataChanged(deps);
+};
+
+const openVideoPreviewById = async ({ deps, itemId } = {}) => {
+  const { store, render, projectService } = deps;
+  if (!itemId) {
+    return;
   }
 
+  const videoItem = store.selectVideoItemById({ itemId });
+  if (!videoItem?.fileId) {
+    return;
+  }
+
+  const { url } = await projectService.getFileContent(videoItem.fileId);
+  store.setVideoVisible({
+    video: {
+      url,
+      fileType: videoItem.fileType,
+    },
+  });
   render();
 };
 
-export const handleFormExtraEvent = async (deps) => {
-  const { appService, projectService, store, render } = deps;
+const {
+  handleBeforeMount,
+  refreshData: handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerDoubleClick,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleSearchInput,
+  handleItemClick: handleVideoItemClick,
+  handleItemDoubleClick: handleVideoItemDoubleClick,
+  handleItemEdit: handleVideoItemEdit,
+} = createMediaPageHandlers({
+  resourceType: "videos",
+  selectItemById: (store, { itemId }) => store.selectVideoItemById({ itemId }),
+  getEditPreviewFileId: (item) => item?.thumbnailFileId,
+});
 
+export {
+  handleBeforeMount,
+  handleDataChanged,
+  handleFileExplorerSelectionChanged,
+  handleFileExplorerDoubleClick,
+  handleFileExplorerAction,
+  handleFileExplorerTargetChanged,
+  handleSearchInput,
+  handleVideoItemClick,
+  handleVideoItemDoubleClick,
+  handleVideoItemEdit,
+};
+
+export const handleVideoItemPreview = async (deps, payload) => {
+  const { itemId } = payload._event.detail;
+  await openVideoPreviewById({ deps, itemId });
+};
+
+export const handleUploadClick = async (deps, payload) => {
+  const { appService } = deps;
+  const { groupId } = payload._event.detail;
+  let files;
+
+  try {
+    files = await appService.pickFiles({
+      accept: ".mp4",
+      multiple: true,
+    });
+  } catch {
+    appService.showToast("Failed to select files.", { title: "Error" });
+    return;
+  }
+
+  if (!files?.length) {
+    return;
+  }
+
+  await createVideosFromFiles({
+    deps,
+    files,
+    parentId: resolveResourceParentId(groupId),
+  });
+};
+
+export const handleFilesDropped = async (deps, payload) => {
+  const { files, targetGroupId } = payload._event.detail;
+
+  await createVideosFromFiles({
+    deps,
+    files,
+    parentId: targetGroupId ?? undefined,
+  });
+};
+
+export const handleFormExtraEvent = async (deps) => {
+  const { appService, projectService, store } = deps;
   const selectedItem = store.selectSelectedItem();
   if (!selectedItem) {
     return;
@@ -234,29 +201,17 @@ export const handleFormExtraEvent = async (deps) => {
     },
   });
 
-  const { videos } = projectService.getState();
-  store.setItems({ videosData: videos ?? { tree: [], items: {} } });
-  render();
-};
-
-export const handleSearchInput = (deps, payload) => {
-  const { store, render } = deps;
-  const searchQuery = payload._event.detail.value ?? "";
-
-  store.setSearchQuery({ value: searchQuery });
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleOutsideVideoClick = (deps) => {
   const { store, render } = deps;
-
   store.setVideoNotVisible();
   render();
 };
 
 export const handleEditDialogClose = (deps) => {
   const { store, render } = deps;
-
   store.closeEditDialog();
   render();
 };
@@ -279,7 +234,10 @@ export const handleEditDialogVideoClick = async (deps) => {
     return;
   }
 
-  store.setEditVideoUpload({ uploadResult: result.uploadResult });
+  store.setEditUpload({
+    uploadResult: result.uploadResult,
+    previewFileId: result.uploadResult.thumbnailFileId,
+  });
   render();
 };
 
@@ -296,22 +254,21 @@ export const handleEditFormAction = async (deps, payload) => {
     return;
   }
 
-  const editItemId = store.getState().editItemId;
+  const { editItemId, editUploadResult } = store.getState();
   if (!editItemId) {
     store.closeEditDialog();
     render();
     return;
   }
 
-  const editVideoUploadResult = store.getState().editVideoUploadResult;
-  const videoPatch = editVideoUploadResult
+  const videoPatch = editUploadResult
     ? {
-        fileId: editVideoUploadResult.fileId,
-        thumbnailFileId: editVideoUploadResult.thumbnailFileId,
-        fileType: editVideoUploadResult.file.type,
-        fileSize: editVideoUploadResult.file.size,
-        width: editVideoUploadResult.dimensions?.width,
-        height: editVideoUploadResult.dimensions?.height,
+        fileId: editUploadResult.fileId,
+        thumbnailFileId: editUploadResult.thumbnailFileId,
+        fileType: editUploadResult.file.type,
+        fileSize: editUploadResult.file.size,
+        width: editUploadResult.dimensions?.width,
+        height: editUploadResult.dimensions?.height,
       }
     : {};
 
@@ -325,17 +282,16 @@ export const handleEditFormAction = async (deps, payload) => {
     },
   });
 
-  const { videos } = projectService.getState();
-  store.setItems({ videosData: videos ?? { tree: [], items: {} } });
   store.closeEditDialog();
-  render();
+  await handleDataChanged(deps);
 };
 
 export const handleItemDelete = async (deps, payload) => {
-  const { projectService, appService, store, render } = deps;
-  const { resourceType, itemId } = payload._event.detail;
+  const { projectService, appService, render } = deps;
+  const { itemId } = payload._event.detail;
+
   const result = await projectService.deleteResourceItemIfUnused({
-    resourceType,
+    resourceType: "videos",
     resourceId: itemId,
     checkTargets: ["scenes", "layouts"],
   });
@@ -346,7 +302,5 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  const data = projectService.getState()[resourceType];
-  store.setItems({ videosData: data ?? { tree: [], items: {} } });
-  render();
+  await handleDataChanged(deps);
 };

--- a/src/pages/videos/videos.store.js
+++ b/src/pages/videos/videos.store.js
@@ -1,22 +1,5 @@
-import { toFlatGroups, toFlatItems } from "../../domain/treeHelpers.js";
 import { formatFileSize } from "../../utils/index.js";
-
-const folderContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-child-folder" },
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const itemContextMenuItems = [
-  { label: "Duplicate", type: "item", value: "duplicate-item" },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const emptyContextMenuItems = [
-  { label: "New Folder", type: "item", value: "new-item" },
-];
+import { createMediaPageStore } from "../../deps/features/resourcePages/media/createMediaPageStore.js";
 
 const formatDimensions = (item) => {
   if (!item?.width || !item?.height) {
@@ -26,63 +9,128 @@ const formatDimensions = (item) => {
   return `${item.width} × ${item.height}`;
 };
 
-export const createInitialState = () => ({
-  videosData: { tree: [], items: {} },
-  selectedItemId: undefined,
-  searchQuery: "",
-  isEditDialogOpen: false,
-  editItemId: undefined,
-  editDefaultValues: {
-    name: "",
-    description: "",
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
+  }
+
+  return [
+    {
+      type: "slot",
+      slot: "video-thumbnail-file-id",
+      label: "",
+    },
+    {
+      type: "description",
+      value: item.description ?? "",
+    },
+    {
+      type: "text",
+      label: "File Type",
+      value: item.fileType ?? "",
+    },
+    {
+      type: "text",
+      label: "File Size",
+      value: formatFileSize(item.fileSize),
+    },
+    {
+      type: "text",
+      label: "Dimensions",
+      value: formatDimensions(item),
+    },
+  ];
+};
+
+const buildMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "video",
+  thumbnailFileId: item.thumbnailFileId,
+  canPreview: true,
+});
+
+const createEditForm = () => ({
+  title: "Edit Video",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "description",
+      type: "input-textarea",
+      label: "Description",
+      required: false,
+    },
+    {
+      type: "slot",
+      slot: "video-slot",
+      label: "Video",
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Update Video",
+      },
+    ],
   },
-  editThumbnailFileId: undefined,
-  editVideoUploadResult: undefined,
+});
+
+const {
+  createInitialState: createMediaInitialState,
+  setItems,
+  setSelectedItemId,
+  openEditDialog,
+  closeEditDialog,
+  setEditUpload,
+  selectSelectedItem,
+  selectItemById,
+  selectSelectedItemId,
+  setSearchQuery,
+  selectViewData: selectMediaViewData,
+} = createMediaPageStore({
+  itemType: "video",
+  resourceType: "videos",
+  title: "Videos",
+  selectedResourceId: "videos",
+  uploadText: "Upload Video",
+  acceptedFileTypes: [".mp4"],
+  buildDetailFields,
+  buildMediaItem,
+  createEditForm,
+  getSelectedPreviewFileId: (item) => item?.thumbnailFileId,
+  extendViewData: ({ state, baseViewData }) => ({
+    ...baseViewData,
+    videoVisible: state.videoVisible,
+    selectedVideo: state.selectedVideo,
+  }),
+});
+
+export const createInitialState = () => ({
+  ...createMediaInitialState(),
   videoVisible: false,
   selectedVideo: undefined,
 });
 
-export const setItems = ({ state }, { videosData } = {}) => {
-  state.videosData = videosData;
+export {
+  setItems,
+  setSelectedItemId,
+  openEditDialog,
+  closeEditDialog,
+  setEditUpload,
+  selectSelectedItem,
+  selectSelectedItemId,
+  setSearchQuery,
 };
 
-export const setSelectedItemId = ({ state }, { itemId } = {}) => {
-  state.selectedItemId = itemId;
-};
-
-export const setSearchQuery = ({ state }, { value } = {}) => {
-  state.searchQuery = value ?? "";
-};
-
-export const openEditDialog = (
-  { state },
-  { itemId, defaultValues, thumbnailFileId } = {},
-) => {
-  state.isEditDialogOpen = true;
-  state.editItemId = itemId;
-  state.editDefaultValues = {
-    name: defaultValues?.name ?? "",
-    description: defaultValues?.description ?? "",
-  };
-  state.editThumbnailFileId = thumbnailFileId;
-  state.editVideoUploadResult = undefined;
-};
-
-export const closeEditDialog = ({ state }, _payload = {}) => {
-  state.isEditDialogOpen = false;
-  state.editItemId = undefined;
-  state.editDefaultValues = {
-    name: "",
-    description: "",
-  };
-  state.editThumbnailFileId = undefined;
-  state.editVideoUploadResult = undefined;
-};
-
-export const setEditVideoUpload = ({ state }, { uploadResult } = {}) => {
-  state.editVideoUploadResult = uploadResult;
-  state.editThumbnailFileId = uploadResult?.thumbnailFileId;
-};
+export const selectVideoItemById = selectItemById;
 
 export const setVideoVisible = ({ state }, { video } = {}) => {
   state.videoVisible = true;
@@ -94,144 +142,6 @@ export const setVideoNotVisible = ({ state }, _payload = {}) => {
   state.selectedVideo = undefined;
 };
 
-export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) {
-    return undefined;
-  }
-
-  const flatItems = toFlatItems(state.videosData);
-  return flatItems.find((item) => item.id === state.selectedItemId);
-};
-
-export const selectVideoItemById = ({ state }, { itemId } = {}) => {
-  const item = state.videosData?.items?.[itemId];
-  return item?.type === "video" ? item : undefined;
-};
-
-export const selectSelectedItemId = ({ state }) => {
-  return state.selectedItemId;
-};
-
-export const selectViewData = ({ state }) => {
-  const flatItems = toFlatItems(state.videosData);
-  const rawFlatGroups = toFlatGroups(state.videosData);
-  const searchQuery = (state.searchQuery ?? "").toLowerCase();
-
-  const matchesSearch = (item) => {
-    if (!searchQuery) {
-      return true;
-    }
-
-    const name = (item.name ?? "").toLowerCase();
-    const description = (item.description ?? "").toLowerCase();
-
-    return name.includes(searchQuery) || description.includes(searchQuery);
-  };
-
-  const flatGroups = rawFlatGroups
-    .map((group) => {
-      const filteredChildren = (group.children ?? []).filter(matchesSearch);
-      const hasMatchingChildren = filteredChildren.length > 0;
-      const shouldShowGroup = !searchQuery || hasMatchingChildren;
-
-      return {
-        ...group,
-        children: filteredChildren,
-        hasChildren: filteredChildren.length > 0,
-        shouldDisplay: shouldShowGroup,
-      };
-    })
-    .filter((group) => group.shouldDisplay);
-
-  const selectedItem = state.selectedItemId
-    ? flatItems.find((item) => item.id === state.selectedItemId)
-    : undefined;
-
-  const detailFields = selectedItem
-    ? [
-        {
-          type: "slot",
-          slot: "video-thumbnail-file-id",
-          label: "",
-        },
-        {
-          type: "description",
-          value: selectedItem.description ?? "",
-        },
-        {
-          type: "text",
-          label: "File Type",
-          value: selectedItem.fileType ?? "",
-        },
-        {
-          type: "text",
-          label: "File Size",
-          value: formatFileSize(selectedItem.fileSize),
-        },
-        {
-          type: "text",
-          label: "Dimensions",
-          value: formatDimensions(selectedItem),
-        },
-      ]
-    : [];
-
-  const editForm = {
-    title: "Edit Video",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Name",
-        required: true,
-      },
-      {
-        name: "description",
-        type: "input-textarea",
-        label: "Description",
-        required: false,
-      },
-      {
-        type: "slot",
-        slot: "video-slot",
-        label: "Video",
-      },
-    ],
-    actions: {
-      layout: "",
-      buttons: [
-        {
-          id: "submit",
-          variant: "pr",
-          label: "Update Video",
-        },
-      ],
-    },
-  };
-
-  return {
-    flatItems,
-    flatGroups,
-    resourceCategory: "assets",
-    selectedResourceId: "videos",
-    selectedItemId: state.selectedItemId,
-    selectedItemName: selectedItem?.name ?? "",
-    detailFields,
-    title: "Videos",
-    searchQuery: state.searchQuery,
-    resourceType: "videos",
-    uploadText: "Upload Video",
-    acceptedFileTypes: [".mp4"],
-    folderContextMenuItems,
-    itemContextMenuItems,
-    emptyContextMenuItems,
-    selectedVideoThumbnailFileId: selectedItem?.thumbnailFileId,
-    isEditDialogOpen: state.isEditDialogOpen,
-    editItemId: state.editItemId,
-    editForm,
-    editDefaultValues: state.editDefaultValues,
-    editThumbnailFileId: state.editThumbnailFileId,
-    videoVisible: state.videoVisible,
-    selectedVideo: state.selectedVideo,
-  };
+export const selectViewData = (context) => {
+  return selectMediaViewData(context);
 };

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -19,8 +19,10 @@ refs:
         handler: handleVideoItemPreview
       item-edit:
         handler: handleVideoItemEdit
-      files-uploaded:
-        handler: handleDragDropFileSelected
+      files-dropped:
+        handler: handleFilesDropped
+      upload-click:
+        handler: handleUploadClick
       search-input:
         handler: handleSearchInput
       item-delete:
@@ -61,7 +63,7 @@ template:
                   - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
                   - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
           - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
-              - rvn-group-resources-view#groupview w=f h=f :navTitle=title :resourceType=resourceType :flatGroups=flatGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes: null
+              - rvn-media-resources-view#groupview w=f h=f :navTitle=title :groups=mediaGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
@@ -69,8 +71,8 @@ template:
                           - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
                               - rtgl-text c=mu-fg: ${selectedItemName}
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
-                              - $if selectedVideoThumbnailFileId:
-                                  - rvn-file-image#detailThumbnail slot="video-thumbnail-file-id" fileId=${selectedVideoThumbnailFileId} h=135 bw=xs bc=bo br=md cur=pointer: null
+                              - $if selectedPreviewFileId:
+                                  - rvn-file-image#detailThumbnail slot="video-thumbnail-file-id" fileId=${selectedPreviewFileId} h=135 bw=xs bc=bo br=md cur=pointer: null
                                 $else:
                                   - rtgl-view#detailThumbnailPlaceholder slot="video-thumbnail-file-id" w=f h=135 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                                       - rtgl-text c=mu-fg s=sm: Click to Upload
@@ -80,8 +82,8 @@ template:
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=editDefaultValues :form=editForm w=f:
-              - $if editThumbnailFileId:
-                  - rvn-file-image#editDialogThumbnail slot="video-slot" fileId=${editThumbnailFileId} h=120 bw=xs bc=bo br=md cur=pointer key=${editThumbnailFileId}: null
+              - $if editPreviewFileId:
+                  - rvn-file-image#editDialogThumbnail slot="video-slot" fileId=${editPreviewFileId} h=120 bw=xs bc=bo br=md cur=pointer key=${editPreviewFileId}: null
                 $else:
                   - rtgl-view#editDialogThumbnailPlaceholder slot="video-slot" w=f h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                       - rtgl-text c=mu-fg s=sm: Click to Upload


### PR DESCRIPTION
## Summary
- add a UI-only `mediaResourcesView` center-pane component for media-family resource pages
- move shared media page store/handler orchestration into `src/deps/features/resourcePages/media`
- migrate `images`, `sounds`, `videos`, and `fonts` to the shared media-family pattern
- update `docs/engineering.md` with the resource page family structure and boundaries

## Validation
- `bun x oxlint src/components/mediaResourcesView src/deps/features/resourcePages/media src/pages/images src/pages/sounds src/pages/videos src/pages/fonts`
- `bun x prettier --check src/components/mediaResourcesView src/deps/features/resourcePages/media src/pages/images src/pages/sounds src/pages/videos src/pages/fonts`
- `bun run build:web`

## Notes
- this PR only covers the media-family resource pages
- no additional resource pages were migrated in this branch