### PR TITLE
fix: preserve scene editor NVL dialogue behavior

### DIFF
--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -6,6 +6,19 @@ const getLayoutTypeByMode = (mode) => {
   return mode === "nvl" ? "nvl" : "dialogue";
 };
 
+const resolveDialogueMode = ({ layouts, dialogue } = {}) => {
+  const resourceId = dialogue?.ui?.resourceId ?? dialogue?.gui?.resourceId;
+  const layoutType = (layouts ?? []).find(
+    (layout) => layout.id === resourceId,
+  )?.layoutType;
+
+  if (dialogue?.mode === "nvl" || layoutType === "nvl") {
+    return "nvl";
+  }
+
+  return "adv";
+};
+
 const resolveSelectedResourceId = ({ layouts, mode, resourceId } = {}) => {
   const selectedLayoutType = getLayoutTypeByMode(mode);
   const availableLayouts = (layouts ?? []).filter(
@@ -20,6 +33,34 @@ const resolveSelectedResourceId = ({ layouts, mode, resourceId } = {}) => {
   }
 
   return availableLayouts[0]?.id ?? "";
+};
+
+const syncDialogueStateFromProps = (deps, dialogue = {}) => {
+  const { store, props } = deps;
+  const selectedMode = resolveDialogueMode({
+    layouts: props?.layouts,
+    dialogue,
+  });
+  const selectedResourceId =
+    dialogue?.ui?.resourceId || dialogue?.gui?.resourceId || "";
+
+  store.setSelectedMode({
+    mode: selectedMode,
+  });
+  store.setSelectedResource({
+    resourceId: resolveSelectedResourceId({
+      layouts: props?.layouts,
+      mode: selectedMode,
+      resourceId: selectedResourceId,
+    }),
+  });
+  store.setSelectedCharacterId({
+    characterId: dialogue?.characterId || "",
+  });
+
+  store.setClearPage({
+    clearPage: dialogue?.clearPage === true,
+  });
 };
 
 const syncDialogueFormValues = (deps) => {
@@ -39,31 +80,15 @@ const syncDialogueFormValues = (deps) => {
 };
 
 export const handleBeforeMount = (deps) => {
-  const { store, props } = deps;
-  const selectedMode = props?.dialogue?.mode || "adv";
-  const selectedResourceId =
-    props?.dialogue?.ui?.resourceId || props?.dialogue?.gui?.resourceId || "";
-
-  store.setSelectedMode({
-    mode: selectedMode,
-  });
-  store.setSelectedResource({
-    resourceId: resolveSelectedResourceId({
-      layouts: props?.layouts,
-      mode: selectedMode,
-      resourceId: selectedResourceId,
-    }),
-  });
-  store.setSelectedCharacterId({
-    characterId: props?.dialogue?.characterId || "",
-  });
-
-  store.setClearPage({
-    clearPage: props?.dialogue?.clearPage === true,
-  });
+  syncDialogueStateFromProps(deps, deps.props?.dialogue);
 };
 
 export const handleAfterMount = (deps) => {
+  syncDialogueFormValues(deps);
+};
+
+export const handleOnUpdate = (deps, changes) => {
+  syncDialogueStateFromProps(deps, changes?.newProps?.dialogue);
   syncDialogueFormValues(deps);
 };
 
@@ -100,9 +125,18 @@ export const handleSubmitClick = (deps) => {
   const { store, dispatchEvent, props } = deps;
   const { selectedMode, selectedResourceId, selectedCharacterId, clearPage } =
     store.getState();
+  const effectiveMode = resolveDialogueMode({
+    layouts: props?.layouts,
+    dialogue: {
+      mode: selectedMode,
+      ui: {
+        resourceId: selectedResourceId,
+      },
+    },
+  });
   const effectiveResourceId = resolveSelectedResourceId({
     layouts: props?.layouts,
-    mode: selectedMode,
+    mode: effectiveMode,
     resourceId: selectedResourceId,
   });
 
@@ -112,7 +146,7 @@ export const handleSubmitClick = (deps) => {
 
   // Create dialogue object with only non-empty values
   const dialogue = {
-    mode: selectedMode,
+    mode: effectiveMode,
   };
 
   if (effectiveResourceId) {
@@ -123,7 +157,7 @@ export const handleSubmitClick = (deps) => {
   if (selectedCharacterId) {
     dialogue.characterId = selectedCharacterId;
   }
-  if (selectedMode === "nvl" && toBoolean(clearPage)) {
+  if (effectiveMode === "nvl" && toBoolean(clearPage)) {
     dialogue.clearPage = true;
   }
 

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -91,11 +91,13 @@ template:
                                       - rtgl-view pos=abs cor=full bgc=danger av=c ah=c:
                                           - rtgl-svg svg=x wh=16 c=white: null
                           - $if line.hasDialogueLayout:
-                              - rtgl-view#previewDialogue data-type="dialogue" data-id="${line.id}" pos=rel mr=sm w=36 h=24 av=c ah=c:
-                                  - rtgl-svg svg="dialogue" wh=24: null
-                                  - $if line.dialogueChangeType == "delete":
-                                      - rtgl-view pos=abs cor=full bgc=danger av=c ah=c:
-                                          - rtgl-svg svg=x wh=16 c=white: null
+                              - rtgl-view#previewDialogue data-type="dialogue" data-id="${line.id}" d=h av=c g=xs mr=sm:
+                                  - rtgl-view pos=rel w=24 h=24 av=c ah=c:
+                                      - rtgl-svg svg="dialogue" wh=24: null
+                                      - $if line.dialogueChangeType == "delete":
+                                          - rtgl-view pos=abs cor=full bgc=danger av=c ah=c:
+                                              - rtgl-svg svg=x wh=16 c=white: null
+                                  - rtgl-text s=xs c=mu-fg: ${line.dialogueModeLabel}
                           - $if line.hasControl:
                               - rtgl-view#previewControl data-type="control" data-id="${line.id}" pos=rel mr=sm w=36 h=24 av=c ah=c:
                                   - rtgl-svg svg="control" wh=24: null

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -129,6 +129,24 @@ export const setMode = ({ state }, payload = {}) => {
   state.mode = mode;
 };
 
+const resolveDialogueModeLabel = (dialogue, layoutsItems) => {
+  if (dialogue?.mode === "nvl") {
+    return "NVL";
+  }
+
+  if (dialogue?.mode === "adv") {
+    return "ADV";
+  }
+
+  const layoutId = dialogue?.ui?.resourceId ?? dialogue?.gui?.resourceId;
+  const layoutType = layoutsItems?.[layoutId]?.layoutType;
+  if (layoutType === "nvl") {
+    return "NVL";
+  }
+
+  return "ADV";
+};
+
 // Moved from sceneEditor.store.js - now returns object instead of array
 export const selectActionsData = ({ props, state }) => {
   const actions = props.actions || {};
@@ -246,9 +264,14 @@ export const selectActionsData = ({ props, state }) => {
 
   if (presentationState.dialogue) {
     actionsObject.dialogue = presentationState.dialogue;
+    const dialogueModeLabel = resolveDialogueModeLabel(
+      presentationState.dialogue,
+      layoutsItems,
+    );
     if (presentationState.dialogue.clear === true) {
       preview.dialogue = {
         name: "Dialogue: Clear",
+        modeLabel: dialogueModeLabel,
       };
     } else {
       preview.dialogue = {
@@ -257,6 +280,7 @@ export const selectActionsData = ({ props, state }) => {
             presentationState.dialogue.ui?.resourceId ??
               presentationState.dialogue.gui?.resourceId
           ]?.name || "No layout",
+        modeLabel: dialogueModeLabel,
       };
     }
   }

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -73,7 +73,9 @@ template:
               - $if preview.dialogue:
                   - rtgl-view#actionItemDialogue data-mode=dialogue g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=dialogue wh=24: null
-                      - rtgl-text s=sm: ${preview.dialogue.name}
+                      - rtgl-view d=h av=c g=xs:
+                          - rtgl-text s=sm: ${preview.dialogue.name}
+                          - rtgl-text s=xs c=mu-fg: ${preview.dialogue.modeLabel}
               - $if preview.choice && preview.choice.items:
                   - rtgl-view#actionItemChoices data-mode=choice g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md w=f cur=pointer pv=md:
                       - rtgl-svg svg=choices wh=24: null

--- a/src/internal/ui/sceneEditor/lineOperations.js
+++ b/src/internal/ui/sceneEditor/lineOperations.js
@@ -36,23 +36,53 @@ const findFirstControlAction = (repositoryState) => {
   return undefined;
 };
 
-const shouldInheritNvlModeFromPreviousLine = ({
+const getDialogueLayoutType = ({ repositoryState, dialogue } = {}) => {
+  const resourceId = dialogue?.ui?.resourceId ?? dialogue?.gui?.resourceId;
+  if (!resourceId) {
+    return undefined;
+  }
+
+  return repositoryState?.layouts?.items?.[resourceId]?.layoutType;
+};
+
+const resolveEffectiveDialogueMode = ({ repositoryState, dialogue } = {}) => {
+  if (dialogue?.mode === "nvl") {
+    return "nvl";
+  }
+
+  if (getDialogueLayoutType({ repositoryState, dialogue }) === "nvl") {
+    return "nvl";
+  }
+
+  return "adv";
+};
+
+const resolveLineDialogueMode = ({
+  repositoryState,
   lines,
   lineId,
   existingDialogue,
 }) => {
-  if (existingDialogue?.mode === "nvl") {
-    return false;
+  if (
+    resolveEffectiveDialogueMode({
+      repositoryState,
+      dialogue: existingDialogue,
+    }) === "nvl"
+  ) {
+    return "nvl";
   }
 
   const lineOrder = (lines || []).map((line) => line.id);
   const currentIndex = lineOrder.indexOf(lineId);
   if (currentIndex <= 0) {
-    return false;
+    return "adv";
   }
 
   const previousLine = lines[currentIndex - 1];
-  return previousLine?.actions?.dialogue?.mode === "nvl";
+  return resolveEffectiveDialogueMode({
+    repositoryState,
+    dialogue: previousLine?.actions?.dialogue,
+  });
 };
 
 const resolveLineControlAction = ({ repositoryState, line, fallbackLine }) => {
@@ -169,6 +199,7 @@ export const writeDialogueContent = async (
 const createDialogueContentUpdates = (deps, updates = []) => {
   const { store } = deps;
   const currentSectionLines = getCurrentSectionLines(store);
+  const repositoryState = store.selectRepositoryState();
 
   return updates.map(({ lineId, content }) => {
     const existingLine =
@@ -176,7 +207,8 @@ const createDialogueContentUpdates = (deps, updates = []) => {
         ? store.selectSelectedLine()
         : getLineById(currentSectionLines, lineId);
     const existingDialogue = existingLine?.actions?.dialogue || {};
-    const shouldInheritNvlMode = shouldInheritNvlModeFromPreviousLine({
+    const resolvedMode = resolveLineDialogueMode({
+      repositoryState,
       lines: currentSectionLines,
       lineId,
       existingDialogue,
@@ -186,7 +218,7 @@ const createDialogueContentUpdates = (deps, updates = []) => {
       lineId,
       dialogue: {
         ...existingDialogue,
-        ...(shouldInheritNvlMode ? { mode: "nvl" } : {}),
+        mode: resolvedMode,
         content,
       },
     };
@@ -241,44 +273,22 @@ export const handleSplitLineOperation = async (deps, payload) => {
   }
 
   store.setLockingLineId({ lineId });
-  const existingDialogue = currentLine.actions?.dialogue || {};
-  const shouldInheritNvl =
-    existingDialogue?.mode === "nvl" ||
-    shouldInheritNvlModeFromPreviousLine({
-      lines: currentLines,
-      lineId,
-      existingDialogue,
-    });
   const controlAction = resolveLineControlAction({
     repositoryState: projectService.getRepositoryState(),
     line: currentLine,
   });
   const newLineId = nanoid();
-  const shouldCreateDialogueAction = shouldInheritNvl || Boolean(rightContent);
-  const persistedNewLineActions = shouldCreateDialogueAction
-    ? {
-        dialogue: {
-          mode: shouldInheritNvl ? "nvl" : "adv",
-          ...(rightContent
-            ? {
-                content: createDialogueContent(rightContent),
-              }
-            : {}),
-        },
-      }
-    : {};
+  const persistedNewLineActions = {
+    dialogue: {
+      content: createDialogueContent(rightContent ?? ""),
+    },
+  };
 
   if (controlAction) {
     persistedNewLineActions.control = controlAction;
   }
 
-  const sessionNewLineActions = {
-    ...structuredClone(persistedNewLineActions),
-    dialogue: {
-      mode: shouldInheritNvl ? "nvl" : "adv",
-      content: createDialogueContent(rightContent ?? ""),
-    },
-  };
+  const sessionNewLineActions = structuredClone(persistedNewLineActions);
 
   const nextSession = splitSceneEditorSessionLine(store.selectEditorSession(), {
     lineId,
@@ -312,14 +322,6 @@ export const handlePasteLinesOperation = async (deps, payload) => {
     return;
   }
 
-  const existingDialogue = currentLine.actions?.dialogue || {};
-  const shouldInheritNvl =
-    existingDialogue?.mode === "nvl" ||
-    shouldInheritNvlModeFromPreviousLine({
-      lines: currentLines,
-      lineId,
-      existingDialogue,
-    });
   const controlAction = resolveLineControlAction({
     repositoryState: projectService.getRepositoryState(),
     line: currentLine,
@@ -330,7 +332,6 @@ export const handlePasteLinesOperation = async (deps, payload) => {
     data: {
       actions: {
         dialogue: {
-          mode: shouldInheritNvl ? "nvl" : "adv",
           content: createDialogueContent(content),
         },
         ...(controlAction ? { control: structuredClone(controlAction) } : {}),
@@ -377,14 +378,6 @@ export const handleNewLineOperation = async (deps, payload) => {
   const baseLine = baseLineId
     ? getLineById(currentLines, baseLineId)
     : selectedLine;
-  const existingDialogue = baseLine?.actions?.dialogue || {};
-  const shouldInheritNvl =
-    existingDialogue?.mode === "nvl" ||
-    shouldInheritNvlModeFromPreviousLine({
-      lines: currentLines,
-      lineId: baseLineId,
-      existingDialogue,
-    });
   const controlAction = resolveLineControlAction({
     repositoryState: projectService.getRepositoryState(),
     line: baseLine,
@@ -392,24 +385,16 @@ export const handleNewLineOperation = async (deps, payload) => {
   });
 
   const newLineId = nanoid();
-  const persistedActions = shouldInheritNvl
-    ? {
-        dialogue: {
-          mode: "nvl",
-        },
-      }
-    : {};
+  const persistedActions = {
+    dialogue: {
+      content: createDialogueContent(""),
+    },
+  };
   if (controlAction) {
     persistedActions.control = controlAction;
   }
 
-  const sessionActions = {
-    ...structuredClone(persistedActions),
-    dialogue: {
-      mode: shouldInheritNvl ? "nvl" : "adv",
-      content: createDialogueContent(""),
-    },
-  };
+  const sessionActions = structuredClone(persistedActions);
 
   const nextSession = insertSceneEditorSessionLine(
     store.selectEditorSession(),

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -171,6 +171,30 @@ const buildDialogueSpeakerPreview = (line, characterLookups) => {
   return characterLookups.flatCharacterById.get(characterId)?.fileId;
 };
 
+const resolveDialogueModeLabel = (repositoryState, line) => {
+  const lineActions = normalizeLineActions(line.actions || {});
+  const dialogue = lineActions?.dialogue;
+  if (!dialogue) {
+    return undefined;
+  }
+
+  if (dialogue.mode === "nvl") {
+    return "NVL";
+  }
+
+  if (dialogue.mode === "adv") {
+    return "ADV";
+  }
+
+  const layoutId = dialogue.ui?.resourceId ?? dialogue.gui?.resourceId;
+  const layoutType = repositoryState?.layouts?.items?.[layoutId]?.layoutType;
+  if (layoutType === "nvl") {
+    return "NVL";
+  }
+
+  return "ADV";
+};
+
 export const buildSceneEditorLineViewModels = ({
   lines,
   repositoryState,
@@ -211,6 +235,7 @@ export const buildSceneEditorLineViewModels = ({
         !!changes.setNextLineConfig || !!lineActions?.setNextLineConfig,
       setNextLineConfigChangeType: changes.setNextLineConfig?.changeType,
       hasDialogueLayout: !!changes.dialogue,
+      dialogueModeLabel: resolveDialogueModeLabel(repositoryState, line),
       dialogueChangeType: changes.dialogue?.changeType,
       hasControl: !!changes.control,
       controlChangeType: changes.control?.changeType,

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -357,8 +357,9 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     },
   });
 
+  const presentationState = graphicsService.engineSelectPresentationState();
   store.setPresentationState({
-    presentationState: graphicsService.engineSelectPresentationState(),
+    presentationState,
   });
 };
 


### PR DESCRIPTION
## Summary
- keep command line dialogue box synced with selected line updates instead of stale mounted state
- stop Enter-created scene editor lines from stamping dialogue mode or layout metadata, so dialogue presentation can inherit normally
- show ADV/NVL labels in system action and lines editor dialogue previews for easier debugging
- remove temporary NVL debug logs

## Validation
- bunx oxlint src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js src/components/commandLineDialogueBox/commandLineDialogueBox.store.js src/components/linesEditor/linesEditor.view.yaml src/components/systemActions/systemActions.store.js src/components/systemActions/systemActions.view.yaml src/internal/ui/sceneEditor/lineOperations.js src/internal/ui/sceneEditor/lineViewModels.js src/internal/ui/sceneEditor/runtime.js
- bun prettier --check src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js src/components/commandLineDialogueBox/commandLineDialogueBox.store.js src/components/linesEditor/linesEditor.view.yaml src/components/systemActions/systemActions.store.js src/components/systemActions/systemActions.view.yaml src/internal/ui/sceneEditor/lineOperations.js src/internal/ui/sceneEditor/lineViewModels.js src/internal/ui/sceneEditor/runtime.js
- bun run test:smoke