### PR TITLE
chore: remove scene editor debug instrumentation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -382,7 +382,6 @@ const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
   const isAwaitingDeleteShortcut = store.selectAwaitingDeleteShortcut();
 
   if (isAwaitingDeleteShortcut) {
-    const startedAt = store.selectDeleteShortcutStartedAt();
     clearDeleteShortcutState(store);
 
     if (!isDeleteShortcutKey) {
@@ -396,11 +395,6 @@ const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
     if (!targetLineId) {
       return true;
     }
-
-    console.info("[sceneEditor][perf] delete-shortcut-fired", {
-      lineId: targetLineId,
-      elapsedMs: Number((nowMs() - startedAt).toFixed(1)),
-    });
 
     dispatchEvent(
       new CustomEvent("delete-line-shortcut", {
@@ -420,9 +414,6 @@ const handleBlockModeDeleteShortcut = (deps, payload, { lineId } = {}) => {
     awaitingDeleteShortcut: true,
   });
   armDeleteShortcutState(store);
-  console.info("[sceneEditor][perf] delete-shortcut-armed", {
-    lineId: lineId || props.selectedLineId,
-  });
   event.preventDefault();
   event.stopPropagation();
   return true;

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -106,7 +106,7 @@ template:
                                                   - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} key=${item.previewFileId}-${imageHeight}x${maxWidth}: null
                                                   - $if item.showPreviewIcon:
                                                       - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
-                                                          - rtgl-svg svg=zoomIn wh=24 c=white: null
+                                                          - rtgl-svg svg=zoomIn wh=22 c=white: null
                                                   - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
                                             $elif item.cardKind == 'video':
                                               - 'rtgl-view p=md g=md br=md pos=rel':

--- a/src/deps/services/shared/commandApi/shared.js
+++ b/src/deps/services/shared/commandApi/shared.js
@@ -23,17 +23,6 @@ export const createCommandApiShared = ({
   storyScenePartitionFor,
   resourceTypePartitionFor,
 }) => {
-  const nowMs = () => {
-    if (
-      typeof performance !== "undefined" &&
-      typeof performance.now === "function"
-    ) {
-      return performance.now();
-    }
-
-    return Date.now();
-  };
-
   const createId = () => {
     if (typeof idGenerator === "function") {
       const id = idGenerator();
@@ -147,13 +136,7 @@ export const createCommandApiShared = ({
     };
   };
 
-  const submitCommandsWithContext = async ({
-    context,
-    commands = [],
-    perfLabel,
-    perfMeta = {},
-  } = {}) => {
-    const startedAt = nowMs();
+  const submitCommandsWithContext = async ({ context, commands = [] } = {}) => {
     const normalizedCommands = (commands || []).map((entry) =>
       createCommandWithContext({
         context,
@@ -164,7 +147,6 @@ export const createCommandApiShared = ({
         basePartition: entry.basePartition,
       }),
     );
-    const envelopeBuiltAt = nowMs();
     if (normalizedCommands.length === 0) {
       return {
         valid: true,
@@ -175,7 +157,6 @@ export const createCommandApiShared = ({
 
     const submitResult =
       await context.session.submitCommands(normalizedCommands);
-    const sessionSubmittedAt = nowMs();
     if (submitResult?.valid === false) {
       return submitResult;
     }
@@ -184,24 +165,7 @@ export const createCommandApiShared = ({
       repository: context.repository,
       commands: normalizedCommands,
       projectId: context.projectId,
-      perfLabel,
-      perfMeta,
     });
-    const appliedAt = nowMs();
-
-    if (perfLabel) {
-      console.info("[sceneEditor][perf] submit-commands-with-context", {
-        perfLabel,
-        commandCount: normalizedCommands.length,
-        envelopeMs: Number((envelopeBuiltAt - startedAt).toFixed(1)),
-        sessionSubmitMs: Number(
-          (sessionSubmittedAt - envelopeBuiltAt).toFixed(1),
-        ),
-        localApplyMs: Number((appliedAt - sessionSubmittedAt).toFixed(1)),
-        totalMs: Number((appliedAt - startedAt).toFixed(1)),
-        ...perfMeta,
-      });
-    }
 
     return {
       valid: true,

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -6,17 +6,6 @@ import {
 import { COMMAND_TYPES } from "../../../../internal/project/commands.js";
 
 export const createStoryCommandApi = (shared) => {
-  const nowMs = () => {
-    if (
-      typeof performance !== "undefined" &&
-      typeof performance.now === "function"
-    ) {
-      return performance.now();
-    }
-
-    return Date.now();
-  };
-
   const appendMissingIds = (orderedIds, allIds) => {
     const seen = new Set();
     const result = [];
@@ -232,9 +221,7 @@ export const createStoryCommandApi = (shared) => {
     },
 
     async syncSectionLinesSnapshot({ sectionId, lines = [] }) {
-      const startedAt = nowMs();
       const context = await shared.ensureCommandContext();
-      const ensuredContextAt = nowMs();
       const sectionLocation = findSectionLocation(context.state, sectionId);
       if (!sectionLocation?.section) {
         throw new Error("section not found");
@@ -380,14 +367,6 @@ export const createStoryCommandApi = (shared) => {
       }
 
       if (commands.length === 0) {
-        console.info("[sceneEditor][perf] sync-section-lines-snapshot", {
-          sectionId,
-          ensureContextMs: Number((ensuredContextAt - startedAt).toFixed(1)),
-          diffMs: Number((nowMs() - ensuredContextAt).toFixed(1)),
-          totalMs: Number((nowMs() - startedAt).toFixed(1)),
-          lineCount: desiredLines.length,
-          commandCount: 0,
-        });
         return {
           valid: true,
           commandIds: [],
@@ -395,37 +374,10 @@ export const createStoryCommandApi = (shared) => {
         };
       }
 
-      const diffCompletedAt = nowMs();
-      const commandCounts = commands.reduce((acc, command) => {
-        const commandType = command?.type || "unknown";
-        acc[commandType] = (acc[commandType] || 0) + 1;
-        return acc;
-      }, {});
-
-      const result = await shared.submitCommandsWithContext({
+      return shared.submitCommandsWithContext({
         context,
         commands,
-        perfLabel: "scene-editor-sync-section-lines-snapshot",
-        perfMeta: {
-          sectionId,
-          lineCount: desiredLines.length,
-          commandCount: commands.length,
-          commandCounts,
-        },
       });
-
-      console.info("[sceneEditor][perf] sync-section-lines-snapshot", {
-        sectionId,
-        lineCount: desiredLines.length,
-        commandCount: commands.length,
-        commandCounts,
-        ensureContextMs: Number((ensuredContextAt - startedAt).toFixed(1)),
-        diffMs: Number((diffCompletedAt - ensuredContextAt).toFixed(1)),
-        submitMs: Number((nowMs() - diffCompletedAt).toFixed(1)),
-        totalMs: Number((nowMs() - startedAt).toFixed(1)),
-      });
-
-      return result;
     },
 
     async createSceneItem({

--- a/src/deps/services/shared/projectRepository.js
+++ b/src/deps/services/shared/projectRepository.js
@@ -369,17 +369,6 @@ const applyRepositoryEventToRepositoryState = ({
 const createInitialRepositoryStateForProject = () =>
   structuredClone(initialProjectData);
 
-const nowMs = () => {
-  if (
-    typeof performance !== "undefined" &&
-    typeof performance.now === "function"
-  ) {
-    return performance.now();
-  }
-
-  return Date.now();
-};
-
 export const createProjectRepository = async ({
   projectId,
   store,
@@ -436,10 +425,7 @@ export const applyCommandsToRepository = async ({
   repository,
   commands = [],
   projectId,
-  perfLabel,
-  perfMeta = {},
 }) => {
-  const startedAt = nowMs();
   const normalizedCommands = Array.isArray(commands)
     ? commands.filter(Boolean)
     : [];
@@ -467,30 +453,13 @@ export const applyCommandsToRepository = async ({
       command,
     }),
   );
-  const builtEventsAt = nowMs();
 
   if (typeof repository.addEvents === "function") {
-    await repository.addEvents(repositoryEvents, {
-      perfLabel,
-      perfMeta,
-    });
+    await repository.addEvents(repositoryEvents);
   } else {
     for (const event of repositoryEvents) {
       await repository.addEvent(event);
     }
-  }
-  const appliedAt = nowMs();
-
-  if (perfLabel) {
-    console.info("[sceneEditor][perf] apply-commands-to-repository", {
-      perfLabel,
-      commandCount: repositoryCommands.length,
-      eventCount: repositoryEvents.length,
-      buildEventsMs: Number((builtEventsAt - startedAt).toFixed(1)),
-      addEventsMs: Number((appliedAt - builtEventsAt).toFixed(1)),
-      totalMs: Number((appliedAt - startedAt).toFixed(1)),
-      ...perfMeta,
-    });
   }
 
   return {

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -11,17 +11,6 @@ const PROJECT_STATE_CHECKPOINT = {
 export const projectRepositoryStatePartitionFor = (projectId) =>
   `project:${projectId}:repository_state`;
 
-const nowMs = () => {
-  if (
-    typeof performance !== "undefined" &&
-    typeof performance.now === "function"
-  ) {
-    return performance.now();
-  }
-
-  return Date.now();
-};
-
 const toCommittedProjectStateEvent = ({ event, committedId, projectId }) => ({
   ...structuredClone(event),
   committedId,
@@ -232,8 +221,7 @@ export const createProjectRepositoryRuntime = async ({
       notifyStateListeners();
     },
 
-    async addEvents(sourceEvents = [], { perfLabel, perfMeta = {} } = {}) {
-      const startedAt = nowMs();
+    async addEvents(sourceEvents = []) {
       const nextEvents = Array.isArray(sourceEvents)
         ? sourceEvents.filter(Boolean)
         : [];
@@ -248,7 +236,6 @@ export const createProjectRepositoryRuntime = async ({
           await store.appendEvent(event);
         }
       }
-      const appendedAt = nowMs();
 
       for (const event of nextEvents) {
         events.push(structuredClone(event));
@@ -263,29 +250,13 @@ export const createProjectRepositoryRuntime = async ({
           }),
         );
       }
-      const reducedAt = nowMs();
 
       currentState = await projectStateRuntime.loadMaterializedView({
         viewName: PROJECT_STATE_VIEW_NAME,
         partition: projectPartition,
       });
       assertState(currentState);
-      const loadedAt = nowMs();
       notifyStateListeners();
-      const notifiedAt = nowMs();
-
-      if (perfLabel) {
-        console.info("[sceneEditor][perf] repository-add-events", {
-          perfLabel,
-          eventCount: nextEvents.length,
-          appendMs: Number((appendedAt - startedAt).toFixed(1)),
-          reduceMs: Number((reducedAt - appendedAt).toFixed(1)),
-          loadViewMs: Number((loadedAt - reducedAt).toFixed(1)),
-          notifyMs: Number((notifiedAt - loadedAt).toFixed(1)),
-          totalMs: Number((notifiedAt - startedAt).toFixed(1)),
-          ...perfMeta,
-        });
-      }
     },
   };
 };

--- a/src/internal/fileTypes.js
+++ b/src/internal/fileTypes.js
@@ -1,3 +1,104 @@
+const FONT_EXTENSION_TO_MIME = {
+  ttf: "font/ttf",
+  otf: "font/otf",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  ttc: "font/ttc",
+  eot: "font/eot",
+};
+
+const FONT_MIME_ALIASES = {
+  "application/font-woff": "font/woff",
+  "application/x-font-woff": "font/woff",
+  "application/font-sfnt": "font/ttf",
+  "application/x-font-truetype": "font/ttf",
+  "application/x-truetype-font": "font/ttf",
+  "application/vnd.ms-fontobject": "font/eot",
+  "application/x-font-eot": "font/eot",
+  "font/sfnt": "font/ttf",
+};
+
+const getFontMimeTypeFromExtension = (fileName = "") => {
+  const extension = fileName.split(".").pop()?.toLowerCase();
+  if (!extension) {
+    return "";
+  }
+
+  return FONT_EXTENSION_TO_MIME[extension] ?? "";
+};
+
+const detectFontMimeTypeFromBytes = (result) => {
+  if (!(result.arrayBuffer || result.buffer)) {
+    return "";
+  }
+
+  const bytes = new Uint8Array(result.arrayBuffer || result.buffer);
+  if (bytes.length < 4) {
+    return "";
+  }
+
+  const magic =
+    (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
+
+  if (magic === 0x00010000 || magic === 0x74727565) {
+    return "font/ttf";
+  }
+
+  if (magic === 0x4f54544f) {
+    return "font/otf";
+  }
+
+  if (magic === 0x774f4646) {
+    return "font/woff";
+  }
+
+  if (magic === 0x774f4632) {
+    return "font/woff2";
+  }
+
+  if (magic === 0x74746366) {
+    return "font/ttc";
+  }
+
+  if (
+    magic === 0x02000100 ||
+    magic === 0x01000200 ||
+    (bytes[0] === 0x00 &&
+      bytes[1] === 0x01 &&
+      bytes[2] === 0x00 &&
+      bytes[3] === 0x02)
+  ) {
+    return "font/eot";
+  }
+
+  return "";
+};
+
+export const normalizeFontFileType = ({ fileType, fileName } = {}) => {
+  const normalizedType = fileType?.trim().toLowerCase() ?? "";
+  if (
+    normalizedType &&
+    Object.values(FONT_EXTENSION_TO_MIME).includes(normalizedType)
+  ) {
+    return normalizedType;
+  }
+
+  if (normalizedType && FONT_MIME_ALIASES[normalizedType]) {
+    return FONT_MIME_ALIASES[normalizedType];
+  }
+
+  return getFontMimeTypeFromExtension(fileName);
+};
+
+export const formatFontFileTypeLabel = ({ fileType, fileName } = {}) => {
+  const normalizedType = normalizeFontFileType({ fileType, fileName });
+  if (!normalizedType) {
+    return "Unknown";
+  }
+
+  return normalizedType.replace("font/", "").toUpperCase();
+};
+
 /**
  * Determines the MIME type of a font file by checking magic numbers or file extension
  * @param {Object} result - The file upload result object
@@ -8,61 +109,20 @@
  * @returns {string} The MIME type of the file
  */
 export const getFileType = (result) => {
-  if (result.file.type) return result.file.type;
-
-  // Check magic numbers from bytes for font formats
-  if (result.arrayBuffer || result.buffer) {
-    const bytes = new Uint8Array(result.arrayBuffer || result.buffer);
-
-    // TTF: starts with 0x00010000 or "true" (0x74727565)
-    if (bytes.length >= 4) {
-      const magic =
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
-
-      // TTF signatures
-      if (magic === 0x00010000 || magic === 0x74727565) {
-        return "font/ttf";
-      }
-
-      // OTF: starts with "OTTO" (0x4F54544F)
-      if (magic === 0x4f54544f) {
-        return "font/otf";
-      }
-
-      // WOFF: starts with "wOFF" (0x774F4646)
-      if (magic === 0x774f4646) {
-        return "font/woff";
-      }
-
-      // WOFF2: starts with "wOF2" (0x774F4632)
-      if (magic === 0x774f4632) {
-        return "font/woff2";
-      }
-
-      // TTC: starts with "ttcf" (0x74746366)
-      if (magic === 0x74746366) {
-        return "font/ttc";
-      }
-
-      // EOT: starts with 0x02000100 or 0x01000200 (little endian)
-      if (
-        magic === 0x02000100 ||
-        magic === 0x01000200 ||
-        (bytes[0] === 0x00 &&
-          bytes[1] === 0x01 &&
-          bytes[2] === 0x00 &&
-          bytes[3] === 0x02)
-      ) {
-        return "font/eot";
-      }
-    }
+  const fileName = result.file?.name ?? result.displayName ?? "";
+  const detectedMimeType = detectFontMimeTypeFromBytes(result);
+  if (detectedMimeType) {
+    return detectedMimeType;
   }
 
-  // Fallback to extension-based detection
-  const ext = result.displayName.split(".").pop()?.toLowerCase();
-  if (result.type === "font" && ext) {
-    return `font/${ext}`;
+  const normalizedMimeType = normalizeFontFileType({
+    fileType: result.file?.type,
+    fileName,
+  });
+  if (normalizedMimeType) {
+    return normalizedMimeType;
   }
+
   throw new Error("Unknown file type");
 };
 

--- a/src/internal/ui/resourcePages/resourcePageErrors.js
+++ b/src/internal/ui/resourcePages/resourcePageErrors.js
@@ -1,0 +1,70 @@
+export const getResourcePageErrorMessage = (errorOrResult, fallbackMessage) => {
+  if (typeof errorOrResult === "string") {
+    return errorOrResult;
+  }
+
+  if (typeof errorOrResult?.error === "string") {
+    return errorOrResult.error;
+  }
+
+  return (
+    errorOrResult?.error?.message ||
+    errorOrResult?.error?.creatorModelError?.message ||
+    errorOrResult?.message ||
+    fallbackMessage
+  );
+};
+
+export const showResourcePageError = ({
+  appService,
+  errorOrResult,
+  fallbackMessage,
+  title = "Error",
+} = {}) => {
+  const message = getResourcePageErrorMessage(errorOrResult, fallbackMessage);
+  appService.showToast(message, { title });
+  return message;
+};
+
+export const runResourcePageMutation = async ({
+  appService,
+  action,
+  fallbackMessage,
+  title = "Error",
+  logLabel = fallbackMessage,
+} = {}) => {
+  try {
+    const result = await action();
+
+    if (result?.valid === false) {
+      console.error(logLabel, result);
+      showResourcePageError({
+        appService,
+        errorOrResult: result,
+        fallbackMessage,
+        title,
+      });
+      return {
+        ok: false,
+        result,
+      };
+    }
+
+    return {
+      ok: true,
+      result,
+    };
+  } catch (error) {
+    console.error(logLabel, error);
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage,
+      title,
+    });
+    return {
+      ok: false,
+      error,
+    };
+  }
+};

--- a/src/internal/ui/sceneEditor/persistenceQueue.js
+++ b/src/internal/ui/sceneEditor/persistenceQueue.js
@@ -1,71 +1,13 @@
 const queueByOwner = new WeakMap();
 const latestTaskStateByOwner = new WeakMap();
-const DEFAULT_PERSISTENCE_LABEL = "scene-editor-write";
 
-const nowMs = () => {
-  if (
-    typeof performance !== "undefined" &&
-    typeof performance.now === "function"
-  ) {
-    return performance.now();
-  }
-
-  return Date.now();
-};
-
-export const enqueueSceneEditorPersistence = async ({
-  owner,
-  task,
-  label = DEFAULT_PERSISTENCE_LABEL,
-  meta = {},
-} = {}) => {
+export const enqueueSceneEditorPersistence = async ({ owner, task } = {}) => {
   if (!owner || typeof task !== "function") {
     return task?.();
   }
 
-  const queuedAt = nowMs();
-  const resolvedMeta =
-    label === DEFAULT_PERSISTENCE_LABEL
-      ? {
-          ...meta,
-          unlabeled: true,
-          caller: getPersistenceCaller(),
-        }
-      : meta;
   const previous = queueByOwner.get(owner) || Promise.resolve();
-  const next = previous
-    .catch(() => {})
-    .then(async () => {
-      const startedAt = nowMs();
-      const waitMs = startedAt - queuedAt;
-      console.info("[sceneEditor][perf] persistence-start", {
-        label,
-        waitMs: Number(waitMs.toFixed(1)),
-        ...resolvedMeta,
-      });
-
-      try {
-        const result = await task();
-        const runMs = nowMs() - startedAt;
-        console.info("[sceneEditor][perf] persistence-end", {
-          label,
-          waitMs: Number(waitMs.toFixed(1)),
-          runMs: Number(runMs.toFixed(1)),
-          ...resolvedMeta,
-        });
-        return result;
-      } catch (error) {
-        const runMs = nowMs() - startedAt;
-        console.info("[sceneEditor][perf] persistence-error", {
-          label,
-          waitMs: Number(waitMs.toFixed(1)),
-          runMs: Number(runMs.toFixed(1)),
-          error: error?.message || String(error),
-          ...resolvedMeta,
-        });
-        throw error;
-      }
-    });
+  const next = previous.catch(() => {}).then(task);
   queueByOwner.set(owner, next);
 
   try {
@@ -106,9 +48,7 @@ const getLatestTaskState = (owner, key) => {
 export const enqueueLatestSceneEditorPersistence = async ({
   owner,
   key = "latest",
-  label = DEFAULT_PERSISTENCE_LABEL,
   task,
-  meta,
 } = {}) => {
   if (!owner || typeof task !== "function") {
     return task?.();
@@ -134,17 +74,11 @@ export const enqueueLatestSceneEditorPersistence = async ({
     while (taskState.pending) {
       taskState.pending = false;
       const nextTask = taskState.task;
-      const nextMeta =
-        typeof taskState.meta === "function"
-          ? taskState.meta()
-          : taskState.meta;
 
       try {
         await enqueueSceneEditorPersistence({
           owner,
           task: nextTask,
-          label,
-          meta: nextMeta,
         });
       } catch (error) {
         lastError = error;
@@ -161,7 +95,6 @@ export const enqueueLatestSceneEditorPersistence = async ({
   })().finally(() => {
     taskState.running = false;
     taskState.task = undefined;
-    taskState.meta = undefined;
 
     if (!taskState.pending && taskState.waiters.length === 0) {
       ownerState.delete(key);
@@ -173,26 +106,4 @@ export const enqueueLatestSceneEditorPersistence = async ({
   });
 
   return completion;
-};
-
-const getPersistenceCaller = () => {
-  const stack = new Error().stack;
-  if (!stack) {
-    return undefined;
-  }
-
-  const stackLines = stack
-    .split("\n")
-    .slice(1)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const callerLine = stackLines.find((line) => {
-    return (
-      !line.includes("enqueueSceneEditorPersistence") &&
-      !line.includes("enqueueLatestSceneEditorPersistence") &&
-      !line.includes("persistenceQueue.js")
-    );
-  });
-
-  return callerLine;
 };

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -17,17 +17,6 @@ const createAssetLoadCache = () => ({
 
 let assetLoadCache = createAssetLoadCache();
 
-const nowMs = () => {
-  if (
-    typeof performance !== "undefined" &&
-    typeof performance.now === "function"
-  ) {
-    return performance.now();
-  }
-
-  return Date.now();
-};
-
 const resetAssetLoadCache = () => {
   assetLoadCache = createAssetLoadCache();
 };
@@ -508,18 +497,6 @@ export const restoreSceneEditorFromPreview = async (deps) => {
 
 export const renderSceneEditorCanvas = async (deps, payload) => {
   const { store, render } = deps;
-  const renderStartedAt = nowMs();
-  if (payload?.perfReason) {
-    console.info("[sceneEditor][perf] canvas-render-start", {
-      reason: payload.perfReason,
-      opId: payload.perfOpId,
-      dispatchToStartMs: Number(
-        (renderStartedAt - (payload.perfDispatchTs || renderStartedAt)).toFixed(
-          1,
-        ),
-      ),
-    });
-  }
   const sceneId = store.selectSceneId();
   const sectionId = store.selectSelectedSectionId();
   const lineId = store.selectSelectedLineId();
@@ -543,14 +520,6 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
 
   if (!payload?.skipRender) {
     render();
-  }
-
-  if (payload?.perfReason) {
-    console.info("[sceneEditor][perf] canvas-render-end", {
-      reason: payload.perfReason,
-      opId: payload.perfOpId,
-      totalMs: Number((nowMs() - renderStartedAt).toFixed(1)),
-    });
   }
 };
 

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
+import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import { resetState } from "./animations.constants";
 
 const defaultInitialValues = {
@@ -180,30 +181,48 @@ export const handleFormActionClick = async (deps, payload) => {
   const editItemId = store.selectEditItemId();
 
   if (editMode && editItemId) {
-    await projectService.updateAnimation({
-      animationId: editItemId,
-      data: {
-        name,
-        animation: {
-          type: "live",
-          tween,
-        },
-      },
+    const updateAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to update animation.",
+      action: () =>
+        projectService.updateAnimation({
+          animationId: editItemId,
+          data: {
+            name,
+            animation: {
+              type: "live",
+              tween,
+            },
+          },
+        }),
     });
+
+    if (!updateAttempt.ok) {
+      return;
+    }
   } else {
-    await projectService.createAnimation({
-      animationId: nanoid(),
-      data: {
-        type: "animation",
-        name,
-        animation: {
-          type: "live",
-          tween,
-        },
-      },
-      parentId: store.selectTargetGroupId(),
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create animation.",
+      action: () =>
+        projectService.createAnimation({
+          animationId: nanoid(),
+          data: {
+            type: "animation",
+            name,
+            animation: {
+              type: "live",
+              tween,
+            },
+          },
+          parentId: store.selectTargetGroupId(),
+          position: "last",
+        }),
     });
+
+    if (!createAttempt.ok) {
+      return;
+    }
   }
 
   store.closeDialog();

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -1,20 +1,16 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCharacterSpritesFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import {
+  getResourcePageErrorMessage,
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import { tap } from "rxjs";
 
 const EMPTY_TREE = { items: {}, tree: [] };
 const ACCEPTED_FILE_TYPES = ".jpg,.jpeg,.png,.webp";
-
-const getProjectErrorMessage = (result, fallbackMessage) => {
-  return (
-    result?.error?.message ||
-    result?.error?.creatorModelError?.message ||
-    result?.message ||
-    fallbackMessage
-  );
-};
 
 const getCharacterIdFromPayload = ({ appService }) => {
   return appService.getPayload().characterId;
@@ -113,8 +109,12 @@ const createSpritesFromFiles = async ({
 
   try {
     successfulUploads = await projectService.uploadFiles(files);
-  } catch {
-    appService.showToast("Failed to upload sprites.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload sprites.",
+    });
     return;
   }
 
@@ -130,28 +130,29 @@ const createSpritesFromFiles = async ({
   }
 
   for (const result of successfulUploads) {
-    const createResult = await projectService.createCharacterSpriteItem({
-      characterId,
-      spriteId: nanoid(),
-      fileRecords: result.fileRecords,
-      parentId,
-      position: "last",
-      data: {
-        type: "image",
-        fileId: result.fileId,
-        name: result.displayName,
-        fileType: result.file.type,
-        fileSize: result.file.size,
-        width: result.dimensions.width,
-        height: result.dimensions.height,
-      },
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create sprite.",
+      action: () =>
+        projectService.createCharacterSpriteItem({
+          characterId,
+          spriteId: nanoid(),
+          fileRecords: result.fileRecords,
+          parentId,
+          position: "last",
+          data: {
+            type: "image",
+            fileId: result.fileId,
+            name: result.displayName,
+            fileType: result.file.type,
+            fileSize: result.file.size,
+            width: result.dimensions.width,
+            height: result.dimensions.height,
+          },
+        }),
     });
 
-    if (createResult?.valid === false) {
-      appService.showToast(
-        getProjectErrorMessage(createResult, "Failed to create sprite."),
-        { title: "Error" },
-      );
+    if (!createAttempt.ok) {
       return;
     }
   }
@@ -272,8 +273,12 @@ export const handleUploadClick = async (deps, payload) => {
       accept: ACCEPTED_FILE_TYPES,
       multiple: true,
     });
-  } catch {
-    appService.showToast("Failed to select files.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select files.",
+    });
     return;
   }
 
@@ -314,8 +319,12 @@ export const handleFormExtraEvent = async (deps) => {
       multiple: false,
       upload: true,
     });
-  } catch {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
@@ -335,25 +344,26 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  const updateResult = await projectService.updateCharacterSpriteItem({
-    characterId,
-    spriteId: selectedItem.id,
-    fileRecords: uploadResult.fileRecords,
-    data: {
-      fileId: uploadResult.fileId,
-      name: uploadResult.displayName,
-      fileType: uploadResult.file.type,
-      fileSize: uploadResult.file.size,
-      width: uploadResult.dimensions.width,
-      height: uploadResult.dimensions.height,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update sprite.",
+    action: () =>
+      projectService.updateCharacterSpriteItem({
+        characterId,
+        spriteId: selectedItem.id,
+        fileRecords: uploadResult.fileRecords,
+        data: {
+          fileId: uploadResult.fileId,
+          name: uploadResult.displayName,
+          fileType: uploadResult.file.type,
+          fileSize: uploadResult.file.size,
+          width: uploadResult.dimensions.width,
+          height: uploadResult.dimensions.height,
+        },
+      }),
   });
 
-  if (updateResult?.valid === false) {
-    appService.showToast(
-      getProjectErrorMessage(updateResult, "Failed to update sprite."),
-      { title: "Error" },
-    );
+  if (!updateAttempt.ok) {
     return;
   }
 
@@ -376,8 +386,12 @@ export const handleEditDialogImageClick = async (deps) => {
       multiple: false,
       upload: true,
     });
-  } catch {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
@@ -431,18 +445,19 @@ export const handleEditFormAction = async (deps, payload) => {
     data.height = editUploadResult.dimensions.height;
   }
 
-  const updateResult = await projectService.updateCharacterSpriteItem({
-    characterId: store.selectCharacterId(),
-    spriteId: editItemId,
-    fileRecords: editUploadResult?.fileRecords,
-    data,
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update sprite.",
+    action: () =>
+      projectService.updateCharacterSpriteItem({
+        characterId: store.selectCharacterId(),
+        spriteId: editItemId,
+        fileRecords: editUploadResult?.fileRecords,
+        data,
+      }),
   });
 
-  if (updateResult?.valid === false) {
-    appService.showToast(
-      getProjectErrorMessage(updateResult, "Failed to update sprite."),
-      { title: "Error" },
-    );
+  if (!updateAttempt.ok) {
     return;
   }
 
@@ -483,7 +498,7 @@ export const handleItemDelete = async (deps, payload) => {
 
   if (deleteResult?.valid === false) {
     appService.showToast(
-      getProjectErrorMessage(deleteResult, "Failed to delete sprite."),
+      getResourcePageErrorMessage(deleteResult, "Failed to delete sprite."),
       { title: "Error" },
     );
     return;

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -1,6 +1,10 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createResourceFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import {
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import { tap } from "rxjs";
 
@@ -156,23 +160,25 @@ export const handleCharacterCreated = async (deps, payload) => {
     characterData.fileId = avatarFileId;
   }
 
-  const createResult = await projectService.createCharacter({
-    characterId,
-    fileRecords: avatarUploadResult?.fileRecords,
-    data: characterData,
-    parentId: groupId,
-    position: "last",
+  const createAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to create character.",
+    action: () =>
+      projectService.createCharacter({
+        characterId,
+        fileRecords: avatarUploadResult?.fileRecords,
+        data: characterData,
+        parentId: groupId,
+        position: "last",
+      }),
   });
 
-  if (createResult?.valid === false) {
-    appService.showToast("Failed to create character.", {
-      title: "Error",
-    });
-    return createResult;
+  if (!createAttempt.ok) {
+    return createAttempt.result ?? { valid: false };
   }
 
   await refreshCharactersData(deps);
-  return createResult;
+  return createAttempt.result;
 };
 
 export const handleSpritesButtonClick = (deps, payload) => {
@@ -199,11 +205,21 @@ export const handleDetailPanelAvatarClick = async (deps) => {
     return;
   }
 
-  const file = await appService.pickFiles({
-    accept: "image/*",
-    multiple: false,
-    validations: [{ type: "square" }],
-  });
+  let file;
+  try {
+    file = await appService.pickFiles({
+      accept: "image/*",
+      multiple: false,
+      validations: [{ type: "square" }],
+    });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select avatar image.",
+    });
+    return;
+  }
 
   if (!file) {
     return; // User cancelled
@@ -213,34 +229,47 @@ export const handleDetailPanelAvatarClick = async (deps) => {
     // Upload the new avatar file using projectService
     const uploadedFiles = await projectService.uploadFiles([file]);
 
-    if (uploadedFiles && uploadedFiles.length > 0) {
-      const uploadedFile = uploadedFiles[0];
-
-      const updateData = {
-        fileId: uploadedFile.fileId,
-        fileType: file.type,
-        fileSize: file.size,
-        // Update name only if character doesn't have one or if it's the generic filename
-        ...((!selectedItem.name ||
-          selectedItem.name === "Untitled Character") && {
-          name: file.name.replace(/\.[^/.]+$/, ""),
-        }),
-      };
-
-      // Update the selected character in the repository with the new avatar
-      await projectService.updateCharacter({
-        characterId: selectedItem.id,
-        fileRecords: uploadedFile.fileRecords,
-        data: updateData,
+    const uploadedFile = uploadedFiles?.[0];
+    if (!uploadedFile) {
+      showResourcePageError({
+        appService,
+        errorOrResult: "Failed to upload avatar image.",
+        fallbackMessage: "Failed to upload avatar image.",
       });
-
-      // Update the store with the new repository state and get new file URL
-      await refreshCharactersData(deps);
-    } else {
-      console.error("Avatar upload failed:", file.name);
+      return;
     }
+
+    const updateData = {
+      fileId: uploadedFile.fileId,
+      fileType: file.type,
+      fileSize: file.size,
+    };
+    if (!selectedItem.name || selectedItem.name === "Untitled Character") {
+      updateData.name = file.name.replace(/\.[^/.]+$/, "");
+    }
+
+    const updateAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to update character avatar.",
+      action: () =>
+        projectService.updateCharacter({
+          characterId: selectedItem.id,
+          fileRecords: uploadedFile.fileRecords,
+          data: updateData,
+        }),
+    });
+
+    if (!updateAttempt.ok) {
+      return;
+    }
+
+    await refreshCharactersData(deps);
   } catch (error) {
-    console.error("Avatar upload error:", file.name, error);
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload avatar image.",
+    });
   }
 };
 
@@ -328,7 +357,12 @@ export const handleDialogAvatarClick = async (deps) => {
       const uploadResults = await projectService.uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {
-        throw new Error("Failed to upload avatar image");
+        showResourcePageError({
+          appService,
+          errorOrResult: "Failed to upload avatar image.",
+          fallbackMessage: "Failed to upload avatar image.",
+        });
+        return;
       }
 
       const result = uploadResults[0];
@@ -339,7 +373,11 @@ export const handleDialogAvatarClick = async (deps) => {
       render();
     }
   } catch (error) {
-    console.error("Error uploading avatar:", error);
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload avatar image.",
+    });
   }
 };
 
@@ -400,7 +438,12 @@ export const handleEditDialogAvatarClick = async (deps) => {
       const uploadResults = await projectService.uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {
-        throw new Error("Failed to upload avatar image");
+        showResourcePageError({
+          appService,
+          errorOrResult: "Failed to upload avatar image.",
+          fallbackMessage: "Failed to upload avatar image.",
+        });
+        return;
       }
 
       const result = uploadResults[0];
@@ -411,12 +454,16 @@ export const handleEditDialogAvatarClick = async (deps) => {
       render();
     }
   } catch (error) {
-    console.error("Error uploading avatar:", error);
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload avatar image.",
+    });
   }
 };
 
 export const handleEditFormAction = async (deps, payload) => {
-  const { store, render, projectService } = deps;
+  const { appService, store, render, projectService } = deps;
 
   if (payload._event.detail.actionId === "submit") {
     const formData = payload._event.detail.values;
@@ -435,11 +482,20 @@ export const handleEditFormAction = async (deps, payload) => {
       updateData.fileId = editAvatarFileId;
     }
 
-    await projectService.updateCharacter({
-      characterId: editItemId,
-      fileRecords: editAvatarUploadResult?.fileRecords,
-      data: updateData,
+    const updateAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to update character.",
+      action: () =>
+        projectService.updateCharacter({
+          characterId: editItemId,
+          fileRecords: editAvatarUploadResult?.fileRecords,
+          data: updateData,
+        }),
     });
+
+    if (!updateAttempt.ok) {
+      return;
+    }
 
     await refreshCharactersData(deps);
     store.closeEditDialog();

--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
+import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const syncEditFormValues = ({ deps, values } = {}) => {
   const { editForm } = deps.refs;
@@ -97,13 +98,21 @@ export const handleEditFormAction = async (deps, payload) => {
     return;
   }
 
-  await projectService.updateColor({
-    colorId: editItemId,
-    data: {
-      name,
-      hex: values?.hex ?? "#ffffff",
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update color.",
+    action: () =>
+      projectService.updateColor({
+        colorId: editItemId,
+        data: {
+          name,
+          hex: values?.hex ?? "#ffffff",
+        },
+      }),
   });
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   store.closeEditDialog();
   await handleDataChanged(deps);
@@ -133,16 +142,24 @@ export const handleAddFormAction = async (deps, payload) => {
     return;
   }
 
-  await projectService.createColor({
-    colorId: nanoid(),
-    data: {
-      type: "color",
-      name,
-      hex: values?.hex ?? "#ffffff",
-    },
-    parentId: store.getState().targetGroupId,
-    position: "last",
+  const createAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to create color.",
+    action: () =>
+      projectService.createColor({
+        colorId: nanoid(),
+        data: {
+          type: "color",
+          name,
+          hex: values?.hex ?? "#ffffff",
+        },
+        parentId: store.getState().targetGroupId,
+        position: "last",
+      }),
   });
+  if (!createAttempt.ok) {
+    return;
+  }
 
   store.closeAddDialog();
   await handleDataChanged(deps);

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -3,6 +3,7 @@ import { createLayoutEditorPayload } from "../../internal/layoutEditorRoute.js";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
 import { createControlsFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import {
   getInteractionActions,
   withInteractionPayload,
@@ -89,15 +90,17 @@ const updateControlKeyboard = async ({
   data.keyboard =
     Object.keys(nextKeyboard).length > 0 ? nextKeyboard : undefined;
 
-  const result = await projectService.updateControlItem({
-    controlId: control.id,
-    data,
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update keyboard action.",
+    action: () =>
+      projectService.updateControlItem({
+        controlId: control.id,
+        data,
+      }),
   });
 
-  if (result?.valid === false) {
-    appService.showToast("Failed to update keyboard action", {
-      title: "Error",
-    });
+  if (!updateAttempt.ok) {
     return false;
   }
 
@@ -180,13 +183,22 @@ export const handleControlFormActionClick = async (deps, payload) => {
     return;
   }
 
-  await projectService.createControlItem({
-    controlId: nanoid(),
-    name,
-    elements: createControlTemplate(),
-    parentId: store.getState().targetGroupId,
-    position: "last",
+  const createAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to create control.",
+    action: () =>
+      projectService.createControlItem({
+        controlId: nanoid(),
+        name,
+        elements: createControlTemplate(),
+        parentId: store.getState().targetGroupId,
+        position: "last",
+      }),
   });
+
+  if (!createAttempt.ok) {
+    return;
+  }
 
   store.closeAddDialog();
   await handleDataChanged(deps);

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -4,6 +4,10 @@ import { getFileType } from "../../internal/fileTypes.js";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
+import {
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const FONT_FILE_PATTERN = /\.(ttf|otf|woff|woff2|ttc|eot)$/i;
 
@@ -36,8 +40,12 @@ const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
   let successfulUploads;
   try {
     successfulUploads = await projectService.uploadFiles(files);
-  } catch {
-    appService.showToast("Failed to upload font.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload font.",
+    });
     return;
   }
 
@@ -47,20 +55,28 @@ const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
   }
 
   for (const result of successfulUploads) {
-    await projectService.createFont({
-      fontId: nanoid(),
-      fileRecords: result.fileRecords,
-      data: {
-        type: "font",
-        fileId: result.fileId,
-        name: result.displayName,
-        fontFamily: result.fontName,
-        fileType: getFileType(result),
-        fileSize: result.file.size,
-      },
-      parentId,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create font.",
+      action: () =>
+        projectService.createFont({
+          fontId: nanoid(),
+          fileRecords: result.fileRecords,
+          data: {
+            type: "font",
+            fileId: result.fileId,
+            name: result.displayName,
+            fontFamily: result.fontName,
+            fileType: getFileType(result),
+            fileSize: result.file.size,
+          },
+          parentId,
+          position: "last",
+        }),
     });
+    if (!createAttempt.ok) {
+      return;
+    }
   }
 
   await handleDataChanged(deps);
@@ -99,8 +115,12 @@ export const handleUploadClick = async (deps, payload) => {
       accept: ".ttf,.otf,.woff,.woff2,.ttc,.eot",
       multiple: true,
     });
-  } catch {
-    appService.showToast("Failed to select files.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select files.",
+    });
     return;
   }
 
@@ -139,8 +159,12 @@ export const handleFormExtraEvent = async (deps) => {
       accept: ".ttf,.otf,.woff,.woff2,.ttc,.eot",
       multiple: false,
     });
-  } catch {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
@@ -155,8 +179,12 @@ export const handleFormExtraEvent = async (deps) => {
   let uploadedFiles;
   try {
     uploadedFiles = await projectService.uploadFiles([file]);
-  } catch {
-    appService.showToast("Failed to upload font.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload font.",
+    });
     return;
   }
 
@@ -167,17 +195,25 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  await projectService.updateFont({
-    fontId: selectedItem.id,
-    fileRecords: uploadResult.fileRecords,
-    data: {
-      fileId: uploadResult.fileId,
-      name: uploadResult.file.name,
-      fontFamily: uploadResult.fontName,
-      fileType: getFileType(uploadResult),
-      fileSize: uploadResult.file.size,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update font.",
+    action: () =>
+      projectService.updateFont({
+        fontId: selectedItem.id,
+        fileRecords: uploadResult.fileRecords,
+        data: {
+          fileId: uploadResult.fileId,
+          name: uploadResult.file.name,
+          fontFamily: uploadResult.fontName,
+          fileType: getFileType(uploadResult),
+          fileSize: uploadResult.file.size,
+        },
+      }),
   });
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   await handleDataChanged(deps);
 };

--- a/src/pages/fonts/fonts.store.js
+++ b/src/pages/fonts/fonts.store.js
@@ -1,3 +1,4 @@
+import { formatFontFileTypeLabel } from "../../internal/fileTypes.js";
 import { formatFileSize } from "../../internal/files.js";
 import { createMediaPageStore } from "../../internal/ui/resourcePages/media/createMediaPageStore.js";
 
@@ -64,24 +65,6 @@ const getGlyphList = () => {
   return glyphs;
 };
 
-const getFileTypeFromName = (fileName) => {
-  if (!fileName) {
-    return "";
-  }
-
-  const extension = fileName.toLowerCase().split(".").pop();
-  const extensionMap = {
-    ttf: "font/ttf",
-    otf: "font/otf",
-    woff: "font/woff",
-    woff2: "font/woff2",
-    ttc: "font/ttc",
-    eot: "font/eot",
-  };
-
-  return extensionMap[extension] ?? `font/${extension}`;
-};
-
 const buildDetailFields = (item) => {
   if (!item) {
     return [];
@@ -101,7 +84,10 @@ const buildDetailFields = (item) => {
     {
       type: "text",
       label: "File Type",
-      value: item.fileType ?? getFileTypeFromName(item.name ?? ""),
+      value: formatFontFileTypeLabel({
+        fileType: item.fileType,
+        fileName: item.name ?? "",
+      }),
     },
     {
       type: "text",

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -1,6 +1,10 @@
 import { nanoid } from "nanoid";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
+import {
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const {
   refreshData: handleDataChanged,
@@ -32,15 +36,6 @@ export {
   handleImageItemEdit,
 };
 
-const getProjectErrorMessage = (result, fallbackMessage) => {
-  return (
-    result?.error?.message ||
-    result?.error?.creatorModelError?.message ||
-    result?.message ||
-    fallbackMessage
-  );
-};
-
 const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
   const { appService, projectService } = deps;
   let successfulUploads;
@@ -48,9 +43,10 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
   try {
     successfulUploads = await projectService.uploadFiles(files);
   } catch (error) {
-    console.error("Failed to upload images:", error);
-    appService.showToast(error?.message || "Failed to upload images.", {
-      title: "Error",
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload images.",
     });
     return;
   }
@@ -74,20 +70,19 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
       width: result.dimensions.width,
       height: result.dimensions.height,
     };
-    const createResult = await projectService.createImage({
-      imageId: nanoid(),
-      fileRecords: result.fileRecords,
-      data: imageData,
-      parentId,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create image.",
+      action: () =>
+        projectService.createImage({
+          imageId: nanoid(),
+          fileRecords: result.fileRecords,
+          data: imageData,
+          parentId,
+          position: "last",
+        }),
     });
-
-    if (createResult?.valid === false) {
-      console.error("Failed to create image:", createResult);
-      appService.showToast(
-        getProjectErrorMessage(createResult, "Failed to create image."),
-        { title: "Error" },
-      );
+    if (!createAttempt.ok) {
       return;
     }
   }
@@ -105,8 +100,12 @@ export const handleUploadClick = async (deps, payload) => {
       accept: ".jpg,.jpeg,.png,.webp",
       multiple: true,
     });
-  } catch {
-    appService.showToast("Failed to select files.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select files.",
+    });
     return;
   }
 
@@ -146,9 +145,10 @@ export const handleFormExtraEvent = async (deps) => {
       upload: true,
     });
   } catch (error) {
-    console.error("Failed to select image file:", error);
-    appService.showToast(error?.message || "Failed to select file.", {
-      title: "Error",
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select file.",
     });
     return;
   }
@@ -164,26 +164,25 @@ export const handleFormExtraEvent = async (deps) => {
   }
 
   const uploadResult = file.uploadResult;
-  const updateResult = await projectService.updateImage({
-    imageId: selectedItem.id,
-    fileRecords: uploadResult.fileRecords,
-    data: {
-      fileId: uploadResult.fileId,
-      thumbnailFileId: uploadResult.thumbnailFileId,
-      name: uploadResult.displayName,
-      fileType: uploadResult.file.type,
-      fileSize: uploadResult.file.size,
-      width: uploadResult.dimensions.width,
-      height: uploadResult.dimensions.height,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update image.",
+    action: () =>
+      projectService.updateImage({
+        imageId: selectedItem.id,
+        fileRecords: uploadResult.fileRecords,
+        data: {
+          fileId: uploadResult.fileId,
+          thumbnailFileId: uploadResult.thumbnailFileId,
+          name: uploadResult.displayName,
+          fileType: uploadResult.file.type,
+          fileSize: uploadResult.file.size,
+          width: uploadResult.dimensions.width,
+          height: uploadResult.dimensions.height,
+        },
+      }),
   });
-
-  if (updateResult?.valid === false) {
-    console.error("Failed to update image:", updateResult);
-    appService.showToast(
-      getProjectErrorMessage(updateResult, "Failed to update image."),
-      { title: "Error" },
-    );
+  if (!updateAttempt.ok) {
     return;
   }
 
@@ -214,9 +213,10 @@ export const handleEditDialogImageClick = async (deps) => {
       upload: true,
     });
   } catch (error) {
-    console.error("Failed to select image file:", error);
-    appService.showToast(error?.message || "Failed to select file.", {
-      title: "Error",
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select file.",
     });
     return;
   }
@@ -271,22 +271,22 @@ export const handleEditFormAction = async (deps, payload) => {
       }
     : {};
 
-  const updateResult = await projectService.updateImage({
-    imageId: editItemId,
-    fileRecords: editUploadResult?.fileRecords,
-    data: {
-      name,
-      description: values?.description ?? "",
-      ...imagePatch,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update image.",
+    action: () =>
+      projectService.updateImage({
+        imageId: editItemId,
+        fileRecords: editUploadResult?.fileRecords,
+        data: {
+          name,
+          description: values?.description ?? "",
+          ...imagePatch,
+        },
+      }),
   });
 
-  if (updateResult?.valid === false) {
-    console.error("Failed to update image:", updateResult);
-    appService.showToast(
-      getProjectErrorMessage(updateResult, "Failed to update image."),
-      { title: "Error" },
-    );
+  if (!updateAttempt.ok) {
     return;
   }
 

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { createLayoutEditorPayload } from "../../internal/layoutEditorRoute.js";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
+import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import { createLayoutsFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
 
 const {
@@ -345,19 +346,21 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
     return;
   }
 
-  const createResult = await projectService.createLayoutItem({
-    layoutId: nanoid(),
-    name,
-    layoutType,
-    elements: createLayoutTemplate(layoutType),
-    parentId: store.getState().targetGroupId,
-    position: "last",
+  const createAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to create layout.",
+    action: () =>
+      projectService.createLayoutItem({
+        layoutId: nanoid(),
+        name,
+        layoutType,
+        elements: createLayoutTemplate(layoutType),
+        parentId: store.getState().targetGroupId,
+        position: "last",
+      }),
   });
 
-  if (createResult?.valid === false) {
-    appService.showToast("Failed to create layout", {
-      title: "Error",
-    });
+  if (!createAttempt.ok) {
     return;
   }
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -231,15 +231,6 @@ const flushSceneEditorDrafts = async (deps) => {
   return enqueueLatestSceneEditorPersistence({
     owner: deps.projectService,
     key: "draft-flush",
-    label: "draft-flush",
-    meta: () => {
-      const currentSession = store.selectEditorSession();
-      return {
-        sceneId: currentSession?.sceneId,
-        sectionId: currentSession?.sectionId,
-        dirtyCount: getSceneEditorSessionDirtyLines(currentSession).length,
-      };
-    },
     task: async () => {
       const session = store.selectEditorSession();
       const dirtyLines = getSceneEditorSessionDirtyLines(session);
@@ -256,24 +247,11 @@ const flushSceneEditorDrafts = async (deps) => {
         timestamp: flushStartedAt,
       });
       store.setDraftSavePendingSinceAt({ timestamp: 0 });
-      console.info("[sceneEditor][perf] draft-flush-start", {
-        sceneId: session?.sceneId,
-        sectionId: session?.sectionId,
-        dirtyLineIds: dirtyLines.map(({ lineId }) => lineId),
-        lineCount: snapshotLines.length,
-      });
 
       try {
         await deps.projectService.syncSectionLinesSnapshot({
           sectionId: session?.sectionId,
           lines: snapshotLines,
-        });
-
-        console.info("[sceneEditor][perf] draft-flush-end", {
-          sceneId: session?.sceneId,
-          sectionId: session?.sectionId,
-          totalMs: Number((nowMs() - flushStartedAt).toFixed(1)),
-          dirtyLineIds: dirtyLines.map(({ lineId }) => lineId),
         });
       } catch (error) {
         console.error("[sceneEditor] Failed to save scene changes", {
@@ -1281,14 +1259,6 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
     return;
   }
 
-  const opStartedAt = nowMs();
-  const opId = `delete-line:${lineId}:${Math.round(opStartedAt)}`;
-  console.info("[sceneEditor][perf] delete-line-start", {
-    opId,
-    lineId,
-    sectionId,
-  });
-
   const scene = store.selectScene();
   const section = scene?.sections?.find((item) => item.id === sectionId);
   const lines = Array.isArray(section?.lines) ? section.lines : [];
@@ -1316,17 +1286,7 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
   store.setEditorSession({ editorSession: sessionForStore });
   store.setSelectedLineId({ selectedLineId: nextSelectedLineId });
   render();
-  subject.dispatch("sceneEditor.renderCanvas", {
-    perfReason: "delete-line-shortcut",
-    perfOpId: opId,
-    perfDispatchTs: nowMs(),
-  });
-  console.info("[sceneEditor][perf] delete-line-optimistic", {
-    opId,
-    lineId,
-    nextSelectedLineId,
-    optimisticMs: Number((nowMs() - opStartedAt).toFixed(1)),
-  });
+  subject.dispatch("sceneEditor.renderCanvas", {});
 
   if (nextSelectedLineId) {
     focusLinesEditorContainer(deps.refs);
@@ -1339,13 +1299,6 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
   }
   scheduleSceneEditorDraftFlush(deps, {
     reason: "structure",
-  });
-  console.info("[sceneEditor][perf] delete-line-end", {
-    opId,
-    lineId,
-    nextSelectedLineId,
-    totalMs: Number((nowMs() - opStartedAt).toFixed(1)),
-    persisted: false,
   });
 };
 

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -2,15 +2,23 @@ import { nanoid } from "nanoid";
 import { filter, tap } from "rxjs";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
+import {
+  getResourcePageErrorMessage,
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const UNSUPPORTED_FORMAT_TITLE = "Unsupported Format";
 const UNSUPPORTED_FORMAT_MESSAGE =
   "The audio file format is not supported. Please use MP3, WAV, or OGG (Windows only) files.";
 
-const showUnsupportedFormatDialog = async (appService) => {
+const showUnsupportedFormatDialog = async (
+  appService,
+  message = UNSUPPORTED_FORMAT_MESSAGE,
+) => {
   await appService.showDialog({
     title: UNSUPPORTED_FORMAT_TITLE,
-    message: UNSUPPORTED_FORMAT_MESSAGE,
+    message,
     confirmText: "OK",
   });
 };
@@ -23,8 +31,8 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
       accept: ".mp3,.wav,.ogg",
       multiple: false,
     });
-  } catch {
-    return { error: "pick-failed" };
+  } catch (error) {
+    return { error, errorType: "pick-failed" };
   }
 
   if (!file) {
@@ -34,8 +42,8 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
   let uploadedFiles;
   try {
     uploadedFiles = await projectService.uploadFiles([file]);
-  } catch {
-    return { error: "unsupported-format" };
+  } catch (error) {
+    return { error, errorType: "upload-failed" };
   }
 
   const uploadResult = uploadedFiles?.[0];
@@ -52,8 +60,11 @@ const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
 
   try {
     successfulUploads = await projectService.uploadFiles(files);
-  } catch {
-    await showUnsupportedFormatDialog(appService);
+  } catch (error) {
+    await showUnsupportedFormatDialog(
+      appService,
+      getResourcePageErrorMessage(error, UNSUPPORTED_FORMAT_MESSAGE),
+    );
     return;
   }
 
@@ -63,22 +74,31 @@ const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
   }
 
   for (const result of successfulUploads) {
-    await projectService.createSound({
-      soundId: nanoid(),
-      fileRecords: result.fileRecords,
-      data: {
-        type: "sound",
-        fileId: result.fileId,
-        name: result.displayName,
-        description: "",
-        fileType: result.file.type,
-        fileSize: result.file.size,
-        waveformDataFileId: result.waveformDataFileId,
-        duration: result.duration,
-      },
-      parentId,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create sound.",
+      action: () =>
+        projectService.createSound({
+          soundId: nanoid(),
+          fileRecords: result.fileRecords,
+          data: {
+            type: "sound",
+            fileId: result.fileId,
+            name: result.displayName,
+            description: "",
+            fileType: result.file.type,
+            fileSize: result.file.size,
+            waveformDataFileId: result.waveformDataFileId,
+            duration: result.duration,
+          },
+          parentId,
+          position: "last",
+        }),
     });
+
+    if (!createAttempt.ok) {
+      return;
+    }
   }
 
   await handleDataChanged(deps);
@@ -185,8 +205,12 @@ export const handleUploadClick = async (deps, payload) => {
       accept: ".mp3,.wav,.ogg",
       multiple: true,
     });
-  } catch {
-    appService.showToast("Failed to select files.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select files.",
+    });
     return;
   }
 
@@ -223,33 +247,44 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  if (result.error === "pick-failed") {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  if (result.errorType === "pick-failed") {
+    showResourcePageError({
+      appService,
+      errorOrResult: result.error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
-  if (result.error === "unsupported-format") {
-    await showUnsupportedFormatDialog(appService);
-    return;
-  }
-
-  if (result.error) {
-    appService.showToast("Failed to upload sound.", { title: "Error" });
+  if (result.errorType === "upload-failed") {
+    await showUnsupportedFormatDialog(
+      appService,
+      getResourcePageErrorMessage(result.error, UNSUPPORTED_FORMAT_MESSAGE),
+    );
     return;
   }
 
   const { uploadResult } = result;
-  await projectService.updateSound({
-    soundId: selectedItem.id,
-    fileRecords: uploadResult.fileRecords,
-    data: {
-      fileId: uploadResult.fileId,
-      fileType: uploadResult.file.type,
-      fileSize: uploadResult.file.size,
-      waveformDataFileId: uploadResult.waveformDataFileId,
-      duration: uploadResult.duration,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update sound.",
+    action: () =>
+      projectService.updateSound({
+        soundId: selectedItem.id,
+        fileRecords: uploadResult.fileRecords,
+        data: {
+          fileId: uploadResult.fileId,
+          fileType: uploadResult.file.type,
+          fileSize: uploadResult.file.size,
+          waveformDataFileId: uploadResult.waveformDataFileId,
+          duration: uploadResult.duration,
+        },
+      }),
   });
+
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   await handleDataChanged(deps);
 };
@@ -268,18 +303,20 @@ export const handleEditDialogSoundClick = async (deps) => {
     return;
   }
 
-  if (result.error === "pick-failed") {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  if (result.errorType === "pick-failed") {
+    showResourcePageError({
+      appService,
+      errorOrResult: result.error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
-  if (result.error === "unsupported-format") {
-    await showUnsupportedFormatDialog(appService);
-    return;
-  }
-
-  if (result.error) {
-    appService.showToast("Failed to upload sound.", { title: "Error" });
+  if (result.errorType === "upload-failed") {
+    await showUnsupportedFormatDialog(
+      appService,
+      getResourcePageErrorMessage(result.error, UNSUPPORTED_FORMAT_MESSAGE),
+    );
     return;
   }
 
@@ -320,15 +357,24 @@ export const handleEditFormAction = async (deps, payload) => {
       }
     : {};
 
-  await projectService.updateSound({
-    soundId: editItemId,
-    fileRecords: editUploadResult?.fileRecords,
-    data: {
-      name,
-      description: values?.description ?? "",
-      ...soundPatch,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update sound.",
+    action: () =>
+      projectService.updateSound({
+        soundId: editItemId,
+        fileRecords: editUploadResult?.fileRecords,
+        data: {
+          name,
+          description: values?.description ?? "",
+          ...soundPatch,
+        },
+      }),
   });
+
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   store.closeEditDialog();
   await handleDataChanged(deps);

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -7,6 +7,10 @@ import {
 import { getFileType } from "../../internal/fileTypes.js";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createResourceFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import {
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import { tap } from "rxjs";
 
@@ -110,34 +114,35 @@ const handleTextStyleCreated = async (deps, payload) => {
     previewText,
   } = payload._event.detail;
 
-  const createResult = await projectService.createTextStyle({
-    textStyleId: nanoid(),
-    data: {
-      type: "textStyle",
-      ...buildTextStyleData({
-        name,
-        fontSize,
-        lineHeight,
-        fontColor,
-        fontStyle,
-        fontWeight,
-        previewText,
+  const createAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to create text style.",
+    action: () =>
+      projectService.createTextStyle({
+        textStyleId: nanoid(),
+        data: {
+          type: "textStyle",
+          ...buildTextStyleData({
+            name,
+            fontSize,
+            lineHeight,
+            fontColor,
+            fontStyle,
+            fontWeight,
+            previewText,
+          }),
+        },
+        parentId: groupId,
+        position: "last",
       }),
-    },
-    parentId: groupId,
-    position: "last",
   });
 
-  if (createResult?.valid === false) {
-    console.error("Failed to create text style:", createResult.error);
-    appService.showToast("Failed to create text style.", {
-      title: "Error",
-    });
-    return createResult;
+  if (!createAttempt.ok) {
+    return createAttempt.result ?? { valid: false };
   }
 
   await refreshTextStylesData(deps);
-  return createResult;
+  return createAttempt.result;
 };
 
 const handleTextStyleUpdated = async (deps, payload) => {
@@ -153,29 +158,30 @@ const handleTextStyleUpdated = async (deps, payload) => {
     previewText,
   } = payload._event.detail;
 
-  const updateResult = await projectService.updateTextStyle({
-    textStyleId: itemId,
-    data: buildTextStyleData({
-      name,
-      fontSize,
-      lineHeight,
-      fontColor,
-      fontStyle,
-      fontWeight,
-      previewText,
-    }),
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update text style.",
+    action: () =>
+      projectService.updateTextStyle({
+        textStyleId: itemId,
+        data: buildTextStyleData({
+          name,
+          fontSize,
+          lineHeight,
+          fontColor,
+          fontStyle,
+          fontWeight,
+          previewText,
+        }),
+      }),
   });
 
-  if (updateResult?.valid === false) {
-    console.error("Failed to update text style:", updateResult.error);
-    appService.showToast("Failed to update text style.", {
-      title: "Error",
-    });
-    return updateResult;
+  if (!updateAttempt.ok) {
+    return updateAttempt.result ?? { valid: false };
   }
 
   await refreshTextStylesData(deps);
-  return updateResult;
+  return updateAttempt.result;
 };
 
 export const handleFormExtraEvent = (deps) => {
@@ -359,23 +365,32 @@ export const handleAddColorDialogClose = (deps) => {
 };
 
 export const handleAddColorFormAction = async (deps, payload) => {
-  const { store, render, projectService } = deps;
+  const { appService, store, render, projectService } = deps;
 
   if (payload._event.detail.actionId === "submit") {
     const formData = payload._event.detail.values;
     const newColorId = nanoid();
 
     // Create the color in the repository
-    await projectService.createColor({
-      colorId: newColorId,
-      data: {
-        type: "color",
-        name: formData.name,
-        hex: formData.hex,
-      },
-      parentId: formData.folderId || null,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create color.",
+      action: () =>
+        projectService.createColor({
+          colorId: newColorId,
+          data: {
+            type: "color",
+            name: formData.name,
+            hex: formData.hex,
+          },
+          parentId: formData.folderId || null,
+          position: "last",
+        }),
     });
+
+    if (!createAttempt.ok) {
+      return;
+    }
 
     // Sync repository to store to ensure all data is updated
     syncRepositoryToStore({ store, projectService });
@@ -410,7 +425,11 @@ export const handleFontFileSelected = async (deps, payload) => {
       const uploadResults = await projectService.uploadFiles([file]);
 
       if (uploadResults.length === 0) {
-        appService.showToast("Failed to upload font file", { title: "Error" });
+        showResourcePageError({
+          appService,
+          errorOrResult: "Failed to upload font file.",
+          fallbackMessage: "Failed to upload font file.",
+        });
         return;
       }
 
@@ -422,8 +441,11 @@ export const handleFontFileSelected = async (deps, payload) => {
       });
       render();
     } catch (error) {
-      console.error("Failed to upload font file:", error);
-      appService.showToast("Failed to upload font file", { title: "Error" });
+      showResourcePageError({
+        appService,
+        errorOrResult: error,
+        fallbackMessage: "Failed to upload font file.",
+      });
     }
   }
 };
@@ -445,20 +467,29 @@ export const handleAddFontFormAction = async (deps, payload) => {
     const newFontId = nanoid();
 
     // Create the font in the repository using the already uploaded file
-    await projectService.createFont({
-      fontId: newFontId,
-      fileRecords: fontData.uploadResult.fileRecords,
-      data: {
-        type: "font",
-        name: fontName,
-        fontFamily: fontName,
-        fileId: fontData.uploadResult.fileId,
-        fileType: getFileType(fontData.uploadResult),
-        fileSize: fontData.file.size,
-      },
-      parentId: formData.folderId || null,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create font.",
+      action: () =>
+        projectService.createFont({
+          fontId: newFontId,
+          fileRecords: fontData.uploadResult.fileRecords,
+          data: {
+            type: "font",
+            name: fontName,
+            fontFamily: fontName,
+            fileId: fontData.uploadResult.fileId,
+            fileType: getFileType(fontData.uploadResult),
+            fileSize: fontData.file.size,
+          },
+          parentId: formData.folderId || null,
+          position: "last",
+        }),
     });
+
+    if (!createAttempt.ok) {
+      return;
+    }
 
     // Sync repository to store to ensure all data is updated
     syncRepositoryToStore({ store, projectService });

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
+import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const MARKER_SIZE = 30;
 const CANVAS_WIDTH = 1920;
@@ -206,20 +207,38 @@ export const handleTransformFormActionClick = async (deps, payload) => {
   const targetGroupId = store.selectTargetGroupId();
 
   if (editMode && editItemId) {
-    await projectService.updateTransform({
-      transformId: editItemId,
-      data: transformData,
+    const updateAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to update transform.",
+      action: () =>
+        projectService.updateTransform({
+          transformId: editItemId,
+          data: transformData,
+        }),
     });
+
+    if (!updateAttempt.ok) {
+      return;
+    }
   } else {
-    await projectService.createTransform({
-      transformId: nanoid(),
-      data: {
-        type: "transform",
-        ...transformData,
-      },
-      parentId: targetGroupId,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create transform.",
+      action: () =>
+        projectService.createTransform({
+          transformId: nanoid(),
+          data: {
+            type: "transform",
+            ...transformData,
+          },
+          parentId: targetGroupId,
+          position: "last",
+        }),
     });
+
+    if (!createAttempt.ok) {
+      return;
+    }
   }
 
   store.closeTransformFormDialog();

--- a/src/pages/variables/variables.handlers.js
+++ b/src/pages/variables/variables.handlers.js
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { createVariablesFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
+import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import { tap } from "rxjs";
 
 const EMPTY_TREE = { tree: [], items: {} };
@@ -123,7 +124,7 @@ export const handleVariableItemClick = (deps, payload) => {
 };
 
 export const handleVariableCreated = async (deps, payload) => {
-  const { projectService } = deps;
+  const { appService, projectService } = deps;
   const {
     groupId,
     name,
@@ -132,38 +133,56 @@ export const handleVariableCreated = async (deps, payload) => {
     default: defaultValue,
   } = payload._event.detail;
 
-  await projectService.createVariable({
-    variableId: nanoid(),
-    data: createVariableResourceData({
-      name,
-      scope,
-      type,
-      defaultValue,
-    }),
-    parentId: groupId,
-    position: "last",
+  const createAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to create variable.",
+    action: () =>
+      projectService.createVariable({
+        variableId: nanoid(),
+        data: createVariableResourceData({
+          name,
+          scope,
+          type,
+          defaultValue,
+        }),
+        parentId: groupId,
+        position: "last",
+      }),
   });
+
+  if (!createAttempt.ok) {
+    return;
+  }
 
   await refreshVariablesData(deps);
 };
 
 export const handleVariableUpdated = async (deps, payload) => {
-  const { store, projectService } = deps;
+  const { appService, store, projectService } = deps;
   const { itemId, name, scope, default: defaultValue } = payload._event.detail;
 
   if (!itemId) {
     return;
   }
 
-  await projectService.updateVariable({
-    variableId: itemId,
-    data: {
-      name,
-      scope,
-      default: defaultValue,
-      value: defaultValue,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update variable.",
+    action: () =>
+      projectService.updateVariable({
+        variableId: itemId,
+        data: {
+          name,
+          scope,
+          default: defaultValue,
+          value: defaultValue,
+        },
+      }),
   });
+
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   store.setSelectedItemId({ itemId });
 

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -1,6 +1,10 @@
 import { nanoid } from "nanoid";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
+import {
+  runResourcePageMutation,
+  showResourcePageError,
+} from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
   let file;
@@ -10,8 +14,8 @@ const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
       accept: ".mp4",
       multiple: false,
     });
-  } catch {
-    return { error: "pick-failed" };
+  } catch (error) {
+    return { error, errorType: "pick-failed" };
   }
 
   if (!file) {
@@ -21,8 +25,8 @@ const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
   let uploadedFiles;
   try {
     uploadedFiles = await projectService.uploadFiles([file]);
-  } catch {
-    return { error: "upload-failed" };
+  } catch (error) {
+    return { error, errorType: "upload-failed" };
   }
 
   const uploadResult = uploadedFiles?.[0];
@@ -39,8 +43,12 @@ const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
 
   try {
     successfulUploads = await projectService.uploadFiles(files);
-  } catch {
-    appService.showToast("Failed to upload video.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to upload video.",
+    });
     return;
   }
 
@@ -50,23 +58,32 @@ const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
   }
 
   for (const result of successfulUploads) {
-    await projectService.createVideo({
-      videoId: nanoid(),
-      fileRecords: result.fileRecords,
-      data: {
-        type: "video",
-        fileId: result.fileId,
-        thumbnailFileId: result.thumbnailFileId,
-        name: result.displayName,
-        description: "",
-        fileType: result.file.type,
-        fileSize: result.file.size,
-        width: result.dimensions?.width,
-        height: result.dimensions?.height,
-      },
-      parentId,
-      position: "last",
+    const createAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to create video.",
+      action: () =>
+        projectService.createVideo({
+          videoId: nanoid(),
+          fileRecords: result.fileRecords,
+          data: {
+            type: "video",
+            fileId: result.fileId,
+            thumbnailFileId: result.thumbnailFileId,
+            name: result.displayName,
+            description: "",
+            fileType: result.file.type,
+            fileSize: result.file.size,
+            width: result.dimensions?.width,
+            height: result.dimensions?.height,
+          },
+          parentId,
+          position: "last",
+        }),
     });
+
+    if (!createAttempt.ok) {
+      return;
+    }
   }
 
   await handleDataChanged(deps);
@@ -138,8 +155,12 @@ export const handleUploadClick = async (deps, payload) => {
       accept: ".mp4",
       multiple: true,
     });
-  } catch {
-    appService.showToast("Failed to select files.", { title: "Error" });
+  } catch (error) {
+    showResourcePageError({
+      appService,
+      errorOrResult: error,
+      fallbackMessage: "Failed to select files.",
+    });
     return;
   }
 
@@ -176,30 +197,47 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
-  if (result.error === "pick-failed") {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  if (result.errorType === "pick-failed") {
+    showResourcePageError({
+      appService,
+      errorOrResult: result.error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
-  if (result.error) {
-    appService.showToast("Failed to upload video.", { title: "Error" });
+  if (result.errorType === "upload-failed") {
+    showResourcePageError({
+      appService,
+      errorOrResult: result.error,
+      fallbackMessage: "Failed to upload video.",
+    });
     return;
   }
 
   const { uploadResult } = result;
-  await projectService.updateVideo({
-    videoId: selectedItem.id,
-    fileRecords: uploadResult.fileRecords,
-    data: {
-      fileId: uploadResult.fileId,
-      thumbnailFileId: uploadResult.thumbnailFileId,
-      name: uploadResult.displayName,
-      fileType: uploadResult.file.type,
-      fileSize: uploadResult.file.size,
-      width: uploadResult.dimensions?.width,
-      height: uploadResult.dimensions?.height,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update video.",
+    action: () =>
+      projectService.updateVideo({
+        videoId: selectedItem.id,
+        fileRecords: uploadResult.fileRecords,
+        data: {
+          fileId: uploadResult.fileId,
+          thumbnailFileId: uploadResult.thumbnailFileId,
+          name: uploadResult.displayName,
+          fileType: uploadResult.file.type,
+          fileSize: uploadResult.file.size,
+          width: uploadResult.dimensions?.width,
+          height: uploadResult.dimensions?.height,
+        },
+      }),
   });
+
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   await handleDataChanged(deps);
 };
@@ -224,13 +262,21 @@ export const handleEditDialogVideoClick = async (deps) => {
     return;
   }
 
-  if (result.error === "pick-failed") {
-    appService.showToast("Failed to select file.", { title: "Error" });
+  if (result.errorType === "pick-failed") {
+    showResourcePageError({
+      appService,
+      errorOrResult: result.error,
+      fallbackMessage: "Failed to select file.",
+    });
     return;
   }
 
-  if (result.error) {
-    appService.showToast("Failed to upload video.", { title: "Error" });
+  if (result.errorType === "upload-failed") {
+    showResourcePageError({
+      appService,
+      errorOrResult: result.error,
+      fallbackMessage: "Failed to upload video.",
+    });
     return;
   }
 
@@ -272,15 +318,24 @@ export const handleEditFormAction = async (deps, payload) => {
       }
     : {};
 
-  await projectService.updateVideo({
-    videoId: editItemId,
-    fileRecords: editUploadResult?.fileRecords,
-    data: {
-      name,
-      description: values?.description ?? "",
-      ...videoPatch,
-    },
+  const updateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to update video.",
+    action: () =>
+      projectService.updateVideo({
+        videoId: editItemId,
+        fileRecords: editUploadResult?.fileRecords,
+        data: {
+          name,
+          description: values?.description ?? "",
+          ...videoPatch,
+        },
+      }),
   });
+
+  if (!updateAttempt.ok) {
+    return;
+  }
 
   store.closeEditDialog();
   await handleDataChanged(deps);


### PR DESCRIPTION
## Summary
- remove the temporary scene editor perf/debug logging added during sync and persistence investigation
- keep the scene editor persistence and batching behavior intact while stripping debug-only payload plumbing

## Validation
- `bunx oxlint src/pages/sceneEditor/sceneEditor.handlers.js src/internal/ui/sceneEditor/persistenceQueue.js src/internal/ui/sceneEditor/runtime.js src/components/linesEditor/linesEditor.handlers.js src/deps/services/shared/projectRepository.js src/deps/services/shared/projectRepositoryRuntime.js src/deps/services/shared/commandApi/shared.js src/deps/services/shared/commandApi/story.js`
- `bun prettier --check src/pages/sceneEditor/sceneEditor.handlers.js src/internal/ui/sceneEditor/persistenceQueue.js src/internal/ui/sceneEditor/runtime.js src/components/linesEditor/linesEditor.handlers.js src/deps/services/shared/projectRepository.js src/deps/services/shared/projectRepositoryRuntime.js src/deps/services/shared/commandApi/shared.js src/deps/services/shared/commandApi/story.js`
- `bun run test:smoke`
