### PR TITLE
fix: scenes, layouts, and whiteboard follow-ups

### DIFF
--- a/src/components/commandLineChoices/commandLineChoices.handlers.js
+++ b/src/components/commandLineChoices/commandLineChoices.handlers.js
@@ -1,8 +1,26 @@
+const resolveSelectedResourceId = ({ layouts, resourceId } = {}) => {
+  const availableLayouts = (layouts ?? []).filter(
+    (layout) => layout.layoutType === "choice",
+  );
+
+  if (
+    resourceId &&
+    availableLayouts.some((layout) => layout.id === resourceId)
+  ) {
+    return resourceId;
+  }
+
+  return availableLayouts[0]?.id ?? "";
+};
+
 export const handleBeforeMount = (deps) => {
   const { store, props } = deps;
   store.setItems({ items: props.choice?.items || [] });
   store.setSelectedResourceId({
-    resourceId: props.choice?.resourceId,
+    resourceId: resolveSelectedResourceId({
+      layouts: props.layouts,
+      resourceId: props.choice?.resourceId,
+    }),
   });
 };
 
@@ -134,9 +152,12 @@ export const handleChoiceItemClick = (deps) => {
 };
 
 export const handleSubmitClick = (deps) => {
-  const { dispatchEvent, store, appService } = deps;
+  const { dispatchEvent, store, appService, props } = deps;
   const items = store.selectItems();
-  const selectedResourceId = store.selectSelectedResourceId();
+  const selectedResourceId = resolveSelectedResourceId({
+    layouts: props.layouts,
+    resourceId: store.selectSelectedResourceId(),
+  });
 
   if (!selectedResourceId) {
     appService.showToast("Please select a choice layout", {

--- a/src/components/commandLineChoices/commandLineChoices.store.js
+++ b/src/components/commandLineChoices/commandLineChoices.store.js
@@ -37,6 +37,30 @@ const CHOICE_FORM_TEMPLATE = Object.freeze({
   ],
 });
 
+const getChoiceLayoutOptions = (layouts = []) => {
+  return layouts
+    .filter((layout) => layout.layoutType === "choice")
+    .map((layout) => ({
+      value: layout?.id || "",
+      label: layout?.name || "",
+    }));
+};
+
+const resolveSelectedResourceId = ({ layouts, resourceId } = {}) => {
+  const resourceOptions = getChoiceLayoutOptions(layouts);
+
+  if (
+    resourceId &&
+    resourceOptions.some(
+      (resourceOption) => resourceOption.value === resourceId,
+    )
+  ) {
+    return resourceId;
+  }
+
+  return resourceOptions[0]?.value ?? "";
+};
+
 export const createInitialState = () => ({
   mode: "list", // "list" or "editChoice"
   items: [
@@ -203,6 +227,7 @@ const form = {
       type: "select",
       label: "Choices Layout",
       required: false,
+      clearable: false,
       options: "${resourceOptions}",
     },
     {
@@ -239,12 +264,11 @@ export const selectViewData = ({ state, props }) => {
     });
   }
 
-  const resourceOptions = layouts
-    .filter((layout) => layout.layoutType === "choice")
-    .map((layout) => ({
-      value: layout?.id || "",
-      label: layout?.name || "",
-    }));
+  const resourceOptions = getChoiceLayoutOptions(layouts);
+  const selectedResourceId = resolveSelectedResourceId({
+    layouts,
+    resourceId: state.selectedResourceId,
+  });
 
   const actionTypeOptions = [
     { value: "continue", label: "Continue (Do Nothing)" },
@@ -302,7 +326,7 @@ export const selectViewData = ({ state, props }) => {
 
   // Create defaultValues with items data
   const defaultValues = {
-    resourceId: state?.selectedResourceId,
+    resourceId: selectedResourceId,
     items: processedItems,
     content: state?.editForm?.content || "",
     actionType: state?.editForm?.actionType,
@@ -314,7 +338,7 @@ export const selectViewData = ({ state, props }) => {
     mode: state?.mode || "list",
     items: processedItems,
     layouts: resourceOptions,
-    selectedResourceId: state?.selectedResourceId || "",
+    selectedResourceId,
     editingIndex: state?.editingIndex ?? -1,
     editForm: state?.editForm,
     editFormContext,

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -6,24 +6,53 @@ const getLayoutTypeByMode = (mode) => {
   return mode === "nvl" ? "nvl" : "dialogue";
 };
 
+const resolveSelectedResourceId = ({ layouts, mode, resourceId } = {}) => {
+  const selectedLayoutType = getLayoutTypeByMode(mode);
+  const availableLayouts = (layouts ?? []).filter(
+    (layout) => layout.layoutType === selectedLayoutType,
+  );
+
+  if (
+    resourceId &&
+    availableLayouts.some((layout) => layout.id === resourceId)
+  ) {
+    return resourceId;
+  }
+
+  return availableLayouts[0]?.id ?? "";
+};
+
+const syncDialogueFormValues = (deps) => {
+  const { refs, store } = deps;
+  const { selectedMode, selectedResourceId, selectedCharacterId, clearPage } =
+    store.getState();
+
+  refs.dialogueForm.reset();
+  refs.dialogueForm.setValues({
+    values: {
+      mode: selectedMode,
+      resourceId: selectedResourceId,
+      characterId: selectedCharacterId,
+      clearPage,
+    },
+  });
+};
+
 export const handleBeforeMount = (deps) => {
   const { store, props } = deps;
   const selectedMode = props?.dialogue?.mode || "adv";
-  const selectedLayoutType = getLayoutTypeByMode(selectedMode);
   const selectedResourceId =
     props?.dialogue?.ui?.resourceId || props?.dialogue?.gui?.resourceId || "";
-  const selectedLayout = (props?.layouts || []).find(
-    (layout) => layout.id === selectedResourceId,
-  );
 
   store.setSelectedMode({
     mode: selectedMode,
   });
   store.setSelectedResource({
-    resourceId:
-      selectedLayout?.layoutType === selectedLayoutType
-        ? selectedResourceId
-        : "",
+    resourceId: resolveSelectedResourceId({
+      layouts: props?.layouts,
+      mode: selectedMode,
+      resourceId: selectedResourceId,
+    }),
   });
   store.setSelectedCharacterId({
     characterId: props?.dialogue?.characterId || "",
@@ -32,6 +61,10 @@ export const handleBeforeMount = (deps) => {
   store.setClearPage({
     clearPage: props?.dialogue?.clearPage === true,
   });
+};
+
+export const handleAfterMount = (deps) => {
+  syncDialogueFormValues(deps);
 };
 
 export const handleFormChange = (deps, payload) => {
@@ -43,35 +76,39 @@ export const handleFormChange = (deps, payload) => {
   }
 
   const selectedMode = formValues.mode === "nvl" ? "nvl" : "adv";
-  const selectedLayoutType = getLayoutTypeByMode(selectedMode);
-  const selectedResourceId = formValues.resourceId || "";
-  const selectedLayout = (props?.layouts || []).find(
-    (layout) => layout.id === selectedResourceId,
-  );
+  const modeChanged = selectedMode !== store.getState().selectedMode;
 
   store.setSelectedMode({ mode: selectedMode });
   store.setSelectedResource({
-    resourceId:
-      selectedLayout?.layoutType === selectedLayoutType
-        ? selectedResourceId
-        : "",
+    resourceId: resolveSelectedResourceId({
+      layouts: props?.layouts,
+      mode: selectedMode,
+      resourceId: formValues.resourceId || "",
+    }),
   });
   store.setSelectedCharacterId({ characterId: formValues.characterId || "" });
   store.setClearPage({ clearPage: formValues.clearPage });
 
   render();
+
+  if (modeChanged) {
+    syncDialogueFormValues(deps);
+  }
 };
 
 export const handleSubmitClick = (deps) => {
   const { store, dispatchEvent, props } = deps;
   const { selectedMode, selectedResourceId, selectedCharacterId, clearPage } =
     store.getState();
-  const selectedLayoutType = getLayoutTypeByMode(selectedMode);
-  const availableLayouts = (props?.layouts || []).filter(
-    (layout) => layout.layoutType === selectedLayoutType,
-  );
-  const effectiveResourceId =
-    selectedResourceId || availableLayouts[0]?.id || "";
+  const effectiveResourceId = resolveSelectedResourceId({
+    layouts: props?.layouts,
+    mode: selectedMode,
+    resourceId: selectedResourceId,
+  });
+
+  if (!effectiveResourceId) {
+    return;
+  }
 
   // Create dialogue object with only non-empty values
   const dialogue = {

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -2,6 +2,27 @@ const getLayoutTypeByMode = (mode) => {
   return mode === "nvl" ? "nvl" : "dialogue";
 };
 
+const getLayoutOptions = ({ layouts, mode } = {}) => {
+  const layoutType = getLayoutTypeByMode(mode);
+  return (layouts ?? [])
+    .filter((layout) => layout.layoutType === layoutType)
+    .map((layout) => ({
+      value: layout.id,
+      label: layout.name,
+    }));
+};
+
+const resolveSelectedResourceId = ({ layoutOptions, resourceId } = {}) => {
+  if (
+    resourceId &&
+    layoutOptions.some((layoutOption) => layoutOption.value === resourceId)
+  ) {
+    return resourceId;
+  }
+
+  return layoutOptions[0]?.value ?? "";
+};
+
 const toBoolean = (value) => {
   return value === true || value === "true";
 };
@@ -28,7 +49,8 @@ export const createInitialState = () => ({
         type: "select",
         label: "Dialogue Mode",
         description: "",
-        required: false,
+        required: true,
+        clearable: false,
         options: [
           { value: "adv", label: "ADV" },
           { value: "nvl", label: "NVL" },
@@ -39,7 +61,8 @@ export const createInitialState = () => ({
         type: "select",
         label: "Dialogue Layout",
         description: "",
-        required: false,
+        required: true,
+        clearable: false,
         placeholder: "Choose a layout...",
         options: [],
       },
@@ -58,7 +81,8 @@ export const createInitialState = () => ({
         type: "select",
         label: "Clear Page",
         description: "",
-        required: false,
+        required: true,
+        clearable: false,
         options: [
           { value: false, label: "No" },
           { value: true, label: "Yes" },
@@ -102,20 +126,14 @@ export const selectViewData = ({ state, props }) => {
   const layouts = props.layouts || [];
   const characters = props.characters || [];
   const selectedMode = state.selectedMode || "adv";
-  const layoutType = getLayoutTypeByMode(selectedMode);
-
-  const layoutOptions = layouts
-    .filter((layout) => layout.layoutType === layoutType)
-    .map((layout) => ({
-      value: layout.id,
-      label: layout.name,
-    }));
-
-  const selectedResourceId = layoutOptions.some(
-    (layoutOption) => layoutOption.value === state.selectedResourceId,
-  )
-    ? state.selectedResourceId
-    : "";
+  const layoutOptions = getLayoutOptions({
+    layouts,
+    mode: selectedMode,
+  });
+  const selectedResourceId = resolveSelectedResourceId({
+    layoutOptions,
+    resourceId: state.selectedResourceId,
+  });
 
   const characterOptions = characters
     .filter((character) => character.type === "character")
@@ -189,7 +207,7 @@ export const selectViewData = ({ state, props }) => {
     selectedCharacterId: state.selectedCharacterId,
     selectedMode,
     clearPage: state.clearPage,
-    submitDisabled: false,
+    submitDisabled: !selectedResourceId,
     breadcrumb,
     form,
     defaultValues,

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -17,4 +17,4 @@ template:
       - rtgl-form#dialogueForm :defaultValues=defaultValues :form=form :context=context w=f: null
       - rtgl-view h=1fg: null
       - rtgl-view d=h av=c ah=e w=f g=lg:
-          - rtgl-button#submitButton: Submit
+          - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit

--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -1,4 +1,4 @@
-import { fromEvent, tap } from "rxjs";
+import { fromEvent, merge, tap } from "rxjs";
 import {
   SCENE_BOX_HEIGHT,
   SCENE_BOX_WIDTH,
@@ -23,6 +23,18 @@ const syncContainerSize = ({ store, refs } = {}) => {
   return true;
 };
 
+const normalizeCursorValue = (cursor) => {
+  if (!cursor) {
+    return undefined;
+  }
+
+  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
+    return cursor;
+  }
+
+  return CSS.supports("cursor", cursor) ? cursor : undefined;
+};
+
 const syncCursorStyles = ({ store, refs, props } = {}) => {
   const container = refs?.container;
   if (!container) {
@@ -32,7 +44,7 @@ const syncCursorStyles = ({ store, refs, props } = {}) => {
   const isPanMode = store.selectIsPanMode();
   const isPanning = store.selectIsPanning();
   const panCursor = isPanning ? "grabbing" : isPanMode ? "grab" : undefined;
-  const overrideCursor = props?.cursor;
+  const overrideCursor = normalizeCursorValue(props?.cursor);
   const containerCursor = panCursor || overrideCursor || "default";
   const itemCursor = panCursor || overrideCursor || "move";
 
@@ -54,6 +66,34 @@ const syncCursorStyles = ({ store, refs, props } = {}) => {
 const renderWithCursorSync = (deps) => {
   deps.render();
   syncCursorStyles(deps);
+};
+
+const getActiveElement = (root = document) => {
+  let active = root?.activeElement;
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement;
+  }
+  return active;
+};
+
+const isTextEntryFocused = () => {
+  const active = getActiveElement(document);
+  if (!active) {
+    return false;
+  }
+
+  if (active instanceof HTMLElement && active.isContentEditable) {
+    return true;
+  }
+
+  const tagName = active.tagName;
+  return ["INPUT", "TEXTAREA", "SELECT"].includes(tagName);
+};
+
+const isSpaceKey = (event) => {
+  const key = String(event?.key || "");
+  const code = String(event?.code || "");
+  return code === "Space" || key === " " || key === "Spacebar";
 };
 
 const dispatchPanChanged = ({ store, dispatchEvent } = {}) => {
@@ -130,8 +170,8 @@ export const handleContainerContextMenu = (deps, payload) => {
 
 export const handlePanButtonClick = (deps) => {
   const { store } = deps;
-  const isPanMode = store.selectIsPanMode();
-  store.togglePanMode({ isPanMode: !isPanMode });
+  const isPanMode = store.selectIsPinnedPanMode();
+  store.setPinnedPanMode({ isPanMode: !isPanMode });
   renderWithCursorSync(deps);
 };
 
@@ -484,34 +524,67 @@ export const handleWindowMouseUp = (deps) => {
 
 // Keyboard event handlers
 export const handleWindowKeyDown = (deps, payload) => {
-  const { store, appService } = deps;
+  const { store } = deps;
+  const isTextFocused = isTextEntryFocused();
 
-  if (appService.isInputFocused()) {
+  if (isTextFocused) {
     return;
   }
 
-  if (payload._event.code === "Space" && !store.selectIsPanMode()) {
+  if (isSpaceKey(payload._event) && !store.selectIsKeyboardPanMode()) {
     payload._event.preventDefault();
-    store.togglePanMode({ isPanMode: true });
+    store.setKeyboardPanMode({ isPanMode: true });
     renderWithCursorSync(deps);
   }
 };
 
 export const handleWindowKeyUp = (deps, payload) => {
-  const { store, appService } = deps;
+  const { store } = deps;
+  const isTextFocused = isTextEntryFocused();
 
-  if (appService.isInputFocused()) {
+  if (isTextFocused && !store.selectIsKeyboardPanMode()) {
     return;
   }
 
-  if (payload._event.code === "Space" && store.selectIsPanMode()) {
+  if (isSpaceKey(payload._event) && store.selectIsKeyboardPanMode()) {
     payload._event.preventDefault();
-    store.togglePanMode({ isPanMode: false });
+    store.setKeyboardPanMode({ isPanMode: false });
+    if (store.selectIsPanning()) {
+      store.stopPanning();
+    }
+    renderWithCursorSync(deps);
+  }
+};
+
+export const handleWindowBlur = (deps) => {
+  const { store } = deps;
+  let didChange = false;
+
+  if (store.selectIsKeyboardPanMode()) {
+    store.setKeyboardPanMode({ isPanMode: false });
+    didChange = true;
+  }
+
+  if (store.selectIsPanning()) {
+    store.stopPanning();
+    didChange = true;
+  }
+
+  if (didChange) {
     renderWithCursorSync(deps);
   }
 };
 
 const subscriptions = (deps) => {
+  const windowKeyDown$ = fromEvent(window, "keydown");
+  const documentKeyDown$ = fromEvent(document, "keydown", {
+    capture: true,
+  });
+  const windowKeyUp$ = fromEvent(window, "keyup");
+  const documentKeyUp$ = fromEvent(document, "keyup", {
+    capture: true,
+  });
+
   return [
     fromEvent(window, "resize").pipe(
       tap((event) => deps.handlers.handleWindowResize(deps, { _event: event })),
@@ -526,13 +599,16 @@ const subscriptions = (deps) => {
         deps.handlers.handleWindowMouseUp(deps, { _event: event }),
       ),
     ),
-    fromEvent(window, "keydown").pipe(
+    merge(windowKeyDown$, documentKeyDown$).pipe(
       tap((event) =>
         deps.handlers.handleWindowKeyDown(deps, { _event: event }),
       ),
     ),
-    fromEvent(window, "keyup").pipe(
+    merge(windowKeyUp$, documentKeyUp$).pipe(
       tap((event) => deps.handlers.handleWindowKeyUp(deps, { _event: event })),
+    ),
+    fromEvent(window, "blur").pipe(
+      tap((event) => deps.handlers.handleWindowBlur(deps, { _event: event })),
     ),
   ];
 };

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -49,7 +49,8 @@ export const createInitialState = () => ({
   lastDraggedPosition: undefined,
   hoveredItemId: undefined,
   // Pan state
-  isPanMode: false,
+  isPinnedPanMode: false,
+  isKeyboardPanMode: false,
   isPanning: false,
   panX: 0,
   panY: 0,
@@ -97,8 +98,12 @@ export const selectLastDraggedPosition = ({ state }) => {
 };
 
 // Pan functions
-export const togglePanMode = ({ state }, { isPanMode } = {}) => {
-  state.isPanMode = isPanMode;
+export const setPinnedPanMode = ({ state }, { isPanMode } = {}) => {
+  state.isPinnedPanMode = isPanMode;
+};
+
+export const setKeyboardPanMode = ({ state }, { isPanMode } = {}) => {
+  state.isKeyboardPanMode = isPanMode;
 };
 
 export const startPanning = ({ state }, { mouseX, mouseY } = {}) => {
@@ -181,7 +186,10 @@ export const setHoveredItemId = ({ state }, { itemId } = {}) => {
   state.hoveredItemId = itemId;
 };
 
-export const selectIsPanMode = ({ state }) => state.isPanMode;
+export const selectIsPanMode = ({ state }) =>
+  state.isPinnedPanMode || state.isKeyboardPanMode;
+export const selectIsPinnedPanMode = ({ state }) => state.isPinnedPanMode;
+export const selectIsKeyboardPanMode = ({ state }) => state.isKeyboardPanMode;
 export const selectIsPanning = ({ state }) => state.isPanning;
 export const selectPan = ({ state }) => ({
   x: state.panX,
@@ -208,6 +216,18 @@ export const setInitialZoomAndPan = (
 };
 
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const normalizeCursorValue = (cursor) => {
+  if (!cursor) {
+    return undefined;
+  }
+
+  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
+    return cursor;
+  }
+
+  return CSS.supports("cursor", cursor) ? cursor : undefined;
+};
 
 const generateMinimapData = (items, pan, zoomLevel, containerSize) => {
   if (!items || items.length === 0) {
@@ -313,8 +333,8 @@ export const selectViewData = ({ state, props }) => {
           : "sm",
   }));
 
-  const containerCursor = props.cursor;
-  const itemCursor = props.cursor || "move";
+  const containerCursor = normalizeCursorValue(props.cursor);
+  const itemCursor = normalizeCursorValue(props.cursor) || "move";
 
   // Calculate adaptive grid size for container background
   const getAdaptiveGridSize = (zoomLevel) => {
@@ -367,8 +387,8 @@ export const selectViewData = ({ state, props }) => {
     ),
     arrowsList,
     selectedItemId: props.selectedItemId,
-    isPanMode: state.isPanMode,
-    panModeV: state.isPanMode ? "pr" : "gh",
+    isPanMode: state.isPinnedPanMode || state.isKeyboardPanMode,
+    panModeV: state.isPinnedPanMode || state.isKeyboardPanMode ? "pr" : "gh",
     panX: state.panX,
     panY: state.panY,
     zoomLevel: state.zoomLevel,

--- a/src/internal/project/engineActions.js
+++ b/src/internal/project/engineActions.js
@@ -43,3 +43,30 @@ export const normalizeEngineActions = (value) => {
 
   return normalizedValue;
 };
+
+const flattenLegacyLineActions = (actions) => {
+  if (!actions || typeof actions !== "object" || Array.isArray(actions)) {
+    return actions;
+  }
+
+  const nestedActions = actions.actions;
+  if (
+    !nestedActions ||
+    typeof nestedActions !== "object" ||
+    Array.isArray(nestedActions)
+  ) {
+    return actions;
+  }
+
+  const flattenedActions = {
+    ...structuredClone(nestedActions),
+    ...actions,
+  };
+  delete flattenedActions.actions;
+
+  return flattenLegacyLineActions(flattenedActions);
+};
+
+export const normalizeLineActions = (value) => {
+  return flattenLegacyLineActions(normalizeEngineActions(value));
+};

--- a/src/internal/project/projection.js
+++ b/src/internal/project/projection.js
@@ -4,7 +4,7 @@ import {
   toRouteEngineKeyboardResource,
 } from "./layout.js";
 import { RESOURCE_TYPES } from "./commands.js";
-import { normalizeEngineActions } from "./engineActions.js";
+import { normalizeLineActions } from "./engineActions.js";
 import { getInteractionActions } from "./interactionPayload.js";
 import { toFlatItems, toHierarchyStructure } from "./tree.js";
 
@@ -433,7 +433,7 @@ export const projectRepositoryStateToDomainState = ({
         state.lines[lineId] = {
           id: lineId,
           sectionId,
-          actions: cloneOr(line?.actions, {}),
+          actions: normalizeLineActions(line?.actions || {}),
           createdAt: toFiniteTimestamp(line?.createdAt, DEFAULT_TIMESTAMP),
           updatedAt: toFiniteTimestamp(
             line?.updatedAt,
@@ -785,7 +785,7 @@ const constructStory = (scenes) => {
 
             transformedSection.lines.push({
               id: lineId,
-              actions: normalizeEngineActions(line.actions || {}),
+              actions: normalizeLineActions(line.actions || {}),
             });
           });
         }
@@ -843,6 +843,22 @@ const getTransitionsFromLayout = (layout) => {
     .filter(Boolean);
 };
 
+const resolveLayoutReference = ({ ref, layouts, controls }) => {
+  if (!ref?.resourceId) {
+    return undefined;
+  }
+
+  if (ref.resourceType === "control") {
+    return controls?.items?.[ref.resourceId];
+  }
+
+  if (ref.resourceType === "layout") {
+    return layouts?.items?.[ref.resourceId];
+  }
+
+  return layouts?.items?.[ref.resourceId] || controls?.items?.[ref.resourceId];
+};
+
 const toSectionLines = (section) => {
   if (Array.isArray(section?.lines)) {
     return section.lines;
@@ -870,17 +886,14 @@ export const getSectionPresentation = ({
   let returnsToMenuScene = false;
 
   lines.forEach((line) => {
-    const pushLayeredView =
-      line.actions?.pushLayeredView || line.actions?.actions?.pushLayeredView;
-    const popLayeredView =
-      line.actions?.popLayeredView || line.actions?.actions?.popLayeredView;
+    const lineActions = normalizeLineActions(line.actions || {});
+    const pushLayeredView = lineActions?.pushLayeredView;
+    const popLayeredView = lineActions?.popLayeredView;
     if (pushLayeredView || popLayeredView) {
       hasMenuReturnAction = true;
     }
 
-    const sectionTransition =
-      line.actions?.sectionTransition ||
-      line.actions?.actions?.sectionTransition;
+    const sectionTransition = lineActions?.sectionTransition;
     if (menuSceneId && sectionTransition?.sceneId === menuSceneId) {
       returnsToMenuScene = true;
     }
@@ -889,7 +902,7 @@ export const getSectionPresentation = ({
       transitions.add(sectionTransitionKey);
     }
 
-    const choice = line.actions?.choice || line.actions?.actions?.choice;
+    const choice = lineActions?.choice;
     const choiceItems = Array.isArray(choice?.items) ? choice.items : [];
     choiceCount += choiceItems.length;
 
@@ -905,23 +918,16 @@ export const getSectionPresentation = ({
       }
     });
 
-    const layoutRefs = [
-      line.actions?.background,
-      line.actions?.control,
-      line.actions?.actions?.background,
-      line.actions?.actions?.control,
-    ].filter((ref) => {
-      return (
-        ref?.resourceId &&
-        (ref.resourceType === "layout" || ref.resourceType === "control")
-      );
-    });
+    const layoutRefs = [lineActions?.background, lineActions?.control].filter(
+      (ref) => ref?.resourceId,
+    );
 
     layoutRefs.forEach((layoutRef) => {
-      const layout =
-        layoutRef.resourceType === "control"
-          ? controls?.items?.[layoutRef.resourceId]
-          : layouts?.items?.[layoutRef.resourceId];
+      const layout = resolveLayoutReference({
+        ref: layoutRef,
+        layouts,
+        controls,
+      });
       const layoutTransitions = getTransitionsFromLayout(layout);
 
       layoutTransitions.forEach((layoutTransition) => {
@@ -1207,14 +1213,23 @@ export const recursivelyCheckResource = ({ state, itemId, checkTargets }) => {
     const keys = RESOURCE_KEYS_MAP[targetName];
     if (!keys) continue;
 
-    const data = state[targetName];
-    if (!data) continue;
+    const targetData =
+      targetName === "scenes"
+        ? [
+            ["scenes", state.scenes],
+            ["sections", state.sections],
+            ["lines", state.lines],
+          ]
+        : [[targetName, state[targetName]]];
 
-    const usages = [];
-    checkNode(data, itemId, keys, usages);
+    for (const [usageTargetName, data] of targetData) {
+      if (!data) continue;
+      const usages = [];
+      checkNode(data, itemId, keys, usages);
 
-    if (usages.length > 0) {
-      inProps[targetName] = usages;
+      if (usages.length > 0) {
+        inProps[usageTargetName] = usages;
+      }
     }
   }
 

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -1,4 +1,5 @@
 import { toFlatItems } from "../../project/tree.js";
+import { normalizeLineActions } from "../../project/engineActions.js";
 
 const getLineChanges = (sectionLineChanges, lineId) => {
   const changesLines = sectionLineChanges?.lines || [];
@@ -111,8 +112,8 @@ const buildCharacterSpritePreview = (
 };
 
 const buildSectionTransitionPreview = (line, sceneLookups) => {
-  const transitionData =
-    line.actions?.sectionTransition || line.actions?.actions?.sectionTransition;
+  const lineActions = normalizeLineActions(line.actions || {});
+  const transitionData = lineActions?.sectionTransition;
   if (!transitionData) {
     return {
       sectionTransition: false,
@@ -145,7 +146,8 @@ const buildSectionTransitionPreview = (line, sceneLookups) => {
 };
 
 const buildChoicesPreview = (line) => {
-  const choicesData = line.actions?.choice || line.actions?.actions?.choice;
+  const lineActions = normalizeLineActions(line.actions || {});
+  const choicesData = lineActions?.choice;
   if (!choicesData?.items?.length) {
     return {
       hasChoices: false,
@@ -160,7 +162,8 @@ const buildChoicesPreview = (line) => {
 };
 
 const buildDialogueSpeakerPreview = (line, characterLookups) => {
-  const characterId = line.actions?.dialogue?.characterId;
+  const lineActions = normalizeLineActions(line.actions || {});
+  const characterId = lineActions?.dialogue?.characterId;
   if (!characterId) {
     return undefined;
   }
@@ -177,6 +180,7 @@ export const buildSceneEditorLineViewModels = ({
   const sceneLookups = buildSceneLookups(repositoryState);
 
   return (lines || []).map((line, index) => {
+    const lineActions = normalizeLineActions(line.actions || {});
     const changes = getLineChanges(sectionLineChanges, line.id);
     const transitionPreview = buildSectionTransitionPreview(line, sceneLookups);
     const choicesPreview = buildChoicesPreview(line);
@@ -204,9 +208,7 @@ export const buildSceneEditorLineViewModels = ({
       hasSfx: !!changes.sfx,
       sfxChangeType: changes.sfx?.changeType,
       hasSetNextLineConfig:
-        !!changes.setNextLineConfig ||
-        !!line.actions?.setNextLineConfig ||
-        !!line.actions?.actions?.setNextLineConfig,
+        !!changes.setNextLineConfig || !!lineActions?.setNextLineConfig,
       setNextLineConfigChangeType: changes.setNextLineConfig?.changeType,
       hasDialogueLayout: !!changes.dialogue,
       dialogueChangeType: changes.dialogue?.changeType,

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -327,6 +327,28 @@ const createLayoutTemplate = (layoutType) => {
   };
 };
 
+const protectedLayoutTypeLabels = {
+  dialogue: "Dialogue",
+  nvl: "NVL",
+  choice: "Choice",
+};
+
+const canDeleteLayoutItem = (layouts, itemId) => {
+  const items = Object.values(layouts?.items || {});
+  const item = layouts?.items?.[itemId];
+  const layoutType = item?.layoutType;
+
+  if (!protectedLayoutTypeLabels[layoutType]) {
+    return true;
+  }
+
+  const matchingCount = items.filter(
+    (layout) => layout?.layoutType === layoutType,
+  ).length;
+
+  return matchingCount > 1;
+};
+
 export const handleLayoutFormActionClick = async (deps, payload) => {
   const { store, projectService, appService } = deps;
   const { actionId, values } = payload._event.detail;
@@ -371,15 +393,25 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
 export const handleItemDelete = async (deps, payload) => {
   const { projectService, appService, render } = deps;
   const { itemId } = payload._event.detail;
+  const state = projectService.getState();
+  const layoutType = state.layouts?.items?.[itemId]?.layoutType;
 
   const usage = recursivelyCheckResource({
-    state: projectService.getState(),
+    state,
     itemId,
     checkTargets: ["scenes"],
   });
 
   if (usage.isUsed) {
     appService.showToast("Cannot delete resource, it is currently in use.");
+    render();
+    return;
+  }
+
+  if (!canDeleteLayoutItem(state.layouts, itemId)) {
+    appService.showToast(
+      `Cannot delete the last ${protectedLayoutTypeLabels[layoutType]} layout. At least one ${protectedLayoutTypeLabels[layoutType]} layout must remain.`,
+    );
     render();
     return;
   }

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -4,6 +4,7 @@ import {
   matchesRemoteTargets,
 } from "../../internal/ui/collabRefresh.js";
 import { createScenesFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import { normalizeLineActions } from "../../internal/project/engineActions.js";
 import { getInteractionActions } from "../../internal/project/interactionPayload.js";
 import {
   SCENE_BOX_HEIGHT,
@@ -45,6 +46,22 @@ const getTransitionsFromLayout = (layout) => {
     }
   }
   return transitions;
+};
+
+const resolveLayoutReference = ({ ref, layouts, controls }) => {
+  if (!ref?.resourceId) {
+    return undefined;
+  }
+
+  if (ref.resourceType === "control") {
+    return controls?.items?.[ref.resourceId];
+  }
+
+  if (ref.resourceType === "layout") {
+    return layouts?.items?.[ref.resourceId];
+  }
+
+  return layouts?.items?.[ref.resourceId] || controls?.items?.[ref.resourceId];
 };
 
 /**
@@ -90,10 +107,9 @@ const getTransitionsForScene = (sections, layouts, controls) => {
     if (section.lines && section.lines.items) {
       // Iterate through all lines in this section
       for (const line of Object.values(section.lines.items)) {
+        const lineActions = normalizeLineActions(line.actions || {});
         // Check for sectionTransition in actions
-        const sectionTransition =
-          line.actions?.sectionTransition ||
-          line.actions?.actions?.sectionTransition;
+        const sectionTransition = lineActions?.sectionTransition;
         if (
           sectionTransition &&
           sectionTransition.sceneId &&
@@ -103,7 +119,7 @@ const getTransitionsForScene = (sections, layouts, controls) => {
         }
 
         // Check for transitions within choices
-        const choice = line.actions?.choice || line.actions?.actions?.choice;
+        const choice = lineActions?.choice;
         if (choice && choice.items && Array.isArray(choice.items)) {
           for (const choiceItem of choice.items) {
             const choiceTransition =
@@ -120,22 +136,16 @@ const getTransitionsForScene = (sections, layouts, controls) => {
 
         // Check for transitions within layouts referenced by background or control
         const layoutRefs = [
-          line.actions?.background,
-          line.actions?.control,
-          line.actions?.actions?.background,
-          line.actions?.actions?.control,
-        ].filter((ref) => {
-          return (
-            ref?.resourceId &&
-            (ref.resourceType === "layout" || ref.resourceType === "control")
-          );
-        });
+          lineActions?.background,
+          lineActions?.control,
+        ].filter((ref) => ref?.resourceId);
 
         for (const ref of layoutRefs) {
-          const layout =
-            ref.resourceType === "control"
-              ? controls?.items?.[ref.resourceId]
-              : layouts?.items?.[ref.resourceId];
+          const layout = resolveLayoutReference({
+            ref,
+            layouts,
+            controls,
+          });
           if (layout) {
             const layoutTransitions = getTransitionsFromLayout(layout);
             for (const sceneId of layoutTransitions) {


### PR DESCRIPTION
## Summary
- fix layout deletion guards so in-use layouts are blocked first and required dialogue/nvl/choice layouts cannot be removed
- normalize legacy nested line actions to canonical flat line.actions keys and use that shape in scenes/scene editor consumers
- tighten choice/dialogue layout selection defaults so command dialogs always resolve a valid matching layout
- fix whiteboard Space-pan cursor reset by ignoring invalid cursor override values after keyboard pan ends

## Validation
- bunx oxlint src/components/commandLineChoices/commandLineChoices.handlers.js src/components/commandLineChoices/commandLineChoices.store.js src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js src/components/commandLineDialogueBox/commandLineDialogueBox.store.js src/components/whiteboard/whiteboard.handlers.js src/components/whiteboard/whiteboard.store.js src/internal/project/engineActions.js src/internal/project/projection.js src/internal/ui/sceneEditor/lineViewModels.js src/pages/layouts/layouts.handlers.js src/pages/scenes/scenes.handlers.js
- bun prettier --check src/components/commandLineChoices/commandLineChoices.handlers.js src/components/commandLineChoices/commandLineChoices.store.js src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js src/components/commandLineDialogueBox/commandLineDialogueBox.store.js src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml src/components/whiteboard/whiteboard.handlers.js src/components/whiteboard/whiteboard.store.js src/internal/project/engineActions.js src/internal/project/projection.js src/internal/ui/sceneEditor/lineViewModels.js src/pages/layouts/layouts.handlers.js src/pages/scenes/scenes.handlers.js
- bun run test:smoke