### PR TITLE
fix: align character sprites detail panel with images

### DIFF
--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -7,6 +7,15 @@ import { tap } from "rxjs";
 const EMPTY_TREE = { items: {}, tree: [] };
 const ACCEPTED_FILE_TYPES = ".jpg,.jpeg,.png,.webp";
 
+const getProjectErrorMessage = (result, fallbackMessage) => {
+  return (
+    result?.error?.message ||
+    result?.error?.creatorModelError?.message ||
+    result?.message ||
+    fallbackMessage
+  );
+};
+
 const getCharacterIdFromPayload = ({ appService }) => {
   return appService.getPayload().characterId;
 };
@@ -15,74 +24,21 @@ const getCharacter = ({ projectService, characterId }) => {
   return projectService.getState().characters.items?.[characterId];
 };
 
-const createDetailFormValues = (item, imageSrc) => ({
-  fileId: imageSrc,
-  name: item?.name ?? "",
-  description: item?.description ?? "",
-});
-
-const syncDetailForm = ({ refs, values } = {}) => {
-  const { detailForm } = refs;
-  if (!detailForm) {
-    return;
-  }
-
-  detailForm.reset();
-  detailForm.setValues({ values });
-};
-
-const getPreviewImageSrc = async ({ projectService, item } = {}) => {
-  if (!item?.fileId) {
-    return undefined;
-  }
-
-  const { url } = await projectService.getFileContent(item.fileId);
-  return url;
-};
-
-const resolveSelectedPreviewImageSrc = async ({
-  projectService,
-  store,
-  previousSelectedItem,
-  selectedItem,
-} = {}) => {
-  if (!selectedItem?.fileId) {
-    return undefined;
-  }
-
-  const currentPreviewImageSrc = store.selectPreviewImageSrc();
-  if (
-    currentPreviewImageSrc &&
-    previousSelectedItem?.id === selectedItem.id &&
-    previousSelectedItem?.fileId === selectedItem.fileId
-  ) {
-    return currentPreviewImageSrc;
-  }
-
-  return getPreviewImageSrc({
-    projectService,
-    item: selectedItem,
-  });
-};
-
-const syncCharacterSpritesData = async (deps) => {
+const syncCharacterSpritesData = ({ deps, repositoryState } = {}) => {
   const { appService, projectService, store } = deps;
   const characterId =
     store.selectCharacterId() ?? getCharacterIdFromPayload(deps);
+  const state = repositoryState ?? projectService.getState();
 
   if (!characterId) {
     appService.showToast("Character is missing.", { title: "Error" });
-    return {};
+    return false;
   }
 
-  const character = getCharacter({
-    projectService,
-    characterId,
-  });
-
+  const character = state?.characters?.items?.[characterId];
   if (!character) {
     appService.showToast("Character not found.", { title: "Error" });
-    return {};
+    return false;
   }
 
   store.setCharacterId({ characterId });
@@ -93,100 +49,21 @@ const syncCharacterSpritesData = async (deps) => {
     store.setSelectedItemId({ itemId: undefined });
   }
 
-  const selectedItem = store.selectSelectedItem();
-  const imageSrc = await getPreviewImageSrc({
-    projectService,
-    item: selectedItem,
-  });
-
-  store.setContext({
-    context: {
-      fileId: {
-        src: imageSrc,
-      },
-    },
-  });
-
-  return {
-    characterId,
-    selectedItem,
-    imageSrc,
-  };
+  return true;
 };
 
 const refreshCharacterSpritesData = async (deps) => {
-  const { render, refs } = deps;
-  const { selectedItem, imageSrc } = await syncCharacterSpritesData(deps);
-  render();
-
-  if (selectedItem) {
-    syncDetailForm({
-      refs,
-      values: createDetailFormValues(selectedItem, imageSrc),
-    });
-  }
-};
-
-const syncCharacterSpritesRepositoryState = async ({
-  deps,
-  repositoryState,
-} = {}) => {
-  const { appService, projectService, store, render, refs } = deps;
-  const characterId =
-    store.selectCharacterId() ?? getCharacterIdFromPayload(deps);
-  const character = repositoryState?.characters?.items?.[characterId];
-
-  if (!characterId) {
-    appService.showToast("Character is missing.", { title: "Error" });
-    store.clearCharacterSpritesView();
-    render();
+  const { render } = deps;
+  const synced = syncCharacterSpritesData({ deps });
+  if (!synced) {
     return;
   }
 
-  if (!character) {
-    appService.showToast("Character not found.", { title: "Error" });
-    store.clearCharacterSpritesView();
-    render();
-    return;
-  }
-
-  const previousSelectedItem = store.selectSelectedItem();
-  store.setCharacterId({ characterId });
-  store.setCharacterName({ characterName: character.name });
-  store.setItems({ spritesData: character.sprites ?? EMPTY_TREE });
-
-  if (store.selectSelectedItemId() && !store.selectSelectedItem()) {
-    store.setSelectedItemId({ itemId: undefined });
-  }
-
-  const selectedItem = store.selectSelectedItem();
-  const imageSrc = await resolveSelectedPreviewImageSrc({
-    projectService,
-    store,
-    previousSelectedItem,
-    selectedItem,
-  });
-
-  store.setContext({
-    context: {
-      fileId: {
-        src: imageSrc,
-      },
-    },
-  });
-
   render();
-
-  if (selectedItem) {
-    syncDetailForm({
-      refs,
-      values: createDetailFormValues(selectedItem, imageSrc),
-    });
-  }
 };
 
-const selectSprite = async ({ deps, itemId, syncExplorer = false } = {}) => {
-  const { projectService, refs, render, store } = deps;
+const selectSprite = ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { refs, render, store } = deps;
   const item = store.selectSpriteItemById({ itemId });
 
   if (!itemId || !item) {
@@ -199,24 +76,31 @@ const selectSprite = async ({ deps, itemId, syncExplorer = false } = {}) => {
     refs.fileExplorer.selectItem({ itemId });
   }
 
-  const imageSrc = await getPreviewImageSrc({
-    projectService,
-    item,
-  });
-
-  store.setContext({
-    context: {
-      fileId: {
-        src: imageSrc,
-      },
-    },
-  });
-
   render();
-  syncDetailForm({
-    refs,
-    values: createDetailFormValues(item, imageSrc),
+};
+
+const openEditDialogForSprite = ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { refs, render, store } = deps;
+  const item = store.selectSpriteItemById({ itemId });
+
+  if (!itemId || !item) {
+    return;
+  }
+
+  store.setSelectedItemId({ itemId });
+  if (syncExplorer) {
+    refs.fileExplorer.selectItem({ itemId });
+  }
+
+  store.openEditDialog({
+    itemId,
+    defaultValues: {
+      name: item.name ?? "",
+      description: item.description ?? "",
+    },
+    previewFileId: item.fileId,
   });
+  render();
 };
 
 const createSpritesFromFiles = async ({
@@ -246,7 +130,7 @@ const createSpritesFromFiles = async ({
   }
 
   for (const result of successfulUploads) {
-    await projectService.createCharacterSpriteItem({
+    const createResult = await projectService.createCharacterSpriteItem({
       characterId,
       spriteId: nanoid(),
       fileRecords: result.fileRecords,
@@ -262,6 +146,14 @@ const createSpritesFromFiles = async ({
         height: result.dimensions.height,
       },
     });
+
+    if (createResult?.valid === false) {
+      appService.showToast(
+        getProjectErrorMessage(createResult, "Failed to create sprite."),
+        { title: "Error" },
+      );
+      return;
+    }
   }
 
   await refreshCharacterSpritesData(deps);
@@ -272,10 +164,12 @@ export const handleBeforeMount = (deps) => {
   const subscription = createProjectStateStream({ projectService })
     .pipe(
       tap(({ repositoryState }) => {
-        void syncCharacterSpritesRepositoryState({
-          deps,
-          repositoryState,
-        });
+        const { store, render } = deps;
+        const synced = syncCharacterSpritesData({ deps, repositoryState });
+        if (!synced) {
+          store.clearCharacterSpritesView();
+        }
+        render();
       }),
     )
     .subscribe();
@@ -302,18 +196,11 @@ export const handleFileExplorerSelectionChanged = async (deps, payload) => {
 
   if (isFolder) {
     store.setSelectedItemId({ itemId: undefined });
-    store.setContext({
-      context: {
-        fileId: {
-          src: undefined,
-        },
-      },
-    });
     render();
     return;
   }
 
-  await selectSprite({
+  selectSprite({
     deps,
     itemId,
   });
@@ -334,7 +221,7 @@ export const handleFileExplorerDoubleClick = (deps, payload) => {
 export const handleSpriteItemClick = async (deps, payload) => {
   const { itemId } = payload._event.detail;
 
-  await selectSprite({
+  selectSprite({
     deps,
     itemId,
     syncExplorer: true,
@@ -351,6 +238,28 @@ export const handleSpriteItemDoubleClick = (deps, payload) => {
 
   store.showFullImagePreview({ itemId });
   render();
+};
+
+export const handleSpriteItemPreview = (deps, payload) => {
+  const { render, store } = deps;
+  const { itemId } = payload._event.detail;
+
+  if (!itemId) {
+    return;
+  }
+
+  store.showFullImagePreview({ itemId });
+  render();
+};
+
+export const handleSpriteItemEdit = (deps, payload) => {
+  const { itemId } = payload._event.detail;
+
+  openEditDialogForSprite({
+    deps,
+    itemId,
+    syncExplorer: true,
+  });
 };
 
 export const handleUploadClick = async (deps, payload) => {
@@ -387,34 +296,6 @@ export const handleFilesDropped = async (deps, payload) => {
     files,
     parentId: targetGroupId,
   });
-};
-
-export const handleFormChange = async (deps, payload) => {
-  const { projectService, render, store } = deps;
-  const characterId = store.selectCharacterId();
-  const selectedItemId = store.selectSelectedItemId();
-
-  if (!characterId || !selectedItemId) {
-    return;
-  }
-
-  await projectService.updateCharacterSpriteItem({
-    characterId,
-    spriteId: selectedItemId,
-    data: {
-      [payload._event.detail.name]: payload._event.detail.value,
-    },
-  });
-
-  const character = getCharacter({
-    projectService,
-    characterId,
-  });
-
-  store.setItems({
-    spritesData: character?.sprites ?? EMPTY_TREE,
-  });
-  render();
 };
 
 export const handleFormExtraEvent = async (deps) => {
@@ -454,7 +335,7 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  await projectService.updateCharacterSpriteItem({
+  const updateResult = await projectService.updateCharacterSpriteItem({
     characterId,
     spriteId: selectedItem.id,
     fileRecords: uploadResult.fileRecords,
@@ -468,6 +349,104 @@ export const handleFormExtraEvent = async (deps) => {
     },
   });
 
+  if (updateResult?.valid === false) {
+    appService.showToast(
+      getProjectErrorMessage(updateResult, "Failed to update sprite."),
+      { title: "Error" },
+    );
+    return;
+  }
+
+  await refreshCharacterSpritesData(deps);
+};
+
+export const handleEditDialogClose = (deps) => {
+  const { store, render } = deps;
+  store.closeEditDialog();
+  render();
+};
+
+export const handleEditDialogImageClick = async (deps) => {
+  const { appService, store, render } = deps;
+  let file;
+
+  try {
+    file = await appService.pickFiles({
+      accept: ACCEPTED_FILE_TYPES,
+      multiple: false,
+      upload: true,
+    });
+  } catch {
+    appService.showToast("Failed to select file.", { title: "Error" });
+    return;
+  }
+
+  if (!file) {
+    return;
+  }
+
+  if (!(file.uploadSucessful && file.uploadResult)) {
+    appService.showToast("Failed to upload sprite.", { title: "Error" });
+    return;
+  }
+
+  store.setEditUpload({
+    uploadResult: file.uploadResult,
+    previewFileId: file.uploadResult.fileId,
+  });
+  render();
+};
+
+export const handleEditFormAction = async (deps, payload) => {
+  const { appService, projectService, store, render } = deps;
+  const { actionId, values } = payload._event.detail;
+
+  if (actionId !== "submit") {
+    return;
+  }
+
+  const name = values?.name?.trim();
+  if (!name) {
+    appService.showToast("Sprite name is required.", { title: "Warning" });
+    return;
+  }
+
+  const { editItemId, editUploadResult } = store.getState();
+  if (!editItemId) {
+    store.closeEditDialog();
+    render();
+    return;
+  }
+
+  const data = {
+    name,
+    description: values?.description ?? "",
+  };
+
+  if (editUploadResult) {
+    data.fileId = editUploadResult.fileId;
+    data.fileType = editUploadResult.file.type;
+    data.fileSize = editUploadResult.file.size;
+    data.width = editUploadResult.dimensions.width;
+    data.height = editUploadResult.dimensions.height;
+  }
+
+  const updateResult = await projectService.updateCharacterSpriteItem({
+    characterId: store.selectCharacterId(),
+    spriteId: editItemId,
+    fileRecords: editUploadResult?.fileRecords,
+    data,
+  });
+
+  if (updateResult?.valid === false) {
+    appService.showToast(
+      getProjectErrorMessage(updateResult, "Failed to update sprite."),
+      { title: "Error" },
+    );
+    return;
+  }
+
+  store.closeEditDialog();
   await refreshCharacterSpritesData(deps);
 };
 
@@ -497,10 +476,18 @@ export const handleItemDelete = async (deps, payload) => {
     return;
   }
 
-  await projectService.deleteCharacterSpriteItem({
+  const deleteResult = await projectService.deleteCharacterSpriteItem({
     characterId,
     spriteIds: [itemId],
   });
+
+  if (deleteResult?.valid === false) {
+    appService.showToast(
+      getProjectErrorMessage(deleteResult, "Failed to delete sprite."),
+      { title: "Error" },
+    );
+    return;
+  }
 
   await refreshCharacterSpritesData(deps);
 };

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -20,10 +20,6 @@ const getCharacterIdFromPayload = ({ appService }) => {
   return appService.getPayload().characterId;
 };
 
-const getCharacter = ({ projectService, characterId }) => {
-  return projectService.getState().characters.items?.[characterId];
-};
-
 const syncCharacterSpritesData = ({ deps, repositoryState } = {}) => {
   const { appService, projectService, store } = deps;
   const characterId =
@@ -79,7 +75,11 @@ const selectSprite = ({ deps, itemId, syncExplorer = false } = {}) => {
   render();
 };
 
-const openEditDialogForSprite = ({ deps, itemId, syncExplorer = false } = {}) => {
+const openEditDialogForSprite = ({
+  deps,
+  itemId,
+  syncExplorer = false,
+} = {}) => {
   const { refs, render, store } = deps;
   const item = store.selectSpriteItemById({ itemId });
 

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -1,3 +1,4 @@
+import { formatFileSize } from "../../internal/files.js";
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
 
 const EMPTY_TREE = { tree: [], items: {} };
@@ -18,31 +19,75 @@ const emptyContextMenuItems = [
 ];
 
 const centerItemContextMenuItems = [
+  { label: "Edit", type: "item", value: "edit-item" },
+  { label: "Preview", type: "item", value: "preview-item" },
   { label: "Delete", type: "item", value: "delete-item" },
 ];
 
-const form = {
-  fields: [
+const buildDetailFields = (item) => {
+  if (!item) {
+    return [];
+  }
+
+  return [
     {
-      name: "fileId",
-      type: "image",
-      width: 240,
-      clickable: true,
-      extraEvent: true,
+      type: "slot",
+      slot: "image-file-id",
+      label: "",
     },
-    { name: "name", type: "popover-input", label: "Name" },
     {
-      name: "description",
-      type: "popover-input",
-      label: "Description",
+      type: "description",
+      value: item.description ?? "",
     },
-  ],
+    {
+      type: "text",
+      label: "File Type",
+      value: item.fileType ?? "",
+    },
+    {
+      type: "text",
+      label: "File Size",
+      value: formatFileSize(item.fileSize),
+    },
+    {
+      type: "text",
+      label: "Dimensions",
+      value: item.width && item.height ? `${item.width} × ${item.height}` : "",
+    },
+  ];
 };
 
-const createDetailValues = (item, imageSrc) => ({
-  fileId: imageSrc,
-  name: item?.name ?? "",
-  description: item?.description ?? "",
+const createEditForm = () => ({
+  title: "Edit Sprite",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "description",
+      type: "input-textarea",
+      label: "Description",
+      required: false,
+    },
+    {
+      type: "slot",
+      slot: "image-slot",
+      label: "Image",
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Update Sprite",
+      },
+    ],
+  },
 });
 
 const matchesSearch = (item, searchQuery) => {
@@ -61,19 +106,18 @@ export const createInitialState = () => ({
   selectedItemId: undefined,
   characterId: undefined,
   characterName: undefined,
-  context: {
-    fileId: {
-      src: undefined,
-    },
-  },
   searchQuery: "",
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
+  isEditDialogOpen: false,
+  editItemId: undefined,
+  editDefaultValues: {
+    name: "",
+    description: "",
+  },
+  editPreviewFileId: undefined,
+  editUploadResult: undefined,
 });
-
-export const setContext = ({ state }, { context } = {}) => {
-  state.context = context;
-};
 
 export const setItems = ({ state }, { spritesData } = {}) => {
   state.spritesData = spritesData ?? EMPTY_TREE;
@@ -91,11 +135,14 @@ export const clearCharacterSpritesView = ({ state }) => {
   state.characterName = undefined;
   state.spritesData = EMPTY_TREE;
   state.selectedItemId = undefined;
-  state.context = {
-    fileId: {
-      src: undefined,
-    },
+  state.isEditDialogOpen = false;
+  state.editItemId = undefined;
+  state.editDefaultValues = {
+    name: "",
+    description: "",
   };
+  state.editPreviewFileId = undefined;
+  state.editUploadResult = undefined;
 };
 
 export const setSelectedItemId = ({ state }, { itemId } = {}) => {
@@ -104,6 +151,36 @@ export const setSelectedItemId = ({ state }, { itemId } = {}) => {
 
 export const setSearchQuery = ({ state }, { query } = {}) => {
   state.searchQuery = query ?? "";
+};
+
+export const openEditDialog = (
+  { state },
+  { itemId, defaultValues, previewFileId } = {},
+) => {
+  state.isEditDialogOpen = true;
+  state.editItemId = itemId;
+  state.editDefaultValues = {
+    name: defaultValues?.name ?? "",
+    description: defaultValues?.description ?? "",
+  };
+  state.editPreviewFileId = previewFileId;
+  state.editUploadResult = undefined;
+};
+
+export const closeEditDialog = ({ state }, _payload = {}) => {
+  state.isEditDialogOpen = false;
+  state.editItemId = undefined;
+  state.editDefaultValues = {
+    name: "",
+    description: "",
+  };
+  state.editPreviewFileId = undefined;
+  state.editUploadResult = undefined;
+};
+
+export const setEditUpload = ({ state }, { uploadResult, previewFileId } = {}) => {
+  state.editUploadResult = uploadResult;
+  state.editPreviewFileId = previewFileId;
 };
 
 export const selectSelectedItem = ({ state }) => {
@@ -122,10 +199,6 @@ export const selectSelectedItemId = ({ state }) => {
 
 export const selectCharacterId = ({ state }) => {
   return state.characterId;
-};
-
-export const selectPreviewImageSrc = ({ state }) => {
-  return state.context?.fileId?.src;
 };
 
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {
@@ -160,6 +233,7 @@ export const selectViewData = ({ state }) => {
           ...item,
           cardKind: "image",
           previewFileId: item.fileId,
+          canPreview: true,
         })),
         hasChildren: children.length > 0,
         shouldDisplay,
@@ -173,14 +247,13 @@ export const selectViewData = ({ state }) => {
     flatItems,
     mediaGroups,
     resourceCategory: "assets",
-    selectedResourceId: "characterSprites",
+    selectedResourceId: "characters",
     selectedItemId: state.selectedItemId,
-    form,
-    context: state.context,
-    defaultValues: createDetailValues(
-      selectedItem?.type === "image" ? selectedItem : undefined,
-      state.context.fileId.src,
-    ),
+    selectedItemName: selectedItem?.name ?? "",
+    detailFields:
+      selectedItem?.type === "image" ? buildDetailFields(selectedItem) : [],
+    selectedPreviewFileId:
+      selectedItem?.type === "image" ? selectedItem.fileId : undefined,
     searchQuery: state.searchQuery,
     uploadText: "Upload Sprite",
     acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
@@ -191,5 +264,9 @@ export const selectViewData = ({ state }) => {
     emptyContextMenuItems,
     centerItemContextMenuItems,
     title: state.characterName,
+    isEditDialogOpen: state.isEditDialogOpen,
+    editForm: createEditForm(),
+    editDefaultValues: state.editDefaultValues,
+    editPreviewFileId: state.editPreviewFileId,
   };
 };

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -178,7 +178,10 @@ export const closeEditDialog = ({ state }, _payload = {}) => {
   state.editUploadResult = undefined;
 };
 
-export const setEditUpload = ({ state }, { uploadResult, previewFileId } = {}) => {
+export const setEditUpload = (
+  { state },
+  { uploadResult, previewFileId } = {},
+) => {
   state.editUploadResult = uploadResult;
   state.editPreviewFileId = previewFileId;
 };

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -15,6 +15,10 @@ refs:
         handler: handleSpriteItemClick
       item-dblclick:
         handler: handleSpriteItemDoubleClick
+      item-preview:
+        handler: handleSpriteItemPreview
+      item-edit:
+        handler: handleSpriteItemEdit
       files-dropped:
         handler: handleFilesDropped
       upload-click:
@@ -29,30 +33,60 @@ refs:
     eventListeners:
       click:
         action: hideFullImagePreview
-  detailForm:
+  editDialog:
     eventListeners:
-      form-field-event:
+      close:
+        handler: handleEditDialogClose
+  editForm:
+    eventListeners:
+      form-action:
+        handler: handleEditFormAction
+  editDialogImage:
+    eventListeners:
+      click:
+        handler: handleEditDialogImageClick
+  editDialogImagePlaceholder:
+    eventListeners:
+      click:
+        handler: handleEditDialogImageClick
+  detailImage:
+    eventListeners:
+      click:
         handler: handleFormExtraEvent
-      form-change:
-        handler: handleFormChange
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorerPanel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
-                  - rvn-resource-types :resourceCategory=resourceCategory  :selectedResourceId=selectedResourceId: null
+                  - rvn-resource-types :resourceCategory=resourceCategory :selectedResourceId=selectedResourceId: null
                   - rvn-base-file-explorer#fileExplorer :items=flatItems shrinkable dropdown-menu allowDrag :folderContextMenuItems=folderContextMenuItems :itemContextMenuItems=itemContextMenuItems :emptyContextMenuItems=emptyContextMenuItems: null
-          - rtgl-view w=1fg h=f:
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
               - rvn-media-resources-view#groupview w=f h=f show-back-button show-zoom-controls :navTitle=title :groups=mediaGroups :selectedItemId=selectedItemId :searchQuery=searchQuery :uploadText=uploadText :acceptedFileTypes=acceptedFileTypes :itemContextMenuItems=centerItemContextMenuItems: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
-                      - rtgl-form#detailForm key=${selectedItemId} w=f h=f :form=form :context=context :defaultValues=defaultValues: null
+                      - rtgl-view d=v w=f h=f:
+                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
+                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
+                              - $if selectedPreviewFileId:
+                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} h=160 bw=xs bc=bo br=md cur=pointer: null
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
-      - $when: fullImagePreviewVisible
-        rtgl-view#previewOverlay pos=fix cor=full ah=c av=c z=3000 cur=pointer:
-          - rtgl-view w=f h=f pos=fix cor=full ah=c av=c bgc=bg op="0.5": null
-          - $if fullImagePreviewFileId:
-              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% z=3001: null
+  - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
+      - rtgl-view slot=content g=md:
+          - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=editDefaultValues :form=editForm w=f:
+              - $if editPreviewFileId:
+                  - rtgl-view slot=image-slot av=c ah=c:
+                      - rvn-file-image#editDialogImage fileId=${editPreviewFileId} h=120 bw=xs bc=bo br=md cur=pointer key=${editPreviewFileId}: null
+                $else:
+                  - rtgl-view slot=image-slot av=c ah=c:
+                      - rtgl-view#editDialogImagePlaceholder w=120 h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
+                          - rtgl-text c=mu-fg s=sm: Click to Upload
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: #000;"': null
+      - $if fullImagePreviewFileId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -57,7 +57,7 @@ template:
                           - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
                               - rtgl-text c=mu-fg: ${selectedItemName}
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
-                              - 'rtgl-view#detailColorPreview slot="color-preview" h=130 br=md bw=xs bc=bo cur=pointer style="background-color: ${selectedColorHex};"': null
+                              - 'rtgl-view#detailColorPreview slot="color-preview" w=f h=130 br=md bw=xs bc=bo cur=pointer style="background-color: ${selectedColorHex};"': null
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection

--- a/src/pages/sidebar/sidebar.store.js
+++ b/src/pages/sidebar/sidebar.store.js
@@ -93,9 +93,7 @@ export const selectViewData = ({ state }) => {
         if (currentPath === item.path) return true;
 
         // Extract the resource type from current path
-        const currentResourceMatch = currentPath.match(
-          /^\/project\/([^/?]+)/,
-        );
+        const currentResourceMatch = currentPath.match(/^\/project\/([^/?]+)/);
         if (!currentResourceMatch) return false;
         const currentResourceType = currentResourceMatch[1];
 

--- a/src/pages/sidebar/sidebar.store.js
+++ b/src/pages/sidebar/sidebar.store.js
@@ -94,7 +94,7 @@ export const selectViewData = ({ state }) => {
 
         // Extract the resource type from current path
         const currentResourceMatch = currentPath.match(
-          /^\/project\/resources\/([^/?]+)/,
+          /^\/project\/([^/?]+)/,
         );
         if (!currentResourceMatch) return false;
         const currentResourceType = currentResourceMatch[1];


### PR DESCRIPTION
## Summary
- align the character sprites page with the images page pattern using a read-only detail panel, full preview, and separate edit dialog
- keep character sprite navigation highlighted under Characters and fix sidebar matching for child project routes
- make the colors detail preview fill the right panel width

## Testing
- `bun run build:web`
- push hook: `oxlint`
- push hook: `bun prettier --check src`