### PR TITLE
fix: polish scene creation flow for rc1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "0.17.0",
+  "version": "1.0.0-rc1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/deps/services/projectService.js
+++ b/src/deps/services/projectService.js
@@ -2,8 +2,14 @@ import { nanoid } from "nanoid";
 import { createProjectServiceCore } from "./shared/projectServiceCore.js";
 import { createTauriProjectServiceAdapters } from "./tauri/projectServiceAdapters.js";
 
+const ENABLE_VERBOSE_COLLAB_LOGS = false;
+
 export const createProjectService = ({ router, db, filePicker }) => {
   const collabLog = (level, message, meta = {}) => {
+    if (!ENABLE_VERBOSE_COLLAB_LOGS && level !== "warn" && level !== "error") {
+      return;
+    }
+
     const fn =
       level === "error"
         ? console.error.bind(console)

--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -2,6 +2,8 @@ import { nanoid } from "nanoid";
 import { createProjectServiceCore } from "../shared/projectServiceCore.js";
 import { createWebProjectServiceAdapters } from "./projectServiceAdapters.js";
 
+const ENABLE_VERBOSE_COLLAB_LOGS = false;
+
 export const createProjectService = ({
   router,
   filePicker,
@@ -9,6 +11,10 @@ export const createProjectService = ({
   db,
 }) => {
   const collabLog = (level, message, meta = {}) => {
+    if (!ENABLE_VERBOSE_COLLAB_LOGS && level !== "warn" && level !== "error") {
+      return;
+    }
+
     const fn =
       level === "error"
         ? console.error.bind(console)

--- a/src/internal/ui/sceneEditor/sectionOperations.js
+++ b/src/internal/ui/sceneEditor/sectionOperations.js
@@ -12,8 +12,18 @@ export const scrollSceneEditorSectionTabIntoView = (deps, sectionId) => {
   const { refs } = deps;
 
   requestAnimationFrame(() => {
-    const refIds = refs?.();
-    const refElements = Object.values(refIds || {});
+    const refElements = Object.values(refs || {}).flatMap((entry) => {
+      if (!entry) {
+        return [];
+      }
+      if (Array.isArray(entry)) {
+        return entry;
+      }
+      if (typeof entry === "object") {
+        return [entry, ...Object.values(entry)];
+      }
+      return [entry];
+    });
     const tabRef = refElements.find(
       (element) => element?.dataset?.sectionId === sectionId,
     );

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -294,6 +294,11 @@ const setSelectedScene = ({ store, appService, sceneId } = {}) => {
   persistSelectedSceneId({ appService, sceneId });
 };
 
+const dismissMapAddHint = ({ store, appService } = {}) => {
+  store.hideMapAddHint();
+  appService.setUserConfig("scenesMap.hideAddSceneHint", true);
+};
+
 const getSceneItemById = ({ store, sceneId } = {}) => {
   if (!sceneId) {
     return undefined;
@@ -602,7 +607,7 @@ export const handleSceneFormClose = (deps) => {
 };
 
 export const handleSceneFormAction = async (deps, payload) => {
-  const { store, render, projectService } = deps;
+  const { store, render, projectService, appService } = deps;
   const actionId = payload._event.detail.actionId;
 
   if (actionId === "cancel") {
@@ -704,6 +709,7 @@ export const handleSceneFormAction = async (deps, payload) => {
         y: sceneWhiteboardPosition.y,
       },
     });
+    dismissMapAddHint({ store, appService });
 
     // Update store with new scenes data
     const { scenes: updatedScenes } = projectService.getState();
@@ -763,8 +769,7 @@ export const handleDropdownMenuClose = (deps) => {
 
 export const handleMapAddHintClose = (deps) => {
   const { store, render, appService } = deps;
-  store.hideMapAddHint();
-  appService.setUserConfig("scenesMap.hideAddSceneHint", true);
+  dismissMapAddHint({ store, appService });
   render();
 };
 

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -625,9 +625,6 @@ export const handleSceneFormAction = async (deps, payload) => {
     const sectionId = nanoid();
     const stepId = nanoid();
 
-    // Generate 31 additional line IDs
-    const additionalLineIds = Array.from({ length: 31 }, () => nanoid());
-
     // Get layouts from repository to find first dialogue and base layouts
     const { layouts } = projectService.getState();
     let dialogueLayoutId = null;
@@ -671,20 +668,6 @@ export const handleSceneFormAction = async (deps, payload) => {
       };
     }
 
-    // Create items object with first line having actions, rest with empty actions
-    const lineItems = {
-      [stepId]: {
-        actions: actions,
-      },
-    };
-
-    // Add 31 lines with empty actions
-    additionalLineIds.forEach((lineId) => {
-      lineItems[lineId] = {
-        actions: {},
-      };
-    });
-
     await projectService.createSceneItem({
       sceneId: newSceneId,
       name: formData.name || `Scene ${new Date().toLocaleTimeString()}`,
@@ -703,18 +686,14 @@ export const handleSceneFormAction = async (deps, payload) => {
       name: "Section New",
       position: "last",
     });
-
-    const allLineIds = [stepId, ...additionalLineIds];
-    let previousLineId = null;
-    for (const currentLineId of allLineIds) {
-      await projectService.createLineItem({
-        sectionId,
-        lineId: currentLineId,
-        line: lineItems[currentLineId] || { actions: {} },
-        afterLineId: previousLineId,
-      });
-      previousLineId = currentLineId;
-    }
+    await projectService.createLineItem({
+      sectionId,
+      lineId: stepId,
+      line: {
+        actions,
+      },
+      position: "last",
+    });
 
     // Add to whiteboard items for visual display
     store.addWhiteboardItem({


### PR DESCRIPTION
## Summary
- create only a single initial line when creating a new scene instead of inserting 32 lines in sequence
- hide the map add hint after a successful scene creation and persist that dismissal
- fix scene editor section creation scrolling so it works with the current object-shaped refs
- suppress verbose collab info/debug console logs for now while keeping warnings and errors
- bump the Tauri app version to `1.0.0-rc1`

## Testing
- `bun run lint`
- `bun run test:smoke`
- `bun run build:web`