### PR TITLE
refactor(layout): simplify editor architecture

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -404,6 +404,8 @@ When deciding where new code goes, apply these rules in order:
 
 1. If it owns one route or screen, put it in `src/pages/`.
 2. If it is reusable visual UI, put it in `src/components/`.
+   `src/components/<name>/` is limited to Rettangoli FE component files only.
+   Do not add ad hoc sibling helper modules there.
 3. If it owns low-level DOM or browser-native behavior, put it in
    `src/primitives/`.
 4. If it is shared UI/page/store/handler glue and may touch refs, render,
@@ -431,6 +433,26 @@ Most pages and many components use Rettangoli’s fixed file pattern:
 - `*.view.yaml`
 - `*.store.js`
 - `*.handlers.js`
+
+Allowed component-folder files are Rettangoli FE files only, for example:
+
+- `*.view.yaml`
+- `*.store.js`
+- `*.handlers.js`
+- optional FE companion files such as `*.schema.yaml`,
+  `*.constants.yaml`, or `*.methods.js`
+
+Do not place ad hoc helper modules, editor-specific orchestration files, or
+other non-FE support files inside `src/components/<name>/`.
+
+If code is shared or specific but is not itself one of the component FE files,
+put it somewhere else based on ownership:
+
+- `src/internal/ui/` for shared UI/store/handler orchestration
+- `src/internal/project/` for project semantics
+- `src/internal/` for small pure app-owned helpers
+- `src/deps/services/` or `src/deps/clients/` for service/client-owned code
+- the owning page folder when the code is page-specific
 
 The intended split is:
 

--- a/docs/notes/layout-editor-cleanup-research.md
+++ b/docs/notes/layout-editor-cleanup-research.md
@@ -1,0 +1,724 @@
+# Layout Editor Cleanup And Redesign Research
+
+Date: 2026-03-19
+
+## Goal
+
+Define the best end state for `src/pages/layoutEditor/`.
+
+This is not only about incremental cleanup. The goal is a materially better
+architecture that makes the layout editor simpler to work on, easier to extend,
+and less fragile when adding or changing item types.
+
+## Rettangoli FE Note: Where Static Component Constants Should Go
+
+Rettangoli FE has an optional `.constants.yaml` file for component-local static,
+read-only data.
+
+Official guidance:
+
+- use `.constants.yaml` for labels, limits, feature flags, and other static
+  values that do not change
+- constants are injected as `deps.constants` in handlers and `ctx.constants` in
+  store functions
+- constants must be treated as read-only
+- values must be JSON-serializable
+
+Source:
+
+- https://rettangoli.dev/fe/docs/guides/constants.md
+- https://rettangoli.dev/llms.txt
+
+### Practical implication for this codebase
+
+If static config is not reused outside the page/component, the preferred home is
+a local `.constants.yaml` file next to that page/component.
+
+Examples:
+
+- `src/pages/layoutEditor/layoutEditor.constants.yaml`
+- `src/pages/layoutEditor/layoutInspector.constants.yaml`
+
+Important constraint:
+
+- `undefined` is not JSON-serializable, so constants data must use explicit
+  values such as `null`, `""`, `0`, or a named enum value, then normalize in
+  store/helpers if needed
+
+This is useful, but it is only part of the solution. Static config extraction
+alone does not fix the deeper architectural problem.
+
+## Executive Summary
+
+The biggest issue is not file length. The bigger issue is that one concept, a
+layout item type, is defined in too many disconnected places.
+
+Today a type like `slider` is spread across:
+
+- creation defaults
+- context menus
+- inspector field config
+- field update rules
+- preview/render mapping
+- drag/selection behavior
+- persistence edge cases
+
+That makes even small changes expensive and risky.
+
+The strongest improvement is to redesign the editor around a single item-type
+system plus clearer surface boundaries:
+
+1. a shared item-type registry
+2. a small page-level orchestrator
+3. a dedicated canvas surface
+4. a dedicated inspector surface
+5. intent-based item updates instead of large handler branches
+
+That is the path most likely to make the layout editor 2x to 3x easier to
+maintain.
+
+## Current Structure
+
+Main files reviewed:
+
+- `src/pages/layoutEditor/layoutEditor.handlers.js`
+- `src/pages/layoutEditor/layoutEditor.store.js`
+- `src/pages/layoutEditor/layoutPreview.js`
+- `src/components/layoutEditPanel/layoutEditPanel.handlers.js`
+- `src/components/layoutEditPanel/layoutEditPanel.store.js`
+- `src/internal/project/layout.js`
+- `src/internal/layoutEditorRoute.js`
+
+Approximate file sizes:
+
+- `layoutEditor.handlers.js`: 946 lines
+- `layoutEditor.store.js`: 871 lines
+- `layoutEditPanel.store.js`: 863 lines
+- `layoutEditPanel.handlers.js`: 401 lines
+- `layoutPreview.js`: 301 lines
+- `src/internal/project/layout.js`: 1277 lines
+
+## Findings
+
+### 1. The page handler owns too many responsibilities
+
+`src/pages/layoutEditor/layoutEditor.handlers.js` currently mixes:
+
+- repository synchronization
+- render-state assembly
+- asset loading and cache recovery
+- graphics preview rendering
+- keyboard movement
+- drag behavior
+- debounced persistence
+- item mutation rules
+
+This file is acting as the page controller, canvas controller, save pipeline,
+and type-specific mutation layer at the same time.
+
+### 2. Large static definitions are sitting inside stores
+
+`src/pages/layoutEditor/layoutEditor.store.js` contains:
+
+- context menu definitions
+- empty-state context menu definitions
+- control-specific menu definitions
+- preview form definitions
+
+`src/components/layoutEditPanel/layoutEditPanel.store.js` contains:
+
+- the edit-panel section and field config
+
+Most of this is static data, not store logic.
+
+This should move to `.constants.yaml` where it is truly static.
+
+### 3. The edit-panel component has blurred ownership
+
+`src/components/layoutEditPanel/layoutEditPanel.handlers.js` still fetches
+repository state on mount to read `textStyles`.
+
+That makes the child component partially repository-aware even though the page
+already owns repository-backed state and already passes `values` and
+`variablesData`.
+
+Cleaner ownership:
+
+- page owns repository data
+- child surfaces receive props
+- child surfaces do not ensure repositories or fetch project state
+
+### 4. A lot of mutation logic is buried in one handler
+
+`handleLayoutEditPanelUpdateHandler` in
+`src/pages/layoutEditor/layoutEditor.handlers.js` contains several different
+rule sets:
+
+- anchor updates
+- nested property updates
+- general deep merge updates
+- slider direction switching and remembered slider assets
+- slider variable binding
+- sprite auto-size fallback
+
+This should become a small pure mutation layer, not page handler code.
+
+### 5. Preview rendering is a coherent subsystem, but it is split awkwardly
+
+The preview flow is logically one thing:
+
+- read repo/store state
+- build render elements
+- collect file references
+- load assets
+- create preview data
+- parse preview
+- create selection overlay
+- render graphics
+
+Today it is spread across `layoutEditor.handlers.js` and `layoutPreview.js`.
+
+That should become a dedicated canvas/preview layer.
+
+### 6. There is avoidable duplication and contract drift
+
+Examples:
+
+- `toAlphanumericId` exists in both
+  `src/pages/layoutEditor/layoutEditor.handlers.js` and
+  `src/internal/project/layout.js`
+- multiple edit-panel handlers repeat the same pattern:
+  update local state, render, dispatch `update`
+- event payload handling sometimes supports multiple fallback shapes
+
+This is not the root problem, but it adds friction.
+
+### 7. There is at least one suspicious config expression
+
+In `src/components/layoutEditPanel/layoutEditPanel.store.js`, the height field
+uses a `$when` condition with a chain of `!= ... || != ...`.
+
+That expression appears effectively always true, which suggests either:
+
+- the condition is wrong, or
+- the field is no longer meant to be conditionally hidden
+
+This is a symptom of config being hard to reason about in its current shape.
+
+## The Real Architectural Problem
+
+The same concept is spread across too many layers with no single source of
+truth.
+
+For an item type such as `slider`, there is no single place to answer:
+
+- what data the item owns
+- how a new one is created
+- which fields the inspector should expose
+- how field changes should be interpreted
+- how the item becomes render elements
+- which special cases exist for this type
+
+That is why the code feels heavier than it should.
+
+The best end state is not just "smaller files". The best end state is "one item
+type definition drives the editor."
+
+## Recommended End State
+
+### 1. Introduce a shared layout item-type system
+
+Create a single registry for layout item types.
+
+Examples:
+
+- `container`
+- `sprite`
+- `text`
+- `slider`
+- `rect`
+
+The registry should define the behavior contract for each type.
+
+At minimum, each type definition should own:
+
+- default item creation data
+- normalization of item data
+- field-change behavior for that type
+- any special mutation rules for that type
+- render mapping or render hooks for that type
+
+Static UI-only metadata should stay separate when appropriate:
+
+- labels
+- menu grouping
+- inspector section ordering
+- display text
+
+Those static pieces can live in `.constants.yaml`.
+
+### 2. Split the editor into 3 clear concerns
+
+The important architectural boundary is conceptual first, not necessarily a
+separate FE surface boundary on day one.
+
+Preferred first implementation:
+
+- keep one FE page
+- move canvas behavior into pure preview helpers
+- move inspector behavior into constants plus mutation helpers
+- only split FE surfaces later if one-page FE ownership is still too heavy
+
+#### Layout editor page
+
+Responsibilities:
+
+- route payload resolution
+- repository subscription/orchestration
+- selected item id
+- dispatching user intents
+- wiring data between canvas and inspector
+
+The page should stop owning detailed preview and type-specific mutation logic.
+
+#### Layout canvas concern
+
+Responsibilities:
+
+- graphics initialization
+- asset loading
+- render pipeline
+- overlay rendering
+- pointer drag interactions
+- keyboard movement if it is canvas-specific
+
+This can start as a helper-backed concern inside the page.
+It does not need to become a separate FE surface immediately.
+
+#### Layout inspector concern
+
+Responsibilities:
+
+- showing fields for the selected item
+- opening popovers and image selectors
+- translating field input into typed update intents
+
+The inspector should not know about repository loading.
+This can also stay inside the page FE surface first.
+
+### 3. Use intent-based updates instead of handler-local mutation branching
+
+The editor should update items through explicit intents, not ad hoc handler
+branches.
+
+Examples:
+
+- `set-field`
+- `move-item`
+- `resize-item`
+- `change-slider-direction`
+- `bind-slider-variable`
+- `replace-image`
+- `create-item`
+
+Then one pure mutation layer applies those intents against the current item
+using the type registry.
+
+Benefits:
+
+- easier testing
+- easier reasoning
+- easier undo/redo later if needed
+- page handlers become orchestration only
+
+### 4. Keep repository ownership at the page level
+
+Repository-backed data should be loaded at the page level and passed down.
+
+That means:
+
+- no `projectService.ensureRepository()` inside the inspector
+- no child component fetching text styles or variables on its own
+- all child surfaces receive stable props from the page
+
+This matches the repo's preferred ownership model.
+
+### 5. Keep static config in `.constants.yaml`, not mixed into store logic
+
+Good `.constants.yaml` candidates:
+
+- context menu item lists
+- preview form definitions
+- inspector section labels
+- field labels and options
+- item creation menu groups
+
+Not good `.constants.yaml` candidates:
+
+- mutation logic
+- render mapping functions
+- save policy
+- normalization code
+
+Those belong in pure JavaScript modules.
+
+## Proposed File Placement
+
+This should follow repo layering rules and avoid fake reusability.
+
+### Page-local surfaces
+
+Preferred starting point:
+
+- keep one FE page only:
+  - `src/pages/layoutEditor/layoutEditor.view.yaml`
+  - `src/pages/layoutEditor/layoutEditor.store.js`
+  - `src/pages/layoutEditor/layoutEditor.handlers.js`
+
+Do not split into many FE page-local surfaces by default.
+
+Adding separate FE surfaces for canvas and inspector creates extra boundaries:
+
+- more event wiring
+- more store/handler coordination
+- more indirection
+- more maintenance overhead
+
+That split should only happen later if the helper-based refactor is still not
+enough.
+
+Possible later split, only if still justified:
+
+- `src/pages/layoutEditor/layoutCanvas.view.yaml`
+- `src/pages/layoutEditor/layoutCanvas.store.js`
+- `src/pages/layoutEditor/layoutCanvas.handlers.js`
+- `src/pages/layoutEditor/layoutInspector.view.yaml`
+- `src/pages/layoutEditor/layoutInspector.store.js`
+- `src/pages/layoutEditor/layoutInspector.handlers.js`
+
+The default plan should not assume those files exist.
+
+### Shared pure editor helpers
+
+Put pure shared editor helpers in `src/internal/` or `src/internal/ui/`
+depending on ownership.
+
+Recommended starting point:
+
+- `src/internal/layoutEditorTypes.js`
+- `src/internal/layoutEditorPreview.js`
+- `src/internal/layoutEditorMutations.js`
+
+Reasoning:
+
+- these are app-owned pure helpers
+- they are shared by page-local surfaces
+- they are not service code
+- they are not broad UI orchestration in the `internal/ui` sense
+
+Do not split item types into many files too early.
+
+Preferred first step:
+
+- keep the full registry in one file
+- keep per-type definitions as internal constants in that file
+- split by type later only if the registry becomes genuinely too large or too
+  contentious for parallel editing
+
+### Constants files
+
+Examples:
+
+- `src/pages/layoutEditor/layoutEditor.constants.yaml`
+- `src/pages/layoutEditor/layoutInspector.constants.yaml`
+
+## Target Quality Bar
+
+In the best end state:
+
+- adding a new layout item type should not require touching 6 to 8 unrelated
+  places
+- page handlers should not contain type-specific mutation logic
+- the inspector should not fetch repository state
+- the page store should not contain huge static config blobs
+- canvas-specific behavior should live with the canvas
+- most item behavior should be discoverable from the type registry
+
+A practical success metric:
+
+- adding a new item type should be possible by touching only:
+  1. one type definition file
+  2. one inspector constants/config entry
+  3. one menu/constants entry if the type is creatable
+
+That is a major improvement over the current spread.
+
+## Master Plan
+
+This plan is phased, but the target is a full architectural improvement, not a
+small cleanup.
+
+### Phase 0. Lock the target architecture
+
+Deliverables:
+
+- this document
+- agreement on the target structure
+- agreement on the type registry contract
+- agreement on which surfaces stay page-local
+
+Exit criteria:
+
+- no implementation starts before the boundaries are clear
+
+### Phase 1. Introduce local constants files
+
+Move static data out of store files into `.constants.yaml`.
+
+Targets:
+
+- layout editor context menus
+- layout editor preview forms
+- inspector field/section config
+
+Goals:
+
+- shrink store files
+- separate static config from behavior
+- make later refactors easier
+
+Exit criteria:
+
+- no large menu/form config blobs left in page/component stores
+
+### Phase 2. Make repository ownership explicit
+
+Refactor data flow so the page owns repository-backed data and passes it down.
+
+Changes:
+
+- inspector receives `textStylesData`, `variablesData`, and any other needed
+  resources as props
+- remove `projectService.ensureRepository()` from child surfaces
+
+Exit criteria:
+
+- child surfaces are prop-driven
+- repository boot/loading is page-owned only
+
+### Phase 3. Extract the layout item-type system
+
+Create the shared item-type registry and move type behavior into it.
+
+Recommended first implementation shape:
+
+- one file: `src/internal/layoutEditorTypes.js`
+
+Move into the type system:
+
+- create defaults
+- normalization helpers
+- field-change rules
+- special mutation rules
+- render mapping helpers or render hooks
+
+Start with the most special-case-heavy types first:
+
+- `slider`
+- `sprite`
+- `text`
+- `container`
+- `rect`
+
+Only split into per-type files later if one-file ownership stops being simpler.
+
+Exit criteria:
+
+- page handlers no longer contain type-specific branches for these types
+
+### Phase 4. Introduce the pure mutation layer
+
+Create pure mutation helpers driven by the type registry.
+
+Examples:
+
+- `applyLayoutItemIntent`
+- `applyFieldChange`
+- `createLayoutItem`
+- `moveLayoutItem`
+- `resizeLayoutItem`
+
+The page and inspector should call these helpers instead of hand-editing nested
+objects.
+
+Exit criteria:
+
+- `handleLayoutEditPanelUpdateHandler` becomes thin orchestration
+- nested merge logic and slider special cases are no longer in the page handler
+
+### Phase 5. Extract the canvas concern
+
+First move preview/canvas work into a dedicated pure helper layer, not
+necessarily a new FE surface.
+
+Move:
+
+- graphics init
+- render pipeline
+- file reference extraction
+- asset loading
+- stale asset cache recovery
+- overlay generation wiring
+- drag pointer behavior
+
+Exit criteria:
+
+- page handler no longer directly owns preview rendering
+
+### Phase 6. Extract the inspector concern
+
+Replace the current generic-feeling `layoutEditPanel` shape with a more focused
+layout-editor inspector model.
+
+Move:
+
+- popover state
+- image selector state
+- field interaction handling
+- action selection UI
+
+Keep:
+
+- actual data mutation in the shared mutation layer
+
+Exit criteria:
+
+- inspector is a focused UI surface
+- inspector handlers are UI-only and mostly dispatch intents
+
+Optional later step:
+
+- if the page FE files are still too heavy after phases 1-6, then split the
+  canvas and/or inspector into separate FE page-local surfaces
+
+### Phase 7. Simplify persistence and refresh flow
+
+After the type system and surfaces exist, simplify save behavior.
+
+Goals:
+
+- keep debounced persistence in one place
+- keep immediate-save rules in one place
+- unify store-to-repository synchronization
+- reduce repeated `render()` and `render preview` calls scattered across
+  handlers
+
+Exit criteria:
+
+- one clear save pipeline
+- one clear preview refresh pipeline
+
+### Phase 8. Remove duplication and dead compatibility paths
+
+Clean up after the architecture shift.
+
+Examples:
+
+- remove duplicate helpers
+- remove multi-shape payload fallbacks where event contracts are now stable
+- rename files and symbols for clarity
+- review suspicious config conditions
+
+Exit criteria:
+
+- no legacy branches left only for the old structure
+
+### Phase 9. Add targeted tests around the new architecture
+
+Focus testing on the new seams.
+
+Priority targets:
+
+- item-type mutation helpers
+- slider-specific behavior
+- preview render state generation
+- selection overlay behavior
+- persistence decisions for immediate vs debounced updates
+
+Exit criteria:
+
+- core type behavior is testable without mounting the whole page
+
+## Implementation Order Recommendation
+
+If this work is executed as a real refactor program, the recommended order is:
+
+1. constants extraction
+2. page-owned repository data flow
+3. type registry
+4. mutation layer
+5. canvas concern extraction
+6. inspector concern extraction
+7. save/render pipeline simplification
+8. cleanup and tests
+
+This order reduces risk because:
+
+- static extraction lowers noise first
+- ownership gets cleaner before surface extraction
+- type behavior becomes explicit before UI layers are split further
+- FE surface splitting is deferred until there is evidence it is still needed
+
+## Risks
+
+### 1. Slider regressions
+
+`slider` currently has the most special-case behavior.
+
+Mitigation:
+
+- migrate slider with focused helper tests first
+
+### 2. Preview parity regressions
+
+Canvas extraction can accidentally change rendering behavior.
+
+Mitigation:
+
+- keep preview rendering pure and testable
+- preserve overlay behavior during the move
+
+### 3. Over-generalization
+
+A registry can become worse if it turns into a framework.
+
+Mitigation:
+
+- keep the contract small
+- use plain objects and pure functions
+- avoid inventing plugin systems or schema compilers
+
+## What Not To Do
+
+Avoid these:
+
+- a big-bang rewrite
+- a generic editor platform abstraction
+- moving everything into `src/components/` just because it becomes separate
+- keeping type behavior split across page handler, inspector config, and render
+  code after the registry exists
+
+## Bottom Line
+
+Incremental cleanup is still worth doing, but it is not enough on its own.
+
+The most important architectural change is:
+
+- move from scattered type-specific logic to a single layout item-type system
+
+The second most important change is:
+
+- split the editor into a page orchestrator, a canvas surface, and an
+  inspector surface
+
+The rest of the cleanup work should support those two moves.

