### PR TITLE
cleanup: remove dead route and sidebar label noise

### DIFF
--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -19,8 +19,6 @@ template:
                   - rvn-project: []
                 $elif currentRoutePattern == "/project/resources":
                   - rvn-resources: []
-                $elif currentRoutePattern == "/project/cgs":
-                  - rvn-cgs: []
                 $elif currentRoutePattern == "/project/resources/images":
                   - rvn-images: []
                 $elif currentRoutePattern == "/project/resources/characters":

--- a/src/pages/resourceTypes/resourceTypes.store.js
+++ b/src/pages/resourceTypes/resourceTypes.store.js
@@ -78,7 +78,7 @@ const settingsItems = [
 const releaseItems = [
   {
     id: "versions",
-    name: "Version",
+    name: "Versions",
     path: "/project/releases/versions",
   },
 ];

--- a/src/pages/sidebar/sidebar.view.yaml
+++ b/src/pages/sidebar/sidebar.view.yaml
@@ -1,5 +1,3 @@
-title: okok
-description: okok
 refs:
   sidebar:
     eventListeners:


### PR DESCRIPTION
## Summary
- remove the dead `/project/cgs` route from the app router
- rename the releases menu label from `Version` to `Versions`
- remove stray sidebar view metadata

## Testing
- `bun x prettier --check src/pages/app/app.view.yaml src/pages/resourceTypes/resourceTypes.store.js src/pages/sidebar/sidebar.view.yaml`
- `bun run build:web`