### PR TITLE
Add Linux Tauri dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lint:fix": "oxlint && bun prettier --check --write src",
     "prepare": "husky",
     "tauri": "tauri",
+    "tauri:dev:linux": "tauri dev",
     "tauri:dev:mac": "tauri dev --target aarch64-apple-darwin",
     "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",


### PR DESCRIPTION
## Summary
- add `tauri:dev:linux` to `package.json`
- wire it to `tauri dev` so Linux dev mode can be started with a dedicated script

## Validation
- bun run tauri:dev:linux -- --help