### PR TITLE
refactor: extract scene editing feature boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,9 @@ Read the links from the following files to familiarize with the code before star
 - Push domain logic, validation, and async complexity into services.
 - Route-level async setup/loading should be handled in app-level orchestration, not repeated in page handlers.
 - Prefer single-purpose store actions (`setCurrentProject`, etc.) over multiple related setter calls.
+- Do not call browser globals like `document` or `window` directly from page handlers for cross-cutting side effects.
+- If a handler needs browser-side behavior such as blurring the active element, global focus changes, history changes, or global listeners, route that through `deps/services` or `deps/infra`.
+- Keep low-level DOM-heavy behavior in `src/primitives/` or in components that own that DOM surface directly.
 
 ## Detail Panel Pattern
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -192,6 +192,35 @@ Handlers must stay thin.
 Stores must not absorb domain logic.
 Views must stay declarative.
 
+## Browser Side Effects
+
+Page and component handlers must not reach for browser globals directly for
+cross-cutting side effects such as:
+
+- `document.activeElement.blur()`
+- `window.addEventListener(...)`
+- `document.querySelector(...)` outside local component DOM ownership
+- global focus, history, or viewport manipulation
+
+Those side effects must live behind an explicit dependency or primitive:
+
+- `src/deps/services/shared/*` when the behavior is app-shell/browser
+  orchestration
+- `src/deps/infra/*` for low-level platform adapters
+- `src/primitives/*` for DOM-heavy browser primitives such as custom elements
+
+This keeps page handlers orchestration-only and prevents hidden browser
+coupling from spreading through route code.
+
+Allowed exceptions:
+
+- local DOM work inside a primitive
+- local DOM work inside a reusable component when that DOM is the component's
+  owned editing or interaction surface
+
+If a page handler needs to affect browser state, add a method to `deps` and
+call that method instead of touching `window` or `document` directly.
+
 ## Resource Page Pattern
 
 Resource pages should stay explicit at the page level.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -256,6 +256,51 @@ They must not own:
 When a set of resource pages shares the same interaction model, add a family-specific component and shared feature helpers.
 Do not force unrelated resource pages into one universal resource-page system.
 
+## Scene Editor Pattern
+
+Scene editing uses three layers:
+
+- `src/primitives/editableText.js`
+  low-level contenteditable/caret behavior
+- `src/components/linesEditor/`
+  UI-only editing surface for line focus, keyboard handling, caret movement,
+  and semantic editor events
+- `src/deps/features/sceneEditing/`
+  shared scene-editing workflows such as line mutations, dialogue queue
+  coordination, and line view-model shaping
+- `src/pages/sceneEditor/`
+  page orchestration, asset loading, preview/canvas rendering, and dialogs
+
+Current scene-editing feature modules:
+
+- `lineViewModels.js`
+  builds enriched line view models for the editor surface
+- `lineOperations.js`
+  owns split/merge/new/paste/swap flows and dialogue queue writes
+- `runtime.js`
+  owns scene-editor runtime concerns such as asset loading, canvas rendering,
+  preview reset, and render subscriptions
+- `sectionOperations.js`
+  owns section selection, section creation, and section-selection reconciliation
+
+Keep `linesEditor` in its fixed Rettangoli component files.
+Do not add ad hoc sibling helper files inside the component folder when the
+logic is really scene-editing orchestration.
+
+`linesEditor` must not own:
+
+- repository or domain state reads
+- project service orchestration
+- split/merge/create/delete persistence workflows
+- scene-specific preview and badge shaping
+
+Those responsibilities belong in `src/deps/features/sceneEditing/` and
+`src/pages/sceneEditor/`.
+
+`sceneEditor.handlers.js` should stay as the page composition layer.
+It may export many handlers because of the framework contract, but the heavy
+work should be delegated into `src/deps/features/sceneEditing/`.
+
 ## Public Service Facades
 
 UI handlers should normally talk to only:

--- a/src/components/linesEditor/linesEditor.schema.yaml
+++ b/src/components/linesEditor/linesEditor.schema.yaml
@@ -9,10 +9,6 @@ propsSchema:
         properties: null
     selectedLineId:
       type: string
-    sectionLineChanges:
-      type: object
-    repositoryState:
-      type: object
 methods:
   type: object
   properties:

--- a/src/components/linesEditor/linesEditor.store.js
+++ b/src/components/linesEditor/linesEditor.store.js
@@ -1,5 +1,3 @@
-import { toFlatItems } from "../../domain/treeHelpers.js";
-
 export const createInitialState = () => ({
   ready: false,
   mode: "block", // 'block' or 'text-editor'
@@ -9,7 +7,6 @@ export const createInitialState = () => ({
   navigationDirection: null, // 'up', 'down', 'end', or null - for proper cursor positioning
   awaitingCharacterShortcut: false,
   awaitingDeleteShortcut: false,
-  repositoryState: {},
 });
 
 export const setMode = ({ state }, { mode } = {}) => {
@@ -22,11 +19,6 @@ export const setMode = ({ state }, { mode } = {}) => {
 
 export const setReady = ({ state }, _payload = {}) => {
   state.ready = true;
-};
-
-// Compatibility shim while the linesEditor repository dependency is moving to props.
-export const setRepositoryState = ({ state }, { repositoryState } = {}) => {
-  state.repositoryState = repositoryState || {};
 };
 
 export const setCursorPosition = ({ state }, { position } = {}) => {
@@ -94,206 +86,16 @@ export const selectLineContent = ({ props }, payload) => {
 };
 
 export const selectViewData = ({ state, props }) => {
-  const repositoryState = props.repositoryState || state.repositoryState || {};
-  const sectionLineChanges = props.sectionLineChanges || {};
-  const changesLines = sectionLineChanges.lines || [];
-
-  const lines = (props.lines || []).map((line, i) => {
+  const lines = (props.lines || []).map((line, index) => {
     const isSelected = props.selectedLineId === line.id;
     const isBlockMode = state.mode === "block";
 
-    // Find changes for this line
-    const lineChanges = changesLines.find((change) => change.id === line.id);
-    const changes = lineChanges?.changes || {};
-
-    // Process background changes
-    let background;
-    if (changes.background) {
-      const bgData = changes.background.data || {};
-      background = {
-        changeType: changes.background.changeType,
-        resourceId: bgData.resourceId,
-        fileId: repositoryState.images?.items?.[bgData.resourceId]?.fileId,
-      };
-    }
-
-    // Process character changes
-    let characterSprites;
-    if (changes.character) {
-      const charData = changes.character.data || {};
-      if (charData.items && charData.items.length > 0) {
-        characterSprites = {
-          changeType: changes.character.changeType,
-          items: charData.items
-            .map((char) => {
-              const character = repositoryState.characters?.items?.[char.id];
-              let spriteFileId = null;
-
-              if (
-                char.sprites &&
-                char.sprites.length > 0 &&
-                character?.sprites
-              ) {
-                const firstSprite = char.sprites[0];
-                if (firstSprite.resourceId) {
-                  const flatSprites = toFlatItems(character.sprites);
-                  const sprite = flatSprites.find(
-                    (s) => s.id === firstSprite.resourceId,
-                  );
-                  if (sprite?.fileId) {
-                    spriteFileId = sprite.fileId;
-                  } else if (
-                    repositoryState.images?.items?.[firstSprite.resourceId]
-                  ) {
-                    spriteFileId =
-                      repositoryState.images.items[firstSprite.resourceId]
-                        .fileId;
-                  }
-                }
-              }
-
-              return {
-                characterId: char.id,
-                characterName: character?.name || "Unknown",
-                fileId: spriteFileId,
-              };
-            })
-            .filter((char) => char.fileId),
-        };
-      } else {
-        characterSprites = {
-          changeType: changes.character.changeType,
-          items: [],
-        };
-      }
-    }
-
-    // Process BGM changes
-    let bgm;
-    if (changes.bgm) {
-      const bgmData = changes.bgm.data || {};
-      bgm = {
-        changeType: changes.bgm.changeType,
-        resourceId: bgmData.resourceId,
-      };
-    }
-
-    // Process SFX changes
-    let hasSfx = false;
-    let sfxChangeType;
-    if (changes.sfx) {
-      hasSfx = true;
-      sfxChangeType = changes.sfx.changeType;
-    }
-
-    // Process Set Next Line Config changes
-    let hasSetNextLineConfig = false;
-    let setNextLineConfigChangeType;
-    if (changes.setNextLineConfig) {
-      hasSetNextLineConfig = true;
-      setNextLineConfigChangeType = changes.setNextLineConfig.changeType;
-    }
-
-    // Process dialogue layout changes
-    let hasDialogueLayout = false;
-    let dialogueChangeType;
-    if (changes.dialogue) {
-      hasDialogueLayout = true;
-      dialogueChangeType = changes.dialogue.changeType;
-    }
-
-    // Process base changes
-    let hasBase = false;
-    let baseChangeType;
-    if (changes.base) {
-      hasBase = true;
-      baseChangeType = changes.base.changeType;
-    }
-
-    // Dialogue character icon (who is speaking) - still from line.actions
-    let characterFileId;
-    if (line.actions?.dialogue?.characterId) {
-      const characters = toFlatItems(repositoryState.characters || []);
-      const character = characters.find(
-        (c) => c.id === line.actions.dialogue.characterId,
-      );
-      if (character && character.fileId) {
-        characterFileId = character.fileId;
-      }
-    }
-
-    // Section transitions and choices - still from line.actions
-    let sectionTransition;
-    let transitionTarget;
-    let hasChoices;
-    let choices;
-
-    const sectionTransitionData =
-      line.actions?.sectionTransition ||
-      line.actions?.actions?.sectionTransition;
-    if (sectionTransitionData) {
-      if (sectionTransitionData.sceneId) {
-        sectionTransition = true;
-        const allScenes = toFlatItems(repositoryState.scenes || []);
-        const targetScene = allScenes.find(
-          (scene) => scene.id === sectionTransitionData.sceneId,
-        );
-        transitionTarget = targetScene?.name || "Unknown Scene";
-      } else if (sectionTransitionData.sectionId) {
-        sectionTransition = true;
-        const allScenes = toFlatItems(repositoryState.scenes || []);
-        let sectionName = "Unknown Section";
-        for (const scene of allScenes) {
-          if (scene.sections) {
-            const sections = toFlatItems(scene.sections);
-            const targetSection = sections.find(
-              (section) => section.id === sectionTransitionData.sectionId,
-            );
-            if (targetSection) {
-              sectionName = targetSection.name || sectionName;
-              break;
-            }
-          }
-        }
-        transitionTarget = sectionName;
-      }
-    }
-
-    const choicesData = line.actions?.choice || line.actions?.actions?.choice;
-    if (choicesData && choicesData.items && choicesData.items.length > 0) {
-      hasChoices = true;
-      choices = choicesData.items;
-    }
-
-    if (
-      line.actions?.setNextLineConfig ||
-      line.actions?.actions?.setNextLineConfig
-    ) {
-      hasSetNextLineConfig = true;
-    }
-
     return {
       ...line,
-      lineNumber: i + 1,
+      lineNumber: line.lineNumber ?? index + 1,
       lineColor: isSelected ? "fg" : "mu-fg",
-      background,
-      bgm,
       backgroundColor:
         isSelected && isBlockMode ? "var(--muted)" : "transparent",
-      characterFileId,
-      characterSprites,
-      sectionTransition,
-      transitionTarget,
-      hasChoices,
-      choices,
-      hasSfx,
-      sfxChangeType,
-      hasSetNextLineConfig,
-      setNextLineConfigChangeType,
-      hasDialogueLayout,
-      dialogueChangeType,
-      hasBase,
-      baseChangeType,
     };
   });
 

--- a/src/deps/features/sceneEditing/lineOperations.js
+++ b/src/deps/features/sceneEditing/lineOperations.js
@@ -1,0 +1,650 @@
+import { nanoid } from "nanoid";
+import { debugLog, previewDebugText } from "../../../utils/debugLog.js";
+
+const getLinesEditorRef = (refs) => {
+  return refs?.linesEditor;
+};
+
+const getDialogueText = (line) => {
+  return (line?.actions?.dialogue?.content || [])
+    .map((item) => item?.text ?? "")
+    .join("");
+};
+
+const isMinimalAdvDialogue = (dialogue) => {
+  if (!dialogue || typeof dialogue !== "object") {
+    return false;
+  }
+
+  const keysWithoutContent = Object.keys(dialogue).filter(
+    (key) => key !== "content",
+  );
+
+  return keysWithoutContent.length === 1 && dialogue.mode === "adv";
+};
+
+const shouldInheritNvlModeFromPreviousLine = ({
+  domainState,
+  sectionId,
+  lineId,
+  existingDialogue,
+}) => {
+  const section = domainState?.sections?.[sectionId];
+  if (!section) {
+    return false;
+  }
+
+  if (existingDialogue?.mode === "nvl") {
+    return false;
+  }
+
+  if (existingDialogue?.mode && !isMinimalAdvDialogue(existingDialogue)) {
+    return false;
+  }
+
+  const lineOrder = section.lineIds || [];
+  const currentIndex = lineOrder.indexOf(lineId);
+  if (currentIndex <= 0) {
+    return false;
+  }
+
+  const previousLineId = lineOrder[currentIndex - 1];
+  if (!previousLineId) {
+    return false;
+  }
+
+  const previousDialogue =
+    domainState?.lines?.[previousLineId]?.actions?.dialogue;
+  return previousDialogue?.mode === "nvl";
+};
+
+const resolveMergeLinesContext = (domainState, currentLineId) => {
+  const currentLine = domainState?.lines?.[currentLineId];
+  const sectionId = currentLine?.sectionId;
+  const section = sectionId ? domainState?.sections?.[sectionId] : undefined;
+  const lineIds = section?.lineIds || [];
+  const currentIndex = lineIds.indexOf(currentLineId);
+
+  if (!currentLine || currentIndex <= 0) {
+    return {};
+  }
+
+  const prevLineId = lineIds[currentIndex - 1];
+  const prevLine = domainState?.lines?.[prevLineId];
+
+  if (!prevLineId || !prevLine) {
+    return {};
+  }
+
+  return {
+    currentLine,
+    prevLineId,
+    prevLine,
+  };
+};
+
+const isMissingLinePreconditionError = (error, lineId) => {
+  return (
+    error?.name === "DomainPreconditionError" &&
+    error?.message === "line not found" &&
+    (!lineId || error?.details?.lineId === lineId)
+  );
+};
+
+export const syncSceneEditorProjectState = (store, projectService) => {
+  const repositoryState = projectService.getState();
+  store.setRepositoryState({ repository: repositoryState });
+  store.setDomainState({
+    domainState: projectService.getDomainState(),
+  });
+  return repositoryState;
+};
+
+export const writeDialogueContent = async (
+  deps,
+  lineId,
+  { sectionId, content },
+) => {
+  const { projectService } = deps;
+  const domainState = projectService.getDomainState();
+  const existingDialogue =
+    domainState?.lines?.[lineId]?.actions?.dialogue || {};
+  const shouldInheritNvlMode = shouldInheritNvlModeFromPreviousLine({
+    domainState,
+    sectionId,
+    lineId,
+    existingDialogue,
+  });
+
+  debugLog("lines", "scene.write-dialogue", {
+    lineId,
+    sectionId,
+    contentLength: (content || []).map((item) => item?.text ?? "").join("")
+      .length,
+    content: previewDebugText(
+      (content || []).map((item) => item?.text ?? "").join(""),
+    ),
+  });
+
+  await projectService.updateLineActions({
+    lineId,
+    patch: {
+      dialogue: {
+        ...existingDialogue,
+        ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
+        content,
+      },
+    },
+    replace: false,
+  });
+};
+
+export const flushDialogueQueue = async (deps) => {
+  const { dialogueQueueService } = deps;
+
+  debugLog("lines", "scene.flush-dialogue-queue:start", {
+    pendingSize: dialogueQueueService.size(),
+  });
+
+  await dialogueQueueService.flush(async (lineId, data) => {
+    await writeDialogueContent(deps, lineId, data);
+  });
+
+  debugLog("lines", "scene.flush-dialogue-queue:end", {
+    pendingSize: dialogueQueueService.size(),
+  });
+};
+
+export const applyPendingDialogueQueueToStore = (
+  store,
+  dialogueQueueService,
+) => {
+  for (const [lineId, data] of dialogueQueueService.entries()) {
+    if (!lineId || !Array.isArray(data?.content)) {
+      continue;
+    }
+
+    store.setLineTextContent({
+      lineId,
+      content: data.content,
+    });
+  }
+};
+
+export const findCharacterIdByShortcut = (repositoryState, shortcut) => {
+  const normalizedShortcut = String(shortcut || "").trim();
+  if (!normalizedShortcut) {
+    return null;
+  }
+
+  const characters = repositoryState?.characters?.items || {};
+  for (const [characterId, character] of Object.entries(characters)) {
+    if (character?.type !== "character") {
+      continue;
+    }
+
+    if (String(character?.shortcut || "").trim() === normalizedShortcut) {
+      return characterId;
+    }
+  }
+
+  return null;
+};
+
+export const handleSplitLineOperation = async (deps, payload) => {
+  const { projectService, store, render, refs, subject } = deps;
+  const sectionId = store.selectSelectedSectionId();
+  const { lineId, leftContent, rightContent } = payload._event.detail;
+  const lockingLineId = store.selectLockingLineId();
+
+  if (lockingLineId === lineId) {
+    return;
+  }
+
+  store.setLockingLineId({ lineId });
+  let shouldReleaseLockAfterFocus = false;
+
+  try {
+    const newLineId = nanoid();
+    await flushDialogueQueue(deps);
+
+    const domainState = projectService.getDomainState();
+    const existingDialogue =
+      domainState?.lines?.[lineId]?.actions?.dialogue || {};
+
+    debugLog("lines", "scene.split.after-flush", {
+      lineId,
+      newLineId,
+      domainContent: previewDebugText(
+        (domainState?.lines?.[lineId]?.actions?.dialogue?.content || [])
+          .map((item) => item?.text ?? "")
+          .join(""),
+      ),
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
+    });
+
+    const leftContentArray = leftContent
+      ? [{ text: leftContent }]
+      : [{ text: "" }];
+
+    await projectService.updateLineActions({
+      lineId,
+      patch: {
+        dialogue: {
+          ...existingDialogue,
+          content: leftContentArray,
+        },
+      },
+      replace: false,
+    });
+
+    const rightContentArray = rightContent
+      ? [{ text: rightContent }]
+      : [{ text: "" }];
+    const shouldInheritNvl =
+      existingDialogue?.mode === "nvl" ||
+      shouldInheritNvlModeFromPreviousLine({
+        domainState,
+        sectionId,
+        lineId,
+        existingDialogue,
+      });
+    const shouldCreateDialogueAction = shouldInheritNvl || !!rightContent;
+    const newLineActions = shouldCreateDialogueAction
+      ? {
+          dialogue: {
+            mode: shouldInheritNvl ? "nvl" : "adv",
+            ...(rightContent ? { content: rightContentArray } : {}),
+          },
+        }
+      : {};
+
+    const linesEditorRef = getLinesEditorRef(refs);
+    debugLog("lines", "scene.split.start", {
+      lineId,
+      sectionId,
+      newLineId,
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
+    });
+
+    await projectService.createLineItem({
+      sectionId,
+      lineId: newLineId,
+      line: {
+        actions: newLineActions,
+      },
+      afterLineId: lineId,
+    });
+    debugLog("lines", "scene.split.created-line", {
+      lineId,
+      newLineId,
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
+    });
+
+    syncSceneEditorProjectState(store, projectService);
+    store.setSelectedLineId({ selectedLineId: newLineId });
+    render();
+    shouldReleaseLockAfterFocus = true;
+
+    requestAnimationFrame(() => {
+      linesEditorRef?.focusLine({
+        lineId: newLineId,
+        cursorPosition: 0,
+        goalColumn: 0,
+        direction: "down",
+        syncLineId: lineId,
+      });
+
+      requestAnimationFrame(() => {
+        store.clearLockingLineId();
+      });
+    });
+
+    subject.dispatch("sceneEditor.renderCanvas", {});
+  } finally {
+    if (!shouldReleaseLockAfterFocus) {
+      store.clearLockingLineId();
+    }
+  }
+};
+
+export const handlePasteLinesOperation = async (deps, payload) => {
+  const { projectService, store, render, refs, subject } = deps;
+  const sectionId = store.selectSelectedSectionId();
+  const { lineId, leftContent, rightContent, lines } = payload._event.detail;
+
+  await flushDialogueQueue(deps);
+
+  const domainState = projectService.getDomainState();
+  const existingDialogue =
+    domainState?.lines?.[lineId]?.actions?.dialogue || {};
+  const shouldInheritNvl =
+    existingDialogue?.mode === "nvl" ||
+    shouldInheritNvlModeFromPreviousLine({
+      domainState,
+      sectionId,
+      lineId,
+      existingDialogue,
+    });
+
+  const firstLineContent = leftContent + lines[0];
+  const firstContentArray = [{ text: firstLineContent }];
+  await projectService.updateLineActions({
+    lineId,
+    patch: {
+      dialogue: {
+        ...existingDialogue,
+        content: firstContentArray,
+      },
+    },
+    replace: false,
+  });
+
+  let lastCreatedLineId = lineId;
+  let afterLineId = lineId;
+
+  for (let index = 1; index < lines.length; index++) {
+    const newLineId = nanoid();
+    const isLastLine = index === lines.length - 1;
+    const lineContent = isLastLine ? lines[index] + rightContent : lines[index];
+
+    await projectService.createLineItem({
+      sectionId,
+      lineId: newLineId,
+      line: {
+        actions: {
+          dialogue: {
+            mode: shouldInheritNvl ? "nvl" : "adv",
+            content: [{ text: lineContent }],
+          },
+        },
+      },
+      afterLineId,
+    });
+
+    afterLineId = newLineId;
+    lastCreatedLineId = newLineId;
+  }
+
+  if (lines.length === 1) {
+    const combinedContentArray = [{ text: firstLineContent + rightContent }];
+    await projectService.updateLineActions({
+      lineId,
+      patch: {
+        dialogue: {
+          ...existingDialogue,
+          content: combinedContentArray,
+        },
+      },
+      replace: false,
+    });
+    lastCreatedLineId = lineId;
+  }
+
+  syncSceneEditorProjectState(store, projectService);
+  store.setSelectedLineId({ selectedLineId: lastCreatedLineId });
+  render();
+
+  const linesEditorRef = getLinesEditorRef(refs);
+  const lastLineContent =
+    lines.length === 1
+      ? firstLineContent + rightContent
+      : lines[lines.length - 1] + rightContent;
+  const cursorPosition = lastLineContent.length - rightContent.length;
+
+  requestAnimationFrame(() => {
+    linesEditorRef?.focusLine({
+      lineId: lastCreatedLineId,
+      cursorPosition,
+      goalColumn: cursorPosition,
+      direction: null,
+      syncLineId: lineId,
+    });
+  });
+
+  subject.dispatch("sceneEditor.renderCanvas", {});
+};
+
+export const handleNewLineOperation = async (deps, payload) => {
+  const { store, render, projectService, subject, refs } = deps;
+  const detail = payload?._event?.detail || {};
+  const newLineId = nanoid();
+  const sectionId = store.selectSelectedSectionId();
+  if (!sectionId) {
+    return;
+  }
+
+  const requestedPosition =
+    detail.position === "before" || detail.position === "after"
+      ? detail.position
+      : null;
+  const referenceLineId =
+    typeof detail.lineId === "string" && detail.lineId ? detail.lineId : null;
+  const selectedLine = store.selectSelectedLine();
+  const selectedLineId = store.selectSelectedLineId();
+  const baseLineId = referenceLineId || selectedLineId || selectedLine?.id;
+
+  if (requestedPosition && !baseLineId) {
+    return;
+  }
+
+  await flushDialogueQueue(deps);
+
+  const domainState = projectService.getDomainState();
+  const existingDialogue = baseLineId
+    ? domainState?.lines?.[baseLineId]?.actions?.dialogue || {}
+    : selectedLine?.actions?.dialogue || {};
+  const shouldInheritNvl =
+    existingDialogue?.mode === "nvl" ||
+    shouldInheritNvlModeFromPreviousLine({
+      domainState,
+      sectionId,
+      lineId: baseLineId,
+      existingDialogue,
+    });
+
+  const scene = store.selectScene();
+  const selectedSection = scene?.sections?.find(
+    (section) => section?.id === sectionId,
+  );
+  const orderedLineIds = Array.isArray(selectedSection?.lines)
+    ? selectedSection.lines
+        .map((line) => line?.id)
+        .filter((itemId) => typeof itemId === "string" && itemId)
+    : [];
+  const baseLineIndex = baseLineId ? orderedLineIds.indexOf(baseLineId) : -1;
+
+  let afterLineId = null;
+  if (requestedPosition === "after" && baseLineId) {
+    afterLineId = baseLineId;
+  } else if (requestedPosition === "before" && baseLineId) {
+    afterLineId = baseLineIndex > 0 ? orderedLineIds[baseLineIndex - 1] : null;
+  }
+
+  const createLinePayload = {
+    sectionId,
+    lineId: newLineId,
+    line: {
+      actions: shouldInheritNvl
+        ? {
+            dialogue: {
+              mode: "nvl",
+            },
+          }
+        : {},
+    },
+  };
+
+  if (afterLineId) {
+    createLinePayload.afterLineId = afterLineId;
+  } else if (!requestedPosition) {
+    createLinePayload.position = "last";
+  }
+
+  await projectService.createLineItem(createLinePayload);
+
+  if (requestedPosition === "before" && baseLineIndex === 0) {
+    await projectService.moveLineItem({
+      lineId: newLineId,
+      toSectionId: sectionId,
+      index: 0,
+    });
+  }
+
+  syncSceneEditorProjectState(store, projectService);
+  store.setSelectedLineId({ selectedLineId: newLineId });
+  render();
+
+  const linesEditorRef = getLinesEditorRef(refs);
+  if (requestedPosition && linesEditorRef) {
+    requestAnimationFrame(() => {
+      linesEditorRef.focusLine({
+        lineId: newLineId,
+        cursorPosition: 0,
+        goalColumn: 0,
+        direction: null,
+      });
+    });
+  }
+
+  subject.dispatch("sceneEditor.renderCanvas", {});
+};
+
+export const handleSwapLineOperation = async (deps, payload) => {
+  const { store, projectService, render, subject } = deps;
+  const detail = payload?._event?.detail || {};
+  const direction =
+    detail.direction === "up" || detail.direction === "down"
+      ? detail.direction
+      : null;
+  const lineId =
+    typeof detail.lineId === "string" && detail.lineId
+      ? detail.lineId
+      : store.selectSelectedLineId();
+  const sectionId = store.selectSelectedSectionId();
+
+  if (!direction || !lineId || !sectionId) {
+    return;
+  }
+
+  const scene = store.selectScene();
+  const section = scene?.sections?.find((item) => item.id === sectionId);
+  const lines = Array.isArray(section?.lines) ? section.lines : [];
+  const currentIndex = lines.findIndex((line) => line.id === lineId);
+  if (currentIndex < 0) {
+    return;
+  }
+
+  const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+  if (targetIndex < 0 || targetIndex >= lines.length) {
+    return;
+  }
+
+  await flushDialogueQueue(deps);
+  await projectService.moveLineItem({
+    lineId,
+    toSectionId: sectionId,
+    index: targetIndex,
+  });
+
+  syncSceneEditorProjectState(store, projectService);
+  store.setSelectedLineId({ selectedLineId: lineId });
+  render();
+  subject.dispatch("sceneEditor.renderCanvas", {});
+};
+
+export const handleMergeLinesOperation = async (deps, payload) => {
+  const { store, refs, render, projectService, subject } = deps;
+  const { currentLineId } = payload._event.detail;
+  const lockingLineId = store.selectLockingLineId();
+
+  if (lockingLineId) {
+    return;
+  }
+
+  store.setLockingLineId({ lineId: currentLineId });
+  let shouldReleaseLockAfterFocus = false;
+  let resolvedPrevLineId;
+
+  try {
+    await flushDialogueQueue(deps);
+
+    const domainState = projectService.getDomainState();
+    const { currentLine, prevLineId, prevLine } = resolveMergeLinesContext(
+      domainState,
+      currentLineId,
+    );
+    resolvedPrevLineId = prevLineId;
+
+    if (!currentLine || !prevLineId || !prevLine) {
+      return;
+    }
+
+    const prevContentText = getDialogueText(prevLine);
+    const currentContentText = getDialogueText(currentLine);
+    const prevContentLength = prevContentText.length;
+    const existingDialogue = prevLine.actions?.dialogue || {};
+
+    await projectService.updateLineActions({
+      lineId: prevLineId,
+      patch: {
+        dialogue: {
+          ...existingDialogue,
+          content: [{ text: prevContentText + currentContentText }],
+        },
+      },
+      replace: false,
+    });
+
+    if (!projectService.getDomainState()?.lines?.[currentLineId]) {
+      return;
+    }
+
+    try {
+      await projectService.deleteLineItem({ lineId: currentLineId });
+    } catch (error) {
+      if (isMissingLinePreconditionError(error, currentLineId)) {
+        return;
+      }
+
+      throw error;
+    }
+
+    syncSceneEditorProjectState(store, projectService);
+    store.setSelectedLineId({ selectedLineId: prevLineId });
+    render();
+    shouldReleaseLockAfterFocus = true;
+
+    const linesEditorRef = getLinesEditorRef(refs);
+    requestAnimationFrame(() => {
+      linesEditorRef?.focusLine({
+        lineId: prevLineId,
+        cursorPosition: prevContentLength,
+        goalColumn: prevContentLength,
+        direction: null,
+      });
+
+      requestAnimationFrame(() => {
+        store.clearLockingLineId();
+      });
+    });
+
+    subject.dispatch("sceneEditor.renderCanvas", {});
+  } catch (error) {
+    if (
+      isMissingLinePreconditionError(error, currentLineId) ||
+      isMissingLinePreconditionError(error, resolvedPrevLineId)
+    ) {
+      return;
+    }
+
+    throw error;
+  } finally {
+    if (!shouldReleaseLockAfterFocus) {
+      store.clearLockingLineId();
+    }
+  }
+};

--- a/src/deps/features/sceneEditing/lineViewModels.js
+++ b/src/deps/features/sceneEditing/lineViewModels.js
@@ -1,0 +1,217 @@
+import { toFlatItems } from "../../../domain/treeHelpers.js";
+
+const getLineChanges = (sectionLineChanges, lineId) => {
+  const changesLines = sectionLineChanges?.lines || [];
+  const lineChanges = changesLines.find((change) => change.id === lineId);
+  return lineChanges?.changes || {};
+};
+
+const buildCharacterLookups = (repositoryState) => {
+  const characterItems = repositoryState?.characters?.items || {};
+  const flatCharacters = toFlatItems(repositoryState?.characters || []);
+  const flatCharacterById = new Map(
+    flatCharacters.map((character) => [character.id, character]),
+  );
+
+  return {
+    characterItems,
+    flatCharacterById,
+  };
+};
+
+const buildSceneLookups = (repositoryState) => {
+  const flatScenes = toFlatItems(repositoryState?.scenes || []);
+  const sceneNameById = new Map();
+  const sectionNameById = new Map();
+
+  for (const scene of flatScenes) {
+    sceneNameById.set(scene.id, scene.name || "Unknown Scene");
+
+    if (!scene.sections) {
+      continue;
+    }
+
+    const flatSections = toFlatItems(scene.sections);
+    for (const section of flatSections) {
+      sectionNameById.set(section.id, section.name || "Unknown Section");
+    }
+  }
+
+  return {
+    sceneNameById,
+    sectionNameById,
+  };
+};
+
+const resolveCharacterSpriteFileId = ({
+  repositoryState,
+  character,
+  firstSprite,
+}) => {
+  if (!firstSprite?.resourceId || !character?.sprites) {
+    return undefined;
+  }
+
+  const flatSprites = toFlatItems(character.sprites);
+  const sprite = flatSprites.find((item) => item.id === firstSprite.resourceId);
+  if (sprite?.fileId) {
+    return sprite.fileId;
+  }
+
+  return repositoryState?.images?.items?.[firstSprite.resourceId]?.fileId;
+};
+
+const buildBackgroundPreview = (repositoryState, changes) => {
+  if (!changes.background) {
+    return undefined;
+  }
+
+  const backgroundData = changes.background.data || {};
+  return {
+    changeType: changes.background.changeType,
+    resourceId: backgroundData.resourceId,
+    fileId: repositoryState?.images?.items?.[backgroundData.resourceId]?.fileId,
+  };
+};
+
+const buildCharacterSpritePreview = (
+  repositoryState,
+  changes,
+  characterItems,
+) => {
+  if (!changes.character) {
+    return undefined;
+  }
+
+  const characterData = changes.character.data || {};
+  if (!Array.isArray(characterData.items) || characterData.items.length === 0) {
+    return {
+      changeType: changes.character.changeType,
+      items: [],
+    };
+  }
+
+  return {
+    changeType: changes.character.changeType,
+    items: characterData.items
+      .map((characterChange) => {
+        const character = characterItems[characterChange.id];
+        return {
+          characterId: characterChange.id,
+          characterName: character?.name || "Unknown",
+          fileId: resolveCharacterSpriteFileId({
+            repositoryState,
+            character,
+            firstSprite: characterChange.sprites?.[0],
+          }),
+        };
+      })
+      .filter((item) => item.fileId),
+  };
+};
+
+const buildSectionTransitionPreview = (line, sceneLookups) => {
+  const transitionData =
+    line.actions?.sectionTransition || line.actions?.actions?.sectionTransition;
+  if (!transitionData) {
+    return {
+      sectionTransition: false,
+      transitionTarget: undefined,
+    };
+  }
+
+  if (transitionData.sceneId) {
+    return {
+      sectionTransition: true,
+      transitionTarget:
+        sceneLookups.sceneNameById.get(transitionData.sceneId) ||
+        "Unknown Scene",
+    };
+  }
+
+  if (transitionData.sectionId) {
+    return {
+      sectionTransition: true,
+      transitionTarget:
+        sceneLookups.sectionNameById.get(transitionData.sectionId) ||
+        "Unknown Section",
+    };
+  }
+
+  return {
+    sectionTransition: false,
+    transitionTarget: undefined,
+  };
+};
+
+const buildChoicesPreview = (line) => {
+  const choicesData = line.actions?.choice || line.actions?.actions?.choice;
+  if (!choicesData?.items?.length) {
+    return {
+      hasChoices: false,
+      choices: undefined,
+    };
+  }
+
+  return {
+    hasChoices: true,
+    choices: choicesData.items,
+  };
+};
+
+const buildDialogueSpeakerPreview = (line, characterLookups) => {
+  const characterId = line.actions?.dialogue?.characterId;
+  if (!characterId) {
+    return undefined;
+  }
+
+  return characterLookups.flatCharacterById.get(characterId)?.fileId;
+};
+
+export const buildSceneEditorLineViewModels = ({
+  lines,
+  repositoryState,
+  sectionLineChanges,
+}) => {
+  const characterLookups = buildCharacterLookups(repositoryState);
+  const sceneLookups = buildSceneLookups(repositoryState);
+
+  return (lines || []).map((line, index) => {
+    const changes = getLineChanges(sectionLineChanges, line.id);
+    const transitionPreview = buildSectionTransitionPreview(line, sceneLookups);
+    const choicesPreview = buildChoicesPreview(line);
+
+    return {
+      ...line,
+      lineNumber: index + 1,
+      background: buildBackgroundPreview(repositoryState, changes),
+      bgm: changes.bgm
+        ? {
+            changeType: changes.bgm.changeType,
+            resourceId: changes.bgm.data?.resourceId,
+          }
+        : undefined,
+      characterFileId: buildDialogueSpeakerPreview(line, characterLookups),
+      characterSprites: buildCharacterSpritePreview(
+        repositoryState,
+        changes,
+        characterLookups.characterItems,
+      ),
+      sectionTransition: transitionPreview.sectionTransition,
+      transitionTarget: transitionPreview.transitionTarget,
+      hasChoices: choicesPreview.hasChoices,
+      choices: choicesPreview.choices,
+      hasSfx: !!changes.sfx,
+      sfxChangeType: changes.sfx?.changeType,
+      hasSetNextLineConfig:
+        !!changes.setNextLineConfig ||
+        !!line.actions?.setNextLineConfig ||
+        !!line.actions?.actions?.setNextLineConfig,
+      setNextLineConfigChangeType: changes.setNextLineConfig?.changeType,
+      hasDialogueLayout: !!changes.dialogue,
+      dialogueChangeType: changes.dialogue?.changeType,
+      hasBase: !!changes.base,
+      baseChangeType: changes.base?.changeType,
+    };
+  });
+};

--- a/src/deps/features/sceneEditing/runtime.js
+++ b/src/deps/features/sceneEditing/runtime.js
@@ -1,0 +1,530 @@
+import { debounceTime, filter, tap } from "rxjs";
+import {
+  extractFileIdsForLayouts,
+  extractFileIdsForScenes,
+  extractInitialHybridSceneIds,
+  extractLayoutIdsFromValue,
+  extractSceneIdsFromValue,
+  extractTransitionTargetSceneIds,
+  extractTransitionTargetSceneIdsFromActions,
+  resolveEventBindings,
+} from "../../../utils/index.js";
+import { writeDialogueContent } from "./lineOperations.js";
+
+const createAssetLoadCache = () => ({
+  sceneIds: new Set(),
+  fileIds: new Set(),
+});
+
+let assetLoadCache = createAssetLoadCache();
+
+const resetAssetLoadCache = () => {
+  assetLoadCache = createAssetLoadCache();
+};
+
+const findNonCloneablePaths = (root, limit = 5) => {
+  const paths = [];
+  const queue = [{ value: root, path: "$" }];
+  const visited = new WeakSet();
+
+  const isWindowLike = (value) =>
+    typeof window !== "undefined" && value === window;
+  const isNodeLike = (value) =>
+    typeof Node !== "undefined" && value instanceof Node;
+  const isEventLike = (value) =>
+    typeof Event !== "undefined" && value instanceof Event;
+
+  while (queue.length > 0 && paths.length < limit) {
+    const { value, path } = queue.shift();
+
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+
+    if (isWindowLike(value) || isNodeLike(value) || isEventLike(value)) {
+      paths.push(path);
+      continue;
+    }
+
+    if (visited.has(value)) {
+      continue;
+    }
+    visited.add(value);
+
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => {
+        queue.push({ value: item, path: `${path}[${index}]` });
+      });
+      continue;
+    }
+
+    Object.entries(value).forEach(([key, item]) => {
+      queue.push({ value: item, path: `${path}.${key}` });
+    });
+  }
+
+  return paths;
+};
+
+export const cloneWithDiagnostics = (value, label) => {
+  try {
+    return structuredClone(value);
+  } catch (error) {
+    if (error?.name === "DataCloneError") {
+      const paths = findNonCloneablePaths(value);
+      console.error(
+        `[sceneEditor] Non-cloneable data in ${label}. Possible paths:`,
+        paths.length > 0 ? paths : ["(path not detected)"],
+      );
+    }
+    throw error;
+  }
+};
+
+const setSceneAssetLoading = (deps, isLoading) => {
+  const { store, render } = deps;
+  store.setSceneAssetLoading({ isLoading });
+  render();
+};
+
+async function createAssetsFromFileIds(
+  fileReferences,
+  projectService,
+  resources,
+) {
+  const { sounds, images, videos = {}, fonts = {} } = resources;
+  const allItems = Object.entries({
+    ...sounds,
+    ...images,
+    ...videos,
+    ...fonts,
+  }).map(([key, value]) => ({
+    id: key,
+    ...value,
+  }));
+
+  const assets = {};
+  for (const fileObj of fileReferences) {
+    const { url: fileId } = fileObj;
+    const foundItem = allItems.find((item) => item.fileId === fileId);
+
+    try {
+      const { url } = await projectService.getFileContent(fileId);
+      let type = foundItem?.fileType;
+
+      if (!type) {
+        Object.entries(sounds.items || {})
+          .concat(Object.entries(images.items || {}))
+          .concat(Object.entries(videos.items || {}))
+          .concat(Object.entries(fonts.items || {}))
+          .forEach(([_key, item]) => {
+            if (item.fileId === fileId) {
+              type = item.fileType;
+            }
+          });
+      }
+
+      assets[fileId] = {
+        url,
+        type: type || "image/png",
+      };
+    } catch (error) {
+      console.error(`Failed to load file ${fileId}:`, error);
+    }
+  }
+
+  return assets;
+}
+
+async function loadAssetsForSceneIds(
+  deps,
+  projectData,
+  sceneIds,
+  { showLoading = true } = {},
+) {
+  const { graphicsService, projectService, appService } = deps;
+  const allScenes = projectData?.story?.scenes || {};
+
+  const uniqueSceneIds = Array.from(new Set(sceneIds || [])).filter(
+    (sceneId) => !!allScenes[sceneId],
+  );
+  if (uniqueSceneIds.length === 0) {
+    return;
+  }
+
+  const fileReferences = extractFileIdsForScenes(projectData, uniqueSceneIds);
+  const missingFileReferences = fileReferences.filter((fileReference) => {
+    const fileId = fileReference?.url;
+    return fileId && !assetLoadCache.fileIds.has(fileId);
+  });
+  const isAnySceneUntracked = uniqueSceneIds.some(
+    (sceneId) => !assetLoadCache.sceneIds.has(sceneId),
+  );
+
+  if (missingFileReferences.length === 0 && !isAnySceneUntracked) {
+    return;
+  }
+
+  const shouldShowLoading = showLoading && missingFileReferences.length > 0;
+
+  try {
+    if (shouldShowLoading) {
+      setSceneAssetLoading(deps, true);
+    }
+
+    if (missingFileReferences.length > 0) {
+      const assets = await createAssetsFromFileIds(
+        missingFileReferences,
+        projectService,
+        projectData.resources,
+      );
+      await graphicsService.loadAssets(assets);
+
+      Object.keys(assets).forEach((fileId) => {
+        if (fileId) {
+          assetLoadCache.fileIds.add(fileId);
+        }
+      });
+    }
+
+    uniqueSceneIds.forEach((sceneId) => {
+      assetLoadCache.sceneIds.add(sceneId);
+    });
+  } catch (error) {
+    appService?.showToast("Failed to load some scene assets", {
+      title: "Warning",
+    });
+    console.error("[sceneEditor] Failed to load scene assets:", error);
+  } finally {
+    if (shouldShowLoading) {
+      setSceneAssetLoading(deps, false);
+    }
+  }
+}
+
+async function preloadDirectTransitionScenes(deps, projectData, sceneIds) {
+  const directTargets = Array.from(
+    new Set(
+      (sceneIds || []).flatMap((sceneId) =>
+        extractTransitionTargetSceneIds(projectData, sceneId),
+      ),
+    ),
+  );
+
+  if (directTargets.length === 0) {
+    return;
+  }
+
+  await loadAssetsForSceneIds(deps, projectData, directTargets, {
+    showLoading: false,
+  });
+}
+
+async function preloadLayoutAssetsByIds(deps, projectData, layoutIds) {
+  const uniqueLayoutIds = Array.from(new Set(layoutIds || [])).filter(
+    (layoutId) => Boolean(projectData?.resources?.layouts?.[layoutId]),
+  );
+
+  if (uniqueLayoutIds.length === 0) {
+    return;
+  }
+
+  const fileReferences = extractFileIdsForLayouts(projectData, uniqueLayoutIds);
+  const missingFileReferences = fileReferences.filter((fileReference) => {
+    const fileId = fileReference?.url;
+    return fileId && !assetLoadCache.fileIds.has(fileId);
+  });
+
+  if (missingFileReferences.length === 0) {
+    return;
+  }
+
+  const { graphicsService, projectService } = deps;
+  const assets = await createAssetsFromFileIds(
+    missingFileReferences,
+    projectService,
+    projectData.resources,
+  );
+  await graphicsService.loadAssets(assets);
+
+  Object.keys(assets).forEach((fileId) => {
+    if (fileId) {
+      assetLoadCache.fileIds.add(fileId);
+    }
+  });
+}
+
+const createBeforeHandleActionsHook = (deps) => {
+  const { store } = deps;
+
+  return async (actions, eventContext) => {
+    const projectData = store.selectProjectData();
+    const eventData = eventContext?._event;
+    const resolvedActions = resolveEventBindings(actions, eventData);
+    const layoutIds = Array.from(
+      new Set([
+        ...extractLayoutIdsFromValue(resolvedActions, projectData),
+        ...extractLayoutIdsFromValue(eventData, projectData),
+      ]),
+    );
+
+    if (layoutIds.length > 0) {
+      await preloadLayoutAssetsByIds(deps, projectData, layoutIds);
+    }
+
+    const transitionSceneIds = Array.from(
+      new Set([
+        ...extractTransitionTargetSceneIdsFromActions(
+          resolvedActions,
+          projectData,
+        ),
+        ...extractTransitionTargetSceneIdsFromActions(eventData, projectData),
+        ...extractSceneIdsFromValue(resolvedActions, projectData),
+        ...extractSceneIdsFromValue(eventData, projectData),
+      ]),
+    );
+
+    if (transitionSceneIds.length === 0) {
+      return;
+    }
+
+    await loadAssetsForSceneIds(deps, projectData, transitionSceneIds, {
+      showLoading: false,
+    });
+    await preloadDirectTransitionScenes(deps, projectData, transitionSceneIds);
+  };
+};
+
+const createProjectDataWithSelectedEntryPoint = (projectData, selection) => {
+  const { sceneId, sectionId, lineId } = selection;
+  const projectDataWithSelection = structuredClone(projectData);
+
+  if (!sceneId || !projectDataWithSelection?.story?.scenes?.[sceneId]) {
+    return projectDataWithSelection;
+  }
+
+  projectDataWithSelection.story.initialSceneId = sceneId;
+  const selectedScene = projectDataWithSelection.story.scenes[sceneId];
+
+  if (sectionId && selectedScene.sections?.[sectionId]) {
+    selectedScene.initialSectionId = sectionId;
+
+    if (lineId) {
+      selectedScene.sections[sectionId].initialLineId = lineId;
+    }
+  }
+
+  return projectDataWithSelection;
+};
+
+export const renderSceneEditorState = async (deps, payload = {}) => {
+  const { store, graphicsService } = deps;
+  const { skipAnimations = false } = payload;
+  const projectData = store.selectProjectData();
+  const safeProjectData = cloneWithDiagnostics(
+    projectData,
+    "projectData passed to updateProjectData",
+  );
+  const sectionId = store.selectSelectedSectionId();
+  const lineId = store.selectSelectedLineId();
+  const isMuted = store.selectIsMuted();
+
+  graphicsService.engineHandleActions({
+    updateProjectData: {
+      projectData: safeProjectData,
+    },
+    jumpToLine: {
+      sectionId,
+      lineId,
+    },
+  });
+  graphicsService.engineRenderCurrentState({
+    skipAudio: isMuted,
+    skipAnimations,
+  });
+  graphicsService.engineHandleActions({
+    setNextLineConfig: {
+      auto: {
+        enabled: false,
+      },
+    },
+  });
+
+  store.setPresentationState({
+    presentationState: graphicsService.engineSelectPresentationState(),
+  });
+};
+
+export const updateSceneEditorSectionChanges = async (deps) => {
+  const { store, graphicsService } = deps;
+  const sectionId = store.selectSelectedSectionId();
+  if (!sectionId) {
+    return;
+  }
+
+  const changes = graphicsService.engineSelectSectionLineChanges({ sectionId });
+  store.setSectionLineChanges({ changes });
+};
+
+export const initializeSceneEditorPage = async (deps) => {
+  const {
+    refs,
+    graphicsService,
+    store,
+    projectService,
+    appService,
+    render,
+    subject,
+    syncProjectState,
+  } = deps;
+
+  await projectService.ensureRepository();
+
+  const {
+    sceneId,
+    sectionId: payloadSectionId,
+    lineId: payloadLineId,
+  } = appService.getPayload();
+  const state = syncProjectState(store, projectService);
+
+  if (state.fonts?.items) {
+    for (const font of Object.values(state.fonts.items)) {
+      if (font.type === "font" && font.fileId && font.fontFamily) {
+        await projectService.loadFontFile({
+          fontName: font.fontFamily,
+          fileId: font.fileId,
+        });
+      }
+    }
+  }
+
+  store.setSceneId({ sceneId });
+
+  const scene = store.selectScene();
+  if (scene?.sections?.length > 0) {
+    const selectedSection =
+      scene.sections.find((section) => section.id === payloadSectionId) ||
+      scene.sections[0];
+    store.setSelectedSectionId({ selectedSectionId: selectedSection.id });
+
+    if (selectedSection.lines?.length > 0) {
+      const selectedLine =
+        selectedSection.lines.find((line) => line.id === payloadLineId) ||
+        selectedSection.lines[0];
+      store.setSelectedLineId({ selectedLineId: selectedLine.id });
+    } else {
+      store.setSelectedLineId({ selectedLineId: undefined });
+    }
+  }
+
+  resetAssetLoadCache();
+  store.setSceneAssetLoading({ isLoading: false });
+
+  await graphicsService.init({
+    canvas: refs.canvas,
+    beforeHandleActions: createBeforeHandleActionsHook(deps),
+  });
+
+  const projectData = store.selectProjectData();
+  const initialProjectData = createProjectDataWithSelectedEntryPoint(
+    projectData,
+    {
+      sceneId,
+      sectionId: store.selectSelectedSectionId(),
+      lineId: store.selectSelectedLineId(),
+    },
+  );
+  const initialSceneIds = extractInitialHybridSceneIds(projectData, sceneId);
+
+  await loadAssetsForSceneIds(deps, projectData, initialSceneIds, {
+    showLoading: true,
+  });
+  void preloadDirectTransitionScenes(deps, projectData, initialSceneIds);
+  graphicsService.initRouteEngine(initialProjectData);
+
+  render();
+  setTimeout(() => {
+    subject.dispatch("sceneEditor.renderCanvas", {});
+  }, 1000);
+};
+
+export const restoreSceneEditorFromPreview = async (deps) => {
+  const { store, render, graphicsService, refs } = deps;
+
+  store.hidePreviewScene();
+  render();
+
+  resetAssetLoadCache();
+  store.setSceneAssetLoading({ isLoading: false });
+  await graphicsService.init({
+    canvas: refs.canvas,
+    beforeHandleActions: createBeforeHandleActionsHook(deps),
+  });
+
+  const projectData = store.selectProjectData();
+  const sceneId = store.selectSceneId();
+  const initialProjectData = createProjectDataWithSelectedEntryPoint(
+    projectData,
+    {
+      sceneId,
+      sectionId: store.selectSelectedSectionId(),
+      lineId: store.selectSelectedLineId(),
+    },
+  );
+  const initialSceneIds = extractInitialHybridSceneIds(projectData, sceneId);
+
+  await loadAssetsForSceneIds(deps, projectData, initialSceneIds, {
+    showLoading: false,
+  });
+  void preloadDirectTransitionScenes(deps, projectData, initialSceneIds);
+  graphicsService.initRouteEngine(initialProjectData);
+
+  await renderSceneEditorState(deps);
+};
+
+export const renderSceneEditorCanvas = async (deps, payload) => {
+  const { store, render } = deps;
+  const projectData = store.selectProjectData();
+  const sceneId = store.selectSceneId();
+  const sceneIdsToLoad = extractInitialHybridSceneIds(projectData, sceneId);
+
+  await loadAssetsForSceneIds(deps, projectData, sceneIdsToLoad, {
+    showLoading: false,
+  });
+  void preloadDirectTransitionScenes(deps, projectData, sceneIdsToLoad);
+
+  await renderSceneEditorState(deps, payload);
+  await updateSceneEditorSectionChanges(deps);
+
+  if (!payload?.skipRender) {
+    render();
+  }
+};
+
+export const mountSceneEditorSubscriptions = (deps) => {
+  const { subject, dialogueQueueService } = deps;
+
+  dialogueQueueService.onWrite(async (lineId, data) => {
+    await writeDialogueContent(deps, lineId, data);
+  });
+
+  const streams = [
+    subject.pipe(
+      filter(({ action }) => action === "sceneEditor.renderCanvas"),
+      debounceTime(50),
+      tap(async ({ payload }) => {
+        await renderSceneEditorCanvas(deps, payload);
+      }),
+    ),
+  ];
+
+  const active = streams.map((stream) => stream.subscribe());
+  return () => active.forEach((subscription) => subscription?.unsubscribe?.());
+};
+
+export const resetSceneEditorRuntime = (deps) => {
+  const { graphicsService, store } = deps;
+  store.setSceneAssetLoading({ isLoading: false });
+  resetAssetLoadCache();
+  graphicsService.destroy();
+};

--- a/src/deps/features/sceneEditing/sectionOperations.js
+++ b/src/deps/features/sceneEditing/sectionOperations.js
@@ -1,0 +1,170 @@
+import { nanoid } from "nanoid";
+import {
+  renderSceneEditorState,
+  updateSceneEditorSectionChanges,
+} from "./runtime.js";
+
+export const isSectionsOverviewOpen = (store) => {
+  return store.selectIsSectionsOverviewOpen();
+};
+
+export const scrollSceneEditorSectionTabIntoView = (deps, sectionId) => {
+  const { refs } = deps;
+
+  requestAnimationFrame(() => {
+    const refIds = refs?.();
+    const refElements = Object.values(refIds || {});
+    const tabRef = refElements.find(
+      (element) => element?.dataset?.sectionId === sectionId,
+    );
+    const tabElement =
+      tabRef ||
+      Array.from(document.querySelectorAll("[data-section-id]")).find(
+        (element) => element.getAttribute("data-section-id") === sectionId,
+      );
+
+    tabElement?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+  });
+};
+
+export const selectSceneEditorSection = async (deps, sectionId) => {
+  const { store, render, subject } = deps;
+
+  store.setSelectedSectionId({ selectedSectionId: sectionId });
+  const scene = store.selectScene();
+  const nextSection = scene?.sections?.find(
+    (section) => section.id === sectionId,
+  );
+  if (nextSection?.lines?.length > 0) {
+    store.setSelectedLineId({ selectedLineId: nextSection.lines[0].id });
+  } else {
+    store.setSelectedLineId({ selectedLineId: undefined });
+  }
+
+  await updateSceneEditorSectionChanges(deps);
+
+  render();
+  scrollSceneEditorSectionTabIntoView(deps, sectionId);
+  subject.dispatch("sceneEditor.renderCanvas", {});
+};
+
+export const reconcileSceneEditorSelection = (store) => {
+  const scene = store.selectScene();
+  const previousSectionId = store.selectSelectedSectionId();
+  const previousLineId = store.selectSelectedLineId();
+
+  if (!scene || !Array.isArray(scene.sections) || scene.sections.length === 0) {
+    if (previousSectionId !== undefined) {
+      store.setSelectedSectionId({ selectedSectionId: undefined });
+    }
+    if (previousLineId !== undefined) {
+      store.setSelectedLineId({ selectedLineId: undefined });
+    }
+    return {
+      sectionId: undefined,
+      lineId: undefined,
+    };
+  }
+
+  const resolvedSection =
+    scene.sections.find((section) => section.id === previousSectionId) ||
+    scene.sections[0];
+  const resolvedSectionId = resolvedSection?.id;
+  const resolvedLine =
+    resolvedSection?.lines?.find((line) => line.id === previousLineId) ||
+    resolvedSection?.lines?.[0];
+  const resolvedLineId = resolvedLine?.id;
+
+  if (resolvedSectionId !== previousSectionId) {
+    store.setSelectedSectionId({ selectedSectionId: resolvedSectionId });
+  }
+
+  if (resolvedLineId !== previousLineId) {
+    store.setSelectedLineId({ selectedLineId: resolvedLineId });
+  }
+
+  return {
+    sectionId: resolvedSectionId,
+    lineId: resolvedLineId,
+  };
+};
+
+export const createSceneEditorSectionWithName = async (
+  deps,
+  sectionName,
+  syncProjectState,
+) => {
+  const { store, projectService, render } = deps;
+  const sceneId = store.selectSceneId();
+  const newSectionId = nanoid();
+  const newLineId = nanoid();
+
+  const { layouts } = projectService.getState();
+  let dialogueLayoutId;
+  let baseLayoutId;
+
+  if (layouts?.items) {
+    for (const [layoutId, layout] of Object.entries(layouts.items)) {
+      if (!dialogueLayoutId && layout.layoutType === "dialogue") {
+        dialogueLayoutId = layoutId;
+      }
+      if (!baseLayoutId && layout.layoutType === "base") {
+        baseLayoutId = layoutId;
+      }
+      if (dialogueLayoutId && baseLayoutId) {
+        break;
+      }
+    }
+  }
+
+  const actions = {
+    dialogue: dialogueLayoutId
+      ? {
+          gui: {
+            resourceId: dialogueLayoutId,
+          },
+          mode: "adv",
+          content: [{ text: "" }],
+        }
+      : {
+          mode: "adv",
+          content: [{ text: "" }],
+        },
+  };
+
+  if (baseLayoutId) {
+    actions.base = {
+      resourceId: baseLayoutId,
+      resourceType: "layout",
+    };
+  }
+
+  await projectService.createSectionItem({
+    sceneId,
+    sectionId: newSectionId,
+    name: sectionName,
+    position: "last",
+  });
+  await projectService.createLineItem({
+    sectionId: newSectionId,
+    lineId: newLineId,
+    line: {
+      actions,
+    },
+    position: "last",
+  });
+
+  syncProjectState(store, projectService);
+  store.setSelectedSectionId({ selectedSectionId: newSectionId });
+  store.setSelectedLineId({ selectedLineId: newLineId });
+  render();
+  scrollSceneEditorSectionTabIntoView(deps, newSectionId);
+
+  setTimeout(async () => {
+    await renderSceneEditorState(deps);
+  }, 10);
+};

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -8,11 +8,16 @@ const createNoopUpdater = () => ({
   isUpdateAvailable: () => false,
 });
 
-const isInputFocused = (root = document) => {
+const getActiveElement = (root = document) => {
   let active = root.activeElement;
   while (active && active.shadowRoot && active.shadowRoot.activeElement) {
     active = active.shadowRoot.activeElement;
   }
+  return active;
+};
+
+const isInputFocused = (root = document) => {
+  let active = getActiveElement(root);
   if (active) {
     const tagName = active.tagName;
     if (!["BODY", "DIALOG"].includes(tagName)) {
@@ -102,6 +107,13 @@ export const createAppShellService = ({
     },
 
     isInputFocused,
+
+    blurActiveElement(root = document) {
+      const active = getActiveElement(root);
+      if (active?.blur) {
+        active.blur();
+      }
+    },
 
     getAppVersion() {
       return appVersion;

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1,208 +1,33 @@
-import { nanoid } from "nanoid";
 import {
-  extractFileIdsForLayouts,
-  extractSceneIdsFromValue,
-  extractFileIdsForScenes,
-  extractInitialHybridSceneIds,
-  extractLayoutIdsFromValue,
-  resolveEventBindings,
-  extractTransitionTargetSceneIds,
-  extractTransitionTargetSceneIdsFromActions,
-} from "../../utils/index.js";
+  applyPendingDialogueQueueToStore,
+  findCharacterIdByShortcut,
+  flushDialogueQueue,
+  handleMergeLinesOperation,
+  handleNewLineOperation,
+  handlePasteLinesOperation,
+  handleSplitLineOperation,
+  handleSwapLineOperation,
+  syncSceneEditorProjectState as syncStoreProjectState,
+} from "../../deps/features/sceneEditing/lineOperations.js";
+import {
+  cloneWithDiagnostics,
+  initializeSceneEditorPage,
+  mountSceneEditorSubscriptions,
+  renderSceneEditorState,
+  resetSceneEditorRuntime,
+  restoreSceneEditorFromPreview,
+  updateSceneEditorSectionChanges,
+} from "../../deps/features/sceneEditing/runtime.js";
+import {
+  createSceneEditorSectionWithName,
+  isSectionsOverviewOpen,
+  reconcileSceneEditorSelection,
+  selectSceneEditorSection,
+} from "../../deps/features/sceneEditing/sectionOperations.js";
 import { debugLog, previewDebugText } from "../../utils/debugLog.js";
-import { filter, tap, debounceTime } from "rxjs";
 
 const DEAD_END_TOOLTIP_CONTENT =
   "This section has no transition to another scene.";
-
-const mountSubscriptions = (deps) => {
-  const streams = subscriptions(deps) || [];
-  const active = streams.map((stream) => stream.subscribe());
-  return () => active.forEach((subscription) => subscription?.unsubscribe?.());
-};
-
-const findNonCloneablePaths = (root, limit = 5) => {
-  const paths = [];
-  const queue = [{ value: root, path: "$" }];
-  const visited = new WeakSet();
-
-  const isWindowLike = (value) =>
-    typeof window !== "undefined" && value === window;
-  const isNodeLike = (value) =>
-    typeof Node !== "undefined" && value instanceof Node;
-  const isEventLike = (value) =>
-    typeof Event !== "undefined" && value instanceof Event;
-
-  while (queue.length > 0 && paths.length < limit) {
-    const { value, path } = queue.shift();
-
-    if (!value || typeof value !== "object") {
-      continue;
-    }
-
-    if (isWindowLike(value) || isNodeLike(value) || isEventLike(value)) {
-      paths.push(path);
-      continue;
-    }
-
-    if (visited.has(value)) {
-      continue;
-    }
-    visited.add(value);
-
-    if (Array.isArray(value)) {
-      value.forEach((item, index) => {
-        queue.push({ value: item, path: `${path}[${index}]` });
-      });
-      continue;
-    }
-
-    Object.entries(value).forEach(([key, item]) => {
-      queue.push({ value: item, path: `${path}.${key}` });
-    });
-  }
-
-  return paths;
-};
-
-const cloneWithDiagnostics = (value, label) => {
-  try {
-    return structuredClone(value);
-  } catch (error) {
-    if (error?.name === "DataCloneError") {
-      const paths = findNonCloneablePaths(value);
-      console.error(
-        `[sceneEditor] Non-cloneable data in ${label}. Possible paths:`,
-        paths.length > 0 ? paths : ["(path not detected)"],
-      );
-    }
-    throw error;
-  }
-};
-
-// Helper function to create assets object from file references
-async function createAssetsFromFileIds(
-  fileReferences,
-  projectService,
-  resources,
-) {
-  const { sounds, images, videos = {}, fonts = {} } = resources;
-  const allItems = Object.entries({
-    ...sounds,
-    ...images,
-    ...videos,
-    ...fonts,
-  }).map(([key, val]) => {
-    return {
-      id: key,
-      ...val,
-    };
-  });
-  const assets = {};
-  for (const fileObj of fileReferences) {
-    const { url: fileId } = fileObj;
-    const foundItem = allItems.find((item) => item.fileId === fileId);
-    try {
-      const { url } = await projectService.getFileContent(fileId);
-      let type = foundItem?.fileType; // Use type from fileObj first
-
-      // If no type in fileObj, look it up in the resources
-      if (!type) {
-        Object.entries(sounds.items || {})
-          .concat(Object.entries(images.items || {}))
-          .concat(Object.entries(videos.items || {}))
-          .concat(Object.entries(fonts.items || {}))
-          .forEach(([_key, item]) => {
-            if (item.fileId === fileId) {
-              type = item.fileType;
-            }
-          });
-      }
-
-      assets[fileId] = {
-        url,
-        type: type || "image/png", // fallback to image/png
-      };
-    } catch (error) {
-      console.error(`Failed to load file ${fileId}:`, error);
-    }
-  }
-
-  return assets;
-}
-
-const isMinimalAdvDialogue = (dialogue) => {
-  if (!dialogue || typeof dialogue !== "object") {
-    return false;
-  }
-
-  const keysWithoutContent = Object.keys(dialogue).filter(
-    (key) => key !== "content",
-  );
-
-  return keysWithoutContent.length === 1 && dialogue.mode === "adv";
-};
-
-const shouldInheritNvlModeFromPreviousLine = ({
-  domainState,
-  sectionId,
-  lineId,
-  existingDialogue,
-}) => {
-  const section = domainState?.sections?.[sectionId];
-  if (!section) {
-    return false;
-  }
-
-  if (existingDialogue?.mode === "nvl") {
-    return false;
-  }
-
-  if (existingDialogue?.mode && !isMinimalAdvDialogue(existingDialogue)) {
-    return false;
-  }
-
-  const lineOrder = section.lineIds || [];
-  const currentIndex = lineOrder.indexOf(lineId);
-  if (currentIndex <= 0) {
-    return false;
-  }
-
-  const previousLineId = lineOrder[currentIndex - 1];
-  if (!previousLineId) {
-    return false;
-  }
-
-  const previousDialogue =
-    domainState?.lines?.[previousLineId]?.actions?.dialogue;
-  return previousDialogue?.mode === "nvl";
-};
-
-const createAssetLoadCache = () => ({
-  sceneIds: new Set(),
-  fileIds: new Set(),
-});
-
-let assetLoadCache = createAssetLoadCache();
-
-const resetAssetLoadCache = () => {
-  assetLoadCache = createAssetLoadCache();
-};
-
-const setSceneAssetLoading = (deps, isLoading) => {
-  const { store, render } = deps;
-  store.setSceneAssetLoading({ isLoading: isLoading });
-  render();
-};
-
-const syncStoreProjectState = (store, projectService) => {
-  const repositoryState = projectService.getState();
-  store.setRepositoryState({ repository: repositoryState });
-  store.setDomainState({
-    domainState: projectService.getDomainState(),
-  });
-  return repositoryState;
-};
 
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
@@ -226,543 +51,21 @@ const scrollLinesEditorLineIntoView = (refs, lineId) => {
   linesEditorRef.scrollLineIntoView({ lineId });
 };
 
-const getDialogueText = (line) => {
-  return (line?.actions?.dialogue?.content || [])
-    .map((item) => item?.text ?? "")
-    .join("");
-};
-
-const resolveMergeLinesContext = (domainState, currentLineId) => {
-  const currentLine = domainState?.lines?.[currentLineId];
-  const sectionId = currentLine?.sectionId;
-  const section = sectionId ? domainState?.sections?.[sectionId] : undefined;
-  const lineIds = section?.lineIds || [];
-  const currentIndex = lineIds.indexOf(currentLineId);
-
-  if (!currentLine || currentIndex <= 0) {
-    return {};
-  }
-
-  const prevLineId = lineIds[currentIndex - 1];
-  const prevLine = domainState?.lines?.[prevLineId];
-
-  if (!prevLineId || !prevLine) {
-    return {};
-  }
-
-  return {
-    sectionId,
-    currentLine,
-    prevLineId,
-    prevLine,
-  };
-};
-
-const isMissingLinePreconditionError = (error, lineId) => {
-  return (
-    error?.name === "DomainPreconditionError" &&
-    error?.message === "line not found" &&
-    (!lineId || error?.details?.lineId === lineId)
-  );
-};
-
-async function loadAssetsForSceneIds(
-  deps,
-  projectData,
-  sceneIds,
-  { showLoading = true } = {},
-) {
-  const { graphicsService, projectService, appService } = deps;
-  const allScenes = projectData?.story?.scenes || {};
-
-  const uniqueSceneIds = Array.from(new Set(sceneIds || [])).filter(
-    (sceneId) => !!allScenes[sceneId],
-  );
-  if (uniqueSceneIds.length === 0) {
-    return;
-  }
-
-  const fileReferences = extractFileIdsForScenes(projectData, uniqueSceneIds);
-  const missingFileReferences = fileReferences.filter((fileReference) => {
-    const fileId = fileReference?.url;
-    return fileId && !assetLoadCache.fileIds.has(fileId);
-  });
-  const isAnySceneUntracked = uniqueSceneIds.some(
-    (sceneId) => !assetLoadCache.sceneIds.has(sceneId),
-  );
-
-  if (missingFileReferences.length === 0 && !isAnySceneUntracked) {
-    return;
-  }
-
-  const shouldShowLoading = showLoading && missingFileReferences.length > 0;
-
-  try {
-    if (shouldShowLoading) {
-      setSceneAssetLoading(deps, true);
-    }
-
-    if (missingFileReferences.length > 0) {
-      const assets = await createAssetsFromFileIds(
-        missingFileReferences,
-        projectService,
-        projectData.resources,
-      );
-      await graphicsService.loadAssets(assets);
-
-      Object.keys(assets).forEach((fileId) => {
-        if (fileId) {
-          assetLoadCache.fileIds.add(fileId);
-        }
-      });
-    }
-
-    uniqueSceneIds.forEach((sceneId) => {
-      assetLoadCache.sceneIds.add(sceneId);
-    });
-  } catch (error) {
-    appService?.showToast("Failed to load some scene assets", {
-      title: "Warning",
-    });
-    console.error("[sceneEditor] Failed to load scene assets:", error);
-  } finally {
-    if (shouldShowLoading) {
-      setSceneAssetLoading(deps, false);
-    }
-  }
-}
-
-const preloadDirectTransitionScenes = async (deps, projectData, sceneIds) => {
-  const directTargets = Array.from(
-    new Set(
-      (sceneIds || []).flatMap((sceneId) =>
-        extractTransitionTargetSceneIds(projectData, sceneId),
-      ),
-    ),
-  );
-
-  if (directTargets.length === 0) {
-    return;
-  }
-
-  await loadAssetsForSceneIds(deps, projectData, directTargets, {
-    showLoading: false,
-  });
-};
-
-const preloadLayoutAssetsByIds = async (deps, projectData, layoutIds) => {
-  const uniqueLayoutIds = Array.from(new Set(layoutIds || [])).filter(
-    (layoutId) => Boolean(projectData?.resources?.layouts?.[layoutId]),
-  );
-
-  if (uniqueLayoutIds.length === 0) {
-    return;
-  }
-
-  const fileReferences = extractFileIdsForLayouts(projectData, uniqueLayoutIds);
-  const missingFileReferences = fileReferences.filter((fileReference) => {
-    const fileId = fileReference?.url;
-    return fileId && !assetLoadCache.fileIds.has(fileId);
-  });
-
-  if (missingFileReferences.length === 0) {
-    return;
-  }
-
-  const { graphicsService, projectService } = deps;
-  const assets = await createAssetsFromFileIds(
-    missingFileReferences,
-    projectService,
-    projectData.resources,
-  );
-  await graphicsService.loadAssets(assets);
-
-  Object.keys(assets).forEach((fileId) => {
-    if (fileId) {
-      assetLoadCache.fileIds.add(fileId);
-    }
-  });
-};
-
-const createBeforeHandleActionsHook = (deps) => {
-  const { store } = deps;
-  return async (actions, eventContext) => {
-    const projectData = store.selectProjectData();
-    const eventData = eventContext?._event;
-    const resolvedActions = resolveEventBindings(actions, eventData);
-    const layoutIds = Array.from(
-      new Set([
-        ...extractLayoutIdsFromValue(resolvedActions, projectData),
-        ...extractLayoutIdsFromValue(eventData, projectData),
-      ]),
-    );
-    if (layoutIds.length > 0) {
-      await preloadLayoutAssetsByIds(deps, projectData, layoutIds);
-    }
-
-    const transitionSceneIds = Array.from(
-      new Set([
-        ...extractTransitionTargetSceneIdsFromActions(
-          resolvedActions,
-          projectData,
-        ),
-        ...extractTransitionTargetSceneIdsFromActions(eventData, projectData),
-        ...extractSceneIdsFromValue(resolvedActions, projectData),
-        ...extractSceneIdsFromValue(eventData, projectData),
-      ]),
-    );
-
-    if (transitionSceneIds.length === 0) {
-      return;
-    }
-
-    await loadAssetsForSceneIds(deps, projectData, transitionSceneIds, {
-      showLoading: false,
-    });
-    await preloadDirectTransitionScenes(deps, projectData, transitionSceneIds);
-  };
-};
-
-// Helper function to render the scene state
-async function renderSceneState(store, graphicsService, payload = {}) {
-  const { skipAnimations = false } = payload;
-  const projectData = store.selectProjectData();
-  const safeProjectData = cloneWithDiagnostics(
-    projectData,
-    "projectData passed to updateProjectData",
-  );
-  const sectionId = store.selectSelectedSectionId();
-  const lineId = store.selectSelectedLineId();
-  const isMuted = store.selectIsMuted();
-  graphicsService.engineHandleActions({
-    updateProjectData: {
-      projectData: safeProjectData,
-    },
-    jumpToLine: {
-      sectionId,
-      lineId,
-    },
-  });
-  graphicsService.engineRenderCurrentState({
-    skipAudio: isMuted,
-    skipAnimations,
-  });
-
-  // Disable auto-advance in edit mode - setNextLineConfig should only work in preview mode
-  graphicsService.engineHandleActions({
-    setNextLineConfig: {
-      auto: {
-        enabled: false,
-      },
-    },
-  });
-
-  // Update presentation state after rendering
-  const presentationState = graphicsService.engineSelectPresentationState();
-  store.setPresentationState({ presentationState: presentationState });
-}
-
-function createProjectDataWithSelectedEntryPoint(projectData, selection) {
-  const { sceneId, sectionId, lineId } = selection;
-  const projectDataWithSelection = structuredClone(projectData);
-
-  if (!sceneId || !projectDataWithSelection?.story?.scenes?.[sceneId]) {
-    return projectDataWithSelection;
-  }
-
-  projectDataWithSelection.story.initialSceneId = sceneId;
-  const selectedScene = projectDataWithSelection.story.scenes[sceneId];
-
-  if (sectionId && selectedScene.sections?.[sectionId]) {
-    selectedScene.initialSectionId = sectionId;
-
-    if (lineId) {
-      selectedScene.sections[sectionId].initialLineId = lineId;
-    }
-  }
-
-  return projectDataWithSelection;
-}
-
-// Shared helper to write dialogue content to repository
-async function writeDialogueContent(deps, lineId, { sectionId, content }) {
-  const { projectService } = deps;
-
-  // Get existing dialogue to preserve other properties (layoutId, characterId, etc.)
-  const domainState = projectService.getDomainState();
-  const existingDialogue =
-    domainState?.lines?.[lineId]?.actions?.dialogue || {};
-  const shouldInheritNvlMode = shouldInheritNvlModeFromPreviousLine({
-    domainState,
-    sectionId,
-    lineId,
-    existingDialogue,
-  });
-
-  debugLog("lines", "scene.write-dialogue", {
-    lineId,
-    sectionId,
-    contentLength: (content || []).map((item) => item?.text ?? "").join("")
-      .length,
-    content: previewDebugText(
-      (content || []).map((item) => item?.text ?? "").join(""),
-    ),
-  });
-
-  await projectService.updateLineActions({
-    lineId,
-    patch: {
-      dialogue: {
-        ...existingDialogue,
-        ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
-        content,
-      },
-    },
-    replace: false,
-  });
-}
-
-// Helper to flush dialogue queue
-async function flushDialogueQueue(deps) {
-  const { dialogueQueueService } = deps;
-
-  debugLog("lines", "scene.flush-dialogue-queue:start", {
-    pendingSize: dialogueQueueService.size(),
-  });
-
-  await dialogueQueueService.flush(async (lineId, data) => {
-    await writeDialogueContent(deps, lineId, data);
-  });
-
-  debugLog("lines", "scene.flush-dialogue-queue:end", {
-    pendingSize: dialogueQueueService.size(),
-  });
-}
-
-const applyPendingDialogueQueueToStore = (store, dialogueQueueService) => {
-  for (const [lineId, data] of dialogueQueueService.entries()) {
-    if (!lineId || !Array.isArray(data?.content)) {
-      continue;
-    }
-
-    store.setLineTextContent({
-      lineId,
-      content: data.content,
-    });
-  }
-};
-
-const findCharacterIdByShortcut = (repositoryState, shortcut) => {
-  const normalizedShortcut = String(shortcut || "").trim();
-  if (!normalizedShortcut) {
-    return null;
-  }
-
-  const characters = repositoryState?.characters?.items || {};
-  for (const [characterId, character] of Object.entries(characters)) {
-    if (character?.type !== "character") {
-      continue;
-    }
-
-    if (String(character?.shortcut || "").trim() === normalizedShortcut) {
-      return characterId;
-    }
-  }
-
-  return null;
-};
-
 export const handleBeforeMount = (deps) => {
-  const { graphicsService, store } = deps;
-  const cleanupSubscriptions = mountSubscriptions(deps);
+  const cleanupSubscriptions = mountSceneEditorSubscriptions(deps);
 
   return async () => {
     cleanupSubscriptions();
     await flushDialogueQueue(deps);
-    store.setSceneAssetLoading({ isLoading: false });
-    resetAssetLoadCache();
-    graphicsService.destroy();
+    resetSceneEditorRuntime(deps);
   };
 };
-
-async function updateSectionChanges(deps) {
-  const { store, graphicsService } = deps;
-  const sectionId = store.selectSelectedSectionId();
-  if (!sectionId) return;
-
-  const changes = graphicsService.engineSelectSectionLineChanges({ sectionId });
-  store.setSectionLineChanges({ changes: changes });
-}
 
 export const handleAfterMount = async (deps) => {
-  const {
-    refs,
-    graphicsService,
-    store,
-    projectService,
-    appService,
-    render,
-    subject,
-  } = deps;
-
-  // Ensure repository is loaded for sync access
-  await projectService.ensureRepository();
-
-  // Get scene selection from router payload
-  const {
-    sceneId,
-    sectionId: payloadSectionId,
-    lineId: payloadLineId,
-  } = appService.getPayload();
-  const state = syncStoreProjectState(store, projectService);
-
-  if (state.fonts && state.fonts.items) {
-    for (const font of Object.values(state.fonts.items)) {
-      if (font.type === "font" && font.fileId && font.fontFamily) {
-        await projectService.loadFontFile({
-          fontName: font.fontFamily,
-          fileId: font.fileId,
-        });
-      }
-    }
-  }
-
-  store.setSceneId({ sceneId: sceneId });
-
-  // Get scene to set selected section and line
-  const scene = store.selectScene();
-  if (scene && scene.sections && scene.sections.length > 0) {
-    const selectedSection =
-      scene.sections.find((section) => section.id === payloadSectionId) ||
-      scene.sections[0];
-    store.setSelectedSectionId({ selectedSectionId: selectedSection.id });
-
-    // Select requested line in selected section when available, otherwise first line
-    if (selectedSection.lines && selectedSection.lines.length > 0) {
-      const selectedLine =
-        selectedSection.lines.find((line) => line.id === payloadLineId) ||
-        selectedSection.lines[0];
-      store.setSelectedLineId({ selectedLineId: selectedLine.id });
-    } else {
-      store.setSelectedLineId({ selectedLineId: undefined });
-    }
-  }
-
-  const { canvas } = refs;
-
-  resetAssetLoadCache();
-  store.setSceneAssetLoading({ isLoading: false });
-
-  const beforeHandleActions = createBeforeHandleActionsHook(deps);
-  await graphicsService.init({
-    canvas: canvas,
-    beforeHandleActions,
+  await initializeSceneEditorPage({
+    ...deps,
+    syncProjectState: syncStoreProjectState,
   });
-  const projectData = store.selectProjectData();
-  const initialProjectData = createProjectDataWithSelectedEntryPoint(
-    projectData,
-    {
-      sceneId,
-      sectionId: store.selectSelectedSectionId(),
-      lineId: store.selectSelectedLineId(),
-    },
-  );
-
-  const initialSceneIds = extractInitialHybridSceneIds(projectData, sceneId);
-  await loadAssetsForSceneIds(deps, projectData, initialSceneIds, {
-    showLoading: true,
-  });
-  void preloadDirectTransitionScenes(deps, projectData, initialSceneIds);
-  graphicsService.initRouteEngine(initialProjectData);
-
-  render();
-  setTimeout(() => {
-    subject.dispatch("sceneEditor.renderCanvas", {});
-  }, 1000);
-};
-
-const scrollSectionTabIntoView = (deps, sectionId) => {
-  const { refs } = deps;
-
-  requestAnimationFrame(() => {
-    const refIds = refs?.();
-    const refElements = Object.values(refIds || {});
-    const tabRef = refElements.find(
-      (element) => element?.dataset?.sectionId === sectionId,
-    );
-    const tabElement =
-      tabRef ||
-      Array.from(document.querySelectorAll("[data-section-id]")).find(
-        (element) => element.getAttribute("data-section-id") === sectionId,
-      );
-
-    tabElement?.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "nearest",
-    });
-  });
-};
-
-const selectSection = async (deps, sectionId) => {
-  const { store, render, subject } = deps;
-  store.setSelectedSectionId({ selectedSectionId: sectionId });
-  const scene = store.selectScene();
-  const nextSection = scene?.sections?.find(
-    (section) => section.id === sectionId,
-  );
-  if (nextSection && nextSection.lines && nextSection.lines.length > 0) {
-    store.setSelectedLineId({ selectedLineId: nextSection.lines[0].id });
-  } else {
-    store.setSelectedLineId({ selectedLineId: undefined });
-  }
-
-  await updateSectionChanges(deps);
-
-  render();
-  scrollSectionTabIntoView(deps, sectionId);
-  subject.dispatch("sceneEditor.renderCanvas", {});
-};
-
-const reconcileSceneSelection = (store) => {
-  const scene = store.selectScene();
-  const previousSectionId = store.selectSelectedSectionId();
-  const previousLineId = store.selectSelectedLineId();
-
-  if (!scene || !Array.isArray(scene.sections) || scene.sections.length === 0) {
-    if (previousSectionId !== undefined) {
-      store.setSelectedSectionId({ selectedSectionId: undefined });
-    }
-    if (previousLineId !== undefined) {
-      store.setSelectedLineId({ selectedLineId: undefined });
-    }
-    return {
-      sectionId: undefined,
-      lineId: undefined,
-    };
-  }
-
-  const resolvedSection =
-    scene.sections.find((section) => section.id === previousSectionId) ||
-    scene.sections[0];
-  const resolvedSectionId = resolvedSection?.id;
-  const resolvedLine =
-    resolvedSection?.lines?.find((line) => line.id === previousLineId) ||
-    resolvedSection?.lines?.[0];
-  const resolvedLineId = resolvedLine?.id;
-
-  if (resolvedSectionId !== previousSectionId) {
-    store.setSelectedSectionId({ selectedSectionId: resolvedSectionId });
-  }
-
-  if (resolvedLineId !== previousLineId) {
-    store.setSelectedLineId({ selectedLineId: resolvedLineId });
-  }
-
-  return {
-    sectionId: resolvedSectionId,
-    lineId: resolvedLineId,
-  };
 };
 
 export const handleDataChanged = async (deps) => {
@@ -779,17 +82,13 @@ export const handleDataChanged = async (deps) => {
   syncStoreProjectState(store, projectService);
   applyPendingDialogueQueueToStore(store, dialogueQueueService);
 
-  reconcileSceneSelection(store);
+  reconcileSceneEditorSelection(store);
 
-  await updateSectionChanges(deps);
+  await updateSceneEditorSectionChanges(deps);
   render();
   subject.dispatch("sceneEditor.renderCanvas", {
     skipAnimations: true,
   });
-};
-
-const isSectionsOverviewOpen = (store) => {
-  return store.selectIsSectionsOverviewOpen();
 };
 
 export const handleSectionTabClick = async (deps, payload) => {
@@ -802,18 +101,11 @@ export const handleSectionTabClick = async (deps, payload) => {
     payload._event.currentTarget?.dataset?.sectionId ||
     payload._event.currentTarget?.id?.replace("sectionTab", "") ||
     "";
-  await selectSection(deps, sectionId);
+  await selectSceneEditorSection(deps, sectionId);
 };
 
 export const handleCommandLineSubmit = async (deps, payload) => {
-  const {
-    store,
-    render,
-    projectService,
-    subject,
-    graphicsService,
-    appService,
-  } = deps;
+  const { store, render, projectService, subject, appService } = deps;
   const lineId = store.selectSelectedLineId();
 
   // Handle section/scene transitions
@@ -847,7 +139,7 @@ export const handleCommandLineSubmit = async (deps, payload) => {
 
     // Render the canvas with the latest data
     setTimeout(async () => {
-      await renderSceneState(store, graphicsService);
+      await renderSceneEditorState(deps);
     }, 10);
     return;
   }
@@ -883,7 +175,7 @@ export const handleCommandLineSubmit = async (deps, payload) => {
 
     // Render the canvas with the latest data
     setTimeout(async () => {
-      await renderSceneState(store, graphicsService);
+      await renderSceneEditorState(deps);
     }, 10);
     return;
   }
@@ -919,7 +211,7 @@ export const handleCommandLineSubmit = async (deps, payload) => {
 
     // Render the canvas with the latest data
     setTimeout(async () => {
-      await renderSceneState(store, graphicsService);
+      await renderSceneEditorState(deps);
     }, 10);
     return;
   }
@@ -1111,83 +403,6 @@ export const handleAddActionsButtonClick = (deps) => {
   render();
 };
 
-const createSectionWithName = async (deps, sectionName) => {
-  const { store, projectService, render, graphicsService } = deps;
-  const sceneId = store.selectSceneId();
-  const newSectionId = nanoid();
-  const newLineId = nanoid();
-
-  // Get layouts from repository to find first dialogue and base layouts
-  const { layouts } = projectService.getState();
-  let dialogueLayoutId = null;
-  let baseLayoutId = null;
-
-  if (layouts && layouts.items) {
-    for (const [layoutId, layout] of Object.entries(layouts.items)) {
-      if (!dialogueLayoutId && layout.layoutType === "dialogue") {
-        dialogueLayoutId = layoutId;
-      }
-      if (!baseLayoutId && layout.layoutType === "base") {
-        baseLayoutId = layoutId;
-      }
-      if (dialogueLayoutId && baseLayoutId) {
-        break;
-      }
-    }
-  }
-
-  // Create actions object with dialogue and base layouts if found
-  const actions = {
-    dialogue: dialogueLayoutId
-      ? {
-          gui: {
-            resourceId: dialogueLayoutId,
-          },
-          mode: "adv",
-          content: [{ text: "" }],
-        }
-      : {
-          mode: "adv",
-          content: [{ text: "" }],
-        },
-  };
-
-  if (baseLayoutId) {
-    actions.base = {
-      resourceId: baseLayoutId,
-      resourceType: "layout",
-    };
-  }
-
-  await projectService.createSectionItem({
-    sceneId,
-    sectionId: newSectionId,
-    name: sectionName,
-    position: "last",
-  });
-  await projectService.createLineItem({
-    sectionId: newSectionId,
-    lineId: newLineId,
-    line: {
-      actions,
-    },
-    position: "last",
-  });
-
-  // Update store with new repository state
-  syncStoreProjectState(store, projectService);
-
-  store.setSelectedSectionId({ selectedSectionId: newSectionId });
-  store.setSelectedLineId({ selectedLineId: newLineId });
-  render();
-  scrollSectionTabIntoView(deps, newSectionId);
-
-  // Render the canvas with the new section's data
-  setTimeout(async () => {
-    await renderSceneState(store, graphicsService);
-  }, 10);
-};
-
 export const handleSectionAddClick = (deps) => {
   const { store, render } = deps;
   if (isSectionsOverviewOpen(store)) {
@@ -1253,418 +468,28 @@ export const handleSectionsOverviewRowClick = async (deps, payload) => {
   }
 
   store.closeSectionsOverviewPanel();
-  await selectSection(deps, sectionId);
+  await selectSceneEditorSection(deps, sectionId);
 };
 
 export const handleSplitLine = async (deps, payload) => {
-  const { projectService, store, render, refs, subject } = deps;
-  if (isSectionsOverviewOpen(store)) {
+  if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
-
-  const sectionId = store.selectSelectedSectionId();
-  const { lineId, leftContent, rightContent } = payload._event.detail;
-
-  // Check if this line is already being processed (split/merge)
-  const lockingLineId = store.selectLockingLineId();
-
-  if (lockingLineId === lineId) {
-    return;
-  }
-
-  // Mark this line as being processed IMMEDIATELY to prevent duplicate operations
-  store.setLockingLineId({ lineId: lineId });
-  let shouldReleaseLockAfterFocus = false;
-
-  try {
-    const newLineId = nanoid();
-
-    // Flush pending dialogue updates before modifying repository
-    await flushDialogueQueue(deps);
-
-    const domainState = projectService.getDomainState();
-    const existingDialogue =
-      domainState?.lines?.[lineId]?.actions?.dialogue || {};
-    debugLog("lines", "scene.split.after-flush", {
-      lineId,
-      newLineId,
-      domainContent: previewDebugText(
-        (domainState?.lines?.[lineId]?.actions?.dialogue?.content || [])
-          .map((item) => item?.text ?? "")
-          .join(""),
-      ),
-      leftContent: previewDebugText(leftContent),
-      rightContent: previewDebugText(rightContent),
-    });
-
-    // First, update the current line with the left content
-    // Only update the dialogue.content, preserve everything else
-    const leftContentArray = leftContent
-      ? [{ text: leftContent }]
-      : [{ text: "" }];
-
-    if (existingDialogue && Object.keys(existingDialogue).length > 0) {
-      await projectService.updateLineActions({
-        lineId,
-        patch: {
-          dialogue: {
-            ...existingDialogue,
-            content: leftContentArray,
-          },
-        },
-        replace: false,
-      });
-    } else {
-      await projectService.updateLineActions({
-        lineId,
-        patch: {
-          dialogue: {
-            content: leftContentArray,
-          },
-        },
-        replace: false,
-      });
-    }
-
-    // Then, create a new line with the right content and insert it after the current line
-    // New line should have empty actions except for dialogue.content
-    const rightContentArray = rightContent
-      ? [{ text: rightContent }]
-      : [{ text: "" }];
-    const shouldInheritNvl =
-      existingDialogue?.mode === "nvl" ||
-      shouldInheritNvlModeFromPreviousLine({
-        domainState,
-        sectionId,
-        lineId,
-        existingDialogue,
-      });
-    const shouldCreateDialogueAction = shouldInheritNvl || !!rightContent;
-    const newLineActions = shouldCreateDialogueAction
-      ? {
-          dialogue: {
-            mode: shouldInheritNvl ? "nvl" : "adv",
-            ...(rightContent ? { content: rightContentArray } : {}),
-          },
-        }
-      : {};
-
-    const linesEditorRef = getLinesEditorRef(refs);
-    debugLog("lines", "scene.split.start", {
-      lineId,
-      sectionId,
-      newLineId,
-      leftContent: previewDebugText(leftContent),
-      rightContent: previewDebugText(rightContent),
-    });
-
-    await projectService.createLineItem({
-      sectionId,
-      lineId: newLineId,
-      line: {
-        actions: newLineActions,
-      },
-      afterLineId: lineId,
-    });
-    debugLog("lines", "scene.split.created-line", {
-      lineId,
-      newLineId,
-      leftContent: previewDebugText(leftContent),
-      rightContent: previewDebugText(rightContent),
-    });
-
-    syncStoreProjectState(store, projectService);
-    store.setSelectedLineId({ selectedLineId: newLineId });
-    render();
-    shouldReleaseLockAfterFocus = true;
-
-    requestAnimationFrame(() => {
-      if (linesEditorRef) {
-        linesEditorRef.focusLine({
-          lineId: newLineId,
-          cursorPosition: 0,
-          goalColumn: 0,
-          direction: "down",
-          syncLineId: lineId,
-        });
-      }
-
-      requestAnimationFrame(() => {
-        store.clearLockingLineId();
-      });
-    });
-
-    // Trigger debounced canvas render
-    subject.dispatch("sceneEditor.renderCanvas", {});
-  } finally {
-    if (!shouldReleaseLockAfterFocus) {
-      store.clearLockingLineId();
-    }
-  }
+  await handleSplitLineOperation(deps, payload);
 };
 
 export const handlePasteLines = async (deps, payload) => {
-  const { projectService, store, render, refs, subject } = deps;
-  if (isSectionsOverviewOpen(store)) {
+  if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
-
-  const sectionId = store.selectSelectedSectionId();
-  const { lineId, leftContent, rightContent, lines } = payload._event.detail;
-
-  // Flush pending dialogue updates before modifying repository
-  await flushDialogueQueue(deps);
-
-  // Get existing dialogue data to determine mode inheritance
-  const domainState = projectService.getDomainState();
-  const existingDialogue =
-    domainState?.lines?.[lineId]?.actions?.dialogue || {};
-
-  const shouldInheritNvl =
-    existingDialogue?.mode === "nvl" ||
-    shouldInheritNvlModeFromPreviousLine({
-      domainState,
-      sectionId,
-      lineId,
-      existingDialogue,
-    });
-
-  // First line content: leftContent + first pasted line
-  const firstLineContent = leftContent + lines[0];
-
-  // Update the current line with the first line content
-  const firstContentArray = [{ text: firstLineContent }];
-  if (existingDialogue && Object.keys(existingDialogue).length > 0) {
-    await projectService.updateLineActions({
-      lineId,
-      patch: {
-        dialogue: {
-          ...existingDialogue,
-          content: firstContentArray,
-        },
-      },
-      replace: false,
-    });
-  } else {
-    await projectService.updateLineActions({
-      lineId,
-      patch: {
-        dialogue: {
-          content: firstContentArray,
-        },
-      },
-      replace: false,
-    });
-  }
-
-  // Create new lines for remaining pasted lines
-  let lastCreatedLineId = lineId;
-  let afterLineId = lineId;
-
-  for (let i = 1; i < lines.length; i++) {
-    const newLineId = nanoid();
-    const isLastLine = i === lines.length - 1;
-
-    // Last pasted line gets combined with rightContent
-    const lineContent = isLastLine ? lines[i] + rightContent : lines[i];
-
-    const newLineActions = {
-      dialogue: {
-        mode: shouldInheritNvl ? "nvl" : "adv",
-        content: [{ text: lineContent }],
-      },
-    };
-
-    await projectService.createLineItem({
-      sectionId,
-      lineId: newLineId,
-      line: {
-        actions: newLineActions,
-      },
-      afterLineId,
-    });
-
-    afterLineId = newLineId;
-    lastCreatedLineId = newLineId;
-  }
-
-  // If only one line was pasted, add rightContent to current line
-  if (lines.length === 1) {
-    const combinedContent = firstLineContent + rightContent;
-    const combinedContentArray = [{ text: combinedContent }];
-    if (existingDialogue && Object.keys(existingDialogue).length > 0) {
-      await projectService.updateLineActions({
-        lineId,
-        patch: {
-          dialogue: {
-            ...existingDialogue,
-            content: combinedContentArray,
-          },
-        },
-        replace: false,
-      });
-    } else {
-      await projectService.updateLineActions({
-        lineId,
-        patch: {
-          dialogue: {
-            content: combinedContentArray,
-          },
-        },
-        replace: false,
-      });
-    }
-    lastCreatedLineId = lineId;
-  }
-
-  // Update store with new repository state
-  syncStoreProjectState(store, projectService);
-
-  // Set cursor position at end of last line
-  const linesEditorRef = getLinesEditorRef(refs);
-  const lastLineContent =
-    lines.length === 1
-      ? firstLineContent + rightContent
-      : lines[lines.length - 1] + rightContent;
-  const cursorPosition = lastLineContent.length - rightContent.length;
-
-  // Update selectedLineId
-  store.setSelectedLineId({ selectedLineId: lastCreatedLineId });
-
-  // Render after setting the selected line ID
-  render();
-
-  // Focus the last created line
-  requestAnimationFrame(() => {
-    if (linesEditorRef) {
-      linesEditorRef.focusLine({
-        lineId: lastCreatedLineId,
-        cursorPosition: cursorPosition,
-        goalColumn: cursorPosition,
-        direction: null,
-        syncLineId: lineId,
-      });
-    }
-  });
-
-  // Trigger debounced canvas render
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  await handlePasteLinesOperation(deps, payload);
 };
 
 export const handleNewLine = async (deps, payload) => {
-  const { store, render, projectService, subject, refs } = deps;
-  const detail = payload?._event?.detail || {};
-
-  if (isSectionsOverviewOpen(store)) {
+  if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
-
-  const newLineId = nanoid();
-  const sectionId = store.selectSelectedSectionId();
-  if (!sectionId) {
-    return;
-  }
-
-  const requestedPosition =
-    detail.position === "before" || detail.position === "after"
-      ? detail.position
-      : null;
-  const referenceLineId =
-    typeof detail.lineId === "string" && detail.lineId ? detail.lineId : null;
-
-  const selectedLine = store.selectSelectedLine();
-  const selectedLineId = store.selectSelectedLineId();
-  const baseLineId = referenceLineId || selectedLineId || selectedLine?.id;
-
-  if (requestedPosition && !baseLineId) {
-    return;
-  }
-
-  // Persist pending line text before mutating the section structure.
-  await flushDialogueQueue(deps);
-
-  const domainState = projectService.getDomainState();
-  const existingDialogue = baseLineId
-    ? domainState?.lines?.[baseLineId]?.actions?.dialogue || {}
-    : selectedLine?.actions?.dialogue || {};
-  const shouldInheritNvl =
-    existingDialogue?.mode === "nvl" ||
-    shouldInheritNvlModeFromPreviousLine({
-      domainState,
-      sectionId,
-      lineId: baseLineId,
-      existingDialogue,
-    });
-  const newLineActions = shouldInheritNvl
-    ? {
-        dialogue: {
-          mode: "nvl",
-        },
-      }
-    : {};
-
-  const scene = store.selectScene();
-  const selectedSection = scene?.sections?.find(
-    (section) => section?.id === sectionId,
-  );
-  const orderedLineIds = Array.isArray(selectedSection?.lines)
-    ? selectedSection.lines
-        .map((line) => line?.id)
-        .filter((lineId) => typeof lineId === "string" && lineId)
-    : [];
-  const baseLineIndex = baseLineId ? orderedLineIds.indexOf(baseLineId) : -1;
-
-  let afterLineId = null;
-  if (requestedPosition === "after" && baseLineId) {
-    afterLineId = baseLineId;
-  } else if (requestedPosition === "before" && baseLineId) {
-    afterLineId = baseLineIndex > 0 ? orderedLineIds[baseLineIndex - 1] : null;
-  }
-
-  const createLinePayload = {
-    sectionId,
-    lineId: newLineId,
-    line: {
-      actions: newLineActions,
-    },
-  };
-
-  if (afterLineId) {
-    createLinePayload.afterLineId = afterLineId;
-  } else if (!requestedPosition) {
-    createLinePayload.position = "last";
-  }
-
-  await projectService.createLineItem(createLinePayload);
-
-  if (requestedPosition === "before" && baseLineIndex === 0) {
-    await projectService.moveLineItem({
-      lineId: newLineId,
-      toSectionId: sectionId,
-      index: 0,
-    });
-  }
-
-  syncStoreProjectState(store, projectService);
-  store.setSelectedLineId({ selectedLineId: newLineId });
-
-  const shouldEnterInsertMode = !!requestedPosition;
-  const linesEditorRef = getLinesEditorRef(refs);
-
-  render();
-
-  if (shouldEnterInsertMode && linesEditorRef) {
-    requestAnimationFrame(() => {
-      linesEditorRef.focusLine({
-        lineId: newLineId,
-        cursorPosition: 0,
-        goalColumn: 0,
-        direction: null,
-      });
-    });
-  }
-
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  await handleNewLineOperation(deps, payload);
 };
 
 export const handleLineNavigation = (deps, payload) => {
@@ -1756,174 +581,17 @@ export const handleLineNavigation = (deps, payload) => {
 };
 
 export const handleSwapLine = async (deps, payload) => {
-  const { store, projectService, render, subject } = deps;
-  if (isSectionsOverviewOpen(store)) {
+  if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
-
-  const detail = payload?._event?.detail || {};
-  const direction =
-    detail.direction === "up" || detail.direction === "down"
-      ? detail.direction
-      : null;
-  const lineId =
-    typeof detail.lineId === "string" && detail.lineId
-      ? detail.lineId
-      : store.selectSelectedLineId();
-  const sectionId = store.selectSelectedSectionId();
-
-  if (!direction || !lineId || !sectionId) {
-    return;
-  }
-
-  const scene = store.selectScene();
-  const section = scene?.sections?.find((item) => item.id === sectionId);
-  const lines = Array.isArray(section?.lines) ? section.lines : [];
-  const currentIndex = lines.findIndex((line) => line.id === lineId);
-  if (currentIndex < 0) {
-    return;
-  }
-
-  const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
-  if (targetIndex < 0 || targetIndex >= lines.length) {
-    return;
-  }
-
-  await flushDialogueQueue(deps);
-  await projectService.moveLineItem({
-    lineId,
-    toSectionId: sectionId,
-    index: targetIndex,
-  });
-
-  syncStoreProjectState(store, projectService);
-  store.setSelectedLineId({ selectedLineId: lineId });
-  render();
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  await handleSwapLineOperation(deps, payload);
 };
 
 export const handleMergeLines = async (deps, payload) => {
-  const { store, refs, render, projectService, subject } = deps;
-  if (isSectionsOverviewOpen(store)) {
+  if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
-
-  const { currentLineId } = payload._event.detail;
-
-  // Check if this line is already being processed (split/merge)
-  const lockingLineId = store.selectLockingLineId();
-
-  if (lockingLineId) {
-    return;
-  }
-
-  store.setLockingLineId({ lineId: currentLineId });
-  let shouldReleaseLockAfterFocus = false;
-  let resolvedPrevLineId;
-
-  try {
-    // Flush pending dialogue updates before modifying repository
-    await flushDialogueQueue(deps);
-
-    // Re-resolve merge targets from authoritative domain state after the queue
-    // flush so held Backspace cannot operate on stale DOM/store state.
-    const domainState = projectService.getDomainState();
-    const { currentLine, prevLineId, prevLine } = resolveMergeLinesContext(
-      domainState,
-      currentLineId,
-    );
-    resolvedPrevLineId = prevLineId;
-
-    if (!currentLine || !prevLineId || !prevLine) {
-      return;
-    }
-
-    const prevContentText = getDialogueText(prevLine);
-    const currentContentText = getDialogueText(currentLine);
-    const mergedContent = prevContentText + currentContentText;
-
-    // Store the length of the previous content for cursor positioning
-    const prevContentLength = prevContentText.length;
-
-    // Get existing dialogue data to preserve layoutId and characterId
-    let existingDialogue = {};
-    if (prevLine.actions?.dialogue) {
-      existingDialogue = prevLine.actions.dialogue;
-    }
-
-    const finalContent = [{ text: mergedContent }];
-    // Update previous line with merged content
-    await projectService.updateLineActions({
-      lineId: prevLineId,
-      patch: {
-        dialogue: {
-          ...existingDialogue,
-          content: finalContent,
-        },
-      },
-      replace: false,
-    });
-
-    // Re-check existence in case another merge/delete removed the line while the
-    // previous update command was being processed.
-    if (!projectService.getDomainState()?.lines?.[currentLineId]) {
-      return;
-    }
-
-    try {
-      await projectService.deleteLineItem({ lineId: currentLineId });
-    } catch (error) {
-      if (isMissingLinePreconditionError(error, currentLineId)) {
-        return;
-      }
-
-      throw error;
-    }
-
-    // Update repository state in store to reflect the changes
-    syncStoreProjectState(store, projectService);
-
-    // Update selected line to the previous one
-    store.setSelectedLineId({ selectedLineId: prevLineId });
-
-    // Pre-configure the linesEditor for cursor positioning
-    const linesEditorRef = getLinesEditorRef(refs);
-
-    // Render and then focus
-    render();
-    shouldReleaseLockAfterFocus = true;
-
-    requestAnimationFrame(() => {
-      if (linesEditorRef) {
-        linesEditorRef.focusLine({
-          lineId: prevLineId,
-          cursorPosition: prevContentLength,
-          goalColumn: prevContentLength,
-          direction: null,
-        });
-      }
-
-      requestAnimationFrame(() => {
-        store.clearLockingLineId();
-      });
-    });
-
-    // Trigger debounced canvas render
-    subject.dispatch("sceneEditor.renderCanvas", {});
-  } catch (error) {
-    if (
-      isMissingLinePreconditionError(error, currentLineId) ||
-      isMissingLinePreconditionError(error, resolvedPrevLineId)
-    ) {
-      return;
-    }
-
-    throw error;
-  } finally {
-    if (!shouldReleaseLockAfterFocus) {
-      store.clearLockingLineId();
-    }
-  }
+  await handleMergeLinesOperation(deps, payload);
 };
 
 export const handleSectionTabRightClick = (deps, payload) => {
@@ -1976,9 +644,9 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   store.hideDropdownMenu();
 
   if (typeof action === "string" && action.startsWith("go-to-section:")) {
-    const nextSectionId = action.replace("goToSection:", "");
+    const nextSectionId = action.replace("go-to-section:", "");
     if (nextSectionId) {
-      await selectSection(deps, nextSectionId);
+      await selectSceneEditorSection(deps, nextSectionId);
       return;
     }
   }
@@ -2088,7 +756,11 @@ export const handleSectionCreateFormActionClick = async (deps, payload) => {
   if (action === "submit") {
     store.hideSectionCreateDialog();
     if (nextSectionName) {
-      await createSectionWithName(deps, nextSectionName);
+      await createSceneEditorSectionWithName(
+        deps,
+        nextSectionName,
+        syncStoreProjectState,
+      );
       return;
     }
   }
@@ -2120,7 +792,11 @@ export const handleFormActionClick = async (deps, payload) => {
     store.hidePopover();
 
     if (popoverMode === "create-section" && nextSectionName && sceneId) {
-      await createSectionWithName(deps, nextSectionName);
+      await createSceneEditorSectionWithName(
+        deps,
+        nextSectionName,
+        syncStoreProjectState,
+      );
       return;
     }
 
@@ -2245,79 +921,7 @@ export const handleLineDeleteActionItem = async (deps, payload) => {
 };
 
 export const handleHidePreviewScene = async (deps) => {
-  const { store, render, graphicsService, refs } = deps;
-
-  store.hidePreviewScene();
-  render();
-
-  const { canvas } = refs;
-  resetAssetLoadCache();
-  store.setSceneAssetLoading({ isLoading: false });
-  const beforeHandleActions = createBeforeHandleActionsHook(deps);
-  await graphicsService.init({
-    canvas: canvas,
-    beforeHandleActions,
-  });
-
-  const projectData = store.selectProjectData();
-  const sceneId = store.selectSceneId();
-  const initialProjectData = createProjectDataWithSelectedEntryPoint(
-    projectData,
-    {
-      sceneId,
-      sectionId: store.selectSelectedSectionId(),
-      lineId: store.selectSelectedLineId(),
-    },
-  );
-  const initialSceneIds = extractInitialHybridSceneIds(projectData, sceneId);
-  await loadAssetsForSceneIds(deps, projectData, initialSceneIds, {
-    showLoading: false,
-  });
-  void preloadDirectTransitionScenes(deps, projectData, initialSceneIds);
-  graphicsService.initRouteEngine(initialProjectData);
-
-  await renderSceneState(store, graphicsService);
-};
-
-// Handler for debounced canvas rendering
-async function handleRenderCanvas(deps, payload) {
-  const { store, graphicsService, render } = deps;
-  const projectData = store.selectProjectData();
-  const sceneId = store.selectSceneId();
-  const sceneIdsToLoad = extractInitialHybridSceneIds(projectData, sceneId);
-
-  await loadAssetsForSceneIds(deps, projectData, sceneIdsToLoad, {
-    showLoading: false,
-  });
-  void preloadDirectTransitionScenes(deps, projectData, sceneIdsToLoad);
-
-  await renderSceneState(store, graphicsService, payload);
-  await updateSectionChanges(deps);
-
-  if (!payload?.skipRender) {
-    render();
-  }
-}
-
-// RxJS subscriptions for handling events with throttling/debouncing
-const subscriptions = (deps) => {
-  const { subject, dialogueQueueService } = deps;
-
-  // Register write callback for dialogue queue (debounce is handled by the service)
-  dialogueQueueService.onWrite(async (lineId, data) => {
-    await writeDialogueContent(deps, lineId, data);
-  });
-
-  return [
-    // Debounce canvas renders by 50ms to prevent multiple renders on rapid navigation
-    subject.pipe(
-      filter(({ action }) => action === "sceneEditor.renderCanvas"),
-      debounceTime(50),
-      tap(async ({ payload }) => {
-        await handleRenderCanvas(deps, payload);
-      }),
-    ),
-  ];
+  await restoreSceneEditorFromPreview(deps);
 };
 
 export const handleBackClick = (deps) => {

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -417,14 +417,12 @@ export const handleSectionAddClick = (deps) => {
 };
 
 export const handleSectionsOverviewClick = (deps, payload) => {
-  const { store, render } = deps;
+  const { store, render, appService } = deps;
   if (payload?._event) {
     payload._event.preventDefault();
   }
 
-  if (typeof document !== "undefined" && document.activeElement?.blur) {
-    document.activeElement.blur();
-  }
+  appService.blurActiveElement();
 
   store.hideDeadEndTooltip();
   store.openSectionsOverviewPanel();

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -1,4 +1,5 @@
 import { toHierarchyStructure } from "../../domain/treeHelpers.js";
+import { buildSceneEditorLineViewModels } from "../../deps/features/sceneEditing/lineViewModels.js";
 import { layoutHierarchyStructureToRenderState } from "../../utils/index.js";
 import { constructProjectData } from "../../utils/projectDataConstructor.js";
 import { getSectionPresentation } from "../../utils/sectionPresentation.js";
@@ -654,6 +655,11 @@ export const selectViewData = ({ state }) => {
   const selectedLine = currentSection?.lines?.find(
     (line) => line.id === state.selectedLineId,
   );
+  const currentLines = buildSceneEditorLineViewModels({
+    lines: Array.isArray(currentSection?.lines) ? currentSection.lines : [],
+    repositoryState,
+    sectionLineChanges: state.sectionLineChanges,
+  });
 
   const sectionCreateForm = {
     title: "Create Section",
@@ -682,16 +688,13 @@ export const selectViewData = ({ state }) => {
     sections,
     sectionsOverviewOpen: state.sectionsOverviewPanel.isOpen,
     sectionsOverviewItems,
-    currentLines: Array.isArray(currentSection?.lines)
-      ? currentSection.lines
-      : [],
+    currentLines,
     dropdownMenu: state.dropdownMenu,
     popover: state.popover,
     form: sectionForm,
     selectedLineId: state.selectedLineId,
     selectedLine,
     selectedLineActions: toPlainObject(selectedLine?.actions),
-    repositoryState,
     sectionsGraphView: state.sectionsGraphView,
     layouts: Object.entries(selectLayouts({ state })).map(([id, item]) => ({
       id,

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -138,7 +138,7 @@ template:
                           - rtgl-text s=sm: ...
                       - rtgl-view w=1fg: null
                   - rtgl-view w=f p=md sv h=1fg:
-                      - rvn-lines-editor#linesEditor :lines=currentLines :selectedLineId=selectedLineId :sectionLineChanges=sectionLineChanges :repositoryState=repositoryState: null
+                      - rvn-lines-editor#linesEditor :lines=currentLines :selectedLineId=selectedLineId: null
                       - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null
           - rtgl-view w=f:


### PR DESCRIPTION
## Summary
- move scene editor line view-model shaping out of `linesEditor` and into `sceneEditor` via `src/deps/features/sceneEditing/lineViewModels.js`
- extract scene editing workflows into `src/deps/features/sceneEditing/lineOperations.js`, `runtime.js`, and `sectionOperations.js`
- keep `linesEditor` as a fixed Rettangoli component with UI-local state only and document the intended scene editor layering in `docs/engineering.md`

## Testing
- `bun x oxlint src/pages/sceneEditor src/deps/features/sceneEditing docs/engineering.md`
- `bun x prettier --check src/pages/sceneEditor src/deps/features/sceneEditing docs/engineering.md`
- `bun run build:web`

## Notes
- manual scene-editor smoke test not run after this refactor