### PR TITLE
refactor: add editable text primitive for lines editor

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -51,6 +51,7 @@ Local-first collaborative behavior uses Insieme:
 ├── src/
 │   ├── components/
 │   ├── pages/
+│   ├── primitives/
 │   ├── deps/
 │   │   ├── features/
 │   │   ├── infra/
@@ -80,6 +81,9 @@ Local-first collaborative behavior uses Insieme:
 
 - `src/pages/`
   Route-level pages and screen-specific logic.
+
+- `src/primitives/`
+  Registered browser primitives such as custom elements that wrap low-level DOM behavior.
 
 - `src/deps/infra/`
   Low-level platform integrations such as router, DB, file system, pickers, and updater hooks.
@@ -123,6 +127,9 @@ Local-first collaborative behavior uses Insieme:
 - `src/pages/`
   Route-level screens. Pages usually follow the Rettangoli `view/store/handlers` pattern.
 
+- `src/primitives/`
+  Browser-native custom elements and low-level DOM wrappers used when behavior does not fit Rettangoli component files.
+
 - `src/components/`
   Reusable UI building blocks. Components can also use `view/store/handlers` when they own interaction state.
 
@@ -163,6 +170,7 @@ These entry points are responsible for:
 1. creating infrastructure dependencies
 2. creating services
 3. exposing dependencies through `deps`
+4. registering browser primitives needed by the UI runtime
 
 Handlers must not build dependencies themselves.
 

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -1,143 +1,17 @@
-// Helper function to find the position on the last line closest to goal column
-const findLastLinePosition = (element, goalColumn) => {
-  const text = element.textContent;
-  const textLength = text.length;
-
-  // If no text or goal column is at end, return end position
-  if (textLength === 0 || goalColumn >= textLength) {
-    return textLength;
+const getLineContent = (element) => {
+  if (!element || typeof element.getContent !== "function") {
+    return "";
   }
 
-  // Create a range to test each position and find where the last line starts
-  let lastLineStartPos = 0;
-  let lastLineTop = null;
-
-  // Walk backwards from the end to find where the last line starts
-  for (let pos = textLength; pos >= 0; pos--) {
-    try {
-      const range = document.createRange();
-
-      // Position the range at this character position
-      let currentPos = 0;
-      let foundNode = false;
-
-      const walkTextNodes = (node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-          const nodeLength = node.textContent.length;
-          if (currentPos + nodeLength >= pos) {
-            const offset = pos - currentPos;
-            range.setStart(node, offset);
-            range.setEnd(node, offset);
-            foundNode = true;
-            return true;
-          }
-          currentPos += nodeLength;
-        } else {
-          for (let child of node.childNodes) {
-            if (walkTextNodes(child)) return true;
-          }
-        }
-        return false;
-      };
-
-      walkTextNodes(element);
-
-      if (foundNode) {
-        const rect = range.getBoundingClientRect();
-
-        if (lastLineTop === null) {
-          // First position (end of text) - this is definitely the last line
-          lastLineTop = rect.top;
-          lastLineStartPos = pos;
-        } else if (Math.abs(rect.top - lastLineTop) > 5) {
-          // We've moved to a different line (more than 5px difference)
-          // The previous position was the start of the last line
-          break;
-        } else {
-          // Still on the same line
-          lastLineStartPos = pos;
-        }
-      }
-    } catch {
-      // If range creation fails, continue
-      continue;
-    }
-  }
-
-  // Now find the position on the last line closest to the goal column
-  const lastLineLength = textLength - lastLineStartPos;
-  const positionOnLastLine = Math.min(goalColumn, lastLineLength);
-  const finalPosition = lastLineStartPos + positionOnLastLine;
-
-  return finalPosition;
+  return element.getContent();
 };
 
-// Helper function to get selection range, handling Shadow DOM with getComposedRanges
-const getSelectionRange = (element) => {
-  const shadowRoot = element.getRootNode();
-  const isShadowRoot = shadowRoot instanceof ShadowRoot;
-
-  let selection = window.getSelection();
-
-  // Try shadowRoot.getSelection() first for Shadow DOM (non-standard but works in some browsers)
-  if (isShadowRoot && typeof shadowRoot.getSelection === "function") {
-    const shadowSelection = shadowRoot.getSelection();
-    if (shadowSelection && shadowSelection.rangeCount > 0) {
-      const range = shadowSelection.getRangeAt(0);
-      if (element.contains(range.startContainer)) {
-        return range;
-      }
-    }
-  }
-
-  if (!selection || selection.rangeCount === 0) return null;
-
-  // Use getComposedRanges for Shadow DOM (Safari 17+, Chrome 137+, Firefox 142+)
-  if (isShadowRoot && typeof selection.getComposedRanges === "function") {
-    try {
-      const ranges = selection.getComposedRanges(shadowRoot);
-      if (ranges.length > 0) {
-        const staticRange = ranges[0];
-
-        // Validate that the range is actually inside our element
-        // On some browsers (Windows Chrome), getComposedRanges may return body instead of actual element
-        if (element.contains(staticRange.startContainer)) {
-          // Convert StaticRange to Range (StaticRange doesn't have getBoundingClientRect)
-          const range = document.createRange();
-          range.setStart(staticRange.startContainer, staticRange.startOffset);
-          range.setEnd(staticRange.endContainer, staticRange.endOffset);
-          return range;
-        }
-      }
-    } catch {
-      // getComposedRanges not supported, fall through to fallback
-    }
-  }
-
-  // Fallback to regular getRangeAt
-  const range = selection.getRangeAt(0);
-  if (element.contains(range.startContainer)) {
-    return range;
-  }
-
-  return null;
-};
-
-// Helper function to get cursor position in contenteditable
 const getCursorPosition = (element) => {
-  if (!element) {
+  if (!element || typeof element.getCaretPosition !== "function") {
     return 0;
   }
 
-  const range = getSelectionRange(element);
-  if (!range) return 0;
-
-  // For StaticRange (from getComposedRanges), we need to create a new range
-  const preCaretRange = document.createRange();
-  preCaretRange.selectNodeContents(element);
-  preCaretRange.setEnd(range.endContainer, range.endOffset);
-  const position = preCaretRange.toString().length;
-  return position;
+  return element.getCaretPosition();
 };
 
 const getLineIdFromElement = (element) => {
@@ -307,7 +181,7 @@ const enterInsertModeAtLineEnd = (deps, lineId) => {
     return;
   }
 
-  const textLength = lineElement.textContent.length;
+  const textLength = getLineContent(lineElement).length;
   store.setCursorPosition({ position: textLength });
   store.setGoalColumn({ goalColumn: textLength });
   store.setNavigationDirection({ direction: "end" });
@@ -327,113 +201,6 @@ const dispatchBlockModeSwapLine = (dispatchEvent, lineId, direction) => {
       },
     }),
   );
