### PR TITLE
fix: preserve scene editor caret and refine project pages

### DIFF
--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -90,6 +90,67 @@ const getLineElementById = (refs, lineId) => {
   );
 };
 
+const getSelectionRange = (element) => {
+  const root = element?.getRootNode();
+  const isShadowRoot = root instanceof ShadowRoot;
+
+  let selection = window.getSelection();
+
+  if (isShadowRoot && typeof root.getSelection === "function") {
+    const shadowSelection = root.getSelection();
+    if (shadowSelection && shadowSelection.rangeCount > 0) {
+      const range = shadowSelection.getRangeAt(0);
+      if (element.contains(range.startContainer)) {
+        return range;
+      }
+    }
+  }
+
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+
+  if (isShadowRoot && typeof selection.getComposedRanges === "function") {
+    try {
+      const ranges = selection.getComposedRanges(root);
+      if (ranges.length > 0) {
+        const staticRange = ranges[0];
+        if (element.contains(staticRange.startContainer)) {
+          const range = document.createRange();
+          range.setStart(staticRange.startContainer, staticRange.startOffset);
+          range.setEnd(staticRange.endContainer, staticRange.endOffset);
+          return range;
+        }
+      }
+    } catch {
+      // Fall back to the standard selection path.
+    }
+  }
+
+  const range = selection.getRangeAt(0);
+  if (element.contains(range.startContainer)) {
+    return range;
+  }
+
+  return null;
+};
+
+const setSelectionFromRange = (element, range) => {
+  const root = element?.getRootNode();
+  let selection = window.getSelection();
+
+  if (root instanceof ShadowRoot && typeof root.getSelection === "function") {
+    selection = root.getSelection() || selection;
+  }
+
+  if (!selection) {
+    return;
+  }
+
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
 const syncStoredCursorState = (
   store,
   element,
@@ -208,6 +269,31 @@ const renderPreservingLiveLineContent = (deps, element) => {
   const liveContent = getLineContent(element);
   deps.render();
   restoreRenderedLineContent(deps.refs, lineId, liveContent);
+};
+
+const deleteContentFromCaretToEnd = (element) => {
+  if (!element) {
+    return;
+  }
+
+  const selectionRange = getSelectionRange(element);
+  if (!selectionRange) {
+    return;
+  }
+
+  const deleteRange = selectionRange.cloneRange();
+  deleteRange.collapse(true);
+
+  const terminalRange = document.createRange();
+  terminalRange.selectNodeContents(element);
+  terminalRange.collapse(false);
+
+  deleteRange.setEnd(terminalRange.endContainer, terminalRange.endOffset);
+  deleteRange.deleteContents();
+
+  const collapsedRange = deleteRange.cloneRange();
+  collapsedRange.collapse(true);
+  setSelectionFromRange(element, collapsedRange);
 };
 
 const syncRenderedLineContent = (refs, lines, lineId, { skipLineIds } = {}) => {
@@ -474,9 +560,12 @@ const isKeyboardHandlingDisabled = (props) => {
 };
 
 export const handleAfterMount = (deps) => {
-  const { refs } = deps;
+  const { refs, props } = deps;
 
   focusContainerAfterPaint(refs);
+  requestAnimationFrame(() => {
+    syncAllRenderedLineContent(refs, props.lines);
+  });
 };
 
 export const handleBeforeMount = (deps) => {
@@ -1224,6 +1313,7 @@ export const handleLineBeforeInput = (deps, payload) => {
         },
       }),
     );
+    deleteContentFromCaretToEnd(currentElement);
     suppressElementInput(currentElement);
     suppressElementContentSyncUntilBlur(currentElement);
     return;
@@ -1394,8 +1484,6 @@ export const handleOnUpdate = (deps, payload) => {
   const { refs } = deps;
   const oldLines = payload?.oldProps?.lines;
   const newLines = payload?.newProps?.lines;
-  const oldSelectedLineId = payload?.oldProps?.selectedLineId;
-  const newSelectedLineId = payload?.newProps?.selectedLineId;
   const actualActiveElement =
     refs?.container?.shadowRoot?.activeElement ||
     getActualActiveElement(refs?.container);
@@ -1404,13 +1492,9 @@ export const handleOnUpdate = (deps, payload) => {
     : undefined;
   const skipLineIds = new Set();
 
-  if (
-    activeLineId &&
-    oldSelectedLineId &&
-    newSelectedLineId &&
-    oldSelectedLineId !== newSelectedLineId &&
-    activeLineId === oldSelectedLineId
-  ) {
+  // Never rewrite the currently focused editable line during component updates.
+  // Replacing its DOM content can collapse the browser selection back to the start.
+  if (activeLineId) {
     skipLineIds.add(activeLineId);
   }
 

--- a/src/components/linesEditor/linesEditor.methods.js
+++ b/src/components/linesEditor/linesEditor.methods.js
@@ -45,8 +45,6 @@ const focusLineInternally = (element, payload = {}) => {
     element.transformedHandlers.forceSyncContentLine({ lineId: syncLineId });
   }
 
-  element.render();
-
   if (scrollIntoView) {
     requestAnimationFrame(() => {
       element.scrollLineIntoView({ lineId });

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -40,34 +40,32 @@ styles:
     user-select: none
     '-webkit-user-drag': none
 template:
-  - $if ready:
-      - 'rtgl-view#container w=f tabindex=0 style="outline: none;"':
-          - $for line, i in lines:
-              - 'rtgl-view d=h w=f style="background-color: ${line.backgroundColor};"':
-                  - rtgl-view h=f w=32 ah=e mr=md pt=sm:
-                      - rtgl-text s=sm c=${line.lineColor}: ${line.lineNumber}
-                  - rtgl-view wh=24 br=f mr=md:
-                      - $if line.characterFileId:
-                          - rvn-file-image fileId=${line.characterFileId} w=24 h=24 br=f: null
-                  - rtgl-view d=h w=f:
-                      - rtgl-view w=f:
-                          - 'rvn-editable-text#line${i} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;"': ${line.actions.dialogue.content[0].text}
-                          - $if line.hasDraftConflict:
-                              - rtgl-text s=xs c=danger: Conflict
-                          - $if line.sectionTransition:
-                              - rtgl-view#previewSectionTransition data-type="sectionTransition" data-id="${line.id}" d=h:
-                                  - rtgl-svg svg="transition" wh=16: null
-                                  - rtgl-svg svg="section" wh=16: null
-                                  - rtgl-text s=sm: 'Transition to section: ${line.transitionTarget}'
-                          - $if line.hasChoices:
-                              - rtgl-view#previewChoice data-type="choice" data-id="${line.id}" d=v:
-                                  - rtgl-view d=h:
-                                      - rtgl-svg svg="choices" wh=16: null
-                                      - rtgl-text s=sm: 'Choices:'
-                                  - $for choice in line.choices:
-                                      - rtgl-view d=h ml=sm:
-                                          - rtgl-text s=sm: • ${choice.content}
-                      - rtgl-view d=h:
+      - $if ready:
+          - 'rtgl-view#container w=f tabindex=0 style="outline: none;"':
+              - $for line, i in lines:
+                  - 'rtgl-view d=h w=f style="background-color: ${line.backgroundColor};"':
+                      - rtgl-view h=f w=32 ah=e mr=md pt=sm:
+                          - rtgl-text s=sm c=${line.lineColor}: ${line.lineNumber}
+                      - rtgl-view wh=24 br=f mr=md:
+                          - $if line.characterFileId:
+                              - rvn-file-image fileId=${line.characterFileId} w=24 h=24 br=f: null
+                      - rtgl-view d=h w=f:
+                          - rtgl-view w=f:
+                              - 'rvn-editable-text#line${i} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;"': null
+                              - $if line.sectionTransition:
+                                  - rtgl-view#previewSectionTransition data-type="sectionTransition" data-id="${line.id}" d=h:
+                                      - rtgl-svg svg="transition" wh=16: null
+                                      - rtgl-svg svg="section" wh=16: null
+                                      - rtgl-text s=sm: 'Transition to section: ${line.transitionTarget}'
+                              - $if line.hasChoices:
+                                  - rtgl-view#previewChoice data-type="choice" data-id="${line.id}" d=v:
+                                      - rtgl-view d=h:
+                                          - rtgl-svg svg="choices" wh=16: null
+                                          - rtgl-text s=sm: 'Choices:'
+                                      - $for choice in line.choices:
+                                          - rtgl-view d=h ml=sm:
+                                              - rtgl-text s=sm: • ${choice.content}
+                          - rtgl-view d=h:
                           - $if line.background:
                               - rtgl-view#previewBackground data-type="background" data-id="${line.id}" pos=rel mr=sm:
                                   - $if line.background.fileId:

--- a/src/internal/ui/sceneEditor/editorSession.js
+++ b/src/internal/ui/sceneEditor/editorSession.js
@@ -191,6 +191,20 @@ const adoptRepositorySectionIntoSession = (
   return nextSession;
 };
 
+const rebaseDirtyEntryOntoRepositoryText = (entry, repositoryText) => {
+  const rebasedEntry = structuredClone(entry);
+  const draftText = getSceneEditorLineText(rebasedEntry.line);
+
+  rebasedEntry.baseText = repositoryText;
+  rebasedEntry.dirty = draftText !== repositoryText;
+  rebasedEntry.conflict = false;
+  rebasedEntry.saveState = rebasedEntry.dirty
+    ? rebasedEntry.saveState || "scheduled"
+    : "idle";
+
+  return rebasedEntry;
+};
+
 export const createSceneEditorSession = ({
   sceneId,
   sectionId,
@@ -411,8 +425,16 @@ export const reconcileSceneEditorSession = ({
       }
 
       if (repositoryText !== entry.baseText) {
-        entry.conflict = true;
-        entry.saveState = "conflict";
+        nextSession.linesById[lineId] = rebaseDirtyEntryOntoRepositoryText(
+          entry,
+          repositoryText,
+        );
+        console.warn("[sceneEditor] Rebased dirty draft onto repository text", {
+          lineId,
+          repositoryText,
+          draftText,
+          baseText: entry.baseText,
+        });
       }
     }
 
@@ -454,10 +476,16 @@ export const reconcileSceneEditorSession = ({
       continue;
     }
 
-    const conflictedEntry = structuredClone(currentEntry);
-    conflictedEntry.conflict = true;
-    conflictedEntry.saveState = "conflict";
-    nextLinesById[lineId] = conflictedEntry;
+    nextLinesById[lineId] = rebaseDirtyEntryOntoRepositoryText(
+      currentEntry,
+      repositoryText,
+    );
+    console.warn("[sceneEditor] Rebased dirty draft onto repository text", {
+      lineId,
+      repositoryText,
+      draftText,
+      baseText: currentEntry.baseText,
+    });
   }
 
   nextSession.linesById = nextLinesById;

--- a/src/internal/ui/sceneEditor/persistenceQueue.js
+++ b/src/internal/ui/sceneEditor/persistenceQueue.js
@@ -32,7 +32,6 @@ const getLatestTaskState = (owner, key) => {
       running: false,
       pending: false,
       task: undefined,
-      meta: undefined,
       promise: Promise.resolve(),
       waiters: [],
     };
@@ -57,7 +56,6 @@ export const enqueueLatestSceneEditorPersistence = async ({
   const { ownerState, taskState } = getLatestTaskState(owner, key);
   taskState.pending = true;
   taskState.task = task;
-  taskState.meta = meta;
 
   const completion = new Promise((resolve, reject) => {
     taskState.waiters.push({ resolve, reject });

--- a/src/pages/project/project.store.js
+++ b/src/pages/project/project.store.js
@@ -53,12 +53,12 @@ export const selectViewData = ({ state, constants }) => {
     },
     {
       type: "slot",
-      slot: "project-description",
+      slot: "project-icon",
       label: "",
     },
     {
       type: "slot",
-      slot: "project-icon",
+      slot: "project-description",
       label: "",
     },
   ];

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -34,10 +34,10 @@ template:
           - $if projectSource == 'cloud':
               - rtgl-text s=xs c=mu-fg: Cloud Project
   - rtgl-view w=f h=f ph=lg pt=md:
-      - rtgl-view w=320 h=f d=v:
+      - rtgl-view w=f h=f d=v:
           - rvn-detail-view#detailView w=f h=1fg :fields=detailFields:
               - rtgl-view#projectTitle slot=project-title cur=pointer:
-                  - rtgl-text s=md: ${projectName}
+                  - rtgl-text s=h3: ${projectName}
               - rtgl-view#projectDescription slot=project-description cur=pointer:
                   - rtgl-text c=mu-fg: ${projectDescription}
               - rvn-file-image#projectImage slot=project-icon fileId=${projectIconFileId} h=128 bw=xs bc=bo br=md cur=pointer: null

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -614,7 +614,7 @@ export const handleDeleteDialogConfirm = async (deps) => {
     await appService.removeProjectEntry(projectId);
     store.removeProject({ projectId });
   } catch {
-    appService.showToast("Failed to delete project. Please try again.");
+    appService.showToast("Failed to remove project. Please try again.");
   } finally {
     store.closeDeleteDialog();
     render();

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -1,5 +1,5 @@
 export const createInitialState = () => ({
-  localTitle: "Local Projects",
+  localTitle: "Projects",
   cloudTitle: "Cloud Projects",
   showCloudProjects: false,
   loginButtonText: "Login",
@@ -344,7 +344,7 @@ export const openDropdownMenu = (
   state.dropdownMenu.targetProjectId = projectId;
   state.dropdownMenu.items = Array.isArray(items)
     ? items
-    : [{ label: "Delete", type: "item", value: "delete" }];
+    : [{ label: "Remove", type: "item", value: "delete" }];
 };
 
 export const closeDropdownMenu = ({ state }, _payload = {}) => {
@@ -573,8 +573,9 @@ export const selectViewData = ({ state }) => {
     context: {
       platform: state.platform,
     },
-    deleteDialogTitle: "Delete Project",
-    deleteDialogMessage: `Are you sure you want to delete ${deleteDialogProjectName}? This action cannot be undone.`,
+    deleteDialogTitle: "Remove Project",
+    deleteDialogMessage: `Are you sure you want to remove ${deleteDialogProjectName} from the list? The project folder will still remain on disk. Delete the folder yourself if you want to permanently remove the project files.`,
+    deleteDialogConfirmLabel: "Remove",
     hasLocalProjects,
     localEmptyMessage: hasLocalProjects ? "" : "No local projects yet",
     localEmptySubMessage: hasLocalProjects

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -105,23 +105,24 @@ refs:
       click:
         handler: handleDeleteDialogConfirm
 template:
-  - rtgl-view h=100vh w=100vw d=v ah=c:
-      - 'rtgl-view w=f h=f d=v ph=lg style="max-width: 1280px;"':
-          - rtgl-view w=f ah=c pt=md pb=md:
-              - rtgl-view sm-w=f w=640 d=h av=c:
-                  - rtgl-image h=26 w=144 sm-w=112 of=con src="/public/logo1.png": null
-                  - rtgl-view w=1fg: null
-                  - $if showCloudProjects:
-                      - $if isLoggedIn:
-                          - rtgl-view#avatarButton d=h av=c g=sm p=xs br=md cur=pointer h-bgc=mu:
-                              - rtgl-text s=sm: ${profileDisplayName}
-                              - rtgl-image wh=36 br=f bw=xs bc=bo of=cov src=${avatarImageSrc}: null
-                        $else:
-                          - rtgl-button#loginButton variant=se: ${loginButtonText}
-          - rtgl-view w=f h=1fg ah=c:
-              - rtgl-view sm-w=f w=640 h=f d=v mt=xl:
-                  - rtgl-view w=f h=1fg oy=a d=v g=xl:
-                      - rtgl-view w=f d=v g=md:
+  - rtgl-view h=100vh w=100vw d=v:
+      - 'rtgl-view pos=fix w=100vw h=48 bgc=bg ph=lg ah=c av=c style="left: 0; top: 0; z-index: 10;"':
+          - rtgl-view sm-w=f w=640 h=f d=h av=c:
+              - rtgl-image h=22 w=120 sm-w=96 of=con src="/public/logo1.png": null
+              - rtgl-view w=1fg: null
+              - $if showCloudProjects:
+                  - $if isLoggedIn:
+                      - rtgl-view#avatarButton d=h av=c g=sm p=xs br=md cur=pointer h-bgc=mu:
+                          - rtgl-text s=sm: ${profileDisplayName}
+                          - rtgl-image wh=36 br=f bw=xs bc=bo of=cov src=${avatarImageSrc}: null
+                    $else:
+                      - rtgl-button#loginButton variant=se: ${loginButtonText}
+      - 'rtgl-view w=f h=f ah=c style="min-height: 0;"':
+          - 'rtgl-view w=f h=f d=v ph=lg style="max-width: 1280px; min-height: 0;"':
+              - rtgl-view h=64: null
+              - 'rtgl-view w=f h=1fg ah=c style="min-height: 0;"':
+                  - 'rtgl-view sm-w=f w=640 h=f d=v g=lg style="min-height: 0;"':
+                      - rtgl-view w=f d=v:
                           - rtgl-view d=h w=f av=c:
                               - rtgl-text s=h3: ${localTitle}
                               - rtgl-view w=1fg: null
@@ -129,6 +130,7 @@ template:
                                   - rtgl-button#createButton data-testid=create-project-button: ${createButtonText}
                                   - $if platform != 'web':
                                       - rtgl-button#openButton variant=se: ${openButtonText}
+                      - 'rtgl-view w=f h=1fg sv d=v g=xl style="min-height: 0;"':
                           - rtgl-view w=f g=md:
                               - $if localEmptyMessage:
                                   - rtgl-view w=f h=120 ah=c av=c:
@@ -142,37 +144,39 @@ template:
                                         $else:
                                           - rtgl-image wh=48 src="/public/project_logo_placeholder.png" bc=fg of=con br=sm: null
                                       - rtgl-view w=1fg:
-                                          - rtgl-text: ${project.name}
+                                          - rtgl-text ellipsis w=f: ${project.name}
                                           - rtgl-view d=h g=sm av=c mt=xs:
                                               - rtgl-svg wh=14 svg=folder c=mu-fg: null
                                               - rtgl-text s=xs c=mu-fg: ${project.projectPath}
-                      - $if showCloudProjects:
-                          - rtgl-view w=f d=v g=md:
-                              - rtgl-view d=h w=f av=c:
-                                  - rtgl-text s=h3: ${cloudTitle}
-                                  - rtgl-view w=1fg: null
-                                  - $if isLoggedIn:
-                                      - rtgl-button#cloudCreateButton variant=pr: ${createCloudButtonText}
-                              - rtgl-text s=sm c=mu-fg mb=xl: Cloud projects are the projects stored in your RouteVN account.
-                              - rtgl-view w=f g=md:
-                                  - $if cloudEmptyMessage:
-                                      - rtgl-view w=f h=120 ah=c av=c:
-                                          - rtgl-view d=v ah=c g=md:
-                                              - rtgl-text s=lg c=mu-fg: ${cloudEmptyMessage}
-                                              - rtgl-text s=sm c=mu-fg: ${cloudEmptySubMessage}
+                              - rtgl-view h="33vh": null
+                          - $if showCloudProjects:
+                              - rtgl-view w=f d=v g=md:
+                                  - rtgl-view d=h w=f av=c:
+                                      - rtgl-text s=h3: ${cloudTitle}
+                                      - rtgl-view w=1fg: null
+                                      - $if isLoggedIn:
+                                          - rtgl-button#cloudCreateButton variant=pr: ${createCloudButtonText}
+                                  - rtgl-text s=sm c=mu-fg mb=xl: Cloud projects are the projects stored in your RouteVN account.
+                                  - rtgl-view w=f g=md:
+                                      - $if cloudEmptyMessage:
+                                          - rtgl-view w=f h=120 ah=c av=c:
+                                              - rtgl-view d=v ah=c g=md:
+                                                  - rtgl-text s=lg c=mu-fg: ${cloudEmptyMessage}
+                                                  - rtgl-text s=sm c=mu-fg: ${cloudEmptySubMessage}
                                   - $for project, i in cloudProjects:
                                       - rtgl-view#cloudProjectItem${i} data-project-id=${project.id} h=auto w=f bw=xs bc=bo h-bc=ac p=md d=h av=c g=md cur=pointer:
                                           - rtgl-image wh=48 src="/public/project_logo_placeholder.png" bc=fg of=con br=sm: null
                                           - rtgl-view w=1fg:
                                               - rtgl-view d=h av=c:
-                                                  - rtgl-text: ${project.name}
+                                                  - rtgl-text ellipsis w=f: ${project.name}
                                                   - rtgl-view w=1fg: null
                                                   - rtgl-text s=xs c=mu-fg: ${project.role}
                                               - $if project.description:
-                                                  - rtgl-text s=sm c=mu-fg mt=xs: ${project.description}
+                                                  - rtgl-text s=sm c=mu-fg mt=xs ellipsis w=f: ${project.description}
                                               - rtgl-view d=h g=sm av=c mt=xs:
                                                   - rtgl-text s=xs c=mu-fg: Members
                                                   - rtgl-text s=xs c=mu-fg: ${project.memberCount}
+                                  - rtgl-view h="33vh": null
   - rtgl-dialog#createProjectDialog ?open=${isOpen} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#form key=${isOpen} :defaultValues=defaultValues :form=form :context=context w=f:
@@ -186,7 +190,7 @@ template:
               - rtgl-text c=mu-fg: ${deleteDialogMessage}
           - rtgl-view d=h g=sm w=f ah=e:
               - rtgl-button#deleteCancelButton v=se: Cancel
-              - rtgl-button#deleteConfirmButton v=pr: Delete
+              - rtgl-button#deleteConfirmButton v=pr: ${deleteDialogConfirmLabel}
   - rtgl-dialog#cloudCreateProjectDialog ?open=${cloudCreateDialog.isOpen} s=md:
       - rtgl-view slot=content w=f p=lg:
           - rtgl-form#cloudCreateForm key=${cloudCreateDialog.formKey} :form=cloudCreateForm :defaultValues=cloudCreateDialog.defaultValues w=f: null


### PR DESCRIPTION
## Summary
- stop rendering managed text inside the scene editor contenteditable and sync line text imperatively
- keep active lines out of content sync, restore enter split behavior, and auto-rebase dirty drafts while keeping devtools warnings
- include the related project/projects page copy and layout cleanup already staged on this branch

## Validation
- bunx oxlint src/components/linesEditor/linesEditor.handlers.js src/components/linesEditor/linesEditor.methods.js src/internal/ui/sceneEditor/editorSession.js src/internal/ui/sceneEditor/persistenceQueue.js src/pages/project/project.store.js src/pages/projects/projects.handlers.js src/pages/projects/projects.store.js
- bun prettier --check src/components/linesEditor/linesEditor.view.yaml src/components/linesEditor/linesEditor.handlers.js src/components/linesEditor/linesEditor.methods.js src/internal/ui/sceneEditor/editorSession.js src/internal/ui/sceneEditor/persistenceQueue.js src/pages/project/project.store.js src/pages/project/project.view.yaml src/pages/projects/projects.handlers.js src/pages/projects/projects.store.js src/pages/projects/projects.view.yaml