### PR TITLE
Fix file-backed resource creation in a single command context

### DIFF
--- a/scripts/test-collab-adapters.js
+++ b/scripts/test-collab-adapters.js
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import {
+  applyCommandToRepositoryState,
+  initialProjectData,
   createRepositoryCommandEvent,
   repositoryEventToCommand,
 } from "../src/deps/services/shared/projectRepository.js";
+import { createCommandApiShared } from "../src/deps/services/shared/commandApi/shared.js";
+import { createMediaResourceCommandApi } from "../src/deps/services/shared/commandApi/resources/media.js";
 import {
   mainScenePartitionFor,
   scenePartitionFor,
@@ -171,6 +175,101 @@ const createRepositoryEvent = ({
     repositoryEvent.projectId,
   );
   assert.deepEqual(roundTrippedRepositoryEvent.meta, { clientTs: 4321 });
+}
+
+{
+  const uploadProjectId = "project-image-upload-001";
+  let repositoryState = structuredClone(initialProjectData);
+
+  const repository = {
+    getState: () => structuredClone(repositoryState),
+    async addEvent(repositoryEvent) {
+      const command = repositoryEventToCommand(repositoryEvent);
+      const applyResult = applyCommandToRepositoryState({
+        repositoryState,
+        command,
+        projectId: uploadProjectId,
+      });
+      if (applyResult.valid === false) {
+        throw new Error(applyResult.error?.message || "Failed to add event");
+      }
+      repositoryState = applyResult.repositoryState;
+    },
+  };
+
+  let projectedState = structuredClone(repositoryState);
+  const actor = {
+    userId: `local-${uploadProjectId}`,
+    clientId: "local-client",
+  };
+
+  const session = {
+    getActor: () => actor,
+    syncProjectedRepositoryState(nextState) {
+      projectedState = structuredClone(nextState);
+    },
+    async submitCommand(command) {
+      const applyResult = applyCommandToRepositoryState({
+        repositoryState: projectedState,
+        command,
+        projectId: uploadProjectId,
+      });
+      if (applyResult.valid === false) {
+        return applyResult;
+      }
+      projectedState = applyResult.repositoryState;
+      return { valid: true };
+    },
+  };
+
+  const shared = createCommandApiShared({
+    idGenerator: (() => {
+      let counter = 0;
+      return () => `cmd-${++counter}`;
+    })(),
+    now: (() => {
+      let timestamp = 1000;
+      return () => ++timestamp;
+    })(),
+    getCurrentProjectId: () => uploadProjectId,
+    getCurrentRepository: async () => repository,
+    getCachedRepository: () => repository,
+    ensureCommandSessionForProject: async () => session,
+    getOrCreateLocalActor: () => actor,
+    storyBasePartitionFor: () => "m",
+    storyScenePartitionFor: () => "m",
+    scenePartitionFor: () => "m",
+    resourceTypePartitionFor: () => "m",
+  });
+
+  const mediaApi = createMediaResourceCommandApi(shared);
+  const createdImageId = await mediaApi.createImage({
+    imageId: "image-1",
+    fileRecords: [
+      {
+        id: "file-1",
+        mimeType: "image/png",
+        size: 123,
+        sha256: "sha256-1",
+      },
+    ],
+    data: {
+      type: "image",
+      fileId: "file-1",
+      thumbnailFileId: "file-1",
+      name: "Uploaded Image",
+      fileType: "image/png",
+      fileSize: 123,
+      width: 64,
+      height: 64,
+    },
+    parentId: null,
+    position: "last",
+  });
+
+  assert.equal(createdImageId, "image-1");
+  assert.ok(repositoryState.files.items["file-1"]);
+  assert.ok(repositoryState.images.items["image-1"]);
 }
 
 {

--- a/src/deps/services/shared/commandApi/shared.js
+++ b/src/deps/services/shared/commandApi/shared.js
@@ -3,6 +3,7 @@ import { projectRepositoryStateToDomainState } from "../../../../internal/projec
 import { COMMAND_TYPES } from "../../../../internal/project/commands.js";
 import {
   applyCommandToRepository,
+  applyCommandToRepositoryState,
   applyCommandsToRepository,
   assertSupportedProjectState,
   getSiblingOrderNodes,
@@ -134,6 +135,64 @@ export const createCommandApiShared = ({
     });
   };
 
+  const getContextRepositoryState = (context) => {
+    if (context?.state && typeof context.state === "object") {
+      return context.state;
+    }
+    if (typeof context?.repository?.getState === "function") {
+      return context.repository.getState();
+    }
+    return null;
+  };
+
+  const syncSessionProjectedRepositoryState = (context) => {
+    if (typeof context?.session?.syncProjectedRepositoryState !== "function") {
+      return;
+    }
+    const repositoryState = getContextRepositoryState(context);
+    if (!repositoryState) {
+      return;
+    }
+    context.session.syncProjectedRepositoryState(repositoryState);
+  };
+
+  const advanceContextStateWithCommands = ({ context, commands = [] }) => {
+    const normalizedCommands = Array.isArray(commands)
+      ? commands.filter(Boolean)
+      : [];
+    if (!context || normalizedCommands.length === 0) {
+      return;
+    }
+
+    const baseState = getContextRepositoryState(context);
+    if (!baseState) {
+      return;
+    }
+
+    let nextState = baseState;
+    try {
+      for (const command of normalizedCommands) {
+        const applyResult = applyCommandToRepositoryState({
+          repositoryState: nextState,
+          command,
+          projectId: context.projectId,
+        });
+        if (applyResult?.valid === false || !applyResult?.repositoryState) {
+          throw new Error(
+            applyResult?.error?.message ||
+              `Failed to advance context for '${command?.type || "unknown"}'`,
+          );
+        }
+        nextState = applyResult.repositoryState;
+      }
+      context.state = nextState;
+    } catch {
+      if (typeof context.repository?.getState === "function") {
+        context.state = context.repository.getState();
+      }
+    }
+  };
+
   const submitCommandWithContext = async ({
     context,
     scope,
@@ -143,15 +202,7 @@ export const createCommandApiShared = ({
     partitions = [],
     basePartition,
   }) => {
-    if (
-      typeof context.session?.syncProjectedRepositoryState === "function" &&
-      (typeof context.state === "object" ||
-        typeof context.repository?.getState === "function")
-    ) {
-      context.session.syncProjectedRepositoryState(
-        context.state || context.repository.getState(),
-      );
-    }
+    syncSessionProjectedRepositoryState(context);
 
     const command = createCommandWithContext({
       context,
@@ -174,6 +225,11 @@ export const createCommandApiShared = ({
       projectId: context.projectId,
     });
 
+    advanceContextStateWithCommands({
+      context,
+      commands: [command],
+    });
+
     return {
       valid: true,
       commandId: command.id,
@@ -183,15 +239,7 @@ export const createCommandApiShared = ({
   };
 
   const submitCommandsWithContext = async ({ context, commands = [] } = {}) => {
-    if (
-      typeof context.session?.syncProjectedRepositoryState === "function" &&
-      (typeof context.state === "object" ||
-        typeof context.repository?.getState === "function")
-    ) {
-      context.session.syncProjectedRepositoryState(
-        context.state || context.repository.getState(),
-      );
-    }
+    syncSessionProjectedRepositoryState(context);
 
     const normalizedCommands = (commands || []).map((entry) =>
       createCommandWithContext({
@@ -222,6 +270,11 @@ export const createCommandApiShared = ({
       repository: context.repository,
       commands: normalizedCommands,
       projectId: context.projectId,
+    });
+
+    advanceContextStateWithCommands({
+      context,
+      commands: normalizedCommands,
     });
 
     return {


### PR DESCRIPTION
## Summary
- keep command-context repository state in sync after successful submissions
- make sequential flows like `file.create` then `image.create` validate against the updated state
- add a headless regression covering image creation with uploaded file records in one command context

## Verification
- node scripts/test-collab-adapters.js
- bun run lint
- bun run test