-};
-
-// Helper function to check if cursor is on the first line of contenteditable
-const isCursorOnFirstLine = (element) => {
-  const range = getSelectionRange(element);
-  if (!range) return false;
-
-  // Get the bounding rectangle of the cursor position
-  const cursorRect = range.getBoundingClientRect();
-
-  // Create a range at the very beginning of the element
-  const startRange = document.createRange();
-
-  // Instead of using selectNodeContents and collapse, let's position at the actual start
-  let firstTextNode = null;
-
-  // Walk through all text nodes to find the actual first position
-  const walkTextNodes = (node) => {
-    if (node.nodeType === Node.TEXT_NODE && !firstTextNode) {
-      firstTextNode = node;
-      return true; // Stop walking once we find the first text node
-    } else {
-      for (let child of node.childNodes) {
-        if (walkTextNodes(child)) return true;
-      }
-    }
-    return false;
-  };
-
-  walkTextNodes(element);
-
-  // If we found a text node, position the range there
-  if (firstTextNode) {
-    startRange.setStart(firstTextNode, 0);
-    startRange.setEnd(firstTextNode, 0);
-  } else {
-    // Fallback to element positioning if no text nodes found
-    startRange.selectNodeContents(element);
-    startRange.collapse(true);
-  }
-
-  const startRect = startRange.getBoundingClientRect();
-
-  // Consider the cursor on the first line if it's within a reasonable tolerance of the first line
-  const tolerance = 5; // pixels
-  const isOnFirstLine = Math.abs(cursorRect.top - startRect.top) <= tolerance;
-
-  return isOnFirstLine;
-};
-
-// Helper function to check if cursor is on the last line of contenteditable
-const isCursorOnLastLine = (element) => {
-  // First, check if the element has multiple visual lines
-  const elementHeight = element.scrollHeight;
-  const lineHeight =
-    parseFloat(window.getComputedStyle(element).lineHeight) || 20;
-  const hasMultipleLines = elementHeight > lineHeight * 1.5; // Allow some tolerance
-
-  if (!hasMultipleLines) {
-    // Single line content - always navigate to next editor on ArrowDown
-    return true;
-  }
-
-  const range = getSelectionRange(element);
-  if (!range) return false;
-
-  // Get the bounding rectangle of the cursor position
-  const cursorRect = range.getBoundingClientRect();
-
-  // Create a range at the very end of the element
-  const endRange = document.createRange();
-
-  // Instead of using selectNodeContents and collapse, let's position at the actual end
-  let lastTextNode = null;
-  let lastOffset = 0;
-
-  // Walk through all text nodes to find the actual last position
-  const walkTextNodes = (node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      lastTextNode = node;
-      lastOffset = node.textContent.length;
-    } else {
-      for (let child of node.childNodes) {
-        walkTextNodes(child);
-      }
-    }
-  };
-
-  walkTextNodes(element);
-
-  // If we found a text node, position the range there
-  if (lastTextNode) {
-    endRange.setStart(lastTextNode, lastOffset);
-    endRange.setEnd(lastTextNode, lastOffset);
-  } else {
-    // Fallback to element positioning if no text nodes found
-    endRange.selectNodeContents(element);
-    endRange.collapse(false);
-  }
-
-  const endRect = endRange.getBoundingClientRect();
-
-  // Consider the cursor on the last line if it's within a reasonable tolerance of the last line
-  const tolerance = 5; // pixels
-  const isOnLastLine = Math.abs(cursorRect.top - endRect.top) <= tolerance;
-
-  return isOnLastLine;
 };
 
 export const handleAfterMount = async (deps) => {
@@ -493,7 +260,7 @@ export const handleContainerKeyDown = (deps, payload) => {
   const mode = store.selectMode();
 
   // Only handle container keydown if the target is the container itself
-  // If it's a contenteditable, let the line handler handle it
+  // If focus is already inside an editable line primitive, let the line handler own it.
   if (payload._event.target.id !== "container") {
     return;
   }
@@ -843,7 +610,7 @@ export const handleLineKeyDown = (deps, payload) => {
       if (mode === "text-editor") {
         // Check if cursor is at position 0
         const currentPos = getCursorPosition(payload._event.currentTarget);
-        const currentContent = payload._event.currentTarget.textContent;
+        const currentContent = getLineContent(payload._event.currentTarget);
         const currentLineId = getLineIdFromElement(
           payload._event.currentTarget,
         );
@@ -892,7 +659,7 @@ export const handleLineKeyDown = (deps, payload) => {
 
         // Get current cursor position and text content
         const cursorPos = getCursorPosition(payload._event.currentTarget);
-        const fullText = payload._event.currentTarget.textContent;
+        const fullText = getLineContent(payload._event.currentTarget);
 
         // Split the content at cursor position
         const leftContent = fullText.substring(0, cursorPos);
@@ -1005,7 +772,7 @@ export const handleLineKeyDown = (deps, payload) => {
         }
       } else {
         // In text-editor mode, check if cursor is on first line
-        const isOnFirstLine = isCursorOnFirstLine(payload._event.currentTarget);
+        const isOnFirstLine = payload._event.currentTarget.isCaretOnFirstLine();
 
         if (isOnFirstLine) {
           // Cursor is on first line, move to previous line
@@ -1074,7 +841,7 @@ export const handleLineKeyDown = (deps, payload) => {
         }
       } else {
         // In text-editor mode, check if cursor is on last line
-        const isOnLastLine = isCursorOnLastLine(payload._event.currentTarget);
+        const isOnLastLine = payload._event.currentTarget.isCaretOnLastLine();
 
         if (isOnLastLine) {
           // Cursor is on last line, move to next line
@@ -1107,7 +874,7 @@ export const handleLineKeyDown = (deps, payload) => {
       if (mode === "text-editor") {
         // Check if cursor is at the end of the text
         const currentPos = getCursorPosition(payload._event.currentTarget);
-        const textLength = payload._event.currentTarget.textContent.length;
+        const textLength = getLineContent(payload._event.currentTarget).length;
 
         if (currentPos >= textLength) {
           // Cursor is at end, move to next line
@@ -1191,7 +958,7 @@ export const handleOnInput = (deps, payload) => {
   const { dispatchEvent, store } = deps;
 
   const lineId = getLineIdFromElement(payload._event.currentTarget);
-  const content = payload._event.currentTarget.textContent;
+  const content = getLineContent(payload._event.currentTarget);
 
   // Save cursor position on every input
   const cursorPos = getCursorPosition(payload._event.currentTarget);
@@ -1237,7 +1004,7 @@ export const handleLinePaste = (deps, payload) => {
   // Get current cursor position and line content
   const lineId = getLineIdFromElement(event.currentTarget);
   const cursorPos = getCursorPosition(event.currentTarget);
-  const currentContent = event.currentTarget.textContent;
+  const currentContent = getLineContent(event.currentTarget);
 
   // Split current content at cursor position
   const leftContent = currentContent.substring(0, cursorPos);
@@ -1267,9 +1034,7 @@ export const forceSyncContentLine = (deps, payload) => {
     return;
   }
   const lineContent = store.selectLineContent({ lineId });
-  if (lineRef.textContent !== lineContent) {
-    lineRef.textContent = lineContent;
-  }
+  lineRef.updateContent(lineContent);
 };
 
 export const updateSelectedLine = (deps, payload) => {
@@ -1285,14 +1050,14 @@ export const updateSelectedLine = (deps, payload) => {
 
   // Get goal column (desired position) instead of current position
   const goalColumn = store.selectGoalColumn() || 0;
-  const textLength = lineRef.textContent.length;
+  const textLength = getLineContent(lineRef).length;
   const direction = store.selectNavigationDirection();
 
   // Choose positioning strategy based on direction
   let targetPosition;
   if (direction === "up") {
     // For upward navigation, find position on last line
-    targetPosition = findLastLinePosition(lineRef, goalColumn);
+    targetPosition = lineRef.findLastLinePosition(goalColumn);
   } else if (direction === "end") {
     // For end positioning (ArrowLeft navigation), position at absolute end
     targetPosition = textLength;
@@ -1301,77 +1066,10 @@ export const updateSelectedLine = (deps, payload) => {
     targetPosition = Math.min(goalColumn, textLength);
   }
 
-  // Get shadow root for selection if needed
-  let shadowRoot = lineRef.getRootNode();
-  let selection = window.getSelection();
-
-  // Check if we're in a shadow DOM
-  if (shadowRoot && shadowRoot.getSelection) {
-    selection = shadowRoot.getSelection();
-  }
-
-  // Create a range at the desired position before focusing
-  const range = document.createRange();
-
-  // Try to set position before focus
-  let currentPos = 0;
-  let foundNode = false;
-  let lastTextNode = null;
-  let lastTextNodeLength = 0;
-  let actualPosition = 0;
-
-  const walkTextNodes = (node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      const nodeLength = node.textContent.length;
-      lastTextNode = node;
-      lastTextNodeLength = nodeLength;
-
-      if (currentPos + nodeLength >= targetPosition) {
-        const offset = targetPosition - currentPos;
-        range.setStart(node, offset);
-        range.setEnd(node, offset);
-        actualPosition = targetPosition;
-        foundNode = true;
-        return true;
-      }
-      currentPos += nodeLength;
-    } else {
-      for (let child of node.childNodes) {
-        if (walkTextNodes(child)) return true;
-      }
-    }
-    return false;
-  };
-
-  walkTextNodes(lineRef);
-
-  // If we didn't find a position (cursor beyond text), position at end
-  if (!foundNode && lastTextNode) {
-    range.setStart(lastTextNode, lastTextNodeLength);
-    range.setEnd(lastTextNode, lastTextNodeLength);
-    actualPosition = textLength;
-    foundNode = true;
-  }
-
-  // Now focus - this must happen before setting selection in Shadow DOM
-  lineRef.focus({ preventScroll: true });
-
-  // After focus, set the selection using setBaseAndExtent which works better with Shadow DOM
-  if (foundNode) {
-    // Re-get selection after focus - this is important for Shadow DOM
-    selection = window.getSelection();
-
-    // Use setBaseAndExtent instead of addRange - works better in Shadow DOM
-    selection.setBaseAndExtent(
-      range.startContainer,
-      range.startOffset,
-      range.endContainer,
-      range.endOffset,
-    );
-
-    // Update the current cursor position in store to reflect where we actually landed
-    store.setCursorPosition({ position: actualPosition });
-  }
+  const actualPosition = lineRef.setCaretPosition(targetPosition, {
+    preventScroll: true,
+  });
+  store.setCursorPosition({ position: actualPosition });
 };
 
 export const handleOnFocus = (deps, payload) => {

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -14,6 +14,14 @@ const getCursorPosition = (element) => {
   return element.getCaretPosition();
 };
 
+const hasSelectionRange = (element) => {
+  if (!element || typeof element.hasSelectionRange !== "function") {
+    return true;
+  }
+
+  return element.hasSelectionRange();
+};
+
 const getLineIdFromElement = (element) => {
   return element?.dataset?.lineId || element?.id?.replace(/^line/, "") || "";
 };
@@ -22,6 +30,53 @@ const getLineElementById = (refs, lineId) => {
   return Object.values(refs || {}).find(
     (element) => getLineIdFromElement(element) === lineId,
   );
+};
+
+const syncStoredCursorState = (
+  store,
+  element,
+  { updateGoalColumn = true, remainingFrames = 2 } = {},
+) => {
+  requestAnimationFrame(() => {
+    const cursorPosition = getCursorPosition(element);
+    const selectionReady = hasSelectionRange(element);
+
+    if (!selectionReady && remainingFrames > 0) {
+      syncStoredCursorState(store, element, {
+        updateGoalColumn,
+        remainingFrames: remainingFrames - 1,
+      });
+      return;
+    }
+
+    store.setCursorPosition({ position: cursorPosition });
+    if (updateGoalColumn) {
+      store.setGoalColumn({ goalColumn: cursorPosition });
+    }
+  });
+};
+
+const focusContainerAfterPaint = (refs) => {
+  requestAnimationFrame(() => {
+    const container = refs["container"];
+    if (container) {
+      container.focus();
+    }
+  });
+};
+
+const getActualActiveElement = (element) => {
+  const root = element?.getRootNode();
+
+  if (root instanceof ShadowRoot && root.activeElement) {
+    return root.activeElement;
+  }
+
+  return document.activeElement;
+};
+
+const isLineElement = (element) => {
+  return Boolean(element && getLineIdFromElement(element));
 };
 
 const DELETE_SHORTCUT_TIMEOUT_MS = 1200;
@@ -211,12 +266,7 @@ export const handleAfterMount = async (deps) => {
   store.setReady();
 
   // Focus container on mount to enable keyboard navigation
-  setTimeout(() => {
-    const container = refs["container"];
-    if (container) {
-      container.focus();
-    }
-  }, 0);
+  focusContainerAfterPaint(refs);
 };
 
 export const handlePreviewRightClick = async (deps, payload) => {
@@ -311,12 +361,6 @@ export const handleContainerKeyDown = (deps, payload) => {
     if (navKey === "o" || navKey === "O") {
       payload._event.preventDefault();
       payload._event.stopPropagation();
-
-      console.log("[linesEditor][block-new-line] shortcut", {
-        key: navKey,
-        selectedLineId: currentLineId || null,
-        linesCount: lines.length,
-      });
 
       dispatchEvent(
         new CustomEvent("newLine", {
@@ -936,22 +980,7 @@ export const handleLineKeyDown = (deps, payload) => {
 export const handleLineMouseUp = (deps, payload) => {
   const { store } = deps;
 
-  // Save cursor position after mouse up (selection change)
-  // Use multiple attempts with slight delays to ensure selection is established
-  setTimeout(() => {
-    const cursorPos = getCursorPosition(payload._event.currentTarget);
-    if (cursorPos > 0) {
-      store.setCursorPosition({ position: cursorPos });
-      store.setGoalColumn({ goalColumn: cursorPos });
-    } else {
-      // Try again with longer delay if position is 0
-      setTimeout(() => {
-        const cursorPos2 = getCursorPosition(payload._event.currentTarget);
-        store.setCursorPosition({ position: cursorPos2 });
-        store.setGoalColumn({ goalColumn: cursorPos2 });
-      }, 10);
-    }
-  }, 0);
+  syncStoredCursorState(store, payload._event.currentTarget);
 };
 
 export const handleOnInput = (deps, payload) => {
@@ -1109,12 +1138,7 @@ export const handleOnFocus = (deps, payload) => {
   }
 
   // When user clicks to focus (not navigating), set goal column to current position
-  setTimeout(() => {
-    const cursorPos = getCursorPosition(payload._event.currentTarget);
-    if (cursorPos >= 0) {
-      store.setGoalColumn({ goalColumn: cursorPos });
-    }
-  }, 10);
+  syncStoredCursorState(store, payload._event.currentTarget);
 
   render();
 };
@@ -1122,7 +1146,7 @@ export const handleOnFocus = (deps, payload) => {
 export const handleLineBlur = (deps, payload) => {
   const { store, render, refs } = deps;
 
-  // Capture element references before the timeout
+  // Capture element references before focus settles on the next paint.
   const blurredElement = payload._event.currentTarget;
   const shadowRoot = blurredElement.getRootNode();
 
@@ -1131,18 +1155,14 @@ export const handleLineBlur = (deps, payload) => {
     return;
   }
 
-  // Small delay to check if focus is moving to another line or staying within the editor
-  setTimeout(() => {
-    const activeElement = document.activeElement;
+  // Wait one paint so the next focused element is observable.
+  requestAnimationFrame(() => {
     const actualActiveElement =
-      (shadowRoot && shadowRoot.activeElement) || activeElement;
+      (shadowRoot && shadowRoot.activeElement) ||
+      getActualActiveElement(blurredElement);
 
     // Check if focus moved to another line within the editor
-    if (
-      actualActiveElement &&
-      actualActiveElement.id &&
-      actualActiveElement.id.startsWith("line")
-    ) {
+    if (isLineElement(actualActiveElement)) {
       // Focus moved to another line, stay in text-editor mode
       return;
     }
@@ -1164,5 +1184,5 @@ export const handleLineBlur = (deps, payload) => {
 
       render();
     }
-  }, 0);
+  });
 };

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -79,6 +79,71 @@ const isLineElement = (element) => {
   return Boolean(element && getLineIdFromElement(element));
 };
 
+const getLineText = (line) => {
+  return line?.actions?.dialogue?.content?.[0]?.text ?? "";
+};
+
+const syncRenderedLineContent = (refs, lines, lineId) => {
+  if (!lineId) {
+    return;
+  }
+
+  const lineRef = getLineElementById(refs, lineId);
+  if (!lineRef || typeof lineRef.updateContent !== "function") {
+    return;
+  }
+
+  const line = (lines || []).find((item) => item.id === lineId);
+  if (!line) {
+    return;
+  }
+
+  lineRef.updateContent(getLineText(line));
+};
+
+const syncAllRenderedLineContent = (refs, lines) => {
+  for (const line of lines || []) {
+    syncRenderedLineContent(refs, lines, line.id);
+  }
+};
+
+const didLineStructureChange = (oldLines, newLines) => {
+  if ((oldLines || []).length !== (newLines || []).length) {
+    return true;
+  }
+
+  for (let i = 0; i < (newLines || []).length; i++) {
+    if (oldLines?.[i]?.id !== newLines?.[i]?.id) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const syncChangedRenderedLineContent = (refs, oldLines, newLines) => {
+  if (!oldLines || oldLines.length === 0) {
+    syncAllRenderedLineContent(refs, newLines);
+    return;
+  }
+
+  if (didLineStructureChange(oldLines, newLines)) {
+    syncAllRenderedLineContent(refs, newLines);
+    return;
+  }
+
+  const oldLineContentById = new Map(
+    oldLines.map((line) => [line.id, getLineText(line)]),
+  );
+
+  for (const line of newLines || []) {
+    const nextContent = getLineText(line);
+    if (oldLineContentById.get(line.id) !== nextContent) {
+      syncRenderedLineContent(refs, newLines, line.id);
+    }
+  }
+};
+
 const DELETE_SHORTCUT_TIMEOUT_MS = 1200;
 let deleteShortcutTimerId = null;
 
@@ -1053,17 +1118,20 @@ export const handleLinePaste = (deps, payload) => {
 };
 
 export const forceSyncContentLine = (deps, payload) => {
-  const { store, refs } = deps;
-  const refIds = refs;
+  const { refs, props } = deps;
+  syncRenderedLineContent(refs, props.lines, payload?.lineId);
+};
 
-  const { lineId } = payload;
-  const lineRef = getLineElementById(refIds, lineId);
-  // Check if lineRef exists and has the elm property
-  if (!lineRef) {
-    return;
-  }
-  const lineContent = store.selectLineContent({ lineId });
-  lineRef.updateContent(lineContent);
+export const forceSyncAllContentLines = (deps) => {
+  const { refs, props } = deps;
+  syncAllRenderedLineContent(refs, props.lines);
+};
+
+export const handleOnUpdate = (deps, payload) => {
+  const { refs } = deps;
+  const oldLines = payload?.oldProps?.lines;
+  const newLines = payload?.newProps?.lines;
+  syncChangedRenderedLineContent(refs, oldLines, newLines);
 };
 
 export const updateSelectedLine = (deps, payload) => {

--- a/src/components/linesEditor/linesEditor.methods.js
+++ b/src/components/linesEditor/linesEditor.methods.js
@@ -1,0 +1,7 @@
+export function syncContentLine(payload = {}) {
+  this.transformedHandlers.forceSyncContentLine(payload);
+}
+
+export function syncAllContentLines() {
+  this.transformedHandlers.forceSyncAllContentLines({});
+}

--- a/src/components/linesEditor/linesEditor.schema.yaml
+++ b/src/components/linesEditor/linesEditor.schema.yaml
@@ -11,3 +11,14 @@ propsSchema:
       type: string
     sectionLineChanges:
       type: object
+methods:
+  type: object
+  properties:
+    syncContentLine:
+      description: Forces one rendered line element to match the current lines prop.
+      params: []
+      returns: void
+    syncAllContentLines:
+      description: Forces all rendered line elements to match the current lines prop.
+      params: []
+      returns: void

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -22,12 +22,12 @@ refs:
       contextmenu:
         handler: handlePreviewRightClick
 styles:
-  div[contenteditable]:
+  rvn-editable-text:
     font-size: 16px
     font-family: inherit
     line-height: 1.5
     word-break: break-word
-  div[contenteditable]:focus:
+  rvn-editable-text:focus:
     outline: none
   rvn-file-image:
     pointer-events: none
@@ -45,7 +45,7 @@ template:
                           - rvn-file-image fileId=${line.characterFileId} w=24 h=24 br=f: null
                   - rtgl-view d=h w=f:
                       - rtgl-view w=f:
-                          - 'div#line${i} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;" contenteditable=plaintext-only': ${line.actions.dialogue.content[0].text}
+                          - 'rvn-editable-text#line${i} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;"': ${line.actions.dialogue.content[0].text}
                           - $if line.sectionTransition:
                               - rtgl-view#previewSectionTransition data-type="sectionTransition" data-id="${line.id}" d=h:
                                   - rtgl-svg svg="transition" wh=16: null

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -52,6 +52,7 @@ const EDITABLE_TAGS = new Set([
   "rtgl-input",
   "rtgl-select",
   "rtgl-textarea",
+  "rvn-editable-text",
 ]);
 
 const isEditableElement = (element) => {
@@ -70,7 +71,7 @@ const isEditableElement = (element) => {
 
   if (typeof element.closest === "function") {
     const editableParent = element.closest(
-      "[contenteditable], input, textarea, select, rtgl-input, rtgl-select, rtgl-textarea",
+      "[contenteditable], input, textarea, select, rtgl-input, rtgl-select, rtgl-textarea, rvn-editable-text",
     );
     if (editableParent) {
       return true;

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1239,7 +1239,7 @@ export const handleSplitLine = async (deps, payload) => {
         currentLineId: newLineId,
       });
 
-      linesEditorRef.transformedHandlers.forceSyncContentLine({
+      linesEditorRef.syncContentLine({
         lineId,
       });
 
@@ -1404,7 +1404,7 @@ export const handlePasteLines = async (deps, payload) => {
         currentLineId: lastCreatedLineId,
       });
 
-      linesEditorRef.transformedHandlers.forceSyncContentLine({
+      linesEditorRef.syncContentLine({
         lineId,
       });
 
@@ -1419,17 +1419,14 @@ export const handlePasteLines = async (deps, payload) => {
 export const handleNewLine = async (deps, payload) => {
   const { store, render, projectService, subject, refs } = deps;
   const detail = payload?._event?.detail || {};
-  console.log("[sceneEditor][handleNewLine] received", detail);
 
   if (isSectionsOverviewOpen(store)) {
-    console.log("[sceneEditor][handleNewLine] skipped: sections overview open");
     return;
   }
 
   const newLineId = nanoid();
   const sectionId = store.selectSelectedSectionId();
   if (!sectionId) {
-    console.log("[sceneEditor][handleNewLine] skipped: missing sectionId");
     return;
   }
 
@@ -1444,22 +1441,12 @@ export const handleNewLine = async (deps, payload) => {
   const selectedLineId = store.selectSelectedLineId();
   const baseLineId = referenceLineId || selectedLineId || selectedLine?.id;
 
-  console.log("[sceneEditor][handleNewLine] resolved", {
-    sectionId,
-    requestedPosition,
-    referenceLineId,
-    selectedLineId: selectedLineId || null,
-    selectedLineEntityId: selectedLine?.id || null,
-    baseLineId: baseLineId || null,
-    newLineId,
-  });
-
   if (requestedPosition && !baseLineId) {
-    console.log(
-      "[sceneEditor][handleNewLine] skipped: position requested without baseLineId",
-    );
     return;
   }
+
+  // Persist pending line text before mutating the section structure.
+  await flushDialogueQueue(deps);
 
   const domainState = projectService.getDomainState();
   const existingDialogue = baseLineId
@@ -1513,17 +1500,6 @@ export const handleNewLine = async (deps, payload) => {
     createLinePayload.position = "last";
   }
 
-  console.log("[sceneEditor][handleNewLine] createLineItem payload", {
-    sectionId: createLinePayload.sectionId,
-    lineId: createLinePayload.lineId,
-    position: createLinePayload.position ?? null,
-    afterLineId: createLinePayload.afterLineId ?? null,
-    requestedPosition,
-    baseLineId: baseLineId ?? null,
-    baseLineIndex,
-    inheritedMode: newLineActions?.dialogue?.mode || null,
-  });
-
   await projectService.createLineItem(createLinePayload);
 
   if (requestedPosition === "before" && baseLineIndex === 0) {
@@ -1532,15 +1508,7 @@ export const handleNewLine = async (deps, payload) => {
       toSectionId: sectionId,
       index: 0,
     });
-    console.log("[sceneEditor][handleNewLine] moved new line to index 0", {
-      newLineId,
-      sectionId,
-    });
   }
-
-  console.log("[sceneEditor][handleNewLine] createLineItem done", {
-    newLineId,
-  });
 
   syncStoreProjectState(store, projectService);
   store.setSelectedLineId({ selectedLineId: newLineId });

--- a/src/primitives/editableText.js
+++ b/src/primitives/editableText.js
@@ -1,0 +1,257 @@
+const getSelectionRange = (element) => {
+  const root = element.getRootNode();
+  const isShadowRoot = root instanceof ShadowRoot;
+
+  let selection = window.getSelection();
+
+  if (isShadowRoot && typeof root.getSelection === "function") {
+    const shadowSelection = root.getSelection();
+    if (shadowSelection && shadowSelection.rangeCount > 0) {
+      const range = shadowSelection.getRangeAt(0);
+      if (element.contains(range.startContainer)) {
+        return range;
+      }
+    }
+  }
+
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+
+  if (isShadowRoot && typeof selection.getComposedRanges === "function") {
+    try {
+      const ranges = selection.getComposedRanges(root);
+      if (ranges.length > 0) {
+        const staticRange = ranges[0];
+        if (element.contains(staticRange.startContainer)) {
+          const range = document.createRange();
+          range.setStart(staticRange.startContainer, staticRange.startOffset);
+          range.setEnd(staticRange.endContainer, staticRange.endOffset);
+          return range;
+        }
+      }
+    } catch {
+      // Fall back to the standard selection path.
+    }
+  }
+
+  const range = selection.getRangeAt(0);
+  if (element.contains(range.startContainer)) {
+    return range;
+  }
+
+  return null;
+};
+
+const walkTextNodes = (node, visitor) => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return visitor(node);
+  }
+
+  for (const child of node.childNodes) {
+    if (walkTextNodes(child, visitor)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const createCollapsedRangeAtPosition = (element, targetPosition) => {
+  const range = document.createRange();
+  const normalizedTargetPosition = Math.max(0, Number(targetPosition) || 0);
+  let currentPosition = 0;
+  let lastTextNode;
+  let lastTextNodeLength = 0;
+  let actualPosition = 0;
+  let foundNode = false;
+
+  walkTextNodes(element, (node) => {
+    const nodeLength = node.textContent.length;
+    lastTextNode = node;
+    lastTextNodeLength = nodeLength;
+
+    if (currentPosition + nodeLength >= normalizedTargetPosition) {
+      const offset = normalizedTargetPosition - currentPosition;
+      range.setStart(node, offset);
+      range.setEnd(node, offset);
+      actualPosition = normalizedTargetPosition;
+      foundNode = true;
+      return true;
+    }
+
+    currentPosition += nodeLength;
+    return false;
+  });
+
+  if (!foundNode && lastTextNode) {
+    range.setStart(lastTextNode, lastTextNodeLength);
+    range.setEnd(lastTextNode, lastTextNodeLength);
+    actualPosition = currentPosition;
+    foundNode = true;
+  }
+
+  if (!foundNode) {
+    range.selectNodeContents(element);
+    range.collapse(true);
+  }
+
+  return {
+    range,
+    actualPosition,
+  };
+};
+
+const setSelectionFromRange = (element, range) => {
+  const root = element.getRootNode();
+  let selection = window.getSelection();
+
+  if (root instanceof ShadowRoot && typeof root.getSelection === "function") {
+    selection = root.getSelection() || selection;
+  }
+
+  if (!selection) {
+    return;
+  }
+
+  if (typeof selection.setBaseAndExtent === "function") {
+    selection.setBaseAndExtent(
+      range.startContainer,
+      range.startOffset,
+      range.endContainer,
+      range.endOffset,
+    );
+    return;
+  }
+
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
+export const EDITABLE_TEXT_TAG_NAME = "rvn-editable-text";
+
+export class EditableTextElement extends HTMLElement {
+  connectedCallback() {
+    this.contentEditable = "plaintext-only";
+    this.setAttribute("contenteditable", "plaintext-only");
+    if (!this.style.display) {
+      this.style.display = "block";
+    }
+  }
+
+  getContent() {
+    return this.textContent ?? "";
+  }
+
+  updateContent(content = "") {
+    const nextContent = content ?? "";
+    if (this.textContent !== nextContent) {
+      this.textContent = nextContent;
+    }
+  }
+
+  getCaretPosition() {
+    const range = getSelectionRange(this);
+    if (!range) {
+      return 0;
+    }
+
+    const preCaretRange = document.createRange();
+    preCaretRange.selectNodeContents(this);
+    preCaretRange.setEnd(range.endContainer, range.endOffset);
+    return preCaretRange.toString().length;
+  }
+
+  setCaretPosition(position, { preventScroll = true } = {}) {
+    const { range, actualPosition } = createCollapsedRangeAtPosition(
+      this,
+      position,
+    );
+
+    this.focus({ preventScroll });
+    setSelectionFromRange(this, range);
+    return actualPosition;
+  }
+
+  moveCaretToFirst(options) {
+    return this.setCaretPosition(0, options);
+  }
+
+  moveCaretToLast(options) {
+    return this.setCaretPosition(this.getContent().length, options);
+  }
+
+  findLastLinePosition(goalColumn) {
+    const textLength = this.getContent().length;
+    if (textLength === 0 || goalColumn >= textLength) {
+      return textLength;
+    }
+
+    let lastLineStartPosition = 0;
+    let lastLineTop;
+
+    for (let position = textLength; position >= 0; position--) {
+      try {
+        const { range } = createCollapsedRangeAtPosition(this, position);
+        const rect = range.getBoundingClientRect();
+
+        if (lastLineTop === undefined) {
+          lastLineTop = rect.top;
+          lastLineStartPosition = position;
+        } else if (Math.abs(rect.top - lastLineTop) > 5) {
+          break;
+        } else {
+          lastLineStartPosition = position;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    const lastLineLength = textLength - lastLineStartPosition;
+    const positionOnLastLine = Math.min(goalColumn, lastLineLength);
+    return lastLineStartPosition + positionOnLastLine;
+  }
+
+  isCaretOnFirstLine() {
+    const range = getSelectionRange(this);
+    if (!range) {
+      return false;
+    }
+
+    const cursorRect = range.getBoundingClientRect();
+    const startRange = document.createRange();
+    const { range: firstRange } = createCollapsedRangeAtPosition(this, 0);
+
+    startRange.setStart(firstRange.startContainer, firstRange.startOffset);
+    startRange.setEnd(firstRange.endContainer, firstRange.endOffset);
+
+    return (
+      Math.abs(cursorRect.top - startRange.getBoundingClientRect().top) <= 5
+    );
+  }
+
+  isCaretOnLastLine() {
+    const elementHeight = this.scrollHeight;
+    const lineHeight =
+      parseFloat(window.getComputedStyle(this).lineHeight) || 20;
+    const hasMultipleLines = elementHeight > lineHeight * 1.5;
+
+    if (!hasMultipleLines) {
+      return true;
+    }
+
+    const range = getSelectionRange(this);
+    if (!range) {
+      return false;
+    }
+
+    const cursorRect = range.getBoundingClientRect();
+    const { range: endRange } = createCollapsedRangeAtPosition(
+      this,
+      this.getContent().length,
+    );
+
+    return Math.abs(cursorRect.top - endRange.getBoundingClientRect().top) <= 5;
+  }
+}

--- a/src/primitives/editableText.js
+++ b/src/primitives/editableText.js
@@ -129,6 +129,7 @@ const setSelectionFromRange = (element, range) => {
 };
 
 export const EDITABLE_TEXT_TAG_NAME = "rvn-editable-text";
+const LINE_TOP_TOLERANCE_PX = 5;
 
 export class EditableTextElement extends HTMLElement {
   connectedCallback() {
@@ -160,6 +161,10 @@ export class EditableTextElement extends HTMLElement {
     preCaretRange.selectNodeContents(this);
     preCaretRange.setEnd(range.endContainer, range.endOffset);
     return preCaretRange.toString().length;
+  }
+
+  hasSelectionRange() {
+    return Boolean(getSelectionRange(this));
   }
 
   setCaretPosition(position, { preventScroll = true } = {}) {
@@ -198,7 +203,7 @@ export class EditableTextElement extends HTMLElement {
         if (lastLineTop === undefined) {
           lastLineTop = rect.top;
           lastLineStartPosition = position;
-        } else if (Math.abs(rect.top - lastLineTop) > 5) {
+        } else if (Math.abs(rect.top - lastLineTop) > LINE_TOP_TOLERANCE_PX) {
           break;
         } else {
           lastLineStartPosition = position;
@@ -227,7 +232,8 @@ export class EditableTextElement extends HTMLElement {
     startRange.setEnd(firstRange.endContainer, firstRange.endOffset);
 
     return (
-      Math.abs(cursorRect.top - startRange.getBoundingClientRect().top) <= 5
+      Math.abs(cursorRect.top - startRange.getBoundingClientRect().top) <=
+      LINE_TOP_TOLERANCE_PX
     );
   }
 
@@ -252,6 +258,9 @@ export class EditableTextElement extends HTMLElement {
       this.getContent().length,
     );
 
-    return Math.abs(cursorRect.top - endRange.getBoundingClientRect().top) <= 5;
+    return (
+      Math.abs(cursorRect.top - endRange.getBoundingClientRect().top) <=
+      LINE_TOP_TOLERANCE_PX
+    );
   }
 }

--- a/src/primitives/registerPrimitives.js
+++ b/src/primitives/registerPrimitives.js
@@ -1,0 +1,7 @@
+import { EditableTextElement, EDITABLE_TEXT_TAG_NAME } from "./editableText.js";
+
+export const registerPrimitives = () => {
+  if (!customElements.get(EDITABLE_TEXT_TAG_NAME)) {
+    customElements.define(EDITABLE_TEXT_TAG_NAME, EditableTextElement);
+  }
+};

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -19,6 +19,9 @@ import { createApiService } from "./deps/services/apiService";
 import Subject from "./deps/subject";
 import Router from "./deps/infra/router";
 import { createGraphicsService } from "./deps/services/graphicsService";
+import { registerPrimitives } from "./primitives/registerPrimitives";
+
+registerPrimitives();
 
 // Initialize app database
 const appDb = createDb({ path: "sqlite:app.db" });

--- a/src/setup.web.js
+++ b/src/setup.web.js
@@ -15,6 +15,9 @@ import { createAudioService } from "./deps/services/audioService.js";
 import Subject from "./deps/subject.js";
 import Router from "./deps/infra/router.js";
 import { createGraphicsService } from "./deps/services/graphicsService.js";
+import { registerPrimitives } from "./primitives/registerPrimitives.js";
+
+registerPrimitives();
 
 // Initialize app database using web adapter
 const appDb = createDb({ path: "app" });


### PR DESCRIPTION
## Summary
- add a new `src/primitives/` boundary for registered browser-native DOM wrappers
- register a new `rvn-editable-text` custom element in the setup entry points and use it in `linesEditor`
- move low-level caret/contenteditable selection logic out of `linesEditor.handlers.js` and behind primitive methods
- update the global editable-element guard and engineering docs for the new primitive layer

## Testing
- `bun x oxlint src/primitives src/components/linesEditor src/pages/app/app.handlers.js docs/engineering.md src/setup.web.js src/setup.tauri.js`
- `bun x prettier --check src/primitives src/components/linesEditor src/pages/app/app.handlers.js docs/engineering.md src/setup.web.js src/setup.tauri.js`
- `bun run build:web`

## Notes
- manual editor smoke test not run