### PR TITLE
fix: optimize scene editor asset loading

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "jszip": "^3.10.1",
         "nanoid": "^5.1.5",
         "route-engine-js": "0.3.2",
-        "route-graphics": "1.0.3",
+        "route-graphics": "1.1.1",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
         "snabbdom-to-html": "^7.1.0",
@@ -689,7 +689,7 @@
 
     "route-engine-js": ["route-engine-js@0.3.2", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-FrRK9Mc1Zhncm3pjt1D7M6JXvkf5JKL7Y+64zjS1UEsIAGAj/9IM61ohOwHZj28xddXxSY5fU0wH1S7yN8CldA=="],
 
-    "route-graphics": ["route-graphics@1.0.3", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-XTvKr80Cic4KZKqywLKgpw8OetGVdSIYKKDCSIeu79pJoHP4gtgAn6AWMmxbqxzGaEpPo9jlfTxqSaH0xudyQw=="],
+    "route-graphics": ["route-graphics@1.1.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-pBIKRufMpfUzP8Npia2jrm7vcOENOTlwlgLVr3nWDJILVNM7Ssfe3MWALU9S35iPC+6ensiMNC+yieaEwN3lVg=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -656,6 +656,35 @@ logic is really scene-editing orchestration.
 - split/merge/create/delete persistence workflows
 - scene-specific badge/preview shaping
 
+### Scene Asset Loading
+
+Scene and preview asset loading has a performance-sensitive contract.
+
+- Keep image and video assets URL-backed when possible.
+- Do not regress to fetching large image/video files into JS `ArrayBuffer`
+  memory first and then wrapping them into `Blob` URLs unless there is a
+  strong technical reason.
+- The canonical normalization layer for this is
+  `createAssetBufferManager()` in the `route-graphics` package.
+- The canonical runtime loader behavior is `RouteGraphics.loadAssets()` in the
+  `route-graphics` package.
+
+Current expectation:
+
+- images and videos prefer direct source URLs
+- audio stays buffer-backed because it still needs decode/loading behavior
+- fonts stay buffer-backed because they are registered through `FontFace`
+
+Why this matters:
+
+- the old `URL -> ArrayBuffer -> Blob -> HTMLVideoElement` path caused large
+  JS-side duplication before WebView2/Pixi video decode even began
+- direct URL-backed image/video loading significantly reduced scene-editor
+  memory spikes
+
+If this asset-loading behavior changes, document the reason in the same PR and
+re-check scene-editor memory behavior before merging.
+
 ### Collaboration Runtime
 
 `src/deps/services/web/collabBootstrapService.js` is a web-runtime composition

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jszip": "^3.10.1",
     "nanoid": "^5.1.5",
     "route-engine-js": "0.3.2",
-    "route-graphics": "1.0.3",
+    "route-graphics": "1.1.1",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",
     "snabbdom-to-html": "^7.1.0",

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -1,4 +1,6 @@
 import createRouteGraphics, {
+  Assets,
+  AudioAsset,
   createAssetBufferManager,
   textPlugin,
   rectPlugin,
@@ -14,11 +16,173 @@ import createRouteEngine, { createEffectsHandler } from "route-engine-js";
 import { Ticker } from "pixi.js";
 import { prepareRenderStateKeyboardForGraphics } from "../../internal/project/layout.js";
 
+const cloneBufferForAudioDecode = (value) => {
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0);
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return value.buffer.slice(
+      value.byteOffset,
+      value.byteOffset + value.byteLength,
+    );
+  }
+
+  return new ArrayBuffer(0);
+};
+
+const estimateAudioBufferBytes = (audioBuffer) => {
+  if (!audioBuffer) {
+    return 0;
+  }
+
+  return audioBuffer.length * audioBuffer.numberOfChannels * 4;
+};
+
+let managedAudioDecodeContext;
+let managedAudioCache = new Map();
+let managedAudioPendingLoads = new Map();
+let managedAudioResetToken = 0;
+
+const createManagedAudioDecodeContext = () => {
+  const AudioContextConstructor =
+    globalThis.AudioContext || globalThis.webkitAudioContext;
+
+  if (typeof AudioContextConstructor !== "function") {
+    return undefined;
+  }
+
+  return new AudioContextConstructor();
+};
+
+const getManagedAudioDecodeContext = () => {
+  if (
+    managedAudioDecodeContext &&
+    managedAudioDecodeContext.state !== "closed"
+  ) {
+    return managedAudioDecodeContext;
+  }
+
+  managedAudioDecodeContext = createManagedAudioDecodeContext();
+  return managedAudioDecodeContext;
+};
+
+const closeManagedAudioDecodeContext = async () => {
+  const currentContext = managedAudioDecodeContext;
+  managedAudioDecodeContext = undefined;
+
+  if (!currentContext || currentContext.state === "closed") {
+    return;
+  }
+
+  try {
+    await currentContext.close();
+  } catch (error) {
+    console.error(
+      "[graphicsService] Failed to close managed audio decode context",
+      error,
+    );
+  }
+};
+
+const installManagedAudioAsset = () => {
+  if (AudioAsset?.__rvnManaged === true) {
+    return;
+  }
+
+  const load = async (key, arrayBuffer) => {
+    if (managedAudioCache.has(key)) {
+      return managedAudioCache.get(key);
+    }
+
+    const pendingLoad = managedAudioPendingLoads.get(key);
+    if (pendingLoad) {
+      return await pendingLoad;
+    }
+
+    const decodeContext = getManagedAudioDecodeContext();
+    if (!decodeContext) {
+      return undefined;
+    }
+
+    const decodeSource = cloneBufferForAudioDecode(arrayBuffer);
+    if (decodeSource.byteLength === 0) {
+      return undefined;
+    }
+
+    const currentResetToken = managedAudioResetToken;
+    const nextPendingLoad = decodeContext
+      .decodeAudioData(decodeSource)
+      .then((audioBuffer) => {
+        if (managedAudioResetToken !== currentResetToken) {
+          return undefined;
+        }
+
+        managedAudioCache.set(key, audioBuffer);
+        return audioBuffer;
+      })
+      .catch((error) => {
+        console.error(`AudioAsset.load: Failed to decode ${key}:`, error);
+        return undefined;
+      })
+      .finally(() => {
+        managedAudioPendingLoads.delete(key);
+      });
+
+    managedAudioPendingLoads.set(key, nextPendingLoad);
+    return await nextPendingLoad;
+  };
+
+  const getAsset = (key) => {
+    return managedAudioCache.get(key);
+  };
+
+  const unload = async (key) => {
+    managedAudioCache.delete(key);
+    managedAudioPendingLoads.delete(key);
+
+    if (managedAudioCache.size === 0 && managedAudioPendingLoads.size === 0) {
+      await closeManagedAudioDecodeContext();
+    }
+  };
+
+  const clear = async () => {
+    managedAudioResetToken += 1;
+    managedAudioCache = new Map();
+    managedAudioPendingLoads = new Map();
+    await closeManagedAudioDecodeContext();
+  };
+
+  const getStats = () => {
+    return Array.from(managedAudioCache.entries()).map(
+      ([key, audioBuffer]) => ({
+        key,
+        duration: audioBuffer.duration,
+        channels: audioBuffer.numberOfChannels,
+        sampleRate: audioBuffer.sampleRate,
+        estimatedBytes: estimateAudioBufferBytes(audioBuffer),
+      }),
+    );
+  };
+
+  AudioAsset.load = load;
+  AudioAsset.getAsset = getAsset;
+  AudioAsset.unload = unload;
+  AudioAsset.remove = unload;
+  AudioAsset.clear = clear;
+  AudioAsset.reset = clear;
+  AudioAsset.getStats = getStats;
+  AudioAsset.__rvnManaged = true;
+};
+
+installManagedAudioAsset();
+
 export const createGraphicsService = async ({ subject }) => {
   const RIGHT_CLICK_EVENT_NAMES = new Set(["rightclick", "rightClick"]);
   let routeGraphics;
   let engine;
   let assetBufferManager;
+  let loadedAssetTypes = new Map();
   let enableGlobalKeyboardBindings = true;
   // Create dedicated ticker for auto mode
   let ticker;
@@ -26,8 +190,455 @@ export const createGraphicsService = async ({ subject }) => {
   let actionQueue = Promise.resolve();
   let assetLoadQueue = Promise.resolve();
   let pendingClickInteractionTimeouts = new Map();
+  let deferredAudioRenderToken = 0;
+  let deferredAudioRenderKeySignature = "";
 
   const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
+
+  const classifyAsset = (mimeType) => {
+    if (!mimeType) {
+      return "texture";
+    }
+
+    if (mimeType.startsWith("audio/")) {
+      return "audio";
+    }
+
+    if (
+      mimeType.startsWith("font/") ||
+      [
+        "application/font-woff",
+        "application/font-woff2",
+        "application/x-font-ttf",
+        "application/x-font-otf",
+      ].includes(mimeType)
+    ) {
+      return "font";
+    }
+
+    if (mimeType.startsWith("video/")) {
+      return "video";
+    }
+
+    return "texture";
+  };
+
+  const normalizeFontFamily = (value) => {
+    return value?.replace(/^["']|["']$/g, "");
+  };
+
+  const ensureAudioAssetsLoaded = async (assetKeys = []) => {
+    const uniqueAudioKeys = Array.from(
+      new Set(assetKeys.filter((key) => typeof key === "string" && key)),
+    );
+
+    if (uniqueAudioKeys.length === 0) {
+      return;
+    }
+
+    const bufferMap = assetBufferManager?.getBufferMap?.() ?? {};
+    const keysToDecode = uniqueAudioKeys.filter((key) => {
+      if (!bufferMap[key]) {
+        return false;
+      }
+
+      if (managedAudioPendingLoads.has(key)) {
+        return false;
+      }
+
+      return !AudioAsset.getAsset?.(key);
+    });
+
+    if (keysToDecode.length === 0) {
+      return;
+    }
+
+    await Promise.all(
+      keysToDecode.map((key) => AudioAsset.load(key, bufferMap[key].buffer)),
+    );
+  };
+
+  const invalidateDeferredAudioRender = () => {
+    deferredAudioRenderToken += 1;
+    deferredAudioRenderKeySignature = "";
+  };
+
+  const getRenderStateAudioKeys = (renderState) => {
+    return Array.from(
+      new Set(
+        (renderState?.audio ?? [])
+          .map((audioElement) => audioElement?.src)
+          .filter((key) => typeof key === "string" && key),
+      ),
+    );
+  };
+
+  const getMissingDecodedAudioKeys = (assetKeys = []) => {
+    const uniqueAudioKeys = Array.from(
+      new Set(assetKeys.filter((key) => typeof key === "string" && key)),
+    );
+
+    return uniqueAudioKeys.filter((key) => !AudioAsset.getAsset?.(key));
+  };
+
+  const getDecodableAudioKeys = (assetKeys = []) => {
+    const bufferMap = assetBufferManager?.getBufferMap?.() ?? {};
+    return Array.from(
+      new Set(
+        assetKeys.filter(
+          (key) => typeof key === "string" && key && !!bufferMap[key],
+        ),
+      ),
+    );
+  };
+
+  const splitRenderableAudio = (audioElements = []) => {
+    const renderableAudio = [];
+    const missingAudioKeys = [];
+
+    audioElements.forEach((audioElement) => {
+      const key = audioElement?.src;
+      if (typeof key !== "string" || !key) {
+        renderableAudio.push(audioElement);
+        return;
+      }
+
+      if (AudioAsset.getAsset?.(key)) {
+        renderableAudio.push(audioElement);
+        return;
+      }
+
+      missingAudioKeys.push(key);
+    });
+
+    return {
+      renderableAudio,
+      missingAudioKeys: Array.from(new Set(missingAudioKeys)),
+    };
+  };
+
+  const pruneDecodedAudioCache = async (retainedAudioKeys = []) => {
+    const retainedAudioKeySet = new Set(
+      retainedAudioKeys.filter((key) => typeof key === "string" && key),
+    );
+    const keysToUnload = Array.from(managedAudioCache.keys()).filter(
+      (key) => !retainedAudioKeySet.has(key),
+    );
+
+    if (keysToUnload.length === 0) {
+      return;
+    }
+
+    await Promise.all(keysToUnload.map((key) => AudioAsset.unload?.(key)));
+  };
+
+  const scheduleDeferredAudioRender = (audioKeys = []) => {
+    const uniqueAudioKeys = getDecodableAudioKeys(audioKeys);
+    const nextSignature = uniqueAudioKeys.slice().sort().join("|");
+
+    if (uniqueAudioKeys.length === 0) {
+      return;
+    }
+
+    if (nextSignature === deferredAudioRenderKeySignature) {
+      return;
+    }
+
+    const scheduledToken = deferredAudioRenderToken + 1;
+    deferredAudioRenderToken = scheduledToken;
+    deferredAudioRenderKeySignature = nextSignature;
+
+    void ensureAudioAssetsLoaded(uniqueAudioKeys)
+      .then(() => {
+        if (
+          scheduledToken !== deferredAudioRenderToken ||
+          !engine ||
+          !routeGraphics
+        ) {
+          return;
+        }
+
+        const nextRenderState = engine.selectRenderState();
+        const remainingMissingAudioKeys = getDecodableAudioKeys(
+          getMissingDecodedAudioKeys(getRenderStateAudioKeys(nextRenderState)),
+        );
+
+        if (remainingMissingAudioKeys.length > 0) {
+          scheduleDeferredAudioRender(remainingMissingAudioKeys);
+          return;
+        }
+
+        if (scheduledToken === deferredAudioRenderToken) {
+          deferredAudioRenderKeySignature = "";
+        }
+        renderEngineState(nextRenderState, {
+          allowDeferredAudio: false,
+        });
+      })
+      .catch((error) => {
+        if (scheduledToken === deferredAudioRenderToken) {
+          deferredAudioRenderKeySignature = "";
+        }
+        console.error(
+          "[graphicsService] Failed to decode deferred audio render assets",
+          error,
+        );
+      });
+  };
+
+  const getCachedPixiAsset = (key) => {
+    if (!Assets.cache?.has?.(key)) {
+      return undefined;
+    }
+
+    return Assets.cache.get(key);
+  };
+
+  const getVideoResourceForKey = (key) => {
+    const asset = getCachedPixiAsset(key);
+    const resource =
+      asset?.source?.resource ??
+      asset?.baseTexture?.resource ??
+      asset?.resource ??
+      asset;
+
+    if (
+      typeof HTMLVideoElement !== "undefined" &&
+      resource instanceof HTMLVideoElement
+    ) {
+      return resource;
+    }
+
+    return undefined;
+  };
+
+  const getTrackedVideoEntries = () => {
+    const videoKeys = Array.from(loadedAssetTypes.entries())
+      .filter(([, type]) => type === "video")
+      .map(([key]) => key);
+
+    return videoKeys.map((key) => ({
+      key,
+      video: getVideoResourceForKey(key),
+    }));
+  };
+
+  const releaseVideoElementResource = (video) => {
+    if (!video) {
+      return;
+    }
+
+    try {
+      video.pause();
+    } catch {}
+
+    try {
+      video.currentTime = 0;
+    } catch {}
+
+    try {
+      video.muted = true;
+      video.loop = false;
+      video.preload = "none";
+      video.autoplay = false;
+    } catch {}
+
+    try {
+      video.srcObject = null;
+    } catch {}
+
+    try {
+      Array.from(video.querySelectorAll("source")).forEach((sourceElement) => {
+        sourceElement.removeAttribute("src");
+        sourceElement.remove();
+      });
+    } catch {}
+
+    try {
+      video.src = "";
+    } catch {}
+
+    try {
+      video.removeAttribute("src");
+    } catch {}
+
+    try {
+      video.removeAttribute("poster");
+    } catch {}
+
+    try {
+      video.load();
+    } catch {}
+  };
+
+  const releaseTrackedVideoResources = (entries = getTrackedVideoEntries()) => {
+    if (entries.length === 0) {
+      return;
+    }
+
+    entries.forEach(({ video }) => {
+      releaseVideoElementResource(video);
+    });
+  };
+
+  const clearLoadedFonts = () => {
+    if (typeof document === "undefined" || !document.fonts) {
+      return;
+    }
+
+    const fontKeys = new Set(
+      Array.from(loadedAssetTypes.entries())
+        .filter(([, type]) => type === "font")
+        .map(([key]) => key),
+    );
+
+    if (fontKeys.size === 0) {
+      return;
+    }
+
+    for (const fontFace of document.fonts) {
+      const family = normalizeFontFamily(fontFace.family);
+      if (family && fontKeys.has(family)) {
+        document.fonts.delete(fontFace);
+      }
+    }
+  };
+
+  const unloadTrackedPixiAssets = async () => {
+    const pixiAssetKeys = Array.from(loadedAssetTypes.entries())
+      .filter(([, type]) => type === "texture" || type === "video")
+      .map(([key]) => key);
+
+    if (pixiAssetKeys.length === 0) {
+      return;
+    }
+
+    const destroyCachedPixiAsset = (key) => {
+      const asset = getCachedPixiAsset(key);
+      if (!asset) {
+        return;
+      }
+
+      const texture =
+        typeof asset?.destroy === "function" ? asset : asset?.texture;
+      const source = texture?.source ?? texture?._source;
+      const resource = source?.resource;
+
+      if (
+        typeof HTMLVideoElement !== "undefined" &&
+        resource instanceof HTMLVideoElement
+      ) {
+        releaseVideoElementResource(resource);
+      }
+
+      if (
+        typeof ImageBitmap !== "undefined" &&
+        resource instanceof ImageBitmap &&
+        typeof resource.close === "function"
+      ) {
+        try {
+          resource.close();
+        } catch {}
+      }
+
+      if (
+        texture &&
+        typeof texture.destroy === "function" &&
+        texture.destroyed !== true
+      ) {
+        texture.destroy(true);
+      } else if (
+        source &&
+        typeof source.destroy === "function" &&
+        source.destroyed !== true
+      ) {
+        source.destroy();
+      }
+
+      if (Assets.cache?.has?.(key)) {
+        Assets.cache.remove(key);
+      }
+    };
+
+    await Promise.all(
+      pixiAssetKeys.map(async (key) => {
+        await Assets.unload(key).catch((error) => {
+          console.error(
+            `[graphicsService] Failed to unload asset ${key}`,
+            error,
+          );
+        });
+        destroyCachedPixiAsset(key);
+      }),
+    );
+  };
+
+  const unloadTrackedAudioAssets = async () => {
+    const audioKeys = Array.from(loadedAssetTypes.entries())
+      .filter(([, type]) => type === "audio")
+      .map(([key]) => key);
+
+    if (audioKeys.length === 0) {
+      return { count: 0, strategy: "none" };
+    }
+
+    if (typeof AudioAsset?.unload === "function") {
+      await Promise.all(audioKeys.map((key) => AudioAsset.unload(key)));
+      return { count: audioKeys.length, strategy: "unload" };
+    }
+
+    if (typeof AudioAsset?.remove === "function") {
+      audioKeys.forEach((key) => AudioAsset.remove(key));
+      return { count: audioKeys.length, strategy: "remove" };
+    }
+
+    if (typeof AudioAsset?.clear === "function") {
+      AudioAsset.clear();
+      return { count: audioKeys.length, strategy: "clear" };
+    }
+
+    if (typeof AudioAsset?.reset === "function") {
+      AudioAsset.reset();
+      return { count: audioKeys.length, strategy: "reset" };
+    }
+
+    return {
+      count: audioKeys.length,
+      strategy: "unsupported",
+      availableMethods: Object.keys(AudioAsset ?? {}),
+      keys: audioKeys,
+    };
+  };
+
+  const destroyRuntime = async () => {
+    const trackedVideoEntries = getTrackedVideoEntries();
+
+    releaseTrackedVideoResources(trackedVideoEntries);
+    await unloadTrackedPixiAssets();
+
+    if (routeGraphics) {
+      routeGraphics.destroy();
+      routeGraphics = undefined;
+    }
+
+    await unloadTrackedAudioAssets();
+    clearLoadedFonts();
+    loadedAssetTypes = new Map();
+    assetBufferManager?.clear();
+    assetBufferManager = undefined;
+
+    if (engine) {
+      engine = undefined;
+    }
+    enableGlobalKeyboardBindings = true;
+    beforeHandleActions = undefined;
+    actionQueue = Promise.resolve();
+    assetLoadQueue = Promise.resolve();
+    invalidateDeferredAudioRender();
+    clearAllPendingClickInteractions();
+    ticker?.stop();
+    ticker = undefined;
+  };
 
   const loadBuffersWithRetry = async (assets, retryCount = 1) => {
     let attempt = 0;
@@ -78,7 +689,18 @@ export const createGraphicsService = async ({ subject }) => {
       return;
     }
 
-    await routeGraphics.loadAssets(deltaBufferMap);
+    const renderAssetEntries = Object.entries(deltaBufferMap).filter(
+      ([, value]) => classifyAsset(value?.type) !== "audio",
+    );
+    const renderAssetBufferMap = Object.fromEntries(renderAssetEntries);
+
+    if (Object.keys(renderAssetBufferMap).length > 0) {
+      await routeGraphics.loadAssets(renderAssetBufferMap);
+    }
+
+    newAssetEntries.forEach(([key, asset]) => {
+      loadedAssetTypes.set(key, classifyAsset(asset?.type));
+    });
   };
 
   const runInteractionActions = async (actions, eventContext) => {
@@ -108,12 +730,32 @@ export const createGraphicsService = async ({ subject }) => {
     return undefined;
   };
 
-  const renderEngineState = (renderState) => {
-    const nextRenderState = prepareRenderStateKeyboardForGraphics({
+  const renderEngineState = (renderState, options = {}) => {
+    const { allowDeferredAudio = true } = options;
+    let nextRenderState = prepareRenderStateKeyboardForGraphics({
       renderState,
       enableGlobalKeyboardBindings,
     });
+    const requestedAudioKeys = getRenderStateAudioKeys(nextRenderState);
+    let retainedAudioKeys = requestedAudioKeys;
+
+    if (allowDeferredAudio) {
+      const { renderableAudio, missingAudioKeys } = splitRenderableAudio(
+        nextRenderState.audio,
+      );
+
+      if (missingAudioKeys.length > 0) {
+        nextRenderState = {
+          ...nextRenderState,
+          audio: renderableAudio,
+        };
+        retainedAudioKeys = getRenderStateAudioKeys(nextRenderState);
+        scheduleDeferredAudioRender(missingAudioKeys);
+      }
+    }
+
     routeGraphics.render(nextRenderState);
+    void pruneDecodedAudioCache(retainedAudioKeys);
   };
 
   const enqueueInteractionActions = (actions, eventContext) => {
@@ -161,8 +803,7 @@ export const createGraphicsService = async ({ subject }) => {
   return {
     init: async (options = {}) => {
       if (routeGraphics) {
-        routeGraphics.destroy();
-        routeGraphics = undefined;
+        await destroyRuntime();
       }
 
       ticker = new Ticker();
@@ -171,7 +812,9 @@ export const createGraphicsService = async ({ subject }) => {
       beforeHandleActions = onBeforeHandleActions;
       actionQueue = Promise.resolve();
       assetLoadQueue = Promise.resolve();
+      invalidateDeferredAudioRender();
       clearAllPendingClickInteractions();
+      loadedAssetTypes = new Map();
       assetBufferManager = createAssetBufferManager();
       routeGraphics = createRouteGraphics();
 
@@ -282,23 +925,43 @@ export const createGraphicsService = async ({ subject }) => {
     },
 
     engineSelectPresentationState: () => {
+      if (!engine) {
+        return undefined;
+      }
       return engine.selectPresentationState();
     },
 
     engineSelectRenderState: () => {
+      if (!engine) {
+        return undefined;
+      }
       return engine.selectRenderState();
     },
 
     engineSelectSectionLineChanges: (payload) => {
+      if (!engine) {
+        return [];
+      }
       return engine.selectSectionLineChanges(payload);
     },
 
     engineSelectPresentationChanges: () => {
+      if (!engine) {
+        return undefined;
+      }
       return engine.selectPresentationChanges();
     },
 
+    ensureAudioAssetsLoaded,
+
     engineRenderCurrentState: (options = {}) => {
+      if (!engine || !routeGraphics) {
+        return;
+      }
       const { skipAudio = false, skipAnimations = false } = options;
+      if (skipAudio) {
+        invalidateDeferredAudioRender();
+      }
       let renderState = engine.selectRenderState();
       if (skipAudio) {
         renderState = { ...renderState, audio: [] };
@@ -310,25 +973,14 @@ export const createGraphicsService = async ({ subject }) => {
     },
 
     engineHandleActions: (actions, eventContext) => {
+      if (!engine) {
+        return;
+      }
       engine.handleActions(actions, eventContext);
     },
 
     render: (payload) => routeGraphics.render(payload),
     parse: (payload) => routeGraphics.parse(payload),
-    destroy: () => {
-      if (routeGraphics) {
-        routeGraphics.destroy();
-        routeGraphics = undefined;
-      }
-      if (engine) {
-        engine = undefined;
-      }
-      enableGlobalKeyboardBindings = true;
-      beforeHandleActions = undefined;
-      actionQueue = Promise.resolve();
-      assetLoadQueue = Promise.resolve();
-      clearAllPendingClickInteractions();
-      ticker.stop();
-    },
+    destroy: destroyRuntime,
   };
 };

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -16,7 +16,9 @@ import {
 
 const createAssetLoadCache = () => ({
   sceneIds: new Set(),
+  pendingSceneIds: new Set(),
   fileIds: new Set(),
+  pendingFileLoads: new Map(),
 });
 
 let assetLoadCache = createAssetLoadCache();
@@ -158,42 +160,85 @@ async function loadAssetsForSceneIds(
   const fileReferences = extractFileIdsForScenes(projectData, uniqueSceneIds);
   const missingFileReferences = fileReferences.filter((fileReference) => {
     const fileId = fileReference?.url;
-    return fileId && !assetLoadCache.fileIds.has(fileId);
+    return (
+      fileId &&
+      !assetLoadCache.fileIds.has(fileId) &&
+      !assetLoadCache.pendingFileLoads.has(fileId)
+    );
   });
+  const pendingFileIds = fileReferences
+    .map((fileReference) => fileReference?.url)
+    .filter((fileId) => assetLoadCache.pendingFileLoads.has(fileId));
   const isAnySceneUntracked = uniqueSceneIds.some(
-    (sceneId) => !assetLoadCache.sceneIds.has(sceneId),
+    (sceneId) =>
+      !assetLoadCache.sceneIds.has(sceneId) &&
+      !assetLoadCache.pendingSceneIds.has(sceneId),
   );
 
-  if (missingFileReferences.length === 0 && !isAnySceneUntracked) {
+  if (
+    missingFileReferences.length === 0 &&
+    pendingFileIds.length === 0 &&
+    !isAnySceneUntracked
+  ) {
     return;
   }
 
   const shouldShowLoading = showLoading && missingFileReferences.length > 0;
+  let loadedAssetIds = [];
+  const pendingLoadPromises = pendingFileIds
+    .map((fileId) => assetLoadCache.pendingFileLoads.get(fileId))
+    .filter(Boolean);
+  const newFileIds = missingFileReferences
+    .map((fileReference) => fileReference?.url)
+    .filter(Boolean);
 
   try {
+    uniqueSceneIds.forEach((sceneId) => {
+      assetLoadCache.pendingSceneIds.add(sceneId);
+    });
+
     if (shouldShowLoading) {
       setSceneAssetLoading(deps, true);
     }
 
     if (missingFileReferences.length > 0) {
-      const assets = await createAssetsFromFileIds(
-        missingFileReferences,
-        projectService,
-        projectData.resources,
-      );
-      await graphicsService.loadAssets(assets);
+      const nextLoadPromise = (async () => {
+        const assets = await createAssetsFromFileIds(
+          missingFileReferences,
+          projectService,
+          projectData.resources,
+        );
+        await graphicsService.loadAssets(assets);
+        return Object.keys(assets);
+      })();
 
-      Object.keys(assets).forEach((fileId) => {
-        if (fileId) {
-          assetLoadCache.fileIds.add(fileId);
-        }
+      newFileIds.forEach((fileId) => {
+        assetLoadCache.pendingFileLoads.set(fileId, nextLoadPromise);
+      });
+
+      loadedAssetIds = await nextLoadPromise.finally(() => {
+        newFileIds.forEach((fileId) => {
+          assetLoadCache.pendingFileLoads.delete(fileId);
+        });
+      });
+
+      loadedAssetIds.forEach((fileId) => {
+        assetLoadCache.fileIds.add(fileId);
       });
     }
 
+    if (pendingLoadPromises.length > 0) {
+      await Promise.all(pendingLoadPromises);
+    }
+
     uniqueSceneIds.forEach((sceneId) => {
+      assetLoadCache.pendingSceneIds.delete(sceneId);
       assetLoadCache.sceneIds.add(sceneId);
     });
   } catch (error) {
+    uniqueSceneIds.forEach((sceneId) => {
+      assetLoadCache.pendingSceneIds.delete(sceneId);
+    });
     appService?.showToast("Failed to load some scene assets", {
       title: "Warning",
     });
@@ -235,26 +280,58 @@ async function preloadLayoutAssetsByIds(deps, projectData, layoutIds) {
   const fileReferences = extractFileIdsForLayouts(projectData, uniqueLayoutIds);
   const missingFileReferences = fileReferences.filter((fileReference) => {
     const fileId = fileReference?.url;
-    return fileId && !assetLoadCache.fileIds.has(fileId);
+    return (
+      fileId &&
+      !assetLoadCache.fileIds.has(fileId) &&
+      !assetLoadCache.pendingFileLoads.has(fileId)
+    );
   });
+  const pendingFileIds = fileReferences
+    .map((fileReference) => fileReference?.url)
+    .filter((fileId) => assetLoadCache.pendingFileLoads.has(fileId));
 
-  if (missingFileReferences.length === 0) {
+  if (missingFileReferences.length === 0 && pendingFileIds.length === 0) {
     return;
   }
 
   const { graphicsService, projectService } = deps;
-  const assets = await createAssetsFromFileIds(
-    missingFileReferences,
-    projectService,
-    projectData.resources,
-  );
-  await graphicsService.loadAssets(assets);
+  const pendingLoadPromises = pendingFileIds
+    .map((fileId) => assetLoadCache.pendingFileLoads.get(fileId))
+    .filter(Boolean);
+  const newFileIds = missingFileReferences
+    .map((fileReference) => fileReference?.url)
+    .filter(Boolean);
+  let loadedFileIds = [];
 
-  Object.keys(assets).forEach((fileId) => {
-    if (fileId) {
+  if (missingFileReferences.length > 0) {
+    const nextLoadPromise = (async () => {
+      const assets = await createAssetsFromFileIds(
+        missingFileReferences,
+        projectService,
+        projectData.resources,
+      );
+      await graphicsService.loadAssets(assets);
+      return Object.keys(assets);
+    })();
+
+    newFileIds.forEach((fileId) => {
+      assetLoadCache.pendingFileLoads.set(fileId, nextLoadPromise);
+    });
+
+    loadedFileIds = await nextLoadPromise.finally(() => {
+      newFileIds.forEach((fileId) => {
+        assetLoadCache.pendingFileLoads.delete(fileId);
+      });
+    });
+
+    loadedFileIds.forEach((fileId) => {
       assetLoadCache.fileIds.add(fileId);
-    }
-  });
+    });
+  }
+
+  if (pendingLoadPromises.length > 0) {
+    await Promise.all(pendingLoadPromises);
+  }
 }
 
 const createBeforeHandleActionsHook = (deps) => {
@@ -398,6 +475,18 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
   }
 
   graphicsService.engineHandleActions(nextActions);
+  const currentRenderState = graphicsService.engineSelectRenderState();
+  if (!currentRenderState) {
+    return;
+  }
+
+  const activeAudioFileIds =
+    payload?.skipAudio || isMuted
+      ? []
+      : (currentRenderState.audio || [])
+          .map((audioElement) => audioElement?.src)
+          .filter(Boolean);
+  await graphicsService.ensureAudioAssetsLoaded(activeAudioFileIds);
   graphicsService.engineRenderCurrentState({
     skipAudio: isMuted,
     skipAnimations,
@@ -485,7 +574,7 @@ export const initializeSceneEditorPage = async (deps) => {
     }
   }
 
-  resetAssetLoadCache();
+  resetAssetLoadCache("initialize scene editor");
   store.setSceneAssetLoading({ isLoading: false });
 
   await graphicsService.init({
@@ -520,11 +609,12 @@ export const initializeSceneEditorPage = async (deps) => {
 
 export const restoreSceneEditorFromPreview = async (deps) => {
   const { store, render, graphicsService, refs } = deps;
+  const sceneId = store.selectSceneId();
 
   store.hidePreviewScene();
   render();
 
-  resetAssetLoadCache();
+  resetAssetLoadCache("restore scene editor from preview");
   store.setSceneAssetLoading({ isLoading: false });
   await graphicsService.init({
     canvas: refs.canvas,
@@ -532,7 +622,6 @@ export const restoreSceneEditorFromPreview = async (deps) => {
   });
 
   const projectData = store.selectProjectData();
-  const sceneId = store.selectSceneId();
   const initialProjectData = createProjectDataWithSelectedEntryPoint(
     projectData,
     {
@@ -599,9 +688,9 @@ export const mountSceneEditorSubscriptions = (deps) => {
   return () => active.forEach((subscription) => subscription?.unsubscribe?.());
 };
 
-export const resetSceneEditorRuntime = (deps) => {
+export const resetSceneEditorRuntime = async (deps) => {
   const { graphicsService, store } = deps;
   store.setSceneAssetLoading({ isLoading: false });
-  resetAssetLoadCache();
-  graphicsService.destroy();
+  resetAssetLoadCache("scene editor unmount");
+  await graphicsService.destroy();
 };

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -363,7 +363,7 @@ export const handleBeforeMount = (deps) => {
     await flushSceneEditorDrafts(deps);
     const repository = await projectService.getRepository().catch(() => null);
     await repository?.clearActiveSceneId?.();
-    resetSceneEditorRuntime(deps);
+    await resetSceneEditorRuntime(deps);
   };
 };
 


### PR DESCRIPTION
## Summary
- upgrade the client to `route-graphics@1.1.1` so images and videos can stay URL-backed instead of being copied into JS buffers first
- keep scene-editor asset loading and teardown aligned with the new route-graphics behavior, including awaited runtime cleanup and in-flight asset-load dedupe
- document the scene-asset loading contract so we do not regress to the old `URL -> ArrayBuffer -> Blob` path

## Testing
- `bun install`
- `bun run build:web`
- `bun run lint`