### PR TITLE
fix: wire animations route into project navigation

### DIFF
--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -26,6 +26,7 @@ export const selectCurrentRoutePattern = ({ state }) => {
     "/project/character-sprites",
     "/project/sounds",
     "/project/transforms",
+    "/project/animations",
     "/project/videos",
     "/project/colors",
     "/project/text-styles",

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -27,6 +27,8 @@ template:
                   - rvn-sounds: []
                 $elif currentRoutePattern == "/project/transforms":
                   - rvn-transforms: []
+                $elif currentRoutePattern == "/project/animations":
+                  - rvn-animations: []
                 $elif currentRoutePattern == "/project/videos":
                   - rvn-videos: []
                 $elif currentRoutePattern == "/project/text-styles":

--- a/src/pages/resourceTypes/resourceTypes.store.js
+++ b/src/pages/resourceTypes/resourceTypes.store.js
@@ -24,6 +24,11 @@ export const assetItems = [
     name: "Transforms",
     path: "/project/transforms",
   },
+  {
+    id: "animations",
+    name: "Animations",
+    path: "/project/animations",
+  },
 ];
 
 export const userInterfaceItems = [

--- a/src/pages/resources/resources.store.js
+++ b/src/pages/resources/resources.store.js
@@ -21,6 +21,11 @@ export const createInitialState = () => ({
       route: "/project/transforms",
     },
     {
+      id: "animations",
+      label: "Animations",
+      route: "/project/animations",
+    },
+    {
       id: "videos",
       label: "Videos",
       route: "/project/videos",

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -30,7 +30,7 @@ import {
 } from "../../internal/ui/sceneEditor/sectionOperations.js";
 
 const DEAD_END_TOOLTIP_CONTENT =
-  "This section has no transition to another scene.";
+  "This section has no transition to another section.";
 
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -12,7 +12,7 @@ import {
 } from "../../internal/whiteboard/constants.js";
 
 const DEAD_END_TOOLTIP_CONTENT =
-  "This section has no transition to another scene.";
+  "This section has no transition to another section.";
 
 const getProjectErrorMessage = (result, fallbackMessage) => {
   return (


### PR DESCRIPTION
## Summary
- wire the animations page into app route rendering and project resource navigation
- expose animations in both resource navigation stores so the route is reachable from project UI
- update the scene/section dead-end tooltip copy to say "section" instead of "scene"

## Testing
- `bun run build:web`
- push hook: `oxlint`
- push hook: `bun prettier --check src`