--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -1,0 +1,270 @@
+numberPopoverForm: &numberPopoverForm
+  fields:
+    - name: value
+      type: input-number
+  actions:
+    buttons:
+      - id: submit
+        variant: pr
+        label: Submit
+
+textPopoverForm: &textPopoverForm
+  fields:
+    - name: value
+      type: input-text
+  actions:
+    buttons:
+      - id: submit
+        variant: pr
+        label: Submit
+
+layoutSections:
+  - label: Position
+    items:
+      - type: group
+        fields:
+          - type: clickable-value
+            svg: x
+            name: x
+            value: "${values.x}"
+            popoverForm: *numberPopoverForm
+          - type: clickable-value
+            svg: y
+            name: y
+            value: "${values.y}"
+            popoverForm: *numberPopoverForm
+  - label: Layout
+    items:
+      - type: group
+        fields:
+          - type: clickable-value
+            svg: w
+            name: width
+            value: "${values.width}"
+            popoverForm: *numberPopoverForm
+          - "$when": "supportsHeight"
+            type: clickable-value
+            svg: h
+            name: height
+            value: "${values.height}"
+            popoverForm: *numberPopoverForm
+      - "$when": "supportsAnchor"
+        type: select
+        label: Anchor
+        name: anchor
+        value: "${values.anchor}"
+        options:
+          - label: Top Left
+            value:
+              x: 0
+              y: 0
+          - label: Top Center
+            value:
+              x: 0.5
+              y: 0
+          - label: Top Right
+            value:
+              x: 1
+              y: 0
+          - label: Center Left
+            value:
+              x: 0
+              y: 0.5
+          - label: Center
+            value:
+              x: 0.5
+              y: 0.5
+          - label: Center Right
+            value:
+              x: 1
+              y: 0.5
+          - label: Bottom Left
+            value:
+              x: 0
+              y: 1
+          - label: Bottom Center
+            value:
+              x: 0.5
+              y: 1
+          - label: Bottom Right
+            value:
+              x: 1
+              y: 1
+  - "$when": "supportsDirection"
+    label: Direction
+    items:
+      - type: select
+        label: Direction
+        name: direction
+        value: "${values.direction}"
+        options:
+          - label: Absolute
+            value: ""
+          - label: Horizontal
+            value: horizontal
+          - label: Vertical
+            value: vertical
+      - "$when": "showsGapField"
+        type: group
+        fields:
+          - type: clickable-value
+            label: Gap
+            name: gap
+            value: "${values.gap}"
+            popoverForm: *numberPopoverForm
+  - "$when": "supportsSpriteImages"
+    id: images
+    label: Image
+    "$if canAddSpriteImageVariant":
+      labelAction: plus
+    items:
+      - type: list-bar
+        items:
+          - "$when": "values.imageId"
+            name: imageId
+            label: Default
+            imageId: "${values.imageId}"
+          - "$when": "values.hoverImageId"
+            name: hoverImageId
+            label: Hover
+            imageId: "${values.hoverImageId}"
+          - "$when": "values.clickImageId"
+            name: clickImageId
+            label: Click
+            imageId: "${values.clickImageId}"
+  - "$when": "supportsSliderImages"
+    id: slider-images
+    label: Slider Bar
+    items:
+      - type: list-bar
+        items:
+          - name: barImageId
+            label: Default
+            imageId: "${values.barImageId}"
+          - name: hoverBarImageId
+            label: Hover
+            imageId: "${values.hoverBarImageId}"
+  - "$when": "supportsSliderImages"
+    id: slider-thumb
+    label: Slider Thumb
+    items:
+      - type: list-bar
+        items:
+          - name: thumbImageId
+            label: Default
+            imageId: "${values.thumbImageId}"
+          - name: hoverThumbImageId
+            label: Hover
+            imageId: "${values.hoverThumbImageId}"
+  - "$when": "supportsSliderValues"
+    label: Slider Values
+    items:
+      - type: group
+        fields:
+          - type: clickable-value
+            label: Min
+            name: min
+            value: "${values.min}"
+            popoverForm: *numberPopoverForm
+          - type: clickable-value
+            label: Max
+            name: max
+            value: "${values.max}"
+            popoverForm: *numberPopoverForm
+      - type: group
+        fields:
+          - type: clickable-value
+            label: Step
+            name: step
+            value: "${values.step}"
+            popoverForm: *numberPopoverForm
+      - type: select
+        label: Update Variable
+        name: variableId
+        value: "${values.variableId}"
+        options: "${variableOptionsWithNone}"
+  - "$when": "supportsTextEditing"
+    label: Text
+    items:
+      - type: group
+        fields:
+          - type: clickable-value
+            name: text
+            value: "${values.text}"
+            popoverForm: *textPopoverForm
+  - "$when": "supportsTextStyles"
+    label: Text Styles
+    items:
+      - type: select
+        label: Default
+        name: textStyleId
+        value: "${values.textStyleId}"
+        options: "${textStyleItems}"
+      - type: select
+        label: Hover
+        name: hoverTextStyleId
+        value: "${values.hoverTextStyleId}"
+        options: "${textStyleItemsWithNone}"
+      - type: select
+        label: Clicked
+        name: clickTextStyleId
+        value: "${values.clickTextStyleId}"
+        options: "${textStyleItemsWithNone}"
+  - "$when": "supportsTextAlignment"
+    label: Text Alignment
+    items:
+      - type: select
+        label: Alignment
+        name: style.align
+        value: "${values.style.align}"
+        options:
+          - label: Left
+            value: left
+          - label: Center
+            value: center
+          - label: Right
+            value: right
+  - "$when": "supportsActions"
+    id: actions
+    label: Actions
+    labelAction: plus
+    items:
+      - type: list-item
+        items: "${values.actions}"
+
+controlSections:
+  - label: Position
+    items:
+      - type: group
+        fields:
+          - type: clickable-value
+            svg: x
+            name: x
+            value: "${values.x}"
+            popoverForm: *numberPopoverForm
+          - type: clickable-value
+            svg: y
+            name: y
+            value: "${values.y}"
+            popoverForm: *numberPopoverForm
+  - label: Layout
+    items:
+      - type: group
+        fields:
+          - type: clickable-value
+            svg: w
+            name: width
+            value: "${values.width}"
+            popoverForm: *numberPopoverForm
+          - type: clickable-value
+            svg: h
+            name: height
+            value: "${values.height}"
+            popoverForm: *numberPopoverForm
+  - "$when": "supportsActions"
+    id: actions
+    label: Actions
+    labelAction: plus
+    items:
+      - type: list-item
+        items: "${values.actions}"

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -4,11 +4,51 @@ import {
 } from "../../internal/project/interactionPayload.js";
 
 const ACTION_INTERACTION_TYPES = ["click", "rightClick"];
+const EMPTY_TREE = { items: {}, tree: [] };
 
 const getInteractionPropertyName = (interactionType) => {
   return ACTION_INTERACTION_TYPES.includes(interactionType)
     ? interactionType
     : "click";
+};
+
+const emitPanelUpdate = (
+  { dispatchEvent, store },
+  { name, value, bubbles = false } = {},
+) => {
+  dispatchEvent(
+    new CustomEvent("update", {
+      bubbles,
+      detail: {
+        formValues: store.selectValues(),
+        name,
+        value,
+      },
+    }),
+  );
+};
+
+const applyPanelValueUpdate = (
+  deps,
+  { name, value, closePopover = false, closeImageSelector = false } = {},
+) => {
+  const { store, render } = deps;
+
+  store.updateValueProperty({
+    name,
+    value,
+  });
+
+  if (closePopover) {
+    store.closePopoverForm();
+  }
+
+  if (closeImageSelector) {
+    store.closeImageSelectorDialog();
+  }
+
+  render();
+  emitPanelUpdate(deps, { name, value });
 };
 
 export const handleBeforeMount = (deps) => {
@@ -18,10 +58,10 @@ export const handleBeforeMount = (deps) => {
     values,
   });
   store.setTextStylesData({
-    textStylesData: props.textStylesData || { items: {}, tree: [] },
+    textStylesData: props.textStylesData || EMPTY_TREE,
   });
   store.setVariablesData({
-    variablesData: props.variablesData || { items: {}, tree: [] },
+    variablesData: props.variablesData || EMPTY_TREE,
   });
 };
 
@@ -41,10 +81,10 @@ export const handleOnUpdate = (deps, payload) => {
     values: newProps.values || {},
   });
   store.setTextStylesData({
-    textStylesData: newProps.textStylesData || { items: {}, tree: [] },
+    textStylesData: newProps.textStylesData || EMPTY_TREE,
   });
   store.setVariablesData({
-    variablesData: newProps.variablesData || { items: {}, tree: [] },
+    variablesData: newProps.variablesData || EMPTY_TREE,
   });
   render();
 };
@@ -53,7 +93,7 @@ export const handleGroupItemClick = (deps, payload) => {
   const { render, store } = deps;
   const { _event } = payload;
   const name = _event.currentTarget.dataset.name;
-  const popoverForm = store.selectFieldPopoverForm(name);
+  const popoverForm = store.selectFieldPopoverForm({ name });
   store.openPopoverForm({
     x: _event.clientX,
     y: _event.clientY,
@@ -71,29 +111,14 @@ export const handlePopverFormClose = (deps) => {
 };
 
 export const handleOptionSelected = (deps, payload) => {
-  const { store, render, dispatchEvent } = deps;
   const { _event } = payload;
   const name = _event.currentTarget.dataset.name;
 
-  store.updateValueProperty({
-    name: name,
+  applyPanelValueUpdate(deps, {
+    name,
     value: _event.detail.value,
+    closePopover: true,
   });
-
-  store.closePopoverForm();
-
-  const formValues = store.selectValues();
-  render();
-
-  dispatchEvent(
-    new CustomEvent("update", {
-      detail: {
-        formValues,
-        name,
-        value: _event.detail.value,
-      },
-    }),
-  );
 };
 
 export const handleSectionActionClick = async (deps, payload) => {
@@ -157,31 +182,18 @@ export const handleSectionActionClick = async (deps, payload) => {
 };
 
 export const handleFormActions = (deps, payload) => {
-  const { store, render, dispatchEvent } = deps;
+  const { store } = deps;
   const { _event } = payload;
   const { name } = store.selectPopoverForm();
-  store.updateValueProperty({
+  applyPanelValueUpdate(deps, {
     name,
     value: _event.detail.values.value,
+    closePopover: true,
   });
-
-  store.closePopoverForm();
-  render();
-
-  const formValues = store.selectValues();
-  dispatchEvent(
-    new CustomEvent("update", {
-      detail: {
-        formValues,
-        name,
-        value: _event.detail.values.value,
-      },
-    }),
-  );
 };
 
 export const handleActionsChange = (deps, payload) => {
-  const { store, render, dispatchEvent } = deps;
+  const { store, render } = deps;
   const interactionType = store.selectActiveInteractionType();
   const interactionKey = getInteractionPropertyName(interactionType);
 
@@ -205,17 +217,10 @@ export const handleActionsChange = (deps, payload) => {
   });
 
   render();
-
-  const formValues = store.selectValues();
-  dispatchEvent(
-    new CustomEvent("update", {
-      detail: {
-        formValues,
-        name: `${interactionKey}.payload.actions`,
-        value: newActions,
-      },
-    }),
-  );
+  emitPanelUpdate(deps, {
+    name: `${interactionKey}.payload.actions`,
+    value: newActions,
+  });
 };
 
 export const handleListBarItemClick = async (deps, payload) => {
@@ -239,7 +244,7 @@ export const handlePopoverFormChange = async (deps, payload) => {
 };
 
 export const handleListBarItemRightClick = async (deps, payload) => {
-  const { render, store, appService, dispatchEvent } = deps;
+  const { render, store, appService } = deps;
   const { _event: event } = payload;
   event.preventDefault();
   const { name } = event.currentTarget.dataset;
@@ -287,17 +292,10 @@ export const handleListBarItemRightClick = async (deps, payload) => {
     }
   }
   render();
-
-  const formValues = store.selectValues();
-  dispatchEvent(
-    new CustomEvent("update", {
-      detail: {
-        formValues,
-        name,
-        value: undefined,
-      },
-    }),
-  );
+  emitPanelUpdate(deps, {
+    name,
+    value: undefined,
+  });
 };
 
 // --- List Item ---
@@ -316,7 +314,7 @@ export const handleListItemClick = async (deps, payload) => {
 };
 
 export const handleListItemRightClick = async (deps, payload) => {
-  const { render, store, appService, dispatchEvent } = deps;
+  const { render, store, appService } = deps;
   const { _event: event } = payload;
   event.preventDefault();
   const { id, interaction } = event.currentTarget.dataset;
@@ -347,17 +345,11 @@ export const handleListItemRightClick = async (deps, payload) => {
         actions,
       },
     });
-    const formValues = store.selectValues();
-    dispatchEvent(
-      new CustomEvent("update", {
-        bubbles: true,
-        detail: {
-          formValues,
-          name: `${interactionKey}.payload.actions`,
-          value: actions,
-        },
-      }),
-    );
+    emitPanelUpdate(deps, {
+      name: `${interactionKey}.payload.actions`,
+      value: actions,
+      bubbles: true,
+    });
   }
   render();
 };
@@ -378,25 +370,12 @@ export const handleImageSelectorCancel = (deps) => {
 };
 
 export const handleImageSelectorSubmit = (deps) => {
-  const { store, render, dispatchEvent } = deps;
+  const { store } = deps;
   const imageId = store.selectTempSelectedImageId();
   const { name } = store.selectImageSelectorDialog();
-
-  store.updateValueProperty({
-    name: name,
+  applyPanelValueUpdate(deps, {
+    name,
     value: imageId,
+    closeImageSelector: true,
   });
-  store.closeImageSelectorDialog();
-  render();
-
-  const formValues = store.selectValues();
-  dispatchEvent(
-    new CustomEvent("update", {
-      detail: {
-        formValues,
-        name: name,
-        value: imageId,
-      },
-    }),
-  );
 };

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -17,35 +17,36 @@ export const handleBeforeMount = (deps) => {
   store.setValues({
     values,
   });
+  store.setTextStylesData({
+    textStylesData: props.textStylesData || { items: {}, tree: [] },
+  });
   store.setVariablesData({
     variablesData: props.variablesData || { items: {}, tree: [] },
   });
 };
 
-export const handleAfterMount = async (deps) => {
-  const { projectService, store, render } = deps;
-  await projectService.ensureRepository();
-  const { textStyles } = projectService.getState();
-
-  store.setTextStylesData({
-    textStylesData: textStyles || { items: {}, tree: [] },
-  });
-  render();
-};
-
 export const handleOnUpdate = (deps, payload) => {
   const { oldProps, newProps } = payload;
   const { store, render } = deps;
-  if (oldProps?.key !== newProps?.key) {
-    const values = newProps.values || {};
-    store.setValues({
-      values,
-    });
-    store.setVariablesData({
-      variablesData: newProps.variablesData || { items: {}, tree: [] },
-    });
-    render();
+  if (
+    oldProps?.key === newProps?.key &&
+    oldProps?.values === newProps?.values &&
+    oldProps?.variablesData === newProps?.variablesData &&
+    oldProps?.textStylesData === newProps?.textStylesData
+  ) {
+    return;
   }
+
+  store.setValues({
+    values: newProps.values || {},
+  });
+  store.setTextStylesData({
+    textStylesData: newProps.textStylesData || { items: {}, tree: [] },
+  });
+  store.setVariablesData({
+    variablesData: newProps.variablesData || { items: {}, tree: [] },
+  });
+  render();
 };
 
 export const handleGroupItemClick = (deps, payload) => {

--- a/src/components/layoutEditPanel/layoutEditPanel.schema.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.schema.yaml
@@ -4,6 +4,8 @@ propsSchema:
   properties:
     values:
       type: object
+    textStylesData:
+      type: object
     variablesData:
       type: object
     itemType:

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -3,6 +3,7 @@ import { toFlatGroups } from "../../internal/project/tree.js";
 import { getFirstTextStyleId } from "../../constants/textStyles.js";
 import { getVariableOptions } from "../../internal/project/projection.js";
 import { getInteractionActions } from "../../internal/project/interactionPayload.js";
+import { getLayoutEditorItemCapabilities } from "../../internal/layoutEditorTypes.js";
 
 const ACTION_INTERACTION_LABELS = {
   click: "Click",
@@ -39,585 +40,65 @@ const toLayoutActionItems = (values) => {
   );
 };
 
-const config = {
-  sections: [
-    {
-      label: "Position",
-      items: [
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              svg: "x",
-              name: "x",
-              value: "${values.x}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-            {
-              type: "clickable-value",
-              svg: "y",
-              name: "y",
-              value: "${values.y}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      label: "Layout",
-      items: [
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              svg: "w",
-              name: "width",
-              value: "${values.width}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-            {
-              $when:
-                'itemType != "text" && itemType != "text-ref-character-name" && itemType != "text-revealing-ref-dialogue-content" && itemType != "text-ref-choice-item-content" && itemType != "text-ref-dialogue-line-character-name" && itemType != "text-ref-dialogue-line-content"',
-              type: "clickable-value",
-              svg: "h",
-              name: "height",
-              value: "${values.height}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-        {
-          $when:
-            "itemType == 'container' || itemType == 'container-ref-choice-item' || itemType == 'container-ref-dialogue-line' || itemType == 'text' || itemType == 'text-ref-choice-item-content' || itemType == 'text-ref-character-name' || itemType == 'text-revealing-ref-dialogue-content' || itemType == 'text-ref-dialogue-line-character-name' || itemType == 'text-ref-dialogue-line-content'",
-          type: "select",
-          label: "Anchor",
-          name: "anchor",
-          value: "${values.anchor}",
-          options: [
-            { label: "Top Left", value: { x: 0, y: 0 } },
-            { label: "Top Center", value: { x: 0.5, y: 0 } },
-            { label: "Top Right", value: { x: 1, y: 0 } },
-            { label: "Center Left", value: { x: 0, y: 0.5 } },
-            { label: "Center", value: { x: 0.5, y: 0.5 } },
-            { label: "Center Right", value: { x: 1, y: 0.5 } },
-            { label: "Bottom Left", value: { x: 0, y: 1 } },
-            { label: "Bottom Center", value: { x: 0.5, y: 1 } },
-            { label: "Bottom Right", value: { x: 1, y: 1 } },
-          ],
-        },
-      ],
-    },
-    {
-      $when:
-        'itemType == "container" || itemType == "container-ref-choice-item" || itemType == "container-ref-dialogue-line"',
-      label: "Direction",
-      items: [
-        {
-          type: "select",
-          label: "Direction",
-          name: "direction",
-          value: "${values.direction}",
-          options: [
-            { label: "Absolute", value: undefined },
-            { label: "Horizontal", value: "horizontal" },
-            { label: "Vertical", value: "vertical" },
-          ],
-        },
-        {
-          $when:
-            '(itemType == "container" || itemType == "container-ref-choice-item" || itemType == "container-ref-dialogue-line") && (values.direction == "vertical" || values.direction == "horizontal") ',
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              label: "Gap",
-              name: "gap",
-              value: "${values.gap}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "sprite"',
-      id: "images",
-      label: "Image",
-      "$if !values.imageId || !values.hoverImageId || !values.clickImageId": {
-        labelAction: "plus",
-      },
-      items: [
-        {
-          type: "list-bar",
-          items: [
-            {
-              $when: "values.imageId",
-              name: "imageId",
-              label: "Default",
-              imageId: "${values.imageId}",
-            },
-            {
-              $when: "values.hoverImageId",
-              name: "hoverImageId",
-              label: "Hover",
-              imageId: "${values.hoverImageId}",
-            },
-            {
-              name: "clickImageId",
-              $when: "values.clickImageId",
-              label: "Click",
-              imageId: "${values.clickImageId}",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "slider"',
-      id: "slider-images",
-      label: "Slider Bar",
-      items: [
-        {
-          type: "list-bar",
-          items: [
-            {
-              name: "barImageId",
-              label: "Default",
-              imageId: "${values.barImageId}",
-            },
-            {
-              name: "hoverBarImageId",
-              label: "Hover",
-              imageId: "${values.hoverBarImageId}",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "slider"',
-      id: "slider-thumb",
-      label: "Slider Thumb",
-      items: [
-        {
-          type: "list-bar",
-          items: [
-            {
-              name: "thumbImageId",
-              label: "Default",
-              imageId: "${values.thumbImageId}",
-            },
-            {
-              name: "hoverThumbImageId",
-              label: "Hover",
-              imageId: "${values.hoverThumbImageId}",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "slider"',
-      label: "Slider Values",
-      items: [
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              label: "Min",
-              name: "min",
-              value: "${values.min}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-            {
-              type: "clickable-value",
-              label: "Max",
-              name: "max",
-              value: "${values.max}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              label: "Step",
-              name: "step",
-              value: "${values.step}",
-              popoverForm: {
-                fields: [
-                  {
-                    name: "value",
-                    type: "input-number",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-        {
-          type: "select",
-          label: "Update Variable",
-          name: "variableId",
-          value: "${values.variableId}",
-          options: "${variableOptionsWithNone}",
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "text"',
-      label: "Text",
-      items: [
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              name: "text",
-              value: "${values.text}",
-              popoverForm: {
-                fields: [
-                  // {
-                  //   name: "contentType",
-                  //   description: "Content Type",
-                  //   type: "select",
-                  //   options: [
-                  //     { label: "Variable", value: "variable" },
-                  //     { label: "Plain Text", value: "plain" },
-                  //   ],
-                  // },
-                  // {
-                  //   $when: 'popoverFormValues.contentType == "variable"',
-                  //   name: "value",
-                  //   description: "Variable",
-                  //   type: "select",
-                  //   options: [
-                  //     {
-                  //       label: "Dialogue Character Name",
-                  //       value: "\\${dialogue.character.name}",
-                  //     },
-                  //     {
-                  //       label: "Dialogue Content",
-                  //       value: "\\${dialogue.content[0].text}",
-                  //     },
-                  //     {
-                  //       $when: 'layoutType === "choices"',
-                  //       label: "Choice content",
-                  //       value: "\\${item.content}",
-                  //     },
-                  //   ],
-                  // },
-                  {
-                    // $when: 'popoverFormValues.contentType == "plain"',
-                    name: "value",
-                    type: "input-text",
-                  },
-                ],
-                actions: {
-                  buttons: [
-                    {
-                      id: "submit",
-                      variant: "pr",
-                      label: "Submit",
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      $when:
-        'itemType == "text" || itemType == "text-ref-character-name" || itemType == "text-revealing-ref-dialogue-content" || itemType == "text-ref-choice-item-content" || itemType == "text-ref-dialogue-line-character-name" || itemType == "text-ref-dialogue-line-content"',
-      label: "Text Styles",
-      items: [
-        {
-          type: "select",
-          label: "Default",
-          name: "textStyleId",
-          value: "${values.textStyleId}",
-          options: "${textStyleItems}",
-        },
-        {
-          type: "select",
-          label: "Hover",
-          name: "hoverTextStyleId",
-          value: "${values.hoverTextStyleId}",
-          options: "${textStyleItemsWithNone}",
-        },
-        {
-          type: "select",
-          label: "Clicked",
-          name: "clickTextStyleId",
-          value: "${values.clickTextStyleId}",
-          options: "${textStyleItemsWithNone}",
-        },
-      ],
-    },
-    {
-      $when:
-        'itemType == "text" || itemType == "text-ref-character-name" || itemType == "text-revealing-ref-dialogue-content" || itemType == "text-ref-choice-item-content" || itemType == "text-ref-dialogue-line-character-name" || itemType == "text-ref-dialogue-line-content"',
-      label: "Text Alignment",
-      items: [
-        {
-          type: "select",
-          label: "Alignment",
-          name: "style.align",
-          value: "${values.style.align}",
-          options: [
-            { label: "Left", value: "left" },
-            { label: "Center", value: "center" },
-            { label: "Right", value: "right" },
-          ],
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "text" || itemType == "sprite" || itemType == "rect"',
-      id: "actions",
-      label: "Actions",
-      labelAction: "plus",
-      items: [
-        {
-          type: "list-item",
-          items: "${values.actions}",
-        },
-      ],
-    },
-  ],
+const getLayoutEditPanelSections = ({ constants, resourceType }) => {
+  return resourceType === "controls"
+    ? constants.controlSections || []
+    : constants.layoutSections || [];
 };
 
-const controlConfig = {
-  sections: [
-    {
-      label: "Position",
-      items: [
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              svg: "x",
-              name: "x",
-              value: "${values.x}",
-              popoverForm: {
-                fields: [{ name: "value", type: "input-number" }],
-                actions: {
-                  buttons: [{ id: "submit", variant: "pr", label: "Submit" }],
-                },
-              },
-            },
-            {
-              type: "clickable-value",
-              svg: "y",
-              name: "y",
-              value: "${values.y}",
-              popoverForm: {
-                fields: [{ name: "value", type: "input-number" }],
-                actions: {
-                  buttons: [{ id: "submit", variant: "pr", label: "Submit" }],
-                },
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      label: "Layout",
-      items: [
-        {
-          type: "group",
-          fields: [
-            {
-              type: "clickable-value",
-              svg: "w",
-              name: "width",
-              value: "${values.width}",
-              popoverForm: {
-                fields: [{ name: "value", type: "input-number" }],
-                actions: {
-                  buttons: [{ id: "submit", variant: "pr", label: "Submit" }],
-                },
-              },
-            },
-            {
-              type: "clickable-value",
-              svg: "h",
-              name: "height",
-              value: "${values.height}",
-              popoverForm: {
-                fields: [{ name: "value", type: "input-number" }],
-                actions: {
-                  buttons: [{ id: "submit", variant: "pr", label: "Submit" }],
-                },
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      $when: 'itemType == "rect"',
-      id: "actions",
-      label: "Actions",
-      labelAction: "plus",
-      items: [
-        {
-          type: "list-item",
-          items: "${values.actions}",
-        },
-      ],
-    },
-  ],
-};
-
-const selectFieldPopoverFormFromConfig = (fieldName) => {
-  for (const section of config.sections || []) {
+const findFieldPopoverFormInSections = (sections, fieldName) => {
+  for (const section of sections || []) {
     for (const item of section.items || []) {
       if (item.type !== "group") {
         continue;
       }
 
-      const match = (item.fields || []).find(
-        (field) => field.name === fieldName,
+      const field = (item.fields || []).find(
+        (entry) => entry.name === fieldName,
       );
-      if (match) {
-        return match.popoverForm;
+      if (field?.popoverForm) {
+        return field.popoverForm;
       }
     }
   }
 
   return undefined;
+};
+
+const createDefaultValues = () => ({
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 100,
+  rotation: 0,
+  anchor: {
+    x: 0,
+    y: 0,
+  },
+  direction: undefined,
+  gap: 0,
+  actions: {},
+});
+
+const toTextStyleOptions = (textStylesData = {}) => {
+  const textStyleGroups = toFlatGroups(textStylesData);
+  return textStyleGroups.flatMap((group) =>
+    group.children.map((item) => ({
+      label: item.name,
+      value: item.id,
+    })),
+  );
+};
+
+const toInspectorValues = ({ values, firstTextStyleId }) => {
+  return {
+    ...values,
+    direction: values?.direction ?? "",
+    textStyleId: values?.textStyleId || firstTextStyleId || "",
+    hoverTextStyleId: values?.hoverTextStyleId ?? "",
+    clickTextStyleId: values?.clickTextStyleId ?? "",
+    actions: toLayoutActionItems(values),
+  };
 };
 
 export const createInitialState = () => {
@@ -639,20 +120,7 @@ export const createInitialState = () => {
     },
     textStylesData: { tree: [], items: {} },
     variablesData: { tree: [], items: {} },
-    values: {
-      x: 0,
-      y: 0,
-      width: 100,
-      height: 100,
-      rotation: 0,
-      anchor: {
-        x: 0,
-        y: 0,
-      },
-      direction: undefined,
-      gap: 0,
-      actions: {},
-    },
+    values: createDefaultValues(),
     activeInteractionType: "click",
   };
 };
@@ -661,6 +129,7 @@ export const updateValueProperty = ({ state }, { value, name } = {}) => {
   if (!name) {
     return;
   }
+
   const keys = name.split(".");
 
   if (keys.length === 1) {
@@ -672,13 +141,13 @@ export const updateValueProperty = ({ state }, { value, name } = {}) => {
     return;
   }
 
-  // Handle nested path
   let current = state.values;
-  for (let i = 0; i < keys.length - 1; i++) {
-    if (!current[keys[i]]) {
-      current[keys[i]] = {};
+  for (let index = 0; index < keys.length - 1; index += 1) {
+    const key = keys[index];
+    if (!current[key] || typeof current[key] !== "object") {
+      current[key] = {};
     }
-    current = current[keys[i]];
+    current = current[key];
   }
 
   const lastKey = keys[keys.length - 1];
@@ -693,8 +162,8 @@ export const openPopoverForm = ({ state }, { x, y, name, form } = {}) => {
   if (!name) {
     return;
   }
-  const value = state.values[name];
 
+  const value = state.values[name];
   const popoverFormValues = {
     value,
   };
@@ -739,8 +208,17 @@ export const closePopoverForm = ({ state }, _payload = {}) => {
   };
 };
 
-export const selectFieldPopoverForm = (_deps, name) => {
-  return selectFieldPopoverFormFromConfig(name);
+export const selectFieldPopoverForm = ({ constants, props }, { name } = {}) => {
+  if (!name) {
+    return undefined;
+  }
+
+  const sections = getLayoutEditPanelSections({
+    constants,
+    resourceType: props.resourceType,
+  });
+
+  return findFieldPopoverFormInSections(sections, name);
 };
 
 export const selectPopoverForm = ({ state }) => {
@@ -805,22 +283,13 @@ export const selectTempSelectedImageId = ({ state }) => {
   return state.tempSelectedImageId;
 };
 
-export const selectViewData = ({ state, props: attrs }) => {
-  // Transform text style data to options format
-  const textStyleGroups = toFlatGroups(state.textStylesData);
-  const textStyleItems = textStyleGroups.flatMap((group) =>
-    group.children.map((item) => ({
-      label: item.name,
-      value: item.id,
-    })),
-  );
+export const selectViewData = ({ state, props, constants }) => {
+  const textStyleItems = toTextStyleOptions(state.textStylesData);
   const firstTextStyleId = getFirstTextStyleId(state.textStylesData);
   const textStyleItemsWithNone = [
     { label: "None", value: "" },
     ...textStyleItems,
   ];
-
-  // Transform variables data to options format (number type only for sliders)
   const variableOptions = getVariableOptions(state.variablesData, {
     type: "number",
   });
@@ -828,34 +297,42 @@ export const selectViewData = ({ state, props: attrs }) => {
     { label: "None", value: "" },
     ...variableOptions,
   ];
-
-  const context = {
-    itemType: attrs.itemType,
-    layoutType: attrs.layoutType,
-    resourceType: attrs.resourceType,
-    textStyleItems: textStyleItems,
-    textStyleItemsWithNone: textStyleItemsWithNone,
-    variableOptionsWithNone: variableOptionsWithNone,
-    values: {
-      ...state.values,
-      textStyleId: state.values?.textStyleId || firstTextStyleId || "",
-      hoverTextStyleId: state.values?.hoverTextStyleId ?? "",
-      clickTextStyleId: state.values?.clickTextStyleId ?? "",
-      actions: toLayoutActionItems(state.values),
+  const values = toInspectorValues({
+    values: state.values,
+    firstTextStyleId,
+  });
+  const capabilities = getLayoutEditorItemCapabilities(props.itemType);
+  const sections = parseAndRender(
+    getLayoutEditPanelSections({
+      constants,
+      resourceType: props.resourceType,
+    }),
+    {
+      itemType: props.itemType,
+      layoutType: props.layoutType,
+      resourceType: props.resourceType,
+      textStyleItems,
+      textStyleItemsWithNone,
+      variableOptionsWithNone,
+      values,
+      canAddSpriteImageVariant:
+        !values.imageId || !values.hoverImageId || !values.clickImageId,
+      showsGapField:
+        capabilities.supportsDirection &&
+        (values.direction === "vertical" || values.direction === "horizontal"),
+      ...capabilities,
     },
-  };
-
-  const baseConfig = attrs.resourceType === "controls" ? controlConfig : config;
-  const finalConfig = parseAndRender(baseConfig, context);
+  );
 
   return {
-    actionsDialogOpen: state.actionsDialogOpen,
     values: state.values,
     actionsData: getLayoutInteractionActions(
       state.values,
       state.activeInteractionType,
     ),
-    config: finalConfig,
+    config: {
+      sections,
+    },
     popover: state.popover,
     imageSelectorDialog: state.imageSelectorDialog,
     tempSelectedImageId: state.tempSelectedImageId,

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -128,7 +128,7 @@ const config = {
             },
             {
               $when:
-                'itemType != "text" || itemType != "text-ref-character-name" || itemType != "text-revealing-ref-dialogue-content" || itemType != "text-ref-choice-item-content" || itemType != "text-ref-dialogue-line-character-name" || itemType != "text-ref-dialogue-line-content"',
+                'itemType != "text" && itemType != "text-ref-character-name" && itemType != "text-revealing-ref-dialogue-content" && itemType != "text-ref-choice-item-content" && itemType != "text-ref-dialogue-line-character-name" && itemType != "text-ref-dialogue-line-content"',
               type: "clickable-value",
               svg: "h",
               name: "height",

--- a/src/internal/layoutEditorMutations.js
+++ b/src/internal/layoutEditorMutations.js
@@ -92,3 +92,63 @@ export const applyLayoutItemFieldChange = ({
     }) ?? nextAfterTypeChange
   );
 };
+
+export const applyLayoutItemKeyboardChange = ({
+  item,
+  key,
+  unit = 1,
+  resize = false,
+} = {}) => {
+  if (!item || typeof key !== "string") {
+    return item;
+  }
+
+  let change;
+
+  if (key === "ArrowUp") {
+    change = resize
+      ? { height: Math.round(item.height - unit) }
+      : { y: Math.round(item.y - unit) };
+  } else if (key === "ArrowDown") {
+    change = resize
+      ? { height: Math.round(item.height + unit) }
+      : { y: Math.round(item.y + unit) };
+  } else if (key === "ArrowLeft") {
+    change = resize
+      ? { width: Math.round(item.width - unit) }
+      : { x: Math.round(item.x - unit) };
+  } else if (key === "ArrowRight") {
+    change = resize
+      ? { width: Math.round(item.width + unit) }
+      : { x: Math.round(item.x + unit) };
+  } else {
+    return item;
+  }
+
+  return {
+    ...item,
+    ...change,
+  };
+};
+
+export const applyLayoutItemDragChange = ({
+  item,
+  dragStartPosition,
+  x,
+  y,
+} = {}) => {
+  if (
+    !item ||
+    !dragStartPosition ||
+    typeof x !== "number" ||
+    typeof y !== "number"
+  ) {
+    return item;
+  }
+
+  return {
+    ...item,
+    x: dragStartPosition.itemStartX + x - dragStartPosition.x,
+    y: dragStartPosition.itemStartY + y - dragStartPosition.y,
+  };
+};

--- a/src/internal/layoutEditorMutations.js
+++ b/src/internal/layoutEditorMutations.js
@@ -1,0 +1,94 @@
+import { getLayoutEditorTypeRules } from "./layoutEditorTypes.js";
+
+const cloneWithDeletedValue = (target, key) => {
+  if (!target || typeof target !== "object") {
+    return target;
+  }
+
+  delete target[key];
+  return target;
+};
+
+const setValueAtPath = (target, path, value) => {
+  const segments = path.split(".");
+  let current = target;
+
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index];
+    if (!current[segment] || typeof current[segment] !== "object") {
+      current[segment] = {};
+    }
+    current = current[segment];
+  }
+
+  const lastSegment = segments[segments.length - 1];
+  if (value === undefined) {
+    delete current[lastSegment];
+  } else {
+    current[lastSegment] = value;
+  }
+
+  return target;
+};
+
+const setTopLevelValue = (target, name, value) => {
+  if (value === undefined) {
+    return cloneWithDeletedValue(target, name);
+  }
+
+  target[name] = value;
+  return target;
+};
+
+export const applyLayoutItemFieldChange = ({
+  item,
+  name,
+  value,
+  imagesData,
+} = {}) => {
+  if (!item || !name) {
+    return item;
+  }
+
+  const typeRules = getLayoutEditorTypeRules(item.type);
+  const normalizedValue =
+    typeRules.normalizeFieldValue?.({
+      item,
+      name,
+      value,
+    }) ?? value;
+
+  const nextItem = structuredClone(item);
+
+  if (
+    name === "anchor" &&
+    normalizedValue &&
+    typeof normalizedValue === "object"
+  ) {
+    nextItem.anchorX = normalizedValue.x;
+    nextItem.anchorY = normalizedValue.y;
+  } else if (name.includes(".")) {
+    setValueAtPath(nextItem, name, normalizedValue);
+  } else {
+    setTopLevelValue(nextItem, name, normalizedValue);
+  }
+
+  const nextAfterTypeChange =
+    typeRules.applyFieldChange?.({
+      currentItem: item,
+      nextItem,
+      name,
+      value: normalizedValue,
+      imagesData,
+    }) ?? nextItem;
+
+  return (
+    typeRules.finalizeFieldChange?.({
+      currentItem: item,
+      nextItem: nextAfterTypeChange,
+      name,
+      value: normalizedValue,
+      imagesData,
+    }) ?? nextAfterTypeChange
+  );
+};

--- a/src/internal/layoutEditorPersistence.js
+++ b/src/internal/layoutEditorPersistence.js
@@ -1,0 +1,241 @@
+import { normalizeInteractionValue } from "./project/interactionPayload.js";
+
+export const getLayoutEditorResourceCollection = (
+  repositoryState,
+  resourceType,
+) => {
+  return resourceType === "controls"
+    ? repositoryState.controls || { items: {}, tree: [] }
+    : repositoryState.layouts || { items: {}, tree: [] };
+};
+
+const getLayoutEditorElementOwnerKey = (resourceType) => {
+  return resourceType === "controls" ? "controlId" : "layoutId";
+};
+
+const isPlainObject = (value) => {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+};
+
+const areValuesEqual = (left, right) => {
+  if (left === right) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => areValuesEqual(value, right[index]))
+    );
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key) =>
+          Object.hasOwn(right, key) && areValuesEqual(left[key], right[key]),
+      )
+    );
+  }
+
+  return false;
+};
+
+const createObjectPatch = (previousValue, nextValue) => {
+  const previousObject = isPlainObject(previousValue) ? previousValue : {};
+  const nextObject = isPlainObject(nextValue) ? nextValue : {};
+  const patch = {};
+  let hasChanges = false;
+  let requiresReplace = false;
+
+  for (const key of Object.keys(previousObject)) {
+    if (!Object.hasOwn(nextObject, key)) {
+      requiresReplace = true;
+      break;
+    }
+  }
+
+  for (const [key, value] of Object.entries(nextObject)) {
+    if (!Object.hasOwn(previousObject, key)) {
+      patch[key] = structuredClone(value);
+      hasChanges = true;
+      continue;
+    }
+
+    const previousEntry = previousObject[key];
+
+    if (areValuesEqual(previousEntry, value)) {
+      continue;
+    }
+
+    if (isPlainObject(previousEntry) && isPlainObject(value)) {
+      const nestedResult = createObjectPatch(previousEntry, value);
+      if (nestedResult.requiresReplace) {
+        requiresReplace = true;
+      } else if (nestedResult.hasChanges) {
+        patch[key] = nestedResult.patch;
+        hasChanges = true;
+      }
+      continue;
+    }
+
+    patch[key] = structuredClone(value);
+    hasChanges = true;
+  }
+
+  return {
+    patch,
+    hasChanges,
+    requiresReplace,
+  };
+};
+
+const normalizeLayoutElementInteractions = (item = {}) => {
+  if (!item || typeof item !== "object") {
+    return item;
+  }
+
+  const nextItem = structuredClone(item);
+
+  for (const key of ["click", "rightClick", "change"]) {
+    if (nextItem[key] !== undefined) {
+      nextItem[key] = normalizeInteractionValue(nextItem[key]);
+    }
+  }
+
+  return nextItem;
+};
+
+export const shouldPersistLayoutEditorFieldImmediately = (name) => {
+  if (typeof name !== "string" || name.length === 0) {
+    return false;
+  }
+
+  return (
+    name === "click" ||
+    name.startsWith("click.") ||
+    name === "rightClick" ||
+    name.startsWith("rightClick.") ||
+    name === "change" ||
+    name.startsWith("change.")
+  );
+};
+
+export const createLayoutEditorElementPersistPayload = ({
+  currentItem,
+  updatedItem,
+  replace = false,
+} = {}) => {
+  if (!currentItem || !updatedItem) {
+    return {
+      hasChanges: false,
+      replace: false,
+      data: undefined,
+    };
+  }
+
+  const previousItem = normalizeLayoutElementInteractions(currentItem);
+  const normalizedUpdatedItem = normalizeLayoutElementInteractions(updatedItem);
+  const diff = createObjectPatch(previousItem, normalizedUpdatedItem);
+
+  if (!diff.hasChanges && !diff.requiresReplace) {
+    return {
+      hasChanges: false,
+      replace: false,
+      data: undefined,
+    };
+  }
+
+  const shouldReplace = replace === true || diff.requiresReplace;
+  const { id: _ignoredItemId, ...nextReplaceData } = normalizedUpdatedItem;
+
+  return {
+    hasChanges: true,
+    replace: shouldReplace,
+    data: shouldReplace ? nextReplaceData : diff.patch,
+  };
+};
+
+export const persistLayoutEditorElementUpdate = async ({
+  projectService,
+  layoutId,
+  resourceType,
+  selectedItemId,
+  updatedItem,
+  replace,
+} = {}) => {
+  const ownerCollection = getLayoutEditorResourceCollection(
+    projectService.getRepositoryState(),
+    resourceType,
+  );
+  const currentItem =
+    ownerCollection?.items?.[layoutId]?.elements?.items?.[selectedItemId];
+
+  if (!currentItem || !updatedItem) {
+    return {
+      didPersist: false,
+    };
+  }
+
+  const payload = createLayoutEditorElementPersistPayload({
+    currentItem: {
+      id: selectedItemId,
+      ...currentItem,
+    },
+    updatedItem,
+    replace,
+  });
+
+  if (!payload.hasChanges) {
+    return {
+      didPersist: false,
+    };
+  }
+
+  const ownerPayloadKey = getLayoutEditorElementOwnerKey(resourceType);
+  const updateElement =
+    resourceType === "controls"
+      ? projectService.updateControlElement.bind(projectService)
+      : projectService.updateLayoutElement.bind(projectService);
+
+  await updateElement({
+    [ownerPayloadKey]: layoutId,
+    elementId: selectedItemId,
+    data: payload.data,
+    replace: payload.replace,
+  });
+
+  return {
+    didPersist: true,
+    payload,
+  };
+};
+
+export const syncLayoutEditorRepositoryState = ({
+  store,
+  repositoryState,
+  layoutId,
+  resourceType = "layouts",
+} = {}) => {
+  const { images, textStyles, colors, fonts, variables } = repositoryState;
+  const resourceCollection = getLayoutEditorResourceCollection(
+    repositoryState,
+    resourceType,
+  );
+  const layout = layoutId ? resourceCollection.items?.[layoutId] : undefined;
+
+  store.setLayout({ id: layoutId, layout, resourceType });
+  store.setItems({ layoutData: layout?.elements || { items: {}, tree: [] } });
+  store.setImages({ images: images || { items: {}, tree: [] } });
+  store.setTextStylesData({
+    textStylesData: textStyles || { items: {}, tree: [] },
+  });
+  store.setColorsData({ colorsData: colors || { items: {}, tree: [] } });
+  store.setFontsData({ fontsData: fonts || { items: {}, tree: [] } });
+  store.setVariablesData({
+    variablesData: variables || { items: {}, tree: [] },
+  });
+};

--- a/src/internal/layoutEditorPreview.js
+++ b/src/internal/layoutEditorPreview.js
@@ -224,7 +224,7 @@ const buildOverlayTree = ({ path, overlayId, draggable }) => {
   return overlayTree;
 };
 
-const createLayoutPreviewData = ({
+export const createLayoutEditorPreviewData = ({
   variablesData,
   dialogueDefaultValues,
   choicesData,
@@ -259,7 +259,7 @@ const resolveLayoutPreviewElements = ({ elements, previewData } = {}) => {
   );
 };
 
-const createSelectedLayoutOverlay = ({
+export const createLayoutEditorSelectionOverlay = ({
   parsedElements,
   selectedItemId,
 } = {}) => {
@@ -414,7 +414,7 @@ export const renderLayoutEditorPreview = async (deps) => {
 
     const finalElements = resolveLayoutPreviewElements({
       elements: renderStateElements,
-      previewData: createLayoutPreviewData({
+      previewData: createLayoutEditorPreviewData({
         variablesData,
         dialogueDefaultValues: store.selectDialogueDefaultValues(),
         choicesData: store.selectChoicesData(),
@@ -424,7 +424,7 @@ export const renderLayoutEditorPreview = async (deps) => {
     const parsedState = graphicsService.parse({
       elements: finalElements,
     });
-    const overlayElements = createSelectedLayoutOverlay({
+    const overlayElements = createLayoutEditorSelectionOverlay({
       parsedElements: parsedState.elements,
       selectedItemId: selectedItem?.id,
     });

--- a/src/internal/layoutEditorPreview.js
+++ b/src/internal/layoutEditorPreview.js
@@ -1,4 +1,9 @@
 import { parseAndRender } from "jempl";
+import {
+  buildLayoutRenderElements,
+  extractFileIdsFromRenderState,
+} from "./project/layout.js";
+import { toHierarchyStructure } from "./project/tree.js";
 
 const DEFAULT_DIALOGUE_CHARACTER_NAME = "Character";
 const DEFAULT_DIALOGUE_CONTENT = "This is a sample dialogue content.";
@@ -11,6 +16,8 @@ const OVERLAY_FILL = {
   color: "#ffffff",
   alpha: 0.001,
 };
+
+const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
 
 const toPreviewVariableValue = (variable = {}) => {
   const value = variable.value ?? variable.default;
@@ -217,7 +224,7 @@ const buildOverlayTree = ({ path, overlayId, draggable }) => {
   return overlayTree;
 };
 
-export const createLayoutPreviewData = ({
+const createLayoutPreviewData = ({
   variablesData,
   dialogueDefaultValues,
   choicesData,
@@ -227,7 +234,6 @@ export const createLayoutPreviewData = ({
     DEFAULT_DIALOGUE_CHARACTER_NAME;
   const dialogueContent =
     dialogueDefaultValues?.["dialogue-content"] ?? DEFAULT_DIALOGUE_CONTENT;
-  const choiceItems = createChoiceItems(choicesData);
 
   return {
     variables: createPreviewVariables(variablesData),
@@ -242,21 +248,18 @@ export const createLayoutPreviewData = ({
       }),
     },
     choice: {
-      items: choiceItems,
+      items: createChoiceItems(choicesData),
     },
   };
 };
 
-export const resolveLayoutPreviewElements = ({
-  elements,
-  previewData,
-} = {}) => {
+const resolveLayoutPreviewElements = ({ elements, previewData } = {}) => {
   return toElementList(
     parseAndRender(toElementList(elements), previewData ?? {}),
   );
 };
 
-export const createSelectedLayoutOverlay = ({
+const createSelectedLayoutOverlay = ({
   parsedElements,
   selectedItemId,
 } = {}) => {
@@ -298,4 +301,139 @@ export const createSelectedLayoutOverlay = ({
   }
 
   return [...secondaryOverlays, primaryOverlay];
+};
+
+const loadLayoutEditorAssets = async (deps, fileReferences, fontsItems) => {
+  const { projectService, store } = deps;
+  const assets = {};
+
+  for (const fileReference of fileReferences) {
+    const { url: fileId, type: fileType } = fileReference;
+    const cacheKey = fileId;
+    let url;
+
+    const cachedUrl = store.selectCachedFileContent({ fileId: cacheKey });
+    if (cachedUrl) {
+      if (!isBlobUrl(cachedUrl)) {
+        url = cachedUrl;
+      } else {
+        store.clearCachedFileContent({ fileId: cacheKey });
+      }
+    }
+
+    if (!url) {
+      const result = await projectService.getFileContent(fileId);
+      url = result.url;
+      if (!isBlobUrl(url)) {
+        store.cacheFileContent({ fileId: cacheKey, url });
+      }
+    }
+
+    let type = fileType || "image/png";
+    const fontItem = Object.values(fontsItems).find(
+      (font) => font.fileId === fileId,
+    );
+    if (fontItem) {
+      const fileName = fontItem.name || "";
+      if (fileName.endsWith(".woff2")) {
+        type = "font/woff2";
+      } else if (fileName.endsWith(".woff")) {
+        type = "font/woff";
+      } else if (fileName.endsWith(".ttf")) {
+        type = "font/ttf";
+      } else if (fileName.endsWith(".otf")) {
+        type = "font/otf";
+      } else {
+        type = "font/ttf";
+      }
+    }
+
+    assets[`${fileId}`] = {
+      url,
+      type,
+    };
+  }
+
+  return assets;
+};
+
+export const createLayoutEditorRenderState = (deps) => {
+  const { store, projectService } = deps;
+  const repositoryState = projectService.getRepositoryState();
+  const {
+    layouts,
+    controls,
+    images: { items: imageItems },
+    textStyles: textStylesData,
+    colors: colorsData,
+    fonts: fontsData,
+    variables: variablesData,
+  } = repositoryState;
+  const textStyleItems = textStylesData?.items || {};
+  const colorsItems = colorsData?.items || {};
+  const fontsItems = fontsData?.items || {};
+  const layoutId = store.selectLayoutId();
+  const resourceType = store.selectLayoutResourceType();
+  const storeElements = store.selectItems();
+  const resourceCollection = resourceType === "controls" ? controls : layouts;
+  const layoutElements =
+    storeElements || resourceCollection?.items?.[layoutId]?.elements;
+  const layoutHierarchyStructure = toHierarchyStructure(layoutElements);
+  const renderStateElements = buildLayoutRenderElements(
+    layoutHierarchyStructure,
+    imageItems,
+    { items: textStyleItems },
+    { items: colorsItems },
+    { items: fontsItems },
+    { layoutId },
+  );
+
+  return {
+    renderStateElements,
+    fontsItems,
+    variablesData,
+  };
+};
+
+export const renderLayoutEditorPreview = async (deps) => {
+  try {
+    const { store, graphicsService } = deps;
+    const { renderStateElements, fontsItems, variablesData } =
+      createLayoutEditorRenderState(deps);
+    const selectedItem = store.selectSelectedItemData();
+    const fileReferences = extractFileIdsFromRenderState(renderStateElements);
+
+    let assets = await loadLayoutEditorAssets(deps, fileReferences, fontsItems);
+    try {
+      await graphicsService.loadAssets(assets);
+    } catch {
+      deps.store.clearFileContentCache();
+      assets = await loadLayoutEditorAssets(deps, fileReferences, fontsItems);
+      await graphicsService.loadAssets(assets);
+    }
+
+    const finalElements = resolveLayoutPreviewElements({
+      elements: renderStateElements,
+      previewData: createLayoutPreviewData({
+        variablesData,
+        dialogueDefaultValues: store.selectDialogueDefaultValues(),
+        choicesData: store.selectChoicesData(),
+      }),
+    });
+
+    const parsedState = graphicsService.parse({
+      elements: finalElements,
+    });
+    const overlayElements = createSelectedLayoutOverlay({
+      parsedElements: parsedState.elements,
+      selectedItemId: selectedItem?.id,
+    });
+
+    graphicsService.render({
+      elements: [...finalElements, ...overlayElements],
+      animations: [],
+    });
+  } catch (error) {
+    console.error("[layoutEditor] Failed to render preview", error);
+  }
 };

--- a/src/internal/layoutEditorTypes.js
+++ b/src/internal/layoutEditorTypes.js
@@ -283,10 +283,54 @@ const TYPE_FAMILIES = {
   rect: "rect",
 };
 
+const DEFAULT_CAPABILITIES = {
+  supportsHeight: true,
+  supportsAnchor: false,
+  supportsDirection: false,
+  supportsTextEditing: false,
+  supportsTextStyles: false,
+  supportsTextAlignment: false,
+  supportsActions: false,
+  supportsSpriteImages: false,
+  supportsSliderImages: false,
+  supportsSliderValues: false,
+};
+
+const FAMILY_CAPABILITIES = {
+  container: {
+    supportsAnchor: true,
+    supportsDirection: true,
+  },
+  sprite: {
+    supportsSpriteImages: true,
+    supportsActions: true,
+  },
+  text: {
+    supportsHeight: false,
+    supportsAnchor: true,
+    supportsTextStyles: true,
+    supportsTextAlignment: true,
+  },
+  slider: {
+    supportsSliderImages: true,
+    supportsSliderValues: true,
+  },
+  rect: {
+    supportsActions: true,
+  },
+};
+
+const ITEM_TYPE_CAPABILITY_OVERRIDES = {
+  text: {
+    supportsTextEditing: true,
+    supportsActions: true,
+  },
+};
+
 const TYPE_RULES = {
   container: {
     normalizeFieldValue: ({ name, value }) => {
-      if (name === "direction" && value === null) {
+      if (name === "direction" && (value === null || value === "")) {
         return undefined;
       }
 
@@ -304,7 +348,7 @@ const TYPE_RULES = {
   text: {},
   slider: {
     normalizeFieldValue: ({ name, value }) => {
-      if (name === "direction" && value === null) {
+      if (name === "direction" && (value === null || value === "")) {
         return undefined;
       }
 
@@ -352,6 +396,16 @@ export const isLayoutEditorContainerItemType = (itemType) => {
 export const createLayoutEditorItemTemplate = (createType) => {
   const templateFactory = CREATE_TEMPLATES[createType];
   return templateFactory ? templateFactory() : {};
+};
+
+export const getLayoutEditorItemCapabilities = (itemType) => {
+  const family = TYPE_FAMILIES[itemType];
+
+  return {
+    ...DEFAULT_CAPABILITIES,
+    ...FAMILY_CAPABILITIES[family],
+    ...ITEM_TYPE_CAPABILITY_OVERRIDES[itemType],
+  };
 };
 
 export const getLayoutEditorTypeRules = (itemType) => {

--- a/src/internal/layoutEditorTypes.js
+++ b/src/internal/layoutEditorTypes.js
@@ -1,0 +1,360 @@
+const BASE_TRANSFORM = {
+  x: 0,
+  y: 0,
+  anchorX: 0,
+  anchorY: 0,
+  scaleX: 1,
+  scaleY: 1,
+  rotation: 0,
+};
+
+const TEXT_TYPE_SET = new Set([
+  "text",
+  "text-ref-character-name",
+  "text-revealing-ref-dialogue-content",
+  "text-ref-choice-item-content",
+  "text-ref-dialogue-line-character-name",
+  "text-ref-dialogue-line-content",
+]);
+
+const CONTAINER_TYPE_SET = new Set([
+  "container",
+  "container-ref-choice-item",
+  "container-ref-dialogue-line",
+]);
+
+const CREATE_TEMPLATES = {
+  container: () => ({
+    type: "container",
+    name: "Container",
+    ...BASE_TRANSFORM,
+    gap: 0,
+    width: 100,
+    height: 100,
+  }),
+  sprite: () => ({
+    type: "sprite",
+    name: "Sprite",
+    ...BASE_TRANSFORM,
+    width: 0,
+    height: 0,
+  }),
+  text: () => ({
+    type: "text",
+    name: "Text",
+    ...BASE_TRANSFORM,
+    text: "text",
+    style: {
+      align: "left",
+    },
+  }),
+  "slider-horizontal": () => ({
+    type: "slider",
+    name: "Slider",
+    ...BASE_TRANSFORM,
+    width: 400,
+    height: 20,
+    direction: "horizontal",
+    thumbImageId: "slider_thumb_default",
+    barImageId: "slider_bar_default",
+    hoverThumbImageId: "slider_thumb_hover",
+    hoverBarImageId: "slider_bar_hover",
+    min: 0,
+    max: 100,
+    step: 1,
+    initialValue: 0,
+    variableId: "",
+  }),
+  "slider-vertical": () => ({
+    type: "slider",
+    name: "Slider",
+    ...BASE_TRANSFORM,
+    width: 20,
+    height: 400,
+    direction: "vertical",
+    thumbImageId: "slider_thumb_default",
+    barImageId: "slider_bar_vertical",
+    hoverThumbImageId: "slider_thumb_hover",
+    hoverBarImageId: "slider_bar_vertical_hover",
+    min: 0,
+    max: 100,
+    step: 1,
+    initialValue: 0,
+    variableId: "",
+  }),
+  "text-dialogue-content": () => ({
+    type: "text-revealing-ref-dialogue-content",
+    name: "Text (Dialogue Content)",
+    ...BASE_TRANSFORM,
+    text: "text",
+    style: {
+      wordWrapWidth: 300,
+      align: "left",
+    },
+  }),
+  "text-character-name": () => ({
+    type: "text-ref-character-name",
+    name: "Text (Character Name)",
+    ...BASE_TRANSFORM,
+    text: "text",
+    style: {
+      wordWrapWidth: 300,
+      align: "left",
+    },
+  }),
+  "container-dialogue-line": () => ({
+    type: "container-ref-dialogue-line",
+    name: "Container (Dialogue Line)",
+    ...BASE_TRANSFORM,
+    width: 1640,
+    height: 120,
+  }),
+  "text-dialogue-line-character-name": () => ({
+    type: "text-ref-dialogue-line-character-name",
+    name: "Text (Line Character Name)",
+    $when: "line.characterName",
+    ...BASE_TRANSFORM,
+    width: 280,
+    height: 40,
+    text: "text",
+    style: {
+      wordWrapWidth: 300,
+      align: "left",
+    },
+  }),
+  "text-dialogue-line-content": () => ({
+    type: "text-ref-dialogue-line-content",
+    name: "Text (Line Content)",
+    ...BASE_TRANSFORM,
+    x: 0,
+    y: 44,
+    width: 1640,
+    height: 72,
+    text: "text",
+    style: {
+      wordWrapWidth: 300,
+      align: "left",
+    },
+  }),
+  "container-choice-item": () => ({
+    type: "container-ref-choice-item",
+    name: "Container (Choice Item)",
+    ...BASE_TRANSFORM,
+  }),
+  "text-choice-item-content": () => ({
+    type: "text-ref-choice-item-content",
+    name: "Text (Choice Item Content)",
+    ...BASE_TRANSFORM,
+    text: "text",
+    style: {
+      wordWrapWidth: 300,
+      align: "left",
+    },
+  }),
+  rect: () => ({
+    type: "rect",
+    name: "Rect",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+  }),
+};
+
+const resolveSliderDirection = (value) => {
+  return value === "vertical" ? "vertical" : "horizontal";
+};
+
+const createSliderSavedStateKey = (direction) => {
+  const resolvedDirection = resolveSliderDirection(direction);
+  return `_saved${resolvedDirection.charAt(0).toUpperCase()}${resolvedDirection.slice(1)}`;
+};
+
+const applySliderDirectionChange = ({ currentItem, nextItem, value }) => {
+  const oldDirection = resolveSliderDirection(currentItem.direction);
+  const newDirection = resolveSliderDirection(value);
+
+  nextItem.direction = value === null ? undefined : newDirection;
+  nextItem[createSliderSavedStateKey(oldDirection)] = {
+    barImageId: currentItem.barImageId,
+    hoverBarImageId: currentItem.hoverBarImageId,
+    thumbImageId: currentItem.thumbImageId,
+    hoverThumbImageId: currentItem.hoverThumbImageId,
+    width: currentItem.width,
+    height: currentItem.height,
+  };
+
+  const saved = currentItem[createSliderSavedStateKey(newDirection)];
+  if (saved) {
+    nextItem.barImageId = saved.barImageId;
+    nextItem.hoverBarImageId = saved.hoverBarImageId;
+    nextItem.thumbImageId = saved.thumbImageId;
+    nextItem.hoverThumbImageId = saved.hoverThumbImageId;
+    nextItem.width = saved.width;
+    nextItem.height = saved.height;
+    return nextItem;
+  }
+
+  if (newDirection === "vertical") {
+    nextItem.barImageId = "slider_bar_vertical";
+    nextItem.hoverBarImageId = "slider_bar_vertical_hover";
+  } else {
+    nextItem.barImageId = "slider_bar_default";
+    nextItem.hoverBarImageId = "slider_bar_hover";
+  }
+
+  nextItem.thumbImageId = "slider_thumb_default";
+  nextItem.hoverThumbImageId = "slider_thumb_hover";
+  nextItem.width = currentItem.height;
+  nextItem.height = currentItem.width;
+
+  return nextItem;
+};
+
+const applySliderVariableBindingChange = ({ nextItem, value }) => {
+  const variableId = value ?? "";
+
+  nextItem.variableId = variableId;
+
+  if (variableId) {
+    const updateVariableId = toAlphanumericId(`slider${nextItem.id}update`);
+    nextItem.change = {
+      payload: {
+        actions: {
+          updateVariable: {
+            id: updateVariableId,
+            operations: [
+              {
+                variableId,
+                op: "set",
+                value: "_event.value",
+              },
+            ],
+          },
+        },
+      },
+    };
+    nextItem.initialValue = `\${variables.${variableId}}`;
+    return nextItem;
+  }
+
+  delete nextItem.change;
+  const parsedMin = Number(nextItem.min);
+  nextItem.initialValue = Number.isFinite(parsedMin) ? parsedMin : 0;
+  return nextItem;
+};
+
+const applySpriteAutoSize = ({ nextItem, imagesData }) => {
+  if (
+    nextItem.type !== "sprite" ||
+    (nextItem.width !== 0 && nextItem.height !== 0)
+  ) {
+    return nextItem;
+  }
+
+  const image = imagesData?.items?.[nextItem.imageId];
+  if (!image) {
+    return nextItem;
+  }
+
+  if (nextItem.width === 0 && Number.isFinite(image.width)) {
+    nextItem.width = image.width;
+  }
+  if (nextItem.height === 0 && Number.isFinite(image.height)) {
+    nextItem.height = image.height;
+  }
+
+  return nextItem;
+};
+
+const TYPE_FAMILIES = {
+  container: "container",
+  "container-ref-choice-item": "container",
+  "container-ref-dialogue-line": "container",
+  sprite: "sprite",
+  text: "text",
+  "text-revealing": "text",
+  "text-ref-character-name": "text",
+  "text-revealing-ref-dialogue-content": "text",
+  "text-ref-choice-item-content": "text",
+  "text-ref-dialogue-line-character-name": "text",
+  "text-ref-dialogue-line-content": "text",
+  slider: "slider",
+  rect: "rect",
+};
+
+const TYPE_RULES = {
+  container: {
+    normalizeFieldValue: ({ name, value }) => {
+      if (name === "direction" && value === null) {
+        return undefined;
+      }
+
+      return value;
+    },
+  },
+  sprite: {
+    finalizeFieldChange: ({ nextItem, imagesData }) => {
+      return applySpriteAutoSize({
+        nextItem,
+        imagesData,
+      });
+    },
+  },
+  text: {},
+  slider: {
+    normalizeFieldValue: ({ name, value }) => {
+      if (name === "direction" && value === null) {
+        return undefined;
+      }
+
+      if (name === "variableId" && value === null) {
+        return "";
+      }
+
+      return value;
+    },
+    applyFieldChange: ({ currentItem, nextItem, name, value }) => {
+      if (name === "direction") {
+        return applySliderDirectionChange({
+          currentItem,
+          nextItem,
+          value,
+        });
+      }
+
+      if (name === "variableId") {
+        return applySliderVariableBindingChange({
+          nextItem,
+          value,
+        });
+      }
+
+      return nextItem;
+    },
+  },
+  rect: {},
+};
+
+export const toAlphanumericId = (value, fallback = "sliderUpdate") => {
+  const sanitized = String(value || "").replace(/[^a-zA-Z0-9]/g, "");
+  return sanitized || fallback;
+};
+
+export const isLayoutEditorTextItemType = (itemType) => {
+  return TEXT_TYPE_SET.has(itemType);
+};
+
+export const isLayoutEditorContainerItemType = (itemType) => {
+  return CONTAINER_TYPE_SET.has(itemType);
+};
+
+export const createLayoutEditorItemTemplate = (createType) => {
+  const templateFactory = CREATE_TEMPLATES[createType];
+  return templateFactory ? templateFactory() : {};
+};
+
+export const getLayoutEditorTypeRules = (itemType) => {
+  const family = TYPE_FAMILIES[itemType];
+  return family ? (TYPE_RULES[family] ?? {}) : {};
+};

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -1,5 +1,6 @@
 import { resolveLayoutReferences } from "route-engine-js";
 import { getFirstTextStyleId } from "../../constants/textStyles.js";
+import { toAlphanumericId } from "../layoutEditorTypes.js";
 import { filterTreeCollection } from "./tree.js";
 import { normalizeEngineActions } from "./engineActions.js";
 import {
@@ -97,11 +98,6 @@ export const filterLayoutsExcludingTypes = (
 
     return !blockedLayoutTypes.has(item.layoutType);
   });
-};
-
-const toAlphanumericId = (value, fallback = "sliderUpdate") => {
-  const sanitized = String(value || "").replace(/[^a-zA-Z0-9]/g, "");
-  return sanitized || fallback;
 };
 
 const toWordWrapWidth = (value) => {

--- a/src/pages/layoutEditor/layoutEditor.constants.yaml
+++ b/src/pages/layoutEditor/layoutEditor.constants.yaml
@@ -1,0 +1,139 @@
+contextMenuItems:
+  - label: Container
+    type: item
+    createType: container
+  - label: Sprite
+    type: item
+    createType: sprite
+  - label: Text
+    type: item
+    createType: text
+  - label: Slider (Horizontal)
+    type: item
+    createType: slider-horizontal
+  - label: Slider (Vertical)
+    type: item
+    createType: slider-vertical
+  - "$when": 'layoutType == "dialogue"'
+    label: Text (Dialogue Content)
+    type: item
+    createType: text-dialogue-content
+  - "$when": 'layoutType == "dialogue"'
+    label: Text (Character Name)
+    type: item
+    createType: text-character-name
+  - "$when": 'layoutType == "nvl"'
+    label: Container (Dialogue Line)
+    type: item
+    createType: container-dialogue-line
+  - "$when": 'layoutType == "nvl"'
+    label: Text (Line Character Name)
+    type: item
+    createType: text-dialogue-line-character-name
+  - "$when": 'layoutType == "nvl"'
+    label: Text (Line Content)
+    type: item
+    createType: text-dialogue-line-content
+  - "$when": 'layoutType == "choice"'
+    label: Container (Choice Item)
+    type: item
+    createType: container-choice-item
+  - "$when": 'layoutType == "choice"'
+    label: Text (Choice Item)
+    type: item
+    createType: text-choice-item-content
+  - label: Rename
+    type: item
+    value: rename-item
+  - label: Delete
+    type: item
+    value: delete-item
+
+emptyContextMenuItems:
+  - label: Container
+    type: item
+    createType: container
+  - label: Sprite
+    type: item
+    createType: sprite
+  - label: Text
+    type: item
+    createType: text
+  - label: Slider (Horizontal)
+    type: item
+    createType: slider-horizontal
+  - label: Slider (Vertical)
+    type: item
+    createType: slider-vertical
+  - "$when": 'layoutType == "dialogue"'
+    label: Text (Dialogue Content)
+    type: item
+    createType: text-dialogue-content
+  - "$when": 'layoutType == "dialogue"'
+    label: Text (Character Name)
+    type: item
+    createType: text-character-name
+  - "$when": 'layoutType == "nvl"'
+    label: Container (Dialogue Line)
+    type: item
+    createType: container-dialogue-line
+  - "$when": 'layoutType == "nvl"'
+    label: Text (Line Character Name)
+    type: item
+    createType: text-dialogue-line-character-name
+  - "$when": 'layoutType == "nvl"'
+    label: Text (Line Content)
+    type: item
+    createType: text-dialogue-line-content
+
+controlContextMenuItems:
+  - label: Rename
+    type: item
+    value: rename-item
+  - label: Delete
+    type: item
+    value: delete-item
+
+controlEmptyContextMenuItems:
+  - label: Rect
+    type: item
+    createType: rect
+
+dialogueForm:
+  title: Preview
+  description: Edit to see how the layout will look like with different data
+  fields:
+    - name: dialogue-character-name
+      description: Character Name
+      type: input-text
+    - name: dialogue-content
+      description: Dialogue Content
+      type: input-text
+
+choiceForm:
+  title: Preview
+  description: Edit to see how the layout will look like with different data
+  fields:
+    - name: choicesNum
+      type: select
+      description: Number of Choices
+      options:
+        - label: "1"
+          value: 1
+        - label: "2"
+          value: 2
+        - label: "3"
+          value: 3
+        - label: "4"
+          value: 4
+        - label: "5"
+          value: 5
+        - label: "6"
+          value: 6
+      placeholder: Select number of choices
+      required: true
+    - "$each": 'choice, i in choices'
+      name: 'choices[${i}]'
+      type: input-text
+      description: Choice content text
+      placeholder: Enter choice text

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -8,9 +8,17 @@ import {
   resolveLayoutEditorPayload,
 } from "../../internal/layoutEditorRoute.js";
 import { renderLayoutEditorPreview } from "../../internal/layoutEditorPreview.js";
-import { applyLayoutItemFieldChange } from "../../internal/layoutEditorMutations.js";
+import {
+  applyLayoutItemDragChange,
+  applyLayoutItemFieldChange,
+  applyLayoutItemKeyboardChange,
+} from "../../internal/layoutEditorMutations.js";
+import {
+  persistLayoutEditorElementUpdate,
+  shouldPersistLayoutEditorFieldImmediately,
+  syncLayoutEditorRepositoryState,
+} from "../../internal/layoutEditorPersistence.js";
 import { createLayoutElementsFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
-import { normalizeInteractionValue } from "../../internal/project/interactionPayload.js";
 
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
@@ -31,110 +39,15 @@ const KEYBOARD_UNITS = {
 const getEditorPayload = (appService) =>
   resolveLayoutEditorPayload(appService.getPayload() || {});
 
-const getRepositoryResourceCollection = (repositoryState, resourceType) => {
-  return resourceType === "controls"
-    ? repositoryState.controls || { items: {}, tree: [] }
-    : repositoryState.layouts || { items: {}, tree: [] };
-};
-
-const getEditorElementOwnerKey = (resourceType) => {
-  return resourceType === "controls" ? "controlId" : "layoutId";
-};
-
-const isPlainObject = (value) => {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-};
-
-const areValuesEqual = (left, right) => {
-  if (left === right) {
-    return true;
+const rerenderLayoutEditorSurface = async (
+  deps,
+  { renderPage = true } = {},
+) => {
+  if (renderPage) {
+    deps.render();
   }
 
-  if (Array.isArray(left) && Array.isArray(right)) {
-    return (
-      left.length === right.length &&
-      left.every((value, index) => areValuesEqual(value, right[index]))
-    );
-  }
-
-  if (isPlainObject(left) && isPlainObject(right)) {
-    const leftKeys = Object.keys(left);
-    const rightKeys = Object.keys(right);
-    return (
-      leftKeys.length === rightKeys.length &&
-      leftKeys.every(
-        (key) =>
-          Object.hasOwn(right, key) && areValuesEqual(left[key], right[key]),
-      )
-    );
-  }
-
-  return false;
-};
-
-const createObjectPatch = (previousValue, nextValue) => {
-  const previousObject = isPlainObject(previousValue) ? previousValue : {};
-  const nextObject = isPlainObject(nextValue) ? nextValue : {};
-  const patch = {};
-  let hasChanges = false;
-  let requiresReplace = false;
-
-  for (const key of Object.keys(previousObject)) {
-    if (!Object.hasOwn(nextObject, key)) {
-      requiresReplace = true;
-      break;
-    }
-  }
-
-  for (const [key, value] of Object.entries(nextObject)) {
-    if (!Object.hasOwn(previousObject, key)) {
-      patch[key] = structuredClone(value);
-      hasChanges = true;
-      continue;
-    }
-
-    const previousEntry = previousObject[key];
-
-    if (areValuesEqual(previousEntry, value)) {
-      continue;
-    }
-
-    if (isPlainObject(previousEntry) && isPlainObject(value)) {
-      const nestedResult = createObjectPatch(previousEntry, value);
-      if (nestedResult.requiresReplace) {
-        requiresReplace = true;
-      } else if (nestedResult.hasChanges) {
-        patch[key] = nestedResult.patch;
-        hasChanges = true;
-      }
-      continue;
-    }
-
-    patch[key] = structuredClone(value);
-    hasChanges = true;
-  }
-
-  return {
-    patch,
-    hasChanges,
-    requiresReplace,
-  };
-};
-
-const normalizeLayoutElementInteractions = (item = {}) => {
-  if (!item || typeof item !== "object") {
-    return item;
-  }
-
-  const nextItem = structuredClone(item);
-
-  for (const key of ["click", "rightClick", "change"]) {
-    if (nextItem[key] !== undefined) {
-      nextItem[key] = normalizeInteractionValue(nextItem[key]);
-    }
-  }
-
-  return nextItem;
+  await renderLayoutEditorPreview(deps);
 };
 
 export const handleBeforeMount = (deps) => {
@@ -193,50 +106,22 @@ const scheduleKeyboardSave = (deps, itemId, layoutId) => {
   store.setKeyboardNavigationTimeoutId({ timeoutId });
 };
 
-const syncLayoutEditorState = (
-  deps,
-  repositoryState,
-  layoutId,
-  resourceType = "layouts",
-) => {
-  const { store } = deps;
-  const { images, textStyles, colors, fonts, variables } = repositoryState;
-  const resourceCollection = getRepositoryResourceCollection(
-    repositoryState,
-    resourceType,
-  );
-  const layout = layoutId ? resourceCollection.items?.[layoutId] : undefined;
-
-  store.setLayout({ id: layoutId, layout, resourceType });
-  store.setItems({ layoutData: layout?.elements || { items: {}, tree: [] } });
-  store.setImages({ images: images || { items: {}, tree: [] } });
-  store.setTextStylesData({
-    textStylesData: textStyles || { items: {}, tree: [] },
-  });
-  store.setColorsData({ colorsData: colors || { items: {}, tree: [] } });
-  store.setFontsData({ fontsData: fonts || { items: {}, tree: [] } });
-  store.setVariablesData({
-    variablesData: variables || { items: {}, tree: [] },
-  });
-};
-
 export const handleAfterMount = async (deps) => {
-  const { appService, projectService, render, refs, graphicsService } = deps;
+  const { appService, projectService, refs, graphicsService } = deps;
   const payload = getEditorPayload(appService);
   const { layoutId, resourceType } = payload;
   await projectService.ensureRepository();
-  syncLayoutEditorState(
-    deps,
-    projectService.getRepositoryState(),
+  syncLayoutEditorRepositoryState({
+    store: deps.store,
+    repositoryState: projectService.getRepositoryState(),
     layoutId,
     resourceType,
-  );
+  });
 
   const { canvas } = refs;
   await graphicsService.init({ canvas: canvas });
 
-  await renderLayoutEditorPreview(deps);
-  render();
+  await rerenderLayoutEditorSurface(deps);
 };
 
 export const handleBackClick = (deps) => {
@@ -250,35 +135,33 @@ export const handleBackClick = (deps) => {
 export const handleRenderOnly = (deps) => deps.render();
 
 export const handleFileExplorerItemClick = async (deps, payload) => {
-  const { store, render } = deps;
+  const { store } = deps;
   const detail = payload._event.detail || {};
   const itemId = detail.id || detail.itemId || detail.item?.id;
   if (!itemId) {
     return;
   }
   store.setSelectedItemId({ itemId: itemId });
-  render();
-  await renderLayoutEditorPreview(deps);
+  await rerenderLayoutEditorSurface(deps);
 };
 
 export const handleAddLayoutClick = handleRenderOnly;
 
 const refreshLayoutEditorData = async (deps, payload = {}) => {
-  const { appService, projectService, render, store, refs } = deps;
+  const { appService, projectService, store, refs } = deps;
   const { layoutId, resourceType } = getEditorPayload(appService);
   await projectService.ensureRepository();
-  syncLayoutEditorState(
-    deps,
-    projectService.getRepositoryState(),
+  syncLayoutEditorRepositoryState({
+    store,
+    repositoryState: projectService.getRepositoryState(),
     layoutId,
     resourceType,
-  );
+  });
   if (payload.selectedItemId) {
     store.setSelectedItemId({ itemId: payload.selectedItemId });
     refs.fileExplorer.selectItem({ itemId: payload.selectedItemId });
   }
-  render();
-  await renderLayoutEditorPreview(deps);
+  await rerenderLayoutEditorSurface(deps);
 };
 
 const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
@@ -292,43 +175,24 @@ export { handleFileExplorerAction, handleFileExplorerTargetChanged };
 
 export const handleDataChanged = refreshLayoutEditorData;
 
-const shouldSaveLayoutEditImmediately = (name) => {
-  if (typeof name !== "string" || name.length === 0) {
-    return false;
-  }
-
-  return (
-    name === "click" ||
-    name.startsWith("click.") ||
-    name === "rightClick" ||
-    name.startsWith("rightClick.") ||
-    name === "change" ||
-    name.startsWith("change.")
-  );
-};
-
 export const handleDialogueFormChange = async (deps, payload) => {
-  const { store, render } = deps;
+  const { store } = deps;
   const { name, value: fieldValue } = payload._event.detail;
 
   store.setDialogueDefaultValue({ name, fieldValue });
-  render();
-
-  await renderLayoutEditorPreview(deps);
+  await rerenderLayoutEditorSurface(deps);
 };
 
 export const handleChoiceFormChange = async (deps, payload) => {
-  const { store, render } = deps;
+  const { store } = deps;
   const { name, value: fieldValue } = payload._event.detail;
 
   store.setChoiceDefaultValue({ name, fieldValue });
-  render();
-
-  await renderLayoutEditorPreview(deps);
+  await rerenderLayoutEditorSurface(deps);
 };
 
 export const handleArrowKeyDown = async (deps, payload) => {
-  const { store, render } = deps;
+  const { store } = deps;
   const { _event: e } = payload;
 
   const currentItem = store.selectSelectedItemData();
@@ -337,55 +201,15 @@ export const handleArrowKeyDown = async (deps, payload) => {
   }
 
   const unit = e.shiftKey ? KEYBOARD_UNITS.FAST : KEYBOARD_UNITS.NORMAL;
-  let change = {};
   const layoutId = store.selectLayoutId();
-
-  if (payload._event.key === "ArrowUp") {
-    if (e.metaKey) {
-      change = {
-        height: Math.round(currentItem.height - unit),
-      };
-    } else {
-      change = {
-        y: Math.round(currentItem.y - unit),
-      };
-    }
-  } else if (payload._event.key === "ArrowDown") {
-    if (e.metaKey) {
-      change = {
-        height: Math.round(currentItem.height + unit),
-      };
-    } else {
-      change = {
-        y: Math.round(currentItem.y + unit),
-      };
-    }
-  } else if (payload._event.key === "ArrowLeft") {
-    if (e.metaKey) {
-      change = {
-        width: Math.round(currentItem.width - unit),
-      };
-    } else {
-      change = {
-        x: Math.round(currentItem.x - unit),
-      };
-    }
-  } else if (payload._event.key === "ArrowRight") {
-    if (e.metaKey) {
-      change = {
-        width: Math.round(currentItem.width + unit),
-      };
-    } else {
-      change = {
-        x: Math.round(currentItem.x + unit),
-      };
-    }
-  }
-
-  const updatedItem = { ...currentItem, ...change };
+  const updatedItem = applyLayoutItemKeyboardChange({
+    item: currentItem,
+    key: payload._event.key,
+    unit,
+    resize: e.metaKey,
+  });
   store.updateSelectedItem({ updatedItem: updatedItem });
-  render();
-  await renderLayoutEditorPreview(deps);
+  await rerenderLayoutEditorSurface(deps);
   scheduleKeyboardSave(deps, currentItem.id, layoutId);
 };
 
@@ -399,52 +223,25 @@ async function handleDebouncedUpdate(deps, payload) {
   const { appService, projectService } = deps;
   const { layoutId, resourceType, selectedItemId, updatedItem, replace } =
     payload;
-  const ownerCollection = getRepositoryResourceCollection(
-    projectService.getRepositoryState(),
+  const persistResult = await persistLayoutEditorElementUpdate({
+    projectService,
+    layoutId,
     resourceType,
-  );
-  const currentItem =
-    ownerCollection?.items?.[layoutId]?.elements?.items?.[selectedItemId];
-
-  if (!currentItem || !updatedItem) {
+    selectedItemId,
+    updatedItem,
+    replace,
+  });
+  if (!persistResult.didPersist) {
     return;
   }
 
-  const previousItem = normalizeLayoutElementInteractions({
-    id: selectedItemId,
-    ...currentItem,
-  });
-  const normalizedUpdatedItem = normalizeLayoutElementInteractions(updatedItem);
-  const diff = createObjectPatch(previousItem, normalizedUpdatedItem);
-
-  if (!diff.hasChanges && !diff.requiresReplace) {
-    return;
-  }
-
-  const shouldReplace = replace === true || diff.requiresReplace;
-  const { id: _ignoredItemId, ...nextReplaceData } = normalizedUpdatedItem;
-
-  const ownerPayloadKey = getEditorElementOwnerKey(resourceType);
-  const updateElement =
-    resourceType === "controls"
-      ? projectService.updateControlElement.bind(projectService)
-      : projectService.updateLayoutElement.bind(projectService);
-
-  await updateElement({
-    [ownerPayloadKey]: layoutId,
-    elementId: selectedItemId,
-    data: shouldReplace ? nextReplaceData : diff.patch,
-    replace: shouldReplace,
-  });
-
-  // For form/keyboard updates, sync store with repository
   const currentPayload = getEditorPayload(appService);
-  syncLayoutEditorState(
-    deps,
-    projectService.getRepositoryState(),
-    currentPayload.layoutId || layoutId,
-    currentPayload.resourceType || resourceType,
-  );
+  syncLayoutEditorRepositoryState({
+    store: deps.store,
+    repositoryState: projectService.getRepositoryState(),
+    layoutId: currentPayload.layoutId || layoutId,
+    resourceType: currentPayload.resourceType || resourceType,
+  });
 }
 
 const subscriptions = (deps) => {
@@ -507,7 +304,7 @@ const subscriptions = (deps) => {
 };
 
 export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
-  const { store, render } = deps;
+  const { store } = deps;
   const layoutId = store.selectLayoutId();
   const resourceType = store.selectLayoutResourceType();
   const selectedItemId = store.selectSelectedItemId();
@@ -524,9 +321,8 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
   });
 
   store.updateSelectedItem({ updatedItem: updatedItem });
-  render();
 
-  if (shouldSaveLayoutEditImmediately(detail.name)) {
+  if (shouldPersistLayoutEditorFieldImmediately(detail.name)) {
     await handleDebouncedUpdate(deps, {
       layoutId,
       resourceType,
@@ -543,7 +339,7 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
     });
   }
 
-  await renderLayoutEditorPreview(deps);
+  await rerenderLayoutEditorSurface(deps);
 };
 
 export const handleCanvasMouseMove = (deps, payload) => {
@@ -573,11 +369,12 @@ export const handleCanvasMouseMove = (deps, payload) => {
     return;
   }
 
-  const updatedItem = {
-    ...item,
-    x: drag.dragStartPosition.itemStartX + x - drag.dragStartPosition.x,
-    y: drag.dragStartPosition.itemStartY + y - drag.dragStartPosition.y,
-  };
+  const updatedItem = applyLayoutItemDragChange({
+    item,
+    dragStartPosition: drag.dragStartPosition,
+    x,
+    y,
+  });
 
   store.updateSelectedItem({ updatedItem: updatedItem });
   renderLayoutEditorPreview(deps);

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -7,14 +7,8 @@ import {
   getLayoutEditorBackPath,
   resolveLayoutEditorPayload,
 } from "../../internal/layoutEditorRoute.js";
-import {
-  createLayoutPreviewData,
-  createSelectedLayoutOverlay,
-  resolveLayoutPreviewElements,
-} from "./layoutPreview.js";
-import { buildLayoutRenderElements } from "../../internal/project/layout.js";
-import { toHierarchyStructure } from "../../internal/project/tree.js";
-import { extractFileIdsFromRenderState } from "../../internal/project/layout.js";
+import { renderLayoutEditorPreview } from "../../internal/layoutEditorPreview.js";
+import { applyLayoutItemFieldChange } from "../../internal/layoutEditorMutations.js";
 import { createLayoutElementsFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
 import { normalizeInteractionValue } from "../../internal/project/interactionPayload.js";
 
@@ -33,13 +27,6 @@ const KEYBOARD_UNITS = {
   NORMAL: 1,
   FAST: 10, // With shift key
 };
-
-const toAlphanumericId = (value, fallback = "sliderUpdate") => {
-  const sanitized = String(value || "").replace(/[^a-zA-Z0-9]/g, "");
-  return sanitized || fallback;
-};
-
-const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
 
 const getEditorPayload = (appService) =>
   resolveLayoutEditorPayload(appService.getPayload() || {});
@@ -187,7 +174,7 @@ const scheduleKeyboardSave = (deps, itemId, layoutId) => {
     }
 
     // Final render to ensure bounds are properly updated
-    renderLayoutPreview(deps, { skipAssetLoading: true });
+    renderLayoutEditorPreview(deps);
 
     // Save final position to repository
     const finalItem = store.selectSelectedItemData();
@@ -204,172 +191,6 @@ const scheduleKeyboardSave = (deps, itemId, layoutId) => {
   }, DEBOUNCE_DELAYS.KEYBOARD);
 
   store.setKeyboardNavigationTimeoutId({ timeoutId });
-};
-
-/**
- * Load assets (images and fonts) for rendering
- * @param {Object} deps - Component dependencies
- * @param {Array} fileReferences - File references with url and type to load
- * @param {Object} fontsItems - Font items from repository
- * @returns {Promise<Object>} Loaded assets
- */
-const loadAssets = async (deps, fileReferences, fontsItems) => {
-  const { projectService, store } = deps;
-  const assets = {};
-
-  for (const fileObj of fileReferences) {
-    const { url: fileId, type: fileType } = fileObj;
-
-    // Check cache first
-    let url;
-    const cacheKey = fileId;
-
-    const cachedUrl = store.selectCachedFileContent({ fileId: cacheKey });
-
-    if (cachedUrl) {
-      if (!isBlobUrl(cachedUrl)) {
-        url = cachedUrl;
-      } else {
-        // Blob URLs are short-lived and can be revoked by consumers.
-        store.clearCachedFileContent({ fileId: cacheKey });
-      }
-    }
-
-    if (!url) {
-      // Fetch from API if not in cache
-      const result = await projectService.getFileContent(fileId);
-      url = result.url;
-      // Cache only stable URLs. Blob URLs can become invalid after revoke.
-      if (!isBlobUrl(url)) {
-        store.cacheFileContent({ fileId: cacheKey, url });
-      }
-    }
-
-    // Use type from fileObj, default to image/png
-    let type = fileType || "image/png";
-
-    // Check if this is a font file by looking in fonts data
-    const fontItem = Object.values(fontsItems).find(
-      (font) => font.fileId === fileId,
-    );
-
-    if (fontItem) {
-      // This is a font file, determine MIME type
-      const fileName = fontItem.name || "";
-      if (fileName.endsWith(".woff2")) type = "font/woff2";
-      else if (fileName.endsWith(".woff")) type = "font/woff";
-      else if (fileName.endsWith(".ttf")) type = "font/ttf";
-      else if (fileName.endsWith(".otf")) type = "font/otf";
-      else type = "font/ttf"; // default font type
-
-      assets[`${fileId}`] = {
-        url: url,
-        type: type,
-      };
-    } else {
-      // For non-fonts (like images), use the file reference
-      assets[`${fileId}`] = {
-        url: url,
-        type: type,
-      };
-    }
-  }
-
-  return assets;
-};
-
-/**
- * Get render state from repository and store data
- * @param {Object} deps - Component dependencies
- * @returns {Object} Render state data
- */
-const getRenderState = async (deps) => {
-  const { store, projectService } = deps;
-  const {
-    layouts,
-    controls,
-    images: { items: imageItems },
-    textStyles: textStylesData,
-    colors: colorsData,
-    fonts: fontsData,
-    variables: variablesData,
-  } = projectService.getRepositoryState();
-  const textStyleItems = textStylesData?.items || {};
-  const colorsItems = colorsData?.items || {};
-  const fontsItems = fontsData?.items || {};
-
-  const layoutId = store.selectLayoutId();
-  const resourceType = store.selectLayoutResourceType();
-  const storeElements = store.selectItems();
-  const resourceCollection = resourceType === "controls" ? controls : layouts;
-  const layoutElements =
-    storeElements || resourceCollection?.items?.[layoutId]?.elements;
-  const layoutHierarchyStructure = toHierarchyStructure(layoutElements);
-  const renderStateElements = buildLayoutRenderElements(
-    layoutHierarchyStructure,
-    imageItems,
-    { items: textStyleItems },
-    { items: colorsItems },
-    { items: fontsItems },
-    { layoutId },
-  );
-  return {
-    renderStateElements,
-    layoutHierarchyStructure,
-    fontsItems,
-    imageItems,
-    textStyleItems,
-    colorsItems,
-    variablesData,
-  };
-};
-
-const renderLayoutPreview = async (deps) => {
-  try {
-    const { store, graphicsService } = deps;
-
-    const { renderStateElements, fontsItems, variablesData } =
-      await getRenderState(deps);
-
-    const choicesData = store.selectChoicesData();
-
-    const selectedItem = store.selectSelectedItemData();
-
-    const fileReferences = extractFileIdsFromRenderState(renderStateElements);
-    let assets = await loadAssets(deps, fileReferences, fontsItems);
-    try {
-      await graphicsService.loadAssets(assets);
-    } catch {
-      // Recover from stale URL cache (especially revoked blob URLs).
-      deps.store.clearFileContentCache();
-      assets = await loadAssets(deps, fileReferences, fontsItems);
-      await graphicsService.loadAssets(assets);
-    }
-
-    const finalElements = resolveLayoutPreviewElements({
-      elements: renderStateElements,
-      previewData: createLayoutPreviewData({
-        variablesData,
-        dialogueDefaultValues: store.selectDialogueDefaultValues(),
-        choicesData,
-      }),
-    });
-
-    const parsedState = graphicsService.parse({
-      elements: finalElements,
-    });
-    const overlayElements = createSelectedLayoutOverlay({
-      parsedElements: parsedState.elements,
-      selectedItemId: selectedItem?.id,
-    });
-
-    graphicsService.render({
-      elements: [...finalElements, ...overlayElements],
-      animations: [],
-    });
-  } catch (error) {
-    console.error("[layoutEditor] Failed to render preview", error);
-  }
 };
 
 const syncLayoutEditorState = (
@@ -414,7 +235,7 @@ export const handleAfterMount = async (deps) => {
   const { canvas } = refs;
   await graphicsService.init({ canvas: canvas });
 
-  await renderLayoutPreview(deps);
+  await renderLayoutEditorPreview(deps);
   render();
 };
 
@@ -437,7 +258,7 @@ export const handleFileExplorerItemClick = async (deps, payload) => {
   }
   store.setSelectedItemId({ itemId: itemId });
   render();
-  await renderLayoutPreview(deps);
+  await renderLayoutEditorPreview(deps);
 };
 
 export const handleAddLayoutClick = handleRenderOnly;
@@ -457,7 +278,7 @@ const refreshLayoutEditorData = async (deps, payload = {}) => {
     refs.fileExplorer.selectItem({ itemId: payload.selectedItemId });
   }
   render();
-  await renderLayoutPreview(deps);
+  await renderLayoutEditorPreview(deps);
 };
 
 const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
@@ -470,51 +291,6 @@ const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
 export { handleFileExplorerAction, handleFileExplorerTargetChanged };
 
 export const handleDataChanged = refreshLayoutEditorData;
-
-const unflattenKey = (key, value) => {
-  // Support both "." and "_" as separators
-  const separator = key.includes(".") ? "." : "_";
-  const parts = key.split(separator);
-  if (parts.length === 1) {
-    return { [key]: value };
-  }
-
-  const result = {};
-  let current = result;
-
-  for (let i = 0; i < parts.length - 1; i++) {
-    current[parts[i]] = {};
-    current = current[parts[i]];
-  }
-
-  current[parts[parts.length - 1]] = value;
-  return result;
-};
-
-const deepMerge = (target, source) => {
-  const result = { ...target };
-
-  Object.keys(source).forEach((key) => {
-    if (
-      source[key] &&
-      typeof source[key] === "object" &&
-      !Array.isArray(source[key])
-    ) {
-      // If source is empty object, replace instead of merge
-      if (Object.keys(source[key]).length === 0) {
-        result[key] = source[key];
-      } else if (result[key] && typeof result[key] === "object") {
-        result[key] = deepMerge(result[key], source[key]);
-      } else {
-        result[key] = source[key];
-      }
-    } else {
-      result[key] = source[key];
-    }
-  });
-
-  return result;
-};
 
 const shouldSaveLayoutEditImmediately = (name) => {
   if (typeof name !== "string" || name.length === 0) {
@@ -538,7 +314,7 @@ export const handleDialogueFormChange = async (deps, payload) => {
   store.setDialogueDefaultValue({ name, fieldValue });
   render();
 
-  await renderLayoutPreview(deps);
+  await renderLayoutEditorPreview(deps);
 };
 
 export const handleChoiceFormChange = async (deps, payload) => {
@@ -548,7 +324,7 @@ export const handleChoiceFormChange = async (deps, payload) => {
   store.setChoiceDefaultValue({ name, fieldValue });
   render();
 
-  await renderLayoutPreview(deps);
+  await renderLayoutEditorPreview(deps);
 };
 
 export const handleArrowKeyDown = async (deps, payload) => {
@@ -609,7 +385,7 @@ export const handleArrowKeyDown = async (deps, payload) => {
   const updatedItem = { ...currentItem, ...change };
   store.updateSelectedItem({ updatedItem: updatedItem });
   render();
-  await renderLayoutPreview(deps);
+  await renderLayoutEditorPreview(deps);
   scheduleKeyboardSave(deps, currentItem.id, layoutId);
 };
 
@@ -736,127 +512,16 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
   const resourceType = store.selectLayoutResourceType();
   const selectedItemId = store.selectSelectedItemId();
   const detail = payload._event.detail;
-
-  let updatedItem;
-
-  if (
-    detail.name === "anchor" &&
-    detail.value &&
-    typeof detail.value === "object"
-  ) {
-    const currentItem = store.selectSelectedItemData();
-    updatedItem = deepMerge(currentItem, {
-      anchorX: detail.value.x,
-      anchorY: detail.value.y,
-    });
-  } else if (detail.name.includes(".")) {
-    // For nested paths, directly set the value instead of merging
-    updatedItem = structuredClone(store.selectSelectedItemData());
-    const parts = detail.name.split(".");
-    let current = updatedItem;
-    for (let i = 0; i < parts.length - 1; i++) {
-      if (!current[parts[i]]) {
-        current[parts[i]] = {};
-      }
-      current = current[parts[i]];
-    }
-    current[parts[parts.length - 1]] = detail.value;
-  } else {
-    const currentItem = store.selectSelectedItemData();
-    const unflattenedUpdate = unflattenKey(detail.name, detail.value);
-    updatedItem = deepMerge(currentItem, unflattenedUpdate);
-    updatedItem[detail.name] = detail.value;
-
-    // Auto-switch slider settings when direction changes (remembers per-direction)
-    if (detail.name === "direction" && currentItem.type === "slider") {
-      const oldDirection = currentItem.direction || "horizontal";
-      const newDirection = detail.value;
-
-      // Save current settings to old direction
-      const savedKey = `_saved${oldDirection.charAt(0).toUpperCase() + oldDirection.slice(1)}`;
-      updatedItem[savedKey] = {
-        barImageId: currentItem.barImageId,
-        hoverBarImageId: currentItem.hoverBarImageId,
-        thumbImageId: currentItem.thumbImageId,
-        hoverThumbImageId: currentItem.hoverThumbImageId,
-        width: currentItem.width,
-        height: currentItem.height,
-      };
-
-      // Check for saved settings for new direction
-      const restoreKey = `_saved${newDirection.charAt(0).toUpperCase() + newDirection.slice(1)}`;
-      const saved = currentItem[restoreKey];
-
-      if (saved) {
-        // Restore saved settings
-        updatedItem.barImageId = saved.barImageId;
-        updatedItem.hoverBarImageId = saved.hoverBarImageId;
-        updatedItem.thumbImageId = saved.thumbImageId;
-        updatedItem.hoverThumbImageId = saved.hoverThumbImageId;
-        updatedItem.width = saved.width;
-        updatedItem.height = saved.height;
-      } else {
-        // First time - use defaults and swap dimensions
-        if (newDirection === "vertical") {
-          updatedItem.barImageId = "slider_bar_vertical";
-          updatedItem.hoverBarImageId = "slider_bar_vertical_hover";
-        } else {
-          updatedItem.barImageId = "slider_bar_default";
-          updatedItem.hoverBarImageId = "slider_bar_hover";
-        }
-        // Reset thumb to defaults (same for both directions)
-        updatedItem.thumbImageId = "slider_thumb_default";
-        updatedItem.hoverThumbImageId = "slider_thumb_hover";
-
-        updatedItem.width = currentItem.height;
-        updatedItem.height = currentItem.width;
-      }
-    }
-
-    // Handle slider variable binding
-    if (detail.name === "variableId" && currentItem.type === "slider") {
-      const variableId = detail.value;
-
-      if (variableId) {
-        const updateVariableId = toAlphanumericId(
-          `slider${currentItem.id}update`,
-        );
-        // Set up change.payload for variable binding
-        updatedItem.change = {
-          payload: {
-            actions: {
-              updateVariable: {
-                id: updateVariableId,
-                operations: [
-                  {
-                    variableId: variableId,
-                    op: "set",
-                    value: "_event.value",
-                  },
-                ],
-              },
-            },
-          },
-        };
-        // Bind initialValue to the variable
-        updatedItem.initialValue = `\${variables.${variableId}}`;
-      } else {
-        // Remove change binding when no variable selected
-        delete updatedItem.change;
-        // Reset initialValue to a static numeric value
-        const parsedMin = Number(updatedItem.min);
-        updatedItem.initialValue = Number.isFinite(parsedMin) ? parsedMin : 0;
-      }
-    }
+  const currentItem = store.selectSelectedItemData();
+  if (!currentItem) {
+    return;
   }
-  if (
-    updatedItem.type === "sprite" &&
-    (updatedItem.width === 0 || updatedItem.height === 0)
-  ) {
-    const preloadedImages = store.selectImages();
-    updatedItem.width = preloadedImages.items[updatedItem.imageId].width;
-    updatedItem.height = preloadedImages.items[updatedItem.imageId].height;
-  }
+  const updatedItem = applyLayoutItemFieldChange({
+    item: currentItem,
+    name: detail.name,
+    value: detail.value,
+    imagesData: store.selectImages(),
+  });
 
   store.updateSelectedItem({ updatedItem: updatedItem });
   render();
@@ -878,7 +543,7 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
     });
   }
 
-  await renderLayoutPreview(deps, { skipAssetLoading: false });
+  await renderLayoutEditorPreview(deps);
 };
 
 export const handleCanvasMouseMove = (deps, payload) => {
@@ -915,7 +580,7 @@ export const handleCanvasMouseMove = (deps, payload) => {
   };
 
   store.updateSelectedItem({ updatedItem: updatedItem });
-  renderLayoutPreview(deps);
+  renderLayoutEditorPreview(deps);
 
   subject.dispatch("layoutEditor.updateElement", {
     layoutId: store.selectLayoutId(),

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -1,569 +1,23 @@
-import { toFlatItems, toFlatGroups } from "../../internal/project/tree.js";
+import { toFlatItems } from "../../internal/project/tree.js";
 import { parseAndRender } from "jempl";
+import { createLayoutEditorItemTemplate } from "../../internal/layoutEditorTypes.js";
 
-const contextMenuItems = [
-  {
-    label: "Container",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "container",
-      name: "Container",
-      x: 0,
-      y: 0,
-      gap: 0,
-      width: 100,
-      height: 100,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Sprite",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "sprite",
-      name: "Sprite",
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Text",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text",
-      name: "Text",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Slider (Horizontal)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "slider",
-      name: "Slider",
-      x: 0,
-      y: 0,
-      width: 400,
-      height: 20,
-      direction: "horizontal",
-      thumbImageId: "slider_thumb_default",
-      barImageId: "slider_bar_default",
-      hoverThumbImageId: "slider_thumb_hover",
-      hoverBarImageId: "slider_bar_hover",
-      min: 0,
-      max: 100,
-      step: 1,
-      initialValue: 0,
-      variableId: "",
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Slider (Vertical)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "slider",
-      name: "Slider",
-      x: 0,
-      y: 0,
-      width: 20,
-      height: 400,
-      direction: "vertical",
-      thumbImageId: "slider_thumb_default",
-      barImageId: "slider_bar_vertical",
-      hoverThumbImageId: "slider_thumb_hover",
-      hoverBarImageId: "slider_bar_vertical_hover",
-      min: 0,
-      max: 100,
-      step: 1,
-      initialValue: 0,
-      variableId: "",
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "dialogue"',
-    label: "Text (Dialogue Content)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-revealing-ref-dialogue-content",
-      name: "Text (Dialogue Content)",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "dialogue"',
-    label: "Text (Character Name)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-character-name",
-      name: "Text (Character Name)",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "nvl"',
-    label: "Container (Dialogue Line)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "container-ref-dialogue-line",
-      name: "Container (Dialogue Line)",
-      x: 0,
-      y: 0,
-      width: 1640,
-      height: 120,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "nvl"',
-    label: "Text (Line Character Name)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-dialogue-line-character-name",
-      name: "Text (Line Character Name)",
-      $when: "line.characterName",
-      x: 0,
-      y: 0,
-      width: 280,
-      height: 40,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "nvl"',
-    label: "Text (Line Content)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-dialogue-line-content",
-      name: "Text (Line Content)",
-      x: 0,
-      y: 44,
-      width: 1640,
-      height: 72,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "choice"',
-    label: "Container (Choice Item)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "container-ref-choice-item",
-      name: "Container (Choice Item)",
-      x: 0,
-      y: 0,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "choice"',
-    label: "Text (Choice Item)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-choice-item-content",
-      name: "Text (Choice Item Content)",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
+const toLayoutEditorContextMenuItems = (items = []) => {
+  return items.map((item) => {
+    if (!item?.createType) {
+      return item;
+    }
 
-const emptyContextMenuItems = [
-  {
-    label: "Container",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "container",
-      name: "Container",
-      x: 0,
-      y: 0,
-      gap: 0,
-      width: 100,
-      height: 100,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Sprite",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "sprite",
-      name: "Sprite",
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Text",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text",
-      name: "Text",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Slider (Horizontal)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "slider",
-      name: "Slider",
-      x: 0,
-      y: 0,
-      width: 400,
-      height: 20,
-      direction: "horizontal",
-      thumbImageId: "slider_thumb_default",
-      barImageId: "slider_bar_default",
-      hoverThumbImageId: "slider_thumb_hover",
-      hoverBarImageId: "slider_bar_hover",
-      min: 0,
-      max: 100,
-      step: 1,
-      initialValue: 0,
-      variableId: "",
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    label: "Slider (Vertical)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "slider",
-      name: "Slider",
-      x: 0,
-      y: 0,
-      width: 20,
-      height: 400,
-      direction: "vertical",
-      thumbImageId: "slider_thumb_default",
-      barImageId: "slider_bar_vertical",
-      hoverThumbImageId: "slider_thumb_hover",
-      hoverBarImageId: "slider_bar_vertical_hover",
-      min: 0,
-      max: 100,
-      step: 1,
-      initialValue: 0,
-      variableId: "",
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "dialogue"',
-    label: "Text (Dialogue Content)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-revealing-ref-dialogue-content",
-      name: "Text (Dialogue Content)",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "dialogue"',
-    label: "Text (Character Name)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-character-name",
-      name: "Text (Character Name)",
-      x: 0,
-      y: 0,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "nvl"',
-    label: "Container (Dialogue Line)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "container-ref-dialogue-line",
-      name: "Container (Dialogue Line)",
-      x: 0,
-      y: 0,
-      width: 1640,
-      height: 120,
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "nvl"',
-    label: "Text (Line Character Name)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-dialogue-line-character-name",
-      name: "Text (Line Character Name)",
-      $when: "line.characterName",
-      x: 0,
-      y: 0,
-      width: 280,
-      height: 40,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-  {
-    $when: 'layoutType == "nvl"',
-    label: "Text (Line Content)",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "text-ref-dialogue-line-content",
-      name: "Text (Line Content)",
-      x: 0,
-      y: 44,
-      width: 1640,
-      height: 72,
-      text: "text",
-      style: {
-        wordWrapWidth: 300,
-        align: "left",
-      },
-      anchorX: 0,
-      anchorY: 0,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    },
-  },
-];
+    const { createType, ...nextItem } = item;
 
-const controlContextMenuItems = [
-  { label: "Rename", type: "item", value: "rename-item" },
-  { label: "Delete", type: "item", value: "delete-item" },
-];
-
-const controlEmptyContextMenuItems = [
-  {
-    label: "Rect",
-    type: "item",
-    value: {
-      action: "new-child-item",
-      type: "rect",
-      name: "Rect",
-      x: 0,
-      y: 0,
-      width: 100,
-      height: 100,
-    },
-  },
-];
-
-const dialogueForm = {
-  title: "Preview",
-  description: "Edit to see how the layout will look like with different data",
-  fields: [
-    {
-      name: "dialogue-character-name",
-      description: "Character Name",
-      type: "input-text",
-    },
-    {
-      name: "dialogue-content",
-      description: "Dialogue Content",
-      type: "input-text",
-    },
-  ],
-};
-
-const choiceForm = {
-  title: "Preview",
-  description: "Edit to see how the layout will look like with different data",
-  fields: [
-    {
-      name: "choicesNum",
-      type: "select",
-      description: "Number of Choices",
-      options: [
-        { label: "1", value: 1 },
-        { label: "2", value: 2 },
-        { label: "3", value: 3 },
-        { label: "4", value: 4 },
-        { label: "5", value: 5 },
-        { label: "6", value: 6 },
-      ],
-      placeholder: "Select number of choices",
-      required: true,
-    },
-    {
-      $each: "choice, i in choices",
-      name: "choices[${i}]",
-      type: "input-text",
-      description: "Choice content text",
-      placeholder: "Enter choice text",
-    },
-  ],
+    return {
+      ...nextItem,
+      value: {
+        action: "new-child-item",
+        ...createLayoutEditorItemTemplate(createType),
+      },
+    };
+  });
 };
 
 export const createInitialState = () => ({
@@ -644,6 +98,7 @@ export const setDragStartPosition = (
   ) {
     return;
   }
+
   state.dragStartPosition = {
     x,
     y,
@@ -721,18 +176,24 @@ export const setDialogueDefaultValue = (
 
 export const setChoiceDefaultValue = ({ state }, { name, fieldValue } = {}) => {
   if (name.startsWith("choices[")) {
-    const index = parseInt(name.match(/\d+/)[0]);
+    const index = Number.parseInt(name.match(/\d+/)[0], 10);
     state.choiceDefaultValues.choices[index] = fieldValue;
-  } else {
-    state.choiceDefaultValues[name] = fieldValue;
-    if (name === "choicesNum") {
-      const choices = [];
-      for (let i = 0; i < fieldValue; i++) {
-        choices.push(state.choiceDefaultValues.choices[i] || `Choice ${i + 1}`);
-      }
-      state.choiceDefaultValues.choices = choices;
-    }
+    return;
   }
+
+  state.choiceDefaultValues[name] = fieldValue;
+
+  if (name !== "choicesNum") {
+    return;
+  }
+
+  const choices = [];
+  for (let index = 0; index < fieldValue; index += 1) {
+    choices.push(
+      state.choiceDefaultValues.choices[index] || `Choice ${index + 1}`,
+    );
+  }
+  state.choiceDefaultValues.choices = choices;
 };
 
 export const selectDragging = ({ state }) => {
@@ -765,10 +226,12 @@ export const selectChoiceDefaultValues = ({ state }) => {
 export const selectImages = ({ state }) => state.images;
 
 export const selectSelectedItem = ({ state }) => {
-  if (!state.selectedItemId) return undefined;
-  const flatItems = toFlatItems(state.layoutData);
-  const item = flatItems.find((item) => item.id === state.selectedItemId);
+  if (!state.selectedItemId) {
+    return undefined;
+  }
 
+  const flatItems = toFlatItems(state.layoutData);
+  const item = flatItems.find((entry) => entry.id === state.selectedItemId);
   if (!item) {
     return undefined;
   }
@@ -783,9 +246,11 @@ export const selectSelectedItem = ({ state }) => {
 };
 
 export const selectSelectedItemData = ({ state }) => {
-  if (!state.selectedItemId) return undefined;
-  const item = state.layoutData?.items?.[state.selectedItemId];
+  if (!state.selectedItemId) {
+    return undefined;
+  }
 
+  const item = state.layoutData?.items?.[state.selectedItemId];
   if (!item) {
     return undefined;
   }
@@ -801,9 +266,13 @@ export const selectSelectedItemId = ({ state }) => state.selectedItemId;
 export const selectChoicesData = ({ state }) => {
   const choices = [];
 
-  for (let i = 0; i < state.choiceDefaultValues.choicesNum; i++) {
+  for (
+    let index = 0;
+    index < state.choiceDefaultValues.choicesNum;
+    index += 1
+  ) {
     choices.push({
-      content: state.choiceDefaultValues.choices[i],
+      content: state.choiceDefaultValues.choices[index],
     });
   }
 
@@ -828,44 +297,46 @@ export const selectVariablesData = ({ state }) => {
   return state.variablesData;
 };
 
-export const selectViewData = ({ state }) => {
+export const selectViewData = ({ state, constants }) => {
   const item = selectSelectedItem({ state });
   const flatItems = toFlatItems(state.layoutData);
-  const flatGroups = toFlatGroups(state.layoutData);
   const isControlResource = state.layout?.resourceType === "controls";
+  const layoutType = state.layout?.layoutType;
 
-  const choicesContext = {
-    ...state.choiceDefaultValues,
-  };
+  const parsedContextMenuItems = parseAndRender(
+    isControlResource
+      ? constants.controlContextMenuItems
+      : constants.contextMenuItems,
+    { layoutType },
+  );
+  const parsedEmptyContextMenuItems = parseAndRender(
+    isControlResource
+      ? constants.controlEmptyContextMenuItems
+      : constants.emptyContextMenuItems,
+    { layoutType },
+  );
 
   return {
     item,
     canvasCursor: state.isDragging ? "all-scroll" : "default",
     layoutEditPanelKey: `${item?.id}-${state.lastUpdateDate}`,
     flatItems,
-    flatGroups,
     selectedItemId: state.selectedItemId,
     resourceCategory: isControlResource ? "systemConfig" : "userInterface",
     selectedResourceId: isControlResource ? "controls" : "layout-editor",
-    contextMenuItems: parseAndRender(
-      isControlResource ? controlContextMenuItems : contextMenuItems,
-      {
-        layoutType: state.layout?.layoutType,
-      },
+    contextMenuItems: toLayoutEditorContextMenuItems(parsedContextMenuItems),
+    emptyContextMenuItems: toLayoutEditorContextMenuItems(
+      parsedEmptyContextMenuItems,
     ),
-    emptyContextMenuItems: parseAndRender(
-      isControlResource ? controlEmptyContextMenuItems : emptyContextMenuItems,
-      {
-        layoutType: state.layout?.layoutType,
-      },
-    ),
-    dialogueForm,
+    dialogueForm: constants.dialogueForm,
     dialogueDefaultValues: state.dialogueDefaultValues,
-    choiceForm,
+    choiceForm: constants.choiceForm,
     choiceDefaultValues: state.choiceDefaultValues,
-    choicesContext,
+    choicesContext: {
+      ...state.choiceDefaultValues,
+    },
     layout: state.layout,
-    presentationState: {},
+    textStylesData: state.textStylesData,
     variablesData: state.variablesData,
   };
 };

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -55,7 +55,7 @@ template:
                   - rtgl-view h=48 w=f av=c ph=md:
                       - rtgl-text c=mu-fg: ${item.name} (${item.type})
                   - rtgl-view w=f h=1fg sv pv=md:
-                      - rvn-layout-edit-panel#layoutEditPanel key=${layoutEditPanelKey} layout-type=${layout.layoutType} resource-type=${layout.resourceType} item-type=${item.type} :values=item :variablesData=variablesData: null
+                      - rvn-layout-edit-panel#layoutEditPanel key=${layoutEditPanelKey} layout-type=${layout.layoutType} resource-type=${layout.resourceType} item-type=${item.type} :values=item :textStylesData=textStylesData :variablesData=variablesData: null
                 $else:
                   - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                       - rtgl-text s=md c=mu-fg: No selection

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -60,6 +60,11 @@ export const handleAddDialogClose = (deps) => {
   render();
 };
 
+const createLayoutElement = (id, data) => ({
+  id,
+  ...data,
+});
+
 const createLayoutTemplate = (layoutType) => {
   if (layoutType === "dialogue") {
     const containerId = nanoid();
@@ -68,7 +73,7 @@ const createLayoutTemplate = (layoutType) => {
 
     return {
       items: {
-        [containerId]: {
+        [containerId]: createLayoutElement(containerId, {
           type: "container",
           name: "Dialogue Container",
           x: 35,
@@ -81,8 +86,8 @@ const createLayoutTemplate = (layoutType) => {
           scaleX: 1,
           scaleY: 1,
           rotation: 0,
-        },
-        [nameTextId]: {
+        }),
+        [nameTextId]: createLayoutElement(nameTextId, {
           type: "text",
           name: "Character Name",
           x: 40,
@@ -98,8 +103,8 @@ const createLayoutTemplate = (layoutType) => {
           style: {
             align: "left",
           },
-        },
-        [contentTextId]: {
+        }),
+        [contentTextId]: createLayoutElement(contentTextId, {
           type: "text",
           name: "Dialogue Content",
           x: 40,
@@ -116,7 +121,7 @@ const createLayoutTemplate = (layoutType) => {
           style: {
             align: "left",
           },
-        },
+        }),
       },
       tree: [
         {
@@ -144,7 +149,7 @@ const createLayoutTemplate = (layoutType) => {
 
     return {
       items: {
-        [nvlContainerId]: {
+        [nvlContainerId]: createLayoutElement(nvlContainerId, {
           type: "container",
           name: "NVL Container",
           x: 100,
@@ -156,8 +161,8 @@ const createLayoutTemplate = (layoutType) => {
           scaleX: 1,
           scaleY: 1,
           rotation: 0,
-        },
-        [nvlBackgroundId]: {
+        }),
+        [nvlBackgroundId]: createLayoutElement(nvlBackgroundId, {
           type: "sprite",
           name: "NVL Background",
           x: 0,
@@ -169,9 +174,8 @@ const createLayoutTemplate = (layoutType) => {
           scaleX: 1,
           scaleY: 1,
           rotation: 0,
-          imageId: "iN20__bg4TaS80gh7-XcL",
-        },
-        [nvlLinesId]: {
+        }),
+        [nvlLinesId]: createLayoutElement(nvlLinesId, {
           type: "container",
           name: "NVL Lines",
           x: 40,
@@ -186,8 +190,8 @@ const createLayoutTemplate = (layoutType) => {
           scaleX: 1,
           scaleY: 1,
           rotation: 0,
-        },
-        [lineContainerId]: {
+        }),
+        [lineContainerId]: createLayoutElement(lineContainerId, {
           type: "container-ref-dialogue-line",
           name: "Container (Dialogue Line)",
           x: 0,
@@ -199,8 +203,8 @@ const createLayoutTemplate = (layoutType) => {
           scaleX: 1,
           scaleY: 1,
           rotation: 0,
-        },
-        [lineNameTextId]: {
+        }),
+        [lineNameTextId]: createLayoutElement(lineNameTextId, {
           type: "text-ref-dialogue-line-character-name",
           name: "Text (Line Character Name)",
           $when: "line.characterName",
@@ -217,8 +221,8 @@ const createLayoutTemplate = (layoutType) => {
           style: {
             align: "left",
           },
-        },
-        [lineContentTextId]: {
+        }),
+        [lineContentTextId]: createLayoutElement(lineContentTextId, {
           type: "text-ref-dialogue-line-content",
           name: "Text (Line Content)",
           x: 0,
@@ -234,7 +238,7 @@ const createLayoutTemplate = (layoutType) => {
           style: {
             align: "left",
           },
-        },
+        }),
       },
       tree: [
         {
@@ -271,7 +275,7 @@ const createLayoutTemplate = (layoutType) => {
 
     return {
       items: {
-        [rootId]: {
+        [rootId]: createLayoutElement(rootId, {
           type: "container",
           name: "Root",
           x: 0,
@@ -284,8 +288,8 @@ const createLayoutTemplate = (layoutType) => {
           scaleX: 1,
           scaleY: 1,
           rotation: 0,
-        },
-        [textId]: {
+        }),
+        [textId]: createLayoutElement(textId, {
           type: "text",
           name: "Placeholder Text",
           x: 960,
@@ -300,9 +304,8 @@ const createLayoutTemplate = (layoutType) => {
           text: "The most flexible layout, you can put anything here.",
           style: {
             align: "center",
-            fontSize: 32,
           },
-        },
+        }),
       },
       tree: [
         {
@@ -342,7 +345,7 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
     return;
   }
 
-  await projectService.createLayoutItem({
+  const createResult = await projectService.createLayoutItem({
     layoutId: nanoid(),
     name,
     layoutType,
@@ -350,6 +353,13 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
     parentId: store.getState().targetGroupId,
     position: "last",
   });
+
+  if (createResult?.valid === false) {
+    appService.showToast("Failed to create layout", {
+      title: "Error",
+    });
+    return;
+  }
 
   store.closeAddDialog();
   await handleDataChanged(deps);

--- a/tests/layoutEditor/layoutEditorMutations.test.js
+++ b/tests/layoutEditor/layoutEditorMutations.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyLayoutItemDragChange,
+  applyLayoutItemFieldChange,
+  applyLayoutItemKeyboardChange,
+} from "../../src/internal/layoutEditorMutations.js";
+
+describe("layoutEditorMutations", () => {
+  it("updates nested fields without replacing sibling data", () => {
+    const item = {
+      id: "text-1",
+      type: "text",
+      text: "Hello",
+      style: {
+        align: "left",
+        wordWrapWidth: 300,
+      },
+    };
+
+    const updatedItem = applyLayoutItemFieldChange({
+      item,
+      name: "style.align",
+      value: "center",
+    });
+
+    expect(updatedItem.style).toEqual({
+      align: "center",
+      wordWrapWidth: 300,
+    });
+  });
+
+  it("maps anchor updates to anchorX and anchorY", () => {
+    const item = {
+      id: "container-1",
+      type: "container",
+      anchorX: 0,
+      anchorY: 0,
+    };
+
+    const updatedItem = applyLayoutItemFieldChange({
+      item,
+      name: "anchor",
+      value: { x: 0.5, y: 1 },
+    });
+
+    expect(updatedItem.anchorX).toBe(0.5);
+    expect(updatedItem.anchorY).toBe(1);
+  });
+
+  it("auto-sizes sprites from the selected image when width and height are unset", () => {
+    const item = {
+      id: "sprite-1",
+      type: "sprite",
+      imageId: "image-1",
+      width: 0,
+      height: 0,
+    };
+
+    const updatedItem = applyLayoutItemFieldChange({
+      item,
+      name: "imageId",
+      value: "image-1",
+      imagesData: {
+        items: {
+          "image-1": {
+            width: 320,
+            height: 180,
+          },
+        },
+      },
+    });
+
+    expect(updatedItem.width).toBe(320);
+    expect(updatedItem.height).toBe(180);
+  });
+
+  it("binds slider variables through the shared mutation path", () => {
+    const item = {
+      id: "slider-1",
+      type: "slider",
+      min: 5,
+      variableId: "",
+    };
+
+    const updatedItem = applyLayoutItemFieldChange({
+      item,
+      name: "variableId",
+      value: "volume",
+    });
+
+    expect(updatedItem.variableId).toBe("volume");
+    expect(updatedItem.initialValue).toBe("${variables.volume}");
+    expect(
+      updatedItem.change.payload.actions.updateVariable.operations,
+    ).toEqual([
+      {
+        variableId: "volume",
+        op: "set",
+        value: "_event.value",
+      },
+    ]);
+  });
+
+  it("applies keyboard moves and resizes as explicit item intents", () => {
+    const item = {
+      id: "rect-1",
+      type: "rect",
+      x: 50,
+      y: 70,
+      width: 100,
+      height: 40,
+    };
+
+    expect(
+      applyLayoutItemKeyboardChange({
+        item,
+        key: "ArrowLeft",
+        unit: 3,
+      }),
+    ).toMatchObject({
+      x: 47,
+      width: 100,
+    });
+
+    expect(
+      applyLayoutItemKeyboardChange({
+        item,
+        key: "ArrowDown",
+        unit: 5,
+        resize: true,
+      }),
+    ).toMatchObject({
+      y: 70,
+      height: 45,
+    });
+  });
+
+  it("applies drag movement from the captured drag origin", () => {
+    const item = {
+      id: "rect-1",
+      type: "rect",
+      x: 10,
+      y: 20,
+    };
+
+    const updatedItem = applyLayoutItemDragChange({
+      item,
+      dragStartPosition: {
+        x: 100,
+        y: 150,
+        itemStartX: 10,
+        itemStartY: 20,
+      },
+      x: 118,
+      y: 170,
+    });
+
+    expect(updatedItem).toMatchObject({
+      x: 28,
+      y: 40,
+    });
+  });
+});

--- a/tests/layoutEditor/layoutEditorPersistence.test.js
+++ b/tests/layoutEditor/layoutEditorPersistence.test.js
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createLayoutEditorElementPersistPayload,
+  persistLayoutEditorElementUpdate,
+  shouldPersistLayoutEditorFieldImmediately,
+} from "../../src/internal/layoutEditorPersistence.js";
+
+describe("layoutEditorPersistence", () => {
+  it("marks interaction fields as immediate-save changes", () => {
+    expect(shouldPersistLayoutEditorFieldImmediately("click")).toBe(true);
+    expect(
+      shouldPersistLayoutEditorFieldImmediately("rightClick.payload.actions"),
+    ).toBe(true);
+    expect(shouldPersistLayoutEditorFieldImmediately("x")).toBe(false);
+  });
+
+  it("creates a patch payload for additive nested changes", () => {
+    const result = createLayoutEditorElementPersistPayload({
+      currentItem: {
+        id: "text-1",
+        type: "text",
+        style: {
+          align: "left",
+        },
+      },
+      updatedItem: {
+        id: "text-1",
+        type: "text",
+        style: {
+          align: "center",
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      hasChanges: true,
+      replace: false,
+      data: {
+        style: {
+          align: "center",
+        },
+      },
+    });
+  });
+
+  it("forces replace payloads when fields are removed", () => {
+    const result = createLayoutEditorElementPersistPayload({
+      currentItem: {
+        id: "sprite-1",
+        type: "sprite",
+        imageId: "default",
+        hoverImageId: "hover",
+      },
+      updatedItem: {
+        id: "sprite-1",
+        type: "sprite",
+        imageId: "default",
+      },
+    });
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.replace).toBe(true);
+    expect(result.data).toEqual({
+      type: "sprite",
+      imageId: "default",
+    });
+  });
+
+  it("persists through the correct repository method for control elements", async () => {
+    const updateControlElement = vi.fn(async () => {});
+    const projectService = {
+      getRepositoryState: () => ({
+        controls: {
+          items: {
+            "control-1": {
+              elements: {
+                items: {
+                  "rect-1": {
+                    type: "rect",
+                    x: 0,
+                    y: 0,
+                  },
+                },
+              },
+            },
+          },
+        },
+        layouts: { items: {} },
+      }),
+      updateControlElement,
+      updateLayoutElement: vi.fn(async () => {}),
+    };
+
+    const result = await persistLayoutEditorElementUpdate({
+      projectService,
+      layoutId: "control-1",
+      resourceType: "controls",
+      selectedItemId: "rect-1",
+      updatedItem: {
+        id: "rect-1",
+        type: "rect",
+        x: 20,
+        y: 0,
+      },
+    });
+
+    expect(result.didPersist).toBe(true);
+    expect(updateControlElement).toHaveBeenCalledWith({
+      controlId: "control-1",
+      elementId: "rect-1",
+      data: {
+        x: 20,
+      },
+      replace: false,
+    });
+  });
+});

--- a/tests/layoutEditor/layoutEditorPreview.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  createLayoutEditorPreviewData,
+  createLayoutEditorSelectionOverlay,
+} from "../../src/internal/layoutEditorPreview.js";
+
+describe("layoutEditorPreview", () => {
+  it("builds stable preview data from variables, dialogue defaults, and choices", () => {
+    const previewData = createLayoutEditorPreviewData({
+      variablesData: {
+        items: {
+          numberVar: { type: "number", value: "7" },
+          boolVar: { type: "boolean", value: "true" },
+          folder: { type: "folder" },
+        },
+      },
+      dialogueDefaultValues: {
+        "dialogue-character-name": "Aki",
+        "dialogue-content": "Hello there",
+      },
+      choicesData: {
+        items: [{ content: "First" }, {}],
+      },
+    });
+
+    expect(previewData.variables).toEqual({
+      numberVar: 7,
+      boolVar: true,
+    });
+    expect(previewData.dialogue.character.name).toBe("Aki");
+    expect(previewData.dialogue.content[0].text).toBe("Hello there");
+    expect(previewData.choice.items).toEqual([
+      {
+        content: "First",
+        events: {
+          click: {
+            actions: {},
+          },
+        },
+      },
+      {
+        content: "Choice 2",
+        events: {
+          click: {
+            actions: {},
+          },
+        },
+      },
+    ]);
+  });
+
+  it("creates a draggable primary overlay and non-draggable repeated overlays", () => {
+    const overlays = createLayoutEditorSelectionOverlay({
+      selectedItemId: "target",
+      parsedElements: [
+        {
+          id: "target",
+          type: "rect",
+          x: 10,
+          y: 20,
+          width: 100,
+          height: 40,
+        },
+        {
+          id: "target-0",
+          type: "rect",
+          x: 140,
+          y: 20,
+          width: 100,
+          height: 40,
+        },
+      ],
+    });
+
+    expect(overlays).toHaveLength(2);
+    expect(overlays[0].id).toBe("selected-border-preview-0");
+    expect(overlays[0].drag).toBeUndefined();
+    expect(overlays[1].id).toBe("selected-border");
+    expect(overlays[1].drag).toEqual({
+      start: { payload: {} },
+      move: { payload: {} },
+      end: { payload: {} },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract layout editor type rules, preview orchestration, mutation helpers, and persistence diff/save logic into shared layout-editor modules
- move layout edit panel static inspector config into a `.constants.yaml` file and simplify the panel store around derived capabilities and prop-driven repository data
- thin the layout editor page handler around orchestration, unify repeated render/preview paths, and add targeted vitest coverage for mutations, persistence, and preview overlays
- fix starter layout creation so all offered layout types submit valid repository payloads

## Validation
- `bun run lint`
- `bunx vitest run tests/layoutEditor/layoutEditorMutations.test.js tests/layoutEditor/layoutEditorPersistence.test.js tests/layoutEditor/layoutEditorPreview.test.js`
- `bun run build:web`