### PR TITLE
feat: redesign scene editor sync and structural editing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 1. [Product](./product.md)
 2. [Engineering](./engineering.md)
+3. [Scene Editor Text Sync Redesign](./scene-editor-text-sync-redesign.md)
 
 ## Runbooks
 

--- a/docs/scene-editor-text-sync-redesign.md
+++ b/docs/scene-editor-text-sync-redesign.md
@@ -1,0 +1,676 @@
+# Scene Editor Text Sync Redesign
+
+## Purpose
+
+`src/pages/sceneEditor` currently mixes immediate DOM editing, optimistic store
+mutation, debounced repository writes, and manual repository refresh logic.
+
+That makes the editor feel fragile in exactly the places users notice most:
+
+- typing and pressing Enter quickly
+- deleting/merging lines
+- multi-line paste
+- navigating away before debounce finishes
+- contenteditable reconciliation after rerender or remote sync
+
+This document records the current failure modes and proposes a replacement
+model that separates immediate editing from debounced persistence.
+
+## Current Flow
+
+Today the text path looks like this:
+
+```text
+rvn-editable-text DOM
+-> linesEditor emits input / split / merge / paste events
+-> sceneEditor mutates page store immediately
+-> pendingQueueService debounces repository writes
+-> structural operations flush the queue before mutating the repository
+-> sceneEditor manually resyncs repository/domain state in some handlers
+-> renderCanvas runs on a separate debounced path
+```
+
+The main files involved are:
+
+- `src/primitives/editableText.js`
+- `src/components/linesEditor/linesEditor.handlers.js`
+- `src/pages/sceneEditor/sceneEditor.handlers.js`
+- `src/pages/sceneEditor/sceneEditor.store.js`
+- `src/internal/ui/sceneEditor/lineOperations.js`
+- `src/internal/ui/sceneEditor/runtime.js`
+- `src/deps/services/pendingQueueService.js`
+
+## What Is Wrong With The Current Model
+
+### 1. There is no single authoritative text state while editing
+
+At different moments the "real" text may live in:
+
+- the `contenteditable` DOM
+- `sceneEditor.store` via `setLineTextContent(...)`
+- the pending debounce queue
+- the repository/domain snapshot returned by `projectService`
+
+The code compensates for this by pushing data between layers manually. That is
+why the scene editor needs queue replay, manual flushes, local suppression
+flags, and direct store mutation of repository/domain data.
+
+### 2. Input acceptance is tied to selection, not to the actual edited line
+
+`handleEditorDataChanged(...)` ignores input when:
+
+- the event line is no longer the selected line
+- the line is temporarily locked for split/merge
+
+That guard avoids some stale events, but it also means a late input event can
+be dropped even if it belongs to the line the user just edited.
+
+This is especially risky around:
+
+- Enter
+- Backspace-at-start merge
+- fast click-away after typing
+- fast line navigation after typing
+
+### 3. Pending text replay depends on the selected section
+
+`applyPendingDialogueQueueToStore(...)` replays queued content through
+`setLineTextContent(...)`.
+
+`setLineTextContent(...)` writes through `state.selectedSectionId`, not the
+actual section that owns the queued line. That means a pending draft can fail
+to reapply correctly after the user changes selection before the debounce
+flushes.
+
+This is a real correctness bug, not just an architectural smell.
+
+### 4. Structural edits wait on persistence work before the UI settles
+
+Split, merge, paste, new line, swap, and delete all go through async flows that
+flush queued writes and then submit repository commands before focus and line
+structure are fully settled.
+
+That is why the user can feel:
+
+- a slight delay on Enter
+- a slight delay on deleting/merging a line
+- occasional mismatch between what the DOM just showed and what the model
+  settles to
+
+The UI should not wait on persistence policy to decide whether a new line
+exists visually.
+
+### 5. Enter is implemented as keydown plus requestAnimationFrame snapshotting
+
+The current Enter flow is roughly:
+
+```text
+keydown Enter
+-> preventDefault
+-> requestAnimationFrame(...)
+-> read caret + DOM text
+-> dispatch splitLine
+```
+
+That is brittle for `contenteditable`.
+
+It depends on timing assumptions around:
+
+- caret state already being stable
+- the latest input already being reflected in DOM/store
+- no late input event arriving after the split starts
+
+This is the wrong level to model structural editing. `beforeinput` is a better
+fit because it describes the intended edit (`insertParagraph`,
+`deleteContentBackward`, `insertFromPaste`) before browser mutation.
+
+### 6. The page is not repository-driven like the rest of the app wants
+
+Other project-backed pages mostly subscribe to repository state through
+`createProjectStateStream(...)`.
+
+`sceneEditor` instead:
+
+- manually syncs after local commands
+- listens for a custom remote refresh stream
+- replays pending queue entries back into store
+
+That keeps scene editing on a special sync model that is harder to reason
+about and easier to break.
+
+### 7. Canvas rendering and text rendering are intentionally decoupled
+
+While typing, the page dispatches `sceneEditor.renderCanvas` with
+`skipRender: true` so the full UI does not rerender and disturb caret state.
+
+That is understandable, but it means the current system already admits that the
+repository-backed page render cannot safely be the live text authority during
+editing.
+
+The right response is not more manual syncing. The right response is to add an
+explicit editor-local draft layer.
+
+## Design Goals
+
+The replacement design should satisfy all of these:
+
+- Typing must feel immediate.
+- Enter, merge, and delete must feel immediate.
+- Debounced saves must remain possible.
+- A rerender must never discard newer local text.
+- Navigating away, previewing, or unmounting must flush local drafts.
+- Repository updates must still drive the page when no local draft overrides
+  them.
+- The sync model must be simple enough that we can test it directly.
+
+## Proposed Model
+
+Introduce a dedicated scene editor draft session for the active section.
+
+The important change is:
+
+- repository snapshot is the source of truth for committed state
+- draft session is the source of truth for in-progress editing
+- the DOM is only a view of the draft session, never the hidden canonical state
+
+This means subscribing from the repository does **not** put local typing on a
+repository round-trip. Repository subscription is the committed read model. The
+draft session is the immediate local write model.
+
+### High-Level Architecture
+
+```text
+projectService.subscribeProjectState()
+-> repository snapshot in sceneEditor store
+
+editor input / beforeinput
+-> section draft session updates immediately
+-> selectors overlay draft session on top of repository snapshot
+-> linesEditor + canvas render from draft-aware view data
+
+debounced commit scheduler
+-> persists dirty draft lines to repository
+-> repository subscription acknowledges committed state
+-> dirty draft entries are cleared when acked
+```
+
+### Repository Reads vs Immediate Draft Writes
+
+For the local user, the typing path should be:
+
+```text
+keypress / input
+-> DOM updates
+-> draft session updates immediately
+-> visible UI reads from draft session
+```
+
+The repository path should be separate:
+
+```text
+dirty draft
+-> debounced or explicit commit
+-> repository command accepted
+-> repository subscription emits committed snapshot
+-> draft session marks that work as acknowledged
+```
+
+Important rule:
+
+- local typing must never wait for repository acknowledgement to become visible
+
+If the local user can feel repository delay while typing, the design is wrong.
+
+### Why Section-Scoped Draft Session
+
+Text editing is not only per-line. The hard cases are structural:
+
+- split line
+- merge lines
+- insert line before/after
+- paste multiple lines
+- delete selected line
+
+Those are section operations. A section-scoped session can own:
+
+- line order
+- line text drafts
+- provisional structural changes
+- active selection/caret targets
+- dirty and flushing state
+
+That is a better fit than trying to patch individual lines independently while
+the section structure changes under them.
+
+## Proposed State Shape
+
+The exact names can change, but the model should look like this:
+
+```js
+{
+  repositorySnapshot: {
+    repositoryState,
+    domainState,
+    revision,
+  },
+  editorSession: {
+    sceneId,
+    sectionId,
+    baseRevision,
+    lineOrder: ["l1", "l2"],
+    linesById: {
+      l1: {
+        text: "Hello",
+        baseText: "Hello",
+        dirty: false,
+        saveState: "idle",
+      },
+      l2: {
+        text: "World",
+        baseText: "World",
+        dirty: true,
+        saveState: "scheduled",
+      },
+    },
+    selection: {
+      lineId: "l2",
+      caret: 5,
+      goalColumn: 5,
+    },
+    conflictsByLineId: {},
+  },
+}
+```
+
+Key rules:
+
+- Never mutate `repositorySnapshot` optimistically for text input.
+- Never use `selectedSectionId` as a surrogate for locating a draft line.
+- Dirty state is explicit.
+- Reconciliation uses a local repository `revision` to detect that the snapshot
+  changed, then uses snapshot content comparison to decide whether that change
+  is an ack, an adoptable non-conflicting update, or a conflict.
+
+### What `revision` means here
+
+`revision` is a local repository snapshot counter.
+
+It should increase whenever the local repository instance changes, regardless
+of whether that change came from:
+
+- a local command applied immediately
+- a remote committed event applied to this client
+- replayed repository events during boot or sync
+
+It is **not**:
+
+- a global collaboration version
+- a server commit number
+- a guarantee that two clients share the same value for the same logical state
+
+Its purpose is only:
+
+- tell the editor that the repository snapshot changed
+- let the draft session know its base snapshot is now stale and reconciliation
+  must run
+
+For local-only projects, this still works fine. Even without server commits,
+the local repository snapshot changes when local commands are applied, so the
+local `revision` still increases.
+
+## Input Model
+
+### Use `beforeinput` for structural edits
+
+Move structural editing out of `keydown` timing and onto semantic input types:
+
+- `insertParagraph` -> split line
+- `deleteContentBackward` at caret 0 -> merge with previous line
+- `insertFromPaste` with newline content -> multi-line paste transaction
+
+`keydown` should remain for:
+
+- navigation
+- block-mode shortcuts
+- Escape / preview shortcuts
+- line movement shortcuts
+
+### Use `input` for plain text updates
+
+For normal typing:
+
+1. let native `contenteditable` update the DOM
+2. read text + caret on `input`
+3. write that value into the draft session immediately
+4. schedule a debounced commit
+
+That keeps the typing path simple while still making structural edits explicit.
+
+### Composition / IME contract
+
+The new editor must handle IME composition explicitly.
+
+Rules:
+
+- while composition is active, do not run structural transactions
+- while composition is active, do not treat Enter as split-line
+- while composition is active, plain text draft updates may continue
+- only after composition ends may `beforeinput` structural intents be handled
+
+This is required so the rewrite does not regress Chinese, Japanese, or Korean
+input while fixing Enter and delete timing for Latin-keyboard editing.
+
+At implementation level, the editor session should expose a simple boolean such
+as `isComposing`, and `linesEditor` should route `compositionstart` /
+`compositionend` into that state.
+
+## Save Policy
+
+### Text edits
+
+Plain text changes should be debounced, but the debounce should only affect the
+repository write, not the visible UI.
+
+Recommended behavior:
+
+- debounce text commits per active section or per line
+- use a much shorter debounce than the current 2000ms for active editing
+  sessions, for example 250ms to 400ms
+- flush immediately on blur, selection change, preview, section switch,
+  structural edit, and unmount
+
+This still gives immediate local feedback because the visible editor state comes
+from the draft session, not from the repository.
+
+### Structural edits
+
+Structural edits should update the draft session immediately and persist
+immediately in the background.
+
+Important rule:
+
+- do not wait for the repository round-trip before showing the split/merge/new
+  line in the UI
+
+The repository command is persistence work. The visible line structure should
+already exist in the local draft transaction.
+
+### Caret ownership after transactions
+
+The draft session must be the single owner of post-transaction selection state.
+
+For each structural transaction, the session should produce an explicit
+selection target such as:
+
+```js
+{
+  lineId,
+  caret,
+  goalColumn,
+  direction,
+}
+```
+
+Examples:
+
+- split line: focus new line at caret `0`
+- merge with previous line: focus previous line at the old boundary
+- multi-line paste: focus last inserted/affected line at the expected caret
+- new line before/after: focus created line at caret `0`
+
+Important rule:
+
+- handlers and DOM helpers must not invent competing caret decisions after the
+  transaction is already resolved by the draft session
+
+`linesEditor` can still perform the low-level DOM focus/caret placement, but it
+should do so from one canonical session-produced target.
+
+## Repository Reconciliation
+
+The page should subscribe to project state like other project-backed pages.
+
+On each repository snapshot:
+
+1. update `repositorySnapshot`
+2. if the active section has no dirty draft entries, replace the visible
+   section state from repository
+3. if a line has a dirty draft and repository now matches that draft, treat it
+   as acknowledged and clear dirty state
+4. if a line has a dirty draft and repository differs from that draft, keep the
+   local draft visible and compare against base state
+5. if that differing repository update is non-conflicting for the local draft,
+   adopt the repository change where appropriate
+6. if it conflicts with the local draft, preserve the local draft and mark the
+   line as conflicted
+
+Important clarification:
+
+- `revision` tells us that reconciliation must happen
+- snapshot comparison decides whether the result is ack, adopt, or conflict
+
+We do **not** need a committed cursor or global commit id for the editor to
+work correctly.
+
+### Minimal per-line data needed for reconciliation
+
+For each dirty draft line, keep at least:
+
+- `baseRevision`
+- `baseText` or base structural snapshot
+- `draftText` or draft structural snapshot
+- `dirty`
+- optional `saveState`
+
+Then when a repository snapshot arrives with a higher `revision`:
+
+- if repository state equals `draftText`, clear dirty state
+- if repository state equals `baseText`, keep waiting
+- if repository state differs from both, reconcile as remote change vs local
+  draft and mark conflict if needed
+
+### Minimum conflict UX
+
+The cutover should ship with a minimal explicit conflict policy.
+
+When repository state differs from both base and draft for the same line:
+
+- keep the local draft visible
+- mark the line as conflicted in editor session state
+- show a clear but lightweight visual indicator on that line
+- do not silently overwrite the local draft
+- do not auto-merge text content
+
+We do not need full conflict-resolution UI in the first cutover, but we do need
+deterministic behavior. The minimum acceptable behavior is "preserve local
+draft, mark conflict, avoid silent data loss".
+
+This removes the need for:
+
+- `applyPendingDialogueQueueToStore(...)`
+- direct optimistic mutation of `repositoryState` / `domainState`
+- selection-dependent replay of pending content
+- manual "resync the store after every local command" logic for text edits
+
+## Collaboration Scope
+
+This design fixes local correctness and local UX.
+
+It also makes committed collaboration simpler because every client can read from
+the same repository subscription model.
+
+### What becomes immediate
+
+- local typing becomes immediate from local draft state
+- local structural edits become immediate from local draft transactions
+- committed remote updates become easier to reconcile because the page reads
+  from repository subscription consistently
+
+### What does not automatically become immediate
+
+Repository subscription does **not** mean other collaborators will see every
+keystroke immediately.
+
+If we keep text saves debounced, then remote collaborators will normally see the
+committed result after that debounce and commit path completes.
+
+If we want true live remote drafting, that is a separate capability:
+
+- send ephemeral draft events immediately for the active line/section
+- keep committed repository writes debounced
+- reconcile remote draft presence separately from committed project data
+
+That is the clean design if the product wants "others can see me typing" but we
+do not want every keystroke to become committed repository history.
+
+### Current command-model limit
+
+This design does **not** magically provide character-level collaborative editing
+on the same line. If two clients type into the same line concurrently, the
+current command model is still effectively last-write-wins at line granularity.
+
+If true same-line co-editing is a product requirement, that is a separate
+project and needs one of:
+
+- a text CRDT per line
+- an OT-based text channel
+- an explicit single-writer lock for the active line
+
+We should be explicit about that boundary instead of pretending a better local
+draft model solves collaborative text merging.
+
+## Recommended Implementation Shape
+
+### 1. Make sceneEditor repository-driven
+
+- subscribe through `createProjectStateStream({ projectService })`
+- store repository snapshots directly, including a local `revision`
+- stop relying on the custom remote refresh path for text correctness
+
+### 2. Add a dedicated draft-session module
+
+Suggested home:
+
+- `src/internal/ui/sceneEditor/editorSession.js`
+
+This module should own:
+
+- section draft creation from repository snapshot
+- local transactions for split/merge/paste/new line/delete
+- commit scheduling
+- repository reconciliation
+
+### 3. Keep linesEditor UI-focused
+
+`linesEditor` should stay responsible for:
+
+- caret and focus behavior
+- block-mode and insert-mode interaction
+- dispatching semantic edit intents
+
+It should not own:
+
+- repository syncing
+- debounce queues
+- scene-specific persistence rules
+
+### 4. Render from draft-aware selectors
+
+The selectors that feed:
+
+- the line list
+- selected line actions
+- project data for the preview canvas
+
+should all derive from:
+
+```text
+repository snapshot + editor session overlay
+```
+
+not from optimistic mutation of repository/domain state objects.
+
+## Single-Cutover Plan
+
+We should treat this as one migration, not a long-lived phased hybrid.
+
+The branch can be implemented incrementally, but once merged the editor should
+switch fully from:
+
+- optimistic repository/domain mutation in page store
+- pending queue replay into store
+- manual text resync rules
+
+to:
+
+- repository subscription for committed reads
+- draft session for immediate local editing
+- explicit commit scheduler for persistence
+
+The one-time cutover should include all of the following together:
+
+1. `sceneEditor` subscribes through `createProjectStateStream(...)` for
+   repository snapshots, including a local `revision`.
+2. A new editor-session module owns draft text, section structure drafts,
+   selection targets, dirty state, and reconciliation.
+3. `linesEditor` emits semantic edit intents and no longer relies on Enter
+   snapshot timing for structural correctness.
+4. Text rendering, actions rendering, and preview/canvas project data all read
+   from `repository snapshot + editor session overlay`.
+5. Debounced text persistence moves behind the editor session instead of
+   mutating page store repository/domain objects directly.
+6. Old queue replay and optimistic text mutation paths are removed completely.
+
+There should not be a permanent mixed mode where both the old queue/store
+mutation path and the new draft-session path stay alive together.
+
+## Testing Plan
+
+We should add tests around the new session logic before wiring all UI details.
+
+At minimum:
+
+- typing updates visible text immediately without mutating repository snapshot
+- typing then Enter keeps the latest character and splits at the correct caret
+- typing then fast section/line switch flushes correctly
+- Backspace at start merges instantly and keeps combined text
+- multi-line paste creates the expected local section draft and persisted
+  commands
+- IME composition does not trigger split/merge transactions while composing
+- post-transaction caret lands on the session-selected target
+- local repository revision increments on both local applies and remote applies
+- repository refresh during dirty local edit does not drop the local draft
+- repository refresh that now matches the draft clears dirty state as ack
+- repository refresh that differs from both base and draft preserves local draft
+  and marks conflict
+- clean repository refresh replaces visible text as expected
+
+The main trick is to move the difficult logic into a pure draft-session module
+so it can be tested without the browser first.
+
+That is necessary but not sufficient. We should also run a small browser-level
+test slice for:
+
+- Enter split behavior
+- Backspace-at-start merge behavior
+- multi-line paste behavior
+- caret placement after structural edits
+- IME composition boundaries
+
+## Decision
+
+Do not keep patching the current queue-plus-optimistic-store approach.
+
+The right long-term fix is:
+
+1. repository-driven page snapshots
+2. explicit editor-local draft session for immediate UI
+3. debounced persistence as a separate concern
+4. `beforeinput` transactions for structural contenteditable edits
+5. optional ephemeral draft broadcast if we want remote users to see typing
+   immediately
+
+That is the only model that cleanly resolves both sides of the tension:
+
+- the UI must update immediately
+- saves can still be debounced safely

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -11,6 +11,17 @@ const getLineContent = (element) => {
   return element.getContent();
 };
 
