### PR TITLE
feat: add layout right click actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.0.3",
         "@rettangoli/ui": "1.0.11",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "file:../routevn-creator-model",
+        "@routevn/creator-model": "1.0.2",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -257,7 +257,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@file:../routevn-creator-model", { "devDependencies": { "puty": "0.1.2", "vitest": "^3.2.1" } }],
+    "@routevn/creator-model": ["@routevn/creator-model@1.0.2", "", {}, "sha512-v2phDt/CvrFzRwDFPpUBzbBsJq1T3ycHG8MvZsZqniBCb+Ya79NYCDkeY7x0VnfsOJ5g0eYMUWs11iSKaIp4yQ=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.0.3",
         "@rettangoli/ui": "1.0.3",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.0.1",
+        "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#f9d7a7d",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -263,7 +263,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.0.1", "", {}, "sha512-Ul4VlLFcOxG77nnum4/30MZxp7MUnCLKfxJhD24rT+dy365JXFyUD+v3qI5/vJti3K2qIsOoxMOATbyD+rwZeg=="],
+    "@routevn/creator-model": ["@routevn/creator-model@github:RouteVN/routevn-creator-model#f9d7a7d", {}, "RouteVN-routevn-creator-model-f9d7a7d"],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "dependencies": {
         "@rettangoli/fe": "1.0.3",
-        "@rettangoli/ui": "1.0.3",
+        "@rettangoli/ui": "1.0.11",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#f9d7a7d",
+        "@routevn/creator-model": "file:../routevn-creator-model",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -111,12 +111,6 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
-
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
-
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
-
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -209,7 +203,7 @@
 
     "@rettangoli/fe": ["@rettangoli/fe@1.0.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "0.3.2-rc2", "js-yaml": "^4.1.0", "rxjs": "^7.8.2", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-rTUEYTe1xjf8M0bSaioB/C8E9L0x/X4gze4mgo2FHLQjE97iDAUfrSOqtzr95HdPZnp5OaSQ+vN0g2xzj0idKw=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.0.3", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@rettangoli/fe": "1.0.3", "commander": "^13.1.0", "jempl": "1.0.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "snabbdom": "^3.6.2" } }, "sha512-CQTlWaRpwwmyKrnDZpwzkSrEBMbF/tOF063Y0lrLp9hdnKmpIOSB1GLtalMEU7x1oZuLQq+zBStbNwVVOxS7UQ=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.0.11", "", { "dependencies": { "@rettangoli/fe": "1.0.4", "jempl": "1.0.1" } }, "sha512-wwdCxRbmf7vpfEmTKfnMZcC8ApeXsJY47vS6fddo+FKsEXpXiYcIlwJJJR6p2naZCQME9V29hbVMGHkzsBRuMQ=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.2", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-QHweZ2BJFiQi0mc8KvSLiFjKTm9ovjs++x9cOTtN89AyK/Pn0acuD0mA+kjOu4zgPcaHvjOAINNqMFsqhx9Hgw=="],
 
@@ -263,7 +257,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@github:RouteVN/routevn-creator-model#f9d7a7d", {}, "RouteVN-routevn-creator-model-f9d7a7d"],
+    "@routevn/creator-model": ["@routevn/creator-model@file:../routevn-creator-model", { "devDependencies": { "puty": "0.1.2", "vitest": "^3.2.1" } }],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 
@@ -849,7 +843,9 @@
 
     "@rettangoli/fe/jempl": ["jempl@0.3.2-rc2", "", {}, "sha512-8t6P7vO46Er0cpG00nYlmBIZw/5MhKCNnE0WBm+ZWMaGqi/MCexe1/Bl7SlbFQjgKsFXVC3cdT/K+4PD0XHUVg=="],
 
-    "@rettangoli/ui/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+    "@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.0.4", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-kZ+t2wN00upyn0tSekTj+BJDR/Pg1g126/btUfxr1NEtVl1SaFi5zvqcoEmBEatdULdgbFvo79h9xiVQ/Uk6+A=="],
+
+    "@rettangoli/ui/jempl": ["jempl@1.0.1", "", {}, "sha512-aeOlPrZV1KVhwtMYidkH1vGLlLrCTZ8fk3LlDxLGyTFsZUMHDtvSuqmrCimJL0u2LZFg1rtoE4/1NzGjwmIoUw=="],
 
     "@rettangoli/vt/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "~2",
     "@tauri-apps/plugin-updater": "^2.9.0",
