### PR TITLE
Fix mac scene editor backspace and Tauri mac targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,11 @@
     "lint:fix": "oxlint && bun prettier --check --write src",
     "prepare": "husky",
     "tauri": "tauri",
+    "tauri:dev:mac": "tauri dev --target aarch64-apple-darwin",
     "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
-    "tauri:build:mac": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --bundles dmg"
+    "tauri:build:mac": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles dmg"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.8.3",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.0.0-rc5",
+  "version": "1.0.0-rc6",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -30,6 +30,19 @@ const getCursorPosition = (element) => {
   return element.getCaretPosition();
 };
 
+const isMacOs = () => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const userAgentPlatform = navigator.userAgentData?.platform;
+  if (typeof userAgentPlatform === "string") {
+    return userAgentPlatform === "macOS";
+  }
+
+  return /Mac/.test(navigator.platform || "");
+};
+
 const hasSelectionRange = (element) => {
   if (!element || typeof element.hasSelectionRange !== "function") {
     return true;
@@ -897,7 +910,9 @@ export const handleContainerKeyDown = (deps, payload) => {
 
 export const handleLineKeyDown = (deps, payload) => {
   const { dispatchEvent, store, render, props } = deps;
-  const id = getLineIdFromElement(payload._event.currentTarget);
+  const event = payload._event;
+  const currentElement = event.currentTarget;
+  const id = getLineIdFromElement(currentElement);
   const mode = store.selectMode();
 
   if (isKeyboardHandlingDisabled(props)) {
@@ -949,21 +964,51 @@ export const handleLineKeyDown = (deps, payload) => {
 
   // Capture cursor position immediately before any key handling
   if (mode === "text-editor") {
-    const cursorPos = getCursorPosition(payload._event.currentTarget);
+    const cursorPos = getCursorPosition(currentElement);
     store.setCursorPosition({ position: cursorPos });
+
+    const selectionRange = getSelectionRange(currentElement);
+    const isCollapsedSelection = selectionRange?.collapsed !== false;
+    const isMacBackspaceMerge =
+      isMacOs() &&
+      event.key === "Backspace" &&
+      cursorPos === 0 &&
+      isCollapsedSelection &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey &&
+      !event.shiftKey &&
+      !event.isComposing;
+
+    if (isMacBackspaceMerge) {
+      const currentIndex = (props.lines || []).findIndex(
+        (line) => line.id === id,
+      );
+      if (currentIndex > 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        dispatchEvent(
+          new CustomEvent("mergeLines", {
+            detail: {
+              currentLineId: id,
+            },
+          }),
+        );
+        suppressElementInput(currentElement);
+        suppressElementContentSyncUntilBlur(currentElement);
+        return;
+      }
+    }
 
     // Update goal column for horizontal movement or when setting new vertical position
     if (
-      payload._event.key === "ArrowLeft" ||
-      payload._event.key === "ArrowRight" ||
-      payload._event.key === "Home" ||
-      payload._event.key === "End"
+      event.key === "ArrowLeft" ||
+      event.key === "ArrowRight" ||
+      event.key === "Home" ||
+      event.key === "End"
     ) {
       store.setGoalColumn({ goalColumn: cursorPos });
-    } else if (
-      payload._event.key === "ArrowUp" ||
-      payload._event.key === "ArrowDown"
-    ) {
+    } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
       // For vertical movement, ensure we have the current position as goal column if not set
       const currentGoalColumn = store.selectGoalColumn();
       if (currentGoalColumn === 0) {


### PR DESCRIPTION
## Summary
- add a macOS-only Backspace fallback in the scene editor so line-start delete merges lines even when WebKit does not emit the expected beforeinput event
- add a dedicated mac dev target and make the mac build target universal
- include the Tauri config version bump already in the worktree

## Testing
- bun prettier --check src/components/linesEditor/linesEditor.handlers.js
- git push hook: oxlint && bun prettier --check src