### PR TITLE
fix: stabilize scene editor line split handling

### DIFF
--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -1,3 +1,5 @@
+import { debugLog, previewDebugText } from "../../utils/debugLog.js";
+
 const getLineContent = (element) => {
   if (!element || typeof element.getContent !== "function") {
     return "";
@@ -24,6 +26,45 @@ const hasSelectionRange = (element) => {
 
 const getLineIdFromElement = (element) => {
   return element?.dataset?.lineId || element?.id?.replace(/^line/, "") || "";
+};
+
+const shouldIgnoreElementInput = (element) => {
+  return element?.__rvnIgnoreInputUntilFocus === true;
+};
+
+const suppressElementInputUntilFocus = (element) => {
+  if (element) {
+    element.__rvnIgnoreInputUntilFocus = true;
+  }
+};
+
+const clearElementInputSuppression = (element) => {
+  if (element) {
+    element.__rvnIgnoreInputUntilFocus = false;
+  }
+};
+
+const dispatchEditorDataChanged = (dispatchEvent, element) => {
+  const lineId = getLineIdFromElement(element);
+  if (!lineId) {
+    return;
+  }
+
+  const content = getLineContent(element);
+  debugLog("lines", "editor.dispatch-data-changed", {
+    lineId,
+    contentLength: content.length,
+    content: previewDebugText(content),
+  });
+
+  dispatchEvent(
+    new CustomEvent("editor-data-changed", {
+      detail: {
+        lineId,
+        content,
+      },
+    }),
+  );
 };
 
 const getLineElementById = (refs, lineId) => {
@@ -323,15 +364,15 @@ const dispatchBlockModeSwapLine = (dispatchEvent, lineId, direction) => {
   );
 };
 
-export const handleAfterMount = async (deps) => {
-  const { store, refs, projectService } = deps;
+export const handleAfterMount = (deps) => {
+  const { refs } = deps;
 
-  await projectService.ensureRepository();
-  store.setRepositoryState({ repositoryState: projectService.getState() });
-  store.setReady();
-
-  // Focus container on mount to enable keyboard navigation
   focusContainerAfterPaint(refs);
+};
+
+export const handleBeforeMount = (deps) => {
+  const { store } = deps;
+  store.setReady();
 };
 
 export const handlePreviewRightClick = async (deps, payload) => {
@@ -718,11 +759,9 @@ export const handleLineKeyDown = (deps, payload) => {
     case "Backspace":
       if (mode === "text-editor") {
         // Check if cursor is at position 0
-        const currentPos = getCursorPosition(payload._event.currentTarget);
-        const currentContent = getLineContent(payload._event.currentTarget);
-        const currentLineId = getLineIdFromElement(
-          payload._event.currentTarget,
-        );
+        const currentElement = payload._event.currentTarget;
+        const currentPos = getCursorPosition(currentElement);
+        const currentLineId = getLineIdFromElement(currentElement);
 
         if (currentPos === 0) {
           payload._event.preventDefault();
@@ -734,15 +773,18 @@ export const handleLineKeyDown = (deps, payload) => {
           );
 
           if (currentIndex > 0) {
-            const prevLine = props.lines[currentIndex - 1];
+            dispatchEditorDataChanged(dispatchEvent, currentElement);
+            suppressElementInputUntilFocus(currentElement);
+            debugLog("lines", "editor.merge-request", {
+              lineId: currentLineId,
+              cursorPos: currentPos,
+            });
 
             // Dispatch event to merge lines
             dispatchEvent(
               new CustomEvent("mergeLines", {
                 detail: {
-                  prevLineId: prevLine.id,
                   currentLineId: currentLineId,
-                  contentToAppend: currentContent,
                 },
               }),
             );
@@ -765,15 +807,31 @@ export const handleLineKeyDown = (deps, payload) => {
     case "Enter":
       if (mode === "text-editor") {
         payload._event.preventDefault();
+        const currentElement = payload._event.currentTarget;
 
-        // Get current cursor position and text content
-        const cursorPos = getCursorPosition(payload._event.currentTarget);
-        const fullText = getLineContent(payload._event.currentTarget);
-
-        // Split the content at cursor position
-        const leftContent = fullText.substring(0, cursorPos);
-        const rightContent = fullText.substring(cursorPos);
+        debugLog("lines", "editor.enter-keydown", {
+          lineId: id,
+          textLength: getLineContent(currentElement).length,
+          cursorPos: getCursorPosition(currentElement),
+        });
         requestAnimationFrame(() => {
+          const cursorPos = getCursorPosition(currentElement);
+          const fullText = getLineContent(currentElement);
+          suppressElementInputUntilFocus(currentElement);
+
+          // Split the content at cursor position after the latest DOM/input work
+          // has settled, then let the parent structural handler own the writes.
+          const leftContent = fullText.substring(0, cursorPos);
+          const rightContent = fullText.substring(cursorPos);
+          debugLog("lines", "editor.enter-snapshot", {
+            lineId: id,
+            cursorPos,
+            fullTextLength: fullText.length,
+            fullText: previewDebugText(fullText),
+            leftContent: previewDebugText(leftContent),
+            rightContent: previewDebugText(rightContent),
+          });
+
           dispatchEvent(
             new CustomEvent("splitLine", {
               detail: {
@@ -1050,13 +1108,28 @@ export const handleLineMouseUp = (deps, payload) => {
 
 export const handleOnInput = (deps, payload) => {
   const { dispatchEvent, store } = deps;
+  const currentElement = payload._event.currentTarget;
 
-  const lineId = getLineIdFromElement(payload._event.currentTarget);
-  const content = getLineContent(payload._event.currentTarget);
+  if (shouldIgnoreElementInput(currentElement)) {
+    debugLog("lines", "editor.input-ignored", {
+      lineId: getLineIdFromElement(currentElement),
+      content: previewDebugText(getLineContent(currentElement)),
+    });
+    return;
+  }
+
+  const lineId = getLineIdFromElement(currentElement);
+  const content = getLineContent(currentElement);
 
   // Save cursor position on every input
-  const cursorPos = getCursorPosition(payload._event.currentTarget);
+  const cursorPos = getCursorPosition(currentElement);
   store.setCursorPosition({ position: cursorPos });
+  debugLog("lines", "editor.input", {
+    lineId,
+    cursorPos,
+    contentLength: content.length,
+    content: previewDebugText(content),
+  });
 
   const detail = {
     lineId,
@@ -1171,10 +1244,15 @@ export const updateSelectedLine = (deps, payload) => {
 
 export const handleOnFocus = (deps, payload) => {
   const { store, render, dispatchEvent } = deps;
-  const lineId = getLineIdFromElement(payload._event.currentTarget);
+  const lineElement = payload._event.currentTarget;
+  clearElementInputSuppression(lineElement);
+  const lineId = getLineIdFromElement(lineElement);
+  debugLog("lines", "editor.focus", {
+    lineId,
+    contentLength: getLineContent(lineElement).length,
+  });
 
   // Get the line element's coordinates
-  const lineElement = payload._event.currentTarget;
   const lineRect = lineElement.getBoundingClientRect();
 
   // Always update the selected line ID with coordinates

--- a/src/components/linesEditor/linesEditor.methods.js
+++ b/src/components/linesEditor/linesEditor.methods.js
@@ -1,7 +1,83 @@
+const getLineElement = (element, lineId) => {
+  if (!lineId) {
+    return;
+  }
+
+  return (
+    element.shadowRoot?.querySelector(`[data-line-id="${lineId}"]`) ||
+    element.querySelector(`[data-line-id="${lineId}"]`)
+  );
+};
+
+const focusLineInternally = (element, payload = {}) => {
+  const {
+    lineId,
+    cursorPosition,
+    goalColumn,
+    direction = null,
+    syncLineId,
+    scrollIntoView = true,
+  } = payload;
+
+  if (!lineId) {
+    return;
+  }
+
+  element.store.setIsNavigating({ isNavigating: true });
+
+  if (cursorPosition !== undefined) {
+    element.store.setCursorPosition({ position: cursorPosition });
+    element.store.setGoalColumn({
+      goalColumn: goalColumn ?? cursorPosition,
+    });
+  } else if (goalColumn !== undefined) {
+    element.store.setGoalColumn({ goalColumn });
+  }
+
+  element.store.setNavigationDirection({ direction });
+  element.transformedHandlers.updateSelectedLine({ currentLineId: lineId });
+
+  if (syncLineId) {
+    element.transformedHandlers.forceSyncContentLine({ lineId: syncLineId });
+  }
+
+  element.render();
+
+  if (scrollIntoView) {
+    requestAnimationFrame(() => {
+      element.scrollLineIntoView({ lineId });
+    });
+  }
+};
+
 export function syncContentLine(payload = {}) {
   this.transformedHandlers.forceSyncContentLine(payload);
 }
 
 export function syncAllContentLines() {
   this.transformedHandlers.forceSyncAllContentLines({});
+}
+
+export function focusLine(payload = {}) {
+  focusLineInternally(this, payload);
+}
+
+export function focusContainer() {
+  const container = this.shadowRoot?.querySelector("#container");
+  container?.focus();
+}
+
+export function scrollLineIntoView(payload = {}) {
+  const {
+    lineId,
+    behavior = "auto",
+    block = "nearest",
+    inline = "nearest",
+  } = payload;
+  const lineElement = getLineElement(this, lineId);
+  lineElement?.scrollIntoView({
+    behavior,
+    block,
+    inline,
+  });
 }

--- a/src/components/linesEditor/linesEditor.schema.yaml
+++ b/src/components/linesEditor/linesEditor.schema.yaml
@@ -11,6 +11,10 @@ propsSchema:
       type: string
     sectionLineChanges:
       type: object
+    repositoryState:
+      type: object
+    isLineOperationLocked:
+      type: boolean
 methods:
   type: object
   properties:
@@ -20,5 +24,17 @@ methods:
       returns: void
     syncAllContentLines:
       description: Forces all rendered line elements to match the current lines prop.
+      params: []
+      returns: void
+    focusLine:
+      description: Focuses a rendered line and applies caret/navigation state.
+      params: []
+      returns: void
+    focusContainer:
+      description: Focuses the outer block-mode container.
+      params: []
+      returns: void
+    scrollLineIntoView:
+      description: Scrolls a rendered line into view within the editor viewport.
       params: []
       returns: void

--- a/src/components/linesEditor/linesEditor.schema.yaml
+++ b/src/components/linesEditor/linesEditor.schema.yaml
@@ -13,8 +13,6 @@ propsSchema:
       type: object
     repositoryState:
       type: object
-    isLineOperationLocked:
-      type: boolean
 methods:
   type: object
   properties:

--- a/src/components/linesEditor/linesEditor.store.js
+++ b/src/components/linesEditor/linesEditor.store.js
@@ -24,8 +24,9 @@ export const setReady = ({ state }, _payload = {}) => {
   state.ready = true;
 };
 
+// Compatibility shim while the linesEditor repository dependency is moving to props.
 export const setRepositoryState = ({ state }, { repositoryState } = {}) => {
-  state.repositoryState = repositoryState;
+  state.repositoryState = repositoryState || {};
 };
 
 export const setCursorPosition = ({ state }, { position } = {}) => {
@@ -88,16 +89,12 @@ export const selectAwaitingDeleteShortcut = ({ state }) => {
 
 export const selectLineContent = ({ props }, payload) => {
   const { lineId } = payload;
-  const line = (props.lines || []).find((l) => l.id === lineId);
-  if (line) {
-    const firstContent = line.actions?.dialogue?.content?.[0];
-    if (firstContent) {
-      return firstContent.text || "";
-    }
-  }
+  const line = (props.lines || []).find((item) => item.id === lineId);
+  return line?.actions?.dialogue?.content?.[0]?.text ?? "";
 };
 
 export const selectViewData = ({ state, props }) => {
+  const repositoryState = props.repositoryState || state.repositoryState || {};
   const sectionLineChanges = props.sectionLineChanges || {};
   const changesLines = sectionLineChanges.lines || [];
 
@@ -116,8 +113,7 @@ export const selectViewData = ({ state, props }) => {
       background = {
         changeType: changes.background.changeType,
         resourceId: bgData.resourceId,
-        fileId:
-          state.repositoryState.images?.items?.[bgData.resourceId]?.fileId,
+        fileId: repositoryState.images?.items?.[bgData.resourceId]?.fileId,
       };
     }
 
@@ -130,8 +126,7 @@ export const selectViewData = ({ state, props }) => {
           changeType: changes.character.changeType,
           items: charData.items
             .map((char) => {
-              const character =
-                state.repositoryState.characters?.items?.[char.id];
+              const character = repositoryState.characters?.items?.[char.id];
               let spriteFileId = null;
 
               if (
@@ -148,12 +143,10 @@ export const selectViewData = ({ state, props }) => {
                   if (sprite?.fileId) {
                     spriteFileId = sprite.fileId;
                   } else if (
-                    state.repositoryState.images?.items?.[
-                      firstSprite.resourceId
-                    ]
+                    repositoryState.images?.items?.[firstSprite.resourceId]
                   ) {
                     spriteFileId =
-                      state.repositoryState.images.items[firstSprite.resourceId]
+                      repositoryState.images.items[firstSprite.resourceId]
                         .fileId;
                   }
                 }
@@ -220,7 +213,7 @@ export const selectViewData = ({ state, props }) => {
     // Dialogue character icon (who is speaking) - still from line.actions
     let characterFileId;
     if (line.actions?.dialogue?.characterId) {
-      const characters = toFlatItems(state.repositoryState.characters || []);
+      const characters = toFlatItems(repositoryState.characters || []);
       const character = characters.find(
         (c) => c.id === line.actions.dialogue.characterId,
       );
@@ -241,14 +234,14 @@ export const selectViewData = ({ state, props }) => {
     if (sectionTransitionData) {
       if (sectionTransitionData.sceneId) {
         sectionTransition = true;
-        const allScenes = toFlatItems(state.repositoryState.scenes || []);
+        const allScenes = toFlatItems(repositoryState.scenes || []);
         const targetScene = allScenes.find(
           (scene) => scene.id === sectionTransitionData.sceneId,
         );
         transitionTarget = targetScene?.name || "Unknown Scene";
       } else if (sectionTransitionData.sectionId) {
         sectionTransition = true;
-        const allScenes = toFlatItems(state.repositoryState.scenes || []);
+        const allScenes = toFlatItems(repositoryState.scenes || []);
         let sectionName = "Unknown Section";
         for (const scene of allScenes) {
           if (scene.sections) {

--- a/src/deps/services/pendingQueueService.js
+++ b/src/deps/services/pendingQueueService.js
@@ -1,3 +1,5 @@
+import { debugLog, previewDebugText } from "../../utils/debugLog.js";
+
 /**
  * Creates a pending queue service for managing debounced updates.
  *
@@ -14,7 +16,36 @@
 export function createPendingQueueService({ debounceMs = 2000 } = {}) {
   const pending = new Map();
   const timers = new Map();
+  const activeWrites = new Map();
   let onWriteCallback = null;
+
+  const trackActiveWrite = async (key, writePromise) => {
+    activeWrites.set(key, writePromise);
+
+    try {
+      await writePromise;
+    } finally {
+      if (activeWrites.get(key) === writePromise) {
+        activeWrites.delete(key);
+      }
+    }
+  };
+
+  const waitForActiveWrites = async (key) => {
+    if (key !== undefined) {
+      const writePromise = activeWrites.get(key);
+      if (writePromise) {
+        await writePromise;
+      }
+      return;
+    }
+
+    if (activeWrites.size === 0) {
+      return;
+    }
+
+    await Promise.all(Array.from(activeWrites.values()));
+  };
 
   return {
     /**
@@ -33,6 +64,13 @@ export function createPendingQueueService({ debounceMs = 2000 } = {}) {
      */
     setAndSchedule(key, data) {
       pending.set(key, data);
+      debugLog("lines", "queue.set-and-schedule", {
+        key,
+        pendingSize: pending.size,
+        content: previewDebugText(
+          data?.content?.map((item) => item?.text ?? "").join(""),
+        ),
+      });
 
       // Clear existing timer for this key
       if (timers.has(key)) {
@@ -43,18 +81,43 @@ export function createPendingQueueService({ debounceMs = 2000 } = {}) {
       const timer = setTimeout(async () => {
         timers.delete(key);
         const currentData = pending.get(key);
+        debugLog("lines", "queue.timer-fired", {
+          key,
+          hasCurrentData: !!currentData,
+          pendingSize: pending.size,
+        });
 
         if (currentData && onWriteCallback) {
-          try {
-            await onWriteCallback(key, currentData);
-            // Only delete if reference matches (prevents race condition)
-            if (pending.get(key) === currentData) {
-              pending.delete(key);
+          const writePromise = (async () => {
+            try {
+              debugLog("lines", "queue.write-start", {
+                key,
+                content: previewDebugText(
+                  currentData?.content
+                    ?.map((item) => item?.text ?? "")
+                    .join(""),
+                ),
+              });
+              await onWriteCallback(key, currentData);
+              // Only delete if reference matches (prevents race condition)
+              if (pending.get(key) === currentData) {
+                pending.delete(key);
+              }
+              debugLog("lines", "queue.write-success", {
+                key,
+                pendingSize: pending.size,
+              });
+            } catch (error) {
+              console.error(`Debounced write failed for ${key}:`, error);
+              // Keep in pending for next attempt or flush
+              debugLog("lines", "queue.write-failed", {
+                key,
+                message: error?.message,
+              });
             }
-          } catch (error) {
-            console.error(`Debounced write failed for ${key}:`, error);
-            // Keep in pending for next attempt or flush
-          }
+          })();
+
+          await trackActiveWrite(key, writePromise);
         }
       }, debounceMs);
 
@@ -82,6 +145,10 @@ export function createPendingQueueService({ debounceMs = 2000 } = {}) {
       return pending.size;
     },
 
+    entries() {
+      return Array.from(pending.entries());
+    },
+
     /**
      * Flush all pending updates immediately.
      * Cancels all pending debounce timers first,
@@ -91,11 +158,19 @@ export function createPendingQueueService({ debounceMs = 2000 } = {}) {
      * @param {Function} writeFn - async (key, data) => void
      */
     async flush(writeFn) {
+      debugLog("lines", "queue.flush-start", {
+        pendingSize: pending.size,
+        activeWrites: activeWrites.size,
+      });
       // Cancel all pending timers first
       for (const timer of timers.values()) {
         clearTimeout(timer);
       }
       timers.clear();
+
+      // Wait for any debounced write that has already started so a structural
+      // mutation does not race against an older text write landing afterward.
+      await waitForActiveWrites();
 
       if (pending.size === 0) {
         return;
@@ -104,17 +179,43 @@ export function createPendingQueueService({ debounceMs = 2000 } = {}) {
       // Snapshot and clear immediately
       const entries = Array.from(pending.entries());
       pending.clear();
+      debugLog("lines", "queue.flush-entries", {
+        count: entries.length,
+        keys: entries.map(([key]) => key),
+      });
 
       // Write all entries
       for (const [key, data] of entries) {
         try {
+          debugLog("lines", "queue.flush-write-start", {
+            key,
+            content: previewDebugText(
+              data?.content?.map((item) => item?.text ?? "").join(""),
+            ),
+          });
           await writeFn(key, data);
+          debugLog("lines", "queue.flush-write-success", {
+            key,
+          });
         } catch (error) {
           // Restore failed entry back to queue
           pending.set(key, data);
           console.error(`Flush failed for ${key}:`, error);
+          debugLog("lines", "queue.flush-write-failed", {
+            key,
+            message: error?.message,
+          });
         }
       }
+
+      debugLog("lines", "queue.flush-end", {
+        pendingSize: pending.size,
+        activeWrites: activeWrites.size,
+      });
+    },
+
+    async waitForIdle(key) {
+      await waitForActiveWrites(key);
     },
   };
 }

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -9,6 +9,7 @@ import {
   extractTransitionTargetSceneIds,
   extractTransitionTargetSceneIdsFromActions,
 } from "../../utils/index.js";
+import { debugLog, previewDebugText } from "../../utils/debugLog.js";
 import { filter, tap, debounceTime } from "rxjs";
 
 const DEAD_END_TOOLTIP_CONTENT =
@@ -201,6 +202,68 @@ const syncStoreProjectState = (store, projectService) => {
     domainState: projectService.getDomainState(),
   });
   return repositoryState;
+};
+
+const getLinesEditorRef = (refs) => {
+  return refs?.linesEditor;
+};
+
+const focusLinesEditorLine = (refs, payload = {}) => {
+  const linesEditorRef = getLinesEditorRef(refs);
+  if (!linesEditorRef) {
+    return;
+  }
+
+  linesEditorRef.focusLine(payload);
+};
+
+const scrollLinesEditorLineIntoView = (refs, lineId) => {
+  const linesEditorRef = getLinesEditorRef(refs);
+  if (!linesEditorRef || !lineId) {
+    return;
+  }
+
+  linesEditorRef.scrollLineIntoView({ lineId });
+};
+
+const getDialogueText = (line) => {
+  return (line?.actions?.dialogue?.content || [])
+    .map((item) => item?.text ?? "")
+    .join("");
+};
+
+const resolveMergeLinesContext = (domainState, currentLineId) => {
+  const currentLine = domainState?.lines?.[currentLineId];
+  const sectionId = currentLine?.sectionId;
+  const section = sectionId ? domainState?.sections?.[sectionId] : undefined;
+  const lineIds = section?.lineIds || [];
+  const currentIndex = lineIds.indexOf(currentLineId);
+
+  if (!currentLine || currentIndex <= 0) {
+    return {};
+  }
+
+  const prevLineId = lineIds[currentIndex - 1];
+  const prevLine = domainState?.lines?.[prevLineId];
+
+  if (!prevLineId || !prevLine) {
+    return {};
+  }
+
+  return {
+    sectionId,
+    currentLine,
+    prevLineId,
+    prevLine,
+  };
+};
+
+const isMissingLinePreconditionError = (error, lineId) => {
+  return (
+    error?.name === "DomainPreconditionError" &&
+    error?.message === "line not found" &&
+    (!lineId || error?.details?.lineId === lineId)
+  );
 };
 
 async function loadAssetsForSceneIds(
@@ -436,6 +499,16 @@ async function writeDialogueContent(deps, lineId, { sectionId, content }) {
     existingDialogue,
   });
 
+  debugLog("lines", "scene.write-dialogue", {
+    lineId,
+    sectionId,
+    contentLength: (content || []).map((item) => item?.text ?? "").join("")
+      .length,
+    content: previewDebugText(
+      (content || []).map((item) => item?.text ?? "").join(""),
+    ),
+  });
+
   await projectService.updateLineActions({
     lineId,
     patch: {
@@ -453,10 +526,31 @@ async function writeDialogueContent(deps, lineId, { sectionId, content }) {
 async function flushDialogueQueue(deps) {
   const { dialogueQueueService } = deps;
 
+  debugLog("lines", "scene.flush-dialogue-queue:start", {
+    pendingSize: dialogueQueueService.size(),
+  });
+
   await dialogueQueueService.flush(async (lineId, data) => {
     await writeDialogueContent(deps, lineId, data);
   });
+
+  debugLog("lines", "scene.flush-dialogue-queue:end", {
+    pendingSize: dialogueQueueService.size(),
+  });
 }
+
+const applyPendingDialogueQueueToStore = (store, dialogueQueueService) => {
+  for (const [lineId, data] of dialogueQueueService.entries()) {
+    if (!lineId || !Array.isArray(data?.content)) {
+      continue;
+    }
+
+    store.setLineTextContent({
+      lineId,
+      content: data.content,
+    });
+  }
+};
 
 const findCharacterIdByShortcut = (repositoryState, shortcut) => {
   const normalizedShortcut = String(shortcut || "").trim();
@@ -672,9 +766,18 @@ const reconcileSceneSelection = (store) => {
 };
 
 export const handleDataChanged = async (deps) => {
-  const { store, projectService, render, subject } = deps;
+  const { store, projectService, render, subject, dialogueQueueService } = deps;
   await projectService.ensureRepository();
+
+  if (store.selectLockingLineId()) {
+    debugLog("lines", "scene.data-changed-skipped-while-locked", {
+      lockingLineId: store.selectLockingLineId(),
+    });
+    return;
+  }
+
   syncStoreProjectState(store, projectService);
+  applyPendingDialogueQueueToStore(store, dialogueQueueService);
 
   reconcileSceneSelection(store);
 
@@ -874,14 +977,47 @@ export const handleEditorDataChanged = async (deps, payload) => {
   }
 
   const lineId = payload._event.detail.lineId;
+  const selectedLineId = store.selectSelectedLineId();
+  const lockingLineId = store.selectLockingLineId();
+
+  if (!lineId) {
+    return;
+  }
+
+  // Ignore late input events from a line that is no longer selected or is in
+  // the middle of a structural split/merge operation.
+  if (lineId !== selectedLineId || lineId === lockingLineId) {
+    debugLog("lines", "scene.editor-data-ignored", {
+      lineId,
+      selectedLineId,
+      lockingLineId,
+      content: previewDebugText(payload._event.detail.content),
+    });
+    return;
+  }
+
   const content = [{ text: payload._event.detail.content }];
+  debugLog("lines", "scene.editor-data-accepted", {
+    lineId,
+    selectedLineId,
+    lockingLineId,
+    contentLength: payload._event.detail.content.length,
+    content: previewDebugText(payload._event.detail.content),
+  });
 
   // Update local store immediately for UI responsiveness
   store.setLineTextContent({ lineId, content });
 
   // Queue the pending update and schedule debounced write
-  const sectionId = store.selectSelectedSectionId();
+  const sectionId =
+    store.selectDomainState()?.lines?.[lineId]?.sectionId ??
+    store.selectSelectedSectionId();
   try {
+    debugLog("lines", "scene.editor-data-queued", {
+      lineId,
+      sectionId,
+      content: previewDebugText(payload._event.detail.content),
+    });
     dialogueQueueService.setAndSchedule(lineId, { sectionId, content });
   } catch (error) {
     console.error("[sceneEditor] Failed to queue dialogue update:", error);
@@ -1138,122 +1274,133 @@ export const handleSplitLine = async (deps, payload) => {
 
   // Mark this line as being processed IMMEDIATELY to prevent duplicate operations
   store.setLockingLineId({ lineId: lineId });
+  let shouldReleaseLockAfterFocus = false;
 
-  const newLineId = nanoid();
+  try {
+    const newLineId = nanoid();
 
-  // Flush pending dialogue updates before modifying repository
-  await flushDialogueQueue(deps);
+    // Flush pending dialogue updates before modifying repository
+    await flushDialogueQueue(deps);
 
-  // Get existing actions data to preserve everything except dialogue content
-  const domainState = projectService.getDomainState();
-  const existingDialogue =
-    domainState?.lines?.[lineId]?.actions?.dialogue || {};
-
-  // First, update the current line with the left content
-  // Only update the dialogue.content, preserve everything else
-  const leftContentArray = leftContent
-    ? [{ text: leftContent }]
-    : [{ text: "" }];
-
-  if (existingDialogue && Object.keys(existingDialogue).length > 0) {
-    await projectService.updateLineActions({
+    const domainState = projectService.getDomainState();
+    const existingDialogue =
+      domainState?.lines?.[lineId]?.actions?.dialogue || {};
+    debugLog("lines", "scene.split.after-flush", {
       lineId,
-      patch: {
-        dialogue: {
-          ...existingDialogue,
-          content: leftContentArray,
-        },
-      },
-      replace: false,
+      newLineId,
+      domainContent: previewDebugText(
+        (domainState?.lines?.[lineId]?.actions?.dialogue?.content || [])
+          .map((item) => item?.text ?? "")
+          .join(""),
+      ),
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
     });
-  } else {
-    await projectService.updateLineActions({
-      lineId,
-      patch: {
-        dialogue: {
-          content: leftContentArray,
-        },
-      },
-      replace: false,
-    });
-  }
 
-  // Then, create a new line with the right content and insert it after the current line
-  // New line should have empty actions except for dialogue.content
-  const rightContentArray = rightContent
-    ? [{ text: rightContent }]
-    : [{ text: "" }];
-  const shouldInheritNvl =
-    existingDialogue?.mode === "nvl" ||
-    shouldInheritNvlModeFromPreviousLine({
-      domainState,
-      sectionId,
-      lineId,
-      existingDialogue,
-    });
-  const shouldCreateDialogueAction = shouldInheritNvl || !!rightContent;
-  const newLineActions = shouldCreateDialogueAction
-    ? {
-        dialogue: {
-          mode: shouldInheritNvl ? "nvl" : "adv",
-          ...(rightContent ? { content: rightContentArray } : {}),
-        },
-      }
-    : {};
+    // First, update the current line with the left content
+    // Only update the dialogue.content, preserve everything else
+    const leftContentArray = leftContent
+      ? [{ text: leftContent }]
+      : [{ text: "" }];
 
-  await projectService.createLineItem({
-    sectionId,
-    lineId: newLineId,
-    line: {
-      actions: newLineActions,
-    },
-    afterLineId: lineId,
-  });
-
-  // Update store with new repository state (pending updates were already flushed)
-  syncStoreProjectState(store, projectService);
-
-  // Handle UI updates immediately for responsiveness
-  // Pre-configure the linesEditor before rendering
-  const refIds = refs;
-  const linesEditorRef = refIds["linesEditor"];
-
-  if (linesEditorRef) {
-    // Set cursor position to 0 (beginning of new line)
-    linesEditorRef.store.setCursorPosition({ position: 0 });
-    linesEditorRef.store.setGoalColumn({ goalColumn: 0 });
-    linesEditorRef.store.setNavigationDirection({ direction: "down" });
-    linesEditorRef.store.setIsNavigating({ isNavigating: true });
-  }
-
-  // Update selectedLineId through the store (not directly in linesEditor)
-  store.setSelectedLineId({ selectedLineId: newLineId });
-
-  // Render after setting the selected line ID
-  render();
-
-  // Use requestAnimationFrame for focus operations
-  requestAnimationFrame(() => {
-    if (linesEditorRef) {
-      linesEditorRef.transformedHandlers.updateSelectedLine({
-        currentLineId: newLineId,
-      });
-
-      linesEditorRef.syncContentLine({
+    if (existingDialogue && Object.keys(existingDialogue).length > 0) {
+      await projectService.updateLineActions({
         lineId,
+        patch: {
+          dialogue: {
+            ...existingDialogue,
+            content: leftContentArray,
+          },
+        },
+        replace: false,
       });
-
-      linesEditorRef.render();
+    } else {
+      await projectService.updateLineActions({
+        lineId,
+        patch: {
+          dialogue: {
+            content: leftContentArray,
+          },
+        },
+        replace: false,
+      });
     }
 
-    // Clear the splitting lock - allows new line to be split if Enter is still held
-    requestAnimationFrame(() => {
-      store.clearLockingLineId();
-    });
-  });
+    // Then, create a new line with the right content and insert it after the current line
+    // New line should have empty actions except for dialogue.content
+    const rightContentArray = rightContent
+      ? [{ text: rightContent }]
+      : [{ text: "" }];
+    const shouldInheritNvl =
+      existingDialogue?.mode === "nvl" ||
+      shouldInheritNvlModeFromPreviousLine({
+        domainState,
+        sectionId,
+        lineId,
+        existingDialogue,
+      });
+    const shouldCreateDialogueAction = shouldInheritNvl || !!rightContent;
+    const newLineActions = shouldCreateDialogueAction
+      ? {
+          dialogue: {
+            mode: shouldInheritNvl ? "nvl" : "adv",
+            ...(rightContent ? { content: rightContentArray } : {}),
+          },
+        }
+      : {};
 
-  // Trigger debounced canvas render
-  subject.dispatch("sceneEditor.renderCanvas", {});
+    const linesEditorRef = getLinesEditorRef(refs);
+    debugLog("lines", "scene.split.start", {
+      lineId,
+      sectionId,
+      newLineId,
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
+    });
+
+    await projectService.createLineItem({
+      sectionId,
+      lineId: newLineId,
+      line: {
+        actions: newLineActions,
+      },
+      afterLineId: lineId,
+    });
+    debugLog("lines", "scene.split.created-line", {
+      lineId,
+      newLineId,
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
+    });
+
+    syncStoreProjectState(store, projectService);
+    store.setSelectedLineId({ selectedLineId: newLineId });
+    render();
+    shouldReleaseLockAfterFocus = true;
+
+    requestAnimationFrame(() => {
+      if (linesEditorRef) {
+        linesEditorRef.focusLine({
+          lineId: newLineId,
+          cursorPosition: 0,
+          goalColumn: 0,
+          direction: "down",
+          syncLineId: lineId,
+        });
+      }
+
+      requestAnimationFrame(() => {
+        store.clearLockingLineId();
+      });
+    });
+
+    // Trigger debounced canvas render
+    subject.dispatch("sceneEditor.renderCanvas", {});
+  } finally {
+    if (!shouldReleaseLockAfterFocus) {
+      store.clearLockingLineId();
+    }
+  }
 };
 
 export const handlePasteLines = async (deps, payload) => {
@@ -1374,22 +1521,12 @@ export const handlePasteLines = async (deps, payload) => {
   syncStoreProjectState(store, projectService);
 
   // Set cursor position at end of last line
-  const refIds = refs;
-  const linesEditorRef = refIds["linesEditor"];
-
-  if (linesEditorRef) {
-    // Calculate cursor position (end of last pasted content)
-    const lastLineContent =
-      lines.length === 1
-        ? firstLineContent + rightContent
-        : lines[lines.length - 1] + rightContent;
-    const cursorPosition = lastLineContent.length - rightContent.length;
-
-    linesEditorRef.store.setCursorPosition({ position: cursorPosition });
-    linesEditorRef.store.setGoalColumn({ goalColumn: cursorPosition });
-    linesEditorRef.store.setNavigationDirection({ direction: null });
-    linesEditorRef.store.setIsNavigating({ isNavigating: true });
-  }
+  const linesEditorRef = getLinesEditorRef(refs);
+  const lastLineContent =
+    lines.length === 1
+      ? firstLineContent + rightContent
+      : lines[lines.length - 1] + rightContent;
+  const cursorPosition = lastLineContent.length - rightContent.length;
 
   // Update selectedLineId
   store.setSelectedLineId({ selectedLineId: lastCreatedLineId });
@@ -1400,15 +1537,13 @@ export const handlePasteLines = async (deps, payload) => {
   // Focus the last created line
   requestAnimationFrame(() => {
     if (linesEditorRef) {
-      linesEditorRef.transformedHandlers.updateSelectedLine({
-        currentLineId: lastCreatedLineId,
+      linesEditorRef.focusLine({
+        lineId: lastCreatedLineId,
+        cursorPosition: cursorPosition,
+        goalColumn: cursorPosition,
+        direction: null,
+        syncLineId: lineId,
       });
-
-      linesEditorRef.syncContentLine({
-        lineId,
-      });
-
-      linesEditorRef.render();
     }
   });
 
@@ -1514,22 +1649,18 @@ export const handleNewLine = async (deps, payload) => {
   store.setSelectedLineId({ selectedLineId: newLineId });
 
   const shouldEnterInsertMode = !!requestedPosition;
-  const linesEditorRef = refs?.linesEditor;
-  if (shouldEnterInsertMode && linesEditorRef) {
-    linesEditorRef.store.setCursorPosition({ position: 0 });
-    linesEditorRef.store.setGoalColumn({ goalColumn: 0 });
-    linesEditorRef.store.setNavigationDirection({ direction: null });
-    linesEditorRef.store.setIsNavigating({ isNavigating: true });
-  }
+  const linesEditorRef = getLinesEditorRef(refs);
 
   render();
 
   if (shouldEnterInsertMode && linesEditorRef) {
     requestAnimationFrame(() => {
-      linesEditorRef.transformedHandlers.updateSelectedLine({
-        currentLineId: newLineId,
+      linesEditorRef.focusLine({
+        lineId: newLineId,
+        cursorPosition: 0,
+        goalColumn: 0,
+        direction: null,
       });
-      linesEditorRef.render();
     });
   }
 
@@ -1542,7 +1673,7 @@ export const handleLineNavigation = (deps, payload) => {
     return;
   }
 
-  const { targetLineId, mode, direction, targetCursorPosition, lineRect } =
+  const { targetLineId, mode, direction, targetCursorPosition } =
     payload._event.detail;
 
   // For block mode, just update the selection and handle scrolling
@@ -1563,65 +1694,14 @@ export const handleLineNavigation = (deps, payload) => {
     store.setSelectedLineId({ selectedLineId: targetLineId });
     render();
 
-    // Check if we need to scroll the line into view using provided coordinates
-    if (lineRect) {
+    if (targetLineId) {
       requestAnimationFrame(() => {
-        const refIds = refs;
-        const linesEditorRef = refIds["linesEditor"];
-
-        if (linesEditorRef) {
-          const linesEditorElm = linesEditorRef;
-
-          // The scroll container is actually the parent of the lines-editor component
-          // It's the rtgl-view with 'sv' (scroll vertical) attribute
-          const scrollContainer = linesEditorElm.parentElement;
-
-          const containerRect = scrollContainer?.getBoundingClientRect() || {};
-
-          // Check if the line is fully visible in the viewport using provided coordinates
-          const isAboveViewport = lineRect.top < containerRect.top;
-          const isBelowViewport = lineRect.bottom > containerRect.bottom;
-
-          // Only scroll if the line is not fully visible
-          if (isAboveViewport || isBelowViewport) {
-            // Query for the line element to scroll it
-            // The line elements are inside the lines-editor component
-            let lineElement = null;
-
-            // First try shadow DOM
-            if (linesEditorElm.shadowRoot) {
-              lineElement = linesEditorElm.shadowRoot.querySelector(
-                `#line${targetLineId}`,
-              );
-            }
-
-            // If not found, try regular DOM inside the component
-            if (!lineElement) {
-              lineElement = linesEditorElm.querySelector(
-                `#line${targetLineId}`,
-              );
-            }
-
-            // Last resort: search in the whole document
-            if (!lineElement) {
-              lineElement = document.querySelector(`#line${targetLineId}`);
-            }
-
-            if (lineElement) {
-              lineElement.scrollIntoView({
-                behavior: "auto", // Immediate scroll, no animation
-                block: "nearest",
-                inline: "nearest",
-              });
-            }
-          }
-        }
+        scrollLinesEditorLineIntoView(refs, targetLineId);
       });
     }
 
     // Trigger debounced canvas render
     subject.dispatch("sceneEditor.renderCanvas", {});
-    render();
     return;
   }
 
@@ -1640,58 +1720,30 @@ export const handleLineNavigation = (deps, payload) => {
 
   // Handle navigation to different line
   if (nextLineId && nextLineId !== currentLineId) {
-    const refIds = refs;
-    const linesEditorRef = refIds["linesEditor"];
+    const linesEditorRef = getLinesEditorRef(refs);
 
     // Update selectedLineId through the store
     store.setSelectedLineId({ selectedLineId: nextLineId });
+    render();
 
-    // Handle cursor positioning based on direction
-    if (linesEditorRef) {
-      if (targetCursorPosition !== undefined) {
-        if (targetCursorPosition === -1) {
-          // Special value: position at end of target line (for ArrowLeft navigation)
-          // Set a large goal column - updateSelectedLine will clamp to actual text length
-          // when direction is "end"
-          linesEditorRef.store.setCursorPosition({
-            position: Number.MAX_SAFE_INTEGER,
-          });
-          linesEditorRef.store.setGoalColumn({
-            goalColumn: Number.MAX_SAFE_INTEGER,
-          });
-          linesEditorRef.store.setNavigationDirection({ direction: "end" }); // Special direction for end positioning
-        } else {
-          linesEditorRef.store.setCursorPosition({
-            position: targetCursorPosition,
-          });
-          if (targetCursorPosition === 0) {
-            // When moving to beginning, set goal column to 0 as well
-            linesEditorRef.store.setGoalColumn({ goalColumn: 0 });
-          }
-        }
-      }
-
-      // Set direction flag in store before calling updateSelectedLine
-      if (direction) {
-        linesEditorRef.store.setNavigationDirection({ direction: direction });
-      }
-
-      linesEditorRef.transformedHandlers.updateSelectedLine({
-        currentLineId: nextLineId,
-      });
-    }
-
-    // Force a render to update line colors after navigation
-    setTimeout(() => {
-      render();
-      // Also render the linesEditor to update line colors
+    requestAnimationFrame(() => {
       if (linesEditorRef) {
-        linesEditorRef.render();
+        const isEndNavigation = targetCursorPosition === -1;
+        focusLinesEditorLine(refs, {
+          lineId: nextLineId,
+          cursorPosition: isEndNavigation
+            ? Number.MAX_SAFE_INTEGER
+            : targetCursorPosition,
+          goalColumn: isEndNavigation
+            ? Number.MAX_SAFE_INTEGER
+            : targetCursorPosition,
+          direction: direction ?? null,
+        });
       }
 
       // Trigger debounced canvas render
       subject.dispatch("sceneEditor.renderCanvas", {});
-    }, 0);
+    });
   } else if (direction === "up" && currentLineId === targetLineId) {
     // First line - show animation effects
     graphicsService.render({
@@ -1756,95 +1808,122 @@ export const handleMergeLines = async (deps, payload) => {
     return;
   }
 
-  const { prevLineId, currentLineId, contentToAppend } = payload._event.detail;
-
-  const sectionId = store.selectSelectedSectionId();
+  const { currentLineId } = payload._event.detail;
 
   // Check if this line is already being processed (split/merge)
   const lockingLineId = store.selectLockingLineId();
 
-  if (lockingLineId === currentLineId) {
+  if (lockingLineId) {
     return;
   }
 
   store.setLockingLineId({ lineId: currentLineId });
+  let shouldReleaseLockAfterFocus = false;
+  let resolvedPrevLineId;
 
-  // Flush pending dialogue updates before modifying repository
-  await flushDialogueQueue(deps);
+  try {
+    // Flush pending dialogue updates before modifying repository
+    await flushDialogueQueue(deps);
 
-  // Get previous line content and existing dialogue properties
-  const scene = store.selectScene();
-  const section = scene.sections.find((s) => s.id === sectionId);
-  const prevLine = section.lines.find((s) => s.id === prevLineId);
+    // Re-resolve merge targets from authoritative domain state after the queue
+    // flush so held Backspace cannot operate on stale DOM/store state.
+    const domainState = projectService.getDomainState();
+    const { currentLine, prevLineId, prevLine } = resolveMergeLinesContext(
+      domainState,
+      currentLineId,
+    );
+    resolvedPrevLineId = prevLineId;
 
-  if (!prevLine) {
-    return;
-  }
-
-  // Get previous line content - it's an array of content objects
-  const prevContentArray = prevLine.actions?.dialogue?.content || [];
-  const prevContentText = prevContentArray.map((c) => c.text || "").join("");
-  const mergedContent = prevContentText + contentToAppend;
-
-  // Store the length of the previous content for cursor positioning
-  const prevContentLength = prevContentText.length;
-
-  // Get existing dialogue data to preserve layoutId and characterId
-  let existingDialogue = {};
-  if (prevLine.actions?.dialogue) {
-    existingDialogue = prevLine.actions.dialogue;
-  }
-
-  const finalContent = [{ text: mergedContent }];
-  // Update previous line with merged content
-  await projectService.updateLineActions({
-    lineId: prevLineId,
-    patch: {
-      dialogue: {
-        ...existingDialogue,
-        content: finalContent,
-      },
-    },
-    replace: false,
-  });
-
-  await projectService.deleteLineItem({ lineId: currentLineId });
-
-  // Update repository state in store to reflect the changes
-  syncStoreProjectState(store, projectService);
-
-  // Update selected line to the previous one
-  store.setSelectedLineId({ selectedLineId: prevLineId });
-
-  // Pre-configure the linesEditor for cursor positioning
-  const refIds = refs;
-  const linesEditorRef = refIds["linesEditor"];
-
-  if (linesEditorRef) {
-    // Set cursor position to where the previous content ended
-    linesEditorRef.store.setCursorPosition({ position: prevContentLength });
-    linesEditorRef.store.setGoalColumn({ goalColumn: prevContentLength });
-    linesEditorRef.store.setIsNavigating({ isNavigating: true });
-  }
-
-  // Render and then focus
-  render();
-
-  requestAnimationFrame(() => {
-    if (linesEditorRef) {
-      linesEditorRef.transformedHandlers.updateSelectedLine({
-        currentLineId: prevLineId,
-      });
-      linesEditorRef.render();
+    if (!currentLine || !prevLineId || !prevLine) {
+      return;
     }
 
-    requestAnimationFrame(() => {
-      store.clearLockingLineId();
-    });
-  });
+    const prevContentText = getDialogueText(prevLine);
+    const currentContentText = getDialogueText(currentLine);
+    const mergedContent = prevContentText + currentContentText;
 
-  // Trigger debounced canvas render
-  subject.dispatch("sceneEditor.renderCanvas", {});
+    // Store the length of the previous content for cursor positioning
+    const prevContentLength = prevContentText.length;
+
+    // Get existing dialogue data to preserve layoutId and characterId
+    let existingDialogue = {};
+    if (prevLine.actions?.dialogue) {
+      existingDialogue = prevLine.actions.dialogue;
+    }
+
+    const finalContent = [{ text: mergedContent }];
+    // Update previous line with merged content
+    await projectService.updateLineActions({
+      lineId: prevLineId,
+      patch: {
+        dialogue: {
+          ...existingDialogue,
+          content: finalContent,
+        },
+      },
+      replace: false,
+    });
+
+    // Re-check existence in case another merge/delete removed the line while the
+    // previous update command was being processed.
+    if (!projectService.getDomainState()?.lines?.[currentLineId]) {
+      return;
+    }
+
+    try {
+      await projectService.deleteLineItem({ lineId: currentLineId });
+    } catch (error) {
+      if (isMissingLinePreconditionError(error, currentLineId)) {
+        return;
+      }
+
+      throw error;
+    }
+
+    // Update repository state in store to reflect the changes
+    syncStoreProjectState(store, projectService);
+
+    // Update selected line to the previous one
+    store.setSelectedLineId({ selectedLineId: prevLineId });
+
+    // Pre-configure the linesEditor for cursor positioning
+    const linesEditorRef = getLinesEditorRef(refs);
+
+    // Render and then focus
+    render();
+    shouldReleaseLockAfterFocus = true;
+
+    requestAnimationFrame(() => {
+      if (linesEditorRef) {
+        linesEditorRef.focusLine({
+          lineId: prevLineId,
+          cursorPosition: prevContentLength,
+          goalColumn: prevContentLength,
+          direction: null,
+        });
+      }
+
+      requestAnimationFrame(() => {
+        store.clearLockingLineId();
+      });
+    });
+
+    // Trigger debounced canvas render
+    subject.dispatch("sceneEditor.renderCanvas", {});
+  } catch (error) {
+    if (
+      isMissingLinePreconditionError(error, currentLineId) ||
+      isMissingLinePreconditionError(error, resolvedPrevLineId)
+    ) {
+      return;
+    }
+
+    throw error;
+  } finally {
+    if (!shouldReleaseLockAfterFocus) {
+      store.clearLockingLineId();
+    }
+  }
 };
 
 export const handleSectionTabRightClick = (deps, payload) => {

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -569,7 +569,6 @@ export const selectViewData = ({ state }) => {
       ),
       isSceneAssetLoading: state.isSceneAssetLoading,
       deadEndTooltip: state.deadEndTooltip,
-      isLineOperationLocked: !!state.lockingLineId,
     };
   }
 
@@ -717,7 +716,6 @@ export const selectViewData = ({ state }) => {
     muteIcon: state.isMuted ? "mute" : "unmute",
     isSceneAssetLoading: state.isSceneAssetLoading,
     deadEndTooltip: state.deadEndTooltip,
-    isLineOperationLocked: !!state.lockingLineId,
   };
 };
 

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -497,6 +497,49 @@ export const setLineTextContent = ({ state }, { lineId, content } = {}) => {
   }
 };
 
+export const splitLineOptimistically = (
+  { state },
+  { sectionId, lineId, newLineId, leftContent, newLineActions } = {},
+) => {
+  if (!sectionId || !lineId || !newLineId) {
+    return;
+  }
+
+  const section = state.domainState?.sections?.[sectionId];
+  const currentLine = state.domainState?.lines?.[lineId];
+  if (!section || !currentLine) {
+    return;
+  }
+
+  if (!currentLine.actions) {
+    currentLine.actions = {};
+  }
+
+  const existingDialogue = currentLine.actions.dialogue || {};
+  currentLine.actions.dialogue = {
+    ...existingDialogue,
+    content: leftContent || [{ text: "" }],
+  };
+  currentLine.updatedAt = Date.now();
+
+  if (!state.domainState.lines) {
+    state.domainState.lines = {};
+  }
+
+  state.domainState.lines[newLineId] = {
+    id: newLineId,
+    sectionId,
+    actions: structuredClone(newLineActions || {}),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+
+  const currentIndex = section.lineIds.indexOf(lineId);
+  const insertIndex =
+    currentIndex >= 0 ? currentIndex + 1 : section.lineIds.length;
+  section.lineIds.splice(insertIndex, 0, newLineId);
+};
+
 export const selectProjectData = ({ state }) => {
   return constructProjectData(state.repositoryState);
 };
@@ -526,6 +569,7 @@ export const selectViewData = ({ state }) => {
       ),
       isSceneAssetLoading: state.isSceneAssetLoading,
       deadEndTooltip: state.deadEndTooltip,
+      isLineOperationLocked: !!state.lockingLineId,
     };
   }
 
@@ -673,6 +717,7 @@ export const selectViewData = ({ state }) => {
     muteIcon: state.isMuted ? "mute" : "unmute",
     isSceneAssetLoading: state.isSceneAssetLoading,
     deadEndTooltip: state.deadEndTooltip,
+    isLineOperationLocked: !!state.lockingLineId,
   };
 };
 

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -138,7 +138,7 @@ template:
                           - rtgl-text s=sm: ...
                       - rtgl-view w=1fg: null
                   - rtgl-view w=f p=md sv h=1fg:
-                      - rvn-lines-editor#linesEditor :lines=currentLines :selectedLineId=selectedLineId :sectionLineChanges=sectionLineChanges :repositoryState=repositoryState :isLineOperationLocked=isLineOperationLocked: null
+                      - rvn-lines-editor#linesEditor :lines=currentLines :selectedLineId=selectedLineId :sectionLineChanges=sectionLineChanges :repositoryState=repositoryState: null
                       - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null
           - rtgl-view w=f:

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -138,7 +138,7 @@ template:
                           - rtgl-text s=sm: ...
                       - rtgl-view w=1fg: null
                   - rtgl-view w=f p=md sv h=1fg:
-                      - rvn-lines-editor#linesEditor :lines=currentLines :selectedLineId=selectedLineId :sectionLineChanges=sectionLineChanges: null
+                      - rvn-lines-editor#linesEditor :lines=currentLines :selectedLineId=selectedLineId :sectionLineChanges=sectionLineChanges :repositoryState=repositoryState :isLineOperationLocked=isLineOperationLocked: null
                       - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null
           - rtgl-view w=f:

--- a/src/utils/debugLog.js
+++ b/src/utils/debugLog.js
@@ -1,5 +1,4 @@
 let debugSequence = 0;
-const ALWAYS_ENABLED_SCOPES = new Set(["lines"]);
 
 const getWindowDebugKey = (scope) => {
   return `__RVN_DEBUG_${String(scope || "")
@@ -8,10 +7,6 @@ const getWindowDebugKey = (scope) => {
 };
 
 export const isDebugEnabled = (scope) => {
-  if (ALWAYS_ENABLED_SCOPES.has(scope)) {
-    return true;
-  }
-
   if (typeof window === "undefined") {
     return false;
   }

--- a/src/utils/debugLog.js
+++ b/src/utils/debugLog.js
@@ -1,0 +1,53 @@
+let debugSequence = 0;
+const ALWAYS_ENABLED_SCOPES = new Set(["lines"]);
+
+const getWindowDebugKey = (scope) => {
+  return `__RVN_DEBUG_${String(scope || "")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .toUpperCase()}__`;
+};
+
+export const isDebugEnabled = (scope) => {
+  if (ALWAYS_ENABLED_SCOPES.has(scope)) {
+    return true;
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const windowKey = getWindowDebugKey(scope);
+  if (window.__RVN_DEBUG_ALL__ === true || window[windowKey] === true) {
+    return true;
+  }
+
+  return false;
+};
+
+export const previewDebugText = (value, maxLength = 120) => {
+  const text = String(value ?? "");
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength)}...`;
+};
+
+export const debugLog = (scope, event, data = {}) => {
+  if (!isDebugEnabled(scope)) {
+    return;
+  }
+
+  debugSequence += 1;
+  const timestamp =
+    typeof performance !== "undefined" && typeof performance.now === "function"
+      ? Number(performance.now().toFixed(2))
+      : Date.now();
+
+  console.log(`[rvn.debug.${scope}]`, {
+    seq: debugSequence,
+    event,
+    ts: timestamp,
+    ...data,
+  });
+};


### PR DESCRIPTION
## Summary
- stabilize scene editor and lines editor coordination around line splitting and merging
- expose focused linesEditor methods so sceneEditor stops reaching into child internals
- add trace logging and queue hardening to investigate and reduce split/input race conditions

## Validation
- bun x oxlint src/components/linesEditor src/pages/sceneEditor src/deps/services/pendingQueueService.js src/utils/debugLog.js
- bun x prettier --check src/components/linesEditor src/pages/sceneEditor src/deps/services/pendingQueueService.js src/utils/debugLog.js
- bun run build:web
- manual local verification of the scene editor Enter and Backspace flows during debugging
