### PR TITLE
refactor: migrate client to route-engine 0.1.37

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "jsdom": "^26.1.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.5",
-        "route-engine-js": "0.1.36",
+        "route-engine-js": "0.1.37",
         "route-graphics": "0.0.34",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
@@ -203,6 +203,8 @@
 
     "@pixi/utils": ["@pixi/utils@7.4.3", "", { "dependencies": { "@pixi/color": "7.4.3", "@pixi/constants": "7.4.3", "@pixi/settings": "7.4.3", "@types/earcut": "^2.1.0", "earcut": "^2.2.4", "eventemitter3": "^4.0.0", "url": "^0.11.0" } }, "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA=="],
 
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
     "@rettangoli/fe": ["@rettangoli/fe@1.0.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "rxjs": "^7.8.2", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-rTUEYTe1xjf8M0bSaioB/C8E9L0x/X4gze4mgo2FHLQjE97iDAUfrSOqtzr95HdPZnp5OaSQ+vN0g2xzj0idKw=="],
 
     "@rettangoli/ui": ["@rettangoli/ui@1.0.3", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@rettangoli/fe": "1.0.3", "commander": "^13.1.0", "jempl": "1.0.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "snabbdom": "^3.6.2" } }, "sha512-CQTlWaRpwwmyKrnDZpwzkSrEBMbF/tOF063Y0lrLp9hdnKmpIOSB1GLtalMEU7x1oZuLQq+zBStbNwVVOxS7UQ=="],
@@ -347,6 +349,8 @@
 
     "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
 
