### PR TITLE
Bump insieme to 2.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@tauri-apps/plugin-updater": "^2.9.0",
         "file-type": "^21.0.0",
         "immer": "^10.1.1",
-        "insieme": "2.0.0",
+        "insieme": "2.0.1",
         "jempl": "1.0.0",
         "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
@@ -523,7 +523,7 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
-    "insieme": ["insieme@2.0.0", "", { "dependencies": { "immer": "^11.1.4" } }, "sha512-C2vpRdu2vh2ptuqYL7nJmgu28vQV1dEcKXmBNco2aUjlbN/NQFnOGTfyi4xkTnFihnNlWf12lfHXka+v7ciKDg=="],
+    "insieme": ["insieme@2.0.1", "", { "dependencies": { "immer": "^11.1.4" } }, "sha512-KyDNLf4HEmZOcPSXSVAOz0ODa2KEH7B7aGzFIQVMirfw3XppOnmR+obReO/U040J0P99fJ+ZO8rx3Ro+lfPe8w=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tauri-apps/plugin-updater": "^2.9.0",
     "file-type": "^21.0.0",
     "immer": "^10.1.1",
-    "insieme": "2.0.0",
+    "insieme": "2.0.1",
     "jempl": "1.0.0",
     "js-yaml": "^4.1.0",
     "jsdom": "^26.1.0",

--- a/scripts/collab/start-sync-server.js
+++ b/scripts/collab/start-sync-server.js
@@ -1,5 +1,5 @@
 import { createSyncServer, createSqliteSyncStore } from "insieme/server";
-import { validateCommandSubmitItem } from "insieme/client";
+import { validateCommandSubmitItem } from "../../src/deps/services/shared/collab/insiemeCompat.js";
 import { committedEventToCommand } from "../../src/deps/services/shared/collab/mappers.js";
 import {
   applyCommandToRepositoryState,

--- a/scripts/collabTestSupport.js
+++ b/scripts/collabTestSupport.js
@@ -1,4 +1,4 @@
-import { validateCommandSubmitItem } from "insieme/client";
+import { validateCommandSubmitItem } from "../src/deps/services/shared/collab/insiemeCompat.js";
 import { createInMemorySyncStore, createSyncServer } from "insieme/server";
 import {
   committedEventToCommand,

--- a/src/deps/services/shared/collab/createProjectCollabService.js
+++ b/src/deps/services/shared/collab/createProjectCollabService.js
@@ -1,4 +1,4 @@
-import { createCommandSyncSession } from "insieme/browser";
+import { createCommandSyncSession } from "./insiemeCompat.js";
 import {
   createProjectionGap,
   evaluateRemoteCommandCompatibility,

--- a/src/deps/services/shared/collab/insiemeCompat.js
+++ b/src/deps/services/shared/collab/insiemeCompat.js
@@ -1,0 +1,10 @@
+// `insieme` 2.0.1 trimmed several exports that RouteVN still uses internally.
+// Keep those package-internal imports in one place until the public surface
+// catches back up.
+export {
+  commandToSyncEvent,
+  committedSyncEventToCommand,
+  createCommandSyncSession,
+  createMaterializedViewRuntime,
+  validateCommandSubmitItem,
+} from "../../../../../node_modules/insieme/src/index.js";

--- a/src/deps/services/shared/collab/mappers.js
+++ b/src/deps/services/shared/collab/mappers.js
@@ -1,7 +1,7 @@
 import {
   committedSyncEventToCommand,
   commandToSyncEvent as mapCommandToSyncEvent,
-} from "insieme/client";
+} from "./insiemeCompat.js";
 import { COMMAND_EVENT_MODEL } from "../../../../internal/project/commands.js";
 
 const normalizeSchemaVersion = (value) => {

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -1,4 +1,4 @@
-import { createMaterializedViewRuntime } from "insieme/client";
+import { createMaterializedViewRuntime } from "./collab/insiemeCompat.js";
 import {
   mainScenePartitionFor,
   scenePartitionFor,

--- a/src/deps/services/web/collabClientStore.js
+++ b/src/deps/services/web/collabClientStore.js
@@ -1,4 +1,4 @@
-import { createIndexedDBClientStore } from "insieme/client";
+import { createIndexedDbClientStore } from "insieme/client";
 
 const CLIENT_STORE_VERSION = "2";
 
@@ -11,7 +11,7 @@ export const createPersistedInMemoryClientStore = async ({
   materializedViews = [],
   logger = () => {},
 }) => {
-  const store = createIndexedDBClientStore({
+  const store = createIndexedDbClientStore({
     dbName: buildClientStoreDbName(projectId),
     materializedViews,
   });

--- a/tests/puty/insiemeStorageScenario.js
+++ b/tests/puty/insiemeStorageScenario.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import Database from "better-sqlite3";
-import { validateCommandSubmitItem } from "insieme/client";
+import { validateCommandSubmitItem } from "../../src/deps/services/shared/collab/insiemeCompat.js";
 import { createSqliteSyncStore, createSyncServer } from "insieme/server";
 import {
   committedEventToCommand,


### PR DESCRIPTION
## Summary
- bump `insieme` from `2.0.0` to `2.0.1`
- adapt the client to the trimmed `2.0.1` public export surface with a small local compat shim for the APIs RouteVN still uses
- switch the web collab store to the new public `createIndexedDbClientStore` name

## Details
- update `package.json` and `bun.lock` to `insieme` `2.0.1`
- route `createMaterializedViewRuntime`, `createCommandSyncSession`, and command/profile helpers through one local compat module instead of importing removed symbols from `insieme/client` or `insieme/browser`
- keep the rest of the client on the published package interface

## Verification
- `bun run test`
- `bun run test:integration`
- `bun run test:puty`
- `bun run lint`
- `cargo check --manifest-path src-tauri/Cargo.toml`
