### PR TITLE
feat: use thumbnails for image previews

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.0.3",
         "@rettangoli/ui": "1.0.3",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.0.0",
+        "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#68ef67e0f81b3d80fce48cd05daebaadae5d4cef",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -263,7 +263,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.0.0", "", {}, "sha512-eYagCYSApGb/s5be2uCXyO6DKW+x+gYOzg/rDIyXAFYJWmUG/3oNa/WzS7YTJixqAJZtlu0aszwbmM0J9WqasA=="],
+    "@routevn/creator-model": ["@routevn/creator-model@github:RouteVN/routevn-creator-model#68ef67e", {}, "RouteVN-routevn-creator-model-68ef67e"],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.0.3",
         "@rettangoli/ui": "1.0.3",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#54c96dab0c4d9fc1150e90492f1f314cda9049b0",
+        "@routevn/creator-model": "1.0.1",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -263,7 +263,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@github:RouteVN/routevn-creator-model#54c96da", {}, "RouteVN-routevn-creator-model-54c96da"],
+    "@routevn/creator-model": ["@routevn/creator-model@1.0.1", "", {}, "sha512-Ul4VlLFcOxG77nnum4/30MZxp7MUnCLKfxJhD24rT+dy365JXFyUD+v3qI5/vJti3K2qIsOoxMOATbyD+rwZeg=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.0.3",
         "@rettangoli/ui": "1.0.3",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#68ef67e0f81b3d80fce48cd05daebaadae5d4cef",
+        "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#54c96dab0c4d9fc1150e90492f1f314cda9049b0",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -263,7 +263,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@github:RouteVN/routevn-creator-model#68ef67e", {}, "RouteVN-routevn-creator-model-68ef67e"],
+    "@routevn/creator-model": ["@routevn/creator-model@github:RouteVN/routevn-creator-model#54c96da", {}, "RouteVN-routevn-creator-model-54c96da"],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "~2",
     "@tauri-apps/plugin-updater": "^2.9.0",
-    "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#68ef67e0f81b3d80fce48cd05daebaadae5d4cef",
+    "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#54c96dab0c4d9fc1150e90492f1f314cda9049b0",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
     "insieme": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "~2",
     "@tauri-apps/plugin-updater": "^2.9.0",
-    "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#54c96dab0c4d9fc1150e90492f1f314cda9049b0",
+    "@routevn/creator-model": "1.0.1",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
     "insieme": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "~2",
     "@tauri-apps/plugin-updater": "^2.9.0",
-    "@routevn/creator-model": "1.0.0",
+    "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#68ef67e0f81b3d80fce48cd05daebaadae5d4cef",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
     "insieme": "1.3.0",

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -173,7 +173,7 @@ export const selectSelectedResource = ({ state }) => {
   return {
     resourceId: state.selectedResourceId,
     resourceType: state.selectedResourceType,
-    fileId: item.fileId || item.thumbnailFileId,
+    fileId: item.thumbnailFileId || item.fileId,
     name: item.name,
     layoutType: item.layoutType,
     layoutTypeDisplay: item.layoutType

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -159,7 +159,7 @@ export const selectVisualsWithRepositoryData = ({ state }) => {
       resource: resourceData,
       resourceType,
       displayName: resourceData?.name || "Unknown Resource",
-      fileId: resourceData?.fileId || resourceData?.thumbnailFileId,
+      fileId: resourceData?.thumbnailFileId || resourceData?.fileId,
     };
   });
 };
@@ -172,7 +172,7 @@ export const selectViewData = ({ state }) => {
     children: group.children.map((child) => ({
       ...child,
       resourceType: "image",
-      previewFileId: child.fileId || child.thumbnailFileId,
+      previewFileId: child.thumbnailFileId || child.fileId,
       bw: child.id === state.tempSelectedResourceId ? "md" : "",
     })),
   }));
@@ -199,7 +199,7 @@ export const selectViewData = ({ state }) => {
         .map((child) => ({
           ...child,
           resourceType: "layout",
-          previewFileId: child.fileId || child.thumbnailFileId,
+          previewFileId: child.thumbnailFileId || child.fileId,
           bw: child.id === state.tempSelectedResourceId ? "md" : "",
         })),
     }))