-    "@routevn/creator-model": "1.0.1",
+    "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#f9d7a7d",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
     "insieme": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "dependencies": {
     "@rettangoli/fe": "1.0.3",
-    "@rettangoli/ui": "1.0.3",
+    "@rettangoli/ui": "1.0.11",
     "@rettangoli/vt": "1.0.2",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "~2",
     "@tauri-apps/plugin-updater": "^2.9.0",
-    "@routevn/creator-model": "git+https://github.com/RouteVN/routevn-creator-model.git#f9d7a7d",
+    "@routevn/creator-model": "file:../routevn-creator-model",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
     "insieme": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "~2",
     "@tauri-apps/plugin-updater": "^2.9.0",
-    "@routevn/creator-model": "file:../routevn-creator-model",
+    "@routevn/creator-model": "1.0.2",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
     "insieme": "1.3.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ set -e
 
 BUILD_TYPE=${1:-web}
 SETUP_FILE="src/setup.${BUILD_TYPE}.js"
-RETTANGOLI_VERSION="1.0.3"
+RETTANGOLI_VERSION="1.0.11"
 RETTANGOLI_URL="https://cdn.jsdelivr.net/npm/@rettangoli/ui@${RETTANGOLI_VERSION}/dist/rettangoli-iife-ui.min.js"
 RETTANGOLI_DIR="static/public/@rettangoli/ui@${RETTANGOLI_VERSION}/dist"
 RETTANGOLI_FILE="${RETTANGOLI_DIR}/rettangoli-iife-ui.min.js"

--- a/scripts/test-smoke.js
+++ b/scripts/test-smoke.js
@@ -8,7 +8,10 @@ import {
 } from "../src/deps/services/shared/projectRepository.js";
 import { buildLayoutRenderElements } from "../src/internal/project/layout.js";
 import { extractFileIdsFromRenderState } from "../src/internal/project/layout.js";
-import { projectRepositoryStateToDomainState } from "../src/internal/project/projection.js";
+import {
+  constructProjectData,
+  projectRepositoryStateToDomainState,
+} from "../src/internal/project/projection.js";
 import { toHierarchyStructure } from "../src/internal/project/tree.js";
 
 const projectId = "proj-smoke-001";
@@ -255,6 +258,31 @@ await applyCommandToRepository({
   projectId,
   command: makeEnvelope({
     scope: "resources",
+    partitions: [`project:${projectId}:resources:layouts`],
+    clientTs: 1075,
+    type: "layout.update",
+    payload: {
+      layoutId: "layout-main",
+      data: {
+        keyboard: {
+          enter: {
+            payload: {
+              actions: {
+                nextLine: {},
+              },
+            },
+          },
+        },
+      },
+    },
+  }),
+});
+
+await applyCommandToRepository({
+  repository,
+  projectId,
+  command: makeEnvelope({
+    scope: "resources",
     partitions: [`project:${projectId}:resources:characters`],
     clientTs: 1080,
     type: "character.create",
@@ -390,6 +418,15 @@ assert.equal(
   "payload.positionTargetId must reference a line in the target section",
 );
 assert.deepEqual(repository.getState(), beforeInvalidApply);
+assert.deepEqual(repositoryState.layouts.items["layout-main"].keyboard, {
+  enter: {
+    payload: {
+      actions: {
+        nextLine: {},
+      },
+    },
+  },
+});
 
 const layoutHierarchy = toHierarchyStructure(
   repositoryState.layouts.items["layout-main"].elements,
@@ -438,6 +475,9 @@ const domainState = projectRepositoryStateToDomainState({
   repositoryState,
   projectId,
 });
+const projectData = constructProjectData(repositoryState, {
+  initialSceneId: "scene-1",
+});
 assert.equal(domainState.story.initialSceneId, "scene-1");
 assert.deepEqual(domainState.scenes["scene-1"].sectionIds, [
   "section-1",
@@ -452,7 +492,25 @@ assert.equal(
     .fileId,
   "hero-smile.png",
 );
+assert.deepEqual(domainState.layouts.items["layout-main"].keyboard, {
+  enter: {
+    payload: {
+      actions: {
+        nextLine: {},
+      },
+    },
+  },
+});
+assert.deepEqual(projectData.resources.layouts["layout-main"].keyboard, {
+  enter: {
+    payload: {
+      actions: {
+        nextLine: {},
+      },
+    },
+  },
+});
 
-assert.equal(store._debug.getEvents().length, 13);
+assert.equal(store._debug.getEvents().length, 14);
 
 console.log("Smoke tests: PASS");

--- a/scripts/test-smoke.js
+++ b/scripts/test-smoke.js
@@ -171,6 +171,26 @@ await applyCommandToRepository({
   projectId,
   command: makeEnvelope({
     scope: "resources",
+    partitions: [`project:${projectId}:resources:files`],
+    clientTs: 1045,
+    type: "file.create",
+    payload: {
+      fileId: "hero.png",
+      data: {
+        type: "image",
+        mimeType: "image/png",
+        size: 1024,
+        sha256: "sha256-hero",
+      },
+    },
+  }),
+});
+
+await applyCommandToRepository({
+  repository,
+  projectId,
+  command: makeEnvelope({
+    scope: "resources",
     partitions: [`project:${projectId}:resources:images`],
     clientTs: 1050,
     type: "image.create",
@@ -278,6 +298,26 @@ await applyCommandToRepository({
       data: {
         type: "folder",
         name: "Expressions",
+      },
+    },
+  }),
+});
+
+await applyCommandToRepository({
+  repository,
+  projectId,
+  command: makeEnvelope({
+    scope: "resources",
+    partitions: [`project:${projectId}:resources:files`],
+    clientTs: 1095,
+    type: "file.create",
+    payload: {
+      fileId: "hero-smile.png",
+      data: {
+        type: "image",
+        mimeType: "image/png",
+        size: 2048,
+        sha256: "sha256-hero-smile",
       },
     },
   }),
@@ -413,6 +453,6 @@ assert.equal(
   "hero-smile.png",
 );
 
-assert.equal(store._debug.getEvents().length, 11);
+assert.equal(store._debug.getEvents().length, 13);
 
 console.log("Smoke tests: PASS");

--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -25,6 +25,12 @@ const SYSTEM_ACTIONS = [
     mode: "toggleSkipMode",
   },
   {
+    id: "18",
+    label: "Toggle Dialogue Box",
+    icon: "dialogue",
+    mode: "toggleDialogueUI",
+  },
+  {
     id: "15",
     label: "Push Layered View",
     icon: "layers",

--- a/src/components/commandLineChoices/commandLineChoices.handlers.js
+++ b/src/components/commandLineChoices/commandLineChoices.handlers.js
@@ -9,7 +9,7 @@ export const handleBeforeMount = (deps) => {
 export const handleAfterMount = async (deps) => {
   const { projectService, store, render } = deps;
   await projectService.ensureRepository();
-  const { scenes } = projectService.getState();
+  const { scenes } = projectService.getRepositoryState();
   store.setScenes({
     scenes,
   });

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js
@@ -1,7 +1,7 @@
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
-  const { scenes } = projectService.getState();
+  const { scenes } = projectService.getRepositoryState();
 
   // Safe access to nested properties
   const sectionTransition = props?.sectionTransition;

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.handlers.js
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.handlers.js
@@ -1,0 +1,36 @@
+export const handleFormChange = (deps, payload) => {
+  const { render } = deps;
+  const { values: formValues } = payload._event.detail;
+
+  if (!formValues) {
+    return;
+  }
+
+  render();
+};
+
+export const handleSubmitClick = (deps) => {
+  const { dispatchEvent } = deps;
+
+  const toggleDialogueUI = {};
+
+  dispatchEvent(
+    new CustomEvent("submit", {
+      detail: {
+        toggleDialogueUI,
+      },
+    }),
+  );
+};
+
+export const handleBreadcumbClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+
+  if (payload._event.detail.id === "actions") {
+    dispatchEvent(
+      new CustomEvent("back-to-actions", {
+        detail: {},
+      }),
+    );
+  }
+};

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.schema.yaml
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.schema.yaml
@@ -1,0 +1,6 @@
+componentName: rvn-command-line-toggle-dialogue-ui
+propsSchema:
+  type: object
+  properties:
+    toggleDialogueUI:
+      type: object

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.store.js
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.store.js
@@ -1,0 +1,39 @@
+export const createInitialState = () => ({
+  defaultValues: {},
+
+  form: {
+    fields: [
+      {
+        name: "placeholder",
+        type: "read-only-text",
+        label: "Toggle Dialogue Box Action",
+        description: "This action will show or hide the dialogue box",
+        required: false,
+      },
+    ],
+    actions: {
+      layout: "",
+      buttons: [],
+    },
+  },
+});
+
+export const selectViewData = ({ state }) => {
+  const breadcrumb = [
+    {
+      id: "actions",
+      label: "Actions",
+      click: true,
+    },
+    {
+      label: "Toggle Dialogue Box",
+    },
+  ];
+
+  return {
+    submitDisabled: false,
+    breadcrumb,
+    form: state.form,
+    defaultValues: state.defaultValues,
+  };
+};

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
@@ -1,0 +1,20 @@
+refs:
+  breadcumb:
+    eventListeners:
+      item-click:
+        handler: handleBreadcumbClick
+  toggleDialogueUIForm:
+    eventListeners:
+      form-change:
+        handler: handleFormChange
+  submitButton:
+    eventListeners:
+      click:
+        handler: handleSubmitClick
+template:
+  - rtgl-view w=f h=f p=lg:
+      - rtgl-breadcrumb#breadcumb :items=breadcrumb: null
+      - rtgl-form#toggleDialogueUIForm :defaultValues=defaultValues :form=form w=f: null
+      - rtgl-view h=1fg: null
+      - rtgl-view d=h av=c ah=e w=f g=lg:
+          - rtgl-button#submitButton: Submit

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -3,6 +3,14 @@ import {
   getInteractionPayload,
 } from "../../internal/project/interactionPayload.js";
 
+const ACTION_INTERACTION_TYPES = ["click", "rightClick"];
+
+const getInteractionPropertyName = (interactionType) => {
+  return ACTION_INTERACTION_TYPES.includes(interactionType)
+    ? interactionType
+    : "click";
+};
+
 export const handleBeforeMount = (deps) => {
   const { props, store } = deps;
   const values = props.values || {};
@@ -93,6 +101,24 @@ export const handleSectionActionClick = async (deps, payload) => {
   const id = _event.currentTarget.dataset.id;
 
   if (id === "actions") {
+    const result = await appService.showDropdownMenu({
+      items: [
+        { type: "item", label: "Click", key: "click" },
+        { type: "item", label: "Right Click", key: "rightClick" },
+      ],
+      x: _event.clientX,
+      y: _event.clientY,
+      place: "bs",
+    });
+    if (!result) {
+      return;
+    }
+
+    const { item } = result;
+    const interactionType = getInteractionPropertyName(item.key);
+    store.setActiveInteractionType({
+      interactionType,
+    });
     const systemActions = refs["systemActions"];
     systemActions.transformedHandlers.open({
       mode: "actions",
@@ -155,16 +181,22 @@ export const handleFormActions = (deps, payload) => {
 
 export const handleActionsChange = (deps, payload) => {
   const { store, render, dispatchEvent } = deps;
+  const interactionType = store.selectActiveInteractionType();
+  const interactionKey = getInteractionPropertyName(interactionType);
 
-  const currentActions = getInteractionActions(store.selectValues().click);
+  const currentActions = getInteractionActions(
+    store.selectValues()[interactionKey],
+  );
   const newActions = {
     ...currentActions,
     ...payload._event.detail,
   };
-  const currentPayload = getInteractionPayload(store.selectValues().click);
+  const currentPayload = getInteractionPayload(
+    store.selectValues()[interactionKey],
+  );
 
   store.updateValueProperty({
-    name: "click.payload",
+    name: `${interactionKey}.payload`,
     value: {
       ...currentPayload,
       actions: newActions,
@@ -178,7 +210,7 @@ export const handleActionsChange = (deps, payload) => {
     new CustomEvent("update", {
       detail: {
         formValues,
-        name: "click.payload.actions",
+        name: `${interactionKey}.payload.actions`,
         value: newActions,
       },
     }),
@@ -269,10 +301,13 @@ export const handleListBarItemRightClick = async (deps, payload) => {
 
 // --- List Item ---
 export const handleListItemClick = async (deps, payload) => {
-  const { render, refs } = deps;
+  const { render, refs, store } = deps;
   const { _event: event } = payload;
   const systemActions = refs["systemActions"];
-  const { id } = event.currentTarget.dataset;
+  const { id, interaction } = event.currentTarget.dataset;
+  store.setActiveInteractionType({
+    interactionType: getInteractionPropertyName(interaction),
+  });
   systemActions.transformedHandlers.open({
     mode: id,
   });
@@ -283,7 +318,8 @@ export const handleListItemRightClick = async (deps, payload) => {
   const { render, store, appService, dispatchEvent } = deps;
   const { _event: event } = payload;
   event.preventDefault();
-  const id = event.currentTarget.dataset.id;
+  const { id, interaction } = event.currentTarget.dataset;
+  const interactionKey = getInteractionPropertyName(interaction);
   const result = await appService.showDropdownMenu({
     items: [{ type: "item", label: "Remove", key: "remove" }],
     x: event.clientX,
@@ -295,12 +331,16 @@ export const handleListItemRightClick = async (deps, payload) => {
   }
   const { item } = result;
   if (item.key === "remove") {
-    const currentActions = getInteractionActions(store.selectValues().click);
+    const currentActions = getInteractionActions(
+      store.selectValues()[interactionKey],
+    );
     const actions = structuredClone(currentActions);
-    const currentPayload = getInteractionPayload(store.selectValues().click);
+    const currentPayload = getInteractionPayload(
+      store.selectValues()[interactionKey],
+    );
     delete actions[id];
     store.updateValueProperty({
-      name: "click.payload",
+      name: `${interactionKey}.payload`,
       value: {
         ...currentPayload,
         actions,
@@ -312,7 +352,7 @@ export const handleListItemRightClick = async (deps, payload) => {
         bubbles: true,
         detail: {
           formValues,
-          name: "click.payload.actions",
+          name: `${interactionKey}.payload.actions`,
           value: actions,
         },
       }),

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -4,6 +4,41 @@ import { getFirstTextStyleId } from "../../constants/textStyles.js";
 import { getVariableOptions } from "../../internal/project/projection.js";
 import { getInteractionActions } from "../../internal/project/interactionPayload.js";
 
+const ACTION_INTERACTION_LABELS = {
+  click: "Click",
+  rightClick: "Right Click",
+};
+
+const ACTION_LABELS = {
+  nextLine: "Next Line",
+  sectionTransition: "Section Transition",
+  toggleAutoMode: "Toggle Auto Mode",
+  toggleSkipMode: "Toggle Skip Mode",
+  toggleDialogueUI: "Toggle Dialogue Box",
+  pushLayeredView: "Push Layered View",
+  popLayeredView: "Pop Layered View",
+  updateVariable: "Update Variable",
+};
+
+const ACTION_INTERACTION_TYPES = ["click", "rightClick"];
+
+const getLayoutInteractionActions = (values, interactionType) => {
+  return getInteractionActions(values?.[interactionType]);
+};
+
+const toLayoutActionItems = (values) => {
+  return ACTION_INTERACTION_TYPES.flatMap((interactionType) =>
+    Object.entries(getLayoutInteractionActions(values, interactionType)).map(
+      ([key]) => ({
+        id: key,
+        interactionType,
+        label: `${ACTION_INTERACTION_LABELS[interactionType]}: ${ACTION_LABELS[key] ?? key}`,
+        svg: `action-${key}`,
+      }),
+    ),
+  );
+};
+
 const config = {
   sections: [
     {
@@ -533,6 +568,7 @@ export const createInitialState = () => {
       gap: 0,
       actions: {},
     },
+    activeInteractionType: "click",
   };
 };
 
@@ -645,6 +681,21 @@ export const setValues = ({ state }, { values } = {}) => {
   state.values = values ?? {};
 };
 
+export const setActiveInteractionType = (
+  { state },
+  { interactionType } = {},
+) => {
+  if (!ACTION_INTERACTION_TYPES.includes(interactionType)) {
+    return;
+  }
+
+  state.activeInteractionType = interactionType;
+};
+
+export const selectActiveInteractionType = ({ state }) => {
+  return state.activeInteractionType ?? "click";
+};
+
 export const setTextStylesData = ({ state }, { textStylesData } = {}) => {
   state.textStylesData = textStylesData;
 };
@@ -693,16 +744,6 @@ export const selectViewData = ({ state, props: attrs }) => {
     ...variableOptions,
   ];
 
-  const actionsLabelMap = {
-    nextLine: "Next Line",
-    sectionTransition: "Section Transition",
-    toggleAutoMode: "Toggle Auto Mode",
-    toggleSkipMode: "Toggle Skip Mode",
-    pushLayeredView: "Push Layered View",
-    popLayeredView: "Pop Layered View",
-    updateVariable: "Update Variable",
-  };
-
   const context = {
     itemType: attrs.itemType,
     layoutType: attrs.layoutType,
@@ -714,13 +755,7 @@ export const selectViewData = ({ state, props: attrs }) => {
       textStyleId: state.values?.textStyleId || firstTextStyleId || "",
       hoverTextStyleId: state.values?.hoverTextStyleId ?? "",
       clickTextStyleId: state.values?.clickTextStyleId ?? "",
-      actions: Object.entries(getInteractionActions(state.values?.click)).map(
-        ([key, _value]) => ({
-          id: key,
-          label: actionsLabelMap[key],
-          svg: `action-${key}`,
-        }),
-      ),
+      actions: toLayoutActionItems(state.values),
     },
   };
 
@@ -729,7 +764,10 @@ export const selectViewData = ({ state, props: attrs }) => {
   return {
     actionsDialogOpen: state.actionsDialogOpen,
     values: state.values,
-    actionsData: getInteractionActions(state.values?.click),
+    actionsData: getLayoutInteractionActions(
+      state.values,
+      state.activeInteractionType,
+    ),
     config: finalConfig,
     popover: state.popover,
     imageSelectorDialog: state.imageSelectorDialog,

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -82,7 +82,7 @@ template:
                           - rtgl-select#selectItem${i}x${j} data-name=${item.name} w=f no-clear :selectedValue=#{item.value} :options=#{item.options}: null
                 $elif item.type == 'list-item':
                   - $for listItem, k in item.items:
-                      - rtgl-view#listItem${i}x${j}x${k} data-id=${listItem.id} d=h w=f g=md av=c p=md br=md bw=xs h-bgc=mu cur=pointer:
+                      - rtgl-view#listItem${i}x${j}x${k} data-id=${listItem.id} data-interaction=${listItem.interactionType} d=h w=f g=md av=c p=md br=md bw=xs h-bgc=mu cur=pointer:
                           - rtgl-svg svg=${listItem.svg} wh=16: null
                           - rtgl-text s=xs: ${listItem.label}
                 $elif item.type == 'list-bar':

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -294,6 +294,11 @@ export const selectActionsData = ({ props, state }) => {
     preview.toggleSkipMode = actions.toggleSkipMode;
   }
 
+  if (actions.toggleDialogueUI !== undefined) {
+    actionsObject.toggleDialogueUI = actions.toggleDialogueUI;
+    preview.toggleDialogueUI = actions.toggleDialogueUI;
+  }
+
   // Visual
   if (presentationState.visual?.items) {
     actionsObject.visual = presentationState.visual;

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -30,7 +30,7 @@ refs:
 template:
   - $if showSelected:
       - rtgl-view g=md w=f:
-          - $if preview.background || preview.bgm || preview.sfx || preview.character || preview.visual || preview.sectionTransition || preview.dialogue || preview.choice || preview.base || preview.nextLine || preview.toggleAutoMode || preview.toggleSkipMode || preview.setNextLineConfig || preview.pushLayeredView || preview.popLayeredView || preview.updateVariable:
+          - $if preview.background || preview.bgm || preview.sfx || preview.character || preview.visual || preview.sectionTransition || preview.dialogue || preview.choice || preview.base || preview.nextLine || preview.toggleAutoMode || preview.toggleSkipMode || preview.toggleDialogueUI || preview.setNextLineConfig || preview.pushLayeredView || preview.popLayeredView || preview.updateVariable:
               - $if preview.base:
                   - rtgl-view#actionItemBase data-mode=base g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=screen wh=24: null
@@ -93,6 +93,10 @@ template:
                   - rtgl-view#actionItemToggleSkipMode data-mode=toggleSkipMode g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg="next-line" wh=24: null
                       - rtgl-text s=sm: Toggle Skip Mode
+              - $if preview.toggleDialogueUI:
+                  - rtgl-view#actionItemToggleDialogueUI data-mode=toggleDialogueUI g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
+                      - rtgl-svg svg="dialogue" wh=24: null
+                      - rtgl-text s=sm: Toggle Dialogue Box
               - $if preview.pushLayeredView:
                   - rtgl-view#actionItemPushLayeredView data-mode=pushLayeredView g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg="layers" wh=24: null
@@ -138,6 +142,8 @@ template:
               - rvn-command-line-toggle-auto-mode#commandLineToggleAutoMode :toggleAutoMode=actions.toggleAutoMode: null
             $elif mode == "toggleSkipMode":
               - rvn-command-line-toggle-skip-mode#commandLineToggleSkipMode :toggleSkipMode=actions.toggleSkipMode: null
+            $elif mode == "toggleDialogueUI":
+              - rvn-command-line-toggle-dialogue-ui#commandLineToggleDialogueUI :toggleDialogueUI=actions.toggleDialogueUI: null
             $elif mode == "pushLayeredView":
               - rvn-command-line-push-layered-view#commandLinePushLayeredView :pushLayeredView=actions.pushLayeredView: null
             $elif mode == "popLayeredView":

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -22,6 +22,7 @@ export const createGraphicsService = async ({ subject }) => {
   let beforeHandleActions;
   let actionQueue = Promise.resolve();
   let assetLoadQueue = Promise.resolve();
+  let pendingClickInteractionTimeouts = new Map();
 
   const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
 
@@ -99,6 +100,38 @@ export const createGraphicsService = async ({ subject }) => {
       });
   };
 
+  const clearPendingClickInteraction = (interactionId) => {
+    const timeoutId = pendingClickInteractionTimeouts.get(interactionId);
+    if (timeoutId === undefined) {
+      return;
+    }
+
+    clearTimeout(timeoutId);
+    pendingClickInteractionTimeouts.delete(interactionId);
+  };
+
+  const clearAllPendingClickInteractions = () => {
+    for (const timeoutId of pendingClickInteractionTimeouts.values()) {
+      clearTimeout(timeoutId);
+    }
+    pendingClickInteractionTimeouts = new Map();
+  };
+
+  const scheduleClickInteraction = (actions, eventContext) => {
+    const interactionId = eventContext?._event?.id ?? "__unknown__";
+    clearPendingClickInteraction(interactionId);
+
+    // Route Graphics currently emits the generic click path on right mouse
+    // release for some element plugins. Delay left-click processing one task
+    // so a same-element rightClick can cancel it.
+    const timeoutId = setTimeout(() => {
+      pendingClickInteractionTimeouts.delete(interactionId);
+      enqueueInteractionActions(actions, eventContext);
+    }, 0);
+
+    pendingClickInteractionTimeouts.set(interactionId, timeoutId);
+  };
+
   return {
     init: async (options = {}) => {
       if (routeGraphics) {
@@ -112,6 +145,7 @@ export const createGraphicsService = async ({ subject }) => {
       beforeHandleActions = onBeforeHandleActions;
       actionQueue = Promise.resolve();
       assetLoadQueue = Promise.resolve();
+      clearAllPendingClickInteractions();
       assetBufferManager = createAssetBufferManager();
       routeGraphics = createRouteGraphics();
 
@@ -160,10 +194,23 @@ export const createGraphicsService = async ({ subject }) => {
           }
 
           if (payload.actions && engine) {
-            enqueueInteractionActions(
-              payload.actions,
-              payload._event ? { _event: payload._event } : undefined,
-            );
+            const eventContext = payload._event
+              ? { _event: payload._event }
+              : undefined;
+            const interactionId = eventContext?._event?.id ?? "__unknown__";
+
+            if (eventName === "rightClick") {
+              clearPendingClickInteraction(interactionId);
+              enqueueInteractionActions(payload.actions, eventContext);
+              return;
+            }
+
+            if (eventName === "click") {
+              scheduleClickInteraction(payload.actions, eventContext);
+              return;
+            }
+
+            enqueueInteractionActions(payload.actions, eventContext);
           }
         },
       });
@@ -242,6 +289,7 @@ export const createGraphicsService = async ({ subject }) => {
       beforeHandleActions = undefined;
       actionQueue = Promise.resolve();
       assetLoadQueue = Promise.resolve();
+      clearAllPendingClickInteractions();
       ticker.stop();
     },
   };

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -14,6 +14,7 @@ import createRouteEngine, { createEffectsHandler } from "route-engine-js";
 import { Ticker } from "pixi.js";
 
 export const createGraphicsService = async ({ subject }) => {
+  const RIGHT_CLICK_EVENT_NAMES = new Set(["rightclick", "rightClick"]);
   let routeGraphics;
   let engine;
   let assetBufferManager;
@@ -199,7 +200,7 @@ export const createGraphicsService = async ({ subject }) => {
               : undefined;
             const interactionId = eventContext?._event?.id ?? "__unknown__";
 
-            if (eventName === "rightClick") {
+            if (RIGHT_CLICK_EVENT_NAMES.has(eventName)) {
               clearPendingClickInteraction(interactionId);
               enqueueInteractionActions(payload.actions, eventContext);
               return;

--- a/src/deps/services/shared/commandApi/characterSprites.js
+++ b/src/deps/services/shared/commandApi/characterSprites.js
@@ -5,12 +5,21 @@ export const createCharacterSpriteCommandApi = (shared) => ({
     characterId,
     spriteId,
     data,
+    fileRecords = [],
     parentId = null,
     position = "last",
     positionTargetId,
     index,
   }) {
     const context = await shared.ensureCommandContext();
+    const ensureFilesResult = await shared.ensureFilesExist({
+      context,
+      fileRecords,
+    });
+    if (ensureFilesResult?.valid === false) {
+      return ensureFilesResult;
+    }
+
     const nextSpriteId = spriteId || shared.createId();
     const character = context.state?.characters?.items?.[characterId];
     const resolvedIndex = shared.resolveCharacterSpriteIndex({
@@ -51,8 +60,21 @@ export const createCharacterSpriteCommandApi = (shared) => ({
     return nextSpriteId;
   },
 
-  async updateCharacterSpriteItem({ characterId, spriteId, data }) {
+  async updateCharacterSpriteItem({
+    characterId,
+    spriteId,
+    data,
+    fileRecords = [],
+  }) {
     const context = await shared.ensureCommandContext();
+    const ensureFilesResult = await shared.ensureFilesExist({
+      context,
+      fileRecords,
+    });
+    if (ensureFilesResult?.valid === false) {
+      return ensureFilesResult;
+    }
+
     const resourcePartition = shared.resourceTypePartitionFor(
       context.projectId,
       "characters",

--- a/src/deps/services/shared/commandApi/layouts.js
+++ b/src/deps/services/shared/commandApi/layouts.js
@@ -78,6 +78,26 @@ export const createLayoutCommandApi = (shared) => ({
     });
   },
 
+  async updateLayoutItem({ layoutId, data }) {
+    const context = await shared.ensureCommandContext();
+    const resourcePartition = shared.resourceTypePartitionFor(
+      context.projectId,
+      "layouts",
+    );
+
+    return shared.submitCommandWithContext({
+      context,
+      scope: "resources",
+      basePartition: resourcePartition,
+      type: COMMAND_TYPES.LAYOUT_UPDATE,
+      payload: {
+        layoutId,
+        data: structuredClone(data || {}),
+      },
+      partitions: [],
+    });
+  },
+
   async deleteLayoutItem({ layoutIds }) {
     const context = await shared.ensureCommandContext();
     const resourcePartition = shared.resourceTypePartitionFor(

--- a/src/deps/services/shared/commandApi/resources/catalog.js
+++ b/src/deps/services/shared/commandApi/resources/catalog.js
@@ -65,6 +65,7 @@ export const createCatalogResourceCommandApi = (shared) => ({
   createCharacter: async ({
     characterId,
     data,
+    fileRecords,
     parentId,
     position = "last",
     positionTargetId,
@@ -77,12 +78,13 @@ export const createCatalogResourceCommandApi = (shared) => ({
       idField: "characterId",
       idValue: characterId,
       data,
+      fileRecords,
       parentId,
       position,
       positionTargetId,
       index,
     }),
-  updateCharacter: async ({ characterId, data }) =>
+  updateCharacter: async ({ characterId, data, fileRecords }) =>
     submitUpdateResourceCommand({
       shared,
       resourceType: "characters",
@@ -90,6 +92,7 @@ export const createCatalogResourceCommandApi = (shared) => ({
       idField: "characterId",
       idValue: characterId,
       data,
+      fileRecords,
     }),
   moveCharacter: async ({
     characterId,

--- a/src/deps/services/shared/commandApi/resources/media.js
+++ b/src/deps/services/shared/commandApi/resources/media.js
@@ -10,6 +10,7 @@ export const createMediaResourceCommandApi = (shared) => ({
   createImage: async ({
     imageId,
     data,
+    fileRecords,
     parentId,
     position = "last",
     positionTargetId,
@@ -22,12 +23,13 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "imageId",
       idValue: imageId,
       data,
+      fileRecords,
       parentId,
       position,
       positionTargetId,
       index,
     }),
-  updateImage: async ({ imageId, data }) =>
+  updateImage: async ({ imageId, data, fileRecords }) =>
     submitUpdateResourceCommand({
       shared,
       resourceType: "images",
@@ -35,6 +37,7 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "imageId",
       idValue: imageId,
       data,
+      fileRecords,
     }),
   moveImage: async ({
     imageId,
@@ -65,6 +68,7 @@ export const createMediaResourceCommandApi = (shared) => ({
   createSound: async ({
     soundId,
     data,
+    fileRecords,
     parentId,
     position = "last",
     positionTargetId,
@@ -77,12 +81,13 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "soundId",
       idValue: soundId,
       data,
+      fileRecords,
       parentId,
       position,
       positionTargetId,
       index,
     }),
-  updateSound: async ({ soundId, data }) =>
+  updateSound: async ({ soundId, data, fileRecords }) =>
     submitUpdateResourceCommand({
       shared,
       resourceType: "sounds",
@@ -90,6 +95,7 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "soundId",
       idValue: soundId,
       data,
+      fileRecords,
     }),
   moveSound: async ({
     soundId,
@@ -120,6 +126,7 @@ export const createMediaResourceCommandApi = (shared) => ({
   createVideo: async ({
     videoId,
     data,
+    fileRecords,
     parentId,
     position = "last",
     positionTargetId,
@@ -132,12 +139,13 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "videoId",
       idValue: videoId,
       data,
+      fileRecords,
       parentId,
       position,
       positionTargetId,
       index,
     }),
-  updateVideo: async ({ videoId, data }) =>
+  updateVideo: async ({ videoId, data, fileRecords }) =>
     submitUpdateResourceCommand({
       shared,
       resourceType: "videos",
@@ -145,6 +153,7 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "videoId",
       idValue: videoId,
       data,
+      fileRecords,
     }),
   moveVideo: async ({
     videoId,
@@ -175,6 +184,7 @@ export const createMediaResourceCommandApi = (shared) => ({
   createFont: async ({
     fontId,
     data,
+    fileRecords,
     parentId,
     position = "last",
     positionTargetId,
@@ -187,12 +197,13 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "fontId",
       idValue: fontId,
       data,
+      fileRecords,
       parentId,
       position,
       positionTargetId,
       index,
     }),
-  updateFont: async ({ fontId, data }) =>
+  updateFont: async ({ fontId, data, fileRecords }) =>
     submitUpdateResourceCommand({
       shared,
       resourceType: "fonts",
@@ -200,6 +211,7 @@ export const createMediaResourceCommandApi = (shared) => ({
       idField: "fontId",
       idValue: fontId,
       data,
+      fileRecords,
     }),
   moveFont: async ({
     fontId,

--- a/src/deps/services/shared/commandApi/resources/shared.js
+++ b/src/deps/services/shared/commandApi/resources/shared.js
@@ -13,8 +13,17 @@ export const submitCreateResourceCommand = async ({
   position = "last",
   positionTargetId,
   index,
+  fileRecords = [],
 }) => {
   const context = await shared.ensureCommandContext();
+  const ensureFilesResult = await shared.ensureFilesExist({
+    context,
+    fileRecords,
+  });
+  if (ensureFilesResult?.valid === false) {
+    return ensureFilesResult;
+  }
+
   const nextResourceId = idValue ?? shared.createId();
   const resolvedIndex = shared.resolveResourceIndex({
     state: context.state,
@@ -61,8 +70,16 @@ export const submitUpdateResourceCommand = async ({
   idField,
   idValue,
   data,
+  fileRecords = [],
 }) => {
   const context = await shared.ensureCommandContext();
+  const ensureFilesResult = await shared.ensureFilesExist({
+    context,
+    fileRecords,
+  });
+  if (ensureFilesResult?.valid === false) {
+    return ensureFilesResult;
+  }
 
   return shared.submitCommandWithContext({
     context,

--- a/src/deps/services/shared/commandApi/shared.js
+++ b/src/deps/services/shared/commandApi/shared.js
@@ -1,5 +1,6 @@
 import { createCommandEnvelope } from "../collab/commandEnvelope.js";
 import { projectRepositoryStateToDomainState } from "../../../../internal/project/projection.js";
+import { COMMAND_TYPES } from "../../../../internal/project/commands.js";
 import {
   applyCommandToRepository,
   assertSupportedProjectState,
@@ -40,6 +41,9 @@ export const createCommandApiShared = ({
     const value = Number(now());
     return Number.isFinite(value) ? value : 0;
   };
+
+  const filePartitionFor = (projectId) =>
+    resourceTypePartitionFor(projectId, "files");
 
   const ensureCommandContext = async () => {
     const repository = await getCurrentRepository();
@@ -105,6 +109,70 @@ export const createCommandApiShared = ({
       eventCount: applyResult.events.length,
       applyMode: applyResult.mode,
     };
+  };
+
+  const ensureFilesExist = async ({ context, fileRecords = [] } = {}) => {
+    const normalizedFileRecords = Array.isArray(fileRecords) ? fileRecords : [];
+    if (normalizedFileRecords.length === 0) {
+      return { valid: true, createdCount: 0 };
+    }
+
+    const knownFileIds = new Set(
+      Object.keys(context.state?.files?.items || {}),
+    );
+    let createdCount = 0;
+
+    for (const fileRecord of normalizedFileRecords) {
+      if (
+        !fileRecord ||
+        typeof fileRecord.id !== "string" ||
+        fileRecord.id.length === 0
+      ) {
+        throw new Error("fileRecords must include a non-empty id");
+      }
+
+      if (knownFileIds.has(fileRecord.id)) {
+        continue;
+      }
+
+      if (
+        typeof fileRecord.type !== "string" ||
+        fileRecord.type.length === 0 ||
+        typeof fileRecord.mimeType !== "string" ||
+        fileRecord.mimeType.length === 0 ||
+        !Number.isFinite(fileRecord.size) ||
+        typeof fileRecord.sha256 !== "string" ||
+        fileRecord.sha256.length === 0
+      ) {
+        throw new Error(
+          `fileRecord ${fileRecord.id} is missing required metadata`,
+        );
+      }
+
+      const submitResult = await submitCommandWithContext({
+        context,
+        scope: "resources",
+        basePartition: filePartitionFor(context.projectId),
+        type: COMMAND_TYPES.FILE_CREATE,
+        payload: {
+          fileId: fileRecord.id,
+          data: {
+            type: fileRecord.type,
+            mimeType: fileRecord.mimeType,
+            size: fileRecord.size,
+            sha256: fileRecord.sha256,
+          },
+        },
+      });
+      if (submitResult?.valid === false) {
+        return submitResult;
+      }
+
+      knownFileIds.add(fileRecord.id);
+      createdCount += 1;
+    }
+
+    return { valid: true, createdCount };
   };
 
   const buildPlacementPayload = ({
@@ -266,6 +334,7 @@ export const createCommandApiShared = ({
     createId,
     getCurrentProjectId,
     ensureCommandContext,
+    ensureFilesExist,
     submitCommandWithContext,
     buildPlacementPayload,
     resolveResourceIndex,
@@ -274,6 +343,7 @@ export const createCommandApiShared = ({
     resolveLineIndex,
     resolveLayoutElementIndex,
     resolveCharacterSpriteIndex,
+    filePartitionFor,
     storyBasePartitionFor,
     storyScenePartitionFor,
     resourceTypePartitionFor,

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -11,6 +11,37 @@ import { loadFont } from "./fontLoader.js";
 const IMAGE_THUMBNAIL_MAX_WIDTH = 320;
 const IMAGE_THUMBNAIL_MAX_HEIGHT = 320;
 const IMAGE_THUMBNAIL_MIN_FILE_SIZE_BYTES = 32 * 1024;
+const FILE_RECORD_DEFAULT_MIME_TYPES = Object.freeze({
+  image: "image/png",
+  "image-thumbnail": "image/webp",
+  audio: "audio/mpeg",
+  "audio-waveform": "application/json",
+  video: "video/mp4",
+  "video-thumbnail": "image/jpeg",
+  font: "font/ttf",
+});
+
+const bufferToHex = (buffer) =>
+  Array.from(new Uint8Array(buffer), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+
+const getFileRecordMimeType = ({ file, type }) =>
+  file.type ||
+  FILE_RECORD_DEFAULT_MIME_TYPES[type] ||
+  "application/octet-stream";
+
+const computeSha256 = async (file) => {
+  if (!crypto?.subtle?.digest) {
+    throw new Error("SHA-256 hashing is unavailable in this runtime.");
+  }
+
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    await file.arrayBuffer(),
+  );
+  return bufferToHex(digest);
+};
 
 const storeMetadata = async ({ data, storeFile, idGenerator }) => {
   const jsonString = JSON.stringify(data, null, 2);
@@ -40,6 +71,24 @@ export const createProjectAssetService = ({
     });
   };
 
+  const storeFileWithRecord = async ({ file, type }) => {
+    const [stored, sha256] = await Promise.all([
+      storeFile(file),
+      computeSha256(file),
+    ]);
+
+    return {
+      ...stored,
+      fileRecord: {
+        id: stored.fileId,
+        type,
+        mimeType: getFileRecordMimeType({ file, type }),
+        size: file.size,
+        sha256,
+      },
+    };
+  };
+
   const getFileContent = async (fileId) => {
     return fileAdapter.getFileContent({
       fileId,
@@ -55,7 +104,7 @@ export const createProjectAssetService = ({
     if (fileType === "image") {
       const [dimensions, stored] = await Promise.all([
         getImageDimensions(file),
-        storeFile(file),
+        storeFileWithRecord({ file, type: "image" }),
       ]);
 
       const shouldReuseOriginalAsThumbnail =
@@ -70,6 +119,7 @@ export const createProjectAssetService = ({
           thumbnailFileId: stored.fileId,
           dimensions,
           type: "image",
+          fileRecords: [stored.fileRecord],
         };
       }
 
@@ -79,13 +129,17 @@ export const createProjectAssetService = ({
         preferredFormat: "image/webp",
         quality: 0.85,
       });
-      const thumbnailResult = await storeFile(thumbnailData.blob);
+      const thumbnailResult = await storeFileWithRecord({
+        file: thumbnailData.blob,
+        type: "image-thumbnail",
+      });
       return {
         ...stored,
         thumbnailFileId: thumbnailResult.fileId,
         thumbnailData,
         dimensions,
         type: "image",
+        fileRecords: [stored.fileRecord, thumbnailResult.fileRecord],
       };
     }
 
@@ -99,9 +153,13 @@ export const createProjectAssetService = ({
       });
 
       const waveformData = await extractWaveformData(fileForWaveform);
-      const stored = await storeFile(fileForStorage);
+      const stored = await storeFileWithRecord({
+        file: fileForStorage,
+        type: "audio",
+      });
 
       let waveformDataFileId = null;
+      let waveformResult = null;
       if (waveformData) {
         const compressedWaveformData = {
           ...waveformData,
@@ -109,9 +167,13 @@ export const createProjectAssetService = ({
             Math.round(value * 255),
           ),
         };
-        const waveformResult = await storeMetadata({
+        waveformResult = await storeMetadata({
           data: compressedWaveformData,
-          storeFile,
+          storeFile: (metadataFile) =>
+            storeFileWithRecord({
+              file: metadataFile,
+              type: "audio-waveform",
+            }),
           idGenerator,
         });
         waveformDataFileId = waveformResult.fileId;
@@ -123,6 +185,10 @@ export const createProjectAssetService = ({
         waveformData,
         duration: waveformData?.duration,
         type: "audio",
+        fileRecords: [
+          stored.fileRecord,
+          ...(waveformResult ? [waveformResult.fileRecord] : []),
+        ],
       };
     }
 
@@ -138,8 +204,11 @@ export const createProjectAssetService = ({
         }),
       ]);
       const [videoResult, thumbnailResult] = await Promise.all([
-        storeFile(file),
-        storeFile(thumbnailData.blob),
+        storeFileWithRecord({ file, type: "video" }),
+        storeFileWithRecord({
+          file: thumbnailData.blob,
+          type: "video-thumbnail",
+        }),
       ]);
       return {
         ...videoResult,
@@ -147,6 +216,7 @@ export const createProjectAssetService = ({
         thumbnailData,
         dimensions,
         type: "video",
+        fileRecords: [videoResult.fileRecord, thumbnailResult.fileRecord],
       };
     }
 
@@ -161,12 +231,16 @@ export const createProjectAssetService = ({
         throw new Error(`Invalid font file: ${loadError.message}`);
       }
 
-      const stored = await storeFile(file);
+      const stored = await storeFileWithRecord({
+        file,
+        type: "font",
+      });
       return {
         ...stored,
         fontName,
         fontUrl,
         type: "font",
+        fileRecords: [stored.fileRecord],
       };
     }
 
@@ -174,6 +248,7 @@ export const createProjectAssetService = ({
     return {
       ...stored,
       type: "generic",
+      fileRecords: [],
     };
   };
 

--- a/src/deps/services/shared/projectCollabCore.js
+++ b/src/deps/services/shared/projectCollabCore.js
@@ -1,5 +1,5 @@
 import { createWebSocketTransport } from "../web/collab/createWebSocketTransport.js";
-import { RESOURCE_TYPES } from "../../../internal/project/commands.js";
+import { COLLAB_RESOURCE_TYPES } from "../../../internal/project/commands.js";
 import { recursivelyCheckResource } from "../../../internal/project/projection.js";
 import { createCommandApi } from "./commandApi.js";
 
@@ -36,7 +36,7 @@ export const createProjectCollabCore = ({
   const getBasePartitions = (projectId, partitions) =>
     partitions || [
       storyBasePartitionFor(projectId),
-      ...RESOURCE_TYPES.map((resourceType) =>
+      ...COLLAB_RESOURCE_TYPES.map((resourceType) =>
         resourceTypePartitionFor(projectId, resourceType),
       ),
       `project:${projectId}:layouts`,

--- a/src/deps/services/shared/projectRepository.js
+++ b/src/deps/services/shared/projectRepository.js
@@ -24,6 +24,7 @@ export const initialProjectData = {
   story: {
     initialSceneId: null,
   },
+  files: createTreeCollection(),
   images: createTreeCollection(),
   sounds: createTreeCollection(),
   videos: createTreeCollection(),

--- a/src/internal/project/commands.js
+++ b/src/internal/project/commands.js
@@ -14,6 +14,17 @@ export const RESOURCE_TYPES = Object.freeze([
   "layouts",
 ]);
 
+export const COLLAB_RESOURCE_TYPES = Object.freeze([
+  ...RESOURCE_TYPES,
+  "files",
+]);
+
+const FILE_COMMAND_TYPES = Object.freeze([
+  "file.create",
+  "file.delete",
+  "file.move",
+]);
+
 const RESOURCE_COMMAND_FAMILIES = Object.freeze([
   "image",
   "sound",
@@ -59,6 +70,7 @@ const LAYOUT_COMMAND_TYPES = Object.freeze([
 ]);
 
 const RESOURCE_COMMAND_TYPES = Object.freeze([
+  ...FILE_COMMAND_TYPES,
   ...RESOURCE_COMMAND_FAMILIES.flatMap((family) =>
     RESOURCE_COMMAND_OPERATIONS.map((operation) => `${family}.${operation}`),
   ),

--- a/src/internal/project/interactionPayload.js
+++ b/src/internal/project/interactionPayload.js
@@ -3,7 +3,7 @@ export const getInteractionPayload = (interaction = {}) => {
     return {};
   }
 
-  return interaction.payload ?? {};
+  return interaction.payload ?? interaction.actionPayload ?? {};
 };
 
 export const getInteractionActions = (interaction = {}) => {
@@ -14,8 +14,28 @@ export const withInteractionPayload = (interaction = {}, payload = {}) => {
   const nextInteraction =
     interaction && typeof interaction === "object" ? { ...interaction } : {};
 
-  return {
+  const nextValue = {
     ...nextInteraction,
     payload,
   };
+
+  delete nextValue.actionPayload;
+
+  return nextValue;
+};
+
+export const normalizeInteractionValue = (interaction = {}) => {
+  if (!interaction || typeof interaction !== "object") {
+    return interaction;
+  }
+
+  const payload = getInteractionPayload(interaction);
+  const nextValue = {
+    ...interaction,
+    payload,
+  };
+
+  delete nextValue.actionPayload;
+
+  return nextValue;
 };

--- a/src/internal/project/interactionPayload.js
+++ b/src/internal/project/interactionPayload.js
@@ -14,14 +14,10 @@ export const withInteractionPayload = (interaction = {}, payload = {}) => {
   const nextInteraction =
     interaction && typeof interaction === "object" ? { ...interaction } : {};
 
-  const nextValue = {
+  return {
     ...nextInteraction,
     payload,
   };
-
-  delete nextValue.actionPayload;
-
-  return nextValue;
 };
 
 export const normalizeInteractionValue = (interaction = {}) => {
@@ -34,8 +30,6 @@ export const normalizeInteractionValue = (interaction = {}) => {
     ...interaction,
     payload,
   };
-
-  delete nextValue.actionPayload;
 
   return nextValue;
 };

--- a/src/internal/project/interactionPayload.js
+++ b/src/internal/project/interactionPayload.js
@@ -3,7 +3,7 @@ export const getInteractionPayload = (interaction = {}) => {
     return {};
   }
 
-  return interaction.payload ?? interaction.actionPayload ?? {};
+  return interaction.payload ?? {};
 };
 
 export const getInteractionActions = (interaction = {}) => {

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -185,17 +185,17 @@ const normalizeSliderChange = (change, sliderId) => {
   const interactionPayload = getInteractionPayload(change);
   const updateVariable = interactionPayload?.actions?.updateVariable;
   if (!updateVariable) {
-    return toRouteGraphicsInteraction(change);
+    return normalizeEngineActions(change);
   }
 
   const fallbackId = toAlphanumericId(`slider${sliderId}update`);
   const sanitizedId = toAlphanumericId(updateVariable.id, fallbackId);
 
   if (sanitizedId === updateVariable.id) {
-    return toRouteGraphicsInteraction(change);
+    return normalizeEngineActions(change);
   }
 
-  return toRouteGraphicsInteraction(
+  return normalizeEngineActions(
     withInteractionPayload(change, {
       ...interactionPayload,
       actions: {
@@ -244,22 +244,6 @@ const getImageFileId = (imageItems, imageId) => {
     : undefined;
 };
 
-const toRouteGraphicsInteraction = (interaction) => {
-  if (!interaction || typeof interaction !== "object") {
-    return interaction;
-  }
-
-  const payload = getInteractionPayload(interaction);
-  const nextInteraction = {
-    ...interaction,
-    actionPayload: payload,
-  };
-
-  delete nextInteraction.payload;
-
-  return normalizeEngineActions(nextInteraction);
-};
-
 const buildBaseElement = (node) => {
   const element = {
     id: node.id,
@@ -273,8 +257,8 @@ const buildBaseElement = (node) => {
     scaleX: node.scaleX ?? 1,
     scaleY: node.scaleY ?? 1,
     rotation: node.rotation ?? 0,
-    click: toRouteGraphicsInteraction(node.click),
-    rightClick: toRouteGraphicsInteraction(node.rightClick),
+    click: normalizeEngineActions(node.click),
+    rightClick: normalizeEngineActions(node.rightClick),
   };
 
   if (node["$when"]) {
@@ -458,7 +442,7 @@ const applyContainerNode = ({ element, node }) => {
       ? {
           click: {
             ...nextElement.click,
-            ...toRouteGraphicsInteraction(repeatingConfig.click),
+            ...normalizeEngineActions(repeatingConfig.click),
           },
         }
       : {}),

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -258,6 +258,7 @@ const buildBaseElement = (node) => {
     scaleY: node.scaleY ?? 1,
     rotation: node.rotation ?? 0,
     click: normalizeEngineActions(node.click),
+    rightClick: normalizeEngineActions(node.rightClick),
   };
 
   if (node["$when"]) {

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -185,17 +185,17 @@ const normalizeSliderChange = (change, sliderId) => {
   const interactionPayload = getInteractionPayload(change);
   const updateVariable = interactionPayload?.actions?.updateVariable;
   if (!updateVariable) {
-    return normalizeEngineActions(change);
+    return toRouteGraphicsInteraction(change);
   }
 
   const fallbackId = toAlphanumericId(`slider${sliderId}update`);
   const sanitizedId = toAlphanumericId(updateVariable.id, fallbackId);
 
   if (sanitizedId === updateVariable.id) {
-    return normalizeEngineActions(change);
+    return toRouteGraphicsInteraction(change);
   }
 
-  return normalizeEngineActions(
+  return toRouteGraphicsInteraction(
     withInteractionPayload(change, {
       ...interactionPayload,
       actions: {
@@ -244,6 +244,22 @@ const getImageFileId = (imageItems, imageId) => {
     : undefined;
 };
 
+const toRouteGraphicsInteraction = (interaction) => {
+  if (!interaction || typeof interaction !== "object") {
+    return interaction;
+  }
+
+  const payload = getInteractionPayload(interaction);
+  const nextInteraction = {
+    ...interaction,
+    actionPayload: payload,
+  };
+
+  delete nextInteraction.payload;
+
+  return normalizeEngineActions(nextInteraction);
+};
+
 const buildBaseElement = (node) => {
   const element = {
     id: node.id,
@@ -257,8 +273,8 @@ const buildBaseElement = (node) => {
     scaleX: node.scaleX ?? 1,
     scaleY: node.scaleY ?? 1,
     rotation: node.rotation ?? 0,
-    click: normalizeEngineActions(node.click),
-    rightClick: normalizeEngineActions(node.rightClick),
+    click: toRouteGraphicsInteraction(node.click),
+    rightClick: toRouteGraphicsInteraction(node.rightClick),
   };
 
   if (node["$when"]) {
@@ -442,7 +458,7 @@ const applyContainerNode = ({ element, node }) => {
       ? {
           click: {
             ...nextElement.click,
-            ...normalizeEngineActions(repeatingConfig.click),
+            ...toRouteGraphicsInteraction(repeatingConfig.click),
           },
         }
       : {}),

--- a/src/internal/project/projection.js
+++ b/src/internal/project/projection.js
@@ -801,9 +801,10 @@ const getTransitionsFromLayout = (layout) => {
   }
 
   return Object.values(layout.elements.items)
-    .map((element) => {
-      return getInteractionActions(element?.click).sectionTransition;
-    })
+    .flatMap((element) => [
+      getInteractionActions(element?.click).sectionTransition,
+      getInteractionActions(element?.rightClick).sectionTransition,
+    ])
     .filter(Boolean);
 };
 

--- a/src/internal/project/projection.js
+++ b/src/internal/project/projection.js
@@ -645,6 +645,11 @@ const constructLayoutResources = (
       name: layout.name,
       layoutType: layout.layoutType,
       elements,
+      ...(layout.keyboard &&
+      typeof layout.keyboard === "object" &&
+      !Array.isArray(layout.keyboard)
+        ? { keyboard: structuredClone(layout.keyboard) }
+        : {}),
       ...(Array.isArray(layout.transitions)
         ? { transitions: structuredClone(layout.transitions) }
         : {}),

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -249,6 +249,7 @@ const createSpritesFromFiles = async ({
     await projectService.createCharacterSpriteItem({
       characterId,
       spriteId: nanoid(),
+      fileRecords: result.fileRecords,
       parentId,
       position: "last",
       data: {
@@ -456,6 +457,7 @@ export const handleFormExtraEvent = async (deps) => {
   await projectService.updateCharacterSpriteItem({
     characterId,
     spriteId: selectedItem.id,
+    fileRecords: uploadResult.fileRecords,
     data: {
       fileId: uploadResult.fileId,
       name: uploadResult.displayName,

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -120,8 +120,14 @@ export const handleCharacterItemDoubleClick = async (deps, payload) => {
 
 export const handleCharacterCreated = async (deps, payload) => {
   const { appService, projectService } = deps;
-  const { groupId, name, description, shortcut, avatarFileId } =
-    payload._event.detail;
+  const {
+    groupId,
+    name,
+    description,
+    shortcut,
+    avatarFileId,
+    avatarUploadResult,
+  } = payload._event.detail;
   const characterId = nanoid();
   const defaultSpritesFolderId = nanoid();
   const characterData = {
@@ -152,6 +158,7 @@ export const handleCharacterCreated = async (deps, payload) => {
 
   const createResult = await projectService.createCharacter({
     characterId,
+    fileRecords: avatarUploadResult?.fileRecords,
     data: characterData,
     parentId: groupId,
     position: "last",
@@ -223,6 +230,7 @@ export const handleDetailPanelAvatarClick = async (deps) => {
       // Update the selected character in the repository with the new avatar
       await projectService.updateCharacter({
         characterId: selectedItem.id,
+        fileRecords: uploadedFile.fileRecords,
         data: updateData,
       });
 
@@ -274,6 +282,7 @@ export const handleDialogFormActionClick = async (deps, payload) => {
 
     const targetGroupId = store.selectTargetGroupId();
     const avatarFileId = store.selectAvatarFileId();
+    const avatarUploadResult = store.getState().avatarUploadResult;
 
     // Create a synthetic event payload with the correct structure
     const characterCreatedPayload = {
@@ -284,6 +293,7 @@ export const handleDialogFormActionClick = async (deps, payload) => {
           description: formData.description,
           shortcut: formData.shortcut || "",
           avatarFileId: avatarFileId,
+          avatarUploadResult,
         },
       },
     };
@@ -322,7 +332,10 @@ export const handleDialogAvatarClick = async (deps) => {
       }
 
       const result = uploadResults[0];
-      store.setAvatarFileId({ fileId: result.fileId });
+      store.setAvatarFileId({
+        fileId: result.fileId,
+        uploadResult: result,
+      });
       render();
     }
   } catch (error) {
@@ -391,7 +404,10 @@ export const handleEditDialogAvatarClick = async (deps) => {
       }
 
       const result = uploadResults[0];
-      store.setEditAvatarFileId({ fileId: result.fileId });
+      store.setEditAvatarFileId({
+        fileId: result.fileId,
+        uploadResult: result,
+      });
       render();
     }
   } catch (error) {
@@ -405,7 +421,7 @@ export const handleEditFormAction = async (deps, payload) => {
   if (payload._event.detail.actionId === "submit") {
     const formData = payload._event.detail.values;
     const editItemId = store.getState().editItemId;
-    const editAvatarFileId = store.getState().editAvatarFileId;
+    const { editAvatarFileId, editAvatarUploadResult } = store.getState();
 
     // Update the character in the repository
     const updateData = {
@@ -421,6 +437,7 @@ export const handleEditFormAction = async (deps, payload) => {
 
     await projectService.updateCharacter({
       characterId: editItemId,
+      fileRecords: editAvatarUploadResult?.fileRecords,
       data: updateData,
     });
 

--- a/src/pages/characters/characters.store.js
+++ b/src/pages/characters/characters.store.js
@@ -35,6 +35,7 @@ export const createInitialState = () => ({
   isDialogOpen: false,
   targetGroupId: null,
   avatarFileId: null,
+  avatarUploadResult: null,
   dialogDefaultValues: {
     name: "",
     description: "",
@@ -83,6 +84,7 @@ export const createInitialState = () => ({
   isEditDialogOpen: false,
   editItemId: null,
   editAvatarFileId: null,
+  editAvatarUploadResult: null,
 });
 
 export const setItems = ({ state }, { charactersData } = {}) => {
@@ -105,12 +107,14 @@ export const toggleDialog = ({ state }, _payload = {}) => {
   state.isDialogOpen = !state.isDialogOpen;
 };
 
-export const setAvatarFileId = ({ state }, { fileId } = {}) => {
-  state.avatarFileId = fileId;
+export const setAvatarFileId = ({ state }, { fileId, uploadResult } = {}) => {
+  state.avatarFileId = fileId ?? uploadResult?.fileId ?? null;
+  state.avatarUploadResult = uploadResult ?? null;
 };
 
 export const clearAvatarState = ({ state }, _payload = {}) => {
   state.avatarFileId = null;
+  state.avatarUploadResult = null;
 };
 
 export const openEditDialog = ({ state }, { itemId } = {}) => {
@@ -121,16 +125,22 @@ export const openEditDialog = ({ state }, { itemId } = {}) => {
   const flatItems = toFlatItems(state.charactersData);
   const editItem = flatItems.find((item) => item.id === itemId);
   state.editAvatarFileId = editItem?.fileId || null;
+  state.editAvatarUploadResult = null;
 };
 
 export const closeEditDialog = ({ state }, _payload = {}) => {
   state.isEditDialogOpen = false;
   state.editItemId = null;
   state.editAvatarFileId = null;
+  state.editAvatarUploadResult = null;
 };
 
-export const setEditAvatarFileId = ({ state }, { fileId } = {}) => {
-  state.editAvatarFileId = fileId;
+export const setEditAvatarFileId = (
+  { state },
+  { fileId, uploadResult } = {},
+) => {
+  state.editAvatarFileId = fileId ?? uploadResult?.fileId ?? null;
+  state.editAvatarUploadResult = uploadResult ?? null;
 };
 
 export const selectTargetGroupId = ({ state }) => state.targetGroupId;

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -49,6 +49,7 @@ const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
   for (const result of successfulUploads) {
     await projectService.createFont({
       fontId: nanoid(),
+      fileRecords: result.fileRecords,
       data: {
         type: "font",
         fileId: result.fileId,
@@ -168,6 +169,7 @@ export const handleFormExtraEvent = async (deps) => {
 
   await projectService.updateFont({
     fontId: selectedItem.id,
+    fileRecords: uploadResult.fileRecords,
     data: {
       fileId: uploadResult.fileId,
       name: uploadResult.file.name,

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -51,6 +51,7 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
   for (const result of successfulUploads) {
     const createResult = await projectService.createImage({
       imageId: nanoid(),
+      fileRecords: result.fileRecords,
       data: {
         type: "image",
         fileId: result.fileId,
@@ -142,6 +143,7 @@ export const handleFormExtraEvent = async (deps) => {
   const uploadResult = file.uploadResult;
   const updateResult = await projectService.updateImage({
     imageId: selectedItem.id,
+    fileRecords: uploadResult.fileRecords,
     data: {
       fileId: uploadResult.fileId,
       thumbnailFileId: uploadResult.thumbnailFileId,
@@ -241,6 +243,7 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const updateResult = await projectService.updateImage({
     imageId: editItemId,
+    fileRecords: editUploadResult?.fileRecords,
     data: {
       name,
       description: values?.description ?? "",

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -12,6 +12,7 @@ import { buildLayoutRenderElements } from "../../internal/project/layout.js";
 import { toHierarchyStructure } from "../../internal/project/tree.js";
 import { extractFileIdsFromRenderState } from "../../internal/project/layout.js";
 import { createLayoutElementsFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import { normalizeInteractionValue } from "../../internal/project/interactionPayload.js";
 
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
@@ -114,6 +115,22 @@ const createObjectPatch = (previousValue, nextValue) => {
     hasChanges,
     requiresReplace,
   };
+};
+
+const normalizeLayoutElementInteractions = (item = {}) => {
+  if (!item || typeof item !== "object") {
+    return item;
+  }
+
+  const nextItem = structuredClone(item);
+
+  for (const key of ["click", "rightClick", "change"]) {
+    if (nextItem[key] !== undefined) {
+      nextItem[key] = normalizeInteractionValue(nextItem[key]);
+    }
+  }
+
+  return nextItem;
 };
 
 export const handleBeforeMount = (deps) => {
@@ -454,6 +471,21 @@ const deepMerge = (target, source) => {
   return result;
 };
 
+const shouldSaveLayoutEditImmediately = (name) => {
+  if (typeof name !== "string" || name.length === 0) {
+    return false;
+  }
+
+  return (
+    name === "click" ||
+    name.startsWith("click.") ||
+    name === "rightClick" ||
+    name.startsWith("rightClick.") ||
+    name === "change" ||
+    name.startsWith("change.")
+  );
+};
+
 export const handleDialogueFormChange = async (deps, payload) => {
   const { store, render } = deps;
   const { name, value: fieldValue } = payload._event.detail;
@@ -553,18 +585,19 @@ async function handleDebouncedUpdate(deps, payload) {
     return;
   }
 
-  const previousItem = {
+  const previousItem = normalizeLayoutElementInteractions({
     id: selectedItemId,
     ...currentItem,
-  };
-  const diff = createObjectPatch(previousItem, updatedItem);
+  });
+  const normalizedUpdatedItem = normalizeLayoutElementInteractions(updatedItem);
+  const diff = createObjectPatch(previousItem, normalizedUpdatedItem);
 
   if (!diff.hasChanges && !diff.requiresReplace) {
     return;
   }
 
   const shouldReplace = replace === true || diff.requiresReplace;
-  const { id: _ignoredItemId, ...nextReplaceData } = updatedItem;
+  const { id: _ignoredItemId, ...nextReplaceData } = normalizedUpdatedItem;
 
   // Save to repository
   await projectService.updateLayoutElement({
@@ -770,12 +803,21 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
   store.updateSelectedItem({ updatedItem: updatedItem });
   render();
 
-  const { subject } = deps;
-  subject.dispatch("layoutEditor.updateElement", {
-    layoutId,
-    selectedItemId,
-    updatedItem,
-  });
+  if (shouldSaveLayoutEditImmediately(detail.name)) {
+    await handleDebouncedUpdate(deps, {
+      layoutId,
+      selectedItemId,
+      updatedItem,
+    });
+  } else {
+    const { subject } = deps;
+    subject.dispatch("layoutEditor.updateElement", {
+      layoutId,
+      selectedItemId,
+      updatedItem,
+    });
+  }
+
   await renderLayoutPreview(deps, { skipAssetLoading: false });
 };
 

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -2,6 +2,10 @@ import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
 import { createLayoutsFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import {
+  getInteractionActions,
+  withInteractionPayload,
+} from "../../internal/project/interactionPayload.js";
 
 const {
   handleBeforeMount,
@@ -27,6 +31,85 @@ export {
   handleFileExplorerTargetChanged,
   handleLayoutItemClick,
   handleSearchInput,
+};
+
+const KEYBOARD_KEY_OPTIONS = [
+  { value: "enter", label: "Enter" },
+  { value: "space", label: "Space" },
+  { value: "esc", label: "Escape" },
+  { value: "left", label: "Left Arrow" },
+  { value: "right", label: "Right Arrow" },
+  { value: "up", label: "Up Arrow" },
+  { value: "down", label: "Down Arrow" },
+];
+
+const getSelectedBaseLayout = (store) => {
+  const selectedItem = store.selectSelectedItem();
+  if (selectedItem?.layoutType !== "base") {
+    return undefined;
+  }
+
+  return selectedItem;
+};
+
+const getKeyboardEntryActions = (layout, key) => {
+  return getInteractionActions(layout?.keyboard?.[key]);
+};
+
+const getKeyboardEditorMode = (actions = {}) => {
+  const actionIds = Object.keys(actions);
+  if (actionIds.length !== 1) {
+    return "actions";
+  }
+
+  return actionIds[0];
+};
+
+const updateLayoutKeyboard = async ({
+  appService,
+  projectService,
+  store,
+  key,
+  interaction,
+}) => {
+  const layout = getSelectedBaseLayout(store);
+  if (!layout?.id || !key) {
+    return false;
+  }
+
+  const currentKeyboard =
+    layout.keyboard && typeof layout.keyboard === "object"
+      ? layout.keyboard
+      : {};
+  const nextKeyboard = {};
+
+  Object.entries(currentKeyboard).forEach(([entryKey, entryValue]) => {
+    if (entryKey !== key) {
+      nextKeyboard[entryKey] = structuredClone(entryValue);
+    }
+  });
+
+  if (interaction !== undefined) {
+    nextKeyboard[key] = interaction;
+  }
+
+  const data = {};
+  data.keyboard =
+    Object.keys(nextKeyboard).length > 0 ? nextKeyboard : undefined;
+
+  const result = await projectService.updateLayoutItem({
+    layoutId: layout.id,
+    data,
+  });
+
+  if (result?.valid === false) {
+    appService.showToast("Failed to update keyboard action", {
+      title: "Error",
+    });
+    return false;
+  }
+
+  return true;
 };
 
 export const handleItemDoubleClick = (deps, payload) => {
@@ -402,4 +485,137 @@ export const handleItemDelete = async (deps, payload) => {
 
   await projectService.deleteLayoutItem({ layoutIds: [itemId] });
   await handleDataChanged(deps);
+};
+
+export const handleKeyboardAddClick = async (deps, payload) => {
+  const { appService, refs, render, store } = deps;
+  const layout = getSelectedBaseLayout(store);
+  if (!layout) {
+    return;
+  }
+
+  const assignedKeys = new Set(Object.keys(layout.keyboard || {}));
+  const availableItems = KEYBOARD_KEY_OPTIONS.filter(
+    (item) => !assignedKeys.has(item.value),
+  ).map((item) => ({
+    type: "item",
+    key: item.value,
+    label: item.label,
+  }));
+
+  if (availableItems.length === 0) {
+    appService.showToast("All available keyboard keys are already assigned", {
+      title: "Warning",
+    });
+    return;
+  }
+
+  const result = await appService.showDropdownMenu({
+    items: availableItems,
+    x: payload._event.clientX,
+    y: payload._event.clientY,
+    place: "bs",
+  });
+  if (!result?.item?.key) {
+    return;
+  }
+
+  store.openKeyboardEditor({
+    key: result.item.key,
+    actions: {},
+  });
+  render();
+
+  refs.keyboardSystemActions.transformedHandlers.open({
+    mode: "actions",
+  });
+};
+
+export const handleKeyboardItemClick = (deps, payload) => {
+  const { refs, render, store } = deps;
+  const layout = getSelectedBaseLayout(store);
+  if (!layout) {
+    return;
+  }
+
+  const key = payload._event.currentTarget.dataset.key;
+  if (!key) {
+    return;
+  }
+
+  const actions = getKeyboardEntryActions(layout, key);
+  store.openKeyboardEditor({
+    key,
+    actions,
+  });
+  render();
+
+  refs.keyboardSystemActions.transformedHandlers.open({
+    mode: getKeyboardEditorMode(actions),
+  });
+};
+
+export const handleKeyboardItemRightClick = async (deps, payload) => {
+  const { appService, render } = deps;
+  const event = payload._event;
+  event.preventDefault();
+
+  const key = event.currentTarget.dataset.key;
+  if (!key) {
+    return;
+  }
+
+  const result = await appService.showDropdownMenu({
+    items: [{ type: "item", key: "remove", label: "Delete" }],
+    x: event.clientX,
+    y: event.clientY,
+    place: "bs",
+  });
+  if (result?.item?.key !== "remove") {
+    return;
+  }
+
+  const updated = await updateLayoutKeyboard({
+    appService,
+    projectService: deps.projectService,
+    store: deps.store,
+    key,
+    interaction: undefined,
+  });
+  if (!updated) {
+    return;
+  }
+
+  render();
+};
+
+export const handleKeyboardActionsChange = async (deps, payload) => {
+  const { appService, render, store } = deps;
+  const key = store.selectKeyboardEditorKey();
+  if (!key) {
+    return;
+  }
+
+  const actions = payload._event.detail || {};
+  const interaction = withInteractionPayload({}, { actions });
+  const updated = await updateLayoutKeyboard({
+    appService,
+    projectService: deps.projectService,
+    store,
+    key,
+    interaction,
+  });
+
+  store.closeKeyboardEditor();
+  render();
+
+  if (!updated) {
+    return;
+  }
+};
+
+export const handleKeyboardActionsClose = (deps) => {
+  const { render, store } = deps;
+  store.closeKeyboardEditor();
+  render();
 };

--- a/src/pages/layouts/layouts.store.js
+++ b/src/pages/layouts/layouts.store.js
@@ -1,4 +1,5 @@
 import { createCatalogPageStore } from "../../internal/ui/resourcePages/catalog/createCatalogPageStore.js";
+import { getInteractionActions } from "../../internal/project/interactionPayload.js";
 
 const layoutForm = {
   title: "Add Layout",
@@ -45,6 +46,71 @@ const layoutTypeLabels = {
   nvl: "NVL",
   choice: "Choice",
   base: "Base",
+};
+
+const KEYBOARD_KEY_OPTIONS = [
+  { value: "enter", label: "Enter" },
+  { value: "space", label: "Space" },
+  { value: "esc", label: "Escape" },
+  { value: "left", label: "Left Arrow" },
+  { value: "right", label: "Right Arrow" },
+  { value: "up", label: "Up Arrow" },
+  { value: "down", label: "Down Arrow" },
+];
+
+const KEYBOARD_KEY_LABELS = Object.fromEntries(
+  KEYBOARD_KEY_OPTIONS.map((item) => [item.value, item.label]),
+);
+
+const SYSTEM_ACTION_LABELS = {
+  nextLine: "Next Line",
+  sectionTransition: "Transition",
+  toggleAutoMode: "Toggle Auto Mode",
+  toggleSkipMode: "Toggle Skip Mode",
+  toggleDialogueUI: "Toggle Dialogue Box",
+  pushLayeredView: "Push Layered View",
+  popLayeredView: "Pop Layered View",
+  updateVariable: "Update Variable",
+};
+
+const toKeyboardItems = (keyboardValue = {}) => {
+  const keyboard =
+    keyboardValue && typeof keyboardValue === "object" ? keyboardValue : {};
+
+  return Object.entries(keyboard)
+    .map(([key, interaction]) => {
+      const actions = getInteractionActions(interaction);
+      const actionIds = Object.keys(actions);
+      const actionLabel =
+        actionIds
+          .map((actionId) => SYSTEM_ACTION_LABELS[actionId] ?? actionId)
+          .join(", ") || "No action";
+
+      return {
+        key,
+        keyLabel: KEYBOARD_KEY_LABELS[key] ?? key,
+        actionLabel,
+      };
+    })
+    .sort((left, right) => {
+      const leftIndex = KEYBOARD_KEY_OPTIONS.findIndex(
+        (item) => item.value === left.key,
+      );
+      const rightIndex = KEYBOARD_KEY_OPTIONS.findIndex(
+        (item) => item.value === right.key,
+      );
+
+      if (leftIndex >= 0 && rightIndex >= 0) {
+        return leftIndex - rightIndex;
+      }
+      if (leftIndex >= 0) {
+        return -1;
+      }
+      if (rightIndex >= 0) {
+        return 1;
+      }
+      return left.key.localeCompare(right.key);
+    });
 };
 
 const buildDetailFields = (item) => {
@@ -101,6 +167,8 @@ export const createInitialState = () => ({
   ...createCatalogInitialState(),
   isAddDialogOpen: false,
   targetGroupId: undefined,
+  keyboardEditorKey: undefined,
+  keyboardEditorActions: {},
 });
 
 export {
@@ -113,6 +181,8 @@ export {
 
 export const selectLayoutItemById = selectItemById;
 
+export const selectKeyboardEditorKey = ({ state }) => state.keyboardEditorKey;
+
 export const openAddDialog = ({ state }, { groupId } = {}) => {
   state.isAddDialogOpen = true;
   state.targetGroupId = groupId === "_root" ? undefined : groupId;
@@ -123,6 +193,27 @@ export const closeAddDialog = ({ state }, _payload = {}) => {
   state.targetGroupId = undefined;
 };
 
+export const openKeyboardEditor = ({ state }, { key, actions = {} } = {}) => {
+  state.keyboardEditorKey = key;
+  state.keyboardEditorActions = actions;
+};
+
+export const closeKeyboardEditor = ({ state }, _payload = {}) => {
+  state.keyboardEditorKey = undefined;
+  state.keyboardEditorActions = {};
+};
+
 export const selectViewData = (context) => {
-  return selectCatalogViewData(context);
+  const baseViewData = selectCatalogViewData(context);
+  const selectedItem = selectSelectedItem(context);
+  const isBaseLayoutSelected = selectedItem?.layoutType === "base";
+
+  return {
+    ...baseViewData,
+    isBaseLayoutSelected,
+    keyboardItems: toKeyboardItems(selectedItem?.keyboard),
+    keyboardEditorKey: context.state.keyboardEditorKey,
+    keyboardEditorActions: context.state.keyboardEditorActions,
+    keyboardEmptyMessage: "No keyboard actions added yet",
+  };
 };

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -29,6 +29,22 @@ refs:
     eventListeners:
       form-action:
         handler: handleLayoutFormActionClick
+  keyboardAddButton:
+    eventListeners:
+      click:
+        handler: handleKeyboardAddClick
+  keyboardItem*:
+    eventListeners:
+      click:
+        handler: handleKeyboardItemClick
+      contextmenu:
+        handler: handleKeyboardItemRightClick
+  keyboardSystemActions:
+    eventListeners:
+      actions-change:
+        handler: handleKeyboardActionsChange
+      close:
+        handler: handleKeyboardActionsClose
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -44,9 +60,26 @@ template:
                       - rtgl-view d=v w=f h=f:
                           - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
                               - rtgl-text c=mu-fg: ${selectedItemName}
-                          - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields: null
+                          - rvn-detail-view#detailView key=${selectedItemId} w=f :fields=detailFields: null
+                          - $if isBaseLayoutSelected:
+                              - rtgl-view h=1 w=f bgc=mu: null
+                              - 'rtgl-view d=v w=f h=1fg p=md g=md style="min-height: 0; overflow: auto;"':
+                                  - rtgl-view d=h w=f av=c:
+                                      - rtgl-text s=sm: Keyboard
+                                      - rtgl-view w=1fg: null
+                                      - rtgl-button#keyboardAddButton pre=plus sq s=sm v=gh: null
+                                  - $if keyboardItems.length > 0:
+                                      - $for item, i in keyboardItems:
+                                          - rtgl-view#keyboardItem${i} data-key=${item.key} d=h w=f av=c g=md p=md bw=xs br=md h-bgc=mu cur=pointer:
+                                              - rtgl-view d=v g=xs w=1fg:
+                                                  - rtgl-text s=sm: ${item.keyLabel}
+                                                  - rtgl-text s=xs c=mu-fg: ${item.actionLabel}
+                                  - $if keyboardItems.length == 0:
+                                      - rtgl-view w=f p=md bgc=mu br=md:
+                                          - rtgl-text s=xs c=mu-fg: ${keyboardEmptyMessage}
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
+  - rvn-system-actions#keyboardSystemActions :actions=keyboardEditorActions actionType=system: null
   - rtgl-dialog#addLayoutDialog ?open=${isAddDialogOpen} s=md:
       - rtgl-form#layoutForm slot=content :defaultValues=layoutFormDefaults :form=layoutForm w=f: null

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -10,7 +10,7 @@ const DEAD_END_TOOLTIP_CONTENT =
   "This section has no transition to another scene.";
 
 /**
- * Extract transitions from layout element click actions
+ * Extract transitions from layout element click and right-click actions
  * @param {Object} layout - Layout object with elements
  * @returns {Array} Array of sceneIds found in click actions
  */
@@ -19,10 +19,15 @@ const getTransitionsFromLayout = (layout) => {
   if (!layout?.elements?.items) return transitions;
 
   for (const element of Object.values(layout.elements.items)) {
-    const sceneId = getInteractionActions(element.click).sectionTransition
-      ?.sceneId;
-    if (sceneId && !transitions.includes(sceneId)) {
-      transitions.push(sceneId);
+    const sceneIds = [
+      getInteractionActions(element.click).sectionTransition?.sceneId,
+      getInteractionActions(element.rightClick).sectionTransition?.sceneId,
+    ];
+
+    for (const sceneId of sceneIds) {
+      if (sceneId && !transitions.includes(sceneId)) {
+        transitions.push(sceneId);
+      }
     }
   }
   return transitions;

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -65,6 +65,7 @@ const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
   for (const result of successfulUploads) {
     await projectService.createSound({
       soundId: nanoid(),
+      fileRecords: result.fileRecords,
       data: {
         type: "sound",
         fileId: result.fileId,
@@ -240,6 +241,7 @@ export const handleFormExtraEvent = async (deps) => {
   const { uploadResult } = result;
   await projectService.updateSound({
     soundId: selectedItem.id,
+    fileRecords: uploadResult.fileRecords,
     data: {
       fileId: uploadResult.fileId,
       fileType: uploadResult.file.type,
@@ -320,6 +322,7 @@ export const handleEditFormAction = async (deps, payload) => {
 
   await projectService.updateSound({
     soundId: editItemId,
+    fileRecords: editUploadResult?.fileRecords,
     data: {
       name,
       description: values?.description ?? "",

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -447,6 +447,7 @@ export const handleAddFontFormAction = async (deps, payload) => {
     // Create the font in the repository using the already uploaded file
     await projectService.createFont({
       fontId: newFontId,
+      fileRecords: fontData.uploadResult.fileRecords,
       data: {
         type: "font",
         name: fontName,

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -52,6 +52,7 @@ const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
   for (const result of successfulUploads) {
     await projectService.createVideo({
       videoId: nanoid(),
+      fileRecords: result.fileRecords,
       data: {
         type: "video",
         fileId: result.fileId,
@@ -188,6 +189,7 @@ export const handleFormExtraEvent = async (deps) => {
   const { uploadResult } = result;
   await projectService.updateVideo({
     videoId: selectedItem.id,
+    fileRecords: uploadResult.fileRecords,
     data: {
       fileId: uploadResult.fileId,
       thumbnailFileId: uploadResult.thumbnailFileId,
@@ -272,6 +274,7 @@ export const handleEditFormAction = async (deps, payload) => {
 
   await projectService.updateVideo({
     videoId: editItemId,
+    fileRecords: editUploadResult?.fileRecords,
     data: {
       name,
       description: values?.description ?? "",

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -332,6 +332,122 @@
       }
     ]
   },
+  "files": {
+    "items": {
+      "options_black_bg": {
+        "id": "options_black_bg",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 8556,
+        "sha256": "b369e13fe70ff2090cac8bf14990cae1fe6c93a18a9c0d25e250d84e7bdcab14"
+      },
+      "iXuoDMU56sb6F4x6xrNqa": {
+        "id": "iXuoDMU56sb6F4x6xrNqa",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 4468,
+        "sha256": "2fb58f5c2cb8b182c3fd1e92428d4c0d586d552905cdaa0ba7a1710baa643117"
+      },
+      "dFVjRAgExl3smbbTHf2Yf": {
+        "id": "dFVjRAgExl3smbbTHf2Yf",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 2120,
+        "sha256": "3154b024d256dd6eebafd15ca7c10b514a7ba838ed111f9bdcec4f1d7040e4a4"
+      },
+      "pmR6Jl5Tk3FthCYe7QEQ5": {
+        "id": "pmR6Jl5Tk3FthCYe7QEQ5",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 862,
+        "sha256": "667234f3d2665bf079d0d986f6c17e75ea351aa1cdedbfc3a65343630159830c"
+      },
+      "Vv45YQP6fUdmuI51iI7SW": {
+        "id": "Vv45YQP6fUdmuI51iI7SW",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 531,
+        "sha256": "5b3ad5225caf9cf6e8b9ac0c8b715a2a9579ec9f2d675dfb784a7c1765e6d502"
+      },
+      "MSRaaZrrAls6RYTk8dZl7": {
+        "id": "MSRaaZrrAls6RYTk8dZl7",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 579,
+        "sha256": "dda13266be391fe99b5c0beb57228548f9d04934c941254d7e7dd1e35ad91ced"
+      },
+      "QVDFwFnI0tjTy7qfbyiGV": {
+        "id": "QVDFwFnI0tjTy7qfbyiGV",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 555,
+        "sha256": "899dfc462486118be0f91439b9ddb0baf1eb10d691320abc8fba68aa087e13c4"
+      },
+      "-WGqH4Nj2GKnx8DFc9t2D": {
+        "id": "-WGqH4Nj2GKnx8DFc9t2D",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 591,
+        "sha256": "c067757447047dfc271309d0ace9937b91d4cab84921cb1084ea750d78533dc8"
+      },
+      "L5Vmww9xcMh6v3_cl2rNg": {
+        "id": "L5Vmww9xcMh6v3_cl2rNg",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 558,
+        "sha256": "1e079393b0c88181f2f1cef939df2c84e5fc3fe1c75299f115662c301af185ac"
+      },
+      "kC9Z1-lmclgU4bNtaf7PS": {
+        "id": "kC9Z1-lmclgU4bNtaf7PS",
+        "type": "image",
+        "mimeType": "image/png",
+        "size": 578,
+        "sha256": "f32c167a5403b7ccd25b910c7bf4bfc08147a17aeaa6a63b49593c49921bfa33"
+      },
+      "0CuKeuNPATcuH0EDcsoJd": {
+        "id": "0CuKeuNPATcuH0EDcsoJd",
+        "type": "font",
+        "mimeType": "font/sample_font",
+        "size": 857712,
+        "sha256": "0090683b3ad4b60f59d5699504c4a5aa7b93f6925a376cf18755b5c9a37e4db6"
+      }
+    },
+    "tree": [
+      {
+        "id": "options_black_bg"
+      },
+      {
+        "id": "iXuoDMU56sb6F4x6xrNqa"
+      },
+      {
+        "id": "dFVjRAgExl3smbbTHf2Yf"
+      },
+      {
+        "id": "pmR6Jl5Tk3FthCYe7QEQ5"
+      },
+      {
+        "id": "Vv45YQP6fUdmuI51iI7SW"
+      },
+      {
+        "id": "MSRaaZrrAls6RYTk8dZl7"
+      },
+      {
+        "id": "QVDFwFnI0tjTy7qfbyiGV"
+      },
+      {
+        "id": "-WGqH4Nj2GKnx8DFc9t2D"
+      },
+      {
+        "id": "L5Vmww9xcMh6v3_cl2rNg"
+      },
+      {
+        "id": "kC9Z1-lmclgU4bNtaf7PS"
+      },
+      {
+        "id": "0CuKeuNPATcuH0EDcsoJd"
+      }
+    ]
+  },
   "images": {
     "items": {
       "zZO4u50ZEEt1WIugqEiW4": {

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -1090,7 +1090,7 @@
               "scaleY": 1,
               "rotation": 0,
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "nextLine": {}
                   }
@@ -1245,7 +1245,7 @@
               "rotation": 0,
               "text": "START",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "sectionTransition": {
                       "sceneId": "eXLwPZNpFqDjmXjORfonq",
@@ -1271,7 +1271,7 @@
               "rotation": 0,
               "text": "LOAD",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "pushLayeredView": {
                       "resourceId": "LoadPageDefaultLayout"
@@ -1296,7 +1296,7 @@
               "rotation": 0,
               "text": "OPTIONS",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "pushLayeredView": {
                       "resourceId": "OptionsPageDefaultLayout"
@@ -1475,7 +1475,7 @@
               "rotation": 0,
               "text": "BACK",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "popLayeredView": {}
                   }
@@ -1609,7 +1609,7 @@
               "initialValue": "${variables._musicVolume}",
               "variableId": "_musicVolume",
               "change": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsBgmSlider",
@@ -1681,7 +1681,7 @@
               "initialValue": "${variables._soundVolume}",
               "variableId": "_soundVolume",
               "change": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsSfxSlider",
@@ -1744,7 +1744,7 @@
               "rotation": 0,
               "text": "${variables._muteAll}",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsMuteToggle",
@@ -1816,7 +1816,7 @@
               "initialValue": "${variables._textSpeed}",
               "variableId": "_textSpeed",
               "change": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsSpeedSlider",
@@ -1888,7 +1888,7 @@
               "initialValue": "${variables._autoForwardTime}",
               "variableId": "_autoForwardTime",
               "change": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsAutoSlider",
@@ -1967,7 +1967,7 @@
               "rotation": 0,
               "text": "${variables._skipUnseenText}",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsSkipUnseen",
@@ -2014,7 +2014,7 @@
               "rotation": 0,
               "text": "${variables._skipTransitionsAndAnimations}",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "updateVariable": {
                       "id": "optionsSkipTransitions",
@@ -2045,7 +2045,7 @@
               "rotation": 0,
               "text": "BACK",
               "click": {
-                "actionPayload": {
+                "payload": {
                   "actions": {
                     "popLayeredView": {}
                   }


### PR DESCRIPTION
## Summary
- add right-click action editing for layout elements, including persistence fixes for older `actionPayload` interaction data
- add `toggleDialogueUI` to system actions and layout panel flows
- handle right-click layout transitions in scene tooling and fix repository-state lookups for scene choice/transition pickers
- point `@routevn/creator-model` to the model PR commit until a new package release is published

## Verification
- bun run lint
- bun run test:smoke