### PR TITLE
fix: show scene map viewport in minimap

### DIFF
--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -4,6 +4,47 @@ import {
   SCENE_BOX_WIDTH,
 } from "../../internal/whiteboard/constants.js";
 
+const syncContainerSize = ({ store, refs } = {}) => {
+  const container = refs?.container;
+  if (!container) {
+    return false;
+  }
+
+  const rect = container.getBoundingClientRect();
+  const width = Math.round(rect.width);
+  const height = Math.round(rect.height);
+  const currentSize = store.selectContainerSize();
+
+  if (currentSize.width === width && currentSize.height === height) {
+    return false;
+  }
+
+  store.setContainerSize({ width, height });
+  return true;
+};
+
+const dispatchPanChanged = ({ store, dispatchEvent } = {}) => {
+  const pan = store.selectPan();
+
+  dispatchEvent(
+    new CustomEvent("pan-changed", {
+      detail: { panX: pan.x, panY: pan.y },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+const dispatchZoomChanged = ({ store, dispatchEvent } = {}) => {
+  dispatchEvent(
+    new CustomEvent("zoom-changed", {
+      detail: { zoomLevel: store.selectZoomLevel() },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
   const active = streams.map((stream) => stream.subscribe());
@@ -12,6 +53,15 @@ const mountSubscriptions = (deps) => {
 
 export const handleBeforeMount = (deps) => {
   return mountSubscriptions(deps);
+};
+
+export const handleAfterMount = (deps) => {
+  const { render } = deps;
+  const didUpdateSize = syncContainerSize(deps);
+
+  if (didUpdateSize) {
+    render();
+  }
 };
 
 export const handleContainerContextMenu = (deps, payload) => {
@@ -105,16 +155,11 @@ export const handleContainerWheel = (deps, payload) => {
 
   event.preventDefault();
   store.zoomAt({ mouseX, mouseY, scaleFactor });
+  syncContainerSize(deps);
   render();
 
-  // Dispatch zoom change event to parent
-  dispatchEvent(
-    new CustomEvent("zoom-changed", {
-      detail: { zoomLevel: store.selectZoomLevel() },
-      bubbles: true,
-      composed: true,
-    }),
-  );
+  dispatchZoomChanged({ store, dispatchEvent });
+  dispatchPanChanged({ store, dispatchEvent });
 };
 
 export const handleZoomInClick = (deps) => {
@@ -129,16 +174,11 @@ export const handleZoomInClick = (deps) => {
     containerHeight: rect.height,
   });
 
+  syncContainerSize(deps);
   render();
 
-  // Dispatch zoom change event to parent
-  dispatchEvent(
-    new CustomEvent("zoom-changed", {
-      detail: { zoomLevel: store.selectZoomLevel() },
-      bubbles: true,
-      composed: true,
-    }),
-  );
+  dispatchZoomChanged({ store, dispatchEvent });
+  dispatchPanChanged({ store, dispatchEvent });
 };
 
 export const handleZoomOutClick = (deps) => {
@@ -153,16 +193,11 @@ export const handleZoomOutClick = (deps) => {
     containerHeight: rect.height,
   });
 
+  syncContainerSize(deps);
   render();
 
-  // Dispatch zoom change event to parent
-  dispatchEvent(
-    new CustomEvent("zoom-changed", {
-      detail: { zoomLevel: store.selectZoomLevel() },
-      bubbles: true,
-      composed: true,
-    }),
-  );
+  dispatchZoomChanged({ store, dispatchEvent });
+  dispatchPanChanged({ store, dispatchEvent });
 };
 
 export const handleItemMouseDown = (deps, payload) => {
@@ -288,6 +323,7 @@ export const handleItemMouseLeave = (deps) => {
 
 export const handleWindowMouseMove = (deps, payload) => {
   const { store, refs, render, dispatchEvent } = deps;
+  const didUpdateSize = syncContainerSize(deps);
 
   if (store.selectIsPanning()) {
     // Handle panning
@@ -297,14 +333,7 @@ export const handleWindowMouseMove = (deps, payload) => {
     });
 
     // Dispatch pan changed event
-    const pan = store.selectPan();
-    dispatchEvent(
-      new CustomEvent("pan-changed", {
-        detail: { panX: pan.x, panY: pan.y },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    dispatchPanChanged({ store, dispatchEvent });
 
     render();
   } else if (store.selectIsDragging()) {
@@ -366,6 +395,8 @@ export const handleWindowMouseMove = (deps, payload) => {
         },
       }),
     );
+  } else if (didUpdateSize) {
+    render();
   }
 };
 
@@ -444,6 +475,9 @@ export const handleWindowKeyUp = (deps, payload) => {
 
 const subscriptions = (deps) => {
   return [
+    fromEvent(window, "resize").pipe(
+      tap((event) => deps.handlers.handleWindowResize(deps, { _event: event })),
+    ),
     fromEvent(window, "mousemove").pipe(
       tap((event) =>
         deps.handlers.handleWindowMouseMove(deps, { _event: event }),
@@ -470,4 +504,13 @@ export const handleInitialZoomAndPanSetup = (deps, payload) => {
   const { zoomLevel, panX, panY } = payload;
 
   store.setInitialZoomAndPan({ zoomLevel, panX, panY });
+  syncContainerSize(deps);
+};
+
+export const handleWindowResize = (deps) => {
+  const { render } = deps;
+
+  if (syncContainerSize(deps)) {
+    render();
+  }
 };

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -59,6 +59,10 @@ export const createInitialState = () => ({
   panStartMouseY: 0,
   // Zoom state
   zoomLevel: 1,
+  containerSize: {
+    width: 0,
+    height: 0,
+  },
 });
 
 export const startDragging = ({ state }, { itemId } = {}) => {
@@ -185,6 +189,15 @@ export const selectPan = ({ state }) => ({
 });
 export const selectZoomLevel = ({ state }) => state.zoomLevel;
 
+export const setContainerSize = ({ state }, { width, height } = {}) => {
+  state.containerSize = {
+    width: width ?? 0,
+    height: height ?? 0,
+  };
+};
+
+export const selectContainerSize = ({ state }) => state.containerSize;
+
 export const setInitialZoomAndPan = (
   { state },
   { zoomLevel, panX, panY } = {},
@@ -194,7 +207,9 @@ export const setInitialZoomAndPan = (
   state.panY = panY;
 };
 
-const generateMinimapData = (items, pan) => {
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const generateMinimapData = (items, pan, zoomLevel, containerSize) => {
   if (!items || items.length === 0) {
     return {
       items: [],
@@ -241,6 +256,25 @@ const generateMinimapData = (items, pan) => {
 
   const scaledPanX = pan.x * scale;
   const scaledPanY = pan.y * scale;
+  const worldLeft = x_tl - padding;
+  const worldTop = y_tl - padding;
+  const viewportLeft = -pan.x / zoomLevel;
+  const viewportTop = -pan.y / zoomLevel;
+  const viewportRight = viewportLeft + containerSize.width / zoomLevel;
+  const viewportBottom = viewportTop + containerSize.height / zoomLevel;
+  const rawViewportLeft = (viewportLeft - worldLeft) * scale + offsetX;
+  const rawViewportTop = (viewportTop - worldTop) * scale + offsetY;
+  const rawViewportRight = (viewportRight - worldLeft) * scale + offsetX;
+  const rawViewportBottom = (viewportBottom - worldTop) * scale + offsetY;
+  const clippedViewportLeft = clamp(rawViewportLeft, 0, minimapWidth);
+  const clippedViewportTop = clamp(rawViewportTop, 0, minimapHeight);
+  const clippedViewportRight = clamp(rawViewportRight, 0, minimapWidth);
+  const clippedViewportBottom = clamp(rawViewportBottom, 0, minimapHeight);
+  const viewportWidth = Math.max(0, clippedViewportRight - clippedViewportLeft);
+  const viewportHeight = Math.max(
+    0,
+    clippedViewportBottom - clippedViewportTop,
+  );
 
   return {
     items: minimapItems,
@@ -250,6 +284,17 @@ const generateMinimapData = (items, pan) => {
     scaledItem: { width: scaledItemWidth, height: scaledItemHeight },
     offset: { x: offsetX, y: offsetY },
     scaledPan: { x: scaledPanX, y: scaledPanY },
+    viewport: {
+      x: clippedViewportLeft,
+      y: clippedViewportTop,
+      width: viewportWidth,
+      height: viewportHeight,
+      visible:
+        containerSize.width > 0 &&
+        containerSize.height > 0 &&
+        viewportWidth > 0 &&
+        viewportHeight > 0,
+    },
   };
 };
 
@@ -275,21 +320,15 @@ export const selectViewData = ({ state, props }) => {
 
   // Calculate adaptive grid size for container background
   const getAdaptiveGridSize = (zoomLevel) => {
-    // Fixed canvas grid size
     const canvasGridSize = 20;
     const visualGridSize = canvasGridSize * zoomLevel;
+    const minVisualGridSize = 28;
+    const gridMultiplier = Math.max(
+      1,
+      Math.ceil(minVisualGridSize / visualGridSize),
+    );
 
-    // This prevents dots from becoming too dense while maintaining grid alignment
-    if (visualGridSize < 8) {
-      // At very low zoom, merge 4x4 grid cells into one (multiply by 4)
-      return canvasGridSize * 4 * zoomLevel;
-    } else if (visualGridSize < 12) {
-      // At low zoom, merge 2x2 grid cells into one (multiply by 2)
-      return canvasGridSize * 2 * zoomLevel;
-    }
-
-    // Normal case: no merging needed
-    return visualGridSize;
+    return canvasGridSize * gridMultiplier * zoomLevel;
   };
 
   const arrowsList = [];
@@ -322,7 +361,12 @@ export const selectViewData = ({ state, props }) => {
   return {
     items,
     showMinimap: items.length > 1,
-    minimapData: generateMinimapData(items, { x: state.panX, y: state.panY }),
+    minimapData: generateMinimapData(
+      items,
+      { x: state.panX, y: state.panY },
+      state.zoomLevel,
+      state.containerSize,
+    ),
     arrowsList,
     selectedItemId: props.selectedItemId,
     isPanMode: state.isPanMode,

--- a/src/components/whiteboard/whiteboard.view.yaml
+++ b/src/components/whiteboard/whiteboard.view.yaml
@@ -56,6 +56,8 @@ template:
               - $for item in minimapData.items:
                   - 'rtgl-view d=h pos=abs style="left: ${item.x}px; top: ${item.y}px; z-index: 10; user-select: none;"':
                       - rtgl-view w=${minimapData.scaledItem.width} h=${minimapData.scaledItem.height} bgc=ac: null
+              - $if minimapData.viewport.visible:
+                  - 'rtgl-view pos=abs bw=xs bc=fg style="left: ${minimapData.viewport.x}px; top: ${minimapData.viewport.y}px; width: ${minimapData.viewport.width}px; height: ${minimapData.viewport.height}px; z-index: 20; pointer-events: none; box-sizing: border-box;"': null
       - 'rtgl-view pos=abs z=100 ah=c p=md bgc=mu br=md style="right: 20px; bottom: 20px;"':
           - rtgl-view d=h av=c gap=sm:
               - rtgl-button#panBtn sq pre=hand v=${panModeV}: null


### PR DESCRIPTION
## Summary
- track the whiteboard container size so the scene-map minimap can derive the live visible viewport
- render a viewport rectangle in the minimap and keep pan persistence aligned when zoom changes adjust pan
- make the scene-map background grid dots thin out more aggressively at low zoom levels

## Testing
- `bun run build:web`
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`