+    "@vitest/ui": ["@vitest/ui@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "fflate": "^0.8.2", "flatted": "^3.3.3", "pathe": "^2.0.3", "sirv": "^3.0.1", "tinyglobby": "^0.2.14", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "vitest": "3.2.4" } }, "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA=="],
+
     "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
@@ -435,9 +439,13 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
     "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "flatted": ["flatted@3.4.1", "", {}, "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -525,6 +533,8 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -546,6 +556,8 @@
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -623,7 +635,7 @@
 
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
 
-    "route-engine-js": ["route-engine-js@0.1.36", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-Ajgf2m+g25dW8ir3UmFY/8qt1noCWMtde6Dcmoe7YcPag53j8c9Z7Dmngld70+6p+LyChRFJeltZI8LZXdNKPA=="],
+    "route-engine-js": ["route-engine-js@0.1.37", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-i2Nm7uSRuF87LP+NVCRN24I+MWATx2Cz+vN+gzsY/ZSKcDe0cgSv+zCCrf5MeHoHjq+BasoGCa248S0d5fZKng=="],
 
     "route-graphics": ["route-graphics@0.0.34", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-MNOmlzrEIj4Jp7ArJLFGaKlrLz/RmYTpyKw9CMxZ/WCSZqFHoPAo6wnWoIH2iL6VtDIEhWoD44fHE6qmroF0gA=="],
 
@@ -656,6 +668,8 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
@@ -702,6 +716,8 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
@@ -771,6 +787,10 @@
 
     "@rettangoli/vt/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
+    "@vitest/ui/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@vitest/ui/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
     "insieme/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "liquidjs/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
@@ -784,5 +804,7 @@
     "url/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@vitest/ui/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsdom": "^26.1.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.5",
-    "route-engine-js": "0.1.36",
+    "route-engine-js": "0.1.37",
     "route-graphics": "0.0.34",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -207,7 +207,6 @@ const prepareEngine = async ({ jsonData, assetBufferMap }) => {
     engine.init({
       initialState: {
         global: {
-          currentLocalizationPackageId: "eklekfjwalefj",
           saveSlots,
           variables: { ...globalDeviceVariables, ...globalAccountVariables },
         },

--- a/scripts/test-smoke.js
+++ b/scripts/test-smoke.js
@@ -583,7 +583,7 @@ const renderedChoiceLayout = buildLayoutRenderElements(
     items: {
       "font-body": {
         id: "font-body",
-        fontFamily: "Smoke Sans",
+        fileId: "font-body-file",
       },
     },
     tree: [],
@@ -597,7 +597,7 @@ assert.equal(renderedChoiceLayout[0].children[0].id, "choice-label-${i}");
 assert.equal(renderedChoiceLayout[0].children[0].content, "${item.content}");
 assert.equal(
   renderedChoiceLayout[0].children[0].textStyle.fontFamily,
-  "Smoke Sans",
+  "font-body-file",
 );
 
 const dedupedFileReferences = extractFileIdsFromRenderState({

--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -326,7 +326,11 @@ export const handleSubmitClick = (deps) => {
   }
 
   // Only add animations object if there's a valid tween selected
-  if (selectedTweenId && selectedTweenId !== "none") {
+  if (
+    selectedResource?.resourceId &&
+    selectedTweenId &&
+    selectedTweenId !== "none"
+  ) {
     backgroundData.animations = {
       in: {
         resourceId: selectedTweenId,

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -222,18 +222,6 @@ export const selectViewData = ({ state }) => {
   const selectedResource = selectSelectedResource({ state });
   const breadcrumb = selectBreadcrumb({ state });
 
-  // Create tween options from repository tweens using the same pattern as layouts
-  const flatTweens = toFlatItems(state.tweenItems || []).filter(
-    (item) => item.type === "tween",
-  );
-  const tweenOptions = flatTweens.map((tween) => ({
-    value: tween.id,
-    label: tween.name || tween.id,
-  }));
-
-  // Add a "None" option at the beginning
-  tweenOptions.unshift({ value: "none", label: "None" });
-
   const formFields = [
     {
       type: "slot",
@@ -254,20 +242,12 @@ export const selectViewData = ({ state }) => {
     });
   }
 
-  formFields.push({
-    name: "tween",
-    label: "Tween Animation",
-    type: "select",
-    options: tweenOptions,
-  });
-
   const form = {
     fields: formFields,
   };
 
   const defaultValues = {
     background: selectedResource?.fileId || "",
-    tween: state.selectedTweenId,
     loop: state.backgroundLoop ?? false,
   };
 

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -10,7 +10,8 @@ export const handleBeforeMount = (deps) => {
   const { store, props } = deps;
   const selectedMode = props?.dialogue?.mode || "adv";
   const selectedLayoutType = getLayoutTypeByMode(selectedMode);
-  const selectedResourceId = props?.dialogue?.gui?.resourceId || "";
+  const selectedResourceId =
+    props?.dialogue?.ui?.resourceId || props?.dialogue?.gui?.resourceId || "";
   const selectedLayout = (props?.layouts || []).find(
     (layout) => layout.id === selectedResourceId,
   );
@@ -87,7 +88,7 @@ export const handleSubmitClick = (deps) => {
   };
 
   if (effectiveResourceId) {
-    dialogue.gui = {
+    dialogue.ui = {
       resourceId: effectiveResourceId,
     };
   }

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.schema.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.schema.yaml
@@ -29,6 +29,11 @@ propsSchema:
           type: boolean
         clear:
           type: boolean
+        ui:
+          type: object
+          properties:
+            resourceId:
+              type: string
         gui:
           type: object
           properties:

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -255,8 +255,10 @@ export const selectActionsData = ({ props, state }) => {
     } else {
       preview.dialogue = {
         name:
-          layoutsItems[presentationState.dialogue.gui?.resourceId]?.name ||
-          "No layout",
+          layoutsItems[
+            presentationState.dialogue.ui?.resourceId ??
+              presentationState.dialogue.gui?.resourceId
+          ]?.name || "No layout",
       };
     }
   }

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -61,10 +61,10 @@ async function loadAssetsForSceneIds(
   const fileReferences = extractFileIdsForScenes(projectData, uniqueSceneIds);
   const missingFileReferences = fileReferences.filter((fileReference) => {
     const fileId = fileReference?.url;
-    return fileId && !store.hasLoadedAssetFileId({ fileId });
+    return fileId && !store.selectHasLoadedAssetFileId({ fileId });
   });
   const isAnySceneUntracked = uniqueSceneIds.some(
-    (sceneId) => !store.hasLoadedAssetSceneId({ sceneId }),
+    (sceneId) => !store.selectHasLoadedAssetSceneId({ sceneId }),
   );
 
   if (missingFileReferences.length === 0 && !isAnySceneUntracked) {
@@ -134,7 +134,7 @@ const preloadLayoutAssetsByIds = async (deps, projectData, layoutIds) => {
   const fileReferences = extractFileIdsForLayouts(projectData, uniqueLayoutIds);
   const missingFileReferences = fileReferences.filter((fileReference) => {
     const fileId = fileReference?.url;
-    return fileId && !store.hasLoadedAssetFileId({ fileId });
+    return fileId && !store.selectHasLoadedAssetFileId({ fileId });
   });
 
   if (missingFileReferences.length === 0) {

--- a/src/components/vnPreview/vnPreview.store.js
+++ b/src/components/vnPreview/vnPreview.store.js
@@ -1,9 +1,43 @@
+const createEmptyAssetLoadCache = () => ({
+  sceneIds: [],
+  fileIds: [],
+});
+
+const readAssetLoadCache = (state) => {
+  if (!state || typeof state !== "object") {
+    return createEmptyAssetLoadCache();
+  }
+
+  if (
+    !state.assetLoadCache ||
+    !Array.isArray(state.assetLoadCache.sceneIds) ||
+    !Array.isArray(state.assetLoadCache.fileIds)
+  ) {
+    return createEmptyAssetLoadCache();
+  }
+
+  return state.assetLoadCache;
+};
+
+const ensureAssetLoadCache = (state) => {
+  if (!state || typeof state !== "object") {
+    return createEmptyAssetLoadCache();
+  }
+
+  if (
+    !state.assetLoadCache ||
+    !Array.isArray(state.assetLoadCache.sceneIds) ||
+    !Array.isArray(state.assetLoadCache.fileIds)
+  ) {
+    state.assetLoadCache = createEmptyAssetLoadCache();
+  }
+
+  return state.assetLoadCache;
+};
+
 export const createInitialState = () => ({
   isAssetLoading: false,
-  assetLoadCache: {
-    sceneIds: [],
-    fileIds: [],
-  },
+  assetLoadCache: createEmptyAssetLoadCache(),
 });
 
 export const setAssetLoading = ({ state }, { isLoading } = {}) => {
@@ -11,37 +45,38 @@ export const setAssetLoading = ({ state }, { isLoading } = {}) => {
 };
 
 export const resetAssetLoadCache = ({ state }, _payload = {}) => {
-  state.assetLoadCache = {
-    sceneIds: [],
-    fileIds: [],
-  };
+  state.assetLoadCache = createEmptyAssetLoadCache();
 };
 
-export const selectAssetLoadCache = ({ state }) => state.assetLoadCache;
+export const selectAssetLoadCache = ({ state }) => readAssetLoadCache(state);
 
-export const hasLoadedAssetFileId = ({ state }, { fileId } = {}) => {
-  return !!fileId && state.assetLoadCache.fileIds.includes(fileId);
+export const selectHasLoadedAssetFileId = ({ state }, { fileId } = {}) => {
+  return !!fileId && readAssetLoadCache(state).fileIds.includes(fileId);
 };
 
-export const hasLoadedAssetSceneId = ({ state }, { sceneId } = {}) => {
-  return !!sceneId && state.assetLoadCache.sceneIds.includes(sceneId);
+export const selectHasLoadedAssetSceneId = ({ state }, { sceneId } = {}) => {
+  return !!sceneId && readAssetLoadCache(state).sceneIds.includes(sceneId);
 };
 
 export const markAssetFileIdsLoaded = ({ state }, { fileIds } = {}) => {
+  const assetLoadCache = ensureAssetLoadCache(state);
+
   for (const fileId of fileIds ?? []) {
-    if (!fileId || state.assetLoadCache.fileIds.includes(fileId)) {
+    if (!fileId || assetLoadCache.fileIds.includes(fileId)) {
       continue;
     }
-    state.assetLoadCache.fileIds.push(fileId);
+    assetLoadCache.fileIds.push(fileId);
   }
 };
 
 export const markAssetSceneIdsLoaded = ({ state }, { sceneIds } = {}) => {
+  const assetLoadCache = ensureAssetLoadCache(state);
+
   for (const sceneId of sceneIds ?? []) {
-    if (!sceneId || state.assetLoadCache.sceneIds.includes(sceneId)) {
+    if (!sceneId || assetLoadCache.sceneIds.includes(sceneId)) {
       continue;
     }
-    state.assetLoadCache.sceneIds.push(sceneId);
+    assetLoadCache.sceneIds.push(sceneId);
   }
 };
 

--- a/src/deps/features/sceneEditing/runtime.js
+++ b/src/deps/features/sceneEditing/runtime.js
@@ -385,18 +385,7 @@ export const initializeSceneEditorPage = async (deps) => {
     sectionId: payloadSectionId,
     lineId: payloadLineId,
   } = appService.getPayload();
-  const state = syncProjectState(store, projectService);
-
-  if (state.fonts?.items) {
-    for (const font of Object.values(state.fonts.items)) {
-      if (font.type === "font" && font.fileId && font.fontFamily) {
-        await projectService.loadFontFile({
-          fontName: font.fontFamily,
-          fileId: font.fileId,
-        });
-      }
-    }
-  }
+  syncProjectState(store, projectService);
 
   store.setSceneId({ sceneId });
 

--- a/src/deps/features/sceneEditing/sectionOperations.js
+++ b/src/deps/features/sceneEditing/sectionOperations.js
@@ -124,7 +124,7 @@ export const createSceneEditorSectionWithName = async (
   const actions = {
     dialogue: dialogueLayoutId
       ? {
-          gui: {
+          ui: {
             resourceId: dialogueLayoutId,
           },
           mode: "adv",

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -195,9 +195,7 @@ export const createGraphicsService = async ({ subject }) => {
       engine = createRouteEngine({ handlePendingEffects });
       engine.init({
         initialState: {
-          global: {
-            currentLocalizationPackageId: "abcd",
-          },
+          global: {},
           projectData,
         },
       });

--- a/src/internal/project/engineActions.js
+++ b/src/internal/project/engineActions.js
@@ -1,0 +1,45 @@
+const normalizeDialogueAction = (dialogue = {}) => {
+  const normalizedDialogue = {
+    ...dialogue,
+  };
+
+  if (normalizedDialogue.gui && !normalizedDialogue.ui) {
+    normalizedDialogue.ui = normalizedDialogue.gui;
+  }
+  delete normalizedDialogue.gui;
+
+  if (typeof normalizedDialogue.content === "string") {
+    normalizedDialogue.content = [{ text: normalizedDialogue.content }];
+  }
+
+  return normalizedDialogue;
+};
+
+export const normalizeEngineActions = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeEngineActions(entry));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const normalizedValue = Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      normalizeEngineActions(entry),
+    ]),
+  );
+
+  if (
+    normalizedValue.dialogue &&
+    typeof normalizedValue.dialogue === "object" &&
+    !Array.isArray(normalizedValue.dialogue)
+  ) {
+    normalizedValue.dialogue = normalizeDialogueAction(
+      normalizedValue.dialogue,
+    );
+  }
+
+  return normalizedValue;
+};

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -1,4 +1,6 @@
+import { resolveLayoutReferences } from "route-engine-js";
 import { getFirstTypographyId } from "../../constants/typography.js";
+import { normalizeEngineActions } from "./engineActions.js";
 
 const TEXT_NODE_TYPES = new Set([
   "text",
@@ -40,11 +42,10 @@ const REPEATING_CONTAINER_CONFIG = {
   },
 };
 
-const DEFAULT_TEXT_STYLE = {
+const DEFAULT_TEXT_STYLE_RESOURCE = {
   fontSize: 24,
-  fontFamily: "sans-serif",
   fontWeight: "normal",
-  fill: "white",
+  fontStyle: "normal",
   lineHeight: 1.2,
   breakWords: true,
 };
@@ -59,31 +60,135 @@ const toWordWrapWidth = (value) => {
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
-const resolveTypographyForNode = (nodeTypographyId, typographyData = {}) => {
+const toFiniteNumber = (value, fallback) => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const resolveTypographyId = (nodeTypographyId, typographyData = {}) => {
   const typographyItems = typographyData.items || {};
 
   if (nodeTypographyId && typographyItems[nodeTypographyId]) {
-    return typographyItems[nodeTypographyId];
+    return nodeTypographyId;
   }
 
-  const firstTypographyId = getFirstTypographyId(typographyData);
-  return firstTypographyId ? typographyItems[firstTypographyId] : undefined;
+  return getFirstTypographyId(typographyData);
+};
+
+const normalizeTextStyleResource = (typography) => {
+  if (!typography?.fontId || !typography?.colorId) {
+    return undefined;
+  }
+
+  const textStyle = {
+    fontId: typography.fontId,
+    colorId: typography.colorId,
+    fontSize: toFiniteNumber(
+      typography.fontSize,
+      DEFAULT_TEXT_STYLE_RESOURCE.fontSize,
+    ),
+    fontWeight: typography.fontWeight ?? DEFAULT_TEXT_STYLE_RESOURCE.fontWeight,
+    fontStyle: typography.fontStyle ?? DEFAULT_TEXT_STYLE_RESOURCE.fontStyle,
+    lineHeight: toFiniteNumber(
+      typography.lineHeight,
+      DEFAULT_TEXT_STYLE_RESOURCE.lineHeight,
+    ),
+    breakWords: typography.breakWords ?? DEFAULT_TEXT_STYLE_RESOURCE.breakWords,
+  };
+
+  if (typeof typography.align === "string" && typography.align.length > 0) {
+    textStyle.align = typography.align;
+  }
+
+  const wordWrapWidth = toWordWrapWidth(typography.wordWrapWidth);
+  if (wordWrapWidth !== undefined) {
+    textStyle.wordWrap = typography.wordWrap ?? true;
+    textStyle.wordWrapWidth = wordWrapWidth;
+  } else if (typeof typography.wordWrap === "boolean") {
+    textStyle.wordWrap = typography.wordWrap;
+  }
+
+  if (typography.strokeColorId) {
+    textStyle.strokeColorId = typography.strokeColorId;
+  }
+  if (typography.strokeAlpha !== undefined) {
+    textStyle.strokeAlpha = typography.strokeAlpha;
+  }
+  if (typography.strokeWidth !== undefined) {
+    textStyle.strokeWidth = typography.strokeWidth;
+  }
+
+  return textStyle;
+};
+
+const buildNodeTextStyleOverrides = (node) => {
+  const overrides = {};
+
+  if (typeof node.style?.align === "string" && node.style.align.length > 0) {
+    overrides.align = node.style.align;
+  }
+
+  const wordWrapWidth = toWordWrapWidth(node.style?.wordWrapWidth);
+  if (wordWrapWidth !== undefined) {
+    overrides.wordWrap = true;
+    overrides.wordWrapWidth = wordWrapWidth;
+    overrides.breakWords = true;
+  }
+
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+};
+
+const ensureNodeTextStyleId = ({
+  textStyles,
+  typographyData,
+  layoutId,
+  node,
+  typographyId,
+  variant,
+}) => {
+  const resolvedTypographyId = resolveTypographyId(
+    typographyId,
+    typographyData,
+  );
+  if (!resolvedTypographyId) {
+    return undefined;
+  }
+
+  const overrides = buildNodeTextStyleOverrides(node);
+  if (!overrides) {
+    return resolvedTypographyId;
+  }
+
+  const derivedId = `__layout:${layoutId}:${node.id}:${variant}`;
+  if (!textStyles[derivedId]) {
+    const baseTextStyle = textStyles[resolvedTypographyId];
+    if (!baseTextStyle) {
+      return resolvedTypographyId;
+    }
+
+    textStyles[derivedId] = {
+      ...baseTextStyle,
+      ...overrides,
+    };
+  }
+
+  return derivedId;
 };
 
 const normalizeSliderChange = (change, sliderId) => {
   const updateVariable = change?.actionPayload?.actions?.updateVariable;
   if (!updateVariable) {
-    return change;
+    return normalizeEngineActions(change);
   }
 
   const fallbackId = toAlphanumericId(`slider${sliderId}update`);
   const sanitizedId = toAlphanumericId(updateVariable.id, fallbackId);
 
   if (sanitizedId === updateVariable.id) {
-    return change;
+    return normalizeEngineActions(change);
   }
 
-  return {
+  return normalizeEngineActions({
     ...change,
     actionPayload: {
       ...change.actionPayload,
@@ -95,7 +200,7 @@ const normalizeSliderChange = (change, sliderId) => {
         },
       },
     },
-  };
+  });
 };
 
 const updateChildrenIds = (children, indexVar) => {
@@ -126,6 +231,13 @@ const isNvlLinesContainer = (node) => {
   );
 };
 
+const getImageFileId = (imageItems, imageId) => {
+  const fileId = imageItems?.[imageId]?.fileId;
+  return typeof fileId === "string" && fileId.length > 0
+    ? `${fileId}`
+    : undefined;
+};
+
 const buildBaseElement = (node) => {
   const element = {
     id: node.id,
@@ -139,7 +251,7 @@ const buildBaseElement = (node) => {
     scaleX: node.scaleX ?? 1,
     scaleY: node.scaleY ?? 1,
     rotation: node.rotation ?? 0,
-    click: node.click,
+    click: normalizeEngineActions(node.click),
   };
 
   if (node["$when"]) {
@@ -153,104 +265,62 @@ const buildBaseElement = (node) => {
   return element;
 };
 
-const buildTextStyle = ({
-  node,
-  typography,
-  colorsData,
-  fontsData,
-  fallbackStyle = DEFAULT_TEXT_STYLE,
-}) => {
-  const colorItem = colorsData.items?.[typography?.colorId];
-  const fontItem = fontsData.items?.[typography?.fontId];
-  const fontSize =
-    Number.parseFloat(typography?.fontSize ?? fallbackStyle.fontSize ?? 24) ||
-    24;
-  const lineHeightRatio =
-    Number.parseFloat(
-      typography?.lineHeight ?? fallbackStyle.lineHeight ?? 1.2,
-    ) || 1.2;
-  const wordWrapWidth = toWordWrapWidth(node.style?.wordWrapWidth);
-
-  return {
-    fontSize,
-    fontFamily:
-      fontItem?.fontFamily || fallbackStyle.fontFamily || "sans-serif",
-    fontWeight: typography?.fontWeight || fallbackStyle.fontWeight || "normal",
-    fill: colorItem?.hex || fallbackStyle.fill || "white",
-    lineHeight:
-      fallbackStyle === DEFAULT_TEXT_STYLE
-        ? (typography?.lineHeight ?? fallbackStyle.lineHeight ?? 1.2)
-        : Math.round(fontSize * lineHeightRatio),
-    align: node.style?.align,
-    breakWords: true,
-    ...(wordWrapWidth !== undefined ? { wordWrapWidth } : {}),
-  };
-};
-
-const applyTextNode = ({
-  element,
-  node,
-  typographyData,
-  colorsData,
-  fontsData,
-}) => {
+const applyTextNode = ({ element, node, context }) => {
   if (!TEXT_NODE_TYPES.has(node.type)) {
     return element;
   }
-
-  const typography = resolveTypographyForNode(
-    node.typographyId,
-    typographyData,
-  );
-  const wordWrapWidth = toWordWrapWidth(node.style?.wordWrapWidth);
-  const baseTextStyle = typography
-    ? buildTextStyle({
-        node,
-        typography,
-        colorsData,
-        fontsData,
-      })
-    : {
-        ...DEFAULT_TEXT_STYLE,
-        align: node.style?.align,
-        ...(wordWrapWidth !== undefined ? { wordWrapWidth } : {}),
-      };
 
   const nextElement = {
     ...element,
     type: TEXT_RENDER_TYPE_BY_TYPE[node.type] || element.type,
     text: node.text,
     content: TEXT_CONTENT_BY_TYPE[node.type] || node.text,
-    textStyle: baseTextStyle,
   };
 
+  const textStyleId = ensureNodeTextStyleId({
+    textStyles: context.textStyles,
+    typographyData: context.typographyData,
+    layoutId: context.layoutId,
+    node,
+    typographyId: node.typographyId,
+    variant: "base",
+  });
+  if (textStyleId) {
+    nextElement.textStyleId = textStyleId;
+  }
+
   if (node.hoverTypographyId) {
-    const hoverTypography = typographyData.items?.[node.hoverTypographyId];
-    if (hoverTypography) {
+    const hoverTextStyleId = ensureNodeTextStyleId({
+      textStyles: context.textStyles,
+      typographyData: context.typographyData,
+      layoutId: context.layoutId,
+      node,
+      typographyId: node.hoverTypographyId,
+      variant: "hover",
+    });
+
+    if (hoverTextStyleId) {
       nextElement.hover = {
-        textStyle: buildTextStyle({
-          node,
-          typography: hoverTypography,
-          colorsData,
-          fontsData,
-          fallbackStyle: baseTextStyle,
-        }),
+        ...nextElement.hover,
+        textStyleId: hoverTextStyleId,
       };
     }
   }
 
   if (node.clickedTypographyId) {
-    const clickedTypography = typographyData.items?.[node.clickedTypographyId];
-    if (clickedTypography) {
+    const clickTextStyleId = ensureNodeTextStyleId({
+      textStyles: context.textStyles,
+      typographyData: context.typographyData,
+      layoutId: context.layoutId,
+      node,
+      typographyId: node.clickedTypographyId,
+      variant: "click",
+    });
+
+    if (clickTextStyleId) {
       nextElement.click = {
         ...nextElement.click,
-        textStyle: buildTextStyle({
-          node,
-          typography: clickedTypography,
-          colorsData,
-          fontsData,
-          fallbackStyle: baseTextStyle,
-        }),
+        textStyleId: clickTextStyleId,
       };
     }
   }
@@ -258,35 +328,17 @@ const applyTextNode = ({
   return nextElement;
 };
 
-const applySpriteNode = ({ element, node, imageItems }) => {
+const applySpriteNode = ({ element, node }) => {
   if (node.type !== "sprite") {
     return element;
   }
 
-  const nextElement = { ...element };
-
-  const image = imageItems?.[node.imageId];
-  if (image?.fileId) {
-    nextElement.src = `${image.fileId}`;
-  }
-
-  const hoverImage = imageItems?.[node.hoverImageId];
-  if (hoverImage?.fileId) {
-    nextElement.hover = {
-      ...nextElement.hover,
-      src: `${hoverImage.fileId}`,
-    };
-  }
-
-  const clickImage = imageItems?.[node.clickImageId];
-  if (clickImage?.fileId) {
-    nextElement.click = {
-      ...nextElement.click,
-      src: `${clickImage.fileId}`,
-    };
-  }
-
-  return nextElement;
+  return {
+    ...element,
+    ...(node.imageId ? { imageId: node.imageId } : {}),
+    ...(node.hoverImageId ? { hoverImageId: node.hoverImageId } : {}),
+    ...(node.clickImageId ? { clickImageId: node.clickImageId } : {}),
+  };
 };
 
 const applySliderNode = ({ element, node, imageItems }) => {
@@ -303,29 +355,42 @@ const applySliderNode = ({ element, node, imageItems }) => {
     initialValue: node.initialValue ?? 0,
   };
 
-  const thumbImage = imageItems?.[node.thumbImageId];
-  if (thumbImage?.fileId) {
-    nextElement.thumbSrc = `${thumbImage.fileId}`;
+  if (node.thumbImageId) {
+    nextElement.thumbImageId = node.thumbImageId;
+  }
+  if (node.barImageId) {
+    nextElement.barImageId = node.barImageId;
+  }
+  if (node.hoverThumbImageId) {
+    nextElement.hoverThumbImageId = node.hoverThumbImageId;
+  }
+  if (node.hoverBarImageId) {
+    nextElement.hoverBarImageId = node.hoverBarImageId;
   }
 
-  const barImage = imageItems?.[node.barImageId];
-  if (barImage?.fileId) {
-    nextElement.barSrc = `${barImage.fileId}`;
+  const thumbSrc = getImageFileId(imageItems, node.thumbImageId);
+  if (thumbSrc) {
+    nextElement.thumbSrc = thumbSrc;
   }
 
-  const hoverThumbImage = imageItems?.[node.hoverThumbImageId];
-  const hoverBarImage = imageItems?.[node.hoverBarImageId];
-  if (hoverThumbImage?.fileId || hoverBarImage?.fileId) {
+  const barSrc = getImageFileId(imageItems, node.barImageId);
+  if (barSrc) {
+    nextElement.barSrc = barSrc;
+  }
+
+  const hoverThumbSrc = getImageFileId(imageItems, node.hoverThumbImageId);
+  const hoverBarSrc = getImageFileId(imageItems, node.hoverBarImageId);
+  if (hoverThumbSrc || hoverBarSrc) {
     nextElement.hover = {
       ...nextElement.hover,
     };
 
-    if (hoverThumbImage?.fileId) {
-      nextElement.hover.thumbSrc = `${hoverThumbImage.fileId}`;
+    if (hoverThumbSrc) {
+      nextElement.hover.thumbSrc = hoverThumbSrc;
     }
 
-    if (hoverBarImage?.fileId) {
-      nextElement.hover.barSrc = `${hoverBarImage.fileId}`;
+    if (hoverBarSrc) {
+      nextElement.hover.barSrc = hoverBarSrc;
     }
   }
 
@@ -370,30 +435,22 @@ const applyContainerNode = ({ element, node }) => {
       ? {
           click: {
             ...nextElement.click,
-            ...repeatingConfig.click,
+            ...normalizeEngineActions(repeatingConfig.click),
           },
         }
       : {}),
   };
 };
 
-const mapLayoutNode = ({
-  node,
-  imageItems,
-  typographyData,
-  colorsData,
-  fontsData,
-}) => {
+const mapLayoutNode = ({ node, imageItems, context }) => {
   let element = buildBaseElement(node);
 
   element = applyTextNode({
     element,
     node,
-    typographyData,
-    colorsData,
-    fontsData,
+    context,
   });
-  element = applySpriteNode({ element, node, imageItems });
+  element = applySpriteNode({ element, node });
   element = applySliderNode({ element, node, imageItems });
   element = applyContainerNode({ element, node });
 
@@ -402,9 +459,7 @@ const mapLayoutNode = ({
       mapLayoutNode({
         node: child,
         imageItems,
-        typographyData,
-        colorsData,
-        fontsData,
+        context,
       }),
     );
 
@@ -416,20 +471,168 @@ const mapLayoutNode = ({
   return element;
 };
 
+const createImageResources = (imageItems = {}) => {
+  const images = {};
+
+  Object.entries(imageItems).forEach(([imageId, item]) => {
+    if (!item?.fileId) {
+      return;
+    }
+
+    if (item.type && item.type !== "image") {
+      return;
+    }
+
+    const image = {
+      fileId: `${item.fileId}`,
+    };
+
+    if (item.fileType) {
+      image.fileType = item.fileType;
+    }
+    if (item.width !== undefined) {
+      image.width = item.width;
+    }
+    if (item.height !== undefined) {
+      image.height = item.height;
+    }
+
+    images[imageId] = image;
+  });
+
+  return images;
+};
+
+const createColorResources = (colorsData = {}) => {
+  return Object.entries(colorsData.items || {}).reduce(
+    (result, [colorId, item]) => {
+      if (item?.type && item.type !== "color") {
+        return result;
+      }
+      if (!item?.hex) {
+        return result;
+      }
+
+      result[colorId] = {
+        hex: item.hex,
+      };
+      return result;
+    },
+    {},
+  );
+};
+
+const createFontResources = (fontsData = {}) => {
+  return Object.entries(fontsData.items || {}).reduce(
+    (result, [fontId, item]) => {
+      if (item?.type && item.type !== "font") {
+        return result;
+      }
+      if (!item?.fileId) {
+        return result;
+      }
+
+      result[fontId] = {
+        fileId: `${item.fileId}`,
+        ...(item.fileType ? { fileType: item.fileType } : {}),
+      };
+      return result;
+    },
+    {},
+  );
+};
+
+const createTextStyleResources = (typographyData = {}) => {
+  return Object.entries(typographyData.items || {}).reduce(
+    (result, [typographyId, item]) => {
+      if (item?.type && item.type !== "typography") {
+        return result;
+      }
+
+      const textStyle = normalizeTextStyleResource(item);
+      if (!textStyle) {
+        return result;
+      }
+
+      result[typographyId] = textStyle;
+      return result;
+    },
+    {},
+  );
+};
+
+export const createLayoutReferenceResources = (
+  imageItems,
+  typographyData,
+  colorsData,
+  fontsData,
+) => {
+  return {
+    images: createImageResources(imageItems),
+    colors: createColorResources(colorsData),
+    fonts: createFontResources(fontsData),
+    textStyles: createTextStyleResources(typographyData),
+  };
+};
+
+export const buildLayoutElements = (
+  layout,
+  imageItems,
+  typographyData,
+  colorsData,
+  fontsData,
+  options = {},
+) => {
+  const resources = createLayoutReferenceResources(
+    imageItems,
+    typographyData,
+    colorsData,
+    fontsData,
+  );
+  const textStyles = {
+    ...resources.textStyles,
+  };
+  const context = {
+    layoutId: options.layoutId ?? "preview",
+    typographyData,
+    textStyles,
+  };
+
+  const elements = (layout || []).map((node) =>
+    mapLayoutNode({
+      node,
+      imageItems,
+      context,
+    }),
+  );
+
+  return {
+    elements,
+    resources: {
+      ...resources,
+      textStyles,
+    },
+  };
+};
+
 export const buildLayoutRenderElements = (
   layout,
   imageItems,
   typographyData,
   colorsData,
   fontsData,
+  options = {},
 ) => {
-  return layout.map((node) =>
-    mapLayoutNode({
-      node,
-      imageItems,
-      typographyData,
-      colorsData,
-      fontsData,
-    }),
+  const { elements, resources } = buildLayoutElements(
+    layout,
+    imageItems,
+    typographyData,
+    colorsData,
+    fontsData,
+    options,
   );
+
+  return resolveLayoutReferences(elements, {
+    resources,
+  });
 };

--- a/src/internal/projectData.js
+++ b/src/internal/projectData.js
@@ -1,265 +1,315 @@
-import { buildLayoutRenderElements } from "./project/layout.js";
+import {
+  buildLayoutElements,
+  createLayoutReferenceResources,
+} from "./project/layout.js";
+import { normalizeEngineActions } from "./project/engineActions.js";
 import { toHierarchyStructure } from "./project/tree.js";
 
-export function constructProjectData(state, options = {}) {
-  // Helper functions
-  function constructImages(repositoryImages = {}) {
-    const processedImages = {};
-    Object.entries(repositoryImages).forEach(([id, item]) => {
-      if (item.type === "image") {
-        processedImages[id] = item;
-      }
-    });
-    return processedImages;
-  }
+const pickResourceFields = (item, fields) => {
+  return fields.reduce((result, fieldName) => {
+    if (item?.[fieldName] !== undefined) {
+      result[fieldName] = item[fieldName];
+    }
+    return result;
+  }, {});
+};
 
-  function constructVideos(repositoryVideos = {}) {
-    const processedVideos = {};
-    Object.entries(repositoryVideos).forEach(([id, item]) => {
-      if (item.type === "video") {
-        processedVideos[id] = item;
-      }
-    });
-    return processedVideos;
-  }
-
-  function constructSounds(repositorySound = {}) {
-    const processedSounds = {};
-    Object.entries(repositorySound).forEach(([id, item]) => {
-      if (item.type === "sound") {
-        processedSounds[id] = item;
-      }
-    });
-    return processedSounds;
-  }
-
-  function constructFonts(repositoryFonts = {}) {
-    const processedFonts = {};
-    Object.entries(repositoryFonts).forEach(([id, item]) => {
-      if (item.type === "font") {
-        processedFonts[id] = item;
-      }
-    });
-    return processedFonts;
-  }
-
-  function constructTweens(repositoryTweens = {}) {
-    const items = {};
-    Object.entries(repositoryTweens).forEach(([id, item]) => {
-      if (item.type === "tween") {
-        items[id] = {
-          id,
-          properties: item.properties,
-        };
-      }
-    });
-    return items;
-  }
-
-  function constructCharacters(repositoryCharacters = {}) {
-    const processedCharacters = {};
-
-    Object.keys(repositoryCharacters).forEach((characterId) => {
-      const character = repositoryCharacters[characterId];
-      if (character.type === "character") {
-        processedCharacters[characterId] = {
-          name: character.name,
-          variables: {
-            name: character.name || "Unnamed Character",
-          },
-        };
-      }
-    });
-
-    return processedCharacters;
-  }
-
-  function constructTransforms(repositoryTransforms = {}) {
-    const processedTransforms = {};
-
-    Object.keys(repositoryTransforms).forEach((transformId) => {
-      const transform = repositoryTransforms[transformId];
-      if (transform.type === "transform") {
-        processedTransforms[transformId] = transform;
-      }
-    });
-
-    return processedTransforms;
-  }
-
-  function constructLayouts(
-    repositoryLayouts = {},
-    images = {},
-    typography = { items: {}, tree: [] },
-    colors = { items: {}, tree: [] },
-    fonts = { items: {}, tree: [] },
-  ) {
-    const processedLayouts = {};
-
-    Object.keys(repositoryLayouts).forEach((layoutId) => {
-      const layout = repositoryLayouts[layoutId];
-      if (layout.type === "layout") {
-        processedLayouts[layoutId] = {
-          id: layoutId,
-          name: layout.name,
-          layoutType: layout.layoutType,
-          elements: buildLayoutRenderElements(
-            toHierarchyStructure(layout.elements),
-            images,
-            typography,
-            colors,
-            fonts,
-          ),
-        };
-      }
-    });
-
-    return processedLayouts;
-  }
-
-  function extractCharacterImages(repositoryCharacters = {}) {
-    const characterImages = {};
-    Object.entries(repositoryCharacters).forEach(([, character]) => {
-      if (character.type === "character" && character.sprites?.items) {
-        Object.entries(character.sprites.items).forEach(
-          ([spriteId, sprite]) => {
-            if (sprite.fileId) {
-              characterImages[spriteId] = {
-                fileId: sprite.fileId,
-                width: sprite.width,
-                height: sprite.height,
-              };
-            }
-          },
-        );
-      }
-    });
-    return characterImages;
-  }
-
-  function constructResources(repositoryState) {
-    const images = repositoryState.images?.items || {};
-    const videos = repositoryState.videos?.items || {};
-    const sounds = repositoryState.sounds?.items || {};
-    const tweens = repositoryState.tweens?.items || {};
-    const characters = repositoryState.characters?.items || {};
-    const transforms = repositoryState.transforms?.items || {};
-    const layouts = repositoryState.layouts?.items || {};
-    const typography = repositoryState.typography || { items: {}, tree: [] };
-    const colors = repositoryState.colors || { items: {}, tree: [] };
-    const fonts = repositoryState.fonts || { items: {}, tree: [] };
-    // Filter out folder items - only include actual variables
-    const variables = Object.fromEntries(
-      Object.entries(repositoryState.variables?.items || {}).filter(
-        ([, item]) => item.type !== "folder",
-      ),
-    );
-
-    const processedCharacters = constructCharacters(characters);
-    const characterImages = extractCharacterImages(characters);
-
-    return {
-      images: { ...constructImages(images), ...characterImages },
-      videos: constructVideos(videos),
-      transforms: constructTransforms(transforms),
-      characters: processedCharacters,
-      sounds: constructSounds(sounds),
-      fonts: constructFonts(fonts.items || {}),
-      layouts: constructLayouts(layouts, images, typography, colors, fonts),
-      tweens: constructTweens(tweens),
-      variables,
-    };
-  }
-
-  // Story construction (from storyConstructor.js)
-  function constructStory(scenes) {
-    const transformedScenes = {};
-
-    if (!scenes?.items) {
-      return transformedScenes;
+const constructImageResources = (repositoryImages = {}) => {
+  return Object.entries(repositoryImages).reduce((result, [imageId, item]) => {
+    if (item?.type && item.type !== "image") {
+      return result;
+    }
+    if (!item?.fileId) {
+      return result;
     }
 
-    // Process each scene
-    Object.entries(scenes.items).forEach(([sceneId, scene]) => {
-      if (scene.type !== "scene") {
-        return;
+    result[imageId] = pickResourceFields(item, [
+      "fileId",
+      "fileType",
+      "width",
+      "height",
+    ]);
+    return result;
+  }, {});
+};
+
+const constructVideoResources = (repositoryVideos = {}) => {
+  return Object.entries(repositoryVideos).reduce((result, [videoId, item]) => {
+    if (item?.type !== "video" || !item.fileId) {
+      return result;
+    }
+
+    result[videoId] = pickResourceFields(item, [
+      "fileId",
+      "fileType",
+      "width",
+      "height",
+    ]);
+    return result;
+  }, {});
+};
+
+const constructSoundResources = (repositorySounds = {}) => {
+  return Object.entries(repositorySounds).reduce((result, [soundId, item]) => {
+    if (item?.type !== "sound" || !item.fileId) {
+      return result;
+    }
+
+    result[soundId] = pickResourceFields(item, ["fileId", "fileType"]);
+    return result;
+  }, {});
+};
+
+const constructTweenResources = (repositoryTweens = {}) => {
+  return Object.entries(repositoryTweens).reduce((result, [tweenId, item]) => {
+    if (item?.type !== "tween") {
+      return result;
+    }
+
+    result[tweenId] = {
+      properties: item.properties,
+    };
+    return result;
+  }, {});
+};
+
+const constructCharacterResources = (repositoryCharacters = {}) => {
+  return Object.entries(repositoryCharacters).reduce(
+    (result, [characterId, character]) => {
+      if (character?.type !== "character") {
+        return result;
       }
 
-      // Get first section ID from the sections
-      let firstSectionId = null;
-      if (scene.sections?.tree && scene.sections.tree.length > 0) {
-        const firstSection = scene.sections.tree[0];
-        firstSectionId =
-          typeof firstSection === "string" ? firstSection : firstSection.id;
-      }
-
-      const transformedScene = {
-        name: scene.name,
-        initialSectionId: firstSectionId, // Default to first section
-        sections: {},
+      result[characterId] = {
+        name: character.name,
+        variables: {
+          name: character.name || "Unnamed Character",
+        },
       };
+      return result;
+    },
+    {},
+  );
+};
 
-      // Process sections
-      if (scene.sections?.items) {
-        Object.entries(scene.sections.items).forEach(([sectionId, section]) => {
-          // Don't check for type since sections don't have type property
-          const transformedSection = {
-            name: section.name || "Unnamed Section",
-            lines: [],
-          };
-
-          // Convert lines from tree structure to flat array
-          if (section.lines?.tree && section.lines?.items) {
-            // Use tree sequence to maintain line flow
-            section.lines.tree.forEach((lineNode) => {
-              const lineId =
-                typeof lineNode === "string" ? lineNode : lineNode.id;
-              const line = section.lines.items[lineId];
-              if (line) {
-                const transformedLine = {
-                  id: lineId,
-                  actions: line.actions || {},
-                };
-                transformedSection.lines.push(transformedLine);
-              }
-            });
-          }
-
-          transformedScene.sections[sectionId] = transformedSection;
-        });
+const constructTransformResources = (repositoryTransforms = {}) => {
+  return Object.entries(repositoryTransforms).reduce(
+    (result, [transformId, transform]) => {
+      if (transform?.type !== "transform") {
+        return result;
       }
 
-      transformedScenes[sceneId] = transformedScene;
-    });
+      result[transformId] = pickResourceFields(transform, [
+        "x",
+        "y",
+        "anchorX",
+        "anchorY",
+        "scaleX",
+        "scaleY",
+        "rotation",
+      ]);
+      return result;
+    },
+    {},
+  );
+};
 
+const extractCharacterImages = (repositoryCharacters = {}) => {
+  return Object.entries(repositoryCharacters).reduce(
+    (result, [, character]) => {
+      if (character?.type !== "character" || !character.sprites?.items) {
+        return result;
+      }
+
+      Object.entries(character.sprites.items).forEach(([spriteId, sprite]) => {
+        if (!sprite?.fileId) {
+          return;
+        }
+
+        result[spriteId] = pickResourceFields(sprite, [
+          "fileId",
+          "fileType",
+          "width",
+          "height",
+        ]);
+      });
+
+      return result;
+    },
+    {},
+  );
+};
+
+const constructLayoutResources = (
+  repositoryLayouts = {},
+  imageItems = {},
+  typography = { items: {}, tree: [] },
+  colors = { items: {}, tree: [] },
+  fonts = { items: {}, tree: [] },
+) => {
+  const baseLayoutResources = createLayoutReferenceResources(
+    imageItems,
+    typography,
+    colors,
+    fonts,
+  );
+  const textStyles = {
+    ...baseLayoutResources.textStyles,
+  };
+  const layouts = {};
+
+  Object.entries(repositoryLayouts).forEach(([layoutId, layout]) => {
+    if (layout?.type !== "layout") {
+      return;
+    }
+
+    const { elements, resources } = buildLayoutElements(
+      toHierarchyStructure(layout.elements),
+      imageItems,
+      typography,
+      colors,
+      fonts,
+      { layoutId },
+    );
+
+    Object.assign(textStyles, resources.textStyles);
+
+    layouts[layoutId] = {
+      id: layoutId,
+      name: layout.name,
+      layoutType: layout.layoutType,
+      elements,
+      ...(Array.isArray(layout.transitions)
+        ? { transitions: structuredClone(layout.transitions) }
+        : {}),
+    };
+  });
+
+  return {
+    resources: {
+      images: baseLayoutResources.images,
+      colors: baseLayoutResources.colors,
+      fonts: baseLayoutResources.fonts,
+      textStyles,
+    },
+    layouts,
+  };
+};
+
+const constructProjectResources = (repositoryState = {}) => {
+  const repositoryImages = repositoryState.images?.items || {};
+  const repositoryVideos = repositoryState.videos?.items || {};
+  const repositorySounds = repositoryState.sounds?.items || {};
+  const repositoryTweens = repositoryState.tweens?.items || {};
+  const repositoryCharacters = repositoryState.characters?.items || {};
+  const repositoryTransforms = repositoryState.transforms?.items || {};
+  const repositoryLayouts = repositoryState.layouts?.items || {};
+  const typography = repositoryState.typography || { items: {}, tree: [] };
+  const colors = repositoryState.colors || { items: {}, tree: [] };
+  const fonts = repositoryState.fonts || { items: {}, tree: [] };
+  const variables = Object.fromEntries(
+    Object.entries(repositoryState.variables?.items || {}).filter(
+      ([, item]) => item.type !== "folder",
+    ),
+  );
+
+  const characterImages = extractCharacterImages(repositoryCharacters);
+  const imageItems = {
+    ...constructImageResources(repositoryImages),
+    ...characterImages,
+  };
+  const { resources: layoutResources, layouts } = constructLayoutResources(
+    repositoryLayouts,
+    imageItems,
+    typography,
+    colors,
+    fonts,
+  );
+
+  return {
+    images: layoutResources.images,
+    videos: constructVideoResources(repositoryVideos),
+    sounds: constructSoundResources(repositorySounds),
+    fonts: layoutResources.fonts,
+    colors: layoutResources.colors,
+    textStyles: layoutResources.textStyles,
+    transforms: constructTransformResources(repositoryTransforms),
+    characters: constructCharacterResources(repositoryCharacters),
+    layouts,
+    tweens: constructTweenResources(repositoryTweens),
+    variables,
+  };
+};
+
+const constructStory = (scenes) => {
+  const transformedScenes = {};
+
+  if (!scenes?.items) {
     return transformedScenes;
   }
 
-  function getInitialSceneId(scenes, story) {
-    return options.initialSceneId || story?.initialSceneId;
-  }
+  Object.entries(scenes.items).forEach(([sceneId, scene]) => {
+    if (scene.type !== "scene") {
+      return;
+    }
 
-  // Construct final project data
-  const projectData = {
+    let firstSectionId;
+    if (scene.sections?.tree && scene.sections.tree.length > 0) {
+      const firstSection = scene.sections.tree[0];
+      firstSectionId =
+        typeof firstSection === "string" ? firstSection : firstSection.id;
+    }
+
+    const transformedScene = {
+      name: scene.name,
+      initialSectionId: firstSectionId,
+      sections: {},
+    };
+
+    if (scene.sections?.items) {
+      Object.entries(scene.sections.items).forEach(([sectionId, section]) => {
+        const transformedSection = {
+          name: section.name || "Unnamed Section",
+          lines: [],
+        };
+
+        if (section.lines?.tree && section.lines?.items) {
+          section.lines.tree.forEach((lineNode) => {
+            const lineId =
+              typeof lineNode === "string" ? lineNode : lineNode.id;
+            const line = section.lines.items[lineId];
+            if (!line) {
+              return;
+            }
+
+            transformedSection.lines.push({
+              id: lineId,
+              actions: normalizeEngineActions(line.actions || {}),
+            });
+          });
+        }
+
+        transformedScene.sections[sectionId] = transformedSection;
+      });
+    }
+
+    transformedScenes[sceneId] = transformedScene;
+  });
+
+  return transformedScenes;
+};
+
+export function constructProjectData(state, options = {}) {
+  return {
     screen: {
       width: 1920,
       height: 1080,
       backgroundColor: "#000000",
     },
-    resources: constructResources(state),
+    resources: constructProjectResources(state),
     story: {
-      initialSceneId: getInitialSceneId(state.scenes, state.story),
+      initialSceneId: options.initialSceneId || state.story?.initialSceneId,
       scenes: constructStory(state.scenes),
     },
-    l10n: {
-      packages: {
-        abcd: {
-          label: "English",
-          lang: "en",
-          keys: {},
-        },
-      },
-    },
   };
-  return projectData;
 }

--- a/src/internal/projectPreview.js
+++ b/src/internal/projectPreview.js
@@ -69,8 +69,11 @@ const RESOURCE_REFERENCE_KEYS = new Set([
   "layoutId",
   "characterId",
   "transformId",
+  "textStyleId",
   "fontId",
   "fontFileId",
+  "colorId",
+  "strokeColorId",
   "imageId",
   "hoverImageId",
   "clickImageId",
@@ -85,6 +88,8 @@ const createResourceSelection = () => ({
   videos: new Set(),
   sounds: new Set(),
   fonts: new Set(),
+  colors: new Set(),
+  textStyles: new Set(),
   layouts: new Set(),
   characters: new Set(),
   transforms: new Set(),
@@ -107,6 +112,12 @@ const addResourceIdToSelection = (selection, resources, resourceId) => {
   }
   if (resources.fonts?.[resourceId]) {
     selection.fonts.add(resourceId);
+  }
+  if (resources.colors?.[resourceId]) {
+    selection.colors.add(resourceId);
+  }
+  if (resources.textStyles?.[resourceId]) {
+    selection.textStyles.add(resourceId);
   }
   if (resources.layouts?.[resourceId]) {
     selection.layouts.add(resourceId);
@@ -153,59 +164,13 @@ const pickByIds = (items = {}, idSet) => {
   }, {});
 };
 
-const pickFontsByFamily = (fonts = {}, fontFamilySet) => {
-  if (!fontFamilySet || fontFamilySet.size === 0) {
-    return {};
-  }
-
-  return Object.entries(fonts).reduce((result, [fontId, font]) => {
-    if (
-      typeof font?.fontFamily === "string" &&
-      fontFamilySet.has(font.fontFamily)
-    ) {
-      result[fontId] = font;
-    }
-    return result;
-  }, {});
-};
-
-const collectFontFamilies = (value, fontFamilies = new Set()) => {
-  if (!value || typeof value !== "object") {
-    return fontFamilies;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((entry) => {
-      collectFontFamilies(entry, fontFamilies);
-    });
-    return fontFamilies;
-  }
-
-  Object.entries(value).forEach(([key, entry]) => {
-    if (key === "fontFamily" && typeof entry === "string" && entry.length > 0) {
-      fontFamilies.add(entry);
-      return;
-    }
-    collectFontFamilies(entry, fontFamilies);
-  });
-
-  return fontFamilies;
-};
-
-const mergeObjects = (...objects) => {
-  return objects.reduce((result, object) => {
-    return {
-      ...result,
-      ...object,
-    };
-  }, {});
-};
-
 const collectResourceSelectionFromValue = (projectData, value) => {
   const resources = projectData?.resources || {};
   const selection = createResourceSelection();
   const pendingLayoutIds = [];
   const queuedLayoutIds = new Set();
+  const pendingTextStyleIds = [];
+  const queuedTextStyleIds = new Set();
 
   const scanValue = (node) => {
     traverseScene(node, (key, entry) => {
@@ -214,6 +179,7 @@ const collectResourceSelectionFromValue = (projectData, value) => {
       }
 
       const hadLayout = selection.layouts.has(entry);
+      const hadTextStyle = selection.textStyles.has(entry);
       addResourceIdToSelection(selection, resources, entry);
 
       if (
@@ -223,6 +189,15 @@ const collectResourceSelectionFromValue = (projectData, value) => {
       ) {
         queuedLayoutIds.add(entry);
         pendingLayoutIds.push(entry);
+      }
+
+      if (
+        !hadTextStyle &&
+        selection.textStyles.has(entry) &&
+        !queuedTextStyleIds.has(entry)
+      ) {
+        queuedTextStyleIds.add(entry);
+        pendingTextStyleIds.push(entry);
       }
     });
   };
@@ -236,6 +211,15 @@ const collectResourceSelectionFromValue = (projectData, value) => {
       continue;
     }
     scanValue(layout);
+  }
+
+  while (pendingTextStyleIds.length > 0) {
+    const textStyleId = pendingTextStyleIds.shift();
+    const textStyle = resources.textStyles?.[textStyleId];
+    if (!textStyle) {
+      continue;
+    }
+    scanValue(textStyle);
   }
 
   return selection;
@@ -419,17 +403,14 @@ export const extractFileIdsForScene = (projectData, sceneId) => {
   const selection = collectResourceSelectionFromValue(projectData, scene);
 
   const scopedLayouts = pickByIds(resources.layouts, selection.layouts);
-  const scopedFontsById = pickByIds(resources.fonts, selection.fonts);
-  const scopedFontsByFamily = pickFontsByFamily(
-    resources.fonts,
-    collectFontFamilies(scopedLayouts),
-  );
 
   const scopedResources = {
     images: pickByIds(resources.images, selection.images),
     videos: pickByIds(resources.videos, selection.videos),
     sounds: pickByIds(resources.sounds, selection.sounds),
-    fonts: mergeObjects(scopedFontsByFamily, scopedFontsById),
+    fonts: pickByIds(resources.fonts, selection.fonts),
+    colors: pickByIds(resources.colors, selection.colors),
+    textStyles: pickByIds(resources.textStyles, selection.textStyles),
     layouts: scopedLayouts,
     characters: pickByIds(resources.characters, selection.characters),
     transforms: pickByIds(resources.transforms, selection.transforms),
@@ -454,13 +435,18 @@ export const extractFileIdsForLayouts = (projectData, layoutIds = []) => {
     return [];
   }
 
-  const scopedFontsByFamily = pickFontsByFamily(
-    resources.fonts,
-    collectFontFamilies(scopedLayouts),
+  const selection = collectResourceSelectionFromValue(
+    projectData,
+    scopedLayouts,
   );
   const scopedResources = {
+    images: pickByIds(resources.images, selection.images),
+    videos: pickByIds(resources.videos, selection.videos),
+    sounds: pickByIds(resources.sounds, selection.sounds),
     layouts: scopedLayouts,
-    fonts: scopedFontsByFamily,
+    fonts: pickByIds(resources.fonts, selection.fonts),
+    colors: pickByIds(resources.colors, selection.colors),
+    textStyles: pickByIds(resources.textStyles, selection.textStyles),
   };
 
   return dedupeFileReferences(extractFileIdsFromRenderState(scopedResources));

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -175,7 +175,6 @@ const targetPathByKey = {
   v: "/project/resources/videos",
   b: "/project/resources/variables",
   t: "/project/resources/transforms",
-  w: "/project/resources/tweens",
   s: "/project/resources/sounds",
   n: "/project/scenes",
   r: "/project/releases",

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -148,8 +148,7 @@ const loadAssets = async (deps, fileReferences, fontsItems) => {
       else if (fileName.endsWith(".otf")) type = "font/otf";
       else type = "font/ttf"; // default font type
 
-      // For fonts, use fontFamily as the key instead of fileId
-      assets[fontItem.fontFamily] = {
+      assets[`${fileId}`] = {
         url: url,
         type: type,
       };
@@ -195,6 +194,7 @@ const getRenderState = async (deps) => {
     { items: typographyItems },
     { items: colorsItems },
     { items: fontsItems },
+    { layoutId },
   );
   return {
     renderStateElements,

--- a/src/pages/layoutEditor/layoutPreview.js
+++ b/src/pages/layoutEditor/layoutPreview.js
@@ -3,7 +3,7 @@ import { parseAndRender } from "jempl";
 const DEFAULT_DIALOGUE_CHARACTER_NAME = "Character";
 const DEFAULT_DIALOGUE_CONTENT = "This is a sample dialogue content.";
 const OVERLAY_BORDER = {
-  color: "#3b82f6",
+  color: "#ffffff",
   width: 2,
   alpha: 1,
 };

--- a/src/pages/resourceTypes/resourceTypes.store.js
+++ b/src/pages/resourceTypes/resourceTypes.store.js
@@ -24,11 +24,6 @@ export const assetItems = [
     name: "Transforms",
     path: "/project/resources/transforms",
   },
-  {
-    id: "tweens",
-    name: "Tweens",
-    path: "/project/resources/tweens",
-  },
 ];
 
 export const userInterfaceItems = [

--- a/src/pages/resources/resources.store.js
+++ b/src/pages/resources/resources.store.js
@@ -16,11 +16,6 @@ export const createInitialState = () => ({
       route: "/project/resources/sounds",
     },
     {
-      id: "tweens",
-      label: "Tweens",
-      route: "/project/resources/tweens",
-    },
-    {
       id: "transforms",
       label: "Transforms",
       route: "/project/resources/transforms",

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -1,4 +1,4 @@
-import { buildLayoutRenderElements } from "../../internal/project/layout.js";
+import { buildLayoutElements } from "../../internal/project/layout.js";
 import { toHierarchyStructure } from "../../internal/project/tree.js";
 import { buildSceneEditorLineViewModels } from "../../deps/features/sceneEditing/lineViewModels.js";
 import { constructProjectData } from "../../internal/projectData.js";
@@ -203,13 +203,14 @@ export const selectLayouts = ({ state }) => {
         id: layoutId,
         name: layout.name,
         layoutType: layout.layoutType,
-        elements: buildLayoutRenderElements(
+        elements: buildLayoutElements(
           toHierarchyStructure(layout.elements),
           images,
           typography,
           colors,
           fonts,
-        ),
+          { layoutId },
+        ).elements,
       };
     }
   });

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -652,7 +652,7 @@ export const handleSceneFormAction = async (deps, payload) => {
     const actions = {
       dialogue: dialogueLayoutId
         ? {
-            gui: {
+            ui: {
               resourceId: dialogueLayoutId,
             },
             mode: "adv",


### PR DESCRIPTION
## Summary
- migrate the client to the route-engine 0.1.37 reference-based interface
- replace layout/image/text preprocessing with resource-driven layout construction plus `resolveLayoutReferences(...)`, and normalize dialogue actions to the new `dialogue.ui` contract
- remove stale localization init fields, hide the tween resource UI and background tween picker for now, and fix preview/runtime regressions uncovered during the migration

## Testing
- `bun run lint`
- `bun run test:smoke`
- `bun run build:web`