### PR TITLE
fix(scene-editor): stabilize line identity and sync

### DIFF
--- a/src/components/linesEditor/linesEditor.methods.js
+++ b/src/components/linesEditor/linesEditor.methods.js
@@ -39,6 +39,10 @@ const focusLineInternally = (element, payload = {}) => {
   }
 
   element.store.setNavigationDirection({ direction });
+
+  // New lines are seeded imperatively, so make sure the target line has
+  // its latest text before focus/caret placement runs.
+  element.transformedHandlers.forceSyncContentLine({ lineId });
   element.transformedHandlers.updateSelectedLine({ currentLineId: lineId });
 
   if (syncLineId) {

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -43,7 +43,7 @@ template:
       - $if ready:
           - 'rtgl-view#container w=f tabindex=0 style="outline: none;"':
               - $for line, i in lines:
-                  - 'rtgl-view d=h w=f style="background-color: ${line.backgroundColor};"':
+                  - 'rtgl-view#row${line.domRefSuffix} d=h w=f style="background-color: ${line.backgroundColor};"':
                       - rtgl-view h=f w=32 ah=e mr=md pt=sm:
                           - rtgl-text s=sm c=${line.lineColor}: ${line.lineNumber}
                       - rtgl-view wh=24 br=f mr=md:
@@ -51,7 +51,7 @@ template:
                               - rvn-file-image fileId=${line.characterFileId} w=24 h=24 br=f: null
                       - rtgl-view d=h w=f:
                           - rtgl-view w=f:
-                              - 'rvn-editable-text#line${i} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;"': null
+                              - 'rvn-editable-text#line${line.domRefSuffix} data-line-id="${line.id}" style="width: 100%; padding-bottom: 4px;"': null
                               - $if line.sectionTransition:
                                   - rtgl-view#previewSectionTransition data-type="sectionTransition" data-id="${line.id}" d=h:
                                       - rtgl-svg svg="transition" wh=16: null

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -195,6 +195,16 @@ const resolveDialogueModeLabel = (repositoryState, line) => {
   return "ADV";
 };
 
+const toStableDomRefSuffix = (value = "") => {
+  return Array.from(String(value)).reduce((result, char) => {
+    if (/^[a-zA-Z0-9]$/.test(char)) {
+      return `${result}${char}`;
+    }
+
+    return `${result}Z${char.codePointAt(0).toString(16)}`;
+  }, "");
+};
+
 export const buildSceneEditorLineViewModels = ({
   lines,
   repositoryState,
@@ -211,6 +221,7 @@ export const buildSceneEditorLineViewModels = ({
 
     return {
       ...line,
+      domRefSuffix: toStableDomRefSuffix(line.id),
       lineNumber: index + 1,
       background: buildBackgroundPreview(repositoryState, changes),
       bgm: changes.bgm

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -1,4 +1,4 @@
-import { concatMap, filter, from, throttleTime } from "rxjs";
+import { concatMap, filter, from } from "rxjs";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import {
   applySceneEditorSessionTextChange,
@@ -43,8 +43,6 @@ const TEXT_DRAFT_SAVE_DEBOUNCE_MS = 300;
 const STRUCTURE_DRAFT_SAVE_DEBOUNCE_MS = 900;
 const DRAFT_SAVE_MIN_INTERVAL_MS = 1000;
 const DRAFT_SAVE_MAX_INTERVAL_MS = 3000;
-const STRUCTURE_SHORTCUT_THROTTLE_MS = 50;
-
 const nowMs = () => {
   if (
     typeof performance !== "undefined" &&
@@ -195,20 +193,12 @@ const mountSceneEditorShortcutSubscriptions = (deps) => {
   const streams = [
     subject.pipe(
       filter(({ action }) => action === "sceneEditor.requestSplitLine"),
-      throttleTime(STRUCTURE_SHORTCUT_THROTTLE_MS, undefined, {
-        leading: true,
-        trailing: true,
-      }),
       concatMap(({ payload }) =>
         from(processSplitLineRequest(deps, payload).catch(() => {})),
       ),
     ),
     subject.pipe(
       filter(({ action }) => action === "sceneEditor.requestMergeLines"),
-      throttleTime(STRUCTURE_SHORTCUT_THROTTLE_MS, undefined, {
-        leading: true,
-        trailing: true,
-      }),
       concatMap(({ payload }) =>
         from(processMergeLinesRequest(deps, payload).catch(() => {})),
       ),


### PR DESCRIPTION
## Summary
- give scene editor lines stable DOM identities derived from line ids so structural edits do not reuse the wrong editable rows
- ensure focus-to-new-line sync updates the target editable before caret placement
- remove throttled trailing split/merge request replay so structural edits are applied in order

## Notes
- Revise.js was evaluated but intentionally not kept; this PR stays on the existing custom editable implementation

## Validation
- bunx oxlint src/components/linesEditor/linesEditor.methods.js src/components/linesEditor/linesEditor.view.yaml src/internal/ui/sceneEditor/lineViewModels.js src/pages/sceneEditor/sceneEditor.handlers.js
- bun prettier --check src/components/linesEditor/linesEditor.methods.js src/components/linesEditor/linesEditor.view.yaml src/internal/ui/sceneEditor/lineViewModels.js src/pages/sceneEditor/sceneEditor.handlers.js