+const nowMs = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
 const getCursorPosition = (element) => {
   if (!element || typeof element.getCaretPosition !== "function") {
     return 0;
@@ -35,7 +46,7 @@ const shouldIgnoreElementInput = (element) => {
   return element?.__rvnIgnoreInputUntilFocus === true;
 };
 
-const suppressElementInputUntilFocus = (element) => {
+const suppressElementInput = (element) => {
   if (element) {
     element.__rvnIgnoreInputUntilFocus = true;
   }
@@ -47,24 +58,27 @@ const clearElementInputSuppression = (element) => {
   }
 };
 
-const dispatchEditorDataChanged = (dispatchEvent, element) => {
-  const lineId = getLineIdFromElement(element);
-  if (!lineId) {
-    return;
+const shouldIgnoreElementContentSync = (element) => {
+  return element?.__rvnIgnoreContentSyncUntilBlur === true;
+};
+
+const suppressElementContentSyncUntilBlur = (element) => {
+  if (element) {
+    element.__rvnIgnoreContentSyncUntilBlur = true;
   }
+};
 
-  const content = getLineContent(element);
-  debugLog("lines", "editor.dispatch-data-changed", {
-    lineId,
-    contentLength: content.length,
-    content: previewDebugText(content),
-  });
+const clearElementContentSyncSuppression = (element) => {
+  if (element) {
+    element.__rvnIgnoreContentSyncUntilBlur = false;
+  }
+};
 
+const dispatchCompositionStateChanged = (dispatchEvent, isComposing) => {
   dispatchEvent(
-    new CustomEvent("editor-data-changed", {
+    new CustomEvent("composition-state-changed", {
       detail: {
-        lineId,
-        content,
+        isComposing: isComposing === true,
       },
     }),
   );
@@ -127,13 +141,90 @@ const getLineText = (line) => {
   return line?.actions?.dialogue?.content?.[0]?.text ?? "";
 };
 
-const syncRenderedLineContent = (refs, lines, lineId) => {
+const getLineById = (lines, lineId) => {
+  return (lines || []).find((item) => item.id === lineId);
+};
+
+const shouldPreserveLiveElementContent = (element, lines) => {
+  const lineId = getLineIdFromElement(element);
   if (!lineId) {
+    return false;
+  }
+
+  const line = getLineById(lines, lineId);
+  if (!line) {
+    return false;
+  }
+
+  return getLineContent(element) !== getLineText(line);
+};
+
+const dispatchEditorDataChanged = (dispatchEvent, element) => {
+  const lineId = getLineIdFromElement(element);
+  if (!lineId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("editor-data-changed", {
+      detail: {
+        lineId,
+        content: getLineContent(element),
+      },
+    }),
+  );
+};
+
+const restoreRenderedLineContent = (
+  refs,
+  lineId,
+  content,
+  remainingFrames = 2,
+) => {
+  const lineRef = getLineElementById(refs, lineId);
+  if (!lineRef) {
+    if (remainingFrames > 0) {
+      requestAnimationFrame(() => {
+        restoreRenderedLineContent(refs, lineId, content, remainingFrames - 1);
+      });
+    }
+    return;
+  }
+
+  if (typeof lineRef.updateContent !== "function") {
+    return;
+  }
+
+  lineRef.updateContent(content);
+};
+
+const renderPreservingLiveLineContent = (deps, element) => {
+  const lineId = getLineIdFromElement(element);
+  if (!lineId) {
+    deps.render();
+    return;
+  }
+
+  const liveContent = getLineContent(element);
+  deps.render();
+  restoreRenderedLineContent(deps.refs, lineId, liveContent);
+};
+
+const syncRenderedLineContent = (refs, lines, lineId, { skipLineIds } = {}) => {
+  if (!lineId) {
+    return;
+  }
+
+  if (skipLineIds?.has(lineId)) {
     return;
   }
 
   const lineRef = getLineElementById(refs, lineId);
   if (!lineRef || typeof lineRef.updateContent !== "function") {
+    return;
+  }
+
+  if (shouldIgnoreElementContentSync(lineRef)) {
     return;
   }
 
@@ -145,9 +236,9 @@ const syncRenderedLineContent = (refs, lines, lineId) => {
   lineRef.updateContent(getLineText(line));
 };
 
-const syncAllRenderedLineContent = (refs, lines) => {
+const syncAllRenderedLineContent = (refs, lines, options = {}) => {
   for (const line of lines || []) {
-    syncRenderedLineContent(refs, lines, line.id);
+    syncRenderedLineContent(refs, lines, line.id, options);
   }
 };
 
@@ -165,14 +256,19 @@ const didLineStructureChange = (oldLines, newLines) => {
   return false;
 };
 
-const syncChangedRenderedLineContent = (refs, oldLines, newLines) => {
+const syncChangedRenderedLineContent = (
+  refs,
+  oldLines,
+  newLines,
+  options = {},
+) => {
   if (!oldLines || oldLines.length === 0) {
-    syncAllRenderedLineContent(refs, newLines);
+    syncAllRenderedLineContent(refs, newLines, options);
     return;
   }
 
   if (didLineStructureChange(oldLines, newLines)) {
-    syncAllRenderedLineContent(refs, newLines);
+    syncAllRenderedLineContent(refs, newLines, options);
     return;
   }
 
@@ -183,7 +279,7 @@ const syncChangedRenderedLineContent = (refs, oldLines, newLines) => {
   for (const line of newLines || []) {
     const nextContent = getLineText(line);
     if (oldLineContentById.get(line.id) !== nextContent) {
-      syncRenderedLineContent(refs, newLines, line.id);
+      syncRenderedLineContent(refs, newLines, line.id, options);
     }
   }
 };
@@ -250,6 +346,7 @@ const clearDeleteShortcutState = (store) => {
   store.setAwaitingDeleteShortcut({
     awaitingDeleteShortcut: false,
   });
+  store.setDeleteShortcutStartedAt({ startedAt: 0 });
   const timerId = store.selectDeleteShortcutTimerId();
   if (timerId !== undefined) {
     clearTimeout(timerId);
@@ -258,6 +355,7 @@ const clearDeleteShortcutState = (store) => {
 };
 
 const armDeleteShortcutState = (store) => {
+  const startedAt = nowMs();
   const timerId = store.selectDeleteShortcutTimerId();
   if (timerId !== undefined) {
     clearTimeout(timerId);
@@ -267,6 +365,8 @@ const armDeleteShortcutState = (store) => {
     clearDeleteShortcutState(store);
   }, DELETE_SHORTCUT_TIMEOUT_MS);
   store.setDeleteShortcutTimerId({ timerId: nextTimerId });
+  store.setDeleteShortcutStartedAt({ startedAt });
+  return startedAt;
 };
 
 const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
@@ -282,6 +382,7 @@ const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
   const isAwaitingDeleteShortcut = store.selectAwaitingDeleteShortcut();
 
   if (isAwaitingDeleteShortcut) {
+    const startedAt = store.selectDeleteShortcutStartedAt();
     clearDeleteShortcutState(store);
 
     if (!isDeleteShortcutKey) {
@@ -295,6 +396,11 @@ const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
     if (!targetLineId) {
       return true;
     }
+
+    console.info("[sceneEditor][perf] delete-shortcut-fired", {
+      lineId: targetLineId,
+      elapsedMs: Number((nowMs() - startedAt).toFixed(1)),
+    });
 
     dispatchEvent(
       new CustomEvent("delete-line-shortcut", {
@@ -314,6 +420,9 @@ const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
     awaitingDeleteShortcut: true,
   });
   armDeleteShortcutState(store);
+  console.info("[sceneEditor][perf] delete-shortcut-armed", {
+    lineId: lineId || props.selectedLineId,
+  });
   event.preventDefault();
   event.stopPropagation();
   return true;
@@ -784,92 +893,23 @@ export const handleLineKeyDown = (deps, payload) => {
   }
 
   switch (navKey) {
-    case "Backspace":
-      if (mode === "text-editor") {
-        // Check if cursor is at position 0
-        const currentElement = payload._event.currentTarget;
-        const currentPos = getCursorPosition(currentElement);
-        const currentLineId = getLineIdFromElement(currentElement);
-
-        if (currentPos === 0) {
-          payload._event.preventDefault();
-          payload._event.stopPropagation();
-
-          // Find the previous line
-          const currentIndex = props.lines.findIndex(
-            (line) => line.id === currentLineId,
-          );
-
-          if (currentIndex > 0) {
-            dispatchEditorDataChanged(dispatchEvent, currentElement);
-            suppressElementInputUntilFocus(currentElement);
-            debugLog("lines", "editor.merge-request", {
-              lineId: currentLineId,
-              cursorPos: currentPos,
-            });
-
-            // Dispatch event to merge lines
-            dispatchEvent(
-              new CustomEvent("mergeLines", {
-                detail: {
-                  currentLineId: currentLineId,
-                },
-              }),
-            );
-          }
-        }
-      }
-      break;
     case "Escape":
       payload._event.preventDefault();
+      dispatchEditorDataChanged(dispatchEvent, payload._event.currentTarget);
       // Switch to block mode and blur the current element
       store.setMode({ mode: "block" });
+      renderPreservingLiveLineContent(
+        {
+          ...deps,
+          render,
+        },
+        payload._event.currentTarget,
+      );
       payload._event.currentTarget.blur();
       // Focus the container to enable block mode navigation
       const container = deps.refs["container"];
       if (container) {
         container.focus();
-      }
-      render();
-      break;
-    case "Enter":
-      if (mode === "text-editor") {
-        payload._event.preventDefault();
-        const currentElement = payload._event.currentTarget;
-
-        debugLog("lines", "editor.enter-keydown", {
-          lineId: id,
-          textLength: getLineContent(currentElement).length,
-          cursorPos: getCursorPosition(currentElement),
-        });
-        requestAnimationFrame(() => {
-          const cursorPos = getCursorPosition(currentElement);
-          const fullText = getLineContent(currentElement);
-          suppressElementInputUntilFocus(currentElement);
-
-          // Split the content at cursor position after the latest DOM/input work
-          // has settled, then let the parent structural handler own the writes.
-          const leftContent = fullText.substring(0, cursorPos);
-          const rightContent = fullText.substring(cursorPos);
-          debugLog("lines", "editor.enter-snapshot", {
-            lineId: id,
-            cursorPos,
-            fullTextLength: fullText.length,
-            fullText: previewDebugText(fullText),
-            leftContent: previewDebugText(leftContent),
-            rightContent: previewDebugText(rightContent),
-          });
-
-          dispatchEvent(
-            new CustomEvent("splitLine", {
-              detail: {
-                lineId: id,
-                leftContent: leftContent,
-                rightContent: rightContent,
-              },
-            }),
-          );
-        });
       }
       break;
     case "p":
@@ -1136,6 +1176,130 @@ export const handleLineKeyDown = (deps, payload) => {
   }
 };
 
+export const handleLineBeforeInput = (deps, payload) => {
+  const { dispatchEvent, props, store } = deps;
+  const event = payload._event;
+
+  if (
+    isKeyboardHandlingDisabled(props) ||
+    store.selectMode() !== "text-editor"
+  ) {
+    return;
+  }
+
+  if (event.isComposing) {
+    return;
+  }
+
+  const currentElement = event.currentTarget;
+  if (shouldIgnoreElementInput(currentElement)) {
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
+
+  const lineId = getLineIdFromElement(currentElement);
+  if (!lineId) {
+    return;
+  }
+
+  if (
+    event.inputType === "insertParagraph" ||
+    event.inputType === "insertLineBreak"
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const cursorPos = getCursorPosition(currentElement);
+    const fullText = getLineContent(currentElement);
+    const leftContent = fullText.substring(0, cursorPos);
+    const rightContent = fullText.substring(cursorPos);
+
+    debugLog("lines", "editor.beforeinput-split", {
+      lineId,
+      cursorPos,
+      fullTextLength: fullText.length,
+      fullText: previewDebugText(fullText),
+      leftContent: previewDebugText(leftContent),
+      rightContent: previewDebugText(rightContent),
+    });
+
+    dispatchEvent(
+      new CustomEvent("splitLine", {
+        detail: {
+          lineId,
+          leftContent,
+          rightContent,
+        },
+      }),
+    );
+    suppressElementInput(currentElement);
+    suppressElementContentSyncUntilBlur(currentElement);
+    return;
+  }
+
+  if (event.inputType === "deleteContentBackward") {
+    const cursorPos = getCursorPosition(currentElement);
+    const currentIndex = (props.lines || []).findIndex(
+      (line) => line.id === lineId,
+    );
+
+    if (cursorPos === 0 && currentIndex > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      debugLog("lines", "editor.beforeinput-merge", {
+        lineId,
+        cursorPos,
+      });
+
+      dispatchEvent(
+        new CustomEvent("mergeLines", {
+          detail: {
+            currentLineId: lineId,
+          },
+        }),
+      );
+      suppressElementInput(currentElement);
+      suppressElementContentSyncUntilBlur(currentElement);
+    }
+    return;
+  }
+
+  if (event.inputType === "insertFromPaste") {
+    const pastedText = event.dataTransfer?.getData("text/plain") || "";
+    if (!pastedText.includes("\n")) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const lines = pastedText
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0);
+    if (lines.length === 0) {
+      return;
+    }
+
+    const cursorPos = getCursorPosition(currentElement);
+    const currentContent = getLineContent(currentElement);
+
+    dispatchEvent(
+      new CustomEvent("pasteLines", {
+        detail: {
+          lineId,
+          leftContent: currentContent.substring(0, cursorPos),
+          rightContent: currentContent.substring(cursorPos),
+          lines,
+        },
+      }),
+    );
+    suppressElementInput(currentElement);
+    suppressElementContentSyncUntilBlur(currentElement);
+  }
+};
+
 export const handleLineMouseUp = (deps, payload) => {
   const { store } = deps;
 
@@ -1167,16 +1331,7 @@ export const handleOnInput = (deps, payload) => {
     content: previewDebugText(content),
   });
 
-  const detail = {
-    lineId,
-    content,
-  };
-
-  dispatchEvent(
-    new CustomEvent("editor-data-changed", {
-      detail,
-    }),
-  );
+  dispatchEditorDataChanged(dispatchEvent, currentElement);
 };
 
 export const handleLinePaste = (deps, payload) => {
@@ -1226,6 +1381,14 @@ export const handleLinePaste = (deps, payload) => {
   );
 };
 
+export const handleLineCompositionStart = (deps) => {
+  dispatchCompositionStateChanged(deps.dispatchEvent, true);
+};
+
+export const handleLineCompositionEnd = (deps) => {
+  dispatchCompositionStateChanged(deps.dispatchEvent, false);
+};
+
 export const forceSyncContentLine = (deps, payload) => {
   const { refs, props } = deps;
   syncRenderedLineContent(refs, props.lines, payload?.lineId);
@@ -1240,7 +1403,29 @@ export const handleOnUpdate = (deps, payload) => {
   const { refs } = deps;
   const oldLines = payload?.oldProps?.lines;
   const newLines = payload?.newProps?.lines;
-  syncChangedRenderedLineContent(refs, oldLines, newLines);
+  const oldSelectedLineId = payload?.oldProps?.selectedLineId;
+  const newSelectedLineId = payload?.newProps?.selectedLineId;
+  const actualActiveElement =
+    refs?.container?.shadowRoot?.activeElement ||
+    getActualActiveElement(refs?.container);
+  const activeLineId = isLineElement(actualActiveElement)
+    ? getLineIdFromElement(actualActiveElement)
+    : undefined;
+  const skipLineIds = new Set();
+
+  if (
+    activeLineId &&
+    oldSelectedLineId &&
+    newSelectedLineId &&
+    oldSelectedLineId !== newSelectedLineId &&
+    activeLineId === oldSelectedLineId
+  ) {
+    skipLineIds.add(activeLineId);
+  }
+
+  syncChangedRenderedLineContent(refs, oldLines, newLines, {
+    skipLineIds,
+  });
 };
 
 export const updateSelectedLine = (deps, payload) => {
@@ -1326,26 +1511,49 @@ export const handleOnFocus = (deps, payload) => {
 };
 
 export const handleLineBlur = (deps, payload) => {
-  const { store, render, refs } = deps;
+  const { store, render, refs, dispatchEvent } = deps;
 
   // Capture element references before focus settles on the next paint.
   const blurredElement = payload._event.currentTarget;
   const shadowRoot = blurredElement.getRootNode();
+  const shouldPreserveLiveContent = shouldPreserveLiveElementContent(
+    blurredElement,
+    deps.props.lines,
+  );
 
   // Check if we're navigating between lines - if so, don't switch to block mode
   if (store.selectIsNavigating()) {
     return;
   }
 
-  // Wait one paint so the next focused element is observable.
-  requestAnimationFrame(() => {
+  const settleBlur = (remainingTransferFrames = 3) => {
     const actualActiveElement =
       (shadowRoot && shadowRoot.activeElement) ||
       getActualActiveElement(blurredElement);
 
     // Check if focus moved to another line within the editor
     if (isLineElement(actualActiveElement)) {
+      clearElementInputSuppression(blurredElement);
+      clearElementContentSyncSuppression(blurredElement);
+      if (!shouldPreserveLiveContent) {
+        syncRenderedLineContent(
+          refs,
+          deps.props.lines,
+          getLineIdFromElement(blurredElement),
+        );
+      }
+
       // Focus moved to another line, stay in text-editor mode
+      return;
+    }
+
+    if (
+      shouldIgnoreElementContentSync(blurredElement) &&
+      remainingTransferFrames > 0
+    ) {
+      requestAnimationFrame(() => {
+        settleBlur(remainingTransferFrames - 1);
+      });
       return;
     }
 
@@ -1364,7 +1572,24 @@ export const handleLineBlur = (deps, payload) => {
         container.focus();
       }
 
-      render();
+      clearElementInputSuppression(blurredElement);
+      clearElementContentSyncSuppression(blurredElement);
+      if (!shouldPreserveLiveContent) {
+        syncRenderedLineContent(
+          refs,
+          deps.props.lines,
+          getLineIdFromElement(blurredElement),
+        );
+        render();
+      } else {
+        renderPreservingLiveLineContent(deps, blurredElement);
+      }
+      dispatchEvent(new CustomEvent("editor-blur"));
     }
+  };
+
+  // Wait one paint so the next focused element is observable.
+  requestAnimationFrame(() => {
+    settleBlur();
   });
 };

--- a/src/components/linesEditor/linesEditor.methods.js
+++ b/src/components/linesEditor/linesEditor.methods.js
@@ -20,7 +20,11 @@ const focusLineInternally = (element, payload = {}) => {
   } = payload;
 
   if (!lineId) {
-    return;
+    return false;
+  }
+
+  if (!getLineElement(element, lineId)) {
+    return false;
   }
 
   element.store.setIsNavigating({ isNavigating: true });
@@ -48,6 +52,8 @@ const focusLineInternally = (element, payload = {}) => {
       element.scrollLineIntoView({ lineId });
     });
   }
+
+  return true;
 };
 
 export function syncContentLine(payload = {}) {
@@ -59,7 +65,7 @@ export function syncAllContentLines() {
 }
 
 export function focusLine(payload = {}) {
-  focusLineInternally(this, payload);
+  return focusLineInternally(this, payload);
 }
 
 export function focusContainer() {

--- a/src/components/linesEditor/linesEditor.store.js
+++ b/src/components/linesEditor/linesEditor.store.js
@@ -1,6 +1,7 @@
 export const createInitialState = () => ({
   ready: false,
   deleteShortcutTimerId: undefined,
+  deleteShortcutStartedAt: 0,
   mode: "block", // 'block' or 'text-editor'
   cursorPosition: 0, // Track cursor position for navigation
   goalColumn: 0, // Remember the desired column when moving vertically
@@ -15,6 +16,7 @@ export const setMode = ({ state }, { mode } = {}) => {
   if (mode !== "block") {
     state.awaitingCharacterShortcut = false;
     state.awaitingDeleteShortcut = false;
+    state.deleteShortcutStartedAt = 0;
   }
 };
 
@@ -56,6 +58,10 @@ export const setDeleteShortcutTimerId = ({ state }, { timerId } = {}) => {
   state.deleteShortcutTimerId = timerId;
 };
 
+export const setDeleteShortcutStartedAt = ({ state }, { startedAt } = {}) => {
+  state.deleteShortcutStartedAt = Number.isFinite(startedAt) ? startedAt : 0;
+};
+
 export const clearDeleteShortcutTimer = ({ state }, _payload = {}) => {
   state.deleteShortcutTimerId = undefined;
 };
@@ -90,6 +96,10 @@ export const selectAwaitingDeleteShortcut = ({ state }) => {
 
 export const selectDeleteShortcutTimerId = ({ state }) => {
   return state.deleteShortcutTimerId;
+};
+
+export const selectDeleteShortcutStartedAt = ({ state }) => {
+  return state.deleteShortcutStartedAt;
 };
 
 export const selectLineContent = ({ props }, payload) => {

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -9,6 +9,12 @@ refs:
         handler: handleOnFocus
       blur:
         handler: handleLineBlur
+      beforeinput:
+        handler: handleLineBeforeInput
+      compositionstart:
+        handler: handleLineCompositionStart
+      compositionend:
+        handler: handleLineCompositionEnd
       input:
         handler: handleOnInput
       mouseup:
@@ -46,6 +52,8 @@ template:
                   - rtgl-view d=h w=f:
                       - rtgl-view w=f:
                           - 'rvn-editable-text#line${i} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;"': ${line.actions.dialogue.content[0].text}
+                          - $if line.hasDraftConflict:
+                              - rtgl-text s=xs c=danger: Conflict
                           - $if line.sectionTransition:
                               - rtgl-view#previewSectionTransition data-type="sectionTransition" data-id="${line.id}" d=h:
                                   - rtgl-svg svg="transition" wh=16: null

--- a/src/deps/services/shared/collab/createProjectCollabService.js
+++ b/src/deps/services/shared/collab/createProjectCollabService.js
@@ -34,11 +34,15 @@ export const createProjectCollabService = ({
 }) => {
   let lastError = null;
   let session = null;
+  let sessionStarted = false;
+  let onlineTransportAttached = Boolean(transport);
   let serverErrorStopInFlight = false;
   let projectionGap;
   let activeSubmission = null;
   const queuedSubmissions = [];
   const idleWaiters = new Set();
+  let processNextSubmissionTimer;
+  const SUBMISSION_BATCH_WINDOW_MS = 24;
 
   const resolveIdleWaiters = () => {
     if (activeSubmission || queuedSubmissions.length > 0) {
@@ -52,26 +56,64 @@ export const createProjectCollabService = ({
   };
 
   const processNextSubmission = () => {
+    if (processNextSubmissionTimer !== undefined) {
+      clearTimeout(processNextSubmissionTimer);
+      processNextSubmissionTimer = undefined;
+    }
+
     if (activeSubmission || queuedSubmissions.length === 0) {
       resolveIdleWaiters();
       return;
     }
 
-    const nextSubmission = queuedSubmissions.shift();
-    activeSubmission = nextSubmission;
+    const submissions = [];
+    while (queuedSubmissions.length > 0) {
+      submissions.push(queuedSubmissions.shift());
+    }
+    const combinedCommands = submissions.flatMap(
+      (submission) => submission.commands,
+    );
+    activeSubmission = {
+      submissions,
+      commandCount: combinedCommands.length,
+    };
 
     void (async () => {
       try {
-        await session.submitCommands([nextSubmission.command]);
-        nextSubmission.resolve(nextSubmission.command.id);
+        const insertedLocally =
+          await insertDraftCommandsLocally(combinedCommands);
+        if (!insertedLocally) {
+          await session.submitCommands(combinedCommands);
+        }
+        for (const submission of submissions) {
+          submission.resolve(submission.commands.map((command) => command.id));
+        }
         activeSubmission = null;
         processNextSubmission();
       } catch (error) {
         activeSubmission = null;
-        nextSubmission.reject(error);
+        for (const submission of submissions) {
+          submission.reject(error);
+        }
         processNextSubmission();
       }
     })();
+  };
+
+  const scheduleProcessNextSubmission = () => {
+    if (activeSubmission || queuedSubmissions.length === 0) {
+      resolveIdleWaiters();
+      return;
+    }
+
+    if (processNextSubmissionTimer !== undefined) {
+      return;
+    }
+
+    processNextSubmissionTimer = setTimeout(() => {
+      processNextSubmissionTimer = undefined;
+      processNextSubmission();
+    }, SUBMISSION_BATCH_WINDOW_MS);
   };
 
   const waitForIdle = () => {
@@ -100,6 +142,104 @@ export const createProjectCollabService = ({
   };
 
   let projectedRepositoryState = coerceInitialRepositoryState();
+
+  const getCommandPartitions = (command) => {
+    const commandPartitions = Array.isArray(command?.partitions)
+      ? command.partitions.filter(
+          (partition) => typeof partition === "string" && partition.length > 0,
+        )
+      : [];
+
+    if (commandPartitions.length === 0) {
+      throw new Error("Command must include at least one partition");
+    }
+
+    return commandPartitions;
+  };
+
+  const insertDraftCommandsLocally = async (commands) => {
+    if (
+      onlineTransportAttached ||
+      !sessionStarted ||
+      !clientStore ||
+      typeof clientStore.insertDrafts !== "function"
+    ) {
+      return false;
+    }
+
+    await clientStore.insertDrafts(
+      commands.map((command) => ({
+        id: command.id,
+        partitions: getCommandPartitions(command),
+        ...commandToSyncEvent(command),
+        createdAt: Date.now(),
+      })),
+    );
+
+    return true;
+  };
+
+  const enqueueCommands = async (commands) => {
+    const normalizedCommands = Array.isArray(commands)
+      ? commands.filter(Boolean)
+      : [];
+    if (normalizedCommands.length === 0) {
+      return {
+        valid: true,
+        commandIds: [],
+      };
+    }
+
+    let nextProjectedRepositoryState = projectedRepositoryState;
+
+    for (const command of normalizedCommands) {
+      const optimistic = applyCommandToRepositoryState({
+        repositoryState: nextProjectedRepositoryState,
+        command,
+        projectId,
+      });
+
+      if (!optimistic.valid) {
+        lastError = {
+          code: optimistic.error?.code || "validation_failed",
+          message: optimistic.error?.message || "command validation failed",
+          payload: optimistic.error,
+        };
+        return optimistic;
+      }
+
+      nextProjectedRepositoryState = optimistic.repositoryState;
+    }
+
+    projectedRepositoryState = nextProjectedRepositoryState;
+
+    const storedSubmission = new Promise((resolve, reject) => {
+      queuedSubmissions.push({
+        commands: normalizedCommands,
+        resolve,
+        reject: (error) => {
+          if (!isTransportDisconnectedError(error)) {
+            reject(error);
+            return;
+          }
+
+          lastError = {
+            code: "transport_disconnected",
+            message: error?.message || "websocket is not connected",
+          };
+        },
+      });
+    });
+
+    void storedSubmission.catch(() => {});
+    scheduleProcessNextSubmission();
+    await storedSubmission;
+
+    return {
+      valid: true,
+      commandIds: normalizedCommands.map((command) => command.id),
+    };
+  };
 
   session = createCommandSyncSession({
     token,
@@ -222,57 +362,32 @@ export const createProjectCollabService = ({
   return {
     async start() {
       await session.start();
+      sessionStarted = true;
     },
 
     async stop() {
+      if (processNextSubmissionTimer !== undefined) {
+        clearTimeout(processNextSubmissionTimer);
+        processNextSubmissionTimer = undefined;
+      }
       await session.stop();
+      sessionStarted = false;
     },
 
     async submitCommand(command) {
-      const optimistic = applyCommandToRepositoryState({
-        repositoryState: projectedRepositoryState,
-        command,
-        projectId,
-      });
-
-      if (!optimistic.valid) {
-        lastError = {
-          code: optimistic.error?.code || "validation_failed",
-          message: optimistic.error?.message || "command validation failed",
-          payload: optimistic.error,
-        };
-        return optimistic;
+      const submitResult = await enqueueCommands([command]);
+      if (submitResult?.valid === false) {
+        return submitResult;
       }
-
-      projectedRepositoryState = optimistic.repositoryState;
-
-      const storedSubmission = new Promise((resolve, reject) => {
-        queuedSubmissions.push({
-          command,
-          resolve,
-          reject: (error) => {
-            if (!isTransportDisconnectedError(error)) {
-              reject(error);
-              return;
-            }
-
-            // Keep optimistic state and rely on draft persistence for retry.
-            lastError = {
-              code: "transport_disconnected",
-              message: error?.message || "websocket is not connected",
-            };
-          },
-        });
-      });
-
-      void storedSubmission.catch(() => {});
-      processNextSubmission();
-      await storedSubmission;
 
       return {
         valid: true,
         commandId: command.id,
       };
+    },
+
+    async submitCommands(commands) {
+      return enqueueCommands(commands);
     },
 
     async submitEvent(input) {
@@ -319,6 +434,7 @@ export const createProjectCollabService = ({
     },
 
     async setOnlineTransport(nextTransport) {
+      onlineTransportAttached = true;
       await session.setOnlineTransport(nextTransport);
     },
   };

--- a/src/deps/services/shared/commandApi/shared.js
+++ b/src/deps/services/shared/commandApi/shared.js
@@ -3,6 +3,7 @@ import { projectRepositoryStateToDomainState } from "../../../../internal/projec
 import { COMMAND_TYPES } from "../../../../internal/project/commands.js";
 import {
   applyCommandToRepository,
+  applyCommandsToRepository,
   assertSupportedProjectState,
   getSiblingOrderNodes,
   normalizeParentId,
@@ -22,6 +23,17 @@ export const createCommandApiShared = ({
   storyScenePartitionFor,
   resourceTypePartitionFor,
 }) => {
+  const nowMs = () => {
+    if (
+      typeof performance !== "undefined" &&
+      typeof performance.now === "function"
+    ) {
+      return performance.now();
+    }
+
+    return Date.now();
+  };
+
   const createId = () => {
     if (typeof idGenerator === "function") {
       const id = idGenerator();
@@ -46,7 +58,12 @@ export const createCommandApiShared = ({
     resourceTypePartitionFor(projectId, "files");
 
   const ensureCommandContext = async () => {
-    const repository = await getCurrentRepository();
+    let repository;
+    try {
+      repository = getCachedRepository();
+    } catch {
+      repository = await getCurrentRepository();
+    }
     const currentProjectId = getCurrentProjectId();
     if (!currentProjectId) {
       throw new Error("No project selected (missing ?p= in URL)");
@@ -71,7 +88,7 @@ export const createCommandApiShared = ({
     };
   };
 
-  const submitCommandWithContext = async ({
+  const createCommandWithContext = ({
     context,
     scope,
     type,
@@ -81,7 +98,8 @@ export const createCommandApiShared = ({
   }) => {
     const resolvedBasePartition =
       basePartition || `project:${context.projectId}:${scope}`;
-    const command = createCommandEnvelope({
+
+    return createCommandEnvelope({
       id: createId(),
       projectId: context.projectId,
       scope,
@@ -90,6 +108,24 @@ export const createCommandApiShared = ({
       payload,
       actor: context.actor,
       clientTs: getCommandTimestamp(),
+    });
+  };
+
+  const submitCommandWithContext = async ({
+    context,
+    scope,
+    type,
+    payload,
+    partitions = [],
+    basePartition,
+  }) => {
+    const command = createCommandWithContext({
+      context,
+      scope,
+      type,
+      payload,
+      partitions,
+      basePartition,
     });
 
     const submitResult = await context.session.submitCommand(command);
@@ -106,6 +142,70 @@ export const createCommandApiShared = ({
     return {
       valid: true,
       commandId: command.id,
+      eventCount: applyResult.events.length,
+      applyMode: applyResult.mode,
+    };
+  };
+
+  const submitCommandsWithContext = async ({
+    context,
+    commands = [],
+    perfLabel,
+    perfMeta = {},
+  } = {}) => {
+    const startedAt = nowMs();
+    const normalizedCommands = (commands || []).map((entry) =>
+      createCommandWithContext({
+        context,
+        scope: entry.scope,
+        type: entry.type,
+        payload: entry.payload,
+        partitions: entry.partitions,
+        basePartition: entry.basePartition,
+      }),
+    );
+    const envelopeBuiltAt = nowMs();
+    if (normalizedCommands.length === 0) {
+      return {
+        valid: true,
+        commandIds: [],
+        eventCount: 0,
+      };
+    }
+
+    const submitResult =
+      await context.session.submitCommands(normalizedCommands);
+    const sessionSubmittedAt = nowMs();
+    if (submitResult?.valid === false) {
+      return submitResult;
+    }
+
+    const applyResult = await applyCommandsToRepository({
+      repository: context.repository,
+      commands: normalizedCommands,
+      projectId: context.projectId,
+      perfLabel,
+      perfMeta,
+    });
+    const appliedAt = nowMs();
+
+    if (perfLabel) {
+      console.info("[sceneEditor][perf] submit-commands-with-context", {
+        perfLabel,
+        commandCount: normalizedCommands.length,
+        envelopeMs: Number((envelopeBuiltAt - startedAt).toFixed(1)),
+        sessionSubmitMs: Number(
+          (sessionSubmittedAt - envelopeBuiltAt).toFixed(1),
+        ),
+        localApplyMs: Number((appliedAt - sessionSubmittedAt).toFixed(1)),
+        totalMs: Number((appliedAt - startedAt).toFixed(1)),
+        ...perfMeta,
+      });
+    }
+
+    return {
+      valid: true,
+      commandIds: normalizedCommands.map((command) => command.id),
       eventCount: applyResult.events.length,
       applyMode: applyResult.mode,
     };
@@ -330,7 +430,9 @@ export const createCommandApiShared = ({
     getCurrentProjectId,
     ensureCommandContext,
     ensureFilesExist,
+    createCommandWithContext,
     submitCommandWithContext,
+    submitCommandsWithContext,
     buildPlacementPayload,
     resolveResourceIndex,
     resolveSceneIndex,

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -1,14 +1,80 @@
-import { findLineLocation, findSectionLocation } from "../projectRepository.js";
+import {
+  findLineLocation,
+  findSectionLocation,
+  getSiblingOrderNodes,
+} from "../projectRepository.js";
 import { COMMAND_TYPES } from "../../../../internal/project/commands.js";
 
 export const createStoryCommandApi = (shared) => {
+  const nowMs = () => {
+    if (
+      typeof performance !== "undefined" &&
+      typeof performance.now === "function"
+    ) {
+      return performance.now();
+    }
+
+    return Date.now();
+  };
+
+  const appendMissingIds = (orderedIds, allIds) => {
+    const seen = new Set();
+    const result = [];
+
+    for (const id of orderedIds || []) {
+      if (!allIds.includes(id) || seen.has(id)) {
+        continue;
+      }
+
+      seen.add(id);
+      result.push(id);
+    }
+
+    for (const id of allIds || []) {
+      if (seen.has(id)) {
+        continue;
+      }
+
+      seen.add(id);
+      result.push(id);
+    }
+
+    return result;
+  };
+
+  const getOrderedLineIds = (section) => {
+    const lineItems = section?.lines?.items || {};
+    const fallbackIds = Object.keys(lineItems);
+    const orderedFromTree = getSiblingOrderNodes(section?.lines, null)
+      .map((node) => node?.id)
+      .filter(Boolean);
+
+    return appendMissingIds(orderedFromTree, fallbackIds);
+  };
+
+  const getStoryLinePartitions = (context, lineIds) => {
+    const basePartition = shared.storyBasePartitionFor(context.projectId);
+    const partitions = [basePartition];
+    const seenSceneIds = new Set();
+
+    for (const lineId of lineIds || []) {
+      const lineLocation = findLineLocation(context.state, lineId);
+      if (!lineLocation?.sceneId || seenSceneIds.has(lineLocation.sceneId)) {
+        continue;
+      }
+
+      seenSceneIds.add(lineLocation.sceneId);
+      partitions.push(
+        shared.storyScenePartitionFor(context.projectId, lineLocation.sceneId),
+      );
+    }
+
+    return partitions;
+  };
+
   const submitLineActionsData = async ({ lineId, data, replace = false }) => {
     const context = await shared.ensureCommandContext();
-    const basePartition = shared.storyBasePartitionFor(context.projectId);
-    const lineLocation = findLineLocation(context.state, lineId);
-    const scenePartition = lineLocation?.sceneId
-      ? shared.storyScenePartitionFor(context.projectId, lineLocation.sceneId)
-      : null;
+    const partitions = getStoryLinePartitions(context, [lineId]);
 
     return shared.submitCommandWithContext({
       context,
@@ -19,9 +85,7 @@ export const createStoryCommandApi = (shared) => {
         data: structuredClone(data || {}),
         replace: replace === true,
       },
-      partitions: scenePartition
-        ? [basePartition, scenePartition]
-        : [basePartition],
+      partitions,
     });
   };
 
@@ -56,6 +120,312 @@ export const createStoryCommandApi = (shared) => {
         },
         replace: false,
       });
+    },
+
+    async updateLineDialogueActionsBatch({ updates }) {
+      const normalizedUpdates = Array.isArray(updates) ? updates : [];
+      if (normalizedUpdates.length === 0) {
+        return {
+          valid: true,
+          commandIds: [],
+          eventCount: 0,
+        };
+      }
+
+      const context = await shared.ensureCommandContext();
+      return shared.submitCommandsWithContext({
+        context,
+        commands: normalizedUpdates.map(({ lineId, dialogue }) => ({
+          scope: "story",
+          type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+          payload: {
+            lineId,
+            data: {
+              dialogue: structuredClone(dialogue || {}),
+            },
+            replace: false,
+          },
+          partitions: getStoryLinePartitions(context, [lineId]),
+        })),
+      });
+    },
+
+    async splitLineItem({
+      lineId,
+      sectionId,
+      newLineId,
+      leftDialogue,
+      newLineData = {},
+      position = "after",
+      positionTargetId,
+    }) {
+      const context = await shared.ensureCommandContext();
+      const partitions = getStoryLinePartitions(context, [lineId]);
+
+      return shared.submitCommandsWithContext({
+        context,
+        commands: [
+          {
+            scope: "story",
+            type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+            payload: {
+              lineId,
+              data: {
+                dialogue: structuredClone(leftDialogue || {}),
+              },
+              replace: false,
+            },
+            partitions,
+          },
+          {
+            scope: "story",
+            type: COMMAND_TYPES.LINE_CREATE,
+            payload: {
+              sectionId,
+              lines: [
+                {
+                  lineId: newLineId || shared.createId(),
+                  data: structuredClone(newLineData || {}),
+                },
+              ],
+              position,
+              positionTargetId,
+            },
+            partitions,
+          },
+        ],
+      });
+    },
+
+    async mergeLineItem({ previousLineId, currentLineId, mergedDialogue }) {
+      const context = await shared.ensureCommandContext();
+      const partitions = getStoryLinePartitions(context, [
+        previousLineId,
+        currentLineId,
+      ]);
+
+      return shared.submitCommandsWithContext({
+        context,
+        commands: [
+          {
+            scope: "story",
+            type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+            payload: {
+              lineId: previousLineId,
+              data: {
+                dialogue: structuredClone(mergedDialogue || {}),
+              },
+              replace: false,
+            },
+            partitions,
+          },
+          {
+            scope: "story",
+            type: COMMAND_TYPES.LINE_DELETE,
+            payload: {
+              lineIds: [currentLineId],
+            },
+            partitions,
+          },
+        ],
+      });
+    },
+
+    async syncSectionLinesSnapshot({ sectionId, lines = [] }) {
+      const startedAt = nowMs();
+      const context = await shared.ensureCommandContext();
+      const ensuredContextAt = nowMs();
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      if (!sectionLocation?.section) {
+        throw new Error("section not found");
+      }
+
+      const basePartition = shared.storyBasePartitionFor(context.projectId);
+      const scenePartition = sectionLocation.sceneId
+        ? shared.storyScenePartitionFor(
+            context.projectId,
+            sectionLocation.sceneId,
+          )
+        : null;
+      const partitions = scenePartition
+        ? [basePartition, scenePartition]
+        : [basePartition];
+
+      const desiredLines = Array.isArray(lines)
+        ? lines.filter((line) => typeof line?.id === "string" && line.id)
+        : [];
+      const desiredLineIds = desiredLines.map((line) => line.id);
+      const desiredLineIdsSet = new Set(desiredLineIds);
+      const desiredLineById = new Map(
+        desiredLines.map((line) => [line.id, structuredClone(line)]),
+      );
+
+      const currentSection = sectionLocation.section;
+      const currentLineIds = getOrderedLineIds(currentSection);
+      const currentLineIdsSet = new Set(currentLineIds);
+      const currentLineItems = currentSection?.lines?.items || {};
+      const commands = [];
+
+      const deletedLineIds = currentLineIds.filter(
+        (lineId) => !desiredLineIdsSet.has(lineId),
+      );
+      if (deletedLineIds.length > 0) {
+        commands.push({
+          scope: "story",
+          type: COMMAND_TYPES.LINE_DELETE,
+          payload: {
+            lineIds: deletedLineIds,
+          },
+          partitions,
+        });
+      }
+
+      const workingOrder = currentLineIds.filter((lineId) =>
+        desiredLineIdsSet.has(lineId),
+      );
+
+      for (let index = 0; index < desiredLineIds.length; index += 1) {
+        const desiredLineId = desiredLineIds[index];
+
+        if (!currentLineIdsSet.has(desiredLineId)) {
+          const newLines = [];
+          let scanIndex = index;
+
+          while (scanIndex < desiredLineIds.length) {
+            const nextLineId = desiredLineIds[scanIndex];
+            if (currentLineIdsSet.has(nextLineId)) {
+              break;
+            }
+
+            const nextLine = desiredLineById.get(nextLineId);
+            if (nextLine) {
+              newLines.push({
+                lineId: nextLine.id,
+                data: {
+                  actions: structuredClone(nextLine.actions || {}),
+                },
+              });
+            }
+            scanIndex += 1;
+          }
+
+          if (newLines.length > 0) {
+            commands.push({
+              scope: "story",
+              type: COMMAND_TYPES.LINE_CREATE,
+              payload: {
+                sectionId,
+                lines: newLines,
+                index,
+              },
+              partitions,
+            });
+            workingOrder.splice(
+              index,
+              0,
+              ...newLines.map((line) => line.lineId),
+            );
+          }
+
+          index = scanIndex - 1;
+          continue;
+        }
+
+        const currentIndex = workingOrder.indexOf(desiredLineId);
+        if (currentIndex >= 0 && currentIndex !== index) {
+          commands.push({
+            scope: "story",
+            type: COMMAND_TYPES.LINE_MOVE,
+            payload: {
+              lineId: desiredLineId,
+              toSectionId: sectionId,
+              index,
+            },
+            partitions,
+          });
+
+          workingOrder.splice(currentIndex, 1);
+          workingOrder.splice(index, 0, desiredLineId);
+        }
+      }
+
+      for (const lineId of desiredLineIds) {
+        if (!currentLineIdsSet.has(lineId)) {
+          continue;
+        }
+
+        const desiredLine = desiredLineById.get(lineId);
+        const currentLine = currentLineItems[lineId];
+        const desiredDialogue = desiredLine?.actions?.dialogue || {};
+        const currentDialogue = currentLine?.actions?.dialogue || {};
+
+        if (
+          JSON.stringify(currentDialogue) === JSON.stringify(desiredDialogue)
+        ) {
+          continue;
+        }
+
+        commands.push({
+          scope: "story",
+          type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+          payload: {
+            lineId,
+            data: {
+              dialogue: structuredClone(desiredDialogue),
+            },
+            replace: false,
+          },
+          partitions,
+        });
+      }
+
+      if (commands.length === 0) {
+        console.info("[sceneEditor][perf] sync-section-lines-snapshot", {
+          sectionId,
+          ensureContextMs: Number((ensuredContextAt - startedAt).toFixed(1)),
+          diffMs: Number((nowMs() - ensuredContextAt).toFixed(1)),
+          totalMs: Number((nowMs() - startedAt).toFixed(1)),
+          lineCount: desiredLines.length,
+          commandCount: 0,
+        });
+        return {
+          valid: true,
+          commandIds: [],
+          eventCount: 0,
+        };
+      }
+
+      const diffCompletedAt = nowMs();
+      const commandCounts = commands.reduce((acc, command) => {
+        const commandType = command?.type || "unknown";
+        acc[commandType] = (acc[commandType] || 0) + 1;
+        return acc;
+      }, {});
+
+      const result = await shared.submitCommandsWithContext({
+        context,
+        commands,
+        perfLabel: "scene-editor-sync-section-lines-snapshot",
+        perfMeta: {
+          sectionId,
+          lineCount: desiredLines.length,
+          commandCount: commands.length,
+          commandCounts,
+        },
+      });
+
+      console.info("[sceneEditor][perf] sync-section-lines-snapshot", {
+        sectionId,
+        lineCount: desiredLines.length,
+        commandCount: commands.length,
+        commandCounts,
+        ensureContextMs: Number((ensuredContextAt - startedAt).toFixed(1)),
+        diffMs: Number((diffCompletedAt - ensuredContextAt).toFixed(1)),
+        submitMs: Number((nowMs() - diffCompletedAt).toFixed(1)),
+        totalMs: Number((nowMs() - startedAt).toFixed(1)),
+      });
+
+      return result;
     },
 
     async createSceneItem({

--- a/src/deps/services/shared/projectRepository.js
+++ b/src/deps/services/shared/projectRepository.js
@@ -369,6 +369,17 @@ const applyRepositoryEventToRepositoryState = ({
 const createInitialRepositoryStateForProject = () =>
   structuredClone(initialProjectData);
 
+const nowMs = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
 export const createProjectRepository = async ({
   projectId,
   store,
@@ -418,5 +429,75 @@ export const applyCommandToRepository = async ({
         payload: structuredClone(repositoryCommand.payload || {}),
       },
     ],
+  };
+};
+
+export const applyCommandsToRepository = async ({
+  repository,
+  commands = [],
+  projectId,
+  perfLabel,
+  perfMeta = {},
+}) => {
+  const startedAt = nowMs();
+  const normalizedCommands = Array.isArray(commands)
+    ? commands.filter(Boolean)
+    : [];
+  if (normalizedCommands.length === 0) {
+    return {
+      mode: "command_event",
+      events: [],
+    };
+  }
+
+  for (const command of normalizedCommands) {
+    if (!isDirectDomainProjectionCommand(command)) {
+      throw new Error(
+        `No command projection handler for command type '${command?.type || "unknown"}'`,
+      );
+    }
+  }
+
+  const repositoryCommands = normalizedCommands.map((command) => ({
+    ...structuredClone(command),
+    projectId: command?.projectId || projectId,
+  }));
+  const repositoryEvents = repositoryCommands.map((command) =>
+    createRepositoryCommandEvent({
+      command,
+    }),
+  );
+  const builtEventsAt = nowMs();
+
+  if (typeof repository.addEvents === "function") {
+    await repository.addEvents(repositoryEvents, {
+      perfLabel,
+      perfMeta,
+    });
+  } else {
+    for (const event of repositoryEvents) {
+      await repository.addEvent(event);
+    }
+  }
+  const appliedAt = nowMs();
+
+  if (perfLabel) {
+    console.info("[sceneEditor][perf] apply-commands-to-repository", {
+      perfLabel,
+      commandCount: repositoryCommands.length,
+      eventCount: repositoryEvents.length,
+      buildEventsMs: Number((builtEventsAt - startedAt).toFixed(1)),
+      addEventsMs: Number((appliedAt - builtEventsAt).toFixed(1)),
+      totalMs: Number((appliedAt - startedAt).toFixed(1)),
+      ...perfMeta,
+    });
+  }
+
+  return {
+    mode: "command_event",
+    events: repositoryCommands.map((repositoryCommand) => ({
+      type: repositoryCommand.type,
+      payload: structuredClone(repositoryCommand.payload || {}),
+    })),
   };
 };

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -11,6 +11,17 @@ const PROJECT_STATE_CHECKPOINT = {
 export const projectRepositoryStatePartitionFor = (projectId) =>
   `project:${projectId}:repository_state`;
 
+const nowMs = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
 const toCommittedProjectStateEvent = ({ event, committedId, projectId }) => ({
   ...structuredClone(event),
   committedId,
@@ -134,11 +145,16 @@ export const createProjectRepositoryRuntime = async ({
     currentState = createInitialState();
   }
   assertState(currentState);
+  let currentRevision = events.length;
 
   const notifyStateListeners = () => {
-    const snapshot = structuredClone(currentState);
+    const repositoryState = structuredClone(currentState);
+    const revision = currentRevision;
     listeners.forEach((listener) => {
-      listener(snapshot);
+      listener({
+        repositoryState,
+        revision,
+      });
     });
   };
 
@@ -157,6 +173,19 @@ export const createProjectRepositoryRuntime = async ({
       return structuredClone(replayedState);
     },
 
+    getRevision(untilEventIndex) {
+      if (untilEventIndex === undefined || untilEventIndex === null) {
+        return currentRevision;
+      }
+
+      const parsedIndex = Number(untilEventIndex);
+      if (!Number.isFinite(parsedIndex)) {
+        return currentRevision;
+      }
+
+      return Math.max(0, Math.min(Math.floor(parsedIndex), events.length));
+    },
+
     getEvents() {
       return events.map((event) => structuredClone(event));
     },
@@ -168,7 +197,10 @@ export const createProjectRepositoryRuntime = async ({
 
       listeners.add(listener);
       if (emitCurrent) {
-        listener(structuredClone(currentState));
+        listener({
+          repositoryState: structuredClone(currentState),
+          revision: currentRevision,
+        });
       }
 
       return () => {
@@ -182,6 +214,7 @@ export const createProjectRepositoryRuntime = async ({
       }
       events.push(structuredClone(event));
       const committedId = events.length;
+      currentRevision = committedId;
 
       await projectStateRuntime.onCommittedEvent(
         toCommittedProjectStateEvent({
@@ -197,6 +230,62 @@ export const createProjectRepositoryRuntime = async ({
       });
       assertState(currentState);
       notifyStateListeners();
+    },
+
+    async addEvents(sourceEvents = [], { perfLabel, perfMeta = {} } = {}) {
+      const startedAt = nowMs();
+      const nextEvents = Array.isArray(sourceEvents)
+        ? sourceEvents.filter(Boolean)
+        : [];
+      if (nextEvents.length === 0) {
+        return;
+      }
+
+      if (typeof store.appendEvents === "function") {
+        await store.appendEvents(nextEvents);
+      } else if (typeof store.appendEvent === "function") {
+        for (const event of nextEvents) {
+          await store.appendEvent(event);
+        }
+      }
+      const appendedAt = nowMs();
+
+      for (const event of nextEvents) {
+        events.push(structuredClone(event));
+        const committedId = events.length;
+        currentRevision = committedId;
+
+        await projectStateRuntime.onCommittedEvent(
+          toCommittedProjectStateEvent({
+            event,
+            committedId,
+            projectId,
+          }),
+        );
+      }
+      const reducedAt = nowMs();
+
+      currentState = await projectStateRuntime.loadMaterializedView({
+        viewName: PROJECT_STATE_VIEW_NAME,
+        partition: projectPartition,
+      });
+      assertState(currentState);
+      const loadedAt = nowMs();
+      notifyStateListeners();
+      const notifiedAt = nowMs();
+
+      if (perfLabel) {
+        console.info("[sceneEditor][perf] repository-add-events", {
+          perfLabel,
+          eventCount: nextEvents.length,
+          appendMs: Number((appendedAt - startedAt).toFixed(1)),
+          reduceMs: Number((reducedAt - appendedAt).toFixed(1)),
+          loadViewMs: Number((loadedAt - reducedAt).toFixed(1)),
+          notifyMs: Number((notifiedAt - loadedAt).toFixed(1)),
+          totalMs: Number((notifiedAt - startedAt).toFixed(1)),
+          ...perfMeta,
+        });
+      }
     },
   };
 };

--- a/src/deps/services/shared/projectRepositoryService.js
+++ b/src/deps/services/shared/projectRepositoryService.js
@@ -331,6 +331,15 @@ export const createProjectRepositoryService = ({
       throw new Error("No project selected (missing ?p= in URL)");
     }
 
+    if (
+      currentProjectId === projectId &&
+      currentRepository &&
+      currentStore &&
+      currentReference
+    ) {
+      return currentRepository;
+    }
+
     const reference = await resolveProjectReferenceByProjectId(projectId);
     const repository = await getRepositoryByReference(reference);
     const store = await getStoreByReference(reference);

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -70,6 +70,11 @@ export const createProjectServiceCore = ({
     return repository.getState();
   };
 
+  const getRepositoryRevision = () => {
+    const repository = repositoryService.getCachedRepository();
+    return repository.getRevision();
+  };
+
   const getDomainState = () => {
     const repositoryState = getRepositoryState();
     const projectId = getCurrentProjectId() || "unknown-project";
@@ -89,19 +94,23 @@ export const createProjectServiceCore = ({
       repositoryService.ensureProjectCompatibleByProjectId,
     subscribeProjectState(listener, options) {
       const targetProjectId = options?.projectId || getCurrentProjectId();
-      return repositoryService.subscribeProjectState((repositoryState) => {
-        const projectId = targetProjectId || getCurrentProjectId();
-        const domainState = projectRepositoryStateToDomainState({
-          repositoryState,
-          projectId,
-        });
+      return repositoryService.subscribeProjectState(
+        ({ repositoryState, revision }) => {
+          const projectId = targetProjectId || getCurrentProjectId();
+          const domainState = projectRepositoryStateToDomainState({
+            repositoryState,
+            projectId,
+          });
 
-        listener({
-          projectId,
-          repositoryState,
-          domainState,
-        });
-      }, options);
+          listener({
+            projectId,
+            repositoryState,
+            domainState,
+            revision,
+          });
+        },
+        options,
+      );
     },
     ...("getRepositoryByPath" in repositoryService
       ? {
@@ -112,6 +121,7 @@ export const createProjectServiceCore = ({
     getState: getDomainState,
     getDomainState,
     getRepositoryState,
+    getRepositoryRevision,
     getCurrentProjectInfo: repositoryService.getCurrentProjectInfo,
     updateCurrentProjectInfo: repositoryService.updateCurrentProjectInfo,
     addVersionToProject: collabService.addVersionToProject,
@@ -123,6 +133,8 @@ export const createProjectServiceCore = ({
       return storageAdapter.initializeProject(payload);
     },
     createCollabSession: collabService.createCollabSession,
+    ensureCommandSessionForProject:
+      collabService.ensureCommandSessionForProject,
     getCollabSession: collabService.getCollabSession,
     getCollabSessionMode: collabService.getCollabSessionMode,
     stopCollabSession: collabService.stopCollabSession,

--- a/src/internal/ui/sceneEditor/editorSession.js
+++ b/src/internal/ui/sceneEditor/editorSession.js
@@ -1,0 +1,729 @@
+const toArray = (value) => {
+  return Array.isArray(value) ? value : [];
+};
+
+const cloneLine = (line) => {
+  return structuredClone(line || {});
+};
+
+const ensureLineActions = (line) => {
+  if (!line.actions || typeof line.actions !== "object") {
+    line.actions = {};
+  }
+
+  return line.actions;
+};
+
+const ensureDialogueAction = (line) => {
+  const actions = ensureLineActions(line);
+  if (!actions.dialogue || typeof actions.dialogue !== "object") {
+    actions.dialogue = {};
+  }
+
+  return actions.dialogue;
+};
+
+export const getSceneEditorLineText = (line) => {
+  return line?.actions?.dialogue?.content?.[0]?.text ?? "";
+};
+
+export const setSceneEditorLineText = (line, text) => {
+  const dialogue = ensureDialogueAction(line);
+  dialogue.content = [{ text: text ?? "" }];
+  return line;
+};
+
+const createSessionLineEntry = (
+  line,
+  { baseText, dirty = false, conflict = false, saveState = "idle" } = {},
+) => {
+  const nextLine = cloneLine(line);
+  const resolvedBaseText =
+    baseText !== undefined ? baseText : getSceneEditorLineText(nextLine);
+
+  return {
+    line: nextLine,
+    baseText: resolvedBaseText,
+    dirty,
+    conflict,
+    saveState,
+  };
+};
+
+const createSessionLineEntries = (lines = []) => {
+  const linesById = {};
+  const lineOrder = [];
+
+  for (const sourceLine of toArray(lines)) {
+    if (!sourceLine?.id) {
+      continue;
+    }
+
+    lineOrder.push(sourceLine.id);
+    linesById[sourceLine.id] = createSessionLineEntry(sourceLine);
+  }
+
+  return {
+    lineOrder,
+    linesById,
+  };
+};
+
+const getSectionLines = (section) => {
+  return toArray(section?.lines);
+};
+
+const findLineIndex = (lineOrder, lineId) => {
+  return toArray(lineOrder).indexOf(lineId);
+};
+
+const cloneSession = (session) => {
+  return structuredClone(session);
+};
+
+const cloneSelectionTarget = (selectionTarget) => {
+  return selectionTarget ? structuredClone(selectionTarget) : undefined;
+};
+
+const createEmptySession = ({
+  sceneId,
+  sectionId,
+  revision = 0,
+  isComposing = false,
+} = {}) => {
+  return {
+    sceneId,
+    sectionId,
+    baseRevision: Number.isFinite(revision) ? revision : 0,
+    lineOrder: [],
+    linesById: {},
+    selectionTarget: undefined,
+    isComposing,
+    structureDirty: false,
+  };
+};
+
+const setSessionLineEntryText = (
+  session,
+  lineId,
+  text,
+  { saveState = "scheduled" } = {},
+) => {
+  const entry = session?.linesById?.[lineId];
+  if (!entry) {
+    return;
+  }
+
+  if (!entry.dirty) {
+    entry.baseText = getSceneEditorLineText(entry.line);
+  }
+
+  setSceneEditorLineText(entry.line, text);
+  const currentText = getSceneEditorLineText(entry.line);
+  entry.dirty = currentText !== entry.baseText;
+  entry.conflict = false;
+  entry.saveState = entry.dirty ? saveState : "idle";
+};
+
+const createDraftLine = ({ lineId, sectionId, actions = {} } = {}) => {
+  return {
+    id: lineId,
+    sectionId,
+    actions: structuredClone(actions),
+  };
+};
+
+const compareLineOrder = (left = [], right = []) => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const getRepositorySectionState = (section) => {
+  const lines = getSectionLines(section);
+  const lineOrder = lines.map((line) => line.id).filter(Boolean);
+  const linesById = Object.fromEntries(
+    lineOrder.map((lineId) => [
+      lineId,
+      cloneLine(lines.find((line) => line.id === lineId)),
+    ]),
+  );
+
+  return {
+    lineOrder,
+    linesById,
+  };
+};
+
+const hasPendingLineState = (session) => {
+  return Object.values(session?.linesById || {}).some(
+    (entry) => entry?.dirty || entry?.conflict,
+  );
+};
+
+const adoptRepositorySectionIntoSession = (
+  session,
+  section,
+  { revision } = {},
+) => {
+  const repositorySectionState = getRepositorySectionState(section);
+  const nextSession = cloneSession(session);
+
+  nextSession.baseRevision = Number.isFinite(revision)
+    ? revision
+    : nextSession.baseRevision;
+  nextSession.lineOrder = repositorySectionState.lineOrder;
+  nextSession.linesById = Object.fromEntries(
+    repositorySectionState.lineOrder.map((lineId) => [
+      lineId,
+      createSessionLineEntry(repositorySectionState.linesById[lineId]),
+    ]),
+  );
+
+  return nextSession;
+};
+
+export const createSceneEditorSession = ({
+  sceneId,
+  sectionId,
+  section,
+  revision = 0,
+  isComposing = false,
+} = {}) => {
+  const session = createEmptySession({
+    sceneId,
+    sectionId,
+    revision,
+    isComposing,
+  });
+  const { lineOrder, linesById } = createSessionLineEntries(
+    getSectionLines(section),
+  );
+  session.lineOrder = lineOrder;
+  session.linesById = linesById;
+  return session;
+};
+
+export const ensureSceneEditorSession = ({
+  session,
+  sceneId,
+  sectionId,
+  section,
+  revision = 0,
+} = {}) => {
+  if (!sceneId || !sectionId) {
+    return undefined;
+  }
+
+  if (session?.sceneId === sceneId && session?.sectionId === sectionId) {
+    return session;
+  }
+
+  return createSceneEditorSession({
+    sceneId,
+    sectionId,
+    section,
+    revision,
+    isComposing: session?.isComposing === true,
+  });
+};
+
+export const setSceneEditorSessionCompositionState = (
+  session,
+  { isComposing } = {},
+) => {
+  if (!session) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  nextSession.isComposing = isComposing === true;
+  return nextSession;
+};
+
+export const applySceneEditorSessionTextChange = (
+  session,
+  { lineId, content } = {},
+) => {
+  if (!session?.linesById?.[lineId]) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  setSessionLineEntryText(nextSession, lineId, content);
+  return nextSession;
+};
+
+export const clearSceneEditorSessionSelectionTarget = (session) => {
+  if (!session) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  nextSession.selectionTarget = undefined;
+  return nextSession;
+};
+
+export const setSceneEditorSessionSelectionTarget = (
+  session,
+  selectionTarget,
+) => {
+  if (!session) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  nextSession.selectionTarget = cloneSelectionTarget(selectionTarget);
+  return nextSession;
+};
+
+export const getSceneEditorSessionSelectionTarget = (session) => {
+  return cloneSelectionTarget(session?.selectionTarget);
+};
+
+export const getSceneEditorSessionLine = (session, lineId) => {
+  const entry = session?.linesById?.[lineId];
+  return entry ? cloneLine(entry.line) : undefined;
+};
+
+export const getSceneEditorSessionDirtyLines = (session) => {
+  return toArray(session?.lineOrder)
+    .map((lineId) => {
+      const entry = session?.linesById?.[lineId];
+      if (!entry?.dirty) {
+        return undefined;
+      }
+
+      return {
+        lineId,
+        line: cloneLine(entry.line),
+      };
+    })
+    .filter(Boolean);
+};
+
+export const hasSceneEditorSessionPendingChanges = (session) => {
+  return Boolean(session?.structureDirty || hasPendingLineState(session));
+};
+
+export const overlaySceneWithEditorSession = (scene, session) => {
+  if (!scene || !session || session.sceneId !== scene.id) {
+    return scene;
+  }
+
+  const sections = toArray(scene.sections).map((section) => {
+    if (section.id !== session.sectionId) {
+      return section;
+    }
+
+    return {
+      ...section,
+      lines: toArray(session.lineOrder)
+        .map((lineId) => {
+          const entry = session.linesById?.[lineId];
+          if (!entry?.line) {
+            return undefined;
+          }
+
+          return {
+            ...cloneLine(entry.line),
+            hasDraftConflict: entry.conflict === true,
+            isDraftDirty: entry.dirty === true,
+          };
+        })
+        .filter(Boolean),
+    };
+  });
+
+  return {
+    ...scene,
+    sections,
+  };
+};
+
+export const reconcileSceneEditorSession = ({
+  session,
+  sceneId,
+  sectionId,
+  section,
+  revision = 0,
+} = {}) => {
+  if (!sceneId || !sectionId) {
+    return undefined;
+  }
+
+  if (
+    !session ||
+    session.sceneId !== sceneId ||
+    session.sectionId !== sectionId
+  ) {
+    return createSceneEditorSession({
+      sceneId,
+      sectionId,
+      section,
+      revision,
+      isComposing: session?.isComposing === true,
+    });
+  }
+
+  const repositorySectionState = getRepositorySectionState(section);
+  const repositoryOrder = repositorySectionState.lineOrder;
+  const structureMatchesRepository = compareLineOrder(
+    session.lineOrder,
+    repositoryOrder,
+  );
+
+  if (
+    !session.structureDirty &&
+    !hasPendingLineState(session) &&
+    structureMatchesRepository
+  ) {
+    return adoptRepositorySectionIntoSession(session, section, { revision });
+  }
+
+  if (session.structureDirty && !structureMatchesRepository) {
+    const nextSession = cloneSession(session);
+    nextSession.baseRevision = Number.isFinite(revision)
+      ? revision
+      : nextSession.baseRevision;
+
+    for (const lineId of session.lineOrder) {
+      const repositoryLine = repositorySectionState.linesById[lineId];
+      const entry = nextSession.linesById?.[lineId];
+      if (!repositoryLine || !entry?.dirty) {
+        continue;
+      }
+
+      const repositoryText = getSceneEditorLineText(repositoryLine);
+      const draftText = getSceneEditorLineText(entry.line);
+
+      if (repositoryText === draftText) {
+        nextSession.linesById[lineId] = createSessionLineEntry(repositoryLine);
+        continue;
+      }
+
+      if (repositoryText !== entry.baseText) {
+        entry.conflict = true;
+        entry.saveState = "conflict";
+      }
+    }
+
+    return nextSession;
+  }
+
+  const nextSession = cloneSession(session);
+  nextSession.baseRevision = Number.isFinite(revision)
+    ? revision
+    : nextSession.baseRevision;
+  nextSession.structureDirty = false;
+  nextSession.lineOrder = repositoryOrder;
+
+  const nextLinesById = {};
+  for (const lineId of repositoryOrder) {
+    const repositoryLine = repositorySectionState.linesById[lineId];
+    const currentEntry = session.linesById?.[lineId];
+
+    if (!currentEntry) {
+      nextLinesById[lineId] = createSessionLineEntry(repositoryLine);
+      continue;
+    }
+
+    if (!currentEntry.dirty) {
+      nextLinesById[lineId] = createSessionLineEntry(repositoryLine);
+      continue;
+    }
+
+    const repositoryText = getSceneEditorLineText(repositoryLine);
+    const draftText = getSceneEditorLineText(currentEntry.line);
+
+    if (repositoryText === draftText) {
+      nextLinesById[lineId] = createSessionLineEntry(repositoryLine);
+      continue;
+    }
+
+    if (repositoryText === currentEntry.baseText) {
+      nextLinesById[lineId] = structuredClone(currentEntry);
+      continue;
+    }
+
+    const conflictedEntry = structuredClone(currentEntry);
+    conflictedEntry.conflict = true;
+    conflictedEntry.saveState = "conflict";
+    nextLinesById[lineId] = conflictedEntry;
+  }
+
+  nextSession.linesById = nextLinesById;
+  return nextSession;
+};
+
+export const splitSceneEditorSessionLine = (
+  session,
+  {
+    lineId,
+    newLineId,
+    sectionId,
+    leftContent,
+    rightContent,
+    newLineActions,
+  } = {},
+) => {
+  if (!session?.linesById?.[lineId] || !newLineId) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  setSessionLineEntryText(nextSession, lineId, leftContent ?? "", {
+    saveState: "saving",
+  });
+
+  const sourceLine = nextSession.linesById[lineId].line;
+  const newLine = createDraftLine({
+    lineId: newLineId,
+    sectionId: sectionId || sourceLine.sectionId,
+    actions: newLineActions,
+  });
+  setSceneEditorLineText(newLine, rightContent ?? "");
+
+  nextSession.linesById[newLineId] = createSessionLineEntry(newLine, {
+    baseText: rightContent ?? "",
+  });
+
+  const currentIndex = findLineIndex(nextSession.lineOrder, lineId);
+  const insertIndex =
+    currentIndex >= 0 ? currentIndex + 1 : nextSession.lineOrder.length;
+  nextSession.lineOrder.splice(insertIndex, 0, newLineId);
+  nextSession.structureDirty = true;
+  nextSession.selectionTarget = {
+    lineId: newLineId,
+    cursorPosition: 0,
+    goalColumn: 0,
+    direction: "down",
+    syncLineId: lineId,
+  };
+  return nextSession;
+};
+
+export const pasteSceneEditorSessionLines = (
+  session,
+  {
+    lineId,
+    sectionId,
+    leftContent,
+    rightContent,
+    lines = [],
+    newLines = [],
+  } = {},
+) => {
+  if (
+    !session?.linesById?.[lineId] ||
+    !Array.isArray(lines) ||
+    lines.length === 0
+  ) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  const firstLineContent = `${leftContent ?? ""}${lines[0] ?? ""}`;
+  const currentIndex = findLineIndex(nextSession.lineOrder, lineId);
+
+  if (lines.length === 1) {
+    const combinedContent = `${firstLineContent}${rightContent ?? ""}`;
+    setSessionLineEntryText(nextSession, lineId, combinedContent, {
+      saveState: "saving",
+    });
+    nextSession.selectionTarget = {
+      lineId,
+      cursorPosition:
+        combinedContent.length - String(rightContent ?? "").length,
+      goalColumn: combinedContent.length - String(rightContent ?? "").length,
+      direction: undefined,
+    };
+    return nextSession;
+  }
+
+  setSessionLineEntryText(nextSession, lineId, firstLineContent, {
+    saveState: "saving",
+  });
+
+  let insertIndex =
+    currentIndex >= 0 ? currentIndex + 1 : nextSession.lineOrder.length;
+  let lastLineId = lineId;
+  let lastLineContent = firstLineContent;
+
+  for (let index = 0; index < newLines.length; index += 1) {
+    const draftLine = newLines[index];
+    if (!draftLine?.lineId) {
+      continue;
+    }
+
+    const isLastLine = index === newLines.length - 1;
+    const lineText = isLastLine
+      ? `${lines[index + 1] ?? ""}${rightContent ?? ""}`
+      : `${lines[index + 1] ?? ""}`;
+    const sessionLine = createDraftLine({
+      lineId: draftLine.lineId,
+      sectionId,
+      actions: draftLine.data?.actions || {},
+    });
+    setSceneEditorLineText(sessionLine, lineText);
+
+    nextSession.linesById[draftLine.lineId] = createSessionLineEntry(
+      sessionLine,
+      {
+        baseText: lineText,
+      },
+    );
+    nextSession.lineOrder.splice(insertIndex, 0, draftLine.lineId);
+    insertIndex += 1;
+    lastLineId = draftLine.lineId;
+    lastLineContent = lineText;
+  }
+
+  nextSession.structureDirty = true;
+  nextSession.selectionTarget = {
+    lineId: lastLineId,
+    cursorPosition: lastLineContent.length - String(rightContent ?? "").length,
+    goalColumn: lastLineContent.length - String(rightContent ?? "").length,
+    direction: undefined,
+    syncLineId: lineId,
+  };
+  return nextSession;
+};
+
+export const insertSceneEditorSessionLine = (
+  session,
+  { lineId, newLineId, sectionId, position = "last", actions = {} } = {},
+) => {
+  if (!session || !newLineId) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  const draftLine = createDraftLine({
+    lineId: newLineId,
+    sectionId,
+    actions,
+  });
+  const insertLineIndex = findLineIndex(nextSession.lineOrder, lineId);
+
+  nextSession.linesById[newLineId] = createSessionLineEntry(draftLine, {
+    baseText: "",
+  });
+
+  if (position === "before" && insertLineIndex >= 0) {
+    nextSession.lineOrder.splice(insertLineIndex, 0, newLineId);
+  } else if (position === "after" && insertLineIndex >= 0) {
+    nextSession.lineOrder.splice(insertLineIndex + 1, 0, newLineId);
+  } else {
+    nextSession.lineOrder.push(newLineId);
+  }
+
+  nextSession.structureDirty = true;
+  nextSession.selectionTarget = {
+    lineId: newLineId,
+    cursorPosition: 0,
+    goalColumn: 0,
+    direction: undefined,
+  };
+  return nextSession;
+};
+
+export const mergeSceneEditorSessionLine = (
+  session,
+  { currentLineId, previousLineId } = {},
+) => {
+  if (
+    !session?.linesById?.[currentLineId] ||
+    !session?.linesById?.[previousLineId]
+  ) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  const previousEntry = nextSession.linesById[previousLineId];
+  const currentEntry = nextSession.linesById[currentLineId];
+  const previousText = getSceneEditorLineText(previousEntry.line);
+  const currentText = getSceneEditorLineText(currentEntry.line);
+
+  setSessionLineEntryText(
+    nextSession,
+    previousLineId,
+    `${previousText}${currentText}`,
+    {
+      saveState: "saving",
+    },
+  );
+
+  delete nextSession.linesById[currentLineId];
+  nextSession.lineOrder = nextSession.lineOrder.filter(
+    (id) => id !== currentLineId,
+  );
+  nextSession.structureDirty = true;
+  nextSession.selectionTarget = {
+    lineId: previousLineId,
+    cursorPosition: previousText.length,
+    goalColumn: previousText.length,
+    direction: undefined,
+  };
+  return nextSession;
+};
+
+export const deleteSceneEditorSessionLine = (
+  session,
+  { lineId, nextSelectedLineId } = {},
+) => {
+  if (!session?.linesById?.[lineId]) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  delete nextSession.linesById[lineId];
+  nextSession.lineOrder = nextSession.lineOrder.filter((id) => id !== lineId);
+  nextSession.structureDirty = true;
+  nextSession.selectionTarget = nextSelectedLineId
+    ? {
+        lineId: nextSelectedLineId,
+        cursorPosition: undefined,
+        goalColumn: undefined,
+        direction: undefined,
+      }
+    : undefined;
+  return nextSession;
+};
+
+export const swapSceneEditorSessionLine = (
+  session,
+  { lineId, direction } = {},
+) => {
+  if (!session || (direction !== "up" && direction !== "down")) {
+    return session;
+  }
+
+  const nextSession = cloneSession(session);
+  const currentIndex = findLineIndex(nextSession.lineOrder, lineId);
+  if (currentIndex < 0) {
+    return session;
+  }
+
+  const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+  if (targetIndex < 0 || targetIndex >= nextSession.lineOrder.length) {
+    return session;
+  }
+
+  const [movedLineId] = nextSession.lineOrder.splice(currentIndex, 1);
+  nextSession.lineOrder.splice(targetIndex, 0, movedLineId);
+  nextSession.structureDirty = true;
+  nextSession.selectionTarget = {
+    lineId,
+    direction: undefined,
+  };
+  return nextSession;
+};

--- a/src/internal/ui/sceneEditor/lineOperations.js
+++ b/src/internal/ui/sceneEditor/lineOperations.js
@@ -1,93 +1,16 @@
 import { nanoid } from "nanoid";
+import {
+  clearSceneEditorSessionSelectionTarget,
+  getSceneEditorSessionSelectionTarget,
+  insertSceneEditorSessionLine,
+  mergeSceneEditorSessionLine,
+  pasteSceneEditorSessionLines,
+  splitSceneEditorSessionLine,
+  swapSceneEditorSessionLine,
+} from "./editorSession.js";
 
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
-};
-
-const getDialogueText = (line) => {
-  return (line?.actions?.dialogue?.content || [])
-    .map((item) => item?.text ?? "")
-    .join("");
-};
-
-const isMinimalAdvDialogue = (dialogue) => {
-  if (!dialogue || typeof dialogue !== "object") {
-    return false;
-  }
-
-  const keysWithoutContent = Object.keys(dialogue).filter(
-    (key) => key !== "content",
-  );
-
-  return keysWithoutContent.length === 1 && dialogue.mode === "adv";
-};
-
-const shouldInheritNvlModeFromPreviousLine = ({
-  domainState,
-  sectionId,
-  lineId,
-  existingDialogue,
-}) => {
-  const section = domainState?.sections?.[sectionId];
-  if (!section) {
-    return false;
-  }
-
-  if (existingDialogue?.mode === "nvl") {
-    return false;
-  }
-
-  if (existingDialogue?.mode && !isMinimalAdvDialogue(existingDialogue)) {
-    return false;
-  }
-
-  const lineOrder = section.lineIds || [];
-  const currentIndex = lineOrder.indexOf(lineId);
-  if (currentIndex <= 0) {
-    return false;
-  }
-
-  const previousLineId = lineOrder[currentIndex - 1];
-  if (!previousLineId) {
-    return false;
-  }
-
-  const previousDialogue =
-    domainState?.lines?.[previousLineId]?.actions?.dialogue;
-  return previousDialogue?.mode === "nvl";
-};
-
-const resolveMergeLinesContext = (domainState, currentLineId) => {
-  const currentLine = domainState?.lines?.[currentLineId];
-  const sectionId = currentLine?.sectionId;
-  const section = sectionId ? domainState?.sections?.[sectionId] : undefined;
-  const lineIds = section?.lineIds || [];
-  const currentIndex = lineIds.indexOf(currentLineId);
-
-  if (!currentLine || currentIndex <= 0) {
-    return {};
-  }
-
-  const prevLineId = lineIds[currentIndex - 1];
-  const prevLine = domainState?.lines?.[prevLineId];
-
-  if (!prevLineId || !prevLine) {
-    return {};
-  }
-
-  return {
-    currentLine,
-    prevLineId,
-    prevLine,
-  };
-};
-
-const isMissingLinePreconditionError = (error, lineId) => {
-  return (
-    error?.name === "DomainPreconditionError" &&
-    error?.message === "line not found" &&
-    (!lineId || error?.details?.lineId === lineId)
-  );
 };
 
 const cloneControlAction = (action) => {
@@ -113,87 +36,172 @@ const findFirstControlAction = (repositoryState) => {
   return undefined;
 };
 
-const resolveLineControlAction = ({
-  projectService,
-  domainState,
+const shouldInheritNvlModeFromPreviousLine = ({
+  lines,
   lineId,
-  fallbackLineId,
+  existingDialogue,
 }) => {
-  const primaryAction = cloneControlAction(
-    domainState?.lines?.[lineId]?.actions?.control,
-  );
+  if (existingDialogue?.mode === "nvl") {
+    return false;
+  }
+
+  const lineOrder = (lines || []).map((line) => line.id);
+  const currentIndex = lineOrder.indexOf(lineId);
+  if (currentIndex <= 0) {
+    return false;
+  }
+
+  const previousLine = lines[currentIndex - 1];
+  return previousLine?.actions?.dialogue?.mode === "nvl";
+};
+
+const resolveLineControlAction = ({ repositoryState, line, fallbackLine }) => {
+  const primaryAction = cloneControlAction(line?.actions?.control);
   if (primaryAction) {
     return primaryAction;
   }
 
-  const fallbackAction = cloneControlAction(
-    domainState?.lines?.[fallbackLineId]?.actions?.control,
-  );
+  const fallbackAction = cloneControlAction(fallbackLine?.actions?.control);
   if (fallbackAction) {
     return fallbackAction;
   }
 
-  return findFirstControlAction(projectService.getRepositoryState());
+  return findFirstControlAction(repositoryState);
+};
+
+const getCurrentSection = (store) => {
+  const scene = store.selectScene();
+  const sectionId = store.selectSelectedSectionId();
+  return scene?.sections?.find((section) => section.id === sectionId);
+};
+
+const getCurrentSectionLines = (store) => {
+  return getCurrentSection(store)?.lines || [];
+};
+
+const getLineById = (lines, lineId) => {
+  return (lines || []).find((line) => line.id === lineId);
+};
+
+const applyEditorSessionSelectionTarget = (deps, session) => {
+  const { store } = deps;
+  const selectionTarget = getSceneEditorSessionSelectionTarget(session);
+  const sessionWithoutSelection = selectionTarget
+    ? clearSceneEditorSessionSelectionTarget(session)
+    : session;
+
+  store.setEditorSession({ editorSession: sessionWithoutSelection });
+
+  if (!selectionTarget) {
+    return;
+  }
+
+  const linesEditorRef = getLinesEditorRef(deps.refs);
+  const tryFocusSelectionTarget = (remainingAttempts = 4) => {
+    if (linesEditorRef?.focusLine(selectionTarget)) {
+      return;
+    }
+
+    if (remainingAttempts <= 0) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      tryFocusSelectionTarget(remainingAttempts - 1);
+    });
+  };
+
+  requestAnimationFrame(() => {
+    tryFocusSelectionTarget();
+  });
+};
+
+const updateEditorSessionAndRender = (
+  deps,
+  nextSession,
+  { selectedLineId } = {},
+) => {
+  const { store, render, subject } = deps;
+
+  if (selectedLineId !== undefined) {
+    store.setSelectedLineId({ selectedLineId });
+  }
+
+  applyEditorSessionSelectionTarget(deps, nextSession);
+  render();
+  subject.dispatch("sceneEditor.renderCanvas", {});
+};
+
+const createDialogueContent = (text) => {
+  return [{ text: text ?? "" }];
 };
 
 export const syncSceneEditorProjectState = (store, projectService) => {
   const repositoryState = projectService.getRepositoryState();
   const domainState = projectService.getDomainState();
+  const revision = projectService.getRepositoryRevision();
   store.setRepositoryState({ repository: repositoryState });
   store.setDomainState({
     domainState,
   });
+  store.setRepositoryRevision({ revision });
   return repositoryState;
 };
 
 export const writeDialogueContent = async (
   deps,
   lineId,
-  { sectionId, content },
+  { sectionId: _sectionId, content },
 ) => {
-  const { projectService } = deps;
-  const domainState = projectService.getDomainState();
-  const existingDialogue =
-    domainState?.lines?.[lineId]?.actions?.dialogue || {};
-  const shouldInheritNvlMode = shouldInheritNvlModeFromPreviousLine({
-    domainState,
-    sectionId,
-    lineId,
-    existingDialogue,
-  });
-
-  await projectService.updateLineDialogueAction({
-    lineId,
-    dialogue: {
-      ...existingDialogue,
-      ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
+  const [update] = createDialogueContentUpdates(deps, [
+    {
+      lineId,
       content,
     },
-  });
-};
-
-export const flushDialogueQueue = async (deps) => {
-  const { dialogueQueueService } = deps;
-
-  await dialogueQueueService.flush(async (lineId, data) => {
-    await writeDialogueContent(deps, lineId, data);
-  });
-};
-
-export const applyPendingDialogueQueueToStore = (
-  store,
-  dialogueQueueService,
-) => {
-  for (const [lineId, data] of dialogueQueueService.entries()) {
-    if (!lineId || !Array.isArray(data?.content)) {
-      continue;
-    }
-
-    store.setLineTextContent({
-      lineId,
-      content: data.content,
-    });
+  ]);
+  if (!update) {
+    return;
   }
+
+  await deps.projectService.updateLineDialogueAction(update);
+};
+
+const createDialogueContentUpdates = (deps, updates = []) => {
+  const { store } = deps;
+  const currentSectionLines = getCurrentSectionLines(store);
+
+  return updates.map(({ lineId, content }) => {
+    const existingLine =
+      store.selectSelectedLine()?.id === lineId
+        ? store.selectSelectedLine()
+        : getLineById(currentSectionLines, lineId);
+    const existingDialogue = existingLine?.actions?.dialogue || {};
+    const shouldInheritNvlMode = shouldInheritNvlModeFromPreviousLine({
+      lines: currentSectionLines,
+      lineId,
+      existingDialogue,
+    });
+
+    return {
+      lineId,
+      dialogue: {
+        ...existingDialogue,
+        ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
+        content,
+      },
+    };
+  });
+};
+
+export const writeDialogueContents = async (deps, updates = []) => {
+  const normalizedUpdates = createDialogueContentUpdates(deps, updates);
+  if (normalizedUpdates.length === 0) {
+    return;
+  }
+
+  await deps.projectService.updateLineDialogueActionsBatch({
+    updates: normalizedUpdates,
+  });
 };
 
 export const findCharacterIdByShortcut = (repositoryState, shortcut) => {
@@ -217,216 +225,139 @@ export const findCharacterIdByShortcut = (repositoryState, shortcut) => {
 };
 
 export const handleSplitLineOperation = async (deps, payload) => {
-  const { projectService, store, render, refs, subject } = deps;
+  const { projectService, store } = deps;
   const sectionId = store.selectSelectedSectionId();
   const { lineId, leftContent, rightContent } = payload._event.detail;
   const lockingLineId = store.selectLockingLineId();
 
-  if (lockingLineId === lineId) {
+  if (!sectionId || !lineId || lockingLineId === lineId) {
+    return;
+  }
+
+  const currentLines = getCurrentSectionLines(store);
+  const currentLine = getLineById(currentLines, lineId);
+  if (!currentLine) {
     return;
   }
 
   store.setLockingLineId({ lineId });
-  let shouldReleaseLockAfterFocus = false;
-
-  try {
-    const newLineId = nanoid();
-    await flushDialogueQueue(deps);
-
-    const domainState = projectService.getDomainState();
-    const existingDialogue =
-      domainState?.lines?.[lineId]?.actions?.dialogue || {};
-
-    const leftContentArray = leftContent
-      ? [{ text: leftContent }]
-      : [{ text: "" }];
-
-    await projectService.updateLineDialogueAction({
-      lineId,
-      dialogue: {
-        ...existingDialogue,
-        content: leftContentArray,
-      },
-    });
-
-    const rightContentArray = rightContent
-      ? [{ text: rightContent }]
-      : [{ text: "" }];
-    const shouldInheritNvl =
-      existingDialogue?.mode === "nvl" ||
-      shouldInheritNvlModeFromPreviousLine({
-        domainState,
-        sectionId,
-        lineId,
-        existingDialogue,
-      });
-    const shouldCreateDialogueAction = shouldInheritNvl || !!rightContent;
-    const controlAction = resolveLineControlAction({
-      projectService,
-      domainState,
-      lineId,
-    });
-    const newLineActions = shouldCreateDialogueAction
-      ? {
-          dialogue: {
-            mode: shouldInheritNvl ? "nvl" : "adv",
-            ...(rightContent ? { content: rightContentArray } : {}),
-          },
-        }
-      : {};
-    if (controlAction) {
-      newLineActions.control = controlAction;
-    }
-
-    const linesEditorRef = getLinesEditorRef(refs);
-
-    await projectService.createLineItem({
-      sectionId,
-      lineId: newLineId,
-      data: {
-        actions: newLineActions,
-      },
-      position: "after",
-      positionTargetId: lineId,
-    });
-
-    syncSceneEditorProjectState(store, projectService);
-    store.setSelectedLineId({ selectedLineId: newLineId });
-    render();
-    shouldReleaseLockAfterFocus = true;
-
-    requestAnimationFrame(() => {
-      linesEditorRef?.focusLine({
-        lineId: newLineId,
-        cursorPosition: 0,
-        goalColumn: 0,
-        direction: "down",
-        syncLineId: lineId,
-      });
-
-      requestAnimationFrame(() => {
-        store.clearLockingLineId();
-      });
-    });
-
-    subject.dispatch("sceneEditor.renderCanvas", {});
-  } finally {
-    if (!shouldReleaseLockAfterFocus) {
-      store.clearLockingLineId();
-    }
-  }
-};
-
-export const handlePasteLinesOperation = async (deps, payload) => {
-  const { projectService, store, render, refs, subject } = deps;
-  const sectionId = store.selectSelectedSectionId();
-  const { lineId, leftContent, rightContent, lines } = payload._event.detail;
-
-  await flushDialogueQueue(deps);
-
-  const domainState = projectService.getDomainState();
-  const existingDialogue =
-    domainState?.lines?.[lineId]?.actions?.dialogue || {};
-  const controlAction = resolveLineControlAction({
-    projectService,
-    domainState,
-    lineId,
-  });
+  const existingDialogue = currentLine.actions?.dialogue || {};
   const shouldInheritNvl =
     existingDialogue?.mode === "nvl" ||
     shouldInheritNvlModeFromPreviousLine({
-      domainState,
-      sectionId,
+      lines: currentLines,
       lineId,
       existingDialogue,
     });
-
-  const firstLineContent = leftContent + lines[0];
-  const firstContentArray = [{ text: firstLineContent }];
-  await projectService.updateLineDialogueAction({
-    lineId,
-    dialogue: {
-      ...existingDialogue,
-      content: firstContentArray,
-    },
+  const controlAction = resolveLineControlAction({
+    repositoryState: projectService.getRepositoryState(),
+    line: currentLine,
   });
-
-  let lastCreatedLineId = lineId;
-  if (lines.length > 1) {
-    const createdLineIds = await projectService.createLineItem({
-      sectionId,
-      position: "after",
-      positionTargetId: lineId,
-      lines: lines.slice(1).map((content, index) => {
-        const isLastLine = index === lines.length - 2;
-        const lineContent = isLastLine ? content + rightContent : content;
-        return {
-          lineId: nanoid(),
-          data: {
-            actions: (() => {
-              const nextActions = {
-                dialogue: {
-                  mode: shouldInheritNvl ? "nvl" : "adv",
-                  content: [{ text: lineContent }],
-                },
-              };
-
-              if (controlAction) {
-                nextActions.control = structuredClone(controlAction);
+  const newLineId = nanoid();
+  const shouldCreateDialogueAction = shouldInheritNvl || Boolean(rightContent);
+  const persistedNewLineActions = shouldCreateDialogueAction
+    ? {
+        dialogue: {
+          mode: shouldInheritNvl ? "nvl" : "adv",
+          ...(rightContent
+            ? {
+                content: createDialogueContent(rightContent),
               }
+            : {}),
+        },
+      }
+    : {};
 
-              return nextActions;
-            })(),
-          },
-        };
-      }),
-    });
-
-    if (Array.isArray(createdLineIds) && createdLineIds.length > 0) {
-      lastCreatedLineId = createdLineIds[createdLineIds.length - 1];
-    }
+  if (controlAction) {
+    persistedNewLineActions.control = controlAction;
   }
 
-  if (lines.length === 1) {
-    const combinedContentArray = [{ text: firstLineContent + rightContent }];
-    await projectService.updateLineDialogueAction({
-      lineId,
-      dialogue: {
-        ...existingDialogue,
-        content: combinedContentArray,
-      },
-    });
-    lastCreatedLineId = lineId;
-  }
+  const sessionNewLineActions = {
+    ...structuredClone(persistedNewLineActions),
+    dialogue: {
+      mode: shouldInheritNvl ? "nvl" : "adv",
+      content: createDialogueContent(rightContent ?? ""),
+    },
+  };
 
-  syncSceneEditorProjectState(store, projectService);
-  store.setSelectedLineId({ selectedLineId: lastCreatedLineId });
-  render();
-
-  const linesEditorRef = getLinesEditorRef(refs);
-  const lastLineContent =
-    lines.length === 1
-      ? firstLineContent + rightContent
-      : lines[lines.length - 1] + rightContent;
-  const cursorPosition = lastLineContent.length - rightContent.length;
-
+  const nextSession = splitSceneEditorSessionLine(store.selectEditorSession(), {
+    lineId,
+    newLineId,
+    sectionId,
+    leftContent,
+    rightContent,
+    newLineActions: sessionNewLineActions,
+  });
+  updateEditorSessionAndRender(deps, nextSession, {
+    selectedLineId: newLineId,
+  });
   requestAnimationFrame(() => {
-    linesEditorRef?.focusLine({
-      lineId: lastCreatedLineId,
-      cursorPosition,
-      goalColumn: cursorPosition,
-      direction: null,
-      syncLineId: lineId,
+    store.clearLockingLineId();
+  });
+};
+
+export const handlePasteLinesOperation = async (deps, payload) => {
+  const { projectService, store } = deps;
+  const sectionId = store.selectSelectedSectionId();
+  const { lineId, leftContent, rightContent, lines } = payload._event.detail;
+  const currentLines = getCurrentSectionLines(store);
+  const currentLine = getLineById(currentLines, lineId);
+
+  if (
+    !sectionId ||
+    !currentLine ||
+    !Array.isArray(lines) ||
+    lines.length === 0
+  ) {
+    return;
+  }
+
+  const existingDialogue = currentLine.actions?.dialogue || {};
+  const shouldInheritNvl =
+    existingDialogue?.mode === "nvl" ||
+    shouldInheritNvlModeFromPreviousLine({
+      lines: currentLines,
+      lineId,
+      existingDialogue,
     });
+  const controlAction = resolveLineControlAction({
+    repositoryState: projectService.getRepositoryState(),
+    line: currentLine,
   });
 
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  const newLines = lines.slice(1).map((content) => ({
+    lineId: nanoid(),
+    data: {
+      actions: {
+        dialogue: {
+          mode: shouldInheritNvl ? "nvl" : "adv",
+          content: createDialogueContent(content),
+        },
+        ...(controlAction ? { control: structuredClone(controlAction) } : {}),
+      },
+    },
+  }));
+
+  const nextSession = pasteSceneEditorSessionLines(
+    store.selectEditorSession(),
+    {
+      lineId,
+      sectionId,
+      leftContent,
+      rightContent,
+      lines,
+      newLines,
+    },
+  );
+  const selectionTarget = getSceneEditorSessionSelectionTarget(nextSession);
+  updateEditorSessionAndRender(deps, nextSession, {
+    selectedLineId: selectionTarget?.lineId,
+  });
 };
 
 export const handleNewLineOperation = async (deps, payload) => {
-  const { store, render, projectService, subject, refs } = deps;
+  const { store, projectService } = deps;
   const detail = payload?._event?.detail || {};
-  const newLineId = nanoid();
   const sectionId = store.selectSelectedSectionId();
   if (!sectionId) {
     return;
@@ -435,99 +366,73 @@ export const handleNewLineOperation = async (deps, payload) => {
   const requestedPosition =
     detail.position === "before" || detail.position === "after"
       ? detail.position
-      : null;
+      : undefined;
   const referenceLineId =
-    typeof detail.lineId === "string" && detail.lineId ? detail.lineId : null;
+    typeof detail.lineId === "string" && detail.lineId
+      ? detail.lineId
+      : undefined;
   const selectedLine = store.selectSelectedLine();
-  const selectedLineId = store.selectSelectedLineId();
-  const baseLineId = referenceLineId || selectedLineId || selectedLine?.id;
-
-  if (requestedPosition && !baseLineId) {
-    return;
-  }
-
-  await flushDialogueQueue(deps);
-
-  const domainState = projectService.getDomainState();
-  const existingDialogue = baseLineId
-    ? domainState?.lines?.[baseLineId]?.actions?.dialogue || {}
-    : selectedLine?.actions?.dialogue || {};
+  const baseLineId = referenceLineId || selectedLine?.id;
+  const currentLines = getCurrentSectionLines(store);
+  const baseLine = baseLineId
+    ? getLineById(currentLines, baseLineId)
+    : selectedLine;
+  const existingDialogue = baseLine?.actions?.dialogue || {};
   const shouldInheritNvl =
     existingDialogue?.mode === "nvl" ||
     shouldInheritNvlModeFromPreviousLine({
-      domainState,
-      sectionId,
+      lines: currentLines,
       lineId: baseLineId,
       existingDialogue,
     });
+  const controlAction = resolveLineControlAction({
+    repositoryState: projectService.getRepositoryState(),
+    line: baseLine,
+    fallbackLine: selectedLine,
+  });
 
-  let createPosition = "last";
-  let createPositionId;
-  if (requestedPosition === "before") {
-    createPosition = "before";
-    createPositionId = baseLineId;
-  } else if (requestedPosition === "after") {
-    createPosition = "after";
-    createPositionId = baseLineId;
+  const newLineId = nanoid();
+  const persistedActions = shouldInheritNvl
+    ? {
+        dialogue: {
+          mode: "nvl",
+        },
+      }
+    : {};
+  if (controlAction) {
+    persistedActions.control = controlAction;
   }
 
-  const createLinePayload = {
-    sectionId,
-    lineId: newLineId,
-    data: {
-      actions: (() => {
-        const nextActions = shouldInheritNvl
-          ? {
-              dialogue: {
-                mode: "nvl",
-              },
-            }
-          : {};
-        const controlAction = resolveLineControlAction({
-          projectService,
-          domainState,
-          lineId: baseLineId,
-          fallbackLineId: selectedLine?.id,
-        });
-        if (controlAction) {
-          nextActions.control = controlAction;
-        }
-        return nextActions;
-      })(),
+  const sessionActions = {
+    ...structuredClone(persistedActions),
+    dialogue: {
+      mode: shouldInheritNvl ? "nvl" : "adv",
+      content: createDialogueContent(""),
     },
   };
 
-  createLinePayload.position = createPosition;
-  createLinePayload.positionTargetId = createPositionId;
-
-  await projectService.createLineItem(createLinePayload);
-
-  syncSceneEditorProjectState(store, projectService);
-  store.setSelectedLineId({ selectedLineId: newLineId });
-  render();
-
-  const linesEditorRef = getLinesEditorRef(refs);
-  if (requestedPosition && linesEditorRef) {
-    requestAnimationFrame(() => {
-      linesEditorRef.focusLine({
-        lineId: newLineId,
-        cursorPosition: 0,
-        goalColumn: 0,
-        direction: null,
-      });
-    });
-  }
-
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  const nextSession = insertSceneEditorSessionLine(
+    store.selectEditorSession(),
+    {
+      lineId: baseLineId,
+      newLineId,
+      sectionId,
+      position: requestedPosition,
+      actions: sessionActions,
+    },
+  );
+  updateEditorSessionAndRender(deps, nextSession, {
+    selectedLineId: newLineId,
+  });
 };
 
 export const handleSwapLineOperation = async (deps, payload) => {
-  const { store, projectService, render, subject } = deps;
+  const { store } = deps;
   const detail = payload?._event?.detail || {};
   const direction =
     detail.direction === "up" || detail.direction === "down"
       ? detail.direction
-      : null;
+      : undefined;
   const lineId =
     typeof detail.lineId === "string" && detail.lineId
       ? detail.lineId
@@ -551,105 +456,47 @@ export const handleSwapLineOperation = async (deps, payload) => {
     return;
   }
 
-  await flushDialogueQueue(deps);
-  await projectService.moveLineItem({
+  const nextSession = swapSceneEditorSessionLine(store.selectEditorSession(), {
     lineId,
-    toSectionId: sectionId,
-    index: targetIndex,
+    direction,
   });
-
-  syncSceneEditorProjectState(store, projectService);
-  store.setSelectedLineId({ selectedLineId: lineId });
-  render();
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  updateEditorSessionAndRender(deps, nextSession, {
+    selectedLineId: lineId,
+  });
 };
 
 export const handleMergeLinesOperation = async (deps, payload) => {
-  const { store, refs, render, projectService, subject } = deps;
+  const { store } = deps;
   const { currentLineId } = payload._event.detail;
   const lockingLineId = store.selectLockingLineId();
 
-  if (lockingLineId) {
+  if (!currentLineId || lockingLineId) {
+    return;
+  }
+
+  const currentLines = getCurrentSectionLines(store);
+  const currentIndex = currentLines.findIndex(
+    (line) => line.id === currentLineId,
+  );
+  if (currentIndex <= 0) {
+    return;
+  }
+
+  const previousLine = currentLines[currentIndex - 1];
+  const currentLine = currentLines[currentIndex];
+  if (!previousLine || !currentLine) {
     return;
   }
 
   store.setLockingLineId({ lineId: currentLineId });
-  let shouldReleaseLockAfterFocus = false;
-  let resolvedPrevLineId;
-
-  try {
-    await flushDialogueQueue(deps);
-
-    const domainState = projectService.getDomainState();
-    const { currentLine, prevLineId, prevLine } = resolveMergeLinesContext(
-      domainState,
-      currentLineId,
-    );
-    resolvedPrevLineId = prevLineId;
-
-    if (!currentLine || !prevLineId || !prevLine) {
-      return;
-    }
-
-    const prevContentText = getDialogueText(prevLine);
-    const currentContentText = getDialogueText(currentLine);
-    const prevContentLength = prevContentText.length;
-    const existingDialogue = prevLine.actions?.dialogue || {};
-
-    await projectService.updateLineDialogueAction({
-      lineId: prevLineId,
-      dialogue: {
-        ...existingDialogue,
-        content: [{ text: prevContentText + currentContentText }],
-      },
-    });
-
-    if (!projectService.getDomainState()?.lines?.[currentLineId]) {
-      return;
-    }
-
-    try {
-      await projectService.deleteLineItem({ lineIds: [currentLineId] });
-    } catch (error) {
-      if (isMissingLinePreconditionError(error, currentLineId)) {
-        return;
-      }
-
-      throw error;
-    }
-
-    syncSceneEditorProjectState(store, projectService);
-    store.setSelectedLineId({ selectedLineId: prevLineId });
-    render();
-    shouldReleaseLockAfterFocus = true;
-
-    const linesEditorRef = getLinesEditorRef(refs);
-    requestAnimationFrame(() => {
-      linesEditorRef?.focusLine({
-        lineId: prevLineId,
-        cursorPosition: prevContentLength,
-        goalColumn: prevContentLength,
-        direction: null,
-      });
-
-      requestAnimationFrame(() => {
-        store.clearLockingLineId();
-      });
-    });
-
-    subject.dispatch("sceneEditor.renderCanvas", {});
-  } catch (error) {
-    if (
-      isMissingLinePreconditionError(error, currentLineId) ||
-      isMissingLinePreconditionError(error, resolvedPrevLineId)
-    ) {
-      return;
-    }
-
-    throw error;
-  } finally {
-    if (!shouldReleaseLockAfterFocus) {
-      store.clearLockingLineId();
-    }
-  }
+  const nextSession = mergeSceneEditorSessionLine(store.selectEditorSession(), {
+    currentLineId,
+    previousLineId: previousLine.id,
+  });
+  updateEditorSessionAndRender(deps, nextSession, {
+    selectedLineId: previousLine.id,
+  });
+  requestAnimationFrame(() => {
+    store.clearLockingLineId();
+  });
 };

--- a/src/internal/ui/sceneEditor/persistenceQueue.js
+++ b/src/internal/ui/sceneEditor/persistenceQueue.js
@@ -1,0 +1,198 @@
+const queueByOwner = new WeakMap();
+const latestTaskStateByOwner = new WeakMap();
+const DEFAULT_PERSISTENCE_LABEL = "scene-editor-write";
+
+const nowMs = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+export const enqueueSceneEditorPersistence = async ({
+  owner,
+  task,
+  label = DEFAULT_PERSISTENCE_LABEL,
+  meta = {},
+} = {}) => {
+  if (!owner || typeof task !== "function") {
+    return task?.();
+  }
+
+  const queuedAt = nowMs();
+  const resolvedMeta =
+    label === DEFAULT_PERSISTENCE_LABEL
+      ? {
+          ...meta,
+          unlabeled: true,
+          caller: getPersistenceCaller(),
+        }
+      : meta;
+  const previous = queueByOwner.get(owner) || Promise.resolve();
+  const next = previous
+    .catch(() => {})
+    .then(async () => {
+      const startedAt = nowMs();
+      const waitMs = startedAt - queuedAt;
+      console.info("[sceneEditor][perf] persistence-start", {
+        label,
+        waitMs: Number(waitMs.toFixed(1)),
+        ...resolvedMeta,
+      });
+
+      try {
+        const result = await task();
+        const runMs = nowMs() - startedAt;
+        console.info("[sceneEditor][perf] persistence-end", {
+          label,
+          waitMs: Number(waitMs.toFixed(1)),
+          runMs: Number(runMs.toFixed(1)),
+          ...resolvedMeta,
+        });
+        return result;
+      } catch (error) {
+        const runMs = nowMs() - startedAt;
+        console.info("[sceneEditor][perf] persistence-error", {
+          label,
+          waitMs: Number(waitMs.toFixed(1)),
+          runMs: Number(runMs.toFixed(1)),
+          error: error?.message || String(error),
+          ...resolvedMeta,
+        });
+        throw error;
+      }
+    });
+  queueByOwner.set(owner, next);
+
+  try {
+    return await next;
+  } finally {
+    if (queueByOwner.get(owner) === next) {
+      queueByOwner.delete(owner);
+    }
+  }
+};
+
+const getLatestTaskState = (owner, key) => {
+  let ownerState = latestTaskStateByOwner.get(owner);
+  if (!ownerState) {
+    ownerState = new Map();
+    latestTaskStateByOwner.set(owner, ownerState);
+  }
+
+  let taskState = ownerState.get(key);
+  if (!taskState) {
+    taskState = {
+      running: false,
+      pending: false,
+      task: undefined,
+      meta: undefined,
+      promise: Promise.resolve(),
+      waiters: [],
+    };
+    ownerState.set(key, taskState);
+  }
+
+  return {
+    ownerState,
+    taskState,
+  };
+};
+
+export const enqueueLatestSceneEditorPersistence = async ({
+  owner,
+  key = "latest",
+  label = DEFAULT_PERSISTENCE_LABEL,
+  task,
+  meta,
+} = {}) => {
+  if (!owner || typeof task !== "function") {
+    return task?.();
+  }
+
+  const { ownerState, taskState } = getLatestTaskState(owner, key);
+  taskState.pending = true;
+  taskState.task = task;
+  taskState.meta = meta;
+
+  const completion = new Promise((resolve, reject) => {
+    taskState.waiters.push({ resolve, reject });
+  });
+
+  if (taskState.running) {
+    return completion;
+  }
+
+  taskState.running = true;
+  taskState.promise = (async () => {
+    let lastError;
+
+    while (taskState.pending) {
+      taskState.pending = false;
+      const nextTask = taskState.task;
+      const nextMeta =
+        typeof taskState.meta === "function"
+          ? taskState.meta()
+          : taskState.meta;
+
+      try {
+        await enqueueSceneEditorPersistence({
+          owner,
+          task: nextTask,
+          label,
+          meta: nextMeta,
+        });
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    const waiters = taskState.waiters.splice(0);
+    if (lastError) {
+      waiters.forEach(({ reject }) => reject(lastError));
+      throw lastError;
+    }
+
+    waiters.forEach(({ resolve }) => resolve());
+  })().finally(() => {
+    taskState.running = false;
+    taskState.task = undefined;
+    taskState.meta = undefined;
+
+    if (!taskState.pending && taskState.waiters.length === 0) {
+      ownerState.delete(key);
+    }
+
+    if (ownerState.size === 0) {
+      latestTaskStateByOwner.delete(owner);
+    }
+  });
+
+  return completion;
+};
+
+const getPersistenceCaller = () => {
+  const stack = new Error().stack;
+  if (!stack) {
+    return undefined;
+  }
+
+  const stackLines = stack
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const callerLine = stackLines.find((line) => {
+    return (
+      !line.includes("enqueueSceneEditorPersistence") &&
+      !line.includes("enqueueLatestSceneEditorPersistence") &&
+      !line.includes("persistenceQueue.js")
+    );
+  });
+
+  return callerLine;
+};

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -9,7 +9,6 @@ import {
   extractTransitionTargetSceneIdsFromActions,
   resolveEventBindings,
 } from "../../project/layout.js";
-import { writeDialogueContent } from "./lineOperations.js";
 
 const createAssetLoadCache = () => ({
   sceneIds: new Set(),
@@ -17,6 +16,17 @@ const createAssetLoadCache = () => ({
 });
 
 let assetLoadCache = createAssetLoadCache();
+
+const nowMs = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
 
 const resetAssetLoadCache = () => {
   assetLoadCache = createAssetLoadCache();
@@ -387,6 +397,18 @@ export const initializeSceneEditorPage = async (deps) => {
   } = deps;
 
   await projectService.ensureRepository();
+  const ensuredProjectId =
+    typeof projectService.getEnsuredProjectId === "function"
+      ? projectService.getEnsuredProjectId()
+      : undefined;
+  if (
+    ensuredProjectId &&
+    typeof projectService.ensureCommandSessionForProject === "function"
+  ) {
+    void projectService
+      .ensureCommandSessionForProject(ensuredProjectId)
+      .catch(() => {});
+  }
 
   const {
     s,
@@ -486,6 +508,18 @@ export const restoreSceneEditorFromPreview = async (deps) => {
 
 export const renderSceneEditorCanvas = async (deps, payload) => {
   const { store, render } = deps;
+  const renderStartedAt = nowMs();
+  if (payload?.perfReason) {
+    console.info("[sceneEditor][perf] canvas-render-start", {
+      reason: payload.perfReason,
+      opId: payload.perfOpId,
+      dispatchToStartMs: Number(
+        (renderStartedAt - (payload.perfDispatchTs || renderStartedAt)).toFixed(
+          1,
+        ),
+      ),
+    });
+  }
   const sceneId = store.selectSceneId();
   const sectionId = store.selectSelectedSectionId();
   const lineId = store.selectSelectedLineId();
@@ -510,14 +544,18 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
   if (!payload?.skipRender) {
     render();
   }
+
+  if (payload?.perfReason) {
+    console.info("[sceneEditor][perf] canvas-render-end", {
+      reason: payload.perfReason,
+      opId: payload.perfOpId,
+      totalMs: Number((nowMs() - renderStartedAt).toFixed(1)),
+    });
+  }
 };
 
 export const mountSceneEditorSubscriptions = (deps) => {
-  const { subject, dialogueQueueService } = deps;
-
-  dialogueQueueService.onWrite(async (lineId, data) => {
-    await writeDialogueContent(deps, lineId, data);
-  });
+  const { subject } = deps;
 
   const streams = [
     subject.pipe(

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1,11 +1,15 @@
+import { concatMap, filter, from, throttleTime } from "rxjs";
+import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import {
-  createCollabRemoteRefreshStream,
-  matchesRemoteTargets,
-} from "../../internal/ui/collabRefresh.js";
+  applySceneEditorSessionTextChange,
+  deleteSceneEditorSessionLine,
+  getSceneEditorSessionDirtyLines,
+  hasSceneEditorSessionPendingChanges,
+  reconcileSceneEditorSession,
+  setSceneEditorSessionCompositionState,
+} from "../../internal/ui/sceneEditor/editorSession.js";
 import {
-  applyPendingDialogueQueueToStore,
   findCharacterIdByShortcut,
-  flushDialogueQueue,
   handleMergeLinesOperation,
   handleNewLineOperation,
   handlePasteLinesOperation,
@@ -28,9 +32,29 @@ import {
   reconcileSceneEditorSelection,
   selectSceneEditorSection,
 } from "../../internal/ui/sceneEditor/sectionOperations.js";
+import {
+  enqueueLatestSceneEditorPersistence,
+  enqueueSceneEditorPersistence,
+} from "../../internal/ui/sceneEditor/persistenceQueue.js";
 
 const DEAD_END_TOOLTIP_CONTENT =
   "This section has no transition to another section.";
+const TEXT_DRAFT_SAVE_DEBOUNCE_MS = 300;
+const STRUCTURE_DRAFT_SAVE_DEBOUNCE_MS = 900;
+const DRAFT_SAVE_MIN_INTERVAL_MS = 1000;
+const DRAFT_SAVE_MAX_INTERVAL_MS = 3000;
+const STRUCTURE_SHORTCUT_THROTTLE_MS = 50;
+
+const nowMs = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
 
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
@@ -54,31 +78,301 @@ const scrollLinesEditorLineIntoView = (refs, lineId) => {
   linesEditorRef.scrollLineIntoView({ lineId });
 };
 
+const focusLinesEditorContainer = (refs) => {
+  const linesEditorRef = getLinesEditorRef(refs);
+  if (!linesEditorRef?.focusContainer) {
+    return;
+  }
+
+  linesEditorRef.focusContainer();
+  requestAnimationFrame(() => {
+    linesEditorRef.focusContainer();
+  });
+};
+
+const clearScheduledDraftFlush = (store) => {
+  const timerId = store.selectDraftSaveTimerId();
+  if (timerId !== undefined) {
+    clearTimeout(timerId);
+    store.clearDraftSaveTimer();
+  }
+};
+
+const cancelSceneEditorDraftFlush = (deps) => {
+  clearScheduledDraftFlush(deps.store);
+};
+
+const getDraftSaveDelayMs = (store, { reason = "text" } = {}) => {
+  const debounceMs =
+    reason === "structure"
+      ? STRUCTURE_DRAFT_SAVE_DEBOUNCE_MS
+      : TEXT_DRAFT_SAVE_DEBOUNCE_MS;
+  const lastFlushStartedAt = store.selectLastDraftFlushStartedAt();
+  const pendingSinceAt = store.selectDraftSavePendingSinceAt();
+  const remainingThrottleMs =
+    lastFlushStartedAt > 0
+      ? Math.max(0, DRAFT_SAVE_MIN_INTERVAL_MS - (nowMs() - lastFlushStartedAt))
+      : 0;
+  const remainingMaxWaitMs =
+    pendingSinceAt > 0
+      ? Math.max(0, DRAFT_SAVE_MAX_INTERVAL_MS - (nowMs() - pendingSinceAt))
+      : Number.POSITIVE_INFINITY;
+
+  return Math.min(
+    Math.max(debounceMs, remainingThrottleMs),
+    remainingMaxWaitMs,
+  );
+};
+
+const runSceneEditorPersistence = (deps, task, options = {}) => {
+  return enqueueSceneEditorPersistence({
+    owner: deps.projectService,
+    task,
+    ...options,
+  });
+};
+
+const reconcileCurrentEditorSession = (deps) => {
+  const { store } = deps;
+  const sceneId = store.selectSceneId();
+  const selectedSectionId = store.selectSelectedSectionId();
+
+  if (!sceneId || !selectedSectionId) {
+    store.clearEditorSession();
+    return undefined;
+  }
+
+  const committedScene = store.selectCommittedScene();
+  const committedSection = committedScene?.sections?.find(
+    (section) => section.id === selectedSectionId,
+  );
+  const nextSession = reconcileSceneEditorSession({
+    session: store.selectEditorSession(),
+    sceneId,
+    sectionId: selectedSectionId,
+    section: committedSection,
+    revision: store.selectRepositoryRevision(),
+  });
+  store.setEditorSession({ editorSession: nextSession });
+  return nextSession;
+};
+
+const processSplitLineRequest = async (deps, detail = {}) => {
+  if (isSectionsOverviewOpen(deps.store)) {
+    return;
+  }
+
+  cancelSceneEditorDraftFlush(deps);
+  await handleSplitLineOperation(deps, {
+    _event: {
+      detail,
+    },
+  });
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "structure",
+  });
+};
+
+const processMergeLinesRequest = async (deps, detail = {}) => {
+  if (isSectionsOverviewOpen(deps.store)) {
+    return;
+  }
+
+  cancelSceneEditorDraftFlush(deps);
+  await handleMergeLinesOperation(deps, {
+    _event: {
+      detail,
+    },
+  });
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "structure",
+  });
+};
+
+const mountSceneEditorShortcutSubscriptions = (deps) => {
+  const { subject } = deps;
+
+  const streams = [
+    subject.pipe(
+      filter(({ action }) => action === "sceneEditor.requestSplitLine"),
+      throttleTime(STRUCTURE_SHORTCUT_THROTTLE_MS, undefined, {
+        leading: true,
+        trailing: true,
+      }),
+      concatMap(({ payload }) =>
+        from(processSplitLineRequest(deps, payload).catch(() => {})),
+      ),
+    ),
+    subject.pipe(
+      filter(({ action }) => action === "sceneEditor.requestMergeLines"),
+      throttleTime(STRUCTURE_SHORTCUT_THROTTLE_MS, undefined, {
+        leading: true,
+        trailing: true,
+      }),
+      concatMap(({ payload }) =>
+        from(processMergeLinesRequest(deps, payload).catch(() => {})),
+      ),
+    ),
+  ];
+
+  const active = streams.map((stream) => stream.subscribe());
+  return () => active.forEach((subscription) => subscription?.unsubscribe?.());
+};
+
+const flushSceneEditorDrafts = async (deps) => {
+  const { store } = deps;
+  clearScheduledDraftFlush(store);
+
+  if (!hasSceneEditorSessionPendingChanges(store.selectEditorSession())) {
+    store.setDraftSavePendingSinceAt({ timestamp: 0 });
+    return;
+  }
+
+  return enqueueLatestSceneEditorPersistence({
+    owner: deps.projectService,
+    key: "draft-flush",
+    label: "draft-flush",
+    meta: () => {
+      const currentSession = store.selectEditorSession();
+      return {
+        sceneId: currentSession?.sceneId,
+        sectionId: currentSession?.sectionId,
+        dirtyCount: getSceneEditorSessionDirtyLines(currentSession).length,
+      };
+    },
+    task: async () => {
+      const session = store.selectEditorSession();
+      const dirtyLines = getSceneEditorSessionDirtyLines(session);
+      const snapshotLines = (session?.lineOrder || [])
+        .map((lineId) => session?.linesById?.[lineId]?.line)
+        .filter(Boolean)
+        .map((line) => structuredClone(line));
+      if (snapshotLines.length === 0 && dirtyLines.length === 0) {
+        return;
+      }
+
+      const flushStartedAt = nowMs();
+      store.setLastDraftFlushStartedAt({
+        timestamp: flushStartedAt,
+      });
+      store.setDraftSavePendingSinceAt({ timestamp: 0 });
+      console.info("[sceneEditor][perf] draft-flush-start", {
+        sceneId: session?.sceneId,
+        sectionId: session?.sectionId,
+        dirtyLineIds: dirtyLines.map(({ lineId }) => lineId),
+        lineCount: snapshotLines.length,
+      });
+
+      try {
+        await deps.projectService.syncSectionLinesSnapshot({
+          sectionId: session?.sectionId,
+          lines: snapshotLines,
+        });
+
+        console.info("[sceneEditor][perf] draft-flush-end", {
+          sceneId: session?.sceneId,
+          sectionId: session?.sectionId,
+          totalMs: Number((nowMs() - flushStartedAt).toFixed(1)),
+          dirtyLineIds: dirtyLines.map(({ lineId }) => lineId),
+        });
+      } catch (error) {
+        console.error("[sceneEditor] Failed to save scene changes", {
+          error,
+          sceneId: session?.sceneId,
+          sectionId: session?.sectionId,
+          revision: store.selectRepositoryRevision(),
+          dirtyLineIds: dirtyLines.map(({ lineId }) => lineId),
+        });
+        deps.appService?.showToast("Failed to save scene changes", {
+          title: "Error",
+        });
+        throw error;
+      }
+    },
+  });
+};
+
+const scheduleSceneEditorDraftFlush = (
+  deps,
+  { immediate = false, reason = "text" } = {},
+) => {
+  const { store } = deps;
+  clearScheduledDraftFlush(store);
+
+  const session = store.selectEditorSession();
+  if (!hasSceneEditorSessionPendingChanges(session)) {
+    store.setDraftSavePendingSinceAt({ timestamp: 0 });
+    return;
+  }
+
+  if (store.selectDraftSavePendingSinceAt() <= 0) {
+    store.setDraftSavePendingSinceAt({
+      timestamp: nowMs(),
+    });
+  }
+
+  if (immediate) {
+    return flushSceneEditorDrafts(deps);
+  }
+
+  const delayMs = getDraftSaveDelayMs(store, { reason });
+  const timerId = setTimeout(() => {
+    void flushSceneEditorDrafts(deps).catch(() => {});
+  }, delayMs);
+  store.setDraftSaveTimerId({ timerId });
+};
+
+const syncSceneEditorProjectPayload = async (deps, payload = {}) => {
+  const { store, render, subject } = deps;
+  const hadPendingSessionChanges = hasSceneEditorSessionPendingChanges(
+    store.selectEditorSession(),
+  );
+  const { repositoryState, domainState, revision } = payload;
+
+  store.setRepositoryState({ repository: repositoryState });
+  store.setDomainState({ domainState });
+  store.setRepositoryRevision({ revision });
+
+  if (!store.selectSceneId()) {
+    return;
+  }
+
+  reconcileCurrentEditorSession(deps);
+  reconcileSceneEditorSelection(store);
+  await updateSceneEditorSectionChanges(deps);
+
+  if (hadPendingSessionChanges) {
+    subject.dispatch("sceneEditor.renderCanvas", {
+      skipRender: true,
+      skipAnimations: true,
+    });
+    return;
+  }
+
+  render();
+  subject.dispatch("sceneEditor.renderCanvas", {
+    skipAnimations: true,
+  });
+};
+
 export const handleBeforeMount = (deps) => {
-  const cleanupSubscriptions = mountSceneEditorSubscriptions(deps);
-  const collabRefreshSubscription = createCollabRemoteRefreshStream({
-    deps,
-    matches: matchesRemoteTargets([
-      "story",
-      "layouts",
-      "images",
-      "colors",
-      "fonts",
-      "textStyles",
-      "characters",
-      "variables",
-      "sounds",
-      "videos",
-      "transforms",
-      "animations",
-    ]),
-    refresh: handleDataChanged,
-  }).subscribe();
+  const { projectService } = deps;
+  const cleanupRuntimeSubscriptions = mountSceneEditorSubscriptions(deps);
+  const cleanupShortcutSubscriptions =
+    mountSceneEditorShortcutSubscriptions(deps);
+  const projectSubscription = createProjectStateStream({
+    projectService,
+  }).subscribe({
+    next: (payload) => {
+      void syncSceneEditorProjectPayload(deps, payload);
+    },
+  });
 
   return async () => {
-    collabRefreshSubscription.unsubscribe();
-    cleanupSubscriptions();
-    await flushDialogueQueue(deps);
+    projectSubscription.unsubscribe();
+    cleanupRuntimeSubscriptions();
+    cleanupShortcutSubscriptions();
+    await flushSceneEditorDrafts(deps);
     resetSceneEditorRuntime(deps);
   };
 };
@@ -88,25 +382,17 @@ export const handleAfterMount = async (deps) => {
     ...deps,
     syncProjectState: syncStoreProjectState,
   });
+  reconcileCurrentEditorSession(deps);
+  deps.render();
 };
 
 export const handleDataChanged = async (deps) => {
-  const { store, projectService, render, subject, dialogueQueueService } = deps;
+  const { projectService } = deps;
   await projectService.ensureRepository();
-
-  if (store.selectLockingLineId()) {
-    return;
-  }
-
-  syncStoreProjectState(store, projectService);
-  applyPendingDialogueQueueToStore(store, dialogueQueueService);
-
-  reconcileSceneEditorSelection(store);
-
-  await updateSceneEditorSectionChanges(deps);
-  render();
-  subject.dispatch("sceneEditor.renderCanvas", {
-    skipAnimations: true,
+  await syncSceneEditorProjectPayload(deps, {
+    repositoryState: projectService.getRepositoryState(),
+    domainState: projectService.getDomainState(),
+    revision: projectService.getRepositoryRevision(),
   });
 };
 
@@ -120,7 +406,10 @@ export const handleSectionTabClick = async (deps, payload) => {
     payload._event.currentTarget?.dataset?.sectionId ||
     payload._event.currentTarget?.id?.replace("sectionTab", "") ||
     "";
+  await flushSceneEditorDrafts(deps);
   await selectSceneEditorSection(deps, sectionId);
+  reconcileCurrentEditorSession(deps);
+  deps.render();
 };
 
 export const handleCommandLineSubmit = async (deps, payload) => {
@@ -147,13 +436,25 @@ export const handleCommandLineSubmit = async (deps, payload) => {
       return;
     }
 
-    await projectService.updateLineActions({
-      lineId,
-      data: safeDetail,
-      replace: false,
-    });
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        await projectService.updateLineActions({
+          lineId,
+          data: safeDetail,
+          replace: false,
+        });
+      },
+      {
+        label: "section-transition",
+        meta: {
+          lineId,
+        },
+      },
+    );
 
     syncStoreProjectState(store, projectService);
+    reconcileCurrentEditorSession(deps);
     render();
 
     // Render the canvas with the latest data
@@ -183,13 +484,25 @@ export const handleCommandLineSubmit = async (deps, payload) => {
       return;
     }
 
-    await projectService.updateLineActions({
-      lineId,
-      data: safeDetail,
-      replace: false,
-    });
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        await projectService.updateLineActions({
+          lineId,
+          data: safeDetail,
+          replace: false,
+        });
+      },
+      {
+        label: "push-layered-view",
+        meta: {
+          lineId,
+        },
+      },
+    );
 
     syncStoreProjectState(store, projectService);
+    reconcileCurrentEditorSession(deps);
     render();
 
     // Render the canvas with the latest data
@@ -219,13 +532,25 @@ export const handleCommandLineSubmit = async (deps, payload) => {
       return;
     }
 
-    await projectService.updateLineActions({
-      lineId,
-      data: safeDetail,
-      replace: false,
-    });
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        await projectService.updateLineActions({
+          lineId,
+          data: safeDetail,
+          replace: false,
+        });
+      },
+      {
+        label: "pop-layered-view",
+        meta: {
+          lineId,
+        },
+      },
+    );
 
     syncStoreProjectState(store, projectService);
+    reconcileCurrentEditorSession(deps);
     render();
 
     // Render the canvas with the latest data
@@ -269,22 +594,36 @@ export const handleCommandLineSubmit = async (deps, payload) => {
 
   const { dialogue, ...otherActions } = submissionData;
 
-  if (dialogue) {
-    await projectService.updateLineDialogueAction({
-      lineId,
-      dialogue,
-    });
-  }
+  await runSceneEditorPersistence(
+    deps,
+    async () => {
+      if (dialogue) {
+        await projectService.updateLineDialogueAction({
+          lineId,
+          dialogue,
+        });
+      }
 
-  if (Object.keys(otherActions).length > 0) {
-    await projectService.updateLineActions({
-      lineId,
-      data: otherActions,
-      replace: false,
-    });
-  }
+      if (Object.keys(otherActions).length > 0) {
+        await projectService.updateLineActions({
+          lineId,
+          data: otherActions,
+          replace: false,
+        });
+      }
+    },
+    {
+      label: "command-line-submit",
+      meta: {
+        lineId,
+        hasDialogue: Boolean(dialogue),
+        otherActionCount: Object.keys(otherActions).length,
+      },
+    },
+  );
 
   syncStoreProjectState(store, projectService);
+  reconcileCurrentEditorSession(deps);
   render();
 
   // Trigger debounced canvas render
@@ -292,47 +631,55 @@ export const handleCommandLineSubmit = async (deps, payload) => {
 };
 
 export const handleEditorDataChanged = async (deps, payload) => {
-  const { subject, store, dialogueQueueService } = deps;
+  const { subject, store } = deps;
   if (isSectionsOverviewOpen(store)) {
     return;
   }
 
   const lineId = payload._event.detail.lineId;
-  const selectedLineId = store.selectSelectedLineId();
-  const lockingLineId = store.selectLockingLineId();
 
   if (!lineId) {
     return;
   }
 
-  // Ignore late input events from a line that is no longer selected or is in
-  // the middle of a structural split/merge operation.
-  if (lineId !== selectedLineId || lineId === lockingLineId) {
+  const currentSession =
+    store.selectEditorSession() || reconcileCurrentEditorSession(deps);
+  if (!currentSession?.linesById?.[lineId]) {
     return;
   }
 
-  const content = [{ text: payload._event.detail.content }];
+  const nextSession = applySceneEditorSessionTextChange(currentSession, {
+    lineId,
+    content: payload._event.detail.content,
+  });
+  store.setEditorSession({ editorSession: nextSession });
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "text",
+  });
 
-  // Update local store immediately for UI responsiveness
-  store.setLineTextContent({ lineId, content });
-
-  // Queue the pending update and schedule debounced write
-  const sectionId =
-    store.selectDomainState()?.lines?.[lineId]?.sectionId ??
-    store.selectSelectedSectionId();
-  try {
-    dialogueQueueService.setAndSchedule(lineId, { sectionId, content });
-  } catch (error) {
-    console.error("[sceneEditor] Failed to queue dialogue update:", error);
-  }
-
-  // Trigger debounced canvas render with skipRender flag.
-  // skipRender prevents full UI re-render which would reset cursor position while typing.
-  // Typing only updates dialogue content, not presentationState, so State panel doesn't need to update.
   subject.dispatch("sceneEditor.renderCanvas", {
     skipRender: true,
     skipAnimations: true,
   });
+};
+
+export const handleEditorCompositionStateChanged = (deps, payload) => {
+  const { store } = deps;
+  const currentSession = store.selectEditorSession();
+  if (!currentSession) {
+    return;
+  }
+
+  const nextSession = setSceneEditorSessionCompositionState(currentSession, {
+    isComposing: payload?._event?.detail?.isComposing === true,
+  });
+  store.setEditorSession({ editorSession: nextSession });
+};
+
+export const handleEditorBlur = async (deps) => {
+  try {
+    await scheduleSceneEditorDraftFlush(deps, { immediate: true });
+  } catch {}
 };
 
 export const handleDialogueCharacterShortcut = async (deps, payload) => {
@@ -348,11 +695,15 @@ export const handleDialogueCharacterShortcut = async (deps, payload) => {
     return;
   }
 
-  await flushDialogueQueue(deps);
-
-  const domainState = projectService.getDomainState();
-  const existingDialogue =
-    domainState?.lines?.[lineId]?.actions?.dialogue || {};
+  const currentSection = store
+    .selectScene()
+    ?.sections?.find(
+      (section) => section.id === store.selectSelectedSectionId(),
+    );
+  const currentLine =
+    currentSection?.lines?.find((line) => line.id === lineId) ||
+    store.selectSelectedLine();
+  const existingDialogue = currentLine?.actions?.dialogue || {};
 
   const isClearShortcut = String(shortcut) === "0";
   if (isClearShortcut && !existingDialogue.characterId) {
@@ -372,19 +723,8 @@ export const handleDialogueCharacterShortcut = async (deps, payload) => {
     return;
   }
 
-  const selectedLine = store.selectSelectedLine();
-  const selectedLineContent =
-    selectedLine?.id === lineId
-      ? selectedLine?.actions?.dialogue?.content
-      : undefined;
-
   const updatedDialogue = {
     ...existingDialogue,
-    ...(existingDialogue.content
-      ? {}
-      : selectedLineContent
-        ? { content: selectedLineContent }
-        : {}),
   };
 
   if (isClearShortcut) {
@@ -393,12 +733,25 @@ export const handleDialogueCharacterShortcut = async (deps, payload) => {
     updatedDialogue.characterId = characterId;
   }
 
-  await projectService.updateLineDialogueAction({
-    lineId,
-    dialogue: updatedDialogue,
-  });
+  await runSceneEditorPersistence(
+    deps,
+    async () => {
+      await projectService.updateLineDialogueAction({
+        lineId,
+        dialogue: updatedDialogue,
+      });
+    },
+    {
+      label: "dialogue-character-shortcut",
+      meta: {
+        lineId,
+        shortcut,
+      },
+    },
+  );
 
   syncStoreProjectState(store, projectService);
+  reconcileCurrentEditorSession(deps);
   render();
   subject.dispatch("sceneEditor.renderCanvas", {});
 };
@@ -474,28 +827,39 @@ export const handleSectionsOverviewRowClick = async (deps, payload) => {
   }
 
   store.closeSectionsOverviewPanel();
+  await flushSceneEditorDrafts(deps);
   await selectSceneEditorSection(deps, sectionId);
+  reconcileCurrentEditorSession(deps);
+  deps.render();
 };
 
 export const handleSplitLine = async (deps, payload) => {
-  if (isSectionsOverviewOpen(deps.store)) {
-    return;
-  }
-  await handleSplitLineOperation(deps, payload);
+  deps.subject.dispatch(
+    "sceneEditor.requestSplitLine",
+    payload?._event?.detail || {},
+  );
 };
 
 export const handlePasteLines = async (deps, payload) => {
   if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
+  cancelSceneEditorDraftFlush(deps);
   await handlePasteLinesOperation(deps, payload);
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "structure",
+  });
 };
 
 export const handleNewLine = async (deps, payload) => {
   if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
+  cancelSceneEditorDraftFlush(deps);
   await handleNewLineOperation(deps, payload);
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "structure",
+  });
 };
 
 export const handleLineNavigation = (deps, payload) => {
@@ -590,14 +954,18 @@ export const handleSwapLine = async (deps, payload) => {
   if (isSectionsOverviewOpen(deps.store)) {
     return;
   }
+  cancelSceneEditorDraftFlush(deps);
   await handleSwapLineOperation(deps, payload);
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "structure",
+  });
 };
 
 export const handleMergeLines = async (deps, payload) => {
-  if (isSectionsOverviewOpen(deps.store)) {
-    return;
-  }
-  await handleMergeLinesOperation(deps, payload);
+  deps.subject.dispatch(
+    "sceneEditor.requestMergeLines",
+    payload?._event?.detail || {},
+  );
 };
 
 export const handleSectionTabRightClick = (deps, payload) => {
@@ -652,19 +1020,36 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   if (typeof action === "string" && action.startsWith("go-to-section:")) {
     const nextSectionId = action.replace("go-to-section:", "");
     if (nextSectionId) {
+      await flushSceneEditorDrafts(deps);
       await selectSceneEditorSection(deps, nextSectionId);
+      reconcileCurrentEditorSession(deps);
+      render();
       return;
     }
   }
 
   if (action === "delete-section") {
-    await projectService.deleteSectionItem({
-      sceneId,
-      sectionIds: [sectionId],
-    });
+    await flushSceneEditorDrafts(deps);
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        await projectService.deleteSectionItem({
+          sceneId,
+          sectionIds: [sectionId],
+        });
+      },
+      {
+        label: "delete-section",
+        meta: {
+          sceneId,
+          sectionId,
+        },
+      },
+    );
 
     // Update store with new repository state
     syncStoreProjectState(store, projectService);
+    reconcileCurrentEditorSession(deps);
 
     // Update scene data and select first remaining section
     const newScene = store.selectScene();
@@ -673,6 +1058,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
         selectedSectionId: newScene.sections[0].id,
       });
     }
+    reconcileCurrentEditorSession(deps);
   } else if (action === "rename-section") {
     // Show rename popover using the stored position
     store.showPopover({
@@ -684,44 +1070,60 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   } else if (action === "delete-actions") {
     const selectedLineId = store.selectSelectedLineId();
     const selectedSectionId = store.selectSelectedSectionId();
+    const selectedLine = store.selectSelectedLine();
 
     if (actionsType && selectedLineId && selectedSectionId) {
       // Special handling for dialogue - keep content, remove only layoutId and characterId
       if (actionsType === "dialogue") {
-        const stateBefore = projectService.getRepositoryState();
-        const currentActions =
-          stateBefore.scenes?.items?.[sceneId]?.sections?.items?.[
-            selectedSectionId
-          ]?.lines?.items?.[selectedLineId]?.actions;
-
-        if (currentActions?.dialogue) {
+        const currentDialogue = selectedLine?.actions?.dialogue;
+        if (currentDialogue) {
           // Keep content if it exists, remove layoutId and characterId
           const updatedDialogue = {
-            content: currentActions.dialogue.content,
+            content: currentDialogue.content,
           };
 
-          await projectService.updateLineDialogueAction({
-            lineId: selectedLineId,
-            dialogue: updatedDialogue,
-          });
+          await runSceneEditorPersistence(
+            deps,
+            async () => {
+              await projectService.updateLineDialogueAction({
+                lineId: selectedLineId,
+                dialogue: updatedDialogue,
+              });
+            },
+            {
+              label: "delete-dialogue-action",
+              meta: {
+                lineId: selectedLineId,
+              },
+            },
+          );
         }
       } else {
-        const stateBefore = projectService.getRepositoryState();
-        const currentActions =
-          stateBefore.scenes?.items?.[sceneId]?.sections?.items?.[
-            selectedSectionId
-          ]?.lines?.items?.[selectedLineId]?.actions || {};
+        const currentActions = selectedLine?.actions || {};
         const nextActions = structuredClone(currentActions);
         delete nextActions[actionsType];
 
-        await projectService.updateLineActions({
-          lineId: selectedLineId,
-          data: nextActions,
-          replace: true,
-        });
+        await runSceneEditorPersistence(
+          deps,
+          async () => {
+            await projectService.updateLineActions({
+              lineId: selectedLineId,
+              data: nextActions,
+              replace: true,
+            });
+          },
+          {
+            label: "delete-line-action",
+            meta: {
+              lineId: selectedLineId,
+              actionType: actionsType,
+            },
+          },
+        );
       }
 
       syncStoreProjectState(store, projectService);
+      reconcileCurrentEditorSession(deps);
 
       // Trigger re-render to update the view
       subject.dispatch("sceneEditor.renderCanvas", {});
@@ -764,6 +1166,8 @@ export const handleSectionCreateFormActionClick = async (deps, payload) => {
         nextSectionName,
         syncStoreProjectState,
       );
+      reconcileCurrentEditorSession(deps);
+      render();
       return;
     }
   }
@@ -800,18 +1204,33 @@ export const handleFormActionClick = async (deps, payload) => {
         nextSectionName,
         syncStoreProjectState,
       );
+      reconcileCurrentEditorSession(deps);
+      render();
       return;
     }
 
     if (sectionId && nextSectionName && sceneId) {
-      await projectService.renameSectionItem({
-        sceneId,
-        sectionId,
-        name: nextSectionName,
-      });
+      await runSceneEditorPersistence(
+        deps,
+        async () => {
+          await projectService.renameSectionItem({
+            sceneId,
+            sectionId,
+            name: nextSectionName,
+          });
+        },
+        {
+          label: "rename-section",
+          meta: {
+            sceneId,
+            sectionId,
+          },
+        },
+      );
 
       // Update store with new repository state
       syncStoreProjectState(store, projectService);
+      reconcileCurrentEditorSession(deps);
     }
 
     render();
@@ -825,13 +1244,18 @@ export const handleToggleSectionsGraphView = (deps) => {
 };
 
 export const handlePreviewClick = (deps) => {
-  const { store, render, appService } = deps;
-  const sceneId = store.selectSceneId();
-  const sectionId = store.selectSelectedSectionId();
-  const lineId = store.selectSelectedLineId();
-  appService.blurActiveElement();
-  store.showPreviewSceneId({ sceneId, sectionId, lineId });
-  render();
+  const openPreview = async () => {
+    const { store, render, appService } = deps;
+    const sceneId = store.selectSceneId();
+    const sectionId = store.selectSelectedSectionId();
+    const lineId = store.selectSelectedLineId();
+    await flushSceneEditorDrafts(deps);
+    appService.blurActiveElement();
+    store.showPreviewSceneId({ sceneId, sectionId, lineId });
+    render();
+  };
+
+  void openPreview();
 };
 
 export const handlePreviewShortcut = (deps) => {
@@ -839,10 +1263,12 @@ export const handlePreviewShortcut = (deps) => {
 };
 
 export const handleDeleteLineShortcut = async (deps, payload) => {
-  const { store, subject, render, projectService, globalUI, appService } = deps;
+  const { store, render } = deps;
+  const { subject } = deps;
   if (isSectionsOverviewOpen(store)) {
     return;
   }
+  cancelSceneEditorDraftFlush(deps);
 
   const detail = payload?._event?.detail || {};
   const lineId =
@@ -855,6 +1281,14 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
     return;
   }
 
+  const opStartedAt = nowMs();
+  const opId = `delete-line:${lineId}:${Math.round(opStartedAt)}`;
+  console.info("[sceneEditor][perf] delete-line-start", {
+    opId,
+    lineId,
+    sectionId,
+  });
+
   const scene = store.selectScene();
   const section = scene?.sections?.find((item) => item.id === sectionId);
   const lines = Array.isArray(section?.lines) ? section.lines : [];
@@ -863,38 +1297,56 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
     return;
   }
 
-  const dialogOptions = {
-    title: "Delete Line",
-    message: "Are you sure you want to delete this line?",
-    confirmText: "Delete",
-  };
-
-  let confirmationResult = false;
-  if (typeof globalUI?.showConfirm === "function") {
-    confirmationResult = await globalUI.showConfirm(dialogOptions);
-  } else if (typeof appService?.showDialog === "function") {
-    confirmationResult = await appService.showDialog(dialogOptions);
-  }
-
-  const confirmed =
-    typeof confirmationResult === "boolean"
-      ? confirmationResult
-      : !!(confirmationResult?.confirmed ?? confirmationResult?.value);
-  if (!confirmed) {
-    return;
-  }
-
   const nextSelectedLineId =
     lines[currentIndex + 1]?.id || lines[currentIndex - 1]?.id;
 
-  await flushDialogueQueue(deps);
-  await projectService.deleteLineItem({ lineIds: [lineId] });
-
-  syncStoreProjectState(store, projectService);
+  const nextSession = deleteSceneEditorSessionLine(
+    store.selectEditorSession(),
+    {
+      lineId,
+      nextSelectedLineId,
+    },
+  );
+  const sessionForStore = nextSession
+    ? {
+        ...nextSession,
+        selectionTarget: undefined,
+      }
+    : nextSession;
+  store.setEditorSession({ editorSession: sessionForStore });
   store.setSelectedLineId({ selectedLineId: nextSelectedLineId });
-
   render();
-  subject.dispatch("sceneEditor.renderCanvas", {});
+  subject.dispatch("sceneEditor.renderCanvas", {
+    perfReason: "delete-line-shortcut",
+    perfOpId: opId,
+    perfDispatchTs: nowMs(),
+  });
+  console.info("[sceneEditor][perf] delete-line-optimistic", {
+    opId,
+    lineId,
+    nextSelectedLineId,
+    optimisticMs: Number((nowMs() - opStartedAt).toFixed(1)),
+  });
+
+  if (nextSelectedLineId) {
+    focusLinesEditorContainer(deps.refs);
+    requestAnimationFrame(() => {
+      scrollLinesEditorLineIntoView(deps.refs, nextSelectedLineId);
+      focusLinesEditorContainer(deps.refs);
+    });
+  } else {
+    focusLinesEditorContainer(deps.refs);
+  }
+  scheduleSceneEditorDraftFlush(deps, {
+    reason: "structure",
+  });
+  console.info("[sceneEditor][perf] delete-line-end", {
+    opId,
+    lineId,
+    nextSelectedLineId,
+    totalMs: Number((nowMs() - opStartedAt).toFixed(1)),
+    persisted: false,
+  });
 };
 
 export const handleLineDeleteActionItem = async (deps, payload) => {
@@ -916,13 +1368,26 @@ export const handleLineDeleteActionItem = async (deps, payload) => {
       delete newActions[actionType];
     }
   }
-  await projectService.updateLineActions({
-    lineId: selectedLine.id,
-    data: newActions,
-    replace: true,
-  });
+  await runSceneEditorPersistence(
+    deps,
+    async () => {
+      await projectService.updateLineActions({
+        lineId: selectedLine.id,
+        data: newActions,
+        replace: true,
+      });
+    },
+    {
+      label: "line-delete-action-item",
+      meta: {
+        lineId: selectedLine.id,
+        actionType,
+      },
+    },
+  );
   // Update store with new repository state
   syncStoreProjectState(store, projectService);
+  reconcileCurrentEditorSession(deps);
   // Trigger re-render
   render();
   subject.dispatch("sceneEditor.renderCanvas", {});
@@ -932,8 +1397,9 @@ export const handleHidePreviewScene = async (deps) => {
   await restoreSceneEditorFromPreview(deps);
 };
 
-export const handleBackClick = (deps) => {
+export const handleBackClick = async (deps) => {
   const { appService } = deps;
+  await flushSceneEditorDrafts(deps);
   const { p } = appService.getPayload();
   appService.navigate("/project/scenes", { p });
 };
@@ -967,13 +1433,26 @@ export const handleSystemActionsActionDelete = async (deps, payload) => {
     // For non-inherited actions, delete as before
     delete newActions[actionType];
   }
-  await projectService.updateLineActions({
-    lineId: selectedLine.id,
-    data: newActions,
-    replace: true,
-  });
+  await runSceneEditorPersistence(
+    deps,
+    async () => {
+      await projectService.updateLineActions({
+        lineId: selectedLine.id,
+        data: newActions,
+        replace: true,
+      });
+    },
+    {
+      label: "system-action-delete",
+      meta: {
+        lineId: selectedLine.id,
+        actionType,
+      },
+    },
+  );
   // Update store with new repository state
   syncStoreProjectState(store, projectService);
+  reconcileCurrentEditorSession(deps);
   // Trigger re-render
   render();
 

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -1,6 +1,7 @@
 import { buildLayoutElements } from "../../internal/project/layout.js";
 import { toHierarchyStructure } from "../../internal/project/tree.js";
 import { buildSceneEditorLineViewModels } from "../../internal/ui/sceneEditor/lineViewModels.js";
+import { overlaySceneWithEditorSession } from "../../internal/ui/sceneEditor/editorSession.js";
 import {
   constructProjectData,
   getSectionPresentation,
@@ -47,6 +48,25 @@ const toFlatTree = (ids = []) => {
   return ids.map((id) => ({ id }));
 };
 
+const getEditorSessionForSection = (state, sceneId, sectionId) => {
+  const session = state.editorSession;
+  if (!session) {
+    return undefined;
+  }
+
+  if (session.sceneId !== sceneId || session.sectionId !== sectionId) {
+    return undefined;
+  }
+
+  return session;
+};
+
+const getEditorSessionLines = (session) => {
+  return (session?.lineOrder || [])
+    .map((lineId) => session?.linesById?.[lineId]?.line)
+    .filter(Boolean);
+};
+
 const buildProjectDataSourceState = (state) => {
   const repositoryState = state.repositoryState || {};
   const domainState = state.domainState || {};
@@ -72,11 +92,23 @@ const buildProjectDataSourceState = (state) => {
         continue;
       }
 
-      const lineIds = Array.isArray(section.lineIds) ? section.lineIds : [];
+      const editorSession = getEditorSessionForSection(
+        state,
+        sceneId,
+        sectionId,
+      );
+      const sessionLines = getEditorSessionLines(editorSession);
+      const lineIds = editorSession
+        ? sessionLines.map((line) => line.id)
+        : Array.isArray(section.lineIds)
+          ? section.lineIds
+          : [];
       const lineItems = {};
 
       for (const lineId of lineIds) {
-        const line = domainLines[lineId];
+        const line =
+          sessionLines.find((sessionLine) => sessionLine.id === lineId) ||
+          domainLines[lineId];
         if (!line) {
           continue;
         }
@@ -90,7 +122,9 @@ const buildProjectDataSourceState = (state) => {
       sectionItems[sectionId] = {
         id: sectionId,
         name: section.name || `Section ${sectionId}`,
-        initialLineId: section.initialLineId,
+        initialLineId: editorSession
+          ? sessionLines[0]?.id
+          : section.initialLineId,
         lines: {
           items: lineItems,
           tree: toFlatTree(Object.keys(lineItems)),
@@ -156,7 +190,12 @@ export const createInitialState = () => ({
     },
   },
   repositoryState: {},
+  repositoryRevision: 0,
   domainState: {},
+  editorSession: undefined,
+  draftSaveTimerId: undefined,
+  lastDraftFlushStartedAt: 0,
+  draftSavePendingSinceAt: 0,
   previewVisible: false,
   previewSceneId: undefined,
   previewSectionId: undefined,
@@ -182,8 +221,36 @@ export const setRepositoryState = ({ state }, { repository } = {}) => {
   state.repositoryState = repository;
 };
 
+export const setRepositoryRevision = ({ state }, { revision } = {}) => {
+  state.repositoryRevision = Number.isFinite(revision) ? revision : 0;
+};
+
 export const setDomainState = ({ state }, { domainState } = {}) => {
   state.domainState = domainState || {};
+};
+
+export const setEditorSession = ({ state }, { editorSession } = {}) => {
+  state.editorSession = editorSession;
+};
+
+export const clearEditorSession = ({ state }, _payload = {}) => {
+  state.editorSession = undefined;
+};
+
+export const setDraftSaveTimerId = ({ state }, { timerId } = {}) => {
+  state.draftSaveTimerId = timerId;
+};
+
+export const clearDraftSaveTimer = ({ state }, _payload = {}) => {
+  state.draftSaveTimerId = undefined;
+};
+
+export const setLastDraftFlushStartedAt = ({ state }, { timestamp } = {}) => {
+  state.lastDraftFlushStartedAt = Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+export const setDraftSavePendingSinceAt = ({ state }, { timestamp } = {}) => {
+  state.draftSavePendingSinceAt = Number.isFinite(timestamp) ? timestamp : 0;
 };
 
 export const showPreviewSceneId = (
@@ -234,8 +301,28 @@ export const selectRepositoryState = ({ state }) => {
   return state.repositoryState;
 };
 
+export const selectRepositoryRevision = ({ state }) => {
+  return state.repositoryRevision;
+};
+
 export const selectDomainState = ({ state }) => {
   return state.domainState;
+};
+
+export const selectEditorSession = ({ state }) => {
+  return state.editorSession;
+};
+
+export const selectDraftSaveTimerId = ({ state }) => {
+  return state.draftSaveTimerId;
+};
+
+export const selectLastDraftFlushStartedAt = ({ state }) => {
+  return state.lastDraftFlushStartedAt;
+};
+
+export const selectDraftSavePendingSinceAt = ({ state }) => {
+  return state.draftSavePendingSinceAt;
 };
 
 export const selectCharacters = ({ state }) => {
@@ -385,13 +472,18 @@ const buildSceneFromRepositoryState = ({ state }) => {
   };
 };
 
-export const selectScene = ({ state }) => {
+export const selectCommittedScene = ({ state }) => {
   const domainScene = buildSceneFromDomainState({ state });
   if (domainScene) {
     return domainScene;
   }
 
   return buildSceneFromRepositoryState({ state });
+};
+
+export const selectScene = ({ state }) => {
+  const baseScene = selectCommittedScene({ state });
+  return overlaySceneWithEditorSession(baseScene, state.editorSession);
 };
 
 export const selectSceneId = ({ state }) => {
@@ -545,86 +637,6 @@ export const hideSectionCreateDialog = ({ state }, _payload = {}) => {
     ...state.sectionCreateDialog,
     isOpen: false,
   };
-};
-
-export const setLineTextContent = ({ state }, { lineId, content } = {}) => {
-  const sceneId = state.sceneId;
-  const sectionId = state.selectedSectionId;
-  if (!sceneId || !sectionId || !lineId) {
-    return;
-  }
-
-  const domainLine = state.domainState?.lines?.[lineId];
-  if (
-    domainLine &&
-    state.domainState?.sections?.[domainLine.sectionId]?.sceneId === sceneId &&
-    domainLine.sectionId === sectionId
-  ) {
-    if (!domainLine.actions) {
-      domainLine.actions = {};
-    }
-    if (!domainLine.actions.dialogue) {
-      domainLine.actions.dialogue = {};
-    }
-    domainLine.actions.dialogue.content = content;
-  }
-
-  const repositoryLine =
-    state.repositoryState?.scenes?.items?.[sceneId]?.sections?.items?.[
-      sectionId
-    ]?.lines?.items?.[lineId];
-  if (repositoryLine) {
-    if (!repositoryLine.actions) {
-      repositoryLine.actions = {};
-    }
-    if (!repositoryLine.actions.dialogue) {
-      repositoryLine.actions.dialogue = {};
-    }
-    repositoryLine.actions.dialogue.content = content;
-  }
-};
-
-export const splitLineOptimistically = (
-  { state },
-  { sectionId, lineId, newLineId, leftContent, newLineActions } = {},
-) => {
-  if (!sectionId || !lineId || !newLineId) {
-    return;
-  }
-
-  const section = state.domainState?.sections?.[sectionId];
-  const currentLine = state.domainState?.lines?.[lineId];
-  if (!section || !currentLine) {
-    return;
-  }
-
-  if (!currentLine.actions) {
-    currentLine.actions = {};
-  }
-
-  const existingDialogue = currentLine.actions.dialogue || {};
-  currentLine.actions.dialogue = {
-    ...existingDialogue,
-    content: leftContent || [{ text: "" }],
-  };
-  currentLine.updatedAt = Date.now();
-
-  if (!state.domainState.lines) {
-    state.domainState.lines = {};
-  }
-
-  state.domainState.lines[newLineId] = {
-    id: newLineId,
-    sectionId,
-    actions: structuredClone(newLineActions || {}),
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  };
-
-  const currentIndex = section.lineIds.indexOf(lineId);
-  const insertIndex =
-    currentIndex >= 0 ? currentIndex + 1 : section.lineIds.length;
-  section.lineIds.splice(insertIndex, 0, newLineId);
 };
 
 export const selectProjectData = ({ state }) => {

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -3,6 +3,10 @@ refs:
     eventListeners:
       editor-data-changed:
         handler: handleEditorDataChanged
+      composition-state-changed:
+        handler: handleEditorCompositionStateChanged
+      editor-blur:
+        handler: handleEditorBlur
       newLine:
         handler: handleNewLine
       splitLine:


### PR DESCRIPTION
## Summary
- redesign scene editor state around a local draft session reconciled against repository snapshots
- make contenteditable structural editing immediate while moving persistence to queued, coalesced section snapshot flushes
- batch and speed up local/offline persistence, add repository revision propagation, and document the new design

## Key changes
- add the scene editor redesign doc and wire it into the docs index
- introduce `editorSession` and `persistenceQueue` for immediate UI updates, debounced/coalesced saves, and snapshot-based reconciliation
- rework lines editor Enter/Backspace/Escape handling, caret transfer, block-mode transitions, and structural throttling
- batch repository apply and command submission paths, including local/offline fast paths for scene editor flushes
- add perf instrumentation used to trace scene editor persistence latency

## Validation
- `bun run test:smoke`
- `bun run build:web`