--- a/src/components/fileImage/fileImage.handlers.js
+++ b/src/components/fileImage/fileImage.handlers.js
@@ -1,30 +1,25 @@
-import { toFlatItems } from "../../internal/project/tree.js";
-
 const getFileIdFromProps = (attrs, projectService) => {
-  // Validate that both fileId and imageId are not passed
   if (attrs.fileId && attrs.imageId) {
     return;
   }
 
-  // If fileId is provided, use it directly
   if (attrs.fileId) {
     return attrs.fileId;
   }
 
-  // If imageId is provided, convert it to fileId
   if (attrs.imageId) {
-    const state = projectService.getState();
-    const { images } = state;
-    const flatImageItems = toFlatItems(images);
-    const existingImage = flatImageItems.find(
-      (item) => item.id === attrs.imageId,
-    );
-
-    if (existingImage) {
-      return existingImage.fileId;
+    const repositoryState = projectService.getRepositoryState();
+    const imageItem = repositoryState?.images?.items?.[attrs.imageId];
+    if (!imageItem) {
+      throw new Error(`Image with imageId "${attrs.imageId}" not found`);
     }
 
-    throw new Error(`Image with imageId "${attrs.imageId}" not found`);
+    const source = attrs.source ?? "original";
+    if (source === "thumbnail") {
+      return imageItem.thumbnailFileId ?? imageItem.fileId;
+    }
+
+    return imageItem.fileId;
   }
 
   return;

--- a/src/components/fileImage/fileImage.schema.yaml
+++ b/src/components/fileImage/fileImage.schema.yaml
@@ -6,6 +6,8 @@ propsSchema:
       type: string
     imageId:
       type: string
+    source:
+      type: string
     br:
       type: string
     wh:

--- a/src/components/fileImage/fileImage.store.js
+++ b/src/components/fileImage/fileImage.store.js
@@ -1,4 +1,4 @@
-const blacklistedAttrs = ["fileId", "imageId"];
+const blacklistedAttrs = ["fileId", "imageId", "source"];
 
 const stringifyAttrs = (attrs) => {
   return Object.entries(attrs)

--- a/src/components/imageSelector/imageSelector.handlers.js
+++ b/src/components/imageSelector/imageSelector.handlers.js
@@ -9,12 +9,10 @@ export const handleBeforeMount = (deps) => {
 
 export const handleAfterMount = (deps) => {
   const { store, projectService, render } = deps;
-  const state = projectService.getState();
+  const state = projectService.getRepositoryState();
 
-  // Extract images from repository state (raw data)
   const images = state.images || { items: {}, tree: [] };
 
-  // Store raw images data - processing will happen in selectViewData
   store.setImages({ images: images });
   render();
 };

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -11,4 +11,4 @@ template:
           - rtgl-view d=h w=f wrap g=lg:
               - $for item, j in group.children:
                   - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} w=200 h=150 bw=${item.bw} bc=${item.bc} br=sm cur=pointer style="${item.selectedStyle}" key=${item.id}:
-                      - rvn-file-image w=200 h=150 fileId=${item.fileId}: null
+                      - rvn-file-image w=200 h=150 imageId=${item.id} source="thumbnail": null

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -91,7 +91,7 @@ template:
                           - rtgl-text s=xs: ${barItem.label}
                           - rtgl-view w=1fg: null
                           - $if barItem.imageId:
-                              - rvn-file-image imageId=${barItem.imageId} h=32: null
+                              - rvn-file-image imageId=${barItem.imageId} source="thumbnail" h=32: null
                             $else:
                               - rtgl-view d=h av=c ah=c h=32 ph=sm bgc=mu br=sm:
                                   - rtgl-text s=xs c=mu: Not set

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -103,7 +103,7 @@ template:
                                       - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
                                           - $if item.cardKind == 'image':
                                               - 'rtgl-view p=md g=md br=md w=${maxWidth} pos=rel style="max-width: 100%;"':
-                                                  - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.imageFileId} key=${item.imageFileId}-${imageHeight}x${maxWidth}: null
+                                                  - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} key=${item.previewFileId}-${imageHeight}x${maxWidth}: null
                                                   - $if item.showPreviewIcon:
                                                       - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} bw=xs bc=ac bgc=bg br=f w=24 h=24 ah=c av=c pos=abs cur=pointer style="top: 8px; right: 8px; z-index: 2;"':
                                                           - rtgl-svg svg=zoomIn wh=12 c=ac: null

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -20,6 +20,97 @@ export const getImageDimensions = (file) => {
   });
 };
 
