### PR TITLE
Add macOS signing and notarization runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Local-only release settings.
+# Copy this file to .env and fill in real values on your own machine.
+# Do not commit secrets to the repository.
+
+APPLE_SIGNING_IDENTITY="Developer ID Application: Example Company, Inc. (TEAMID1234)"
+
+# Apple notarization via Apple ID + app-specific password.
+APPLE_ID="your-apple-account-email@example.com"
+APPLE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+APPLE_TEAM_ID="TEAMID1234"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ bun run tauri:dev:win
 
 For production we build installer using NSIS: https://v2.tauri.app/distribute/windows-installer/
 
-
 Build the desktop application:
 ```shell
 bun run tauri:build
@@ -173,6 +172,13 @@ Cross-compile for Windows:
 ```shell
 bun run tauri:build:win
 ```
+
+Build and notarize the macOS DMG:
+```shell
+bun run tauri:build:mac
+```
+
+For the Apple signing and notarization setup, see [docs/runbooks/macos-signing-and-notarization.md](docs/runbooks/macos-signing-and-notarization.md).
 
 The built application will be available in `src-tauri/target/release/` with platform-specific installers in `src-tauri/target/release/bundle/`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 ## Runbooks
 
 1. [Collab Server Bootstrap](./runbooks/collab-server-bootstrap.md)
+2. [macOS Signing And Notarization](./runbooks/macos-signing-and-notarization.md)
 
 ## Platform Spec
 

--- a/docs/runbooks/macos-signing-and-notarization.md
+++ b/docs/runbooks/macos-signing-and-notarization.md
@@ -1,0 +1,141 @@
+# macOS Signing And Notarization
+
+This runbook covers the public macOS release flow for RouteVN Creator.
+
+The repository is public. Never commit real Apple credentials, app-specific
+passwords, or private keys. Keep secrets in a local `.env`, which is ignored by
+git.
+
+## Concepts
+
+`Developer ID Application`
+
+- The Apple certificate used to sign the app for distribution outside the Mac
+  App Store.
+
+`.app`
+
+- The actual macOS application bundle.
+- Tauri builds and signs this first.
+- Apple notarization checks this bundle when Tauri submits it during the build.
+
+`.dmg`
+
+- The installer-style disk image that contains the `.app`.
+- This is the file we distribute to end users.
+- Because users download and open the `.dmg`, we also notarize and staple the
+  final `.dmg`.
+
+## Local Setup
+
+1. Install the `Developer ID Application` certificate in Keychain.
+2. Confirm macOS can see the signing identity:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+3. Copy `.env.example` to `.env`.
+4. Fill in local-only values:
+
+```env
+APPLE_SIGNING_IDENTITY="Developer ID Application: Example Company, Inc. (TEAMID1234)"
+APPLE_ID="your-apple-account-email@example.com"
+APPLE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+APPLE_TEAM_ID="TEAMID1234"
+```
+
+Field meaning:
+
+- `APPLE_SIGNING_IDENTITY`: exact Keychain identity name from
+  `security find-identity -v -p codesigning`
+- `APPLE_ID`: Apple account email used for notarization
+- `APPLE_PASSWORD`: app-specific password, not the normal Apple account password
+- `APPLE_TEAM_ID`: Apple Developer team id
+
+## Build Flow
+
+Run:
+
+```bash
+bun run tauri:build:mac
+```
+
+That command uses [`scripts/tauri-build-mac.sh`](../../scripts/tauri-build-mac.sh).
+
+The script does this:
+
+1. Loads local values from `.env`
+2. Builds the Tauri frontend bundle
+3. Builds the macOS app bundle
+4. Signs the `.app`
+5. Lets Tauri notarize and staple the `.app`
+6. Builds the final `.dmg`
+7. Signs the `.dmg`
+8. Submits the `.dmg` with `xcrun notarytool`
+9. Staples the notarization ticket to the `.dmg`
+10. Validates the stapled `.dmg`
+
+## Final Artifact
+
+Send this file to end users:
+
+`src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg`
+
+Do not send the raw `src-tauri/target/.../RouteVN Creator.app` as the default
+public download unless you intentionally want app-bundle distribution.
+
+## Verification
+
+Check the final `.dmg`:
+
+```bash
+codesign --verify --verbose=4 'src-tauri/target/universal-apple-darwin/release/bundle/dmg/RouteVN Creator_1.0.0-rc6_universal.dmg'
+xcrun stapler validate 'src-tauri/target/universal-apple-darwin/release/bundle/dmg/RouteVN Creator_1.0.0-rc6_universal.dmg'
+spctl -a -vvv -t install 'src-tauri/target/universal-apple-darwin/release/bundle/dmg/RouteVN Creator_1.0.0-rc6_universal.dmg'
+```
+
+Expected results:
+
+- `codesign`: valid on disk
+- `stapler validate`: validate action worked
+- `spctl`: accepted, source=`Notarized Developer ID`
+
+## Common Issues
+
+`0 valid identities found`
+
+- The certificate is not installed correctly in Keychain, or macOS cannot use
+  it for code signing yet.
+
+`ambiguous` signing identity
+
+- Keychain contains multiple matching certificates with the same display name.
+- Remove the duplicate certificate or clean up stale Keychain entries.
+
+`Unnotarized Developer ID`
+
+- The artifact is signed but not notarized, or the notarization ticket was not
+  stapled to the final download artifact.
+- For RouteVN Creator, both the `.app` and final `.dmg` should end up notarized.
+
+`stapler validate` fails on the `.dmg`
+
+- The `.dmg` was never submitted to notarization, or the stapling step failed.
+- Re-run `bun run tauri:build:mac` after confirming `.env` has all Apple values.
+
+## Security Rules
+
+- Never commit `.env`
+- Never commit real `APPLE_PASSWORD`
+- Never commit real Apple account emails unless they are meant to be public
+- Never commit private signing keys or exported `.p12` files
+
+## References
+
+- Tauri macOS signing and notarization:
+  https://v2.tauri.app/distribute/sign/macos/
+- Apple Developer ID overview:
+  https://developer.apple.com/developer-id/
+- Apple app-specific passwords:
+  https://support.apple.com/en-us/102654

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
-    "tauri:build:mac": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles dmg"
+    "tauri:build:mac": "./scripts/tauri-build-mac.sh"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.8.3",

--- a/scripts/tauri-build-mac.sh
+++ b/scripts/tauri-build-mac.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+has_notarization_credentials() {
+  [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]
+}
+
+if [ -f ".env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  echo "Error: APPLE_SIGNING_IDENTITY is not set. Add it to .env."
+  exit 1
+fi
+
+echo "Building macOS bundle with signing identity: ${APPLE_SIGNING_IDENTITY}"
+
+if has_notarization_credentials; then
+  if ! xcrun notarytool --version >/dev/null 2>&1; then
+    echo "Error: xcrun notarytool is required for notarization."
+    exit 1
+  fi
+
+  echo "Notarization enabled with APPLE_ID credentials for team: ${APPLE_TEAM_ID}"
+else
+  echo "Warning: notarization is not configured."
+  echo "Set APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID in .env."
+fi
+
+bun run build:tauri
+tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles dmg
+
+DMG_DIR="src-tauri/target/universal-apple-darwin/release/bundle/dmg"
+DMG_PATH=$(find "${DMG_DIR}" -maxdepth 1 -type f -name "*.dmg" -print | sort | tail -n 1)
+
+if [ -z "${DMG_PATH}" ]; then
+  echo "Error: no DMG found in ${DMG_DIR}."
+  exit 1
+fi
+
+echo "Final DMG: ${DMG_PATH}"
+
+if has_notarization_credentials; then
+  echo "Notarizing DMG: ${DMG_PATH}"
+  xcrun notarytool submit "${DMG_PATH}" \
+    --apple-id "${APPLE_ID}" \
+    --password "${APPLE_PASSWORD}" \
+    --team-id "${APPLE_TEAM_ID}" \
+    --wait
+
+  echo "Stapling DMG..."
+  xcrun stapler staple "${DMG_PATH}"
+
+  echo "Validating stapled DMG..."
+  xcrun stapler validate "${DMG_PATH}"
+  spctl -a -vvv -t install "${DMG_PATH}"
+fi


### PR DESCRIPTION
## Summary
- add a dedicated macOS signing and notarization runbook for maintainers
- add a local-only `.env.example` for Apple signing and notarization settings
- route `tauri:build:mac` through a wrapper that loads `.env`, builds the DMG, then notarizes, staples, and validates the final DMG

## Verification
- `bash -n scripts/tauri-build-mac.sh`
- push hook: `oxlint && bun prettier --check src`
- manually verified signed, notarized, stapled, Gatekeeper-accepted DMG locally during the release workflow