### PR TITLE
Update client for creator-model 1.1.2 animations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.0.3",
         "@rettangoli/ui": "1.0.15",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.1.1",
+        "@routevn/creator-model": "1.1.2",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -259,7 +259,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.1.1", "", {}, "sha512-oNx2SPjK9ULqN6aAmBXXLLyislDSjhFizG0jd9NcNgcV3eBBWdlAubwqTr/1j/VKrSOZ2t1OggpYnkmgcetI7A=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.1.2", "", {}, "sha512-OaxfSw47RclG7+MZRJAgr8aqUvoMbdZZVn8b96DstMORZznpfr1D1r/Z8bXTQP5SsaJNem0N0HBUS1RQ/xa+cQ=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@rettangoli/fe": "1.0.3",
     "@rettangoli/ui": "1.0.15",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "1.1.1",
+    "@routevn/creator-model": "1.1.2",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -13,7 +13,7 @@ const defaultInitialValues = {
   rotation: 0,
 };
 
-const normalizeLiveTween = (properties = {}) => {
+const normalizeUpdateTween = (properties = {}) => {
   return Object.fromEntries(
     Object.entries(properties).map(([property, config]) => {
       const normalizedConfig = {
@@ -142,7 +142,7 @@ export const handleCreateTypeMenuItemClick = async (deps, payload) => {
   store.closeCreateTypeMenu();
   render();
 
-  if (type !== "live") {
+  if (type !== "update") {
     await appService.showDialog({
       title: "Coming Soon",
       message: "Not implemented yet. Coming soon.",
@@ -176,7 +176,7 @@ export const handleFormActionClick = async (deps, payload) => {
     return;
   }
 
-  const tween = normalizeLiveTween(store.selectProperties());
+  const tween = normalizeUpdateTween(store.selectProperties());
   const editMode = store.selectEditMode();
   const editItemId = store.selectEditItemId();
 
@@ -190,7 +190,7 @@ export const handleFormActionClick = async (deps, payload) => {
           data: {
             name,
             animation: {
-              type: "live",
+              type: "update",
               tween,
             },
           },
@@ -211,7 +211,7 @@ export const handleFormActionClick = async (deps, payload) => {
             type: "animation",
             name,
             animation: {
-              type: "live",
+              type: "update",
               tween,
             },
           },

--- a/src/pages/animations/animations.store.js
+++ b/src/pages/animations/animations.store.js
@@ -283,14 +283,14 @@ const propertyNameDropdownItems = [
 
 const createTypeMenuItems = [
   {
-    label: "Live",
+    label: "Update",
     type: "item",
-    value: "live",
+    value: "update",
   },
   {
-    label: "Replace",
+    label: "Transition",
     type: "item",
-    value: "replace",
+    value: "transition",
   },
 ];
 
@@ -299,7 +299,7 @@ const addAnimationForm = {
   fields: [
     {
       type: "read-only-text",
-      content: "Type: Live",
+      content: "Type: Update",
     },
     {
       name: "name",
@@ -331,7 +331,7 @@ const editAnimationForm = {
   fields: [
     {
       type: "read-only-text",
-      content: "Type: Live",
+      content: "Type: Update",
     },
     {
       name: "name",
@@ -369,7 +369,7 @@ const defaultInitialValuesByProperty = {
 
 const getAnimationTween = (item = {}) => {
   if (
-    item?.animation?.type === "live" &&
+    item?.animation?.type === "update" &&
     item.animation.tween &&
     typeof item.animation.tween === "object"
   ) {
@@ -734,7 +734,7 @@ const createAnimationRenderState = (properties, includeAnimations = true) => {
       animations.push({
         id: `animation-${property}`,
         targetId: "preview-element",
-        type: "live",
+        type: "update",
         tween,
       });
     }


### PR DESCRIPTION
## Summary
- bump `@routevn/creator-model` from `1.1.1` to `1.1.2`
- rename the client animations page from the old `live | replace` contract to `update | transition`
- keep transition creation gated as the not-yet-implemented path while update animations continue to work

## Verification
- `bun install`
- `bun run test`
- `bun run lint`
- `bun run test:puty`