+const loadImageElement = (file) => {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    const url = URL.createObjectURL(file);
+
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Unable to load image"));
+    };
+
+    image.src = url;
+  });
+};
+
+const canvasToBlob = (canvas, type, quality) => {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error(`Failed to create ${type} thumbnail blob`));
+          return;
+        }
+
+        resolve(blob);
+      },
+      type,
+      quality,
+    );
+  });
+};
+
+export const extractImageThumbnail = async (imageFile, options = {}) => {
+  const {
+    maxWidth = 320,
+    maxHeight = 320,
+    preferredFormat = "image/webp",
+    quality = 0.85,
+  } = options;
+
+  const image = await loadImageElement(imageFile);
+  const sourceWidth = image.naturalWidth;
+  const sourceHeight = image.naturalHeight;
+
+  if (!(sourceWidth > 0) || !(sourceHeight > 0)) {
+    throw new Error("Unable to read image dimensions");
+  }
+
+  const scale = Math.min(maxWidth / sourceWidth, maxHeight / sourceHeight, 1);
+  const width = Math.max(1, Math.round(sourceWidth * scale));
+  const height = Math.max(1, Math.round(sourceHeight * scale));
+
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Unable to create thumbnail canvas context");
+  }
+
+  canvas.width = width;
+  canvas.height = height;
+  context.imageSmoothingEnabled = true;
+  context.imageSmoothingQuality = "high";
+  context.clearRect(0, 0, width, height);
+  context.drawImage(image, 0, 0, width, height);
+
+  let blob;
+  let format = preferredFormat;
+
+  try {
+    blob = await canvasToBlob(canvas, preferredFormat, quality);
+  } catch {
+    format = "image/png";
+    blob = await canvasToBlob(canvas, format);
+  }
+
+  const dataUrl = canvas.toDataURL(format, quality);
+  canvas.remove();
+
+  return {
+    blob,
+    dataUrl,
+    width,
+    height,
+    format,
+  };
+};
+
 export const getVideoDimensions = (file) => {
   return new Promise((resolve) => {
     const video = document.createElement("video");

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -1,11 +1,16 @@
 import {
   getImageDimensions,
+  extractImageThumbnail,
   getVideoDimensions,
   extractWaveformData,
   extractVideoThumbnail,
   detectFileType,
 } from "../../clients/web/fileProcessors.js";
 import { loadFont } from "./fontLoader.js";
+
+const IMAGE_THUMBNAIL_MAX_WIDTH = 320;
+const IMAGE_THUMBNAIL_MAX_HEIGHT = 320;
+const IMAGE_THUMBNAIL_MIN_FILE_SIZE_BYTES = 32 * 1024;
 
 const storeMetadata = async ({ data, storeFile, idGenerator }) => {
   const jsonString = JSON.stringify(data, null, 2);
@@ -48,9 +53,40 @@ export const createProjectAssetService = ({
     const fileType = detectFileType(file);
 
     if (fileType === "image") {
-      const dimensions = await getImageDimensions(file);
-      const stored = await storeFile(file);
-      return { ...stored, dimensions, type: "image" };
+      const [dimensions, stored] = await Promise.all([
+        getImageDimensions(file),
+        storeFile(file),
+      ]);
+
+      const shouldReuseOriginalAsThumbnail =
+        (dimensions &&
+          dimensions.width <= IMAGE_THUMBNAIL_MAX_WIDTH &&
+          dimensions.height <= IMAGE_THUMBNAIL_MAX_HEIGHT) ||
+        file.size <= IMAGE_THUMBNAIL_MIN_FILE_SIZE_BYTES;
+
+      if (shouldReuseOriginalAsThumbnail) {
+        return {
+          ...stored,
+          thumbnailFileId: stored.fileId,
+          dimensions,
+          type: "image",
+        };
+      }
+
+      const thumbnailData = await extractImageThumbnail(file, {
+        maxWidth: IMAGE_THUMBNAIL_MAX_WIDTH,
+        maxHeight: IMAGE_THUMBNAIL_MAX_HEIGHT,
+        preferredFormat: "image/webp",
+        quality: 0.85,
+      });
+      const thumbnailResult = await storeFile(thumbnailData.blob);
+      return {
+        ...stored,
+        thumbnailFileId: thumbnailResult.fileId,
+        thumbnailData,
+        dimensions,
+        type: "image",
+      };
     }
 
     if (fileType === "audio") {

--- a/src/internal/project/projection.js
+++ b/src/internal/project/projection.js
@@ -487,6 +487,7 @@ const constructImageResources = (repositoryImages = {}) => {
 
     result[imageId] = pickResourceFields(item, [
       "fileId",
+      "thumbnailFileId",
       "fileType",
       "width",
       "height",

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -159,7 +159,7 @@ export const selectViewData = ({ state }) => {
         children: children.map((item) => ({
           ...item,
           cardKind: "image",
-          imageFileId: item.fileId,
+          previewFileId: item.fileId,
         })),
         hasChildren: children.length > 0,
         shouldDisplay,

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -16,7 +16,7 @@ const {
 } = createMediaPageHandlers({
   resourceType: "images",
   selectItemById: (store, { itemId }) => store.selectImageItemById({ itemId }),
-  getEditPreviewFileId: (item) => item?.fileId,
+  getEditPreviewFileId: (item) => item?.thumbnailFileId ?? item?.fileId,
 });
 
 export {
@@ -49,11 +49,12 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
   }
 
   for (const result of successfulUploads) {
-    await projectService.createImage({
+    const createResult = await projectService.createImage({
       imageId: nanoid(),
       data: {
         type: "image",
         fileId: result.fileId,
+        thumbnailFileId: result.thumbnailFileId,
         name: result.displayName,
         fileType: result.file.type,
         fileSize: result.file.size,
@@ -63,6 +64,12 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
       parentId,
       position: "last",
     });
+
+    if (createResult?.valid === false) {
+      console.error("Failed to create image:", createResult);
+      appService.showToast("Failed to create image.", { title: "Error" });
+      return;
+    }
   }
 
   await handleDataChanged(deps);
@@ -133,10 +140,11 @@ export const handleFormExtraEvent = async (deps) => {
   }
 
   const uploadResult = file.uploadResult;
-  await projectService.updateImage({
+  const updateResult = await projectService.updateImage({
     imageId: selectedItem.id,
     data: {
       fileId: uploadResult.fileId,
+      thumbnailFileId: uploadResult.thumbnailFileId,
       name: uploadResult.displayName,
       fileType: uploadResult.file.type,
       fileSize: uploadResult.file.size,
@@ -144,6 +152,12 @@ export const handleFormExtraEvent = async (deps) => {
       height: uploadResult.dimensions.height,
     },
   });
+
+  if (updateResult?.valid === false) {
+    console.error("Failed to update image:", updateResult);
+    appService.showToast("Failed to update image.", { title: "Error" });
+    return;
+  }
 
   await handleDataChanged(deps);
 };
@@ -187,7 +201,8 @@ export const handleEditDialogImageClick = async (deps) => {
 
   store.setEditUpload({
     uploadResult: file.uploadResult,
-    previewFileId: file.uploadResult.fileId,
+    previewFileId:
+      file.uploadResult.thumbnailFileId ?? file.uploadResult.fileId,
   });
   render();
 };
@@ -216,6 +231,7 @@ export const handleEditFormAction = async (deps, payload) => {
   const imagePatch = editUploadResult
     ? {
         fileId: editUploadResult.fileId,
+        thumbnailFileId: editUploadResult.thumbnailFileId,
         fileType: editUploadResult.file.type,
         fileSize: editUploadResult.file.size,
         width: editUploadResult.dimensions.width,
@@ -223,7 +239,7 @@ export const handleEditFormAction = async (deps, payload) => {
       }
     : {};
 
-  await projectService.updateImage({
+  const updateResult = await projectService.updateImage({
     imageId: editItemId,
     data: {
       name,
@@ -231,6 +247,12 @@ export const handleEditFormAction = async (deps, payload) => {
       ...imagePatch,
     },
   });
+
+  if (updateResult?.valid === false) {
+    console.error("Failed to update image:", updateResult);
+    appService.showToast("Failed to update image.", { title: "Error" });
+    return;
+  }
 
   store.closeEditDialog();
   await handleDataChanged(deps);

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -38,7 +38,7 @@ const buildMediaItem = (item) => ({
   id: item.id,
   name: item.name,
   cardKind: "image",
-  imageFileId: item.fileId,
+  previewFileId: item.thumbnailFileId ?? item.fileId,
   canPreview: true,
 });
 
@@ -98,7 +98,7 @@ const {
   buildDetailFields,
   buildMediaItem,
   createEditForm,
-  getSelectedPreviewFileId: (item) => item?.fileId,
+  getSelectedPreviewFileId: (item) => item?.thumbnailFileId ?? item?.fileId,
   extendViewData: ({ state, baseViewData }) => ({
     ...baseViewData,
     fullImagePreviewVisible: state.fullImagePreviewVisible,


### PR DESCRIPTION
## Summary
- generate transparent-preserving thumbnails for uploaded images and store `thumbnailFileId`
- use thumbnail-or-original preview ids across image list surfaces while keeping full preview on the original file
- update the client to consume the model thumbnail support from the pending model PR commit

Depends on:
- RouteVN/routevn-creator-model#2

## Testing
- bun run lint
- bun run test:smoke