### PR TITLE
Fix redundant scene and editor writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ static/bundle/main.js
 .env
 /.rettangoli/
 /project.db
+/project.db-shm
+/project.db-wal
 
 # Generated setup file
 src/setup.js

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -87,8 +87,6 @@ refs:
         handler: handleActionsDialogClose
   systemActions:
     eventListeners:
-      submit:
-        handler: handleCommandLineSubmit
       action-delete:
         handler: handleSystemActionsActionDelete
       actions-change:

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -540,6 +540,14 @@ export const handleWhiteboardItemPositionChanged = async (deps, payload) => {
     return;
   }
 
+  const currentScene = store.selectScenesData()?.items?.[itemId];
+  const currentX = Number(currentScene?.position?.x);
+  const currentY = Number(currentScene?.position?.y);
+
+  if (currentX === nextX && currentY === nextY) {
+    return;
+  }
+
   await projectService.updateSceneItem({
     sceneId: itemId,
     data: {
@@ -547,7 +555,8 @@ export const handleWhiteboardItemPositionChanged = async (deps, payload) => {
     },
   });
 
-  // Update local whiteboard state (already updated by position-updating, but keeping for consistency)
+  // Keep local UI and the last persisted scene snapshot aligned.
+  store.updatePersistedScenePosition({ itemId, x: nextX, y: nextY });
   store.updateItemPosition({ itemId, x: nextX, y: nextY });
   render();
 };

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -146,6 +146,16 @@ export const updateItemPosition = ({ state }, { itemId, x, y } = {}) => {
   }
 };
 
+export const updatePersistedScenePosition = (
+  { state },
+  { itemId, x, y } = {},
+) => {
+  const scene = state.scenesData?.items?.[itemId];
+  if (scene) {
+    scene.position = { x, y };
+  }
+};
+
 export const addWhiteboardItem = ({ state }, { newItem } = {}) => {
   state.whiteboardItems.push(newItem);
 };


### PR DESCRIPTION
## Summary
- skip scene position writes when a drag ends at the already-persisted coordinates
- keep the scenes store's persisted scene position snapshot aligned after successful moves
- remove the duplicate scene editor system-actions submit listener so command-line actions are not persisted twice
- ignore local SQLite sidecar files in git

## Testing
- bun run lint
- bun run test:smoke
