### PR TITLE
feat: harden collab compatibility and storage coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,27 @@ Notes:
 - Do not run `bun run build:web` after each change. The user is expected to be running a watch-mode session during active development.
 - Before pushing, run lint/format checks (the push hook also enforces this).
 
+Run tests:
+
+```bash
+bun run test:smoke
+bun run test:integration
+bun run test:convergence
+bun run test:command-only
+bun run test:collab-adapters
+bun run test:puty
+```
+
+Notes:
+
+- `bun run test:puty` runs the YAML-based Puty storage suite in `tests/puty/`.
+- Run a single Puty scenario with `bunx vitest run tests/puty/<file>.spec.yaml`.
+- The Puty suite is the preferred place for SQLite-backed storage assertions:
+  input commands live in YAML `in`, expected committed rows live in YAML `out`.
+- The shared Puty helper for storage scenarios is `tests/puty/insiemeStorageScenario.js`.
+- The `scripts/test-*.js` files remain the home for non-Puty runtime,
+  integration, convergence, and command-contract coverage.
+
 ## Architecture
 
 This project uses a custom frontend framework based on 3 component files: view, store, handlers:

--- a/bun.lock
+++ b/bun.lock
@@ -31,10 +31,13 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.8.3",
+        "better-sqlite3": "^12.6.2",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
         "oxlint": "^1.19.0",
         "prettier": "3.6.2",
+        "puty": "0.1.2",
+        "vitest": "^3.2.1",
       },
     },
   },
@@ -203,8 +206,6 @@
 
     "@pixi/utils": ["@pixi/utils@7.4.3", "", { "dependencies": { "@pixi/color": "7.4.3", "@pixi/constants": "7.4.3", "@pixi/settings": "7.4.3", "@types/earcut": "^2.1.0", "earcut": "^2.2.4", "eventemitter3": "^4.0.0", "url": "^0.11.0" } }, "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA=="],
 
-    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
-
     "@rettangoli/fe": ["@rettangoli/fe@1.0.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "rxjs": "^7.8.2", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-rTUEYTe1xjf8M0bSaioB/C8E9L0x/X4gze4mgo2FHLQjE97iDAUfrSOqtzr95HdPZnp5OaSQ+vN0g2xzj0idKw=="],
 
     "@rettangoli/ui": ["@rettangoli/ui@1.0.3", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@rettangoli/fe": "1.0.3", "commander": "^13.1.0", "jempl": "1.0.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "snabbdom": "^3.6.2" } }, "sha512-CQTlWaRpwwmyKrnDZpwzkSrEBMbF/tOF063Y0lrLp9hdnKmpIOSB1GLtalMEU7x1oZuLQq+zBStbNwVVOxS7UQ=="],
@@ -275,8 +276,6 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
 
     "@tauri-apps/cli": ["@tauri-apps/cli@2.9.6", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.9.6", "@tauri-apps/cli-darwin-x64": "2.9.6", "@tauri-apps/cli-linux-arm-gnueabihf": "2.9.6", "@tauri-apps/cli-linux-arm64-gnu": "2.9.6", "@tauri-apps/cli-linux-arm64-musl": "2.9.6", "@tauri-apps/cli-linux-riscv64-gnu": "2.9.6", "@tauri-apps/cli-linux-x64-gnu": "2.9.6", "@tauri-apps/cli-linux-x64-musl": "2.9.6", "@tauri-apps/cli-win32-arm64-msvc": "2.9.6", "@tauri-apps/cli-win32-ia32-msvc": "2.9.6", "@tauri-apps/cli-win32-x64-msvc": "2.9.6" }, "bin": { "tauri": "tauri.js" } }, "sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw=="],
@@ -337,21 +336,19 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
-    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
-    "@vitest/ui": ["@vitest/ui@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "fflate": "^0.8.2", "flatted": "^3.3.3", "pathe": "^2.0.3", "sirv": "^3.0.1", "tinyglobby": "^0.2.14", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "vitest": "3.2.4" } }, "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA=="],
-
-    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
@@ -369,9 +366,21 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "better-sqlite3": ["better-sqlite3@12.6.2", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browser-split": ["browser-split@0.0.1", "", {}, "sha512-JhvgRb2ihQhsljNda3BI8/UcRHVzrVwo3Q+P8vDtSiyobXuFpuZ9mq+MbRGMnC22CjW3RrfXdg6j6ITX8M+7Ow=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -379,11 +388,15 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -405,6 +418,12 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -416,6 +435,8 @@
     "earcut": ["earcut@3.0.2", "", {}, "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -435,17 +456,19 @@
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
-
     "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "flatted": ["flatted@3.4.1", "", {}, "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ=="],
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -458,6 +481,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "gifuct-js": ["gifuct-js@2.1.2", "", { "dependencies": { "js-binary-schema-parser": "^2.0.3" } }, "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -491,6 +516,8 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "insieme": ["insieme@1.3.0", "", { "dependencies": { "immer": "^11.1.4" } }, "sha512-rjHIQFwRLdDSGRFDsVzrxwJ+Bnt4rrFkMYDxFABzoCzxuIitBkrlz2rA+xyC+CAYbIWq+PESf2G8UCxPsKbgAQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
@@ -506,6 +533,8 @@
     "jempl": ["jempl@1.0.0", "", {}, "sha512-tYWOHqlIwev20Z47k8m1FeLM2EVxG91JY3ogMR166hdzUN1KeOGHxDhRj8Wfh0PmYIVWf57LB+fTUT/vOahoUg=="],
 
     "js-binary-schema-parser": ["js-binary-schema-parser@2.0.3", "", {}, "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -557,7 +586,11 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -565,13 +598,17 @@
 
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "node-abi": ["node-abi@3.88.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w=="],
+
     "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -591,6 +628,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -609,17 +648,23 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "puty": ["puty@0.1.1", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-B5GQiWDIsnbolNVXGRFX/2tmH9uavszQ/uWlsLEgo0mYh4/+YgB20u5QIxpk7TYa3geOkLohvRFtPm3qku372A=="],
+    "puty": ["puty@0.1.2", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-VNEwqORf0u/LiVdjyHPsIOKWC5z4uNuHhMgYu9WGea6u3YCP4OimQHQfWkw0DB/tE3KuWgPO0dhkM8uH4Yweig=="],
 
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -669,7 +714,9 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
@@ -695,19 +742,31 @@
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
     "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "tiny-lru": ["tiny-lru@11.4.7", "", {}, "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
@@ -717,8 +776,6 @@
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
-    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
-
     "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
@@ -726,6 +783,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
@@ -749,7 +808,9 @@
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
-    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -764,6 +825,8 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
@@ -787,9 +850,7 @@
 
     "@rettangoli/vt/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
-    "@vitest/ui/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
-
-    "@vitest/ui/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "insieme/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
@@ -801,10 +862,12 @@
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "route-engine-js/puty": ["puty@0.1.1", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-B5GQiWDIsnbolNVXGRFX/2tmH9uavszQ/uWlsLEgo0mYh4/+YgB20u5QIxpk7TYa3geOkLohvRFtPm3qku372A=="],
+
+    "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "url/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "@vitest/ui/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
   }
 }

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -33,6 +33,74 @@ Local-first collaboration:
 
 - `insieme`
 
+## Testing
+
+This repo currently uses two main test styles:
+
+- script-driven Node tests in `scripts/test-*.js`
+- YAML-driven Puty tests in `tests/puty/`
+
+Common commands:
+
+```bash
+bun run test:smoke
+bun run test:integration
+bun run test:convergence
+bun run test:command-only
+bun run test:collab-adapters
+bun run test:puty
+```
+
+Run one Puty scenario directly:
+
+```bash
+bunx vitest run tests/puty/<file>.spec.yaml
+```
+
+### Test Organization
+
+- `scripts/test-smoke.js`
+  broad project-state and reducer smoke coverage
+
+- `scripts/test-integration.js`
+  collaboration/session integration flows
+
+- `scripts/test-convergence.js`
+  multi-client convergence behavior
+
+- `scripts/test-command-only.js`
+  command-envelope and command-path coverage
+
+- `scripts/test-collab-adapters.js`
+  collab adapter coverage
+
+- `tests/puty/*.spec.yaml`
+  SQLite-backed Insieme storage scenarios expressed declaratively in YAML
+
+- `tests/puty/insiemeStorageScenario.js`
+  shared Puty helper that runs a real RouteVN collab session against the
+  SQLite sync store and returns committed rows for YAML assertions
+
+### Puty Storage Pattern
+
+Use Puty for storage assertions when the goal is:
+
+- define a full command sequence in YAML
+- submit it through the real collab/session path
+- assert the committed events that land in SQLite
+
+Keep the test contract declarative:
+
+- `in`: the commands to submit, or batches of commands to submit
+- `out`: the normalized committed rows expected in storage
+
+Current Puty coverage is intentionally strongest around:
+
+- scene editor story flows
+- layout editor element flows
+- resource tree/storage flows
+- storage idempotency across submit batches
+
 ## Architecture Overview
 
 RouteVN is organized into four ownership zones:
@@ -199,8 +267,8 @@ scene-specific workflows.
   - `projection.js`
   - `tree.js`
   - `layout.js`
-  `src/internal/ui/` is the only shared home for page/store/handler
-  orchestration that does not belong inside one page folder.
+    `src/internal/ui/` is the only shared home for page/store/handler
+    orchestration that does not belong inside one page folder.
 
 - `src/deps/services/shared/`
   Shared handler-facing and internal service logic.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:integration": "node scripts/test-integration.js",
     "test:command-only": "node scripts/test-command-only.js",
     "test:collab-adapters": "node scripts/test-collab-adapters.js",
+    "test:puty": "vitest run tests/puty",
     "check:contracts": "rtgl check --dir src/components --dir src/pages",
     "vt:generate": "bun run build:web && bash ./scripts/run-vt-docker.sh vt screenshot",
     "vt:docker": "bun run vt:generate",
@@ -71,10 +72,13 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.8.3",
+    "better-sqlite3": "^12.6.2",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "oxlint": "^1.19.0",
-    "prettier": "3.6.2"
+    "prettier": "3.6.2",
+    "puty": "0.1.2",
+    "vitest": "^3.2.1"
   },
   "lint-staged": {
     "src/**/*.{js}": [

--- a/scripts/test-collab-adapters.js
+++ b/scripts/test-collab-adapters.js
@@ -26,25 +26,23 @@ const createRepositoryEvent = ({
       name: "Updated",
     },
   },
-  partition = `project:${projectId}:resources`,
   partitions = [
-    partition,
+    `project:${projectId}:resources`,
     `project:${projectId}:resources:images:image-1`,
   ],
-}) =>
-  ({
-    id,
-    partitions,
-    projectId,
-    userId: actor.userId,
-    type,
-    payload,
-    meta: {
-      clientId: actor.clientId,
-      clientTs,
-      ...(meta ? structuredClone(meta) : {}),
-    },
-  });
+}) => ({
+  id,
+  partitions,
+  projectId,
+  userId: actor.userId,
+  type,
+  payload,
+  meta: {
+    clientId: actor.clientId,
+    clientTs,
+    ...(meta ? structuredClone(meta) : {}),
+  },
+});
 
 {
   const repositoryEvent = createRepositoryEvent({
@@ -81,7 +79,6 @@ const createRepositoryEvent = ({
     createRepositoryEvent({
       id: "command-1",
       type: "scene.create",
-      partition: `project:${projectId}:story`,
       partitions: [`project:${projectId}:story`],
       payload: {
         sceneId: "scene-1",
@@ -91,7 +88,6 @@ const createRepositoryEvent = ({
     createRepositoryEvent({
       id: "command-2",
       type: "section.create",
-      partition: `project:${projectId}:story`,
       partitions: [`project:${projectId}:story`],
       payload: {
         sceneId: "scene-1",
@@ -102,7 +98,6 @@ const createRepositoryEvent = ({
     createRepositoryEvent({
       id: "command-3",
       type: "line.insert_after",
-      partition: `project:${projectId}:story`,
       partitions: [`project:${projectId}:story`],
       payload: {
         lineId: "line-1",

--- a/scripts/test-command-only.js
+++ b/scripts/test-command-only.js
@@ -25,6 +25,12 @@ const commandFromItem = (item) => {
   return command;
 };
 
+const normalizePartitions = (partitions) => {
+  return [...new Set(partitions || [])].sort((left, right) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+};
+
 const projectId = "project-command-only-001";
 const actor = { userId: "user-1", clientId: "client-1" };
 
@@ -198,44 +204,154 @@ try {
     `legacy method leakage detected: ${methodNames.join(", ")}`,
   );
 
-  const updateProject = createCommandEnvelope({
-    projectId,
-    scope: "settings",
-    partition: `project:${projectId}:settings`,
-    partitions: [`project:${projectId}:settings`],
-    type: COMMAND_TYPES.PROJECT_UPDATE,
-    payload: {
-      patch: {
-        name: "Command Project",
-        description: "Only commands should sync",
-      },
-    },
-    actor,
-  });
+  const storyBasePartition = `project:${projectId}:story`;
+  const scenePartition = `project:${projectId}:story:scene:scene-1`;
+  const settingsPartition = `project:${projectId}:settings`;
+  const imagesPartition = `project:${projectId}:resources:images`;
+  const layoutsResourcePartition = `project:${projectId}:resources:layouts`;
+  const layoutsPartition = `project:${projectId}:layouts`;
 
-  const createImage = createCommandEnvelope({
-    projectId,
-    scope: "resources",
-    partition: `project:${projectId}:resources`,
-    partitions: [
-      `project:${projectId}:resources`,
-      `project:${projectId}:resources:images:image-1`,
-    ],
-    type: COMMAND_TYPES.RESOURCE_CREATE,
-    payload: {
-      resourceType: "images",
-      resourceId: "image-1",
-      data: {
-        name: "Image 1",
-        type: "image",
-        src: "image-1.png",
+  const commands = [
+    createCommandEnvelope({
+      projectId,
+      scope: "settings",
+      partition: settingsPartition,
+      partitions: [settingsPartition],
+      type: COMMAND_TYPES.PROJECT_UPDATE,
+      payload: {
+        patch: {
+          name: "Command Project",
+          description: "Only commands should sync",
+        },
       },
-    },
-    actor,
-  });
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "resources",
+      partition: imagesPartition,
+      partitions: [imagesPartition],
+      type: COMMAND_TYPES.RESOURCE_CREATE,
+      payload: {
+        resourceType: "images",
+        resourceId: "image-1",
+        data: {
+          name: "Image 1",
+          type: "image",
+          src: "image-1.png",
+        },
+      },
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "story",
+      partition: storyBasePartition,
+      partitions: [storyBasePartition, scenePartition],
+      type: COMMAND_TYPES.SCENE_CREATE,
+      payload: {
+        sceneId: "scene-1",
+        name: "Scene 1",
+      },
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "story",
+      partition: storyBasePartition,
+      partitions: [storyBasePartition, scenePartition],
+      type: COMMAND_TYPES.SECTION_CREATE,
+      payload: {
+        sceneId: "scene-1",
+        sectionId: "section-1",
+        name: "Section 1",
+      },
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "story",
+      partition: storyBasePartition,
+      partitions: [storyBasePartition, scenePartition],
+      type: COMMAND_TYPES.LINE_INSERT_AFTER,
+      payload: {
+        sectionId: "section-1",
+        lineId: "line-1",
+        line: {
+          actions: {
+            dialogue: {
+              content: [{ text: "Hello" }],
+              mode: "adv",
+            },
+          },
+        },
+      },
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "story",
+      partition: storyBasePartition,
+      partitions: [storyBasePartition, scenePartition],
+      type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+      payload: {
+        lineId: "line-1",
+        patch: {
+          dialogue: {
+            content: [{ text: "Hello" }],
+            mode: "nvl",
+            ui: {
+              resourceId: "layout-1",
+            },
+          },
+        },
+        replace: false,
+      },
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "resources",
+      partition: layoutsResourcePartition,
+      partitions: [layoutsResourcePartition],
+      type: COMMAND_TYPES.RESOURCE_CREATE,
+      payload: {
+        resourceType: "layouts",
+        resourceId: "layout-1",
+        data: {
+          name: "Layout 1",
+          layoutType: "normal",
+          elements: {
+            items: {},
+            tree: [],
+          },
+        },
+      },
+      actor,
+    }),
+    createCommandEnvelope({
+      projectId,
+      scope: "layouts",
+      partition: layoutsPartition,
+      partitions: [layoutsPartition],
+      type: COMMAND_TYPES.LAYOUT_ELEMENT_CREATE,
+      payload: {
+        layoutId: "layout-1",
+        elementId: "el-1",
+        element: {
+          type: "text",
+          x: 10,
+          y: 20,
+        },
+      },
+      actor,
+    }),
+  ];
 
-  await collab.submitCommand(updateProject);
-  await collab.submitCommand(createImage);
+  for (const command of commands) {
+    await collab.submitCommand(command);
+  }
+
   await collab.flushDrafts();
   await collab.syncNow({ timeoutMs: 1000 });
   await sleep(30);
@@ -243,9 +359,75 @@ try {
   const observedSet = new Set(observedSchemas);
   assert.ok(observedSet.has(COMMAND_TYPES.PROJECT_UPDATE));
   assert.ok(observedSet.has(COMMAND_TYPES.RESOURCE_CREATE));
+  assert.ok(observedSet.has(COMMAND_TYPES.SCENE_CREATE));
+  assert.ok(observedSet.has(COMMAND_TYPES.LINE_UPDATE_ACTIONS));
+  assert.ok(observedSet.has(COMMAND_TYPES.LAYOUT_ELEMENT_CREATE));
   assert.ok(
     [...observedSet].every((schema) => !schema.startsWith("legacy.")),
     `unexpected schemas: ${[...observedSet].join(", ")}`,
+  );
+
+  const committed = store._debug.getCommitted();
+  assert.equal(committed.length, commands.length);
+  assert.deepEqual(
+    committed.map((event) => event.id),
+    commands.map((command) => command.id),
+  );
+  assert.deepEqual(
+    committed.map((event) => event.type),
+    commands.map((command) => command.type),
+  );
+  assert.deepEqual(
+    committed.map((event) => event.committedId),
+    commands.map((_command, index) => index + 1),
+  );
+
+  for (let index = 0; index < commands.length; index += 1) {
+    const event = committed[index];
+    const command = commands[index];
+    assert.equal(event.projectId, projectId);
+    assert.equal(event.userId, actor.userId);
+    assert.deepEqual(event.payload, command.payload);
+    assert.deepEqual(
+      normalizePartitions(event.partitions),
+      normalizePartitions(command.partitions || [command.partition]),
+    );
+    assert.equal(typeof event.created, "number");
+  }
+
+  const storyPage = await store.listCommittedSince({
+    partitions: [storyBasePartition, scenePartition],
+    sinceCommittedId: 0,
+    limit: 100,
+  });
+  assert.deepEqual(
+    storyPage.events.map((event) => event.type),
+    [
+      COMMAND_TYPES.SCENE_CREATE,
+      COMMAND_TYPES.SECTION_CREATE,
+      COMMAND_TYPES.LINE_INSERT_AFTER,
+      COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+    ],
+  );
+
+  const layoutsPage = await store.listCommittedSince({
+    partitions: [layoutsPartition],
+    sinceCommittedId: 0,
+    limit: 100,
+  });
+  assert.deepEqual(
+    layoutsPage.events.map((event) => event.type),
+    [COMMAND_TYPES.LAYOUT_ELEMENT_CREATE],
+  );
+
+  const layoutResourcePage = await store.listCommittedSince({
+    partitions: [layoutsResourcePartition],
+    sinceCommittedId: 0,
+    limit: 100,
+  });
+  assert.deepEqual(
+    layoutResourcePage.events.map((event) => event.type),
+    [COMMAND_TYPES.RESOURCE_CREATE],
   );
 } finally {
   await collab.stop();

--- a/scripts/test-command-only.js
+++ b/scripts/test-command-only.js
@@ -1,11 +1,18 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createInMemorySyncStore, createSyncServer } from "insieme/server";
-import { validateCommandSubmitItem } from "insieme/client";
 import {
+  createInMemoryClientStore,
+  validateCommandSubmitItem,
+} from "insieme/client";
+import {
+  buildRepositoryProjectionFromCommittedEvents,
   createCommandEnvelope,
   committedEventToCommand,
   createProjectCollabService,
+  commandToSyncEvent,
+  ensureRepositoryProjectionCache,
+  PROJECTOR_CACHE_VERSION,
 } from "../src/deps/services/shared/collab/index.js";
 import { createStoryCommandApi } from "../src/deps/services/shared/commandApi/story.js";
 import { COMMAND_TYPES } from "../src/internal/project/commands.js";
@@ -14,6 +21,7 @@ import {
   createInMemoryServerTransport,
   parseToken,
   sleep,
+  waitFor,
 } from "./collabTestSupport.js";
 
 const commandFromItem = (item) => {
@@ -30,6 +38,63 @@ const normalizePartitions = (partitions) => {
     left < right ? -1 : left > right ? 1 : 0,
   );
 };
+
+const createRepositoryStoreStub = (initialEvents = []) => {
+  let events = initialEvents.map((event) => structuredClone(event));
+  let clearMaterializedViewCheckpointsCount = 0;
+  const appState = new Map();
+
+  return {
+    async getEvents() {
+      return events.map((event) => structuredClone(event));
+    },
+    async appendEvent(event) {
+      events.push(structuredClone(event));
+    },
+    async clearEvents() {
+      events = [];
+    },
+    async clearMaterializedViewCheckpoints() {
+      clearMaterializedViewCheckpointsCount += 1;
+    },
+    app: {
+      async get(key) {
+        return structuredClone(appState.get(key));
+      },
+      async set(key, value) {
+        appState.set(key, structuredClone(value));
+      },
+      async remove(key) {
+        appState.delete(key);
+      },
+    },
+    _debug: {
+      getEvents() {
+        return events.map((event) => structuredClone(event));
+      },
+      getAppValue(key) {
+        return structuredClone(appState.get(key));
+      },
+      getClearMaterializedViewCheckpointsCount() {
+        return clearMaterializedViewCheckpointsCount;
+      },
+    },
+  };
+};
+
+const createCommittedEventFromCommand = (command, committedId, created) => ({
+  committedId,
+  id: command.id,
+  partitions: [...(command.partitions || [])],
+  ...commandToSyncEvent(command),
+  created,
+});
+
+const createSubmitItemFromCommand = (command) => ({
+  id: command.id,
+  partitions: [...(command.partitions || [])],
+  ...commandToSyncEvent(command),
+});
 
 const projectId = "project-command-only-001";
 const actor = { userId: "user-1", clientId: "client-1" };
@@ -215,7 +280,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "settings",
-      partition: settingsPartition,
       partitions: [settingsPartition],
       type: COMMAND_TYPES.PROJECT_UPDATE,
       payload: {
@@ -229,7 +293,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "resources",
-      partition: imagesPartition,
       partitions: [imagesPartition],
       type: COMMAND_TYPES.RESOURCE_CREATE,
       payload: {
@@ -246,7 +309,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "story",
-      partition: storyBasePartition,
       partitions: [storyBasePartition, scenePartition],
       type: COMMAND_TYPES.SCENE_CREATE,
       payload: {
@@ -258,7 +320,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "story",
-      partition: storyBasePartition,
       partitions: [storyBasePartition, scenePartition],
       type: COMMAND_TYPES.SECTION_CREATE,
       payload: {
@@ -271,7 +332,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "story",
-      partition: storyBasePartition,
       partitions: [storyBasePartition, scenePartition],
       type: COMMAND_TYPES.LINE_INSERT_AFTER,
       payload: {
@@ -291,7 +351,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "story",
-      partition: storyBasePartition,
       partitions: [storyBasePartition, scenePartition],
       type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
       payload: {
@@ -312,7 +371,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "resources",
-      partition: layoutsResourcePartition,
       partitions: [layoutsResourcePartition],
       type: COMMAND_TYPES.RESOURCE_CREATE,
       payload: {
@@ -332,7 +390,6 @@ try {
     createCommandEnvelope({
       projectId,
       scope: "layouts",
-      partition: layoutsPartition,
       partitions: [layoutsPartition],
       type: COMMAND_TYPES.LAYOUT_ELEMENT_CREATE,
       payload: {
@@ -390,7 +447,7 @@ try {
     assert.deepEqual(event.payload, command.payload);
     assert.deepEqual(
       normalizePartitions(event.partitions),
-      normalizePartitions(command.partitions || [command.partition]),
+      normalizePartitions(command.partitions),
     );
     assert.equal(typeof event.created, "number");
   }
@@ -432,6 +489,231 @@ try {
 } finally {
   await collab.stop();
   await server.shutdown();
+}
+
+{
+  const futureProjectId = "project-command-only-future";
+  const storyPartition = `project:${futureProjectId}:story`;
+  const currentSceneCommand = createCommandEnvelope({
+    id: "future-scene-1",
+    projectId: futureProjectId,
+    scope: "story",
+    partitions: [storyPartition],
+    type: COMMAND_TYPES.SCENE_CREATE,
+    payload: {
+      sceneId: "scene-1",
+      name: "Scene 1",
+    },
+    actor,
+    clientTs: 4001,
+    commandVersion: 1,
+  });
+  const futureSectionCommand = createCommandEnvelope({
+    id: "future-section-1",
+    projectId: futureProjectId,
+    scope: "story",
+    partitions: [storyPartition],
+    type: COMMAND_TYPES.SECTION_CREATE,
+    payload: {
+      sceneId: "scene-1",
+      sectionId: "section-1",
+      name: "Section 1",
+    },
+    actor,
+    clientTs: 4002,
+    commandVersion: 2,
+  });
+
+  const futureItem = createCommittedEventFromCommand(
+    futureSectionCommand,
+    2,
+    4002,
+  );
+  const futureCommand = commandFromItem(futureItem);
+  assert.equal(futureCommand.commandVersion, 2);
+
+  const committedEvents = [
+    createCommittedEventFromCommand(currentSceneCommand, 1, 4001),
+    futureItem,
+  ];
+  const oldProjection = buildRepositoryProjectionFromCommittedEvents({
+    committedEvents,
+  });
+  assert.equal(oldProjection.repositoryEvents.length, 1);
+  assert.equal(
+    oldProjection.projectionGap?.commandType,
+    COMMAND_TYPES.SECTION_CREATE,
+  );
+  assert.equal(oldProjection.projectionGap?.remoteCommandVersion, 2);
+
+  const upgradedProjection = buildRepositoryProjectionFromCommittedEvents({
+    committedEvents,
+    supportedCommandVersion: 2,
+  });
+  assert.equal(upgradedProjection.repositoryEvents.length, 2);
+  assert.equal(upgradedProjection.projectionGap, undefined);
+
+  const rawClientStore = createInMemoryClientStore();
+  const repositoryStore = createRepositoryStoreStub([
+    oldProjection.repositoryEvents[0],
+  ]);
+  const cacheResult = await ensureRepositoryProjectionCache({
+    repositoryStore,
+    rawClientStore,
+  });
+  assert.equal(cacheResult.rebuilt, true);
+  assert.equal(rawClientStore._debug.getCommitted().length, 1);
+  assert.equal(repositoryStore._debug.getEvents().length, 1);
+  assert.equal(
+    repositoryStore._debug.getAppValue("projector.cacheVersion"),
+    PROJECTOR_CACHE_VERSION,
+  );
+  assert.equal(
+    repositoryStore._debug.getClearMaterializedViewCheckpointsCount(),
+    1,
+  );
+}
+
+{
+  const futureProjectId = "project-command-only-live-future";
+  const storyPartition = `project:${futureProjectId}:story`;
+  const oldClientStore = createInMemoryClientStore();
+  const futureStore = createInMemorySyncStore();
+  const futureServer = createSyncServer({
+    auth: {
+      verifyToken: async (token) => {
+        const identity = parseToken(token);
+        return {
+          clientId: identity.clientId,
+          claims: { userId: identity.userId },
+        };
+      },
+    },
+    authz: {
+      authorizePartitions: async (_identity, partitions) => {
+        if (!Array.isArray(partitions) || partitions.length === 0) return false;
+        return partitions.every((partition) =>
+          partition.startsWith(`project:${futureProjectId}:`),
+        );
+      },
+    },
+    validation: {
+      validate: async (item) => {
+        validateCommandSubmitItem(item);
+      },
+    },
+    store: futureStore,
+    clock: {
+      now: () => Date.now(),
+    },
+  });
+
+  const oldClient = createProjectCollabService({
+    projectId: futureProjectId,
+    projectName: "Future Compatibility",
+    projectDescription: "old client should keep running",
+    token: "user:user-1:client:old-client",
+    actor: {
+      userId: "user-1",
+      clientId: "old-client",
+    },
+    partitions: [storyPartition],
+    clientStore: oldClientStore,
+    transport: createInMemoryServerTransport({
+      server: futureServer,
+      connectionId: "future-old-client",
+    }),
+  });
+
+  const futureWriter = createProjectCollabService({
+    projectId: futureProjectId,
+    projectName: "Future Compatibility",
+    projectDescription: "writer",
+    token: "user:user-2:client:future-writer",
+    actor: {
+      userId: "user-2",
+      clientId: "future-writer",
+    },
+    partitions: [storyPartition],
+    transport: createInMemoryServerTransport({
+      server: futureServer,
+      connectionId: "future-writer-client",
+    }),
+  });
+
+  try {
+    await oldClient.start();
+    await futureWriter.start();
+
+    await futureWriter.submitEvent(
+      createSubmitItemFromCommand(
+        createCommandEnvelope({
+          id: "live-scene-1",
+          projectId: futureProjectId,
+          scope: "story",
+          partitions: [storyPartition],
+          type: COMMAND_TYPES.SCENE_CREATE,
+          payload: {
+            sceneId: "scene-1",
+            name: "Scene 1",
+          },
+          actor: {
+            userId: "user-2",
+            clientId: "future-writer",
+          },
+          clientTs: 5001,
+          commandVersion: 1,
+        }),
+      ),
+    );
+
+    await waitFor(() => Boolean(oldClient.getState().scenes["scene-1"]), {
+      label: "old client applies compatible scene.create",
+    });
+
+    await futureWriter.submitEvent(
+      createSubmitItemFromCommand(
+        createCommandEnvelope({
+          id: "live-section-1",
+          projectId: futureProjectId,
+          scope: "story",
+          partitions: [storyPartition],
+          type: COMMAND_TYPES.SECTION_CREATE,
+          payload: {
+            sceneId: "scene-1",
+            sectionId: "section-1",
+            name: "Section 1",
+          },
+          actor: {
+            userId: "user-2",
+            clientId: "future-writer",
+          },
+          clientTs: 5002,
+          commandVersion: 2,
+        }),
+      ),
+    );
+
+    await waitFor(() => Boolean(oldClient.getProjectionGap()), {
+      label: "old client records projection gap",
+    });
+
+    assert.equal(oldClient.getState().sections["section-1"], undefined);
+    assert.equal(
+      oldClient.getProjectionGap()?.commandType,
+      COMMAND_TYPES.SECTION_CREATE,
+    );
+    assert.equal(oldClient.getProjectionGap()?.remoteCommandVersion, 2);
+    assert.equal(oldClientStore._debug.getCommitted().length, 2);
+    assert.equal(
+      oldClientStore._debug.getCommitted()[1].meta.commandVersion,
+      2,
+    );
+  } finally {
+    await oldClient.stop();
+    await futureWriter.stop();
+    await futureServer.shutdown();
+  }
 }
 
 console.log("Command-only tests: PASS");

--- a/scripts/test-command-only.js
+++ b/scripts/test-command-only.js
@@ -7,6 +7,7 @@ import {
   committedEventToCommand,
   createProjectCollabService,
 } from "../src/deps/services/shared/collab/index.js";
+import { createStoryCommandApi } from "../src/deps/services/shared/commandApi/story.js";
 import { COMMAND_TYPES } from "../src/internal/project/commands.js";
 import { validateCommand } from "../src/internal/project/commands.js";
 import {
@@ -58,6 +59,78 @@ assert.equal(
     hardcodedCommandTypeScan.stdout || ""
   ).trim()}`,
 );
+
+const capturedLineActionSubmits = [];
+const storyCommandApi = createStoryCommandApi({
+  async ensureCommandContext() {
+    return {
+      projectId,
+      state: {
+        scenes: {
+          items: {
+            "scene-1": {
+              sections: {
+                items: {
+                  "section-1": {
+                    lines: {
+                      items: {
+                        "line-1": {
+                          actions: {
+                            dialogue: {
+                              content: [{ text: "hello" }],
+                              characterId: "char-1",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+  },
+  storyBasePartitionFor(currentProjectId) {
+    return `project:${currentProjectId}:story`;
+  },
+  storyScenePartitionFor(currentProjectId, sceneId) {
+    return `project:${currentProjectId}:story:${sceneId}`;
+  },
+  async submitCommandWithContext(payload) {
+    capturedLineActionSubmits.push(payload);
+  },
+});
+
+await storyCommandApi.updateLineDialogueAction({
+  lineId: "line-1",
+  dialogue: {
+    content: [{ text: "updated" }],
+    mode: "adv",
+  },
+});
+
+assert.equal(capturedLineActionSubmits.length, 1);
+assert.equal(
+  capturedLineActionSubmits[0].type,
+  COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+);
+assert.deepEqual(capturedLineActionSubmits[0].payload, {
+  lineId: "line-1",
+  patch: {
+    dialogue: {
+      content: [{ text: "updated" }],
+      mode: "adv",
+    },
+  },
+  replace: false,
+});
+assert.deepEqual(capturedLineActionSubmits[0].partitions, [
+  `project:${projectId}:story`,
+  `project:${projectId}:story:scene-1`,
+]);
 
 const observedSchemas = [];
 const store = createInMemorySyncStore();

--- a/scripts/test-smoke.js
+++ b/scripts/test-smoke.js
@@ -131,6 +131,50 @@ assert.deepEqual(state.sections["section-1"].lineIds, ["line-1", "line-2"]);
 
 apply(
   makeCommand({
+    type: "line.update_actions",
+    ts: 1350,
+    payload: {
+      lineId: "line-1",
+      patch: {
+        dialogue: {
+          content: [{ text: "Hello" }],
+          ui: { resourceId: "layout-1" },
+          characterId: "char-1",
+        },
+      },
+      replace: false,
+    },
+  }),
+);
+assert.deepEqual(state.lines["line-1"].actions.dialogue, {
+  content: [{ text: "Hello" }],
+  ui: { resourceId: "layout-1" },
+  characterId: "char-1",
+});
+assert.equal(state.lines["line-1"].actions.narration, "hello");
+
+apply(
+  makeCommand({
+    type: "line.update_actions",
+    ts: 1360,
+    payload: {
+      lineId: "line-1",
+      patch: {
+        dialogue: {
+          mode: "nvl",
+        },
+      },
+      replace: false,
+    },
+  }),
+);
+assert.deepEqual(state.lines["line-1"].actions.dialogue, {
+  mode: "nvl",
+});
+assert.equal(state.lines["line-1"].actions.narration, "hello");
+
+apply(
+  makeCommand({
     type: "section.create",
     ts: 1400,
     payload: { sceneId: "scene-1", sectionId: "section-2", name: "Section 2" },
@@ -193,6 +237,93 @@ apply(
     },
   }),
 );
+
+apply(
+  makeCommand({
+    type: "layout.element.update",
+    ts: 1850,
+    partition: `project:${projectId}:layouts`,
+    payload: {
+      layoutId: "layout-1",
+      elementId: "B",
+      patch: {
+        textStyle: {
+          color: "#ffffff",
+          shadow: {
+            blur: 4,
+          },
+        },
+        opacity: 0.5,
+      },
+      replace: false,
+    },
+  }),
+);
+apply(
+  makeCommand({
+    type: "layout.element.update",
+    ts: 1860,
+    partition: `project:${projectId}:layouts`,
+    payload: {
+      layoutId: "layout-1",
+      elementId: "B",
+      patch: {
+        textStyle: {
+          shadow: {
+            offsetX: 2,
+          },
+        },
+      },
+      replace: false,
+    },
+  }),
+);
+assert.deepEqual(state.resources.layouts.items["layout-1"].elements["B"], {
+  id: "B",
+  type: "text",
+  parentId: "A",
+  children: [],
+  textStyle: {
+    color: "#ffffff",
+    shadow: {
+      blur: 4,
+      offsetX: 2,
+    },
+  },
+  opacity: 0.5,
+});
+
+apply(
+  makeCommand({
+    type: "layout.element.update",
+    ts: 1870,
+    partition: `project:${projectId}:layouts`,
+    payload: {
+      layoutId: "layout-1",
+      elementId: "B",
+      patch: {
+        type: "text",
+        textStyle: {
+          shadow: {
+            offsetX: 1,
+          },
+        },
+      },
+      replace: true,
+    },
+  }),
+);
+assert.deepEqual(state.resources.layouts.items["layout-1"].elements["B"], {
+  id: "B",
+  type: "text",
+  parentId: "A",
+  children: [],
+  textStyle: {
+    shadow: {
+      offsetX: 1,
+    },
+  },
+});
 
 let invariantFailed = false;
 try {

--- a/scripts/test-smoke.js
+++ b/scripts/test-smoke.js
@@ -24,12 +24,12 @@ const actor = { userId: "user-1", clientId: "client-1" };
 const makeCommand = ({
   type,
   payload,
-  partition = `project:${projectId}:story`,
+  partitions = [`project:${projectId}:story`],
   ts,
 }) => ({
   id: `${type}-${ts}-${Math.random().toString(36).slice(2, 7)}`,
   projectId,
-  partition,
+  partitions: [...partitions],
   type,
   commandVersion: COMMAND_VERSION,
   actor,
@@ -204,7 +204,7 @@ apply(
   makeCommand({
     type: "resource.create",
     ts: 1600,
-    partition: `project:${projectId}:resources:layouts`,
+    partitions: [`project:${projectId}:resources:layouts`],
     payload: {
       resourceType: "layouts",
       resourceId: "layout-1",
@@ -216,7 +216,7 @@ apply(
   makeCommand({
     type: "layout.element.create",
     ts: 1700,
-    partition: `project:${projectId}:layouts`,
+    partitions: [`project:${projectId}:layouts`],
     payload: {
       layoutId: "layout-1",
       elementId: "A",
@@ -228,7 +228,7 @@ apply(
   makeCommand({
     type: "layout.element.create",
     ts: 1800,
-    partition: `project:${projectId}:layouts`,
+    partitions: [`project:${projectId}:layouts`],
     payload: {
       layoutId: "layout-1",
       elementId: "B",
@@ -242,7 +242,7 @@ apply(
   makeCommand({
     type: "layout.element.update",
     ts: 1850,
-    partition: `project:${projectId}:layouts`,
+    partitions: [`project:${projectId}:layouts`],
     payload: {
       layoutId: "layout-1",
       elementId: "B",
@@ -263,7 +263,7 @@ apply(
   makeCommand({
     type: "layout.element.update",
     ts: 1860,
-    partition: `project:${projectId}:layouts`,
+    partitions: [`project:${projectId}:layouts`],
     payload: {
       layoutId: "layout-1",
       elementId: "B",
@@ -297,7 +297,7 @@ apply(
   makeCommand({
     type: "layout.element.update",
     ts: 1870,
-    partition: `project:${projectId}:layouts`,
+    partitions: [`project:${projectId}:layouts`],
     payload: {
       layoutId: "layout-1",
       elementId: "B",
@@ -331,7 +331,7 @@ try {
     makeCommand({
       type: "layout.element.move",
       ts: 1900,
-      partition: `project:${projectId}:layouts`,
+      partitions: [`project:${projectId}:layouts`],
       payload: {
         layoutId: "layout-1",
         elementId: "A",
@@ -349,7 +349,7 @@ apply(
   makeCommand({
     type: "resource.create",
     ts: 2000,
-    partition: `project:${projectId}:resources:variables`,
+    partitions: [`project:${projectId}:resources:variables`],
     payload: {
       resourceType: "variables",
       resourceId: "var-a",
@@ -369,7 +369,7 @@ apply(
   makeCommand({
     type: "resource.create",
     ts: 2100,
-    partition: `project:${projectId}:resources:variables`,
+    partitions: [`project:${projectId}:resources:variables`],
     payload: {
       resourceType: "variables",
       resourceId: "var-b",
@@ -389,7 +389,7 @@ apply(
   makeCommand({
     type: "resource.create",
     ts: 2200,
-    partition: `project:${projectId}:resources:variables`,
+    partitions: [`project:${projectId}:resources:variables`],
     payload: {
       resourceType: "variables",
       resourceId: "var-c",
@@ -415,7 +415,7 @@ apply(
   makeCommand({
     type: "resource.update",
     ts: 2250,
-    partition: `project:${projectId}:resources:variables`,
+    partitions: [`project:${projectId}:resources:variables`],
     payload: {
       resourceType: "variables",
       resourceId: "var-a",
@@ -435,7 +435,7 @@ try {
     makeCommand({
       type: "resource.update",
       ts: 2260,
-      partition: `project:${projectId}:resources:variables`,
+      partitions: [`project:${projectId}:resources:variables`],
       payload: {
         resourceType: "variables",
         resourceId: "var-a",
@@ -456,7 +456,7 @@ try {
     makeCommand({
       type: "resource.update",
       ts: 2270,
-      partition: `project:${projectId}:resources:variables`,
+      partitions: [`project:${projectId}:resources:variables`],
       payload: {
         resourceType: "variables",
         resourceId: "var-a",
@@ -476,7 +476,7 @@ apply(
   makeCommand({
     type: "resource.create",
     ts: 2300,
-    partition: `project:${projectId}:resources:layouts`,
+    partitions: [`project:${projectId}:resources:layouts`],
     payload: {
       resourceType: "layouts",
       resourceId: "layout-folder",
@@ -492,7 +492,7 @@ apply(
   makeCommand({
     type: "resource.create",
     ts: 2350,
-    partition: `project:${projectId}:resources:layouts`,
+    partitions: [`project:${projectId}:resources:layouts`],
     payload: {
       resourceType: "layouts",
       resourceId: "layout-2",
@@ -644,7 +644,6 @@ await applyCommandToRepository({
   command: {
     id: "project-update-layout-projection",
     projectId: projectionProjectId,
-    partition: `project:${projectionProjectId}:settings`,
     partitions: [`project:${projectionProjectId}:settings`],
     type: "project.update",
     commandVersion: COMMAND_VERSION,

--- a/src/deps/clients/tauri/tauriRepositoryAdapter.js
+++ b/src/deps/clients/tauri/tauriRepositoryAdapter.js
@@ -74,6 +74,10 @@ export const createInsiemeTauriStoreAdapter = async (projectPath) => {
       );
     },
 
+    async clearEvents() {
+      await db.execute(`DELETE FROM ${REPOSITORY_EVENTS_TABLE}`);
+    },
+
     async loadMaterializedViewCheckpoint({ viewName, partition }) {
       const rows = await db.select(
         `SELECT view_version, last_committed_id, value, updated_at
@@ -120,6 +124,10 @@ export const createInsiemeTauriStoreAdapter = async (projectPath) => {
          WHERE view_name = $1 AND partition = $2`,
         [viewName, partition],
       );
+    },
+
+    async clearMaterializedViewCheckpoints() {
+      await db.execute(`DELETE FROM ${MATERIALIZED_VIEW_TABLE}`);
     },
 
     // App key-value methods used by project services

--- a/src/deps/clients/web/webRepositoryAdapter.js
+++ b/src/deps/clients/web/webRepositoryAdapter.js
@@ -157,6 +157,16 @@ export const createInsiemeWebStoreAdapter = async (projectId) => {
       });
     },
 
+    async clearEvents() {
+      return new Promise((resolve, reject) => {
+        const transaction = db.transaction("events", "readwrite");
+        const store = transaction.objectStore("events");
+        const request = store.clear();
+        request.onsuccess = () => resolve();
+        request.onerror = (event) => reject(event.target.error);
+      });
+    },
+
     async loadMaterializedViewCheckpoint({ viewName, partition }) {
       return new Promise((resolve, reject) => {
         const transaction = db.transaction(MATERIALIZED_VIEW_STORE, "readonly");
@@ -214,6 +224,19 @@ export const createInsiemeWebStoreAdapter = async (projectId) => {
         );
         const store = transaction.objectStore(MATERIALIZED_VIEW_STORE);
         const request = store.delete([viewName, partition]);
+        request.onsuccess = () => resolve();
+        request.onerror = (event) => reject(event.target.error);
+      });
+    },
+
+    async clearMaterializedViewCheckpoints() {
+      return new Promise((resolve, reject) => {
+        const transaction = db.transaction(
+          MATERIALIZED_VIEW_STORE,
+          "readwrite",
+        );
+        const store = transaction.objectStore(MATERIALIZED_VIEW_STORE);
+        const request = store.clear();
         request.onsuccess = () => resolve();
         request.onerror = (event) => reject(event.target.error);
       });

--- a/src/deps/services/shared/collab/commandEnvelope.js
+++ b/src/deps/services/shared/collab/commandEnvelope.js
@@ -19,6 +19,12 @@ const defaultUuid = () => {
   );
 };
 
+const firstPartition = (partitions = []) => {
+  return Array.isArray(partitions)
+    ? partitions.find((value) => toNonEmptyString(value))
+    : null;
+};
+
 export const partitionFor = ({ projectId, scope }) => {
   const normalizedProjectId = toNonEmptyString(projectId);
   const normalizedScope = toNonEmptyString(scope);
@@ -53,7 +59,6 @@ export const createCommandEnvelope = ({
   id,
   projectId,
   scope,
-  partition,
   partitions,
   type,
   payload,
@@ -63,13 +68,16 @@ export const createCommandEnvelope = ({
   meta,
 }) => {
   const basePartition =
-    toNonEmptyString(partition) || partitionFor({ projectId, scope });
+    firstPartition(partitions) ||
+    (toNonEmptyString(scope) ? partitionFor({ projectId, scope }) : null);
+  if (!basePartition) {
+    throw new Error("Command partitions are required");
+  }
   const resolvedId = toNonEmptyString(id) || defaultUuid();
 
   return {
     id: resolvedId,
     projectId,
-    partition: basePartition,
     partitions: toUniquePartitions({
       basePartition,
       partitions,

--- a/src/deps/services/shared/collab/compatibility.js
+++ b/src/deps/services/shared/collab/compatibility.js
@@ -1,0 +1,100 @@
+import {
+  COMMAND_EVENT_MODEL,
+  isSupportedCommandType,
+  validateCommand,
+} from "../../../../internal/project/commands.js";
+
+export const REMOTE_COMMAND_COMPATIBILITY = Object.freeze({
+  COMPATIBLE: "compatible",
+  FUTURE: "future",
+  INVALID: "invalid",
+});
+
+const normalizeCommandVersion = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return undefined;
+  return parsed;
+};
+
+export const getSupportedCommandVersion = () =>
+  COMMAND_EVENT_MODEL.commandVersion;
+
+export const getCommandVersion = (command) => {
+  return (
+    normalizeCommandVersion(command?.commandVersion) ??
+    COMMAND_EVENT_MODEL.commandVersion
+  );
+};
+
+export const evaluateRemoteCommandCompatibility = (
+  command,
+  { supportedCommandVersion = getSupportedCommandVersion() } = {},
+) => {
+  const remoteCommandVersion = getCommandVersion(command);
+
+  if (remoteCommandVersion > supportedCommandVersion) {
+    return {
+      status: REMOTE_COMMAND_COMPATIBILITY.FUTURE,
+      reason: "command_version_future",
+      supportedCommandVersion,
+      remoteCommandVersion,
+      message: `commandVersion ${remoteCommandVersion} is newer than supported ${supportedCommandVersion}`,
+    };
+  }
+
+  if (!isSupportedCommandType(command?.type)) {
+    return {
+      status: REMOTE_COMMAND_COMPATIBILITY.INVALID,
+      reason: "unsupported_command_type",
+      supportedCommandVersion,
+      remoteCommandVersion,
+      message: `Unsupported command type: ${command?.type || "unknown"}`,
+    };
+  }
+
+  try {
+    validateCommand({
+      ...structuredClone(command),
+      commandVersion: COMMAND_EVENT_MODEL.commandVersion,
+    });
+    return {
+      status: REMOTE_COMMAND_COMPATIBILITY.COMPATIBLE,
+      reason: "ok",
+      supportedCommandVersion,
+      remoteCommandVersion,
+      message: "ok",
+    };
+  } catch (error) {
+    return {
+      status: REMOTE_COMMAND_COMPATIBILITY.INVALID,
+      reason: "validation_failed",
+      supportedCommandVersion,
+      remoteCommandVersion,
+      message: error?.message || "validation failed",
+    };
+  }
+};
+
+export const createProjectionGap = ({
+  command,
+  committedEvent,
+  compatibility,
+  sourceType,
+}) => ({
+  committedId: Number.isFinite(Number(committedEvent?.committedId))
+    ? Number(committedEvent.committedId)
+    : undefined,
+  eventId: committedEvent?.id || command?.id || undefined,
+  commandId: command?.id || undefined,
+  commandType: command?.type || undefined,
+  remoteCommandVersion:
+    compatibility?.remoteCommandVersion ?? getCommandVersion(command),
+  supportedCommandVersion:
+    compatibility?.supportedCommandVersion ?? getSupportedCommandVersion(),
+  sourceType:
+    typeof sourceType === "string" && sourceType.length > 0
+      ? sourceType
+      : undefined,
+  reason: compatibility?.reason || "unknown",
+  message: compatibility?.message || "projection skipped",
+});

--- a/src/deps/services/shared/collab/createProjectCollabService.js
+++ b/src/deps/services/shared/collab/createProjectCollabService.js
@@ -3,6 +3,12 @@ import { processCommand } from "../../../../internal/project/state.js";
 import { assertDomainInvariants } from "../../../../internal/project/state.js";
 import { createEmptyProjectState } from "../../../../internal/project/state.js";
 import { validateCommand } from "../../../../internal/project/commands.js";
+import {
+  createProjectionGap,
+  evaluateRemoteCommandCompatibility,
+  REMOTE_COMMAND_COMPATIBILITY,
+} from "./compatibility.js";
+import { commandToSyncEvent, committedEventToCommand } from "./mappers.js";
 
 const isTransportDisconnectedError = (error) => {
   const code = error?.code;
@@ -30,6 +36,7 @@ export const createProjectCollabService = ({
   let lastError = null;
   let session = null;
   let serverErrorStopInFlight = false;
+  let projectionGap;
 
   let projectedState =
     initialState && typeof initialState === "object"
@@ -47,6 +54,8 @@ export const createProjectCollabService = ({
     transport: transport || undefined,
     store: clientStore || undefined,
     logger,
+    mapCommandToSyncEvent: commandToSyncEvent,
+    mapCommittedToCommand: committedEventToCommand,
     reconnect: {
       enabled: true,
       initialDelayMs: 200,
@@ -62,10 +71,35 @@ export const createProjectCollabService = ({
       sourceType,
       isFromCurrentActor,
     }) => {
+      let compatibility = {
+        status: REMOTE_COMMAND_COMPATIBILITY.COMPATIBLE,
+        reason: "ok",
+      };
+      let projectionStatus = "applied";
+
       if (!isFromCurrentActor) {
-        const result = processCommand({ state: projectedState, command });
-        projectedState = result.state;
-        assertDomainInvariants(projectedState);
+        compatibility = evaluateRemoteCommandCompatibility(command);
+
+        if (projectionGap) {
+          projectionStatus = "skipped_due_to_gap";
+        } else if (
+          compatibility.status === REMOTE_COMMAND_COMPATIBILITY.COMPATIBLE
+        ) {
+          const result = processCommand({ state: projectedState, command });
+          projectedState = result.state;
+          assertDomainInvariants(projectedState);
+        } else {
+          projectionGap = createProjectionGap({
+            command,
+            committedEvent,
+            compatibility,
+            sourceType,
+          });
+          projectionStatus =
+            compatibility.status === REMOTE_COMMAND_COMPATIBILITY.FUTURE
+              ? "skipped_future"
+              : "skipped_invalid";
+        }
       }
 
       if (typeof onCommittedCommand === "function") {
@@ -74,6 +108,11 @@ export const createProjectCollabService = ({
           committedEvent: structuredClone(committedEvent),
           sourceType,
           isFromCurrentActor,
+          compatibility: structuredClone(compatibility),
+          projectionStatus,
+          projectionGap: projectionGap
+            ? structuredClone(projectionGap)
+            : undefined,
         });
       }
     },
@@ -160,6 +199,10 @@ export const createProjectCollabService = ({
     getLastError() {
       if (lastError) return structuredClone(lastError);
       return session.getLastError();
+    },
+
+    getProjectionGap() {
+      return projectionGap ? structuredClone(projectionGap) : undefined;
     },
 
     clearLastError() {

--- a/src/deps/services/shared/collab/index.js
+++ b/src/deps/services/shared/collab/index.js
@@ -1,4 +1,6 @@
 export * from "./commandEnvelope.js";
 export * from "./mappers.js";
 export * from "./remoteEvents.js";
+export * from "./compatibility.js";
+export * from "./projectorCache.js";
 export * from "./createProjectCollabService.js";

--- a/src/deps/services/shared/collab/mappers.js
+++ b/src/deps/services/shared/collab/mappers.js
@@ -4,9 +4,56 @@ import {
 } from "insieme/client";
 import { COMMAND_EVENT_MODEL } from "../../../../internal/project/commands.js";
 
-export const commandToSyncEvent = (command) => mapCommandToSyncEvent(command);
+const normalizeCommandVersion = (value) => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return undefined;
+  return parsed;
+};
 
-export const committedEventToCommand = (committedEvent) =>
-  committedSyncEventToCommand(committedEvent, {
-    defaultCommandVersion: COMMAND_EVENT_MODEL.commandVersion,
+export const getCommittedEventCommandVersion = (committedEvent) => {
+  return (
+    normalizeCommandVersion(committedEvent?.meta?.commandVersion) ??
+    COMMAND_EVENT_MODEL.commandVersion
+  );
+};
+
+const COMMAND_ENVELOPE_FIELDS = new Set([
+  ...COMMAND_EVENT_MODEL.requiredEnvelopeFields,
+  ...COMMAND_EVENT_MODEL.optionalEnvelopeFields,
+]);
+
+const normalizeCommandEnvelope = (command) => {
+  return Object.fromEntries(
+    Object.entries(command || {}).filter(([fieldName]) =>
+      COMMAND_ENVELOPE_FIELDS.has(fieldName),
+    ),
+  );
+};
+
+export const commandToSyncEvent = (command) => {
+  const event = mapCommandToSyncEvent(command);
+  const commandVersion =
+    normalizeCommandVersion(command?.commandVersion) ??
+    COMMAND_EVENT_MODEL.commandVersion;
+
+  return {
+    ...event,
+    meta: {
+      ...(event?.meta ? structuredClone(event.meta) : {}),
+      commandVersion,
+    },
+  };
+};
+
+export const committedEventToCommand = (committedEvent) => {
+  const commandVersion = getCommittedEventCommandVersion(committedEvent);
+  const command = committedSyncEventToCommand(committedEvent, {
+    defaultCommandVersion: commandVersion,
   });
+  if (!command) return null;
+
+  return {
+    ...normalizeCommandEnvelope(command),
+    commandVersion,
+  };
+};

--- a/src/deps/services/shared/collab/projectorCache.js
+++ b/src/deps/services/shared/collab/projectorCache.js
@@ -1,0 +1,258 @@
+import { createRepositoryCommandEvent } from "../projectRepository.js";
+import {
+  createProjectionGap,
+  evaluateRemoteCommandCompatibility,
+  REMOTE_COMMAND_COMPATIBILITY,
+} from "./compatibility.js";
+import { committedEventToCommand } from "./mappers.js";
+
+export const PROJECTOR_CACHE_VERSION = "1";
+
+const PROJECTOR_CACHE_VERSION_KEY = "projector.cacheVersion";
+const PROJECTOR_GAP_KEY = "projector.gap";
+
+const readAppValue = async (store, key) => {
+  if (!store?.app || typeof store.app.get !== "function") return undefined;
+  return store.app.get(key);
+};
+
+const writeAppValue = async (store, key, value) => {
+  if (!store?.app || typeof store.app.set !== "function") return;
+  await store.app.set(key, value);
+};
+
+const removeAppValue = async (store, key) => {
+  if (!store?.app || typeof store.app.remove !== "function") return;
+  await store.app.remove(key);
+};
+
+const getRepositoryEvents = async (repositoryStore) => {
+  if (!repositoryStore || typeof repositoryStore.getEvents !== "function") {
+    return [];
+  }
+  const events = await repositoryStore.getEvents();
+  return Array.isArray(events) ? events : [];
+};
+
+export const listCommittedEvents = async (rawClientStore) => {
+  if (typeof rawClientStore?._debug?.getCommitted !== "function") {
+    throw new Error("raw client store does not expose committed event access");
+  }
+  const events = await rawClientStore._debug.getCommitted();
+  return Array.isArray(events) ? events : [];
+};
+
+const toBootstrappedCommittedEvent = (repositoryEvent, index) => ({
+  ...structuredClone(repositoryEvent),
+  committedId: index + 1,
+  created: Number.isFinite(Number(repositoryEvent?.meta?.clientTs))
+    ? Number(repositoryEvent.meta.clientTs)
+    : index + 1,
+});
+
+export const loadProjectorCacheVersion = async (repositoryStore) => {
+  const value = await readAppValue(
+    repositoryStore,
+    PROJECTOR_CACHE_VERSION_KEY,
+  );
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+export const saveProjectorCacheVersion = async (
+  repositoryStore,
+  version = PROJECTOR_CACHE_VERSION,
+) => {
+  await writeAppValue(repositoryStore, PROJECTOR_CACHE_VERSION_KEY, version);
+};
+
+export const loadProjectionGap = async (repositoryStore) => {
+  const value = await readAppValue(repositoryStore, PROJECTOR_GAP_KEY);
+  return value && typeof value === "object"
+    ? structuredClone(value)
+    : undefined;
+};
+
+export const saveProjectionGap = async (repositoryStore, gap) => {
+  if (!gap || typeof gap !== "object") return;
+  await writeAppValue(repositoryStore, PROJECTOR_GAP_KEY, structuredClone(gap));
+};
+
+export const clearProjectionGap = async (repositoryStore) => {
+  await removeAppValue(repositoryStore, PROJECTOR_GAP_KEY);
+};
+
+export const ensureRawCommittedLogBootstrapped = async ({
+  repositoryStore,
+  rawClientStore,
+}) => {
+  const existingCommittedEvents = await listCommittedEvents(rawClientStore);
+  if (existingCommittedEvents.length > 0) {
+    return {
+      committedEvents: existingCommittedEvents,
+      bootstrapped: false,
+    };
+  }
+
+  const repositoryEvents = await getRepositoryEvents(repositoryStore);
+  if (repositoryEvents.length === 0) {
+    return {
+      committedEvents: [],
+      bootstrapped: false,
+    };
+  }
+
+  await rawClientStore.applyCommittedBatch({
+    events: repositoryEvents.map(toBootstrappedCommittedEvent),
+    nextCursor: repositoryEvents.length,
+  });
+
+  return {
+    committedEvents: await listCommittedEvents(rawClientStore),
+    bootstrapped: true,
+  };
+};
+
+export const buildRepositoryProjectionFromCommittedEvents = ({
+  committedEvents,
+  supportedCommandVersion,
+}) => {
+  const repositoryEvents = [];
+  let projectionGap;
+
+  for (const committedEvent of committedEvents || []) {
+    if (projectionGap) break;
+
+    const command = committedEventToCommand(committedEvent);
+    if (!command) {
+      projectionGap = createProjectionGap({
+        command: undefined,
+        committedEvent,
+        compatibility: {
+          status: REMOTE_COMMAND_COMPATIBILITY.INVALID,
+          reason: "committed_event_unmappable",
+          message: "Failed to map committed event to command",
+        },
+        sourceType: "rebuild",
+      });
+      break;
+    }
+
+    const compatibility = evaluateRemoteCommandCompatibility(command, {
+      supportedCommandVersion,
+    });
+    if (compatibility.status !== REMOTE_COMMAND_COMPATIBILITY.COMPATIBLE) {
+      projectionGap = createProjectionGap({
+        command,
+        committedEvent,
+        compatibility,
+        sourceType: "rebuild",
+      });
+      break;
+    }
+
+    repositoryEvents.push(
+      createRepositoryCommandEvent({
+        command,
+      }),
+    );
+  }
+
+  return {
+    repositoryEvents,
+    projectionGap,
+  };
+};
+
+export const clearDerivedRepositoryState = async (repositoryStore) => {
+  if (typeof repositoryStore?.clearEvents !== "function") {
+    throw new Error("repository store does not support clearEvents()");
+  }
+  if (typeof repositoryStore?.clearMaterializedViewCheckpoints !== "function") {
+    throw new Error(
+      "repository store does not support clearMaterializedViewCheckpoints()",
+    );
+  }
+
+  await repositoryStore.clearEvents();
+  await repositoryStore.clearMaterializedViewCheckpoints();
+};
+
+export const rebuildRepositoryProjectionCache = async ({
+  repositoryStore,
+  rawClientStore,
+}) => {
+  const committedEvents = await listCommittedEvents(rawClientStore);
+  const { repositoryEvents, projectionGap } =
+    buildRepositoryProjectionFromCommittedEvents({
+      committedEvents,
+    });
+
+  await clearDerivedRepositoryState(repositoryStore);
+  for (const event of repositoryEvents) {
+    await repositoryStore.appendEvent(event);
+  }
+
+  await saveProjectorCacheVersion(repositoryStore);
+  if (projectionGap) {
+    await saveProjectionGap(repositoryStore, projectionGap);
+  } else {
+    await clearProjectionGap(repositoryStore);
+  }
+
+  return {
+    rebuilt: true,
+    repositoryEventCount: repositoryEvents.length,
+    committedEventCount: committedEvents.length,
+    projectionGap,
+  };
+};
+
+export const ensureRepositoryProjectionCache = async ({
+  repositoryStore,
+  rawClientStore,
+}) => {
+  const storedVersion = await loadProjectorCacheVersion(repositoryStore);
+  const { committedEvents, bootstrapped } =
+    await ensureRawCommittedLogBootstrapped({
+      repositoryStore,
+      rawClientStore,
+    });
+  const repositoryEvents = await getRepositoryEvents(repositoryStore);
+
+  if (bootstrapped) {
+    if (storedVersion !== PROJECTOR_CACHE_VERSION) {
+      return rebuildRepositoryProjectionCache({
+        repositoryStore,
+        rawClientStore,
+      });
+    }
+
+    await saveProjectorCacheVersion(repositoryStore);
+    return {
+      rebuilt: false,
+      bootstrapped: true,
+      committedEventCount: committedEvents.length,
+      repositoryEventCount: repositoryEvents.length,
+      projectionGap: await loadProjectionGap(repositoryStore),
+    };
+  }
+
+  const needsRebuild =
+    storedVersion !== PROJECTOR_CACHE_VERSION ||
+    (committedEvents.length > 0 && repositoryEvents.length === 0);
+
+  if (!needsRebuild) {
+    return {
+      rebuilt: false,
+      bootstrapped: false,
+      committedEventCount: committedEvents.length,
+      repositoryEventCount: repositoryEvents.length,
+      projectionGap: await loadProjectionGap(repositoryStore),
+    };
+  }
+
+  return rebuildRepositoryProjectionCache({
+    repositoryStore,
+    rawClientStore,
+  });
+};

--- a/src/deps/services/shared/commandApi/shared.js
+++ b/src/deps/services/shared/commandApi/shared.js
@@ -80,7 +80,6 @@ export const createCommandApiShared = ({
       id: createId(),
       projectId: context.projectId,
       scope,
-      partition: resolvedBasePartition,
       partitions: uniquePartitions(resolvedBasePartition, ...partitions),
       type,
       payload,

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -5,335 +5,8 @@ import {
 } from "../projectRepository.js";
 import { COMMAND_TYPES } from "../../../../internal/project/commands.js";
 
-export const createStoryCommandApi = (shared) => ({
-  async createSceneItem({
-    sceneId,
-    name,
-    parentId = null,
-    position = "last",
-    index,
-    data = {},
-  }) {
-    const context = await shared.ensureCommandContext();
-    const finalSceneId = sceneId || shared.createId();
-    const resolvedIndex = shared.resolveSceneIndex({
-      state: context.state,
-      parentId,
-      position,
-      index,
-    });
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      finalSceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SCENE_CREATE,
-      payload: {
-        sceneId: finalSceneId,
-        name,
-        parentId: normalizeParentId(parentId),
-        index: resolvedIndex,
-        position,
-        data: structuredClone(data || {}),
-      },
-      partitions: [basePartition, scenePartition],
-    });
-    return finalSceneId;
-  },
-
-  async updateSceneItem({ sceneId, patch }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      sceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SCENE_UPDATE,
-      payload: {
-        sceneId,
-        patch: structuredClone(patch || {}),
-      },
-      partitions: [basePartition, scenePartition],
-    });
-  },
-
-  async renameSceneItem({ sceneId, name }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      sceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SCENE_RENAME,
-      payload: {
-        sceneId,
-        name,
-      },
-      partitions: [basePartition, scenePartition],
-    });
-  },
-
-  async deleteSceneItem({ sceneId }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      sceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SCENE_DELETE,
-      payload: {
-        sceneId,
-      },
-      partitions: [basePartition, scenePartition],
-    });
-  },
-
-  async setInitialScene({ sceneId }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      sceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SCENE_SET_INITIAL,
-      payload: {
-        sceneId,
-      },
-      partitions: [basePartition, scenePartition],
-    });
-  },
-
-  async reorderSceneItem({
-    sceneId,
-    parentId = null,
-    position = "last",
-    index,
-  }) {
-    const context = await shared.ensureCommandContext();
-    const resolvedIndex = shared.resolveSceneIndex({
-      state: context.state,
-      parentId,
-      position,
-      index,
-      movingId: sceneId,
-    });
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      sceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SCENE_MOVE,
-      payload: {
-        sceneId,
-        parentId: normalizeParentId(parentId),
-        index: resolvedIndex,
-        position,
-      },
-      partitions: [basePartition, scenePartition],
-    });
-  },
-
-  async createSectionItem({
-    sceneId,
-    sectionId,
-    name,
-    parentId = null,
-    position = "last",
-    index,
-    data = {},
-  }) {
-    const context = await shared.ensureCommandContext();
-    const nextSectionId = sectionId || shared.createId();
-    const scene = context.state?.scenes?.items?.[sceneId];
-    const resolvedIndex = shared.resolveSectionIndex({
-      scene,
-      parentId,
-      position,
-      index,
-    });
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = shared.storyScenePartitionFor(
-      context.projectId,
-      sceneId,
-    );
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SECTION_CREATE,
-      payload: {
-        sceneId,
-        sectionId: nextSectionId,
-        name,
-        parentId: normalizeParentId(parentId),
-        index: resolvedIndex,
-        position,
-        data: structuredClone(data || {}),
-      },
-      partitions: [basePartition, scenePartition],
-    });
-
-    return nextSectionId;
-  },
-
-  async renameSectionItem({ sceneId, sectionId, name }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const sectionLocation = findSectionLocation(context.state, sectionId);
-    const sceneIdForPartition = sceneId || sectionLocation?.sceneId;
-    const scenePartition = sceneIdForPartition
-      ? shared.storyScenePartitionFor(context.projectId, sceneIdForPartition)
-      : null;
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SECTION_RENAME,
-      payload: {
-        sectionId,
-        name,
-      },
-      partitions: scenePartition
-        ? [basePartition, scenePartition]
-        : [basePartition],
-    });
-  },
-
-  async deleteSectionItem({ sceneId, sectionId }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const sectionLocation = findSectionLocation(context.state, sectionId);
-    const sceneIdForPartition = sceneId || sectionLocation?.sceneId;
-    const scenePartition = sceneIdForPartition
-      ? shared.storyScenePartitionFor(context.projectId, sceneIdForPartition)
-      : null;
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SECTION_DELETE,
-      payload: {
-        sectionId,
-      },
-      partitions: scenePartition
-        ? [basePartition, scenePartition]
-        : [basePartition],
-    });
-  },
-
-  async reorderSectionItem({
-    sectionId,
-    parentId = null,
-    position = "last",
-    index,
-  }) {
-    const context = await shared.ensureCommandContext();
-    const sectionLocation = findSectionLocation(context.state, sectionId);
-    const resolvedIndex = shared.resolveSectionIndex({
-      scene: sectionLocation?.scene,
-      parentId,
-      position,
-      index,
-      movingId: sectionId,
-    });
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = sectionLocation?.sceneId
-      ? shared.storyScenePartitionFor(
-          context.projectId,
-          sectionLocation.sceneId,
-        )
-      : null;
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.SECTION_REORDER,
-      payload: {
-        sectionId,
-        parentId: normalizeParentId(parentId),
-        index: resolvedIndex,
-        position,
-      },
-      partitions: scenePartition
-        ? [basePartition, scenePartition]
-        : [basePartition],
-    });
-  },
-
-  async createLineItem({
-    sectionId,
-    lineId,
-    line = {},
-    afterLineId,
-    parentId = null,
-    position,
-    index,
-  }) {
-    const context = await shared.ensureCommandContext();
-    const nextLineId = lineId || shared.createId();
-    const sectionLocation = findSectionLocation(context.state, sectionId);
-    const resolvedPosition =
-      position || (afterLineId ? { after: afterLineId } : undefined);
-    const resolvedIndex = shared.resolveLineIndex({
-      section: sectionLocation?.section,
-      parentId,
-      position: resolvedPosition || "last",
-      index,
-    });
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const scenePartition = sectionLocation?.sceneId
-      ? shared.storyScenePartitionFor(
-          context.projectId,
-          sectionLocation.sceneId,
-        )
-      : null;
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.LINE_INSERT_AFTER,
-      payload: {
-        sectionId,
-        lineId: nextLineId,
-        line: structuredClone(line || {}),
-        afterLineId: afterLineId || null,
-        parentId: normalizeParentId(parentId),
-        index: resolvedIndex,
-        position: resolvedPosition || "last",
-      },
-      partitions: scenePartition
-        ? [basePartition, scenePartition]
-        : [basePartition],
-    });
-
-    return nextLineId;
-  },
-
-  async updateLineActions({ lineId, patch, replace = false }) {
+export const createStoryCommandApi = (shared) => {
+  const submitLineActionsPatch = async ({ lineId, patch, replace = false }) => {
     const context = await shared.ensureCommandContext();
     const basePartition = shared.storyBasePartitionFor(context.projectId);
     const lineLocation = findLineLocation(context.state, lineId);
@@ -354,66 +27,430 @@ export const createStoryCommandApi = (shared) => ({
         ? [basePartition, scenePartition]
         : [basePartition],
     });
-  },
+  };
 
-  async deleteLineItem({ lineId }) {
-    const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const lineLocation = findLineLocation(context.state, lineId);
-    const scenePartition = lineLocation?.sceneId
-      ? shared.storyScenePartitionFor(context.projectId, lineLocation.sceneId)
-      : null;
-
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.LINE_DELETE,
-      payload: {
+  return {
+    async updateLineActions({ lineId, patch, replace = false }) {
+      await submitLineActionsPatch({
         lineId,
-      },
-      partitions: scenePartition
-        ? [basePartition, scenePartition]
-        : [basePartition],
-    });
-  },
+        patch,
+        replace,
+      });
+    },
 
-  async moveLineItem({
-    lineId,
-    toSectionId,
-    parentId = null,
-    position = "last",
-    index,
-  }) {
-    const context = await shared.ensureCommandContext();
-    const targetSection = findSectionLocation(context.state, toSectionId);
-    const resolvedIndex = shared.resolveLineIndex({
-      section: targetSection?.section,
-      parentId,
+    async updateLineAction({ lineId, actionType, action }) {
+      if (typeof actionType !== "string" || actionType.length === 0) {
+        throw new Error("actionType is required");
+      }
+
+      await submitLineActionsPatch({
+        lineId,
+        patch: {
+          [actionType]: structuredClone(action || {}),
+        },
+        replace: false,
+      });
+    },
+
+    async updateLineDialogueAction({ lineId, dialogue }) {
+      await submitLineActionsPatch({
+        lineId,
+        patch: {
+          dialogue: structuredClone(dialogue || {}),
+        },
+        replace: false,
+      });
+    },
+
+    async createSceneItem({
+      sceneId,
+      name,
+      parentId = null,
+      position = "last",
+      index,
+      data = {},
+    }) {
+      const context = await shared.ensureCommandContext();
+      const finalSceneId = sceneId || shared.createId();
+      const resolvedIndex = shared.resolveSceneIndex({
+        state: context.state,
+        parentId,
+        position,
+        index,
+      });
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        finalSceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SCENE_CREATE,
+        payload: {
+          sceneId: finalSceneId,
+          name,
+          parentId: normalizeParentId(parentId),
+          index: resolvedIndex,
+          position,
+          data: structuredClone(data || {}),
+        },
+        partitions: [basePartition, scenePartition],
+      });
+      return finalSceneId;
+    },
+
+    async updateSceneItem({ sceneId, patch }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        sceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SCENE_UPDATE,
+        payload: {
+          sceneId,
+          patch: structuredClone(patch || {}),
+        },
+        partitions: [basePartition, scenePartition],
+      });
+    },
+
+    async renameSceneItem({ sceneId, name }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        sceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SCENE_RENAME,
+        payload: {
+          sceneId,
+          name,
+        },
+        partitions: [basePartition, scenePartition],
+      });
+    },
+
+    async deleteSceneItem({ sceneId }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        sceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SCENE_DELETE,
+        payload: {
+          sceneId,
+        },
+        partitions: [basePartition, scenePartition],
+      });
+    },
+
+    async setInitialScene({ sceneId }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        sceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SCENE_SET_INITIAL,
+        payload: {
+          sceneId,
+        },
+        partitions: [basePartition, scenePartition],
+      });
+    },
+
+    async reorderSceneItem({
+      sceneId,
+      parentId = null,
+      position = "last",
+      index,
+    }) {
+      const context = await shared.ensureCommandContext();
+      const resolvedIndex = shared.resolveSceneIndex({
+        state: context.state,
+        parentId,
+        position,
+        index,
+        movingId: sceneId,
+      });
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        sceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SCENE_MOVE,
+        payload: {
+          sceneId,
+          parentId: normalizeParentId(parentId),
+          index: resolvedIndex,
+          position,
+        },
+        partitions: [basePartition, scenePartition],
+      });
+    },
+
+    async createSectionItem({
+      sceneId,
+      sectionId,
+      name,
+      parentId = null,
+      position = "last",
+      index,
+      data = {},
+    }) {
+      const context = await shared.ensureCommandContext();
+      const nextSectionId = sectionId || shared.createId();
+      const scene = context.state?.scenes?.items?.[sceneId];
+      const resolvedIndex = shared.resolveSectionIndex({
+        scene,
+        parentId,
+        position,
+        index,
+      });
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = shared.storyScenePartitionFor(
+        context.projectId,
+        sceneId,
+      );
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SECTION_CREATE,
+        payload: {
+          sceneId,
+          sectionId: nextSectionId,
+          name,
+          parentId: normalizeParentId(parentId),
+          index: resolvedIndex,
+          position,
+          data: structuredClone(data || {}),
+        },
+        partitions: [basePartition, scenePartition],
+      });
+
+      return nextSectionId;
+    },
+
+    async renameSectionItem({ sceneId, sectionId, name }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      const sceneIdForPartition = sceneId || sectionLocation?.sceneId;
+      const scenePartition = sceneIdForPartition
+        ? shared.storyScenePartitionFor(context.projectId, sceneIdForPartition)
+        : null;
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SECTION_RENAME,
+        payload: {
+          sectionId,
+          name,
+        },
+        partitions: scenePartition
+          ? [basePartition, scenePartition]
+          : [basePartition],
+      });
+    },
+
+    async deleteSectionItem({ sceneId, sectionId }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      const sceneIdForPartition = sceneId || sectionLocation?.sceneId;
+      const scenePartition = sceneIdForPartition
+        ? shared.storyScenePartitionFor(context.projectId, sceneIdForPartition)
+        : null;
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SECTION_DELETE,
+        payload: {
+          sectionId,
+        },
+        partitions: scenePartition
+          ? [basePartition, scenePartition]
+          : [basePartition],
+      });
+    },
+
+    async reorderSectionItem({
+      sectionId,
+      parentId = null,
+      position = "last",
+      index,
+    }) {
+      const context = await shared.ensureCommandContext();
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      const resolvedIndex = shared.resolveSectionIndex({
+        scene: sectionLocation?.scene,
+        parentId,
+        position,
+        index,
+        movingId: sectionId,
+      });
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = sectionLocation?.sceneId
+        ? shared.storyScenePartitionFor(
+            context.projectId,
+            sectionLocation.sceneId,
+          )
+        : null;
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.SECTION_REORDER,
+        payload: {
+          sectionId,
+          parentId: normalizeParentId(parentId),
+          index: resolvedIndex,
+          position,
+        },
+        partitions: scenePartition
+          ? [basePartition, scenePartition]
+          : [basePartition],
+      });
+    },
+
+    async createLineItem({
+      sectionId,
+      lineId,
+      line = {},
+      afterLineId,
+      parentId = null,
       position,
       index,
-      movingId: lineId,
-    });
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const sourceLine = findLineLocation(context.state, lineId);
-    const sourceScenePartition = sourceLine?.sceneId
-      ? shared.storyScenePartitionFor(context.projectId, sourceLine.sceneId)
-      : null;
-    const targetScenePartition = targetSection?.sceneId
-      ? shared.storyScenePartitionFor(context.projectId, targetSection.sceneId)
-      : null;
+    }) {
+      const context = await shared.ensureCommandContext();
+      const nextLineId = lineId || shared.createId();
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      const resolvedPosition =
+        position || (afterLineId ? { after: afterLineId } : undefined);
+      const resolvedIndex = shared.resolveLineIndex({
+        section: sectionLocation?.section,
+        parentId,
+        position: resolvedPosition || "last",
+        index,
+      });
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = sectionLocation?.sceneId
+        ? shared.storyScenePartitionFor(
+            context.projectId,
+            sectionLocation.sceneId,
+          )
+        : null;
 
-    await shared.submitCommandWithContext({
-      context,
-      scope: "story",
-      type: COMMAND_TYPES.LINE_MOVE,
-      payload: {
-        lineId,
-        toSectionId,
-        parentId: normalizeParentId(parentId),
-        index: resolvedIndex,
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.LINE_INSERT_AFTER,
+        payload: {
+          sectionId,
+          lineId: nextLineId,
+          line: structuredClone(line || {}),
+          afterLineId: afterLineId || null,
+          parentId: normalizeParentId(parentId),
+          index: resolvedIndex,
+          position: resolvedPosition || "last",
+        },
+        partitions: scenePartition
+          ? [basePartition, scenePartition]
+          : [basePartition],
+      });
+
+      return nextLineId;
+    },
+
+    async deleteLineItem({ lineId }) {
+      const context = await shared.ensureCommandContext();
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const lineLocation = findLineLocation(context.state, lineId);
+      const scenePartition = lineLocation?.sceneId
+        ? shared.storyScenePartitionFor(context.projectId, lineLocation.sceneId)
+        : null;
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.LINE_DELETE,
+        payload: {
+          lineId,
+        },
+        partitions: scenePartition
+          ? [basePartition, scenePartition]
+          : [basePartition],
+      });
+    },
+
+    async moveLineItem({
+      lineId,
+      toSectionId,
+      parentId = null,
+      position = "last",
+      index,
+    }) {
+      const context = await shared.ensureCommandContext();
+      const targetSection = findSectionLocation(context.state, toSectionId);
+      const resolvedIndex = shared.resolveLineIndex({
+        section: targetSection?.section,
+        parentId,
         position,
-      },
-      partitions: [basePartition, sourceScenePartition, targetScenePartition],
-    });
-  },
-});
+        index,
+        movingId: lineId,
+      });
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const sourceLine = findLineLocation(context.state, lineId);
+      const sourceScenePartition = sourceLine?.sceneId
+        ? shared.storyScenePartitionFor(context.projectId, sourceLine.sceneId)
+        : null;
+      const targetScenePartition = targetSection?.sceneId
+        ? shared.storyScenePartitionFor(
+            context.projectId,
+            targetSection.sceneId,
+          )
+        : null;
+
+      await shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        type: COMMAND_TYPES.LINE_MOVE,
+        payload: {
+          lineId,
+          toSectionId,
+          parentId: normalizeParentId(parentId),
+          index: resolvedIndex,
+          position,
+        },
+        partitions: [basePartition, sourceScenePartition, targetScenePartition],
+      });
+    },
+  };
+};

--- a/src/deps/services/shared/projectRepository.js
+++ b/src/deps/services/shared/projectRepository.js
@@ -6,11 +6,11 @@ import {
   COMMAND_TYPES,
   isSupportedCommandType,
 } from "../../../internal/project/commands.js";
+import { validateCommandSubmitItem } from "insieme/client";
 import {
   commandToSyncEvent,
-  committedSyncEventToCommand,
-  validateCommandSubmitItem,
-} from "insieme/client";
+  committedEventToCommand,
+} from "./collab/mappers.js";
 
 export const createTreeCollection = () => {
   return {
@@ -180,7 +180,6 @@ export const createProjectCreatedCommand = ({
   actor,
   commandId,
   clientTs,
-  partition,
   partitions,
   meta,
 }) => {
@@ -196,9 +195,11 @@ export const createProjectCreatedCommand = ({
   }
 
   const basePartition =
-    typeof partition === "string" && partition.length > 0
-      ? partition
-      : defaultInitializationPartition(resolvedProjectId);
+    (Array.isArray(partitions)
+      ? partitions.find(
+          (value) => typeof value === "string" && value.length > 0,
+        )
+      : null) || defaultInitializationPartition(resolvedProjectId);
   const resolvedPartitions = Array.from(
     new Set(
       [basePartition]
@@ -213,7 +214,6 @@ export const createProjectCreatedCommand = ({
         ? commandId
         : `project-created:${resolvedProjectId}`,
     projectId: resolvedProjectId,
-    partition: basePartition,
     partitions: resolvedPartitions,
     type: COMMAND_TYPES.PROJECT_CREATED,
     payload: {
@@ -238,7 +238,6 @@ const resolveCommandPartitions = (command) => {
     partitions.push(value);
   };
 
-  push(command?.partition);
   for (const partition of Array.isArray(command?.partitions)
     ? command.partitions
     : []) {
@@ -283,9 +282,7 @@ export const createRepositoryCommandEvent = ({ command }) => {
 
 export const repositoryEventToCommand = (repositoryEvent) => {
   assertRepositoryCommandEvent(repositoryEvent);
-  const command = committedSyncEventToCommand(repositoryEvent, {
-    defaultCommandVersion: COMMAND_EVENT_MODEL.commandVersion,
-  });
+  const command = committedEventToCommand(repositoryEvent);
   if (!command) {
     throw new Error("Failed to convert repository event to command");
   }
@@ -298,7 +295,6 @@ export const createProjectCreatedRepositoryEvent = ({
   actor,
   commandId,
   clientTs,
-  partition,
   partitions,
   meta,
 }) =>
@@ -309,7 +305,6 @@ export const createProjectCreatedRepositoryEvent = ({
       actor,
       commandId,
       clientTs,
-      partition,
       partitions,
       meta,
     }),

--- a/src/deps/services/tauri/collabClientStore.js
+++ b/src/deps/services/tauri/collabClientStore.js
@@ -1,0 +1,47 @@
+import { join } from "@tauri-apps/api/path";
+import Database from "@tauri-apps/plugin-sql";
+import { createLibsqlClientStore } from "insieme/client";
+
+const COLLAB_CLIENT_DB_NAME = "collab-client.db";
+
+const isReadQuery = (sql) => {
+  const normalized = String(sql || "")
+    .trim()
+    .toUpperCase();
+  return normalized.startsWith("SELECT") || normalized.startsWith("PRAGMA");
+};
+
+const createLibsqlLikeClient = (db) => ({
+  async execute({ sql, args } = {}) {
+    const resolvedArgs = Array.isArray(args) ? args : [];
+
+    if (isReadQuery(sql)) {
+      const rows = await db.select(sql, resolvedArgs);
+      return {
+        rows: Array.isArray(rows) ? rows : [],
+        columns: [],
+        rowsAffected: 0,
+      };
+    }
+
+    const result = await db.execute(sql, resolvedArgs);
+    return {
+      rows: [],
+      columns: [],
+      rowsAffected: Number(result?.rowsAffected ?? result?.changes ?? 0),
+    };
+  },
+});
+
+export const createPersistedTauriCollabClientStore = async ({
+  projectPath,
+  materializedViews = [],
+}) => {
+  const dbPath = await join(projectPath, COLLAB_CLIENT_DB_NAME);
+  const db = await Database.load(`sqlite:${dbPath}`);
+  const store = createLibsqlClientStore(createLibsqlLikeClient(db), {
+    materializedViews,
+  });
+  await store.init();
+  return store;
+};

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -7,7 +7,13 @@ import {
   loadTemplate,
   getTemplateFiles,
 } from "../../clients/web/templateLoader.js";
+import { createPersistedTauriCollabClientStore } from "./collabClientStore.js";
 import { createProjectCollabService } from "../shared/collab/createProjectCollabService.js";
+import {
+  clearProjectionGap,
+  ensureRepositoryProjectionCache,
+  saveProjectionGap,
+} from "../shared/collab/projectorCache.js";
 import { createWebSocketTransport } from "../web/collab/createWebSocketTransport.js";
 import { projectRepositoryStateToDomainState } from "../../../internal/project/projection.js";
 import {
@@ -40,6 +46,19 @@ async function copyTemplateFiles(templateId, targetPath) {
 }
 
 export const createTauriProjectServiceAdapters = ({ collabLog }) => {
+  const collabClientStoresByProjectPath = new Map();
+
+  const getCollabClientStore = async (projectPath) => {
+    const existing = collabClientStoresByProjectPath.get(projectPath);
+    if (existing) return existing;
+
+    const store = await createPersistedTauriCollabClientStore({
+      projectPath,
+    });
+    collabClientStoresByProjectPath.set(projectPath, store);
+    return store;
+  };
+
   const storageAdapter = {
     resolveProjectReferenceByProjectId: async ({ db, projectId }) => {
       const projects = (await db.get("projectEntries")) || [];
@@ -252,6 +271,26 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
   };
 
   const collabAdapter = {
+    beforeCreateRepository: async ({ reference, store }) => {
+      const rawClientStore = await getCollabClientStore(reference.projectPath);
+      const projectionCacheResult = await ensureRepositoryProjectionCache({
+        repositoryStore: store,
+        rawClientStore,
+      });
+
+      collabLog("debug", "repository projection cache ready", {
+        projectId: reference.projectId,
+        projectPath: reference.projectPath,
+        rebuilt: projectionCacheResult.rebuilt,
+        bootstrapped: projectionCacheResult.bootstrapped,
+        repositoryEventCount: projectionCacheResult.repositoryEventCount,
+        committedEventCount: projectionCacheResult.committedEventCount,
+        projectionGap: projectionCacheResult.projectionGap || null,
+      });
+
+      return store.getEvents();
+    },
+
     createTransport: ({ endpointUrl }) =>
       createWebSocketTransport({
         url: endpointUrl,
@@ -268,6 +307,7 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
       mode,
       partitioning,
       getRepositoryByProject,
+      getStoreByProject,
       getProjectMetadataFromEntries,
     }) => {
       collabLog("info", "create session requested", {
@@ -289,6 +329,8 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
         partitions,
       );
       const projectMetadata = await getProjectMetadataFromEntries(projectId);
+      const clientStore = await getCollabClientStore(resolvedProjectId);
+      const repositoryStore = await getStoreByProject(projectId);
       const collabSession = createProjectCollabService({
         projectId: resolvedProjectId,
         projectName: projectMetadata.name,
@@ -303,16 +345,27 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
           clientId,
         },
         partitions: resolvedPartitions,
+        clientStore,
         logger: (entry) => {
           collabLog("debug", "sync-client", entry);
         },
-        onCommittedCommand: async ({ command, isFromCurrentActor }) => {
+        onCommittedCommand: async ({
+          command,
+          isFromCurrentActor,
+          projectionStatus,
+          projectionGap,
+        }) => {
+          if (projectionGap) {
+            await saveProjectionGap(repositoryStore, projectionGap);
+          }
           if (isFromCurrentActor) return;
+          if (projectionStatus !== "applied") return;
           await applyCommandToRepository({
             repository,
             command,
             projectId: resolvedProjectId,
           });
+          await clearProjectionGap(repositoryStore);
         },
       });
 

--- a/src/deps/services/web/collabClientStore.js
+++ b/src/deps/services/web/collabClientStore.js
@@ -1,51 +1,26 @@
-import {
-  loadCommittedCursor,
-  saveCommittedCursor,
-} from "./collabCommittedCursorStore.js";
-import {
-  createInMemoryClientStore,
-  createPersistedCursorClientStore,
-} from "insieme/client";
+import { createIndexedDBClientStore } from "insieme/client";
 
-const clampCursor = (value) => {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return 0;
-  if (parsed < 0) return 0;
-  return Math.floor(parsed);
+const buildClientStoreDbName = (projectId) => {
+  return `routevn-collab-client:${projectId}`;
 };
 
 export const createPersistedInMemoryClientStore = async ({
   projectId,
-  adapter,
   materializedViews = [],
   logger = () => {},
 }) => {
-  const baseStore = createInMemoryClientStore({
+  const store = createIndexedDBClientStore({
+    dbName: buildClientStoreDbName(projectId),
     materializedViews,
   });
-  return createPersistedCursorClientStore({
-    store: baseStore,
-    loadPersistedCursor: async () =>
-      clampCursor(
-        await loadCommittedCursor({
-          adapter,
-          projectId,
-        }),
-      ),
-    savePersistedCursor: async (cursor) =>
-      saveCommittedCursor({
-        adapter,
-        projectId,
-        cursor: clampCursor(cursor),
-      }),
-    logger: (entry) => {
-      logger({
-        level: "warn",
-        event: entry?.event || "cursor_persist_failed",
-        projectId,
-        error: entry?.message || "unknown",
-        cursor: clampCursor(entry?.cursor),
-      });
-    },
+  await store.init();
+
+  logger({
+    level: "debug",
+    event: "collab_client_store_ready",
+    projectId,
+    dbName: buildClientStoreDbName(projectId),
   });
+
+  return store;
 };

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -21,6 +21,11 @@ import {
   toUncommittedSyncSubmissionEvents,
 } from "./projectServiceCollabRuntime.js";
 import {
+  clearProjectionGap,
+  ensureRepositoryProjectionCache,
+  saveProjectionGap,
+} from "../shared/collab/projectorCache.js";
+import {
   applyCommandToRepository,
   assertSupportedProjectState,
 } from "../shared/projectRepository.js";
@@ -38,8 +43,25 @@ export const createWebProjectServiceAdapters = ({
   collabLog,
 }) => {
   const collabApplyQueueByProject = new Map();
+  const collabClientStoresByProject = new Map();
   const collabLastCommittedIdByProject = new Map();
   const collabAppliedCommittedIdsByProject = new Map();
+
+  const getCollabClientStore = async (projectId) => {
+    const existing = collabClientStoresByProject.get(projectId);
+    if (existing) return existing;
+
+    const store = await createPersistedInMemoryClientStore({
+      projectId,
+      logger: (entry) => {
+        if (entry?.level === "warn") {
+          collabLog("warn", "client store warning", entry);
+        }
+      },
+    });
+    collabClientStoresByProject.set(projectId, store);
+    return store;
+  };
 
   const ensureCommittedIdLoaded = async (projectId, getStoreByProject) => {
     return ensureCachedCommittedCursor({
@@ -249,8 +271,22 @@ export const createWebProjectServiceAdapters = ({
           localEventCount: events.length,
         });
       }
+      const rawClientStore = await getCollabClientStore(projectId);
+      const projectionCacheResult = await ensureRepositoryProjectionCache({
+        repositoryStore: store,
+        rawClientStore,
+      });
 
-      return events;
+      collabLog("debug", "repository projection cache ready", {
+        projectId,
+        rebuilt: projectionCacheResult.rebuilt,
+        bootstrapped: projectionCacheResult.bootstrapped,
+        repositoryEventCount: projectionCacheResult.repositoryEventCount,
+        committedEventCount: projectionCacheResult.committedEventCount,
+        projectionGap: projectionCacheResult.projectionGap || null,
+      });
+
+      return store.getEvents();
     },
 
     createTransport: ({ endpointUrl }) =>
@@ -310,15 +346,7 @@ export const createWebProjectServiceAdapters = ({
         partitions,
       );
       const projectMetadata = await getProjectMetadataFromEntries(projectId);
-      const clientStore = await createPersistedInMemoryClientStore({
-        projectId,
-        adapter,
-        logger: (entry) => {
-          if (entry?.level === "warn") {
-            collabLog("warn", "client store warning", entry);
-          }
-        },
-      });
+      const clientStore = await getCollabClientStore(projectId);
       await ensureCommittedIdLoaded(projectId, getStoreByProject);
       const collabSession = createProjectCollabService({
         projectId: resolvedProjectId,
@@ -352,6 +380,9 @@ export const createWebProjectServiceAdapters = ({
           committedEvent,
           sourceType,
           isFromCurrentActor,
+          compatibility,
+          projectionStatus,
+          projectionGap,
         }) =>
           queueCollabApply(projectId, async () => {
             const applyCommittedEventToRepository = async ({
@@ -359,6 +390,9 @@ export const createWebProjectServiceAdapters = ({
               committedEvent,
               sourceType,
               isFromCurrentActor,
+              compatibility,
+              projectionStatus,
+              projectionGap,
             }) => {
               if (isFromCurrentActor) {
                 collabLog("debug", "command skipped (current actor source)", {
@@ -366,6 +400,27 @@ export const createWebProjectServiceAdapters = ({
                   sourceType,
                   commandId: command?.id || null,
                   commandType: command?.type || null,
+                  committedId: Number.isFinite(
+                    Number(committedEvent?.committedId),
+                  )
+                    ? Number(committedEvent.committedId)
+                    : null,
+                });
+                return;
+              }
+
+              if (projectionGap) {
+                await saveProjectionGap(adapter, projectionGap);
+              }
+
+              if (projectionStatus !== "applied") {
+                collabLog("info", "remote command projection skipped", {
+                  projectId,
+                  sourceType,
+                  commandType: command?.type || null,
+                  commandId: command?.id || null,
+                  projectionStatus,
+                  compatibilityStatus: compatibility?.status || null,
                   committedId: Number.isFinite(
                     Number(committedEvent?.committedId),
                   )
@@ -449,15 +504,19 @@ export const createWebProjectServiceAdapters = ({
               committedEvent,
               sourceType,
               isFromCurrentActor,
+              compatibility,
+              projectionStatus,
+              projectionGap,
             });
 
-            if (hasCommittedId) {
+            if (hasCommittedId && !projectionGap) {
               const nextWatermark = Math.max(lastCommittedId, committedId);
               await persistCommittedCursor(
                 projectId,
                 nextWatermark,
                 getStoreByProject,
               );
+              await clearProjectionGap(adapter);
             }
           }),
       });

--- a/src/deps/services/web/projectServiceCollabRuntime.js
+++ b/src/deps/services/web/projectServiceCollabRuntime.js
@@ -1,9 +1,9 @@
-import { commandToSyncEvent } from "insieme/client";
 import {
   assertRepositoryCommandEvent,
   repositoryEventToCommand,
 } from "../shared/projectRepository.js";
 import { COMMAND_TYPES } from "../../../internal/project/commands.js";
+import { commandToSyncEvent } from "../shared/collab/mappers.js";
 
 const normalizeCommittedCursor = (value) => {
   const parsed = Number(value);
@@ -71,7 +71,10 @@ export const summarizeRepositoryEventsForSync = (events = []) => {
     firstCommandType: firstCommand?.type || null,
     firstCommandId: firstCommand?.id || null,
     firstCommandProjectId: firstCommand?.projectId || null,
-    firstCommandPartition: firstCommand?.partition || null,
+    firstCommandPartition:
+      firstCommand?.partitions?.find(
+        (partition) => typeof partition === "string" && partition.length > 0,
+      ) || null,
   };
 };
 

--- a/src/internal/project/commands.js
+++ b/src/internal/project/commands.js
@@ -24,6 +24,8 @@ export const RESOURCE_TYPES = [
   "components",
 ];
 
+const PROJECT_UPDATE_PATCH_FIELDS = Object.freeze(["name", "description"]);
+
 export class DomainValidationError extends Error {
   constructor(message, details = {}) {
     super(message);
@@ -167,6 +169,38 @@ const validateOptionalPlainObjectField = (payload, field, errors) => {
 const validateOptionalBooleanField = (payload, field, errors) => {
   if (payload?.[field] !== undefined && typeof payload[field] !== "boolean") {
     errors.push(`payload.${field} must be a boolean when provided`);
+  }
+};
+
+const validateProjectUpdatePatch = (payload, errors) => {
+  const patch = payload?.patch;
+  if (!isPlainObject(patch)) {
+    return;
+  }
+
+  const keys = Object.keys(patch);
+  if (keys.length === 0) {
+    errors.push(
+      "payload.patch must include at least one of: name, description",
+    );
+    return;
+  }
+
+  for (const key of keys) {
+    if (!PROJECT_UPDATE_PATCH_FIELDS.includes(key)) {
+      errors.push(`payload.patch.${key} is not allowed`);
+    }
+  }
+
+  if (patch.name !== undefined && !assertNonEmptyString(patch.name)) {
+    errors.push("payload.patch.name must be a non-empty string when provided");
+  }
+
+  if (
+    patch.description !== undefined &&
+    typeof patch.description !== "string"
+  ) {
+    errors.push("payload.patch.description must be a string when provided");
   }
 };
 
@@ -842,6 +876,10 @@ export const validateCommandPayload = (command, errors) => {
   if (spec.allowPosition) {
     validatePositionField(payload, errors);
   }
+
+  if (command?.type === COMMAND_TYPES.PROJECT_UPDATE) {
+    validateProjectUpdatePatch(payload, errors);
+  }
 };
 
 export const assertCommandPreconditions = (state, command) => {
@@ -871,7 +909,10 @@ export const validateCommand = (command) => {
   validateCommandPayload(command, errors);
 
   if (errors.length > 0) {
-    throw new DomainValidationError("Command validation failed", { errors });
+    throw new DomainValidationError(
+      `Command validation failed: ${errors.join("; ")}`,
+      { errors },
+    );
   }
 
   return true;

--- a/src/internal/project/commands.js
+++ b/src/internal/project/commands.js
@@ -736,14 +736,14 @@ export const COMMAND_EVENT_MODEL = Object.freeze({
   requiredEnvelopeFields: Object.freeze([
     "id",
     "projectId",
-    "partition",
+    "partitions",
     "type",
     "payload",
     "actor",
     "clientTs",
     "commandVersion",
   ]),
-  optionalEnvelopeFields: Object.freeze(["partitions", "meta"]),
+  optionalEnvelopeFields: Object.freeze(["meta"]),
 });
 
 export const getCommandDefinition = (type) => {
@@ -778,17 +778,13 @@ export const validateCommandEnvelope = (command, errors) => {
   if (!assertNonEmptyString(command.id)) errors.push("id is required");
   if (!assertNonEmptyString(command.projectId))
     errors.push("projectId is required");
-  if (!assertNonEmptyString(command.partition))
-    errors.push("partition is required");
-  if (command.partitions !== undefined) {
-    if (!Array.isArray(command.partitions) || command.partitions.length === 0) {
-      errors.push("partitions must be a non-empty array when provided");
-    } else {
-      for (const partition of command.partitions) {
-        if (!assertNonEmptyString(partition)) {
-          errors.push("partitions entries must be non-empty strings");
-          break;
-        }
+  if (!Array.isArray(command.partitions) || command.partitions.length === 0) {
+    errors.push("partitions must be a non-empty array");
+  } else {
+    for (const partition of command.partitions) {
+      if (!assertNonEmptyString(partition)) {
+        errors.push("partitions entries must be non-empty strings");
+        break;
       }
     }
   }

--- a/src/internal/project/state.js
+++ b/src/internal/project/state.js
@@ -74,6 +74,53 @@ const ensureCollectionTree = (collection) => {
   return collection.tree;
 };
 
+const isPlainObject = (value) => {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+};
+
+const mergePlainObjectPatch = (target, patch) => {
+  if (!isPlainObject(patch)) {
+    return structuredClone(patch);
+  }
+
+  const result = isPlainObject(target) ? structuredClone(target) : {};
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (isPlainObject(value) && isPlainObject(result[key])) {
+      result[key] = mergePlainObjectPatch(result[key], value);
+      continue;
+    }
+
+    result[key] = structuredClone(value);
+  }
+
+  return result;
+};
+
+const mergeLayoutElementPatch = (element, patch, elementId) => {
+  const nextElement = mergePlainObjectPatch(element, patch);
+  nextElement.id = nextElement.id || elementId;
+  if (nextElement.parentId === undefined) {
+    nextElement.parentId = element?.parentId ?? null;
+  }
+  if (!Array.isArray(nextElement.children)) {
+    nextElement.children = structuredClone(element?.children || []);
+  }
+  return nextElement;
+};
+
+const replaceLayoutElement = (element, patch, elementId) => {
+  const nextElement = structuredClone(patch || {});
+  nextElement.id = nextElement.id || elementId;
+  if (nextElement.parentId === undefined) {
+    nextElement.parentId = element?.parentId ?? null;
+  }
+  if (!Array.isArray(nextElement.children)) {
+    nextElement.children = structuredClone(element?.children || []);
+  }
+  return nextElement;
+};
+
 const walkHierarchy = (nodes, parentId, visitor) => {
   if (!Array.isArray(nodes)) return;
   for (const node of nodes) {
@@ -726,8 +773,19 @@ const reducers = {
   [COMMAND_TYPES.LAYOUT_ELEMENT_UPDATE]: ({ state, payload, now }) => {
     const layout = state.resources.layouts.items[payload.layoutId];
     const element = layout.elements[payload.elementId];
-    const patch = structuredClone(payload.patch);
-    layout.elements[payload.elementId] = { ...element, ...patch };
+    if (payload.replace === true) {
+      layout.elements[payload.elementId] = replaceLayoutElement(
+        element,
+        payload.patch,
+        payload.elementId,
+      );
+    } else {
+      layout.elements[payload.elementId] = mergeLayoutElementPatch(
+        element,
+        payload.patch,
+        payload.elementId,
+      );
+    }
     layout.updatedAt = now;
   },
 

--- a/src/internal/ui/sceneEditor/lineOperations.js
+++ b/src/internal/ui/sceneEditor/lineOperations.js
@@ -129,16 +129,13 @@ export const writeDialogueContent = async (
     ),
   });
 
-  await projectService.updateLineActions({
+  await projectService.updateLineDialogueAction({
     lineId,
-    patch: {
-      dialogue: {
-        ...existingDialogue,
-        ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
-        content,
-      },
+    dialogue: {
+      ...existingDialogue,
+      ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
+      content,
     },
-    replace: false,
   });
 };
 
@@ -231,15 +228,12 @@ export const handleSplitLineOperation = async (deps, payload) => {
       ? [{ text: leftContent }]
       : [{ text: "" }];
 
-    await projectService.updateLineActions({
+    await projectService.updateLineDialogueAction({
       lineId,
-      patch: {
-        dialogue: {
-          ...existingDialogue,
-          content: leftContentArray,
-        },
+      dialogue: {
+        ...existingDialogue,
+        content: leftContentArray,
       },
-      replace: false,
     });
 
     const rightContentArray = rightContent
@@ -335,15 +329,12 @@ export const handlePasteLinesOperation = async (deps, payload) => {
 
   const firstLineContent = leftContent + lines[0];
   const firstContentArray = [{ text: firstLineContent }];
-  await projectService.updateLineActions({
+  await projectService.updateLineDialogueAction({
     lineId,
-    patch: {
-      dialogue: {
-        ...existingDialogue,
-        content: firstContentArray,
-      },
+    dialogue: {
+      ...existingDialogue,
+      content: firstContentArray,
     },
-    replace: false,
   });
 
   let lastCreatedLineId = lineId;
@@ -374,15 +365,12 @@ export const handlePasteLinesOperation = async (deps, payload) => {
 
   if (lines.length === 1) {
     const combinedContentArray = [{ text: firstLineContent + rightContent }];
-    await projectService.updateLineActions({
+    await projectService.updateLineDialogueAction({
       lineId,
-      patch: {
-        dialogue: {
-          ...existingDialogue,
-          content: combinedContentArray,
-        },
+      dialogue: {
+        ...existingDialogue,
+        content: combinedContentArray,
       },
-      replace: false,
     });
     lastCreatedLineId = lineId;
   }
@@ -591,15 +579,12 @@ export const handleMergeLinesOperation = async (deps, payload) => {
     const prevContentLength = prevContentText.length;
     const existingDialogue = prevLine.actions?.dialogue || {};
 
-    await projectService.updateLineActions({
+    await projectService.updateLineDialogueAction({
       lineId: prevLineId,
-      patch: {
-        dialogue: {
-          ...existingDialogue,
-          content: [{ text: prevContentText + currentContentText }],
-        },
+      dialogue: {
+        ...existingDialogue,
+        content: [{ text: prevContentText + currentContentText }],
       },
-      replace: false,
     });
 
     if (!projectService.getDomainState()?.lines?.[currentLineId]) {

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -36,6 +36,86 @@ const toAlphanumericId = (value, fallback = "sliderUpdate") => {
 
 const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
 
+const isPlainObject = (value) => {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+};
+
+const areValuesEqual = (left, right) => {
+  if (left === right) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => areValuesEqual(value, right[index]))
+    );
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key) =>
+          Object.hasOwn(right, key) && areValuesEqual(left[key], right[key]),
+      )
+    );
+  }
+
+  return false;
+};
+
+const createObjectPatch = (previousValue, nextValue) => {
+  const previousObject = isPlainObject(previousValue) ? previousValue : {};
+  const nextObject = isPlainObject(nextValue) ? nextValue : {};
+  const patch = {};
+  let hasChanges = false;
+  let requiresReplace = false;
+
+  for (const key of Object.keys(previousObject)) {
+    if (!Object.hasOwn(nextObject, key)) {
+      requiresReplace = true;
+      break;
+    }
+  }
+
+  for (const [key, value] of Object.entries(nextObject)) {
+    if (!Object.hasOwn(previousObject, key)) {
+      patch[key] = structuredClone(value);
+      hasChanges = true;
+      continue;
+    }
+
+    const previousEntry = previousObject[key];
+
+    if (areValuesEqual(previousEntry, value)) {
+      continue;
+    }
+
+    if (isPlainObject(previousEntry) && isPlainObject(value)) {
+      const nestedResult = createObjectPatch(previousEntry, value);
+      if (nestedResult.requiresReplace) {
+        requiresReplace = true;
+      } else if (nestedResult.hasChanges) {
+        patch[key] = nestedResult.patch;
+        hasChanges = true;
+      }
+      continue;
+    }
+
+    patch[key] = structuredClone(value);
+    hasChanges = true;
+  }
+
+  return {
+    patch,
+    hasChanges,
+    requiresReplace,
+  };
+};
+
 export const handleBeforeMount = (deps) => {
   const cleanupSubscriptions = mountSubscriptions(deps);
   return () => {
@@ -82,7 +162,6 @@ const scheduleKeyboardSave = (deps, itemId, layoutId) => {
         layoutId,
         selectedItemId: itemId,
         updatedItem: finalItem,
-        replace: true,
       });
     }
 
@@ -467,13 +546,33 @@ export const handleArrowKeyDown = async (deps, payload) => {
 async function handleDebouncedUpdate(deps, payload) {
   const { appService, projectService } = deps;
   const { layoutId, selectedItemId, updatedItem, replace } = payload;
+  const currentItem =
+    projectService.getState()?.layouts?.items?.[layoutId]?.elements?.items?.[
+      selectedItemId
+    ];
+
+  if (!currentItem || !updatedItem) {
+    return;
+  }
+
+  const previousItem = {
+    id: selectedItemId,
+    ...currentItem,
+  };
+  const diff = createObjectPatch(previousItem, updatedItem);
+
+  if (!diff.hasChanges && !diff.requiresReplace) {
+    return;
+  }
+
+  const shouldReplace = replace === true || diff.requiresReplace;
 
   // Save to repository
   await projectService.updateLayoutElement({
     layoutId,
     elementId: selectedItemId,
-    patch: updatedItem,
-    replace: replace === true,
+    patch: shouldReplace ? updatedItem : diff.patch,
+    replace: shouldReplace,
   });
 
   // For form/keyboard updates, sync store with repository
@@ -677,7 +776,6 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
     layoutId,
     selectedItemId,
     updatedItem,
-    replace: true,
   });
   await renderLayoutPreview(deps, { skipAssetLoading: false });
 };
@@ -722,7 +820,6 @@ export const handleCanvasMouseMove = (deps, payload) => {
     layoutId: store.selectLayoutId(),
     selectedItemId: item.id,
     updatedItem,
-    replace: true,
   });
 };
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -248,11 +248,10 @@ export const handleCommandLineSubmit = async (deps, payload) => {
 
   let submissionData = payload._event.detail;
 
-  // If this is a dialogue submission, preserve the existing content
+  // Dialogue updates replace the full dialogue action, so keep content here.
   if (submissionData.dialogue) {
     const line = store.selectSelectedLine();
     if (line && line.actions?.dialogue?.content) {
-      // Preserve existing text while updating dialogue metadata fields.
       submissionData = {
         ...submissionData,
         dialogue: {
@@ -275,11 +274,22 @@ export const handleCommandLineSubmit = async (deps, payload) => {
     return;
   }
 
-  await projectService.updateLineActions({
-    lineId,
-    patch: submissionData,
-    replace: false,
-  });
+  const { dialogue, ...otherActions } = submissionData;
+
+  if (dialogue) {
+    await projectService.updateLineDialogueAction({
+      lineId,
+      dialogue,
+    });
+  }
+
+  if (Object.keys(otherActions).length > 0) {
+    await projectService.updateLineActions({
+      lineId,
+      patch: otherActions,
+      replace: false,
+    });
+  }
 
   syncStoreProjectState(store, projectService);
   render();
@@ -408,12 +418,9 @@ export const handleDialogueCharacterShortcut = async (deps, payload) => {
     updatedDialogue.characterId = characterId;
   }
 
-  await projectService.updateLineActions({
+  await projectService.updateLineDialogueAction({
     lineId,
-    patch: {
-      dialogue: updatedDialogue,
-    },
-    replace: false,
+    dialogue: updatedDialogue,
   });
 
   syncStoreProjectState(store, projectService);
@@ -718,12 +725,9 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
             content: currentActions.dialogue.content,
           };
 
-          await projectService.updateLineActions({
+          await projectService.updateLineDialogueAction({
             lineId: selectedLineId,
-            patch: {
-              dialogue: updatedDialogue,
-            },
-            replace: false,
+            dialogue: updatedDialogue,
           });
         }
       } else {

--- a/tests/puty/01-settings-project-updates.spec.yaml
+++ b/tests/puty/01-settings-project-updates.spec.yaml
@@ -1,0 +1,107 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage settings
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists sequential project metadata updates
+in:
+  - projectId: project-puty-settings-001
+    actor:
+      userId: user-puty-settings
+      clientId: client-puty-settings
+    sessionPartitions:
+      - project:project-puty-settings-001:settings
+    commands:
+      - id: cmd-settings-name
+        partition: project:project-puty-settings-001:settings
+        partitions:
+          - project:project-puty-settings-001:settings
+        type: project.update
+        clientTs: 201
+        payload:
+          patch:
+            name: Midnight Train
+      - id: cmd-settings-description
+        partition: project:project-puty-settings-001:settings
+        partitions:
+          - project:project-puty-settings-001:settings
+        type: project.update
+        clientTs: 202
+        payload:
+          patch:
+            description: A late-night route through memory
+      - id: cmd-settings-icon
+        partition: project:project-puty-settings-001:settings
+        partitions:
+          - project:project-puty-settings-001:settings
+        type: project.update
+        clientTs: 203
+        payload:
+          patch:
+            iconFileId: icon-file-1
+      - id: cmd-settings-tagline
+        partition: project:project-puty-settings-001:settings
+        partitions:
+          - project:project-puty-settings-001:settings
+        type: project.update
+        clientTs: 204
+        payload:
+          patch:
+            tagline: Choose the right platform
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-settings-name
+      projectId: project-puty-settings-001
+      userId: user-puty-settings
+      partitions:
+        - project:project-puty-settings-001:settings
+      type: project.update
+      payload:
+        patch:
+          name: Midnight Train
+      meta:
+        clientId: client-puty-settings
+        clientTs: 201
+    - committedId: 2
+      id: cmd-settings-description
+      projectId: project-puty-settings-001
+      userId: user-puty-settings
+      partitions:
+        - project:project-puty-settings-001:settings
+      type: project.update
+      payload:
+        patch:
+          description: A late-night route through memory
+      meta:
+        clientId: client-puty-settings
+        clientTs: 202
+    - committedId: 3
+      id: cmd-settings-icon
+      projectId: project-puty-settings-001
+      userId: user-puty-settings
+      partitions:
+        - project:project-puty-settings-001:settings
+      type: project.update
+      payload:
+        patch:
+          iconFileId: icon-file-1
+      meta:
+        clientId: client-puty-settings
+        clientTs: 203
+    - committedId: 4
+      id: cmd-settings-tagline
+      projectId: project-puty-settings-001
+      userId: user-puty-settings
+      partitions:
+        - project:project-puty-settings-001:settings
+      type: project.update
+      payload:
+        patch:
+          tagline: Choose the right platform
+      meta:
+        clientId: client-puty-settings
+        clientTs: 204

--- a/tests/puty/01-settings-project-updates.spec.yaml
+++ b/tests/puty/01-settings-project-updates.spec.yaml
@@ -33,24 +33,6 @@ in:
         payload:
           patch:
             description: A late-night route through memory
-      - id: cmd-settings-icon
-        partition: project:project-puty-settings-001:settings
-        partitions:
-          - project:project-puty-settings-001:settings
-        type: project.update
-        clientTs: 203
-        payload:
-          patch:
-            iconFileId: icon-file-1
-      - id: cmd-settings-tagline
-        partition: project:project-puty-settings-001:settings
-        partitions:
-          - project:project-puty-settings-001:settings
-        type: project.update
-        clientTs: 204
-        payload:
-          patch:
-            tagline: Choose the right platform
 out:
   storedEvents:
     - committedId: 1
@@ -79,29 +61,23 @@ out:
       meta:
         clientId: client-puty-settings
         clientTs: 202
-    - committedId: 3
-      id: cmd-settings-icon
-      projectId: project-puty-settings-001
+---
+case: rejects unknown project patch fields like tagline
+in:
+  - projectId: project-puty-settings-002
+    actor:
       userId: user-puty-settings
-      partitions:
-        - project:project-puty-settings-001:settings
-      type: project.update
-      payload:
-        patch:
-          iconFileId: icon-file-1
-      meta:
-        clientId: client-puty-settings
-        clientTs: 203
-    - committedId: 4
-      id: cmd-settings-tagline
-      projectId: project-puty-settings-001
-      userId: user-puty-settings
-      partitions:
-        - project:project-puty-settings-001:settings
-      type: project.update
-      payload:
-        patch:
-          tagline: Choose the right platform
-      meta:
-        clientId: client-puty-settings
+      clientId: client-puty-settings
+    sessionPartitions:
+      - project:project-puty-settings-002:settings
+    commands:
+      - id: cmd-settings-tagline
+        partition: project:project-puty-settings-002:settings
+        partitions:
+          - project:project-puty-settings-002:settings
+        type: project.update
         clientTs: 204
+        payload:
+          patch:
+            tagline: Choose the right platform
+throws: payload.patch.tagline is not allowed

--- a/tests/puty/01-settings-project-updates.spec.yaml
+++ b/tests/puty/01-settings-project-updates.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage settings
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-settings-001:settings
     commands:
       - id: cmd-settings-name
-        partition: project:project-puty-settings-001:settings
         partitions:
           - project:project-puty-settings-001:settings
         type: project.update
@@ -25,7 +25,6 @@ in:
           patch:
             name: Midnight Train
       - id: cmd-settings-description
-        partition: project:project-puty-settings-001:settings
         partitions:
           - project:project-puty-settings-001:settings
         type: project.update
@@ -61,6 +60,43 @@ out:
       meta:
         clientId: client-puty-settings
         clientTs: 202
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-settings-name
+      eventType: project.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-settings-001
+          name: Midnight Train
+          updatedAt: 201
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-settings-description
+      eventType: project.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: A late-night route through memory
+          id: project-puty-settings-001
+          name: Midnight Train
+          updatedAt: 202
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}
 ---
 case: rejects unknown project patch fields like tagline
 in:
@@ -72,7 +108,6 @@ in:
       - project:project-puty-settings-002:settings
     commands:
       - id: cmd-settings-tagline
-        partition: project:project-puty-settings-002:settings
         partitions:
           - project:project-puty-settings-002:settings
         type: project.update

--- a/tests/puty/02-resources-image-library.spec.yaml
+++ b/tests/puty/02-resources-image-library.spec.yaml
@@ -1,0 +1,187 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage resources image library
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists image library create rename move and update commands
+in:
+  - projectId: project-puty-res-images-001
+    actor:
+      userId: user-puty-res-images
+      clientId: client-puty-res-images
+    sessionPartitions:
+      - project:project-puty-res-images-001:resources
+    commands:
+      - id: cmd-image-folder-create
+        partition: project:project-puty-res-images-001:resources:images
+        partitions:
+          - project:project-puty-res-images-001:resources:images
+        type: resource.create
+        clientTs: 301
+        payload:
+          resourceType: images
+          resourceId: img-folder-cgs
+          data:
+            name: CGs
+            type: folder
+      - id: cmd-image-hero-create
+        partition: project:project-puty-res-images-001:resources:images
+        partitions:
+          - project:project-puty-res-images-001:resources:images
+        type: resource.create
+        clientTs: 302
+        payload:
+          resourceType: images
+          resourceId: img-hero-idle
+          parentId: img-folder-cgs
+          data:
+            name: Hero Idle
+            type: image
+            src: hero-idle.png
+      - id: cmd-image-bg-create
+        partition: project:project-puty-res-images-001:resources:images
+        partitions:
+          - project:project-puty-res-images-001:resources:images
+        type: resource.create
+        clientTs: 303
+        payload:
+          resourceType: images
+          resourceId: img-bg-school
+          data:
+            name: School Rooftop
+            type: image
+            src: school-rooftop.png
+      - id: cmd-image-bg-move
+        partition: project:project-puty-res-images-001:resources:images
+        partitions:
+          - project:project-puty-res-images-001:resources:images
+        type: resource.move
+        clientTs: 304
+        payload:
+          resourceType: images
+          resourceId: img-bg-school
+          parentId: img-folder-cgs
+          index: 1
+      - id: cmd-image-hero-rename
+        partition: project:project-puty-res-images-001:resources:images
+        partitions:
+          - project:project-puty-res-images-001:resources:images
+        type: resource.rename
+        clientTs: 305
+        payload:
+          resourceType: images
+          resourceId: img-hero-idle
+          name: Hero Idle Updated
+      - id: cmd-image-hero-update
+        partition: project:project-puty-res-images-001:resources:images
+        partitions:
+          - project:project-puty-res-images-001:resources:images
+        type: resource.update
+        clientTs: 306
+        payload:
+          resourceType: images
+          resourceId: img-hero-idle
+          patch:
+            src: hero-idle-v2.png
+            thumbnailSrc: hero-idle-thumb.png
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-image-folder-create
+      projectId: project-puty-res-images-001
+      userId: user-puty-res-images
+      partitions:
+        - project:project-puty-res-images-001:resources:images
+      type: resource.create
+      payload:
+        resourceType: images
+        resourceId: img-folder-cgs
+        data:
+          name: CGs
+          type: folder
+      meta:
+        clientId: client-puty-res-images
+        clientTs: 301
+    - committedId: 2
+      id: cmd-image-hero-create
+      projectId: project-puty-res-images-001
+      userId: user-puty-res-images
+      partitions:
+        - project:project-puty-res-images-001:resources:images
+      type: resource.create
+      payload:
+        resourceType: images
+        resourceId: img-hero-idle
+        parentId: img-folder-cgs
+        data:
+          name: Hero Idle
+          type: image
+          src: hero-idle.png
+      meta:
+        clientId: client-puty-res-images
+        clientTs: 302
+    - committedId: 3
+      id: cmd-image-bg-create
+      projectId: project-puty-res-images-001
+      userId: user-puty-res-images
+      partitions:
+        - project:project-puty-res-images-001:resources:images
+      type: resource.create
+      payload:
+        resourceType: images
+        resourceId: img-bg-school
+        data:
+          name: School Rooftop
+          type: image
+          src: school-rooftop.png
+      meta:
+        clientId: client-puty-res-images
+        clientTs: 303
+    - committedId: 4
+      id: cmd-image-bg-move
+      projectId: project-puty-res-images-001
+      userId: user-puty-res-images
+      partitions:
+        - project:project-puty-res-images-001:resources:images
+      type: resource.move
+      payload:
+        resourceType: images
+        resourceId: img-bg-school
+        parentId: img-folder-cgs
+        index: 1
+      meta:
+        clientId: client-puty-res-images
+        clientTs: 304
+    - committedId: 5
+      id: cmd-image-hero-rename
+      projectId: project-puty-res-images-001
+      userId: user-puty-res-images
+      partitions:
+        - project:project-puty-res-images-001:resources:images
+      type: resource.rename
+      payload:
+        resourceType: images
+        resourceId: img-hero-idle
+        name: Hero Idle Updated
+      meta:
+        clientId: client-puty-res-images
+        clientTs: 305
+    - committedId: 6
+      id: cmd-image-hero-update
+      projectId: project-puty-res-images-001
+      userId: user-puty-res-images
+      partitions:
+        - project:project-puty-res-images-001:resources:images
+      type: resource.update
+      payload:
+        resourceType: images
+        resourceId: img-hero-idle
+        patch:
+          src: hero-idle-v2.png
+          thumbnailSrc: hero-idle-thumb.png
+      meta:
+        clientId: client-puty-res-images
+        clientTs: 306

--- a/tests/puty/02-resources-image-library.spec.yaml
+++ b/tests/puty/02-resources-image-library.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage resources image library
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-res-images-001:resources
     commands:
       - id: cmd-image-folder-create
-        partition: project:project-puty-res-images-001:resources:images
         partitions:
           - project:project-puty-res-images-001:resources:images
         type: resource.create
@@ -28,7 +28,6 @@ in:
             name: CGs
             type: folder
       - id: cmd-image-hero-create
-        partition: project:project-puty-res-images-001:resources:images
         partitions:
           - project:project-puty-res-images-001:resources:images
         type: resource.create
@@ -42,7 +41,6 @@ in:
             type: image
             src: hero-idle.png
       - id: cmd-image-bg-create
-        partition: project:project-puty-res-images-001:resources:images
         partitions:
           - project:project-puty-res-images-001:resources:images
         type: resource.create
@@ -55,7 +53,6 @@ in:
             type: image
             src: school-rooftop.png
       - id: cmd-image-bg-move
-        partition: project:project-puty-res-images-001:resources:images
         partitions:
           - project:project-puty-res-images-001:resources:images
         type: resource.move
@@ -66,7 +63,6 @@ in:
           parentId: img-folder-cgs
           index: 1
       - id: cmd-image-hero-rename
-        partition: project:project-puty-res-images-001:resources:images
         partitions:
           - project:project-puty-res-images-001:resources:images
         type: resource.rename
@@ -76,7 +72,6 @@ in:
           resourceId: img-hero-idle
           name: Hero Idle Updated
       - id: cmd-image-hero-update
-        partition: project:project-puty-res-images-001:resources:images
         partitions:
           - project:project-puty-res-images-001:resources:images
         type: resource.update
@@ -185,3 +180,265 @@ out:
       meta:
         clientId: client-puty-res-images
         clientTs: 306
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-image-folder-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-images-001
+          name: ''
+          updatedAt: 301
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              img-folder-cgs:
+                createdAt: 301
+                id: img-folder-cgs
+                name: CGs
+                parentId: null
+                type: folder
+                updatedAt: 301
+            tree:
+              - id: img-folder-cgs
+    - committedId: 2
+      eventId: cmd-image-hero-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-images-001
+          name: ''
+          updatedAt: 302
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              img-folder-cgs:
+                createdAt: 301
+                id: img-folder-cgs
+                name: CGs
+                parentId: null
+                type: folder
+                updatedAt: 301
+              img-hero-idle:
+                createdAt: 302
+                id: img-hero-idle
+                name: Hero Idle
+                parentId: img-folder-cgs
+                src: hero-idle.png
+                type: image
+                updatedAt: 302
+            tree:
+              - id: img-folder-cgs
+                children:
+                  - id: img-hero-idle
+    - committedId: 3
+      eventId: cmd-image-bg-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-images-001
+          name: ''
+          updatedAt: 303
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              img-bg-school:
+                createdAt: 303
+                id: img-bg-school
+                name: School Rooftop
+                parentId: null
+                src: school-rooftop.png
+                type: image
+                updatedAt: 303
+              img-folder-cgs:
+                createdAt: 301
+                id: img-folder-cgs
+                name: CGs
+                parentId: null
+                type: folder
+                updatedAt: 301
+              img-hero-idle:
+                createdAt: 302
+                id: img-hero-idle
+                name: Hero Idle
+                parentId: img-folder-cgs
+                src: hero-idle.png
+                type: image
+                updatedAt: 302
+            tree:
+              - id: img-folder-cgs
+                children:
+                  - id: img-hero-idle
+              - id: img-bg-school
+    - committedId: 4
+      eventId: cmd-image-bg-move
+      eventType: resource.move
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-images-001
+          name: ''
+          updatedAt: 304
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              img-bg-school:
+                createdAt: 303
+                id: img-bg-school
+                name: School Rooftop
+                parentId: img-folder-cgs
+                src: school-rooftop.png
+                type: image
+                updatedAt: 304
+              img-folder-cgs:
+                createdAt: 301
+                id: img-folder-cgs
+                name: CGs
+                parentId: null
+                type: folder
+                updatedAt: 301
+              img-hero-idle:
+                createdAt: 302
+                id: img-hero-idle
+                name: Hero Idle
+                parentId: img-folder-cgs
+                src: hero-idle.png
+                type: image
+                updatedAt: 302
+            tree:
+              - id: img-folder-cgs
+                children:
+                  - id: img-hero-idle
+                  - id: img-bg-school
+    - committedId: 5
+      eventId: cmd-image-hero-rename
+      eventType: resource.rename
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-images-001
+          name: ''
+          updatedAt: 305
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              img-bg-school:
+                createdAt: 303
+                id: img-bg-school
+                name: School Rooftop
+                parentId: img-folder-cgs
+                src: school-rooftop.png
+                type: image
+                updatedAt: 304
+              img-folder-cgs:
+                createdAt: 301
+                id: img-folder-cgs
+                name: CGs
+                parentId: null
+                type: folder
+                updatedAt: 301
+              img-hero-idle:
+                createdAt: 302
+                id: img-hero-idle
+                name: Hero Idle Updated
+                parentId: img-folder-cgs
+                src: hero-idle.png
+                type: image
+                updatedAt: 305
+            tree:
+              - id: img-folder-cgs
+                children:
+                  - id: img-hero-idle
+                  - id: img-bg-school
+    - committedId: 6
+      eventId: cmd-image-hero-update
+      eventType: resource.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-images-001
+          name: ''
+          updatedAt: 306
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              img-bg-school:
+                createdAt: 303
+                id: img-bg-school
+                name: School Rooftop
+                parentId: img-folder-cgs
+                src: school-rooftop.png
+                type: image
+                updatedAt: 304
+              img-folder-cgs:
+                createdAt: 301
+                id: img-folder-cgs
+                name: CGs
+                parentId: null
+                type: folder
+                updatedAt: 301
+              img-hero-idle:
+                createdAt: 302
+                id: img-hero-idle
+                name: Hero Idle Updated
+                parentId: img-folder-cgs
+                src: hero-idle-v2.png
+                thumbnailSrc: hero-idle-thumb.png
+                type: image
+                updatedAt: 306
+            tree:
+              - id: img-folder-cgs
+                children:
+                  - id: img-hero-idle
+                  - id: img-bg-school

--- a/tests/puty/03-resources-duplicate-delete.spec.yaml
+++ b/tests/puty/03-resources-duplicate-delete.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage resources duplicate delete
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-res-characters-001:resources
     commands:
       - id: cmd-character-folder-create
-        partition: project:project-puty-res-characters-001:resources:characters
         partitions:
           - project:project-puty-res-characters-001:resources:characters
         type: resource.create
@@ -28,7 +28,6 @@ in:
             name: Main Cast
             type: folder
       - id: cmd-character-create
-        partition: project:project-puty-res-characters-001:resources:characters
         partitions:
           - project:project-puty-res-characters-001:resources:characters
         type: resource.create
@@ -43,7 +42,6 @@ in:
             portraits:
               - idle
       - id: cmd-character-duplicate
-        partition: project:project-puty-res-characters-001:resources:characters
         partitions:
           - project:project-puty-res-characters-001:resources:characters
         type: resource.duplicate
@@ -55,7 +53,6 @@ in:
           name: Hero Copy
           index: 1
       - id: cmd-character-folder-delete
-        partition: project:project-puty-res-characters-001:resources:characters
         partitions:
           - project:project-puty-res-characters-001:resources:characters
         type: resource.delete
@@ -129,3 +126,141 @@ out:
       meta:
         clientId: client-puty-res-characters
         clientTs: 404
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-character-folder-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-characters-001
+          name: ''
+          updatedAt: 401
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          characters:
+            items:
+              char-folder-main:
+                createdAt: 401
+                id: char-folder-main
+                name: Main Cast
+                parentId: null
+                type: folder
+                updatedAt: 401
+            tree:
+              - id: char-folder-main
+    - committedId: 2
+      eventId: cmd-character-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-characters-001
+          name: ''
+          updatedAt: 402
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          characters:
+            items:
+              char-folder-main:
+                createdAt: 401
+                id: char-folder-main
+                name: Main Cast
+                parentId: null
+                type: folder
+                updatedAt: 401
+              char-hero:
+                createdAt: 402
+                id: char-hero
+                name: Hero
+                parentId: char-folder-main
+                portraits:
+                  - idle
+                type: character
+                updatedAt: 402
+            tree:
+              - id: char-folder-main
+                children:
+                  - id: char-hero
+    - committedId: 3
+      eventId: cmd-character-duplicate
+      eventType: resource.duplicate
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-characters-001
+          name: ''
+          updatedAt: 403
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          characters:
+            items:
+              char-folder-main:
+                createdAt: 401
+                id: char-folder-main
+                name: Main Cast
+                parentId: null
+                type: folder
+                updatedAt: 401
+              char-hero:
+                createdAt: 402
+                id: char-hero
+                name: Hero
+                parentId: char-folder-main
+                portraits:
+                  - idle
+                type: character
+                updatedAt: 402
+              char-hero-copy:
+                createdAt: 403
+                id: char-hero-copy
+                name: Hero Copy
+                parentId: char-folder-main
+                portraits:
+                  - idle
+                type: character
+                updatedAt: 403
+            tree:
+              - id: char-folder-main
+                children:
+                  - id: char-hero
+                  - id: char-hero-copy
+    - committedId: 4
+      eventId: cmd-character-folder-delete
+      eventType: resource.delete
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-res-characters-001
+          name: ''
+          updatedAt: 404
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}

--- a/tests/puty/03-resources-duplicate-delete.spec.yaml
+++ b/tests/puty/03-resources-duplicate-delete.spec.yaml
@@ -1,0 +1,131 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage resources duplicate delete
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists duplicate and delete operations in character resources
+in:
+  - projectId: project-puty-res-characters-001
+    actor:
+      userId: user-puty-res-characters
+      clientId: client-puty-res-characters
+    sessionPartitions:
+      - project:project-puty-res-characters-001:resources
+    commands:
+      - id: cmd-character-folder-create
+        partition: project:project-puty-res-characters-001:resources:characters
+        partitions:
+          - project:project-puty-res-characters-001:resources:characters
+        type: resource.create
+        clientTs: 401
+        payload:
+          resourceType: characters
+          resourceId: char-folder-main
+          data:
+            name: Main Cast
+            type: folder
+      - id: cmd-character-create
+        partition: project:project-puty-res-characters-001:resources:characters
+        partitions:
+          - project:project-puty-res-characters-001:resources:characters
+        type: resource.create
+        clientTs: 402
+        payload:
+          resourceType: characters
+          resourceId: char-hero
+          parentId: char-folder-main
+          data:
+            name: Hero
+            type: character
+            portraits:
+              - idle
+      - id: cmd-character-duplicate
+        partition: project:project-puty-res-characters-001:resources:characters
+        partitions:
+          - project:project-puty-res-characters-001:resources:characters
+        type: resource.duplicate
+        clientTs: 403
+        payload:
+          resourceType: characters
+          sourceId: char-hero
+          newId: char-hero-copy
+          name: Hero Copy
+          index: 1
+      - id: cmd-character-folder-delete
+        partition: project:project-puty-res-characters-001:resources:characters
+        partitions:
+          - project:project-puty-res-characters-001:resources:characters
+        type: resource.delete
+        clientTs: 404
+        payload:
+          resourceType: characters
+          resourceId: char-folder-main
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-character-folder-create
+      projectId: project-puty-res-characters-001
+      userId: user-puty-res-characters
+      partitions:
+        - project:project-puty-res-characters-001:resources:characters
+      type: resource.create
+      payload:
+        resourceType: characters
+        resourceId: char-folder-main
+        data:
+          name: Main Cast
+          type: folder
+      meta:
+        clientId: client-puty-res-characters
+        clientTs: 401
+    - committedId: 2
+      id: cmd-character-create
+      projectId: project-puty-res-characters-001
+      userId: user-puty-res-characters
+      partitions:
+        - project:project-puty-res-characters-001:resources:characters
+      type: resource.create
+      payload:
+        resourceType: characters
+        resourceId: char-hero
+        parentId: char-folder-main
+        data:
+          name: Hero
+          type: character
+          portraits:
+            - idle
+      meta:
+        clientId: client-puty-res-characters
+        clientTs: 402
+    - committedId: 3
+      id: cmd-character-duplicate
+      projectId: project-puty-res-characters-001
+      userId: user-puty-res-characters
+      partitions:
+        - project:project-puty-res-characters-001:resources:characters
+      type: resource.duplicate
+      payload:
+        resourceType: characters
+        sourceId: char-hero
+        newId: char-hero-copy
+        name: Hero Copy
+        index: 1
+      meta:
+        clientId: client-puty-res-characters
+        clientTs: 403
+    - committedId: 4
+      id: cmd-character-folder-delete
+      projectId: project-puty-res-characters-001
+      userId: user-puty-res-characters
+      partitions:
+        - project:project-puty-res-characters-001:resources:characters
+      type: resource.delete
+      payload:
+        resourceType: characters
+        resourceId: char-folder-main
+      meta:
+        clientId: client-puty-res-characters
+        clientTs: 404

--- a/tests/puty/04-scene-editor-scene-tree.spec.yaml
+++ b/tests/puty/04-scene-editor-scene-tree.spec.yaml
@@ -1,0 +1,197 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage scene editor scene tree
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists scene tree creation rename move update and initial-scene changes
+in:
+  - projectId: project-puty-scene-tree-001
+    actor:
+      userId: user-puty-scene-tree
+      clientId: client-puty-scene-tree
+    sessionPartitions:
+      - project:project-puty-scene-tree-001:story
+    commands:
+      - id: cmd-scene-folder-create
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:folder-prologue
+        type: scene.create
+        clientTs: 501
+        payload:
+          sceneId: folder-prologue
+          name: Prologue
+          data:
+            type: folder
+      - id: cmd-scene-intro-create
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:scene-intro
+        type: scene.create
+        clientTs: 502
+        payload:
+          sceneId: scene-intro
+          name: Train Station
+          parentId: folder-prologue
+      - id: cmd-scene-wakeup-create
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:scene-wakeup
+        type: scene.create
+        clientTs: 503
+        payload:
+          sceneId: scene-wakeup
+          name: Morning Room
+          parentId: folder-prologue
+      - id: cmd-scene-intro-update
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:scene-intro
+        type: scene.update
+        clientTs: 504
+        payload:
+          sceneId: scene-intro
+          patch:
+            notes: Opening sequence
+            cameraPreset: wide
+      - id: cmd-scene-wakeup-rename
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:scene-wakeup
+        type: scene.rename
+        clientTs: 505
+        payload:
+          sceneId: scene-wakeup
+          name: Wake Up
+      - id: cmd-scene-wakeup-move
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:scene-wakeup
+        type: scene.move
+        clientTs: 506
+        payload:
+          sceneId: scene-wakeup
+          index: 0
+      - id: cmd-scene-set-initial
+        partition: project:project-puty-scene-tree-001:story
+        partitions:
+          - project:project-puty-scene-tree-001:story
+          - project:project-puty-scene-tree-001:story:scene:scene-intro
+        type: scene.set_initial
+        clientTs: 507
+        payload:
+          sceneId: scene-intro
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-scene-folder-create
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:folder-prologue
+      type: scene.create
+      payload:
+        sceneId: folder-prologue
+        name: Prologue
+        data:
+          type: folder
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 501
+    - committedId: 2
+      id: cmd-scene-intro-create
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:scene-intro
+      type: scene.create
+      payload:
+        sceneId: scene-intro
+        name: Train Station
+        parentId: folder-prologue
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 502
+    - committedId: 3
+      id: cmd-scene-wakeup-create
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:scene-wakeup
+      type: scene.create
+      payload:
+        sceneId: scene-wakeup
+        name: Morning Room
+        parentId: folder-prologue
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 503
+    - committedId: 4
+      id: cmd-scene-intro-update
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:scene-intro
+      type: scene.update
+      payload:
+        sceneId: scene-intro
+        patch:
+          notes: Opening sequence
+          cameraPreset: wide
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 504
+    - committedId: 5
+      id: cmd-scene-wakeup-rename
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:scene-wakeup
+      type: scene.rename
+      payload:
+        sceneId: scene-wakeup
+        name: Wake Up
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 505
+    - committedId: 6
+      id: cmd-scene-wakeup-move
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:scene-wakeup
+      type: scene.move
+      payload:
+        sceneId: scene-wakeup
+        index: 0
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 506
+    - committedId: 7
+      id: cmd-scene-set-initial
+      projectId: project-puty-scene-tree-001
+      userId: user-puty-scene-tree
+      partitions:
+        - project:project-puty-scene-tree-001:story
+        - project:project-puty-scene-tree-001:story:scene:scene-intro
+      type: scene.set_initial
+      payload:
+        sceneId: scene-intro
+      meta:
+        clientId: client-puty-scene-tree
+        clientTs: 507

--- a/tests/puty/04-scene-editor-scene-tree.spec.yaml
+++ b/tests/puty/04-scene-editor-scene-tree.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage scene editor scene tree
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-scene-tree-001:story
     commands:
       - id: cmd-scene-folder-create
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:folder-prologue
@@ -28,7 +28,6 @@ in:
           data:
             type: folder
       - id: cmd-scene-intro-create
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:scene-intro
@@ -39,7 +38,6 @@ in:
           name: Train Station
           parentId: folder-prologue
       - id: cmd-scene-wakeup-create
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:scene-wakeup
@@ -50,7 +48,6 @@ in:
           name: Morning Room
           parentId: folder-prologue
       - id: cmd-scene-intro-update
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:scene-intro
@@ -62,7 +59,6 @@ in:
             notes: Opening sequence
             cameraPreset: wide
       - id: cmd-scene-wakeup-rename
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:scene-wakeup
@@ -72,7 +68,6 @@ in:
           sceneId: scene-wakeup
           name: Wake Up
       - id: cmd-scene-wakeup-move
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:scene-wakeup
@@ -82,7 +77,6 @@ in:
           sceneId: scene-wakeup
           index: 0
       - id: cmd-scene-set-initial
-        partition: project:project-puty-scene-tree-001:story
         partitions:
           - project:project-puty-scene-tree-001:story
           - project:project-puty-scene-tree-001:story:scene:scene-intro
@@ -195,3 +189,364 @@ out:
       meta:
         clientId: client-puty-scene-tree
         clientTs: 507
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-scene-folder-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 501
+        story:
+          initialSceneId: null
+          sceneOrder:
+            - folder-prologue
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-scene-intro-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 502
+        story:
+          initialSceneId: scene-intro
+          sceneOrder:
+            - folder-prologue
+            - scene-intro
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+          scene-intro:
+            createdAt: 502
+            id: scene-intro
+            initialSectionId: null
+            name: Train Station
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 502
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 3
+      eventId: cmd-scene-wakeup-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 503
+        story:
+          initialSceneId: scene-intro
+          sceneOrder:
+            - folder-prologue
+            - scene-intro
+            - scene-wakeup
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+          scene-intro:
+            createdAt: 502
+            id: scene-intro
+            initialSectionId: null
+            name: Train Station
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 502
+          scene-wakeup:
+            createdAt: 503
+            id: scene-wakeup
+            initialSectionId: null
+            name: Morning Room
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 503
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 4
+      eventId: cmd-scene-intro-update
+      eventType: scene.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 504
+        story:
+          initialSceneId: scene-intro
+          sceneOrder:
+            - folder-prologue
+            - scene-intro
+            - scene-wakeup
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+          scene-intro:
+            createdAt: 502
+            id: scene-intro
+            initialSectionId: null
+            name: Train Station
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 504
+          scene-wakeup:
+            createdAt: 503
+            id: scene-wakeup
+            initialSectionId: null
+            name: Morning Room
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 503
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 5
+      eventId: cmd-scene-wakeup-rename
+      eventType: scene.rename
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 505
+        story:
+          initialSceneId: scene-intro
+          sceneOrder:
+            - folder-prologue
+            - scene-intro
+            - scene-wakeup
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+          scene-intro:
+            createdAt: 502
+            id: scene-intro
+            initialSectionId: null
+            name: Train Station
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 504
+          scene-wakeup:
+            createdAt: 503
+            id: scene-wakeup
+            initialSectionId: null
+            name: Wake Up
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 505
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 6
+      eventId: cmd-scene-wakeup-move
+      eventType: scene.move
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 506
+        story:
+          initialSceneId: scene-intro
+          sceneOrder:
+            - folder-prologue
+            - scene-intro
+            - scene-wakeup
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+          scene-intro:
+            createdAt: 502
+            id: scene-intro
+            initialSectionId: null
+            name: Train Station
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 504
+          scene-wakeup:
+            createdAt: 503
+            id: scene-wakeup
+            initialSectionId: null
+            name: Wake Up
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 505
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 7
+      eventId: cmd-scene-set-initial
+      eventType: scene.set_initial
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-tree-001
+          name: ''
+          updatedAt: 507
+        story:
+          initialSceneId: scene-intro
+          sceneOrder:
+            - folder-prologue
+            - scene-intro
+            - scene-wakeup
+        scenes:
+          folder-prologue:
+            createdAt: 501
+            id: folder-prologue
+            initialSectionId: null
+            name: Prologue
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: folder
+            updatedAt: 501
+          scene-intro:
+            createdAt: 502
+            id: scene-intro
+            initialSectionId: null
+            name: Train Station
+            parentId: folder-prologue
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 504
+          scene-wakeup:
+            createdAt: 503
+            id: scene-wakeup
+            initialSectionId: null
+            name: Wake Up
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 505
+        sections: {}
+        lines: {}
+        resources: {}

--- a/tests/puty/05-scene-editor-scene-delete-cascade.spec.yaml
+++ b/tests/puty/05-scene-editor-scene-delete-cascade.spec.yaml
@@ -1,0 +1,189 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage scene editor scene delete
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists scene delete after nested sections and lines were created
+in:
+  - projectId: project-puty-scene-delete-001
+    actor:
+      userId: user-puty-scene-delete
+      clientId: client-puty-scene-delete
+    sessionPartitions:
+      - project:project-puty-scene-delete-001:story
+    commands:
+      - id: cmd-scene-delete-target-create
+        partition: project:project-puty-scene-delete-001:story
+        partitions:
+          - project:project-puty-scene-delete-001:story
+          - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+        type: scene.create
+        clientTs: 601
+        payload:
+          sceneId: scene-delete-target
+          name: Disposable Scene
+      - id: cmd-scene-delete-section-a
+        partition: project:project-puty-scene-delete-001:story
+        partitions:
+          - project:project-puty-scene-delete-001:story
+          - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+        type: section.create
+        clientTs: 602
+        payload:
+          sceneId: scene-delete-target
+          sectionId: section-a
+          name: Start
+      - id: cmd-scene-delete-line-a
+        partition: project:project-puty-scene-delete-001:story
+        partitions:
+          - project:project-puty-scene-delete-001:story
+          - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+        type: line.insert_after
+        clientTs: 603
+        payload:
+          sectionId: section-a
+          lineId: line-a
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: This scene will be removed
+                mode: adv
+      - id: cmd-scene-delete-section-b
+        partition: project:project-puty-scene-delete-001:story
+        partitions:
+          - project:project-puty-scene-delete-001:story
+          - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+        type: section.create
+        clientTs: 604
+        payload:
+          sceneId: scene-delete-target
+          sectionId: section-b
+          name: Branch
+      - id: cmd-scene-delete-line-b
+        partition: project:project-puty-scene-delete-001:story
+        partitions:
+          - project:project-puty-scene-delete-001:story
+          - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+        type: line.insert_after
+        clientTs: 605
+        payload:
+          sectionId: section-b
+          lineId: line-b
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: Alternate path
+                mode: adv
+      - id: cmd-scene-delete-target
+        partition: project:project-puty-scene-delete-001:story
+        partitions:
+          - project:project-puty-scene-delete-001:story
+          - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+        type: scene.delete
+        clientTs: 606
+        payload:
+          sceneId: scene-delete-target
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-scene-delete-target-create
+      projectId: project-puty-scene-delete-001
+      userId: user-puty-scene-delete
+      partitions:
+        - project:project-puty-scene-delete-001:story
+        - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+      type: scene.create
+      payload:
+        sceneId: scene-delete-target
+        name: Disposable Scene
+      meta:
+        clientId: client-puty-scene-delete
+        clientTs: 601
+    - committedId: 2
+      id: cmd-scene-delete-section-a
+      projectId: project-puty-scene-delete-001
+      userId: user-puty-scene-delete
+      partitions:
+        - project:project-puty-scene-delete-001:story
+        - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+      type: section.create
+      payload:
+        sceneId: scene-delete-target
+        sectionId: section-a
+        name: Start
+      meta:
+        clientId: client-puty-scene-delete
+        clientTs: 602
+    - committedId: 3
+      id: cmd-scene-delete-line-a
+      projectId: project-puty-scene-delete-001
+      userId: user-puty-scene-delete
+      partitions:
+        - project:project-puty-scene-delete-001:story
+        - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+      type: line.insert_after
+      payload:
+        sectionId: section-a
+        lineId: line-a
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: This scene will be removed
+              mode: adv
+      meta:
+        clientId: client-puty-scene-delete
+        clientTs: 603
+    - committedId: 4
+      id: cmd-scene-delete-section-b
+      projectId: project-puty-scene-delete-001
+      userId: user-puty-scene-delete
+      partitions:
+        - project:project-puty-scene-delete-001:story
+        - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+      type: section.create
+      payload:
+        sceneId: scene-delete-target
+        sectionId: section-b
+        name: Branch
+      meta:
+        clientId: client-puty-scene-delete
+        clientTs: 604
+    - committedId: 5
+      id: cmd-scene-delete-line-b
+      projectId: project-puty-scene-delete-001
+      userId: user-puty-scene-delete
+      partitions:
+        - project:project-puty-scene-delete-001:story
+        - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+      type: line.insert_after
+      payload:
+        sectionId: section-b
+        lineId: line-b
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: Alternate path
+              mode: adv
+      meta:
+        clientId: client-puty-scene-delete
+        clientTs: 605
+    - committedId: 6
+      id: cmd-scene-delete-target
+      projectId: project-puty-scene-delete-001
+      userId: user-puty-scene-delete
+      partitions:
+        - project:project-puty-scene-delete-001:story
+        - project:project-puty-scene-delete-001:story:scene:scene-delete-target
+      type: scene.delete
+      payload:
+        sceneId: scene-delete-target
+      meta:
+        clientId: client-puty-scene-delete
+        clientTs: 606

--- a/tests/puty/05-scene-editor-scene-delete-cascade.spec.yaml
+++ b/tests/puty/05-scene-editor-scene-delete-cascade.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage scene editor scene delete
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-scene-delete-001:story
     commands:
       - id: cmd-scene-delete-target-create
-        partition: project:project-puty-scene-delete-001:story
         partitions:
           - project:project-puty-scene-delete-001:story
           - project:project-puty-scene-delete-001:story:scene:scene-delete-target
@@ -26,7 +26,6 @@ in:
           sceneId: scene-delete-target
           name: Disposable Scene
       - id: cmd-scene-delete-section-a
-        partition: project:project-puty-scene-delete-001:story
         partitions:
           - project:project-puty-scene-delete-001:story
           - project:project-puty-scene-delete-001:story:scene:scene-delete-target
@@ -37,7 +36,6 @@ in:
           sectionId: section-a
           name: Start
       - id: cmd-scene-delete-line-a
-        partition: project:project-puty-scene-delete-001:story
         partitions:
           - project:project-puty-scene-delete-001:story
           - project:project-puty-scene-delete-001:story:scene:scene-delete-target
@@ -53,7 +51,6 @@ in:
                   - text: This scene will be removed
                 mode: adv
       - id: cmd-scene-delete-section-b
-        partition: project:project-puty-scene-delete-001:story
         partitions:
           - project:project-puty-scene-delete-001:story
           - project:project-puty-scene-delete-001:story:scene:scene-delete-target
@@ -64,7 +61,6 @@ in:
           sectionId: section-b
           name: Branch
       - id: cmd-scene-delete-line-b
-        partition: project:project-puty-scene-delete-001:story
         partitions:
           - project:project-puty-scene-delete-001:story
           - project:project-puty-scene-delete-001:story:scene:scene-delete-target
@@ -80,7 +76,6 @@ in:
                   - text: Alternate path
                 mode: adv
       - id: cmd-scene-delete-target
-        partition: project:project-puty-scene-delete-001:story
         partitions:
           - project:project-puty-scene-delete-001:story
           - project:project-puty-scene-delete-001:story:scene:scene-delete-target
@@ -187,3 +182,275 @@ out:
       meta:
         clientId: client-puty-scene-delete
         clientTs: 606
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-scene-delete-target-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-delete-001
+          name: ''
+          updatedAt: 601
+        story:
+          initialSceneId: scene-delete-target
+          sceneOrder:
+            - scene-delete-target
+        scenes:
+          scene-delete-target:
+            createdAt: 601
+            id: scene-delete-target
+            initialSectionId: null
+            name: Disposable Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 601
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-scene-delete-section-a
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-delete-001
+          name: ''
+          updatedAt: 602
+        story:
+          initialSceneId: scene-delete-target
+          sceneOrder:
+            - scene-delete-target
+        scenes:
+          scene-delete-target:
+            createdAt: 601
+            id: scene-delete-target
+            initialSectionId: section-a
+            name: Disposable Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+            type: scene
+            updatedAt: 601
+        sections:
+          section-a:
+            createdAt: 602
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: Start
+            sceneId: scene-delete-target
+            updatedAt: 602
+        lines: {}
+        resources: {}
+    - committedId: 3
+      eventId: cmd-scene-delete-line-a
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-delete-001
+          name: ''
+          updatedAt: 603
+        story:
+          initialSceneId: scene-delete-target
+          sceneOrder:
+            - scene-delete-target
+        scenes:
+          scene-delete-target:
+            createdAt: 601
+            id: scene-delete-target
+            initialSectionId: section-a
+            name: Disposable Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+            type: scene
+            updatedAt: 601
+        sections:
+          section-a:
+            createdAt: 602
+            id: section-a
+            initialLineId: line-a
+            lineIds:
+              - line-a
+            name: Start
+            sceneId: scene-delete-target
+            updatedAt: 602
+        lines:
+          line-a:
+            actions:
+              dialogue:
+                content:
+                  - text: This scene will be removed
+                mode: adv
+            createdAt: 603
+            id: line-a
+            sectionId: section-a
+            updatedAt: 603
+        resources: {}
+    - committedId: 4
+      eventId: cmd-scene-delete-section-b
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-delete-001
+          name: ''
+          updatedAt: 604
+        story:
+          initialSceneId: scene-delete-target
+          sceneOrder:
+            - scene-delete-target
+        scenes:
+          scene-delete-target:
+            createdAt: 601
+            id: scene-delete-target
+            initialSectionId: section-a
+            name: Disposable Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 601
+        sections:
+          section-a:
+            createdAt: 602
+            id: section-a
+            initialLineId: line-a
+            lineIds:
+              - line-a
+            name: Start
+            sceneId: scene-delete-target
+            updatedAt: 602
+          section-b:
+            createdAt: 604
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Branch
+            sceneId: scene-delete-target
+            updatedAt: 604
+        lines:
+          line-a:
+            actions:
+              dialogue:
+                content:
+                  - text: This scene will be removed
+                mode: adv
+            createdAt: 603
+            id: line-a
+            sectionId: section-a
+            updatedAt: 603
+        resources: {}
+    - committedId: 5
+      eventId: cmd-scene-delete-line-b
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-delete-001
+          name: ''
+          updatedAt: 605
+        story:
+          initialSceneId: scene-delete-target
+          sceneOrder:
+            - scene-delete-target
+        scenes:
+          scene-delete-target:
+            createdAt: 601
+            id: scene-delete-target
+            initialSectionId: section-a
+            name: Disposable Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 601
+        sections:
+          section-a:
+            createdAt: 602
+            id: section-a
+            initialLineId: line-a
+            lineIds:
+              - line-a
+            name: Start
+            sceneId: scene-delete-target
+            updatedAt: 602
+          section-b:
+            createdAt: 604
+            id: section-b
+            initialLineId: line-b
+            lineIds:
+              - line-b
+            name: Branch
+            sceneId: scene-delete-target
+            updatedAt: 604
+        lines:
+          line-a:
+            actions:
+              dialogue:
+                content:
+                  - text: This scene will be removed
+                mode: adv
+            createdAt: 603
+            id: line-a
+            sectionId: section-a
+            updatedAt: 603
+          line-b:
+            actions:
+              dialogue:
+                content:
+                  - text: Alternate path
+                mode: adv
+            createdAt: 605
+            id: line-b
+            sectionId: section-b
+            updatedAt: 605
+        resources: {}
+    - committedId: 6
+      eventId: cmd-scene-delete-target
+      eventType: scene.delete
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-scene-delete-001
+          name: ''
+          updatedAt: 606
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}

--- a/tests/puty/06-scene-editor-sections.spec.yaml
+++ b/tests/puty/06-scene-editor-sections.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage scene editor sections
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-sections-001:story
     commands:
       - id: cmd-sections-scene-create
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -26,7 +26,6 @@ in:
           sceneId: scene-main
           name: Main Scene
       - id: cmd-sections-create-a
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -37,7 +36,6 @@ in:
           sectionId: section-a
           name: Arrival
       - id: cmd-sections-create-b
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -48,7 +46,6 @@ in:
           sectionId: section-b
           name: Choice
       - id: cmd-sections-create-c
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -60,7 +57,6 @@ in:
           name: Aftermath
           index: 1
       - id: cmd-sections-rename-b
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -70,7 +66,6 @@ in:
           sectionId: section-b
           name: Decision
       - id: cmd-sections-reorder-c
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -80,7 +75,6 @@ in:
           sectionId: section-c
           index: 0
       - id: cmd-sections-delete-a
-        partition: project:project-puty-sections-001:story
         partitions:
           - project:project-puty-sections-001:story
           - project:project-puty-sections-001:story:scene:scene-main
@@ -191,3 +185,347 @@ out:
       meta:
         clientId: client-puty-sections
         clientTs: 707
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-sections-scene-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 701
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: null
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 701
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-sections-create-a
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 702
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: section-a
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+            type: scene
+            updatedAt: 701
+        sections:
+          section-a:
+            createdAt: 702
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: Arrival
+            sceneId: scene-main
+            updatedAt: 702
+        lines: {}
+        resources: {}
+    - committedId: 3
+      eventId: cmd-sections-create-b
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 703
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: section-a
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 701
+        sections:
+          section-a:
+            createdAt: 702
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: Arrival
+            sceneId: scene-main
+            updatedAt: 702
+          section-b:
+            createdAt: 703
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Choice
+            sceneId: scene-main
+            updatedAt: 703
+        lines: {}
+        resources: {}
+    - committedId: 4
+      eventId: cmd-sections-create-c
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 704
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: section-a
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-c
+              - section-b
+            type: scene
+            updatedAt: 701
+        sections:
+          section-a:
+            createdAt: 702
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: Arrival
+            sceneId: scene-main
+            updatedAt: 702
+          section-b:
+            createdAt: 703
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Choice
+            sceneId: scene-main
+            updatedAt: 703
+          section-c:
+            createdAt: 704
+            id: section-c
+            initialLineId: null
+            lineIds: []
+            name: Aftermath
+            sceneId: scene-main
+            updatedAt: 704
+        lines: {}
+        resources: {}
+    - committedId: 5
+      eventId: cmd-sections-rename-b
+      eventType: section.rename
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 705
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: section-a
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-c
+              - section-b
+            type: scene
+            updatedAt: 701
+        sections:
+          section-a:
+            createdAt: 702
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: Arrival
+            sceneId: scene-main
+            updatedAt: 702
+          section-b:
+            createdAt: 703
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Decision
+            sceneId: scene-main
+            updatedAt: 705
+          section-c:
+            createdAt: 704
+            id: section-c
+            initialLineId: null
+            lineIds: []
+            name: Aftermath
+            sceneId: scene-main
+            updatedAt: 704
+        lines: {}
+        resources: {}
+    - committedId: 6
+      eventId: cmd-sections-reorder-c
+      eventType: section.reorder
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 706
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: section-a
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-c
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 701
+        sections:
+          section-a:
+            createdAt: 702
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: Arrival
+            sceneId: scene-main
+            updatedAt: 702
+          section-b:
+            createdAt: 703
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Decision
+            sceneId: scene-main
+            updatedAt: 705
+          section-c:
+            createdAt: 704
+            id: section-c
+            initialLineId: null
+            lineIds: []
+            name: Aftermath
+            sceneId: scene-main
+            updatedAt: 704
+        lines: {}
+        resources: {}
+    - committedId: 7
+      eventId: cmd-sections-delete-a
+      eventType: section.delete
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-sections-001
+          name: ''
+          updatedAt: 707
+        story:
+          initialSceneId: scene-main
+          sceneOrder:
+            - scene-main
+        scenes:
+          scene-main:
+            createdAt: 701
+            id: scene-main
+            initialSectionId: section-c
+            name: Main Scene
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-c
+              - section-b
+            type: scene
+            updatedAt: 701
+        sections:
+          section-b:
+            createdAt: 703
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Decision
+            sceneId: scene-main
+            updatedAt: 705
+          section-c:
+            createdAt: 704
+            id: section-c
+            initialLineId: null
+            lineIds: []
+            name: Aftermath
+            sceneId: scene-main
+            updatedAt: 704
+        lines: {}
+        resources: {}

--- a/tests/puty/06-scene-editor-sections.spec.yaml
+++ b/tests/puty/06-scene-editor-sections.spec.yaml
@@ -1,0 +1,193 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage scene editor sections
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists section creation rename reorder and delete commands
+in:
+  - projectId: project-puty-sections-001
+    actor:
+      userId: user-puty-sections
+      clientId: client-puty-sections
+    sessionPartitions:
+      - project:project-puty-sections-001:story
+    commands:
+      - id: cmd-sections-scene-create
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: scene.create
+        clientTs: 701
+        payload:
+          sceneId: scene-main
+          name: Main Scene
+      - id: cmd-sections-create-a
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: section.create
+        clientTs: 702
+        payload:
+          sceneId: scene-main
+          sectionId: section-a
+          name: Arrival
+      - id: cmd-sections-create-b
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: section.create
+        clientTs: 703
+        payload:
+          sceneId: scene-main
+          sectionId: section-b
+          name: Choice
+      - id: cmd-sections-create-c
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: section.create
+        clientTs: 704
+        payload:
+          sceneId: scene-main
+          sectionId: section-c
+          name: Aftermath
+          index: 1
+      - id: cmd-sections-rename-b
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: section.rename
+        clientTs: 705
+        payload:
+          sectionId: section-b
+          name: Decision
+      - id: cmd-sections-reorder-c
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: section.reorder
+        clientTs: 706
+        payload:
+          sectionId: section-c
+          index: 0
+      - id: cmd-sections-delete-a
+        partition: project:project-puty-sections-001:story
+        partitions:
+          - project:project-puty-sections-001:story
+          - project:project-puty-sections-001:story:scene:scene-main
+        type: section.delete
+        clientTs: 707
+        payload:
+          sectionId: section-a
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-sections-scene-create
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: scene.create
+      payload:
+        sceneId: scene-main
+        name: Main Scene
+      meta:
+        clientId: client-puty-sections
+        clientTs: 701
+    - committedId: 2
+      id: cmd-sections-create-a
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: section.create
+      payload:
+        sceneId: scene-main
+        sectionId: section-a
+        name: Arrival
+      meta:
+        clientId: client-puty-sections
+        clientTs: 702
+    - committedId: 3
+      id: cmd-sections-create-b
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: section.create
+      payload:
+        sceneId: scene-main
+        sectionId: section-b
+        name: Choice
+      meta:
+        clientId: client-puty-sections
+        clientTs: 703
+    - committedId: 4
+      id: cmd-sections-create-c
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: section.create
+      payload:
+        sceneId: scene-main
+        sectionId: section-c
+        name: Aftermath
+        index: 1
+      meta:
+        clientId: client-puty-sections
+        clientTs: 704
+    - committedId: 5
+      id: cmd-sections-rename-b
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: section.rename
+      payload:
+        sectionId: section-b
+        name: Decision
+      meta:
+        clientId: client-puty-sections
+        clientTs: 705
+    - committedId: 6
+      id: cmd-sections-reorder-c
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: section.reorder
+      payload:
+        sectionId: section-c
+        index: 0
+      meta:
+        clientId: client-puty-sections
+        clientTs: 706
+    - committedId: 7
+      id: cmd-sections-delete-a
+      projectId: project-puty-sections-001
+      userId: user-puty-sections
+      partitions:
+        - project:project-puty-sections-001:story
+        - project:project-puty-sections-001:story:scene:scene-main
+      type: section.delete
+      payload:
+        sectionId: section-a
+      meta:
+        clientId: client-puty-sections
+        clientTs: 707

--- a/tests/puty/07-scene-editor-line-structure.spec.yaml
+++ b/tests/puty/07-scene-editor-line-structure.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage scene editor line structure
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-lines-001:story
     commands:
       - id: cmd-lines-scene-create
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -26,7 +26,6 @@ in:
           sceneId: scene-lines
           name: Line Flow
       - id: cmd-lines-section-a
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -37,7 +36,6 @@ in:
           sectionId: section-a
           name: First
       - id: cmd-lines-section-b
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -48,7 +46,6 @@ in:
           sectionId: section-b
           name: Second
       - id: cmd-lines-insert-1
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -64,7 +61,6 @@ in:
                   - text: First line
                 mode: adv
       - id: cmd-lines-insert-2
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -81,7 +77,6 @@ in:
                   - text: Second line
                 mode: adv
       - id: cmd-lines-insert-3
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -98,7 +93,6 @@ in:
                   - text: Third line
                 mode: adv
       - id: cmd-lines-move-2
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -109,7 +103,6 @@ in:
           toSectionId: section-b
           index: 0
       - id: cmd-lines-delete-1
-        partition: project:project-puty-lines-001:story
         partitions:
           - project:project-puty-lines-001:story
           - project:project-puty-lines-001:story:scene:scene-lines
@@ -253,3 +246,490 @@ out:
       meta:
         clientId: client-puty-lines
         clientTs: 808
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-lines-scene-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 801
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: null
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 801
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-lines-section-a
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 802
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+        lines: {}
+        resources: {}
+    - committedId: 3
+      eventId: cmd-lines-section-b
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 803
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: null
+            lineIds: []
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+          section-b:
+            createdAt: 803
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Second
+            sceneId: scene-lines
+            updatedAt: 803
+        lines: {}
+        resources: {}
+    - committedId: 4
+      eventId: cmd-lines-insert-1
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 804
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: line-1
+            lineIds:
+              - line-1
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+          section-b:
+            createdAt: 803
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Second
+            sceneId: scene-lines
+            updatedAt: 803
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: First line
+                mode: adv
+            createdAt: 804
+            id: line-1
+            sectionId: section-a
+            updatedAt: 804
+        resources: {}
+    - committedId: 5
+      eventId: cmd-lines-insert-2
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 805
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: line-1
+            lineIds:
+              - line-1
+              - line-2
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+          section-b:
+            createdAt: 803
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Second
+            sceneId: scene-lines
+            updatedAt: 803
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: First line
+                mode: adv
+            createdAt: 804
+            id: line-1
+            sectionId: section-a
+            updatedAt: 804
+          line-2:
+            actions:
+              dialogue:
+                content:
+                  - text: Second line
+                mode: adv
+            createdAt: 805
+            id: line-2
+            sectionId: section-a
+            updatedAt: 805
+        resources: {}
+    - committedId: 6
+      eventId: cmd-lines-insert-3
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 806
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: line-1
+            lineIds:
+              - line-1
+              - line-2
+              - line-3
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+          section-b:
+            createdAt: 803
+            id: section-b
+            initialLineId: null
+            lineIds: []
+            name: Second
+            sceneId: scene-lines
+            updatedAt: 803
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: First line
+                mode: adv
+            createdAt: 804
+            id: line-1
+            sectionId: section-a
+            updatedAt: 804
+          line-2:
+            actions:
+              dialogue:
+                content:
+                  - text: Second line
+                mode: adv
+            createdAt: 805
+            id: line-2
+            sectionId: section-a
+            updatedAt: 805
+          line-3:
+            actions:
+              dialogue:
+                content:
+                  - text: Third line
+                mode: adv
+            createdAt: 806
+            id: line-3
+            sectionId: section-a
+            updatedAt: 806
+        resources: {}
+    - committedId: 7
+      eventId: cmd-lines-move-2
+      eventType: line.move
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 807
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: line-1
+            lineIds:
+              - line-1
+              - line-3
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+          section-b:
+            createdAt: 803
+            id: section-b
+            initialLineId: line-2
+            lineIds:
+              - line-2
+            name: Second
+            sceneId: scene-lines
+            updatedAt: 803
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: First line
+                mode: adv
+            createdAt: 804
+            id: line-1
+            sectionId: section-a
+            updatedAt: 804
+          line-2:
+            actions:
+              dialogue:
+                content:
+                  - text: Second line
+                mode: adv
+            createdAt: 805
+            id: line-2
+            sectionId: section-b
+            updatedAt: 805
+          line-3:
+            actions:
+              dialogue:
+                content:
+                  - text: Third line
+                mode: adv
+            createdAt: 806
+            id: line-3
+            sectionId: section-a
+            updatedAt: 806
+        resources: {}
+    - committedId: 8
+      eventId: cmd-lines-delete-1
+      eventType: line.delete
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-lines-001
+          name: ''
+          updatedAt: 808
+        story:
+          initialSceneId: scene-lines
+          sceneOrder:
+            - scene-lines
+        scenes:
+          scene-lines:
+            createdAt: 801
+            id: scene-lines
+            initialSectionId: section-a
+            name: Line Flow
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-a
+              - section-b
+            type: scene
+            updatedAt: 801
+        sections:
+          section-a:
+            createdAt: 802
+            id: section-a
+            initialLineId: line-3
+            lineIds:
+              - line-3
+            name: First
+            sceneId: scene-lines
+            updatedAt: 802
+          section-b:
+            createdAt: 803
+            id: section-b
+            initialLineId: line-2
+            lineIds:
+              - line-2
+            name: Second
+            sceneId: scene-lines
+            updatedAt: 803
+        lines:
+          line-2:
+            actions:
+              dialogue:
+                content:
+                  - text: Second line
+                mode: adv
+            createdAt: 805
+            id: line-2
+            sectionId: section-b
+            updatedAt: 805
+          line-3:
+            actions:
+              dialogue:
+                content:
+                  - text: Third line
+                mode: adv
+            createdAt: 806
+            id: line-3
+            sectionId: section-a
+            updatedAt: 806
+        resources: {}

--- a/tests/puty/07-scene-editor-line-structure.spec.yaml
+++ b/tests/puty/07-scene-editor-line-structure.spec.yaml
@@ -1,0 +1,255 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage scene editor line structure
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists line insertion movement and deletion commands
+in:
+  - projectId: project-puty-lines-001
+    actor:
+      userId: user-puty-lines
+      clientId: client-puty-lines
+    sessionPartitions:
+      - project:project-puty-lines-001:story
+    commands:
+      - id: cmd-lines-scene-create
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: scene.create
+        clientTs: 801
+        payload:
+          sceneId: scene-lines
+          name: Line Flow
+      - id: cmd-lines-section-a
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: section.create
+        clientTs: 802
+        payload:
+          sceneId: scene-lines
+          sectionId: section-a
+          name: First
+      - id: cmd-lines-section-b
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: section.create
+        clientTs: 803
+        payload:
+          sceneId: scene-lines
+          sectionId: section-b
+          name: Second
+      - id: cmd-lines-insert-1
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: line.insert_after
+        clientTs: 804
+        payload:
+          sectionId: section-a
+          lineId: line-1
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: First line
+                mode: adv
+      - id: cmd-lines-insert-2
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: line.insert_after
+        clientTs: 805
+        payload:
+          sectionId: section-a
+          afterLineId: line-1
+          lineId: line-2
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: Second line
+                mode: adv
+      - id: cmd-lines-insert-3
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: line.insert_after
+        clientTs: 806
+        payload:
+          sectionId: section-a
+          afterLineId: line-2
+          lineId: line-3
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: Third line
+                mode: adv
+      - id: cmd-lines-move-2
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: line.move
+        clientTs: 807
+        payload:
+          lineId: line-2
+          toSectionId: section-b
+          index: 0
+      - id: cmd-lines-delete-1
+        partition: project:project-puty-lines-001:story
+        partitions:
+          - project:project-puty-lines-001:story
+          - project:project-puty-lines-001:story:scene:scene-lines
+        type: line.delete
+        clientTs: 808
+        payload:
+          lineId: line-1
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-lines-scene-create
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: scene.create
+      payload:
+        sceneId: scene-lines
+        name: Line Flow
+      meta:
+        clientId: client-puty-lines
+        clientTs: 801
+    - committedId: 2
+      id: cmd-lines-section-a
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: section.create
+      payload:
+        sceneId: scene-lines
+        sectionId: section-a
+        name: First
+      meta:
+        clientId: client-puty-lines
+        clientTs: 802
+    - committedId: 3
+      id: cmd-lines-section-b
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: section.create
+      payload:
+        sceneId: scene-lines
+        sectionId: section-b
+        name: Second
+      meta:
+        clientId: client-puty-lines
+        clientTs: 803
+    - committedId: 4
+      id: cmd-lines-insert-1
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: line.insert_after
+      payload:
+        sectionId: section-a
+        lineId: line-1
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: First line
+              mode: adv
+      meta:
+        clientId: client-puty-lines
+        clientTs: 804
+    - committedId: 5
+      id: cmd-lines-insert-2
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: line.insert_after
+      payload:
+        sectionId: section-a
+        afterLineId: line-1
+        lineId: line-2
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: Second line
+              mode: adv
+      meta:
+        clientId: client-puty-lines
+        clientTs: 805
+    - committedId: 6
+      id: cmd-lines-insert-3
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: line.insert_after
+      payload:
+        sectionId: section-a
+        afterLineId: line-2
+        lineId: line-3
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: Third line
+              mode: adv
+      meta:
+        clientId: client-puty-lines
+        clientTs: 806
+    - committedId: 7
+      id: cmd-lines-move-2
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: line.move
+      payload:
+        lineId: line-2
+        toSectionId: section-b
+        index: 0
+      meta:
+        clientId: client-puty-lines
+        clientTs: 807
+    - committedId: 8
+      id: cmd-lines-delete-1
+      projectId: project-puty-lines-001
+      userId: user-puty-lines
+      partitions:
+        - project:project-puty-lines-001:story
+        - project:project-puty-lines-001:story:scene:scene-lines
+      type: line.delete
+      payload:
+        lineId: line-1
+      meta:
+        clientId: client-puty-lines
+        clientTs: 808

--- a/tests/puty/08-scene-editor-line-actions.spec.yaml
+++ b/tests/puty/08-scene-editor-line-actions.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage scene editor line actions
 suites:
   - runInsiemeStorageScenario
@@ -16,7 +17,6 @@ in:
       - project:project-puty-line-actions-001:story
     commands:
       - id: cmd-line-actions-scene-create
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -26,7 +26,6 @@ in:
           sceneId: scene-actions
           name: Action Editing
       - id: cmd-line-actions-section-create
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -37,7 +36,6 @@ in:
           sectionId: section-main
           name: Main
       - id: cmd-line-actions-line-create
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -53,7 +51,6 @@ in:
                   - text: Original line
                 mode: adv
       - id: cmd-line-actions-dialogue
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -70,7 +67,6 @@ in:
                 resourceId: layout-dialogue
           replace: false
       - id: cmd-line-actions-background
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -86,7 +82,6 @@ in:
                 enter: fade
           replace: false
       - id: cmd-line-actions-character
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -102,7 +97,6 @@ in:
                   position: center
           replace: false
       - id: cmd-line-actions-replace
-        partition: project:project-puty-line-actions-001:story
         partitions:
           - project:project-puty-line-actions-001:story
           - project:project-puty-line-actions-001:story:scene:scene-actions
@@ -247,3 +241,351 @@ out:
       meta:
         clientId: client-puty-line-actions
         clientTs: 907
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-line-actions-scene-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 901
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: null
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 901
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-line-actions-section-create
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 902
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: section-main
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-main
+            type: scene
+            updatedAt: 901
+        sections:
+          section-main:
+            createdAt: 902
+            id: section-main
+            initialLineId: null
+            lineIds: []
+            name: Main
+            sceneId: scene-actions
+            updatedAt: 902
+        lines: {}
+        resources: {}
+    - committedId: 3
+      eventId: cmd-line-actions-line-create
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 903
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: section-main
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-main
+            type: scene
+            updatedAt: 901
+        sections:
+          section-main:
+            createdAt: 902
+            id: section-main
+            initialLineId: line-main
+            lineIds:
+              - line-main
+            name: Main
+            sceneId: scene-actions
+            updatedAt: 902
+        lines:
+          line-main:
+            actions:
+              dialogue:
+                content:
+                  - text: Original line
+                mode: adv
+            createdAt: 903
+            id: line-main
+            sectionId: section-main
+            updatedAt: 903
+        resources: {}
+    - committedId: 4
+      eventId: cmd-line-actions-dialogue
+      eventType: line.update_actions
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 904
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: section-main
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-main
+            type: scene
+            updatedAt: 901
+        sections:
+          section-main:
+            createdAt: 902
+            id: section-main
+            initialLineId: line-main
+            lineIds:
+              - line-main
+            name: Main
+            sceneId: scene-actions
+            updatedAt: 902
+        lines:
+          line-main:
+            actions:
+              dialogue:
+                content:
+                  - text: Updated dialogue
+                mode: nvl
+                ui:
+                  resourceId: layout-dialogue
+            createdAt: 903
+            id: line-main
+            sectionId: section-main
+            updatedAt: 904
+        resources: {}
+    - committedId: 5
+      eventId: cmd-line-actions-background
+      eventType: line.update_actions
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 905
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: section-main
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-main
+            type: scene
+            updatedAt: 901
+        sections:
+          section-main:
+            createdAt: 902
+            id: section-main
+            initialLineId: line-main
+            lineIds:
+              - line-main
+            name: Main
+            sceneId: scene-actions
+            updatedAt: 902
+        lines:
+          line-main:
+            actions:
+              background:
+                animations:
+                  enter: fade
+                mode: cover
+                resourceId: bg-night
+              dialogue:
+                content:
+                  - text: Updated dialogue
+                mode: nvl
+                ui:
+                  resourceId: layout-dialogue
+            createdAt: 903
+            id: line-main
+            sectionId: section-main
+            updatedAt: 905
+        resources: {}
+    - committedId: 6
+      eventId: cmd-line-actions-character
+      eventType: line.update_actions
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 906
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: section-main
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-main
+            type: scene
+            updatedAt: 901
+        sections:
+          section-main:
+            createdAt: 902
+            id: section-main
+            initialLineId: line-main
+            lineIds:
+              - line-main
+            name: Main
+            sceneId: scene-actions
+            updatedAt: 902
+        lines:
+          line-main:
+            actions:
+              background:
+                animations:
+                  enter: fade
+                mode: cover
+                resourceId: bg-night
+              character:
+                entries:
+                  - characterId: hero
+                    poseId: idle
+                    position: center
+              dialogue:
+                content:
+                  - text: Updated dialogue
+                mode: nvl
+                ui:
+                  resourceId: layout-dialogue
+            createdAt: 903
+            id: line-main
+            sectionId: section-main
+            updatedAt: 906
+        resources: {}
+    - committedId: 7
+      eventId: cmd-line-actions-replace
+      eventType: line.update_actions
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-line-actions-001
+          name: ''
+          updatedAt: 907
+        story:
+          initialSceneId: scene-actions
+          sceneOrder:
+            - scene-actions
+        scenes:
+          scene-actions:
+            createdAt: 901
+            id: scene-actions
+            initialSectionId: section-main
+            name: Action Editing
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-main
+            type: scene
+            updatedAt: 901
+        sections:
+          section-main:
+            createdAt: 902
+            id: section-main
+            initialLineId: line-main
+            lineIds:
+              - line-main
+            name: Main
+            sceneId: scene-actions
+            updatedAt: 902
+        lines:
+          line-main:
+            actions:
+              dialogue:
+                content:
+                  - text: Reset to dialogue only
+                mode: adv
+            createdAt: 903
+            id: line-main
+            sectionId: section-main
+            updatedAt: 907
+        resources: {}

--- a/tests/puty/08-scene-editor-line-actions.spec.yaml
+++ b/tests/puty/08-scene-editor-line-actions.spec.yaml
@@ -1,0 +1,249 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage scene editor line actions
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists scene editor action updates including replace mode
+in:
+  - projectId: project-puty-line-actions-001
+    actor:
+      userId: user-puty-line-actions
+      clientId: client-puty-line-actions
+    sessionPartitions:
+      - project:project-puty-line-actions-001:story
+    commands:
+      - id: cmd-line-actions-scene-create
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: scene.create
+        clientTs: 901
+        payload:
+          sceneId: scene-actions
+          name: Action Editing
+      - id: cmd-line-actions-section-create
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: section.create
+        clientTs: 902
+        payload:
+          sceneId: scene-actions
+          sectionId: section-main
+          name: Main
+      - id: cmd-line-actions-line-create
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: line.insert_after
+        clientTs: 903
+        payload:
+          sectionId: section-main
+          lineId: line-main
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: Original line
+                mode: adv
+      - id: cmd-line-actions-dialogue
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: line.update_actions
+        clientTs: 904
+        payload:
+          lineId: line-main
+          patch:
+            dialogue:
+              content:
+                - text: Updated dialogue
+              mode: nvl
+              ui:
+                resourceId: layout-dialogue
+          replace: false
+      - id: cmd-line-actions-background
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: line.update_actions
+        clientTs: 905
+        payload:
+          lineId: line-main
+          patch:
+            background:
+              resourceId: bg-night
+              mode: cover
+              animations:
+                enter: fade
+          replace: false
+      - id: cmd-line-actions-character
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: line.update_actions
+        clientTs: 906
+        payload:
+          lineId: line-main
+          patch:
+            character:
+              entries:
+                - characterId: hero
+                  poseId: idle
+                  position: center
+          replace: false
+      - id: cmd-line-actions-replace
+        partition: project:project-puty-line-actions-001:story
+        partitions:
+          - project:project-puty-line-actions-001:story
+          - project:project-puty-line-actions-001:story:scene:scene-actions
+        type: line.update_actions
+        clientTs: 907
+        payload:
+          lineId: line-main
+          patch:
+            dialogue:
+              content:
+                - text: Reset to dialogue only
+              mode: adv
+          replace: true
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-line-actions-scene-create
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: scene.create
+      payload:
+        sceneId: scene-actions
+        name: Action Editing
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 901
+    - committedId: 2
+      id: cmd-line-actions-section-create
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: section.create
+      payload:
+        sceneId: scene-actions
+        sectionId: section-main
+        name: Main
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 902
+    - committedId: 3
+      id: cmd-line-actions-line-create
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: line.insert_after
+      payload:
+        sectionId: section-main
+        lineId: line-main
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: Original line
+              mode: adv
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 903
+    - committedId: 4
+      id: cmd-line-actions-dialogue
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: line.update_actions
+      payload:
+        lineId: line-main
+        patch:
+          dialogue:
+            content:
+              - text: Updated dialogue
+            mode: nvl
+            ui:
+              resourceId: layout-dialogue
+        replace: false
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 904
+    - committedId: 5
+      id: cmd-line-actions-background
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: line.update_actions
+      payload:
+        lineId: line-main
+        patch:
+          background:
+            resourceId: bg-night
+            mode: cover
+            animations:
+              enter: fade
+        replace: false
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 905
+    - committedId: 6
+      id: cmd-line-actions-character
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: line.update_actions
+      payload:
+        lineId: line-main
+        patch:
+          character:
+            entries:
+              - characterId: hero
+                poseId: idle
+                position: center
+        replace: false
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 906
+    - committedId: 7
+      id: cmd-line-actions-replace
+      projectId: project-puty-line-actions-001
+      userId: user-puty-line-actions
+      partitions:
+        - project:project-puty-line-actions-001:story
+        - project:project-puty-line-actions-001:story:scene:scene-actions
+      type: line.update_actions
+      payload:
+        lineId: line-main
+        patch:
+          dialogue:
+            content:
+              - text: Reset to dialogue only
+            mode: adv
+        replace: true
+      meta:
+        clientId: client-puty-line-actions
+        clientTs: 907

--- a/tests/puty/09-layout-editor-tree.spec.yaml
+++ b/tests/puty/09-layout-editor-tree.spec.yaml
@@ -1,0 +1,180 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage layout editor tree
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists layout editor element tree creation and movement
+in:
+  - projectId: project-puty-layout-tree-001
+    actor:
+      userId: user-puty-layout-tree
+      clientId: client-puty-layout-tree
+    sessionPartitions:
+      - project:project-puty-layout-tree-001:resources
+      - project:project-puty-layout-tree-001:layouts
+    commands:
+      - id: cmd-layout-tree-resource-create
+        partition: project:project-puty-layout-tree-001:resources:layouts
+        partitions:
+          - project:project-puty-layout-tree-001:resources:layouts
+        type: resource.create
+        clientTs: 1001
+        payload:
+          resourceType: layouts
+          resourceId: layout-hud
+          data:
+            name: HUD Layout
+            layoutType: overlay
+            elements:
+              items: {}
+              tree: []
+      - id: cmd-layout-tree-panel-create
+        partition: project:project-puty-layout-tree-001:layouts
+        partitions:
+          - project:project-puty-layout-tree-001:layouts
+        type: layout.element.create
+        clientTs: 1002
+        payload:
+          layoutId: layout-hud
+          elementId: el-panel
+          element:
+            type: group
+            x: 0
+            y: 0
+            width: 320
+            height: 120
+      - id: cmd-layout-tree-title-create
+        partition: project:project-puty-layout-tree-001:layouts
+        partitions:
+          - project:project-puty-layout-tree-001:layouts
+        type: layout.element.create
+        clientTs: 1003
+        payload:
+          layoutId: layout-hud
+          elementId: el-title
+          parentId: el-panel
+          element:
+            type: text
+            x: 12
+            y: 10
+            text: Status
+      - id: cmd-layout-tree-button-create
+        partition: project:project-puty-layout-tree-001:layouts
+        partitions:
+          - project:project-puty-layout-tree-001:layouts
+        type: layout.element.create
+        clientTs: 1004
+        payload:
+          layoutId: layout-hud
+          elementId: el-button
+          element:
+            type: sprite
+            x: 20
+            y: 60
+            imageId: img-button
+      - id: cmd-layout-tree-button-move
+        partition: project:project-puty-layout-tree-001:layouts
+        partitions:
+          - project:project-puty-layout-tree-001:layouts
+        type: layout.element.move
+        clientTs: 1005
+        payload:
+          layoutId: layout-hud
+          elementId: el-button
+          parentId: el-panel
+          index: 1
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-layout-tree-resource-create
+      projectId: project-puty-layout-tree-001
+      userId: user-puty-layout-tree
+      partitions:
+        - project:project-puty-layout-tree-001:resources:layouts
+      type: resource.create
+      payload:
+        resourceType: layouts
+        resourceId: layout-hud
+        data:
+          name: HUD Layout
+          layoutType: overlay
+          elements:
+            items: {}
+            tree: []
+      meta:
+        clientId: client-puty-layout-tree
+        clientTs: 1001
+    - committedId: 2
+      id: cmd-layout-tree-panel-create
+      projectId: project-puty-layout-tree-001
+      userId: user-puty-layout-tree
+      partitions:
+        - project:project-puty-layout-tree-001:layouts
+      type: layout.element.create
+      payload:
+        layoutId: layout-hud
+        elementId: el-panel
+        element:
+          type: group
+          x: 0
+          y: 0
+          width: 320
+          height: 120
+      meta:
+        clientId: client-puty-layout-tree
+        clientTs: 1002
+    - committedId: 3
+      id: cmd-layout-tree-title-create
+      projectId: project-puty-layout-tree-001
+      userId: user-puty-layout-tree
+      partitions:
+        - project:project-puty-layout-tree-001:layouts
+      type: layout.element.create
+      payload:
+        layoutId: layout-hud
+        elementId: el-title
+        parentId: el-panel
+        element:
+          type: text
+          x: 12
+          y: 10
+          text: Status
+      meta:
+        clientId: client-puty-layout-tree
+        clientTs: 1003
+    - committedId: 4
+      id: cmd-layout-tree-button-create
+      projectId: project-puty-layout-tree-001
+      userId: user-puty-layout-tree
+      partitions:
+        - project:project-puty-layout-tree-001:layouts
+      type: layout.element.create
+      payload:
+        layoutId: layout-hud
+        elementId: el-button
+        element:
+          type: sprite
+          x: 20
+          y: 60
+          imageId: img-button
+      meta:
+        clientId: client-puty-layout-tree
+        clientTs: 1004
+    - committedId: 5
+      id: cmd-layout-tree-button-move
+      projectId: project-puty-layout-tree-001
+      userId: user-puty-layout-tree
+      partitions:
+        - project:project-puty-layout-tree-001:layouts
+      type: layout.element.move
+      payload:
+        layoutId: layout-hud
+        elementId: el-button
+        parentId: el-panel
+        index: 1
+      meta:
+        clientId: client-puty-layout-tree
+        clientTs: 1005

--- a/tests/puty/09-layout-editor-tree.spec.yaml
+++ b/tests/puty/09-layout-editor-tree.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage layout editor tree
 suites:
   - runInsiemeStorageScenario
@@ -17,7 +18,6 @@ in:
       - project:project-puty-layout-tree-001:layouts
     commands:
       - id: cmd-layout-tree-resource-create
-        partition: project:project-puty-layout-tree-001:resources:layouts
         partitions:
           - project:project-puty-layout-tree-001:resources:layouts
         type: resource.create
@@ -32,7 +32,6 @@ in:
               items: {}
               tree: []
       - id: cmd-layout-tree-panel-create
-        partition: project:project-puty-layout-tree-001:layouts
         partitions:
           - project:project-puty-layout-tree-001:layouts
         type: layout.element.create
@@ -43,11 +42,10 @@ in:
           element:
             type: group
             x: 0
-            y: 0
+            'y': 0
             width: 320
             height: 120
       - id: cmd-layout-tree-title-create
-        partition: project:project-puty-layout-tree-001:layouts
         partitions:
           - project:project-puty-layout-tree-001:layouts
         type: layout.element.create
@@ -59,10 +57,9 @@ in:
           element:
             type: text
             x: 12
-            y: 10
+            'y': 10
             text: Status
       - id: cmd-layout-tree-button-create
-        partition: project:project-puty-layout-tree-001:layouts
         partitions:
           - project:project-puty-layout-tree-001:layouts
         type: layout.element.create
@@ -73,10 +70,9 @@ in:
           element:
             type: sprite
             x: 20
-            y: 60
+            'y': 60
             imageId: img-button
       - id: cmd-layout-tree-button-move
-        partition: project:project-puty-layout-tree-001:layouts
         partitions:
           - project:project-puty-layout-tree-001:layouts
         type: layout.element.move
@@ -120,7 +116,7 @@ out:
         element:
           type: group
           x: 0
-          y: 0
+          'y': 0
           width: 320
           height: 120
       meta:
@@ -140,7 +136,7 @@ out:
         element:
           type: text
           x: 12
-          y: 10
+          'y': 10
           text: Status
       meta:
         clientId: client-puty-layout-tree
@@ -158,7 +154,7 @@ out:
         element:
           type: sprite
           x: 20
-          y: 60
+          'y': 60
           imageId: img-button
       meta:
         clientId: client-puty-layout-tree
@@ -178,3 +174,249 @@ out:
       meta:
         clientId: client-puty-layout-tree
         clientTs: 1005
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-layout-tree-resource-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-tree-001
+          name: ''
+          updatedAt: 1001
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-hud:
+                createdAt: 1001
+                elements: {}
+                id: layout-hud
+                layoutType: overlay
+                name: HUD Layout
+                parentId: null
+                rootElementOrder: []
+                type: layout
+                updatedAt: 1001
+            tree:
+              - id: layout-hud
+    - committedId: 2
+      eventId: cmd-layout-tree-panel-create
+      eventType: layout.element.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-tree-001
+          name: ''
+          updatedAt: 1002
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-hud:
+                createdAt: 1001
+                elements:
+                  el-panel:
+                    children: []
+                    height: 120
+                    id: el-panel
+                    parentId: null
+                    type: group
+                    width: 320
+                    x: 0
+                    'y': 0
+                id: layout-hud
+                layoutType: overlay
+                name: HUD Layout
+                parentId: null
+                rootElementOrder:
+                  - el-panel
+                type: layout
+                updatedAt: 1002
+            tree:
+              - id: layout-hud
+    - committedId: 3
+      eventId: cmd-layout-tree-title-create
+      eventType: layout.element.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-tree-001
+          name: ''
+          updatedAt: 1003
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-hud:
+                createdAt: 1001
+                elements:
+                  el-panel:
+                    children:
+                      - el-title
+                    height: 120
+                    id: el-panel
+                    parentId: null
+                    type: group
+                    width: 320
+                    x: 0
+                    'y': 0
+                  el-title:
+                    children: []
+                    id: el-title
+                    parentId: el-panel
+                    text: Status
+                    type: text
+                    x: 12
+                    'y': 10
+                id: layout-hud
+                layoutType: overlay
+                name: HUD Layout
+                parentId: null
+                rootElementOrder:
+                  - el-panel
+                type: layout
+                updatedAt: 1003
+            tree:
+              - id: layout-hud
+    - committedId: 4
+      eventId: cmd-layout-tree-button-create
+      eventType: layout.element.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-tree-001
+          name: ''
+          updatedAt: 1004
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-hud:
+                createdAt: 1001
+                elements:
+                  el-button:
+                    children: []
+                    id: el-button
+                    imageId: img-button
+                    parentId: null
+                    type: sprite
+                    x: 20
+                    'y': 60
+                  el-panel:
+                    children:
+                      - el-title
+                    height: 120
+                    id: el-panel
+                    parentId: null
+                    type: group
+                    width: 320
+                    x: 0
+                    'y': 0
+                  el-title:
+                    children: []
+                    id: el-title
+                    parentId: el-panel
+                    text: Status
+                    type: text
+                    x: 12
+                    'y': 10
+                id: layout-hud
+                layoutType: overlay
+                name: HUD Layout
+                parentId: null
+                rootElementOrder:
+                  - el-panel
+                  - el-button
+                type: layout
+                updatedAt: 1004
+            tree:
+              - id: layout-hud
+    - committedId: 5
+      eventId: cmd-layout-tree-button-move
+      eventType: layout.element.move
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-tree-001
+          name: ''
+          updatedAt: 1005
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-hud:
+                createdAt: 1001
+                elements:
+                  el-button:
+                    children: []
+                    id: el-button
+                    imageId: img-button
+                    parentId: el-panel
+                    type: sprite
+                    x: 20
+                    'y': 60
+                  el-panel:
+                    children:
+                      - el-title
+                      - el-button
+                    height: 120
+                    id: el-panel
+                    parentId: null
+                    type: group
+                    width: 320
+                    x: 0
+                    'y': 0
+                  el-title:
+                    children: []
+                    id: el-title
+                    parentId: el-panel
+                    text: Status
+                    type: text
+                    x: 12
+                    'y': 10
+                id: layout-hud
+                layoutType: overlay
+                name: HUD Layout
+                parentId: null
+                rootElementOrder:
+                  - el-panel
+                type: layout
+                updatedAt: 1005
+            tree:
+              - id: layout-hud

--- a/tests/puty/10-layout-editor-patch-replace-delete.spec.yaml
+++ b/tests/puty/10-layout-editor-patch-replace-delete.spec.yaml
@@ -1,0 +1,212 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage layout editor patch replace delete
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists layout editor patch replace and delete commands
+in:
+  - projectId: project-puty-layout-patch-001
+    actor:
+      userId: user-puty-layout-patch
+      clientId: client-puty-layout-patch
+    sessionPartitions:
+      - project:project-puty-layout-patch-001:resources
+      - project:project-puty-layout-patch-001:layouts
+    commands:
+      - id: cmd-layout-patch-resource-create
+        partition: project:project-puty-layout-patch-001:resources:layouts
+        partitions:
+          - project:project-puty-layout-patch-001:resources:layouts
+        type: resource.create
+        clientTs: 1101
+        payload:
+          resourceType: layouts
+          resourceId: layout-dialogue
+          data:
+            name: Dialogue Layout
+            layoutType: normal
+            elements:
+              items: {}
+              tree: []
+      - id: cmd-layout-patch-element-create
+        partition: project:project-puty-layout-patch-001:layouts
+        partitions:
+          - project:project-puty-layout-patch-001:layouts
+        type: layout.element.create
+        clientTs: 1102
+        payload:
+          layoutId: layout-dialogue
+          elementId: el-frame
+          element:
+            type: sprite
+            x: 0
+            y: 400
+            width: 1280
+            height: 320
+            imageId: frame-a
+      - id: cmd-layout-patch-update-1
+        partition: project:project-puty-layout-patch-001:layouts
+        partitions:
+          - project:project-puty-layout-patch-001:layouts
+        type: layout.element.update
+        clientTs: 1103
+        payload:
+          layoutId: layout-dialogue
+          elementId: el-frame
+          patch:
+            x: 10
+            style:
+              opacity: 0.9
+              tint: "#ffffff"
+          replace: false
+      - id: cmd-layout-patch-update-2
+        partition: project:project-puty-layout-patch-001:layouts
+        partitions:
+          - project:project-puty-layout-patch-001:layouts
+        type: layout.element.update
+        clientTs: 1104
+        payload:
+          layoutId: layout-dialogue
+          elementId: el-frame
+          patch:
+            style:
+              opacity: 1
+              blendMode: screen
+          replace: false
+      - id: cmd-layout-patch-replace
+        partition: project:project-puty-layout-patch-001:layouts
+        partitions:
+          - project:project-puty-layout-patch-001:layouts
+        type: layout.element.update
+        clientTs: 1105
+        payload:
+          layoutId: layout-dialogue
+          elementId: el-frame
+          patch:
+            type: sprite
+            x: 0
+            y: 420
+            imageId: frame-b
+          replace: true
+      - id: cmd-layout-patch-delete
+        partition: project:project-puty-layout-patch-001:layouts
+        partitions:
+          - project:project-puty-layout-patch-001:layouts
+        type: layout.element.delete
+        clientTs: 1106
+        payload:
+          layoutId: layout-dialogue
+          elementId: el-frame
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-layout-patch-resource-create
+      projectId: project-puty-layout-patch-001
+      userId: user-puty-layout-patch
+      partitions:
+        - project:project-puty-layout-patch-001:resources:layouts
+      type: resource.create
+      payload:
+        resourceType: layouts
+        resourceId: layout-dialogue
+        data:
+          name: Dialogue Layout
+          layoutType: normal
+          elements:
+            items: {}
+            tree: []
+      meta:
+        clientId: client-puty-layout-patch
+        clientTs: 1101
+    - committedId: 2
+      id: cmd-layout-patch-element-create
+      projectId: project-puty-layout-patch-001
+      userId: user-puty-layout-patch
+      partitions:
+        - project:project-puty-layout-patch-001:layouts
+      type: layout.element.create
+      payload:
+        layoutId: layout-dialogue
+        elementId: el-frame
+        element:
+          type: sprite
+          x: 0
+          y: 400
+          width: 1280
+          height: 320
+          imageId: frame-a
+      meta:
+        clientId: client-puty-layout-patch
+        clientTs: 1102
+    - committedId: 3
+      id: cmd-layout-patch-update-1
+      projectId: project-puty-layout-patch-001
+      userId: user-puty-layout-patch
+      partitions:
+        - project:project-puty-layout-patch-001:layouts
+      type: layout.element.update
+      payload:
+        layoutId: layout-dialogue
+        elementId: el-frame
+        patch:
+          x: 10
+          style:
+            opacity: 0.9
+            tint: "#ffffff"
+        replace: false
+      meta:
+        clientId: client-puty-layout-patch
+        clientTs: 1103
+    - committedId: 4
+      id: cmd-layout-patch-update-2
+      projectId: project-puty-layout-patch-001
+      userId: user-puty-layout-patch
+      partitions:
+        - project:project-puty-layout-patch-001:layouts
+      type: layout.element.update
+      payload:
+        layoutId: layout-dialogue
+        elementId: el-frame
+        patch:
+          style:
+            opacity: 1
+            blendMode: screen
+        replace: false
+      meta:
+        clientId: client-puty-layout-patch
+        clientTs: 1104
+    - committedId: 5
+      id: cmd-layout-patch-replace
+      projectId: project-puty-layout-patch-001
+      userId: user-puty-layout-patch
+      partitions:
+        - project:project-puty-layout-patch-001:layouts
+      type: layout.element.update
+      payload:
+        layoutId: layout-dialogue
+        elementId: el-frame
+        patch:
+          type: sprite
+          x: 0
+          y: 420
+          imageId: frame-b
+        replace: true
+      meta:
+        clientId: client-puty-layout-patch
+        clientTs: 1105
+    - committedId: 6
+      id: cmd-layout-patch-delete
+      projectId: project-puty-layout-patch-001
+      userId: user-puty-layout-patch
+      partitions:
+        - project:project-puty-layout-patch-001:layouts
+      type: layout.element.delete
+      payload:
+        layoutId: layout-dialogue
+        elementId: el-frame
+      meta:
+        clientId: client-puty-layout-patch
+        clientTs: 1106

--- a/tests/puty/10-layout-editor-patch-replace-delete.spec.yaml
+++ b/tests/puty/10-layout-editor-patch-replace-delete.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage layout editor patch replace delete
 suites:
   - runInsiemeStorageScenario
@@ -17,7 +18,6 @@ in:
       - project:project-puty-layout-patch-001:layouts
     commands:
       - id: cmd-layout-patch-resource-create
-        partition: project:project-puty-layout-patch-001:resources:layouts
         partitions:
           - project:project-puty-layout-patch-001:resources:layouts
         type: resource.create
@@ -32,7 +32,6 @@ in:
               items: {}
               tree: []
       - id: cmd-layout-patch-element-create
-        partition: project:project-puty-layout-patch-001:layouts
         partitions:
           - project:project-puty-layout-patch-001:layouts
         type: layout.element.create
@@ -43,12 +42,11 @@ in:
           element:
             type: sprite
             x: 0
-            y: 400
+            'y': 400
             width: 1280
             height: 320
             imageId: frame-a
       - id: cmd-layout-patch-update-1
-        partition: project:project-puty-layout-patch-001:layouts
         partitions:
           - project:project-puty-layout-patch-001:layouts
         type: layout.element.update
@@ -60,10 +58,9 @@ in:
             x: 10
             style:
               opacity: 0.9
-              tint: "#ffffff"
+              tint: '#ffffff'
           replace: false
       - id: cmd-layout-patch-update-2
-        partition: project:project-puty-layout-patch-001:layouts
         partitions:
           - project:project-puty-layout-patch-001:layouts
         type: layout.element.update
@@ -77,7 +74,6 @@ in:
               blendMode: screen
           replace: false
       - id: cmd-layout-patch-replace
-        partition: project:project-puty-layout-patch-001:layouts
         partitions:
           - project:project-puty-layout-patch-001:layouts
         type: layout.element.update
@@ -88,11 +84,10 @@ in:
           patch:
             type: sprite
             x: 0
-            y: 420
+            'y': 420
             imageId: frame-b
           replace: true
       - id: cmd-layout-patch-delete
-        partition: project:project-puty-layout-patch-001:layouts
         partitions:
           - project:project-puty-layout-patch-001:layouts
         type: layout.element.delete
@@ -134,7 +129,7 @@ out:
         element:
           type: sprite
           x: 0
-          y: 400
+          'y': 400
           width: 1280
           height: 320
           imageId: frame-a
@@ -155,7 +150,7 @@ out:
           x: 10
           style:
             opacity: 0.9
-            tint: "#ffffff"
+            tint: '#ffffff'
         replace: false
       meta:
         clientId: client-puty-layout-patch
@@ -191,7 +186,7 @@ out:
         patch:
           type: sprite
           x: 0
-          y: 420
+          'y': 420
           imageId: frame-b
         replace: true
       meta:
@@ -210,3 +205,251 @@ out:
       meta:
         clientId: client-puty-layout-patch
         clientTs: 1106
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-layout-patch-resource-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-patch-001
+          name: ''
+          updatedAt: 1101
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-dialogue:
+                createdAt: 1101
+                elements: {}
+                id: layout-dialogue
+                layoutType: normal
+                name: Dialogue Layout
+                parentId: null
+                rootElementOrder: []
+                type: layout
+                updatedAt: 1101
+            tree:
+              - id: layout-dialogue
+    - committedId: 2
+      eventId: cmd-layout-patch-element-create
+      eventType: layout.element.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-patch-001
+          name: ''
+          updatedAt: 1102
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-dialogue:
+                createdAt: 1101
+                elements:
+                  el-frame:
+                    children: []
+                    height: 320
+                    id: el-frame
+                    imageId: frame-a
+                    parentId: null
+                    type: sprite
+                    width: 1280
+                    x: 0
+                    'y': 400
+                id: layout-dialogue
+                layoutType: normal
+                name: Dialogue Layout
+                parentId: null
+                rootElementOrder:
+                  - el-frame
+                type: layout
+                updatedAt: 1102
+            tree:
+              - id: layout-dialogue
+    - committedId: 3
+      eventId: cmd-layout-patch-update-1
+      eventType: layout.element.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-patch-001
+          name: ''
+          updatedAt: 1103
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-dialogue:
+                createdAt: 1101
+                elements:
+                  el-frame:
+                    children: []
+                    height: 320
+                    id: el-frame
+                    imageId: frame-a
+                    parentId: null
+                    style:
+                      opacity: 0.9
+                      tint: '#ffffff'
+                    type: sprite
+                    width: 1280
+                    x: 10
+                    'y': 400
+                id: layout-dialogue
+                layoutType: normal
+                name: Dialogue Layout
+                parentId: null
+                rootElementOrder:
+                  - el-frame
+                type: layout
+                updatedAt: 1103
+            tree:
+              - id: layout-dialogue
+    - committedId: 4
+      eventId: cmd-layout-patch-update-2
+      eventType: layout.element.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-patch-001
+          name: ''
+          updatedAt: 1104
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-dialogue:
+                createdAt: 1101
+                elements:
+                  el-frame:
+                    children: []
+                    height: 320
+                    id: el-frame
+                    imageId: frame-a
+                    parentId: null
+                    style:
+                      blendMode: screen
+                      opacity: 1
+                      tint: '#ffffff'
+                    type: sprite
+                    width: 1280
+                    x: 10
+                    'y': 400
+                id: layout-dialogue
+                layoutType: normal
+                name: Dialogue Layout
+                parentId: null
+                rootElementOrder:
+                  - el-frame
+                type: layout
+                updatedAt: 1104
+            tree:
+              - id: layout-dialogue
+    - committedId: 5
+      eventId: cmd-layout-patch-replace
+      eventType: layout.element.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-patch-001
+          name: ''
+          updatedAt: 1105
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-dialogue:
+                createdAt: 1101
+                elements:
+                  el-frame:
+                    children: []
+                    height: 320
+                    id: el-frame
+                    imageId: frame-b
+                    parentId: null
+                    style:
+                      blendMode: screen
+                      opacity: 1
+                      tint: '#ffffff'
+                    type: sprite
+                    width: 1280
+                    x: 0
+                    'y': 420
+                id: layout-dialogue
+                layoutType: normal
+                name: Dialogue Layout
+                parentId: null
+                rootElementOrder:
+                  - el-frame
+                type: layout
+                updatedAt: 1105
+            tree:
+              - id: layout-dialogue
+    - committedId: 6
+      eventId: cmd-layout-patch-delete
+      eventType: layout.element.delete
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-layout-patch-001
+          name: ''
+          updatedAt: 1106
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          layouts:
+            items:
+              layout-dialogue:
+                createdAt: 1101
+                elements: {}
+                id: layout-dialogue
+                layoutType: normal
+                name: Dialogue Layout
+                parentId: null
+                rootElementOrder: []
+                type: layout
+                updatedAt: 1106
+            tree:
+              - id: layout-dialogue

--- a/tests/puty/11-storage-idempotent-submit.spec.yaml
+++ b/tests/puty/11-storage-idempotent-submit.spec.yaml
@@ -1,0 +1,74 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage idempotent submit
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: stores one row for a duplicate command id with identical payload
+in:
+  - projectId: project-puty-idempotent-001
+    actor:
+      userId: user-puty-idempotent
+      clientId: client-puty-idempotent
+    sessionPartitions:
+      - project:project-puty-idempotent-001:settings
+    batches:
+      - commands:
+          - id: cmd-project-name-dedup
+            partition: project:project-puty-idempotent-001:settings
+            partitions:
+              - project:project-puty-idempotent-001:settings
+            type: project.update
+            clientTs: 1201
+            payload:
+              patch:
+                name: Deduped Project
+      - commands:
+          - id: cmd-project-name-dedup
+            partition: project:project-puty-idempotent-001:settings
+            partitions:
+              - project:project-puty-idempotent-001:settings
+            type: project.update
+            clientTs: 1201
+            payload:
+              patch:
+                name: Deduped Project
+          - id: cmd-project-description-unique
+            partition: project:project-puty-idempotent-001:settings
+            partitions:
+              - project:project-puty-idempotent-001:settings
+            type: project.update
+            clientTs: 1202
+            payload:
+              patch:
+                description: Second command should still commit
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-project-name-dedup
+      projectId: project-puty-idempotent-001
+      userId: user-puty-idempotent
+      partitions:
+        - project:project-puty-idempotent-001:settings
+      type: project.update
+      payload:
+        patch:
+          name: Deduped Project
+      meta:
+        clientId: client-puty-idempotent
+        clientTs: 1201
+    - committedId: 2
+      id: cmd-project-description-unique
+      projectId: project-puty-idempotent-001
+      userId: user-puty-idempotent
+      partitions:
+        - project:project-puty-idempotent-001:settings
+      type: project.update
+      payload:
+        patch:
+          description: Second command should still commit
+      meta:
+        clientId: client-puty-idempotent
+        clientTs: 1202

--- a/tests/puty/11-storage-idempotent-submit.spec.yaml
+++ b/tests/puty/11-storage-idempotent-submit.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage idempotent submit
 suites:
   - runInsiemeStorageScenario
@@ -17,7 +18,6 @@ in:
     batches:
       - commands:
           - id: cmd-project-name-dedup
-            partition: project:project-puty-idempotent-001:settings
             partitions:
               - project:project-puty-idempotent-001:settings
             type: project.update
@@ -27,7 +27,6 @@ in:
                 name: Deduped Project
       - commands:
           - id: cmd-project-name-dedup
-            partition: project:project-puty-idempotent-001:settings
             partitions:
               - project:project-puty-idempotent-001:settings
             type: project.update
@@ -36,7 +35,6 @@ in:
               patch:
                 name: Deduped Project
           - id: cmd-project-description-unique
-            partition: project:project-puty-idempotent-001:settings
             partitions:
               - project:project-puty-idempotent-001:settings
             type: project.update
@@ -72,3 +70,40 @@ out:
       meta:
         clientId: client-puty-idempotent
         clientTs: 1202
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-project-name-dedup
+      eventType: project.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: ''
+          id: project-puty-idempotent-001
+          name: Deduped Project
+          updatedAt: 1201
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-project-description-unique
+      eventType: project.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Second command should still commit
+          id: project-puty-idempotent-001
+          name: Deduped Project
+          updatedAt: 1202
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}

--- a/tests/puty/insieme-storage.spec.yaml
+++ b/tests/puty/insieme-storage.spec.yaml
@@ -1,4 +1,5 @@
-file: "./insiemeStorageScenario.js"
+---
+file: ./insiemeStorageScenario.js
 group: insieme storage
 suites:
   - runInsiemeStorageScenario
@@ -19,7 +20,6 @@ in:
       - project:project-puty-storage-001:layouts
     commands:
       - id: cmd-project-update
-        partition: project:project-puty-storage-001:settings
         partitions:
           - project:project-puty-storage-001:settings
         type: project.update
@@ -29,7 +29,6 @@ in:
             name: Command Project
             description: Only commands should sync
       - id: cmd-image-create
-        partition: project:project-puty-storage-001:resources:images
         partitions:
           - project:project-puty-storage-001:resources:images
         type: resource.create
@@ -42,7 +41,6 @@ in:
             type: image
             src: image-1.png
       - id: cmd-scene-create
-        partition: project:project-puty-storage-001:story
         partitions:
           - project:project-puty-storage-001:story
           - project:project-puty-storage-001:story:scene:scene-1
@@ -52,7 +50,6 @@ in:
           sceneId: scene-1
           name: Scene 1
       - id: cmd-section-create
-        partition: project:project-puty-storage-001:story
         partitions:
           - project:project-puty-storage-001:story
           - project:project-puty-storage-001:story:scene:scene-1
@@ -63,7 +60,6 @@ in:
           sectionId: section-1
           name: Section 1
       - id: cmd-line-insert
-        partition: project:project-puty-storage-001:story
         partitions:
           - project:project-puty-storage-001:story
           - project:project-puty-storage-001:story:scene:scene-1
@@ -79,7 +75,6 @@ in:
                   - text: Hello
                 mode: adv
       - id: cmd-line-dialogue-update
-        partition: project:project-puty-storage-001:story
         partitions:
           - project:project-puty-storage-001:story
           - project:project-puty-storage-001:story:scene:scene-1
@@ -96,7 +91,6 @@ in:
                 resourceId: layout-1
           replace: false
       - id: cmd-layout-resource-create
-        partition: project:project-puty-storage-001:resources:layouts
         partitions:
           - project:project-puty-storage-001:resources:layouts
         type: resource.create
@@ -111,7 +105,6 @@ in:
               items: {}
               tree: []
       - id: cmd-layout-element-create
-        partition: project:project-puty-storage-001:layouts
         partitions:
           - project:project-puty-storage-001:layouts
         type: layout.element.create
@@ -122,7 +115,7 @@ in:
           element:
             type: text
             x: 10
-            y: 20
+            'y': 20
 out:
   storedEvents:
     - committedId: 1
@@ -258,7 +251,445 @@ out:
         element:
           type: text
           x: 10
-          y: 20
+          'y': 20
       meta:
         clientId: client-puty-1
         clientTs: 108
+  stateAfterEachEvent:
+    - committedId: 1
+      eventId: cmd-project-update
+      eventType: project.update
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 101
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources: {}
+    - committedId: 2
+      eventId: cmd-image-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 102
+        story:
+          initialSceneId: null
+          sceneOrder: []
+        scenes: {}
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+    - committedId: 3
+      eventId: cmd-scene-create
+      eventType: scene.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 103
+        story:
+          initialSceneId: scene-1
+          sceneOrder:
+            - scene-1
+        scenes:
+          scene-1:
+            createdAt: 103
+            id: scene-1
+            initialSectionId: null
+            name: Scene 1
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds: []
+            type: scene
+            updatedAt: 103
+        sections: {}
+        lines: {}
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+    - committedId: 4
+      eventId: cmd-section-create
+      eventType: section.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 104
+        story:
+          initialSceneId: scene-1
+          sceneOrder:
+            - scene-1
+        scenes:
+          scene-1:
+            createdAt: 103
+            id: scene-1
+            initialSectionId: section-1
+            name: Scene 1
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-1
+            type: scene
+            updatedAt: 103
+        sections:
+          section-1:
+            createdAt: 104
+            id: section-1
+            initialLineId: null
+            lineIds: []
+            name: Section 1
+            sceneId: scene-1
+            updatedAt: 104
+        lines: {}
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+    - committedId: 5
+      eventId: cmd-line-insert
+      eventType: line.insert_after
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 105
+        story:
+          initialSceneId: scene-1
+          sceneOrder:
+            - scene-1
+        scenes:
+          scene-1:
+            createdAt: 103
+            id: scene-1
+            initialSectionId: section-1
+            name: Scene 1
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-1
+            type: scene
+            updatedAt: 103
+        sections:
+          section-1:
+            createdAt: 104
+            id: section-1
+            initialLineId: line-1
+            lineIds:
+              - line-1
+            name: Section 1
+            sceneId: scene-1
+            updatedAt: 104
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: Hello
+                mode: adv
+            createdAt: 105
+            id: line-1
+            sectionId: section-1
+            updatedAt: 105
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+    - committedId: 6
+      eventId: cmd-line-dialogue-update
+      eventType: line.update_actions
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 106
+        story:
+          initialSceneId: scene-1
+          sceneOrder:
+            - scene-1
+        scenes:
+          scene-1:
+            createdAt: 103
+            id: scene-1
+            initialSectionId: section-1
+            name: Scene 1
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-1
+            type: scene
+            updatedAt: 103
+        sections:
+          section-1:
+            createdAt: 104
+            id: section-1
+            initialLineId: line-1
+            lineIds:
+              - line-1
+            name: Section 1
+            sceneId: scene-1
+            updatedAt: 104
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: Hello
+                mode: nvl
+                ui:
+                  resourceId: layout-1
+            createdAt: 105
+            id: line-1
+            sectionId: section-1
+            updatedAt: 106
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+    - committedId: 7
+      eventId: cmd-layout-resource-create
+      eventType: resource.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 107
+        story:
+          initialSceneId: scene-1
+          sceneOrder:
+            - scene-1
+        scenes:
+          scene-1:
+            createdAt: 103
+            id: scene-1
+            initialSectionId: section-1
+            name: Scene 1
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-1
+            type: scene
+            updatedAt: 103
+        sections:
+          section-1:
+            createdAt: 104
+            id: section-1
+            initialLineId: line-1
+            lineIds:
+              - line-1
+            name: Section 1
+            sceneId: scene-1
+            updatedAt: 104
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: Hello
+                mode: nvl
+                ui:
+                  resourceId: layout-1
+            createdAt: 105
+            id: line-1
+            sectionId: section-1
+            updatedAt: 106
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+          layouts:
+            items:
+              layout-1:
+                createdAt: 107
+                elements: {}
+                id: layout-1
+                layoutType: normal
+                name: Layout 1
+                parentId: null
+                rootElementOrder: []
+                type: layout
+                updatedAt: 107
+            tree:
+              - id: layout-1
+    - committedId: 8
+      eventId: cmd-layout-element-create
+      eventType: layout.element.create
+      state:
+        model_version: 2
+        project:
+          createdAt: 0
+          description: Only commands should sync
+          id: project-puty-storage-001
+          name: Command Project
+          updatedAt: 108
+        story:
+          initialSceneId: scene-1
+          sceneOrder:
+            - scene-1
+        scenes:
+          scene-1:
+            createdAt: 103
+            id: scene-1
+            initialSectionId: section-1
+            name: Scene 1
+            parentId: null
+            position:
+              x: 200
+              'y': 200
+            sectionIds:
+              - section-1
+            type: scene
+            updatedAt: 103
+        sections:
+          section-1:
+            createdAt: 104
+            id: section-1
+            initialLineId: line-1
+            lineIds:
+              - line-1
+            name: Section 1
+            sceneId: scene-1
+            updatedAt: 104
+        lines:
+          line-1:
+            actions:
+              dialogue:
+                content:
+                  - text: Hello
+                mode: nvl
+                ui:
+                  resourceId: layout-1
+            createdAt: 105
+            id: line-1
+            sectionId: section-1
+            updatedAt: 106
+        resources:
+          images:
+            items:
+              image-1:
+                createdAt: 102
+                id: image-1
+                name: Image 1
+                parentId: null
+                src: image-1.png
+                type: image
+                updatedAt: 102
+            tree:
+              - id: image-1
+          layouts:
+            items:
+              layout-1:
+                createdAt: 107
+                elements:
+                  el-1:
+                    children: []
+                    id: el-1
+                    parentId: null
+                    type: text
+                    x: 10
+                    'y': 20
+                id: layout-1
+                layoutType: normal
+                name: Layout 1
+                parentId: null
+                rootElementOrder:
+                  - el-1
+                type: layout
+                updatedAt: 108
+            tree:
+              - id: layout-1

--- a/tests/puty/insieme-storage.spec.yaml
+++ b/tests/puty/insieme-storage.spec.yaml
@@ -1,0 +1,264 @@
+file: "./insiemeStorageScenario.js"
+group: insieme storage
+suites:
+  - runInsiemeStorageScenario
+---
+suite: runInsiemeStorageScenario
+exportName: runInsiemeStorageScenario
+---
+case: persists a mixed RouteVN command stream to sqlite storage
+in:
+  - projectId: project-puty-storage-001
+    actor:
+      userId: user-puty-1
+      clientId: client-puty-1
+    sessionPartitions:
+      - project:project-puty-storage-001:settings
+      - project:project-puty-storage-001:resources
+      - project:project-puty-storage-001:story
+      - project:project-puty-storage-001:layouts
+    commands:
+      - id: cmd-project-update
+        partition: project:project-puty-storage-001:settings
+        partitions:
+          - project:project-puty-storage-001:settings
+        type: project.update
+        clientTs: 101
+        payload:
+          patch:
+            name: Command Project
+            description: Only commands should sync
+      - id: cmd-image-create
+        partition: project:project-puty-storage-001:resources:images
+        partitions:
+          - project:project-puty-storage-001:resources:images
+        type: resource.create
+        clientTs: 102
+        payload:
+          resourceType: images
+          resourceId: image-1
+          data:
+            name: Image 1
+            type: image
+            src: image-1.png
+      - id: cmd-scene-create
+        partition: project:project-puty-storage-001:story
+        partitions:
+          - project:project-puty-storage-001:story
+          - project:project-puty-storage-001:story:scene:scene-1
+        type: scene.create
+        clientTs: 103
+        payload:
+          sceneId: scene-1
+          name: Scene 1
+      - id: cmd-section-create
+        partition: project:project-puty-storage-001:story
+        partitions:
+          - project:project-puty-storage-001:story
+          - project:project-puty-storage-001:story:scene:scene-1
+        type: section.create
+        clientTs: 104
+        payload:
+          sceneId: scene-1
+          sectionId: section-1
+          name: Section 1
+      - id: cmd-line-insert
+        partition: project:project-puty-storage-001:story
+        partitions:
+          - project:project-puty-storage-001:story
+          - project:project-puty-storage-001:story:scene:scene-1
+        type: line.insert_after
+        clientTs: 105
+        payload:
+          sectionId: section-1
+          lineId: line-1
+          line:
+            actions:
+              dialogue:
+                content:
+                  - text: Hello
+                mode: adv
+      - id: cmd-line-dialogue-update
+        partition: project:project-puty-storage-001:story
+        partitions:
+          - project:project-puty-storage-001:story
+          - project:project-puty-storage-001:story:scene:scene-1
+        type: line.update_actions
+        clientTs: 106
+        payload:
+          lineId: line-1
+          patch:
+            dialogue:
+              content:
+                - text: Hello
+              mode: nvl
+              ui:
+                resourceId: layout-1
+          replace: false
+      - id: cmd-layout-resource-create
+        partition: project:project-puty-storage-001:resources:layouts
+        partitions:
+          - project:project-puty-storage-001:resources:layouts
+        type: resource.create
+        clientTs: 107
+        payload:
+          resourceType: layouts
+          resourceId: layout-1
+          data:
+            name: Layout 1
+            layoutType: normal
+            elements:
+              items: {}
+              tree: []
+      - id: cmd-layout-element-create
+        partition: project:project-puty-storage-001:layouts
+        partitions:
+          - project:project-puty-storage-001:layouts
+        type: layout.element.create
+        clientTs: 108
+        payload:
+          layoutId: layout-1
+          elementId: el-1
+          element:
+            type: text
+            x: 10
+            y: 20
+out:
+  storedEvents:
+    - committedId: 1
+      id: cmd-project-update
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:settings
+      type: project.update
+      payload:
+        patch:
+          name: Command Project
+          description: Only commands should sync
+      meta:
+        clientId: client-puty-1
+        clientTs: 101
+    - committedId: 2
+      id: cmd-image-create
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:resources:images
+      type: resource.create
+      payload:
+        resourceType: images
+        resourceId: image-1
+        data:
+          name: Image 1
+          type: image
+          src: image-1.png
+      meta:
+        clientId: client-puty-1
+        clientTs: 102
+    - committedId: 3
+      id: cmd-scene-create
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:story
+        - project:project-puty-storage-001:story:scene:scene-1
+      type: scene.create
+      payload:
+        sceneId: scene-1
+        name: Scene 1
+      meta:
+        clientId: client-puty-1
+        clientTs: 103
+    - committedId: 4
+      id: cmd-section-create
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:story
+        - project:project-puty-storage-001:story:scene:scene-1
+      type: section.create
+      payload:
+        sceneId: scene-1
+        sectionId: section-1
+        name: Section 1
+      meta:
+        clientId: client-puty-1
+        clientTs: 104
+    - committedId: 5
+      id: cmd-line-insert
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:story
+        - project:project-puty-storage-001:story:scene:scene-1
+      type: line.insert_after
+      payload:
+        sectionId: section-1
+        lineId: line-1
+        line:
+          actions:
+            dialogue:
+              content:
+                - text: Hello
+              mode: adv
+      meta:
+        clientId: client-puty-1
+        clientTs: 105
+    - committedId: 6
+      id: cmd-line-dialogue-update
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:story
+        - project:project-puty-storage-001:story:scene:scene-1
+      type: line.update_actions
+      payload:
+        lineId: line-1
+        patch:
+          dialogue:
+            content:
+              - text: Hello
+            mode: nvl
+            ui:
+              resourceId: layout-1
+        replace: false
+      meta:
+        clientId: client-puty-1
+        clientTs: 106
+    - committedId: 7
+      id: cmd-layout-resource-create
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:resources:layouts
+      type: resource.create
+      payload:
+        resourceType: layouts
+        resourceId: layout-1
+        data:
+          name: Layout 1
+          layoutType: normal
+          elements:
+            items: {}
+            tree: []
+      meta:
+        clientId: client-puty-1
+        clientTs: 107
+    - committedId: 8
+      id: cmd-layout-element-create
+      projectId: project-puty-storage-001
+      userId: user-puty-1
+      partitions:
+        - project:project-puty-storage-001:layouts
+      type: layout.element.create
+      payload:
+        layoutId: layout-1
+        elementId: el-1
+        element:
+          type: text
+          x: 10
+          y: 20
+      meta:
+        clientId: client-puty-1
+        clientTs: 108

--- a/tests/puty/insiemeStorageScenario.js
+++ b/tests/puty/insiemeStorageScenario.js
@@ -1,0 +1,270 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { validateCommandSubmitItem } from "insieme/client";
+import { createSqliteSyncStore, createSyncServer } from "insieme/server";
+import {
+  committedEventToCommand,
+  createCommandEnvelope,
+  createProjectCollabService,
+} from "../../src/deps/services/shared/collab/index.js";
+import { validateCommand } from "../../src/internal/project/commands.js";
+import {
+  createInMemoryServerTransport,
+  parseToken,
+  sleep,
+} from "../../scripts/collabTestSupport.js";
+
+const DEFAULT_PROJECT_NAME = "Puty Storage Test";
+const DEFAULT_PROJECT_DESCRIPTION = "Puty sqlite sync store scenario";
+
+const asNonEmptyString = (value) =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const uniqueStrings = (values = []) => [
+  ...new Set(
+    values.filter((value) => typeof value === "string" && value.length > 0),
+  ),
+];
+
+const createClock = ({ start = 1000, step = 1 } = {}) => {
+  let current = start;
+  return {
+    now() {
+      const value = current;
+      current += step;
+      return value;
+    },
+  };
+};
+
+const readStoredEvents = (database, { includeCreated = false } = {}) => {
+  const rows = database
+    .prepare(
+      `
+        SELECT
+          committed_id,
+          id,
+          project_id,
+          user_id,
+          partitions,
+          type,
+          payload,
+          meta,
+          created
+        FROM committed_events
+        ORDER BY committed_id ASC
+      `,
+    )
+    .all();
+
+  return rows.map((row) => {
+    const event = {
+      committedId: row.committed_id,
+      id: row.id,
+      projectId: row.project_id || undefined,
+      userId: row.user_id || undefined,
+      partitions: JSON.parse(row.partitions),
+      type: row.type,
+      payload: JSON.parse(row.payload),
+      meta: JSON.parse(row.meta),
+    };
+
+    if (includeCreated) {
+      event.created = row.created;
+    }
+
+    return event;
+  });
+};
+
+const buildCommands = (scenario, commands = []) => {
+  const actor = scenario.actor;
+  const baseClientTs = Number.isFinite(scenario.clientTsStart)
+    ? scenario.clientTsStart
+    : 1;
+
+  return commands.map((command, index) =>
+    createCommandEnvelope({
+      projectId: command.projectId ?? scenario.projectId,
+      actor: command.actor ?? actor,
+      clientTs: command.clientTs ?? baseClientTs + index,
+      commandVersion: command.commandVersion ?? 1,
+      ...command,
+    }),
+  );
+};
+
+const buildCommandBatches = (input, actor) => {
+  if (Array.isArray(input?.batches) && input.batches.length > 0) {
+    return input.batches.map((batch) => {
+      const commands = Array.isArray(batch?.commands) ? batch.commands : [];
+      if (commands.length === 0) {
+        throw new Error(
+          "each scenario batch must include a non-empty commands array",
+        );
+      }
+      return buildCommands(
+        {
+          ...input,
+          actor,
+          clientTsStart: batch.clientTsStart ?? input.clientTsStart,
+        },
+        commands,
+      );
+    });
+  }
+
+  if (Array.isArray(input?.commands) && input.commands.length > 0) {
+    return [buildCommands({ ...input, actor }, input.commands)];
+  }
+
+  throw new Error("scenario.commands or scenario.batches must be provided");
+};
+
+const flattenCommandBatches = (commandBatches) => commandBatches.flat();
+
+const buildSessionPartitions = (scenario, commands) => {
+  if (
+    Array.isArray(scenario.sessionPartitions) &&
+    scenario.sessionPartitions.length > 0
+  ) {
+    return uniqueStrings(scenario.sessionPartitions);
+  }
+
+  return uniqueStrings(
+    commands.flatMap((command) => [
+      command.partition,
+      ...(command.partitions || []),
+    ]),
+  );
+};
+
+const buildScenario = (input) => {
+  const actor = input?.actor;
+  if (!actor?.userId || !actor?.clientId) {
+    throw new Error(
+      "scenario.actor.userId and scenario.actor.clientId are required",
+    );
+  }
+
+  const commandBatches = buildCommandBatches(input, actor);
+  const commands = flattenCommandBatches(commandBatches);
+  const projectId = input.projectId ?? commands[0]?.projectId;
+  if (!projectId) {
+    throw new Error("scenario.projectId is required");
+  }
+
+  return {
+    actor,
+    commandBatches,
+    projectId,
+    projectName: asNonEmptyString(input.projectName) ?? DEFAULT_PROJECT_NAME,
+    projectDescription:
+      asNonEmptyString(input.projectDescription) ?? DEFAULT_PROJECT_DESCRIPTION,
+    token:
+      asNonEmptyString(input.token) ??
+      `user:${actor.userId}:client:${actor.clientId}`,
+    connectionId:
+      asNonEmptyString(input.connectionId) ?? `${projectId}-puty-connection`,
+    timeoutMs: Number.isFinite(input.timeoutMs) ? input.timeoutMs : 1000,
+    settleMs: Number.isFinite(input.settleMs) ? input.settleMs : 30,
+    includeCreated: input.includeCreated === true,
+    sessionPartitions: buildSessionPartitions(input, commands),
+    clock: createClock(input.clock),
+  };
+};
+
+const createServer = ({ projectId, store, clock }) =>
+  createSyncServer({
+    auth: {
+      verifyToken: async (token) => {
+        const identity = parseToken(token);
+        return {
+          clientId: identity.clientId,
+          claims: { userId: identity.userId },
+        };
+      },
+    },
+    authz: {
+      authorizePartitions: async (_identity, partitions) => {
+        if (!Array.isArray(partitions) || partitions.length === 0) return false;
+        return partitions.every((partition) =>
+          partition.startsWith(`project:${projectId}:`),
+        );
+      },
+    },
+    validation: {
+      validate: async (item) => {
+        validateCommandSubmitItem(item);
+        const command = committedEventToCommand(item);
+        if (!command) {
+          throw new Error(
+            "failed to convert normalized submit item to command",
+          );
+        }
+        validateCommand(command);
+      },
+    },
+    store,
+    clock,
+  });
+
+export const runInsiemeStorageScenario = async (input) => {
+  const scenario = buildScenario(input);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "routevn-puty-"));
+  const databasePath =
+    asNonEmptyString(input.databasePath) ??
+    path.join(tempDir, "insieme-sync-store.sqlite");
+  const sqlite = new Database(databasePath);
+  const store = createSqliteSyncStore(sqlite);
+  const server = createServer({
+    projectId: scenario.projectId,
+    store,
+    clock: scenario.clock,
+  });
+  const collab = createProjectCollabService({
+    projectId: scenario.projectId,
+    projectName: scenario.projectName,
+    projectDescription: scenario.projectDescription,
+    token: scenario.token,
+    actor: scenario.actor,
+    partitions: scenario.sessionPartitions,
+    transport: createInMemoryServerTransport({
+      server,
+      connectionId: scenario.connectionId,
+    }),
+  });
+
+  try {
+    await collab.start();
+
+    for (const batch of scenario.commandBatches) {
+      for (const command of batch) {
+        await collab.submitCommand(command);
+      }
+
+      await collab.flushDrafts();
+      await collab.syncNow({ timeoutMs: scenario.timeoutMs });
+      await sleep(scenario.settleMs);
+    }
+
+    return {
+      storedEvents: readStoredEvents(sqlite, {
+        includeCreated: scenario.includeCreated,
+      }),
+    };
+  } finally {
+    try {
+      await collab.stop();
+    } catch {}
+
+    try {
+      await server.shutdown();
+    } catch {}
+
+    sqlite.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+};

--- a/tests/puty/insiemeStorageScenario.js
+++ b/tests/puty/insiemeStorageScenario.js
@@ -9,7 +9,9 @@ import {
   createCommandEnvelope,
   createProjectCollabService,
 } from "../../src/deps/services/shared/collab/index.js";
+import { projectRepositoryStateToDomainState } from "../../src/internal/project/projection.js";
 import { validateCommand } from "../../src/internal/project/commands.js";
+import { createProjectRepository } from "../../src/deps/services/shared/projectRepository.js";
 import {
   createInMemoryServerTransport,
   parseToken,
@@ -39,7 +41,10 @@ const createClock = ({ start = 1000, step = 1 } = {}) => {
   };
 };
 
-const readStoredEvents = (database, { includeCreated = false } = {}) => {
+const readStoredEvents = (
+  database,
+  { includeCreated = false, includeCommandVersionMeta = false } = {},
+) => {
   const rows = database
     .prepare(
       `
@@ -71,11 +76,133 @@ const readStoredEvents = (database, { includeCreated = false } = {}) => {
       meta: JSON.parse(row.meta),
     };
 
+    if (!includeCommandVersionMeta && event.meta?.commandVersion === 1) {
+      delete event.meta.commandVersion;
+    }
+
     if (includeCreated) {
       event.created = row.created;
     }
 
     return event;
+  });
+};
+
+const createInMemoryRepositoryEventStore = () => {
+  const events = [];
+
+  return {
+    async appendEvent(event) {
+      events.push(structuredClone(event));
+    },
+    async getEvents() {
+      return events.map((event) => structuredClone(event));
+    },
+  };
+};
+
+const sortEntries = (entries = []) => {
+  return [...entries].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+};
+
+const normalizeTree = (nodes = []) => {
+  return nodes.map((node) => {
+    if (!Array.isArray(node?.children) || node.children.length === 0) {
+      return { id: node.id };
+    }
+
+    return {
+      id: node.id,
+      children: normalizeTree(node.children),
+    };
+  });
+};
+
+const normalizeValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeValue(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    sortEntries(
+      Object.entries(value)
+        .filter(([, nestedValue]) => nestedValue !== undefined)
+        .map(([key, nestedValue]) => [key, normalizeValue(nestedValue)]),
+    ),
+  );
+};
+
+const normalizeIdMap = (items = {}) => {
+  return Object.fromEntries(
+    sortEntries(
+      Object.entries(items).map(([id, value]) => [id, normalizeValue(value)]),
+    ),
+  );
+};
+
+const normalizeResourceCollection = (collection = {}) => {
+  const items = normalizeIdMap(collection.items || {});
+  const tree = normalizeTree(collection.tree || []);
+
+  if (Object.keys(items).length === 0 && tree.length === 0) {
+    return undefined;
+  }
+
+  return {
+    items,
+    tree,
+  };
+};
+
+const normalizeProjectState = (state = {}) => {
+  const resources = Object.fromEntries(
+    sortEntries(
+      Object.entries(state.resources || {})
+        .map(([resourceType, collection]) => [
+          resourceType,
+          normalizeResourceCollection(collection),
+        ])
+        .filter(([, collection]) => collection !== undefined),
+    ),
+  );
+
+  return {
+    model_version: state.model_version,
+    project: normalizeValue(state.project || {}),
+    story: normalizeValue(state.story || {}),
+    scenes: normalizeIdMap(state.scenes || {}),
+    sections: normalizeIdMap(state.sections || {}),
+    lines: normalizeIdMap(state.lines || {}),
+    resources,
+  };
+};
+
+const buildStateAfterEachEvent = async ({ projectId, committedEvents }) => {
+  const repository = await createProjectRepository({
+    projectId,
+    store: createInMemoryRepositoryEventStore(),
+    events: committedEvents,
+  });
+
+  return committedEvents.map((committedEvent, index) => {
+    const repositoryState = repository.getState(index + 1);
+    const domainState = projectRepositoryStateToDomainState({
+      repositoryState,
+      projectId,
+    });
+
+    return {
+      committedId: committedEvent.committedId,
+      eventId: committedEvent.id,
+      eventType: committedEvent.type,
+      state: normalizeProjectState(domainState),
+    };
   });
 };
 
@@ -133,12 +260,7 @@ const buildSessionPartitions = (scenario, commands) => {
     return uniqueStrings(scenario.sessionPartitions);
   }
 
-  return uniqueStrings(
-    commands.flatMap((command) => [
-      command.partition,
-      ...(command.partitions || []),
-    ]),
-  );
+  return uniqueStrings(commands.flatMap((command) => command.partitions || []));
 };
 
 const buildScenario = (input) => {
@@ -171,6 +293,7 @@ const buildScenario = (input) => {
     timeoutMs: Number.isFinite(input.timeoutMs) ? input.timeoutMs : 1000,
     settleMs: Number.isFinite(input.settleMs) ? input.settleMs : 30,
     includeCreated: input.includeCreated === true,
+    includeCommandVersionMeta: input.includeCommandVersionMeta === true,
     sessionPartitions: buildSessionPartitions(input, commands),
     clock: createClock(input.clock),
   };
@@ -250,9 +373,16 @@ export const runInsiemeStorageScenario = async (input) => {
       await sleep(scenario.settleMs);
     }
 
+    const storedEvents = readStoredEvents(sqlite, {
+      includeCreated: scenario.includeCreated,
+      includeCommandVersionMeta: scenario.includeCommandVersionMeta,
+    });
+
     return {
-      storedEvents: readStoredEvents(sqlite, {
-        includeCreated: scenario.includeCreated,
+      storedEvents,
+      stateAfterEachEvent: await buildStateAfterEachEvent({
+        projectId: scenario.projectId,
+        committedEvents: storedEvents,
       }),
     };
   } finally {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import { putyPlugin } from "puty/vitest";
+
+export default defineConfig({
+  plugins: [putyPlugin()],
+  test: {
+    environment: "node",
+    forceRerunTriggers: [
+      "**/*.js",
+      "**/*.{test,spec}.yaml",
+      "**/*.{test,spec}.yml",
+    ],
+  },
+});

--- a/vt/specs/project/project-flow.yaml
+++ b/vt/specs/project/project-flow.yaml
@@ -185,17 +185,6 @@ steps:
     ms: 500
   - action: screenshot
   - action: select
-    selector: "rvn-resource-types [data-item-id='tweens']"
-    steps:
-      - action: click
-  - action: waitFor
-    selector: "rvn-tweens"
-    state: attached
-    timeoutMs: 10000
-  - action: wait
-    ms: 500
-  - action: screenshot
-  - action: select
     selector: "#sidebar [data-item-id='/project/resources/colors']"
     steps:
       - action: click


### PR DESCRIPTION
## Summary
- add action-scoped line update helpers for story commands and keep line action updates full at the action level
- reduce layout editor command payloads via persisted-state diffing and proper replace semantics
- harden collab compatibility for newer remote events by preserving remote command versions, storing raw committed events, and rebuilding derived projector cache state
- make `partitions` the canonical command envelope field throughout RouteVN and the Puty SQLite specs
- expand the Puty SQLite suite so each scenario asserts both stored events and the projected state after every committed event
- remove the stale tweens VT step from the project flow spec

## Validation
- bun run lint
- bun run test:smoke
- bun run test:command-only
- bun run test:integration
- bun run test:collab-adapters
- bun run test:puty
