### PR TITLE
feat: improve uploads and editor polish

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,8 @@
 
 1. [Product](./product.md)
 2. [Engineering](./engineering.md)
-3. [Scene Editor Text Sync Redesign](./scene-editor-text-sync-redesign.md)
+3. [Upload File Types](./upload-file-types.md)
+4. [Scene Editor Text Sync Redesign](./scene-editor-text-sync-redesign.md)
 
 ## Runbooks
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -104,6 +104,13 @@ behavior:
 - mixed command persistence across partitions
 - storage idempotency across submit batches
 
+## Upload File Types
+
+File-type policy for uploads is documented in `docs/upload-file-types.md`.
+
+If an upload surface changes its accepted file types or validation behavior,
+update that document in the same PR.
+
 ## Architecture Overview
 
 RouteVN is organized into four ownership zones:
@@ -655,6 +662,35 @@ logic is really scene-editing orchestration.
 - project service orchestration
 - split/merge/create/delete persistence workflows
 - scene-specific badge/preview shaping
+
+### Scene Asset Loading
+
+Scene and preview asset loading has a performance-sensitive contract.
+
+- Keep image and video assets URL-backed when possible.
+- Do not regress to fetching large image/video files into JS `ArrayBuffer`
+  memory first and then wrapping them into `Blob` URLs unless there is a
+  strong technical reason.
+- The canonical normalization layer for this is
+  `createAssetBufferManager()` in the `route-graphics` package.
+- The canonical runtime loader behavior is `RouteGraphics.loadAssets()` in the
+  `route-graphics` package.
+
+Current expectation:
+
+- images and videos prefer direct source URLs
+- audio stays buffer-backed because it still needs decode/loading behavior
+- fonts stay buffer-backed because they are registered through `FontFace`
+
+Why this matters:
+
+- the old `URL -> ArrayBuffer -> Blob -> HTMLVideoElement` path caused large
+  JS-side duplication before WebView2/Pixi video decode even began
+- direct URL-backed image/video loading significantly reduced scene-editor
+  memory spikes
+
+If this asset-loading behavior changes, document the reason in the same PR and
+re-check scene-editor memory behavior before merging.
 
 ### Collaboration Runtime
 

--- a/docs/upload-file-types.md
+++ b/docs/upload-file-types.md
@@ -1,0 +1,154 @@
+# Upload File Types
+
+## Purpose
+
+This document is the source of truth for file types that may be uploaded into
+RouteVN Creator.
+
+Use it to keep all upload surfaces aligned:
+
+- picker `accept` filters
+- drag-and-drop accepted extensions
+- page-level validation and user-facing error messages
+- shared upload processing in `projectAssetService`
+
+If an uploadable file type changes, update this document in the same PR.
+
+## Rules
+
+1. Every upload surface must define an explicit allowed file-type set.
+2. Picker `accept` and drag-drop `acceptedFileTypes` must match for the same
+   surface.
+3. Invalid files must produce explicit user feedback.
+   Silent filtering is not acceptable.
+4. Surface-level acceptance must be enforced before calling
+   `projectService.uploadFiles(...)`.
+5. Shared runtime validation such as image-dimension checks or media decoding
+   is additive.
+   It does not replace surface-level file-type validation.
+6. `src/deps/services/shared/projectAssetService.js` file-type detection is a
+   processing fallback, not the product-level policy for what a page accepts.
+
+## Validation Layers
+
+### 1. Picker / Drop Surface
+
+These are the first-line filters:
+
+- picker `accept` values passed to `appService.pickFiles(...)`
+- `acceptedFileTypes` passed into `rvn-media-resources-view`
+- `acceptedFileTypes` passed into `rvn-drag-drop`
+
+Shared extension matching currently lives in:
+
+- `src/internal/fileTypes.js`
+- `src/components/mediaResourcesView/mediaResourcesView.handlers.js`
+- `src/components/dragDrop/dragDrop.handlers.js`
+
+### 2. Page-Level Validation
+
+Pages must validate unsupported types and show a user-facing toast/dialog.
+
+Current explicit page validators:
+
+- `src/pages/videos/videos.handlers.js`
+- `src/pages/fonts/fonts.handlers.js`
+- `src/pages/sounds/sounds.handlers.js` via decoder/upload failure dialog
+
+### 3. Shared Picker Validation
+
+`appService.pickFiles(...)` supports additional validations in
+`src/deps/services/shared/fileSelectionService.js`.
+
+Current validation types:
+
+- `square`
+
+This is used for avatar/icon uploads.
+
+### 4. Upload Processing
+
+`src/deps/services/shared/projectAssetService.js` classifies files using
+`detectFileType(...)` from `src/deps/clients/web/fileProcessors.js`.
+
+This layer decides how to process a file after it has already been accepted by
+the UI surface.
+
+Supported processing buckets today:
+
+- image
+- audio
+- video
+- font
+- generic
+
+## Current Upload Matrix
+
+### Media Resource Pages
+
+| Surface                | Allowed file types                                | Extra validation              | Notes                                  |
+| ---------------------- | ------------------------------------------------- | ----------------------------- | -------------------------------------- |
+| Images page            | `.jpg`, `.jpeg`, `.png`, `.webp`                  | none                          | picker, center drag-drop, edit/replace |
+| Character sprites page | `.jpg`, `.jpeg`, `.png`, `.webp`                  | none                          | picker, center drag-drop, edit/replace |
+| Videos page            | `.mp4`                                            | explicit invalid-format toast | picker, center drag-drop, edit/replace |
+| Sounds page            | `.mp3`, `.wav`, `.ogg`                            | upload/decode failure dialog  | picker, center drag-drop, edit/replace |
+| Fonts page             | `.ttf`, `.otf`, `.woff`, `.woff2`, `.ttc`, `.eot` | explicit invalid-format toast | picker, center drag-drop, edit/replace |
+
+### Dialog / Special Upload Surfaces
+
+| Surface                     | Allowed file types                | Extra validation                             | Notes                                      |
+| --------------------------- | --------------------------------- | -------------------------------------------- | ------------------------------------------ |
+| Character avatar upload     | `image/*`                         | `square`                                     | create dialog, edit dialog, avatar replace |
+| Project icon upload         | `image/*`                         | `square`                                     | project settings dialog                    |
+| Text styles add-font dialog | `.ttf`, `.otf`, `.woff`, `.woff2` | none in page, drop zone filters by extension | narrower than Fonts page today             |
+
+## Current Code Locations
+
+### Surface Filters
+
+- Images: `src/pages/images/images.handlers.js`,
+  `src/pages/images/images.store.js`
+- Character sprites: `src/pages/characterSprites/characterSprites.handlers.js`,
+  `src/pages/characterSprites/characterSprites.store.js`
+- Videos: `src/pages/videos/videos.handlers.js`,
+  `src/pages/videos/videos.store.js`
+- Sounds: `src/pages/sounds/sounds.handlers.js`,
+  `src/pages/sounds/sounds.store.js`
+- Fonts: `src/pages/fonts/fonts.handlers.js`,
+  `src/pages/fonts/fonts.store.js`
+- Text styles font dialog: `src/pages/textStyles/textStyles.view.yaml`,
+  `src/pages/textStyles/textStyles.store.js`,
+  `src/pages/textStyles/textStyles.handlers.js`
+- Character avatars: `src/pages/characters/characters.handlers.js`
+- Project icon: `src/pages/project/project.handlers.js`
+
+### Shared Enforcement
+
+- extension accept / matching: `src/internal/fileTypes.js`
+- media center drag-drop: `src/components/mediaResourcesView/mediaResourcesView.handlers.js`
+- generic drag-drop: `src/components/dragDrop/dragDrop.handlers.js`
+- picker validation flow: `src/deps/services/shared/fileSelectionService.js`
+- upload processing: `src/deps/services/shared/projectAssetService.js`
+- processing type detection: `src/deps/clients/web/fileProcessors.js`
+
+## Maintenance Checklist
+
+When adding or changing an uploadable file type:
+
+1. Update the page-level picker `accept` string.
+2. Update the matching drag-drop `acceptedFileTypes`.
+3. Add or update explicit page-level validation and user-facing error text.
+4. Confirm `projectAssetService` can actually process the accepted file type.
+5. Update this document.
+6. Validate both picker upload and drag-drop upload.
+
+## Current Drift To Watch
+
+- Fonts are not fully centralized yet.
+  The Fonts page accepts `.ttf`, `.otf`, `.woff`, `.woff2`, `.ttc`, `.eot`,
+  while the Text Styles add-font dialog currently accepts only
+  `.ttf`, `.otf`, `.woff`, `.woff2`.
+- Some image-only surfaces still use `image/*` plus `square` validation instead
+  of an explicit extension list.
+  If stricter control is required, those surfaces should be narrowed and
+  documented here in the same change.

--- a/src/components/fontPreview/fontPreview.schema.yaml
+++ b/src/components/fontPreview/fontPreview.schema.yaml
@@ -27,6 +27,14 @@ propsSchema:
       type: string
       description: Text color
       default: currentColor
+    strokeColor:
+      type: string
+      description: Text outline color
+      default: transparent
+    strokeWidth:
+      type: string
+      description: Text outline width in pixels
+      default: '0'
     width:
       type: string
       description: Preview container width

--- a/src/components/fontPreview/fontPreview.store.js
+++ b/src/components/fontPreview/fontPreview.store.js
@@ -44,6 +44,12 @@ export const selectViewData = ({ props: attrs }) => {
   const height = attrs.height ? parseInt(attrs.height) : null;
   const textColor = attrs.color || "currentColor";
   const providedBackground = attrs.backgroundColor;
+  const strokeColor =
+    attrs.strokeColor === "undefined"
+      ? "transparent"
+      : attrs.strokeColor || "transparent";
+  const strokeWidth = Number.parseFloat(attrs.strokeWidth);
+  const resolvedStrokeWidth = Number.isFinite(strokeWidth) ? strokeWidth : 0;
 
   // Only use dynamic background if no background is explicitly provided
   const backgroundColor =
@@ -59,6 +65,8 @@ export const selectViewData = ({ props: attrs }) => {
     lineHeight: attrs.lineHeight || "1.5",
     fontWeight: attrs.fontWeight || "normal",
     color: textColor,
+    strokeColor,
+    strokeWidth: resolvedStrokeWidth,
     width: parseInt(attrs.width) || 200,
     height: height || 150,
     heightStyle: height ? `height: ${height}px;` : "height: 100%;",

--- a/src/components/fontPreview/fontPreview.view.yaml
+++ b/src/components/fontPreview/fontPreview.view.yaml
@@ -1,3 +1,3 @@
 template:
   - 'rtgl-view#main av=${av} ah=${ah} style="width: ${width}px; ${heightStyle} background-color: ${backgroundColor}; overflow: hidden;"':
-      - 'rtgl-text style="font-family: ${fontFamily}, sans-serif; font-size: ${fontSize}px; line-height: ${lineHeight}; font-weight: ${fontWeight}; color: ${color}; text-align: ${textAlign};"': ${previewText}
+      - 'rtgl-text style="font-family: ${fontFamily}, sans-serif; font-size: ${fontSize}px; line-height: ${lineHeight}; font-weight: ${fontWeight}; color: ${color}; text-align: ${textAlign}; -webkit-text-stroke: ${strokeWidth}px ${strokeColor}; paint-order: stroke fill;"': ${previewText}

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -81,9 +81,27 @@ export const handleDrop = (deps, payload) => {
   store.setDraggingGroupId({ groupId: undefined });
   render();
 
-  const files = Array.from(payload._event.dataTransfer?.files ?? []).filter(
-    (file) => isFileTypeAccepted(file, props.acceptedFileTypes),
+  const droppedFiles = Array.from(payload._event.dataTransfer?.files ?? []);
+  const files = droppedFiles.filter((file) =>
+    isFileTypeAccepted(file, props.acceptedFileTypes),
   );
+  const rejectedFiles = droppedFiles.filter(
+    (file) => !isFileTypeAccepted(file, props.acceptedFileTypes),
+  );
+
+  if (rejectedFiles.length > 0) {
+    dispatchEvent(
+      new CustomEvent("files-drop-rejected", {
+        detail: {
+          rejectedFiles,
+          targetGroupId,
+          accept: getAcceptAttribute(props.acceptedFileTypes),
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
 
   if (!files.length) {
     return;

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -114,13 +114,20 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       children: children.map((item) => {
         const isSelected = item.id === props.selectedItemId;
         const defaultBorderColor = resolveDefaultBorderColor(item.cardKind);
+        const isInteractive = item.isInteractive !== false;
 
         return {
           ...item,
+          domItemId: isInteractive ? item.id : "",
+          cursor: isInteractive ? "pointer" : "default",
           itemBorderColor: isSelected ? "pr" : defaultBorderColor,
-          itemHoverBorderColor: isSelected ? "pr" : "ac",
+          itemHoverBorderColor: isSelected
+            ? "pr"
+            : !isInteractive
+              ? defaultBorderColor
+              : "ac",
           showPreviewIcon: Boolean(
-            item.canPreview && item.id === state.hoveredItemId,
+            isInteractive && item.canPreview && item.id === state.hoveredItemId,
           ),
         };
       }),

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -100,17 +100,24 @@ template:
                           - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
                               - $if group.hasChildren:
                                   - $for item, itemIndex in group.children:
-                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.domItemId} cur=${item.cursor} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
                                           - $if item.cardKind == 'image':
                                               - 'rtgl-view p=md g=md br=md w=${maxWidth} pos=rel style="max-width: 100%;"':
-                                                  - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} key=${item.previewFileId}-${imageHeight}x${maxWidth}: null
+                                                  - $if item.isProcessing:
+                                                      - rtgl-view w=f h=${imageHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-text s=sm c=mu-fg: Processing...
+                                                    $else:
+                                                      - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} key=${item.previewFileId}-${imageHeight}x${maxWidth}: null
                                                   - $if item.showPreviewIcon:
                                                       - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
                                                           - rtgl-svg svg=zoomIn wh=22 c=white: null
                                                   - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
                                             $elif item.cardKind == 'video':
                                               - 'rtgl-view p=md g=md br=md pos=rel':
-                                                  - $if item.thumbnailFileId:
+                                                  - $if item.isProcessing:
+                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-text s=sm c=mu-fg: Processing...
+                                                    $elif item.thumbnailFileId:
                                                       - rvn-file-image br=md w=${mediaWidth} h=${mediaHeight} fileId=${item.thumbnailFileId}: null
                                                     $else:
                                                       - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
@@ -121,7 +128,12 @@ template:
                                                   - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
                                             $elif item.cardKind == 'sound':
                                               - 'rtgl-view p=md g=md br=md pos=rel':
-                                                  - $if item.waveformDataFileId:
+                                                  - $if item.isProcessing:
+                                                      - rtgl-view g=md:
+                                                          - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                              - rtgl-text s=sm c=mu-fg: Processing...
+                                                          - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                    $elif item.waveformDataFileId:
                                                       - rtgl-view g=md:
                                                           - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=${mediaWidth} h=${mediaHeight}: null
                                                           - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
@@ -133,7 +145,11 @@ template:
                                                           - rtgl-svg svg=play wh=24 c=white: null
                                             $elif item.cardKind == 'font':
                                               - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
-                                                  - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=${mediaWidth} height=${mediaHeight} av=c ah=c: null
+                                                  - $if item.isProcessing:
+                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-text s=sm c=mu-fg: Processing...
+                                                    $else:
+                                                      - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=${mediaWidth} height=${mediaHeight} av=c ah=c: null
                                                   - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
                                             $else:
                                               - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:

--- a/src/components/resizablePanel/resizablePanel.view.yaml
+++ b/src/components/resizablePanel/resizablePanel.view.yaml
@@ -8,12 +8,12 @@ refs:
       mouseleave:
         handler: handleResizeHandleMouseLeave
 template:
-  - rtgl-view h=f w=${panelWidth} d=h pos=rel:
+  - 'rtgl-view h=f w=${panelWidth} d=h pos=rel style="overflow: visible;"':
       - $if resizeSide=="left":
           - 'rtgl-view#resizeHandle h=f ph=md style="cursor: col-resize; background: transparent; margin-left: calc(var(--spacing-md) * -1); margin-right: calc(var(--spacing-md) * -1);"':
               - rtgl-view w=1 h=f bgc=${dividerColor}: null
       - rtgl-view h=f w=f:
           - slot name="content": null
       - $if resizeSide=="right":
-          - 'rtgl-view#resizeHandle h=f ph=md style="cursor: col-resize; background: transparent; margin-left: calc(var(--spacing-md) * -1); margin-right: calc(var(--spacing-md) * -1);"':
+          - 'rtgl-view#resizeHandle pos=abs d=h ah=c h=f style="cursor: col-resize; background: transparent; top: 0; bottom: 0; right: calc(var(--spacing-md) * -2); width: calc(var(--spacing-md) * 2); z-index: 10;"':
               - rtgl-view w=1 h=f bgc=${dividerColor}: null

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -53,7 +53,7 @@ template:
                                   - $for item, itemIndex in group.children:
                                       - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} w=360 cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
                                           - rtgl-view p=md g=md w=f br=md:
-                                              - rvn-font-preview fontFamily=${item.fontStyle} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=${item.fontSize} lineHeight=${item.lineHeight} color=${item.color} fontWeight=${item.fontWeight} width=${previewWidth} height=96 showBorder=false: null
+                                              - rvn-font-preview fontFamily=${item.fontStyle} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=${item.fontSize} lineHeight=${item.lineHeight} color=${item.color} strokeColor=${item.strokeColor} strokeWidth=${item.strokeWidth} fontWeight=${item.fontWeight} width=${previewWidth} height=96 showBorder=false: null
                                               - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
                                 $else:
                                   - rtgl-view#addBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 av=c ah=c g=md p=lg bw=xs bc=bo br=lg cur=pointer:

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -163,18 +163,27 @@ export const validateIconDimensions = async (file) => {
 };
 
 // Audio waveform extraction and processing utilities
-export const extractWaveformData = async (audioFile, samples = 1000) => {
+export const extractWaveformDataFromArrayBuffer = async (
+  arrayBuffer,
+  samples = 1000,
+) => {
+  let audioContext;
+
   try {
-    const audioContext = new (window.AudioContext ||
-      window.webkitAudioContext)();
-    const arrayBuffer = await audioFile.arrayBuffer();
-    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    const audioBuffer = await audioContext.decodeAudioData(
+      arrayBuffer.slice(0),
+    );
 
     const channelData = audioBuffer.getChannelData(0);
-    const blockSize = Math.floor(channelData.length / samples);
+    const sampleCount = Math.max(
+      1,
+      Math.min(samples, channelData.length || samples),
+    );
+    const blockSize = Math.max(1, Math.floor(channelData.length / sampleCount));
     const waveformData = [];
 
-    for (let i = 0; i < samples; i++) {
+    for (let i = 0; i < sampleCount; i++) {
       const start = i * blockSize;
       const end = start + blockSize;
       let sum = 0;
@@ -188,9 +197,10 @@ export const extractWaveformData = async (audioFile, samples = 1000) => {
     }
 
     const maxAmplitude = Math.max(...waveformData);
-    const normalizedData = waveformData.map((value) => value / maxAmplitude);
-
-    audioContext.close();
+    const normalizedData =
+      maxAmplitude > 0
+        ? waveformData.map((value) => value / maxAmplitude)
+        : waveformData.map(() => 0);
 
     // Return waveform data structure
     // amplitudes: normalized amplitude values (0-1) for visualization
@@ -205,7 +215,18 @@ export const extractWaveformData = async (audioFile, samples = 1000) => {
     throw new Error(
       `Failed to decode audio file: ${error.message || "Unsupported format"}`,
     );
+  } finally {
+    try {
+      await audioContext?.close();
+    } catch {
+      // Ignore close errors from partially initialized contexts.
+    }
   }
+};
+
+export const extractWaveformData = async (audioFile, samples = 1000) => {
+  const arrayBuffer = await audioFile.arrayBuffer();
+  return extractWaveformDataFromArrayBuffer(arrayBuffer, samples);
 };
 
 // Video thumbnail extraction

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -2,14 +2,16 @@ import {
   getImageDimensions,
   extractImageThumbnail,
   getVideoDimensions,
-  extractWaveformData,
+  extractWaveformDataFromArrayBuffer,
   extractVideoThumbnail,
   detectFileType,
 } from "../../clients/web/fileProcessors.js";
+import { processWithConcurrency } from "../../../internal/processWithConcurrency.js";
 import { loadFont } from "./fontLoader.js";
 
 const IMAGE_THUMBNAIL_MAX_WIDTH = 320;
 const IMAGE_THUMBNAIL_MAX_HEIGHT = 320;
+const MAX_PARALLEL_UPLOADS = 1;
 
 const bufferToHex = (buffer) =>
   Array.from(new Uint8Array(buffer), (byte) =>
@@ -19,15 +21,25 @@ const bufferToHex = (buffer) =>
 const getFileRecordMimeType = ({ file }) =>
   file.type || "application/octet-stream";
 
-const computeSha256 = async (file) => {
+const getNow = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
+
+const computeSha256 = async (bytes) => {
   if (!crypto?.subtle?.digest) {
     throw new Error("SHA-256 hashing is unavailable in this runtime.");
   }
 
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    await file.arrayBuffer(),
-  );
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
   return bufferToHex(digest);
 };
 
@@ -49,9 +61,10 @@ export const createProjectAssetService = ({
   getCurrentReference,
   getStoreByProject,
 }) => {
-  const storeFile = async (file) => {
+  const storeFile = async ({ file, bytes } = {}) => {
     return fileAdapter.storeFile({
       file,
+      bytes,
       idGenerator,
       getCurrentStore,
       getCurrentReference,
@@ -59,10 +72,25 @@ export const createProjectAssetService = ({
     });
   };
 
-  const storeFileWithRecord = async ({ file }) => {
+  const storeFileWithRecord = async ({ file, bytes, timings } = {}) => {
+    const fileBytes = bytes ?? (await file.arrayBuffer());
     const [stored, sha256] = await Promise.all([
-      storeFile(file),
-      computeSha256(file),
+      (async () => {
+        const storeStartedAt = getNow();
+        const result = await storeFile({ file, bytes: fileBytes });
+        if (timings) {
+          timings.storeDurationMs = getDurationMs(storeStartedAt);
+        }
+        return result;
+      })(),
+      (async () => {
+        const hashStartedAt = getNow();
+        const result = await computeSha256(fileBytes);
+        if (timings) {
+          timings.hashDurationMs = getDurationMs(hashStartedAt);
+        }
+        return result;
+      })(),
     ]);
 
     return {
@@ -114,50 +142,106 @@ export const createProjectAssetService = ({
     }
 
     if (fileType === "audio") {
-      const arrayBuffer = await file.arrayBuffer();
-      const fileForWaveform = new File([arrayBuffer], file.name, {
-        type: file.type,
-      });
-      const fileForStorage = new File([arrayBuffer], file.name, {
-        type: file.type,
-      });
+      const totalStartedAt = getNow();
+      let readDurationMs = 0;
+      let waveformDurationMs = 0;
+      let storeAndHashDurationMs = 0;
+      let storeDurationMs = 0;
+      let hashDurationMs = 0;
+      let metadataDurationMs = 0;
 
-      const waveformData = await extractWaveformData(fileForWaveform);
-      const stored = await storeFileWithRecord({
-        file: fileForStorage,
-      });
+      try {
+        const readStartedAt = getNow();
+        const arrayBuffer = await file.arrayBuffer();
+        readDurationMs = getDurationMs(readStartedAt);
 
-      let waveformDataFileId = null;
-      let waveformResult = null;
-      if (waveformData) {
-        const compressedWaveformData = {
-          ...waveformData,
-          amplitudes: waveformData.amplitudes.map((value) =>
-            Math.round(value * 255),
-          ),
-        };
-        waveformResult = await storeMetadata({
-          data: compressedWaveformData,
-          storeFile: (metadataFile) =>
-            storeFileWithRecord({
-              file: metadataFile,
-            }),
-          idGenerator,
+        const [waveformData, stored] = await Promise.all([
+          (async () => {
+            const waveformStartedAt = getNow();
+            const result =
+              await extractWaveformDataFromArrayBuffer(arrayBuffer);
+            waveformDurationMs = getDurationMs(waveformStartedAt);
+            return result;
+          })(),
+          (async () => {
+            const storeStartedAt = getNow();
+            const storeAndHashTimings = {};
+            const result = await storeFileWithRecord({
+              file,
+              bytes: arrayBuffer,
+              timings: storeAndHashTimings,
+            });
+            storeAndHashDurationMs = getDurationMs(storeStartedAt);
+            storeDurationMs = storeAndHashTimings.storeDurationMs ?? 0;
+            hashDurationMs = storeAndHashTimings.hashDurationMs ?? 0;
+            return result;
+          })(),
+        ]);
+
+        let waveformDataFileId = null;
+        let waveformResult = null;
+        if (waveformData) {
+          const compressedWaveformData = {
+            ...waveformData,
+            amplitudes: waveformData.amplitudes.map((value) =>
+              Math.round(value * 255),
+            ),
+          };
+          const metadataStartedAt = getNow();
+          waveformResult = await storeMetadata({
+            data: compressedWaveformData,
+            storeFile: (metadataFile) =>
+              storeFileWithRecord({
+                file: metadataFile,
+              }),
+            idGenerator,
+          });
+          metadataDurationMs = getDurationMs(metadataStartedAt);
+          waveformDataFileId = waveformResult.fileId;
+        }
+
+        console.info("[audioUpload] process.complete", {
+          fileName: file.name,
+          fileSize: file.size,
+          fileType: file.type,
+          readDurationMs,
+          waveformDurationMs,
+          storeAndHashDurationMs,
+          storeDurationMs,
+          hashDurationMs,
+          metadataDurationMs,
+          totalDurationMs: getDurationMs(totalStartedAt),
+          decodedDurationSeconds: waveformData?.duration,
+          waveformSampleCount: waveformData?.amplitudes?.length ?? 0,
         });
-        waveformDataFileId = waveformResult.fileId;
-      }
 
-      return {
-        ...stored,
-        waveformDataFileId,
-        waveformData,
-        duration: waveformData?.duration,
-        type: "audio",
-        fileRecords: [
-          stored.fileRecord,
-          ...(waveformResult ? [waveformResult.fileRecord] : []),
-        ],
-      };
+        return {
+          ...stored,
+          waveformDataFileId,
+          waveformData,
+          duration: waveformData?.duration,
+          type: "audio",
+          fileRecords: [
+            stored.fileRecord,
+            ...(waveformResult ? [waveformResult.fileRecord] : []),
+          ],
+        };
+      } catch (error) {
+        console.warn("[audioUpload] process.failed", {
+          fileName: file.name,
+          fileSize: file.size,
+          fileType: file.type,
+          readDurationMs,
+          waveformDurationMs,
+          storeAndHashDurationMs,
+          storeDurationMs,
+          hashDurationMs,
+          metadataDurationMs,
+          totalDurationMs: getDurationMs(totalStartedAt),
+          error: error?.message ?? "Unknown error",
+        });
+        throw error;
+      }
     }
 
     if (fileType === "video") {
@@ -210,7 +294,7 @@ export const createProjectAssetService = ({
       };
     }
 
-    const stored = await storeFile(file);
+    const stored = await storeFile({ file });
     return {
       ...stored,
       type: "generic",
@@ -221,25 +305,30 @@ export const createProjectAssetService = ({
   return {
     async uploadFiles(files) {
       const fileArray = Array.isArray(files) ? files : Array.from(files);
-      const uploadPromises = fileArray.map(async (file) => {
-        try {
-          const result = await processFile(file);
-          return {
-            success: true,
-            file,
-            displayName: file.name.replace(/\.[^.]+$/, ""),
-            ...result,
-          };
-        } catch (error) {
-          if (fileAdapter.continueOnUploadError === false) {
-            throw error;
+      const results = await processWithConcurrency(
+        fileArray,
+        async (file) => {
+          try {
+            const result = await processFile(file);
+            return {
+              success: true,
+              file,
+              displayName: file.name.replace(/\.[^.]+$/, ""),
+              ...result,
+            };
+          } catch (error) {
+            if (fileAdapter.continueOnUploadError === false) {
+              throw error;
+            }
+            console.error(`Failed to upload ${file.name}:`, error);
+            return { success: false, file, error: error.message };
           }
-          console.error(`Failed to upload ${file.name}:`, error);
-          return { success: false, file, error: error.message };
-        }
-      });
-
-      const results = await Promise.all(uploadPromises);
+        },
+        {
+          concurrency: MAX_PARALLEL_UPLOADS,
+          stopOnError: fileAdapter.continueOnUploadError === false,
+        },
+      );
       return results.filter((result) => result.success);
     },
 

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -376,14 +376,14 @@ export const createProjectRepositoryRuntime = async ({
         return structuredClone(getCurrentComposedState());
       }
 
-      return structuredClone(
-        replayEventsToRepositoryState({
-          events,
-          untilEventIndex,
-          createInitialState,
-          reduceEventToState,
-        }),
-      );
+      // Historical snapshots are replayed into a fresh state tree, so returning
+      // that replay result directly avoids one more full clone during export.
+      return replayEventsToRepositoryState({
+        events,
+        untilEventIndex,
+        createInitialState,
+        reduceEventToState,
+      });
     },
 
     getRevision(untilEventIndex) {

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -28,6 +28,21 @@ const normalizeProjectInfo = (projectInfo = {}) => ({
   iconFileId: projectInfo.iconFileId ?? null,
 });
 
+const getNow = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
+
+const isAudioUploadFile = (file) => file?.type?.startsWith("audio/");
+
 async function copyTemplateFiles(templateId, targetPath) {
   const templateFilesPath = `/templates/${templateId}/files/`;
   const filesToCopy = await getTemplateFiles(templateId);
@@ -130,20 +145,58 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
   const fileAdapter = {
     continueOnUploadError: false,
 
-    storeFile: async ({ file, idGenerator, getCurrentReference }) => {
+    storeFile: async ({ file, bytes, idGenerator, getCurrentReference }) => {
       const reference = getCurrentReference();
       const fileId = idGenerator();
-      const arrayBuffer = await file.arrayBuffer();
-      const uint8Array = new Uint8Array(arrayBuffer);
+      const totalStartedAt = getNow();
+      let uint8ArrayDurationMs = 0;
+      let writeFileDurationMs = 0;
 
-      const filesPath = await join(reference.projectPath, "files");
-      const filePath = await join(filesPath, fileId);
-      await writeFile(filePath, uint8Array);
+      try {
+        const arrayBuffer = bytes ?? (await file.arrayBuffer());
 
-      return {
-        fileId,
-        downloadUrl: convertFileSrc(filePath),
-      };
+        const uint8ArrayStartedAt = getNow();
+        const uint8Array = new Uint8Array(arrayBuffer);
+        uint8ArrayDurationMs = getDurationMs(uint8ArrayStartedAt);
+
+        const filesPath = await join(reference.projectPath, "files");
+        const filePath = await join(filesPath, fileId);
+
+        const writeFileStartedAt = getNow();
+        await writeFile(filePath, uint8Array);
+        writeFileDurationMs = getDurationMs(writeFileStartedAt);
+
+        if (isAudioUploadFile(file)) {
+          console.info("[audioUpload.store.tauri] complete", {
+            fileName: file.name,
+            fileSize: file.size,
+            fileType: file.type,
+            usedPreloadedBytes: bytes !== undefined,
+            uint8ArrayDurationMs,
+            writeFileDurationMs,
+            totalDurationMs: getDurationMs(totalStartedAt),
+          });
+        }
+
+        return {
+          fileId,
+          downloadUrl: convertFileSrc(filePath),
+        };
+      } catch (error) {
+        if (isAudioUploadFile(file)) {
+          console.warn("[audioUpload.store.tauri] failed", {
+            fileName: file.name,
+            fileSize: file.size,
+            fileType: file.type,
+            usedPreloadedBytes: bytes !== undefined,
+            uint8ArrayDurationMs,
+            writeFileDurationMs,
+            totalDurationMs: getDurationMs(totalStartedAt),
+            error: error?.message ?? "Unknown error",
+          });
+        }
+        throw error;
+      }
     },
 
     getFileContent: async ({ fileId, getCurrentReference }) => {

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -37,6 +37,21 @@ const countImageEntries = (imagesData) =>
 
 const INITIAL_REMOTE_SYNC_TIMEOUT_MS = 5_000;
 
+const getNow = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
+
+const isAudioUploadFile = (file) => file?.type?.startsWith("audio/");
+
 export const createWebProjectServiceAdapters = ({
   onRemoteEvent,
   collabLog,
@@ -155,14 +170,52 @@ export const createWebProjectServiceAdapters = ({
   const fileAdapter = {
     continueOnUploadError: true,
 
-    storeFile: async ({ file, idGenerator, getCurrentStore }) => {
+    storeFile: async ({ file, bytes, idGenerator, getCurrentStore }) => {
       const adapter = getCurrentStore();
       const fileId = idGenerator();
-      const fileBlob = new Blob([await file.arrayBuffer()], {
-        type: file.type,
-      });
-      await adapter.setFile(fileId, fileBlob);
-      return { fileId };
+      const totalStartedAt = getNow();
+      let blobBuildDurationMs = 0;
+      let adapterWriteDurationMs = 0;
+
+      try {
+        const blobBuildStartedAt = getNow();
+        const fileBlob = new Blob([bytes ?? (await file.arrayBuffer())], {
+          type: file.type,
+        });
+        blobBuildDurationMs = getDurationMs(blobBuildStartedAt);
+
+        const adapterWriteStartedAt = getNow();
+        await adapter.setFile(fileId, fileBlob);
+        adapterWriteDurationMs = getDurationMs(adapterWriteStartedAt);
+
+        if (isAudioUploadFile(file)) {
+          console.info("[audioUpload.store.web] complete", {
+            fileName: file.name,
+            fileSize: file.size,
+            fileType: file.type,
+            usedPreloadedBytes: bytes !== undefined,
+            blobBuildDurationMs,
+            adapterWriteDurationMs,
+            totalDurationMs: getDurationMs(totalStartedAt),
+          });
+        }
+
+        return { fileId };
+      } catch (error) {
+        if (isAudioUploadFile(file)) {
+          console.warn("[audioUpload.store.web] failed", {
+            fileName: file.name,
+            fileSize: file.size,
+            fileType: file.type,
+            usedPreloadedBytes: bytes !== undefined,
+            blobBuildDurationMs,
+            adapterWriteDurationMs,
+            totalDurationMs: getDurationMs(totalStartedAt),
+            error: error?.message ?? "Unknown error",
+          });
+        }
+        throw error;
+      }
     },
 
     getFileContent: async ({ fileId, getCurrentStore }) => {

--- a/src/internal/processWithConcurrency.js
+++ b/src/internal/processWithConcurrency.js
@@ -1,0 +1,46 @@
+export const processWithConcurrency = async (
+  items,
+  worker,
+  { concurrency = 1, stopOnError = false } = {},
+) => {
+  const itemList = Array.isArray(items) ? items : [];
+  if (itemList.length === 0) {
+    return [];
+  }
+
+  const results = Array.from({ length: itemList.length });
+  const workerCount = Math.min(concurrency, itemList.length);
+  let nextIndex = 0;
+  let firstError;
+
+  const runWorker = async () => {
+    while (nextIndex < itemList.length) {
+      if (stopOnError && firstError) {
+        return;
+      }
+
+      const index = nextIndex;
+      nextIndex += 1;
+
+      try {
+        results[index] = await worker(itemList[index], index);
+      } catch (error) {
+        firstError = firstError ?? error;
+
+        if (stopOnError) {
+          return;
+        }
+
+        throw error;
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+  if (firstError) {
+    throw firstError;
+  }
+
+  return results;
+};

--- a/src/internal/ui/fileExplorer.js
+++ b/src/internal/ui/fileExplorer.js
@@ -183,8 +183,21 @@ const RESOURCE_FILE_EXPLORER_API = Object.freeze({
   },
 });
 
+const getDeletionBlockedMessage = ({ itemType, reason } = {}) => {
+  if (reason === "minimum-text-style") {
+    return "At least one text style must remain.";
+  }
+
+  if (reason === "in-use") {
+    return itemType === "folder"
+      ? "Cannot delete folder. There are items in use."
+      : "Cannot delete resource, it is currently in use.";
+  }
+
+  return "Failed to delete resource.";
+};
+
 const validateResourceDeletion = async ({
-  appService,
   projectService,
   resourceType,
   currentItem,
@@ -192,6 +205,46 @@ const validateResourceDeletion = async ({
 }) => {
   const state = projectService.getState();
   const currentItemType = currentItem?.type;
+  const collection = state?.[resourceType];
+
+  if (currentItemType === "folder") {
+    const descendantIds = [];
+    const pendingParentIds = [itemId];
+
+    while (pendingParentIds.length > 0) {
+      const parentId = pendingParentIds.shift();
+
+      for (const [childId, childItem] of Object.entries(
+        collection?.items ?? {},
+      )) {
+        if (childItem?.parentId !== parentId) {
+          continue;
+        }
+
+        descendantIds.push(childId);
+        pendingParentIds.push(childId);
+      }
+    }
+
+    for (const descendantId of descendantIds) {
+      const descendantItem = collection?.items?.[descendantId];
+      if (!descendantItem || descendantItem.type === "folder") {
+        continue;
+      }
+
+      const descendantDeletion = await validateResourceDeletion({
+        projectService,
+        resourceType,
+        currentItem: descendantItem,
+        itemId: descendantId,
+      });
+      if (!descendantDeletion.canDelete) {
+        return descendantDeletion;
+      }
+    }
+
+    return { canDelete: true };
+  }
 
   if (currentItemType === "character") {
     if (currentItem?.sprites?.items) {
@@ -203,10 +256,7 @@ const validateResourceDeletion = async ({
         });
 
         if (usage.isUsed) {
-          appService.showToast(
-            "Cannot delete resource, it is currently in use.",
-          );
-          return false;
+          return { canDelete: false, reason: "in-use" };
         }
       }
     }
@@ -216,8 +266,7 @@ const validateResourceDeletion = async ({
     const textStyleCount = getTextStyleCount(state.textStyles);
     const removalCount = getTextStyleRemovalCount(state.textStyles, itemId);
     if (textStyleCount - removalCount < 1) {
-      appService.showToast("At least one text style must remain.");
-      return false;
+      return { canDelete: false, reason: "minimum-text-style" };
     }
   }
 
@@ -237,11 +286,10 @@ const validateResourceDeletion = async ({
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
-    return false;
+    return { canDelete: false, reason: "in-use" };
   }
 
-  return true;
+  return { canDelete: true };
 };
 
 export const createResourceFileExplorerHandlers = ({
@@ -302,20 +350,29 @@ export const createResourceFileExplorerHandlers = ({
           return;
         }
 
-        const canDelete = await validateResourceDeletion({
-          appService,
+        const deleteValidation = await validateResourceDeletion({
           projectService,
           resourceType,
           currentItem,
           itemId,
         });
-        if (!canDelete) {
+        if (!deleteValidation.canDelete) {
+          appService.showToast(
+            getDeletionBlockedMessage({
+              itemType: currentItem?.type,
+              reason: deleteValidation.reason,
+            }),
+          );
           return;
         }
 
-        await projectService[resourceApi.deleteMethod]({
+        const deleteResult = await projectService[resourceApi.deleteMethod]({
           [resourceApi.deleteField]: [itemId],
         });
+        if (deleteResult?.valid === false) {
+          appService.showToast("Failed to delete resource.");
+          return;
+        }
       } else if (
         action &&
         typeof action === "object" &&

--- a/src/internal/ui/resourcePages/media/createMediaPageStore.js
+++ b/src/internal/ui/resourcePages/media/createMediaPageStore.js
@@ -63,6 +63,7 @@ export const createMediaPageStore = ({
   matchesSearch = defaultMatchesSearch,
   buildDetailFields = () => [],
   buildMediaItem = (item) => item,
+  buildPendingMediaItem,
   createEditForm = () => undefined,
   getSelectedPreviewFileId = () => undefined,
   extendViewData,
@@ -78,6 +79,7 @@ export const createMediaPageStore = ({
 
   const createInitialState = () => ({
     data: EMPTY_TREE,
+    pendingUploads: [],
     selectedItemId: undefined,
     searchQuery: "",
     isEditDialogOpen: false,
@@ -92,6 +94,25 @@ export const createMediaPageStore = ({
 
   const setItems = ({ state }, { data } = {}) => {
     state.data = data ?? EMPTY_TREE;
+  };
+
+  const addPendingUploads = ({ state }, { items } = {}) => {
+    if (!Array.isArray(items) || items.length === 0) {
+      return;
+    }
+
+    state.pendingUploads.push(...items);
+  };
+
+  const removePendingUploads = ({ state }, { itemIds } = {}) => {
+    const idSet = new Set(Array.isArray(itemIds) ? itemIds : []);
+    if (idSet.size === 0) {
+      return;
+    }
+
+    state.pendingUploads = state.pendingUploads.filter(
+      (item) => !idSet.has(item.id),
+    );
   };
 
   const setSelectedItemId = ({ state }, { itemId } = {}) => {
@@ -146,18 +167,39 @@ export const createMediaPageStore = ({
     const flatItems = toFlatItems(state.data);
     const rawFlatGroups = toFlatGroups(state.data);
     const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+    const pendingByGroupId = new Map();
+
+    if (typeof buildPendingMediaItem === "function") {
+      for (const pendingUpload of state.pendingUploads ?? []) {
+        const groupId = pendingUpload?.parentId;
+        if (!groupId) {
+          continue;
+        }
+
+        const existing = pendingByGroupId.get(groupId) ?? [];
+        existing.push(buildPendingMediaItem(pendingUpload));
+        pendingByGroupId.set(groupId, existing);
+      }
+    }
 
     const mediaGroups = rawFlatGroups
       .map((group) => {
-        const filteredChildren = (group.children ?? []).filter((item) =>
-          matchesSearch(item, searchQuery),
-        );
-        const shouldShowGroup = !searchQuery || filteredChildren.length > 0;
+        const filteredChildren = (group.children ?? [])
+          .filter((item) => matchesSearch(item, searchQuery))
+          .map(buildMediaItem);
+        const filteredPendingChildren = (
+          pendingByGroupId.get(group.id) ?? []
+        ).filter((item) => matchesSearch(item, searchQuery));
+        const shouldShowGroup =
+          !searchQuery ||
+          filteredChildren.length > 0 ||
+          filteredPendingChildren.length > 0;
 
         return {
           ...group,
-          children: filteredChildren.map(buildMediaItem),
-          hasChildren: filteredChildren.length > 0,
+          children: [...filteredChildren, ...filteredPendingChildren],
+          hasChildren:
+            filteredChildren.length > 0 || filteredPendingChildren.length > 0,
           shouldDisplay: shouldShowGroup,
         };
       })
@@ -210,6 +252,8 @@ export const createMediaPageStore = ({
   return {
     createInitialState,
     setItems,
+    addPendingUploads,
+    removePendingUploads,
     setSelectedItemId,
     openEditDialog,
     closeEditDialog,

--- a/src/internal/ui/resourcePages/media/processPendingUploads.js
+++ b/src/internal/ui/resourcePages/media/processPendingUploads.js
@@ -1,0 +1,139 @@
+import { nanoid } from "nanoid";
+import { processWithConcurrency } from "../../../processWithConcurrency.js";
+
+const CREATE_ABORT_ERROR = "pending-upload-create-abort";
+
+const createAbortError = () => {
+  const error = new Error(CREATE_ABORT_ERROR);
+  error.code = CREATE_ABORT_ERROR;
+  return error;
+};
+
+const defaultPendingName = (file) => {
+  return file?.name?.replace(/\.[^.]+$/, "") ?? "";
+};
+
+const createPendingUploads = ({
+  files,
+  parentId,
+  pendingIdPrefix,
+  getPendingName = defaultPendingName,
+} = {}) => {
+  if (!parentId) {
+    return [];
+  }
+
+  return (Array.isArray(files) ? files : []).map((file) => ({
+    id: `${pendingIdPrefix}-${nanoid()}`,
+    file,
+    parentId,
+    name: getPendingName(file),
+  }));
+};
+
+export const processPendingUploads = async ({
+  deps,
+  files,
+  parentId,
+  pendingIdPrefix = "pending-item",
+  concurrency = 1,
+  refresh = async () => {},
+  createItem = async () => false,
+  onUploadError,
+  onNoSuccessfulUploads,
+  getPendingName,
+} = {}) => {
+  const { projectService, store, render } = deps;
+  const fileList = Array.isArray(files) ? files : [];
+  const pendingUploads = createPendingUploads({
+    files: fileList,
+    parentId,
+    pendingIdPrefix,
+    getPendingName,
+  });
+  const remainingPendingUploadIds = new Set(
+    pendingUploads.map((item) => item.id),
+  );
+  const pendingUploadIdByFile = new Map(
+    pendingUploads.map((item) => [item.file, item.id]),
+  );
+  const removePendingUploads = (itemIds) => {
+    const normalizedItemIds = (itemIds ?? []).filter((itemId) =>
+      remainingPendingUploadIds.has(itemId),
+    );
+    if (normalizedItemIds.length === 0) {
+      return;
+    }
+
+    store.removePendingUploads({ itemIds: normalizedItemIds });
+    normalizedItemIds.forEach((itemId) =>
+      remainingPendingUploadIds.delete(itemId),
+    );
+    render();
+  };
+
+  if (pendingUploads.length > 0) {
+    store.addPendingUploads({
+      items: pendingUploads.map((item) => ({
+        id: item.id,
+        parentId: item.parentId,
+        name: item.name,
+      })),
+    });
+    render();
+  }
+
+  let successfulUploadCount = 0;
+
+  try {
+    await processWithConcurrency(
+      fileList,
+      async (file) => {
+        const pendingUploadId = pendingUploadIdByFile.get(file);
+        const uploadResults = await projectService.uploadFiles([file]);
+        const uploadResult = uploadResults?.[0];
+
+        if (!uploadResult) {
+          removePendingUploads([pendingUploadId]);
+          return { ok: false, reason: "upload-failed" };
+        }
+
+        successfulUploadCount += 1;
+
+        const created = await createItem({
+          file,
+          uploadResult,
+          parentId,
+        });
+
+        removePendingUploads([pendingUploadId]);
+
+        if (!created) {
+          throw createAbortError();
+        }
+
+        await refresh(deps);
+        return { ok: true };
+      },
+      {
+        concurrency,
+        stopOnError: true,
+      },
+    );
+  } catch (error) {
+    removePendingUploads([...remainingPendingUploadIds]);
+    if (error?.code === CREATE_ABORT_ERROR) {
+      return { status: "create-aborted" };
+    }
+
+    await onUploadError?.({ error });
+    return { status: "upload-failed", error };
+  }
+
+  if (successfulUploadCount === 0) {
+    onNoSuccessfulUploads?.({ fileCount: fileList.length });
+    return { status: "no-successful-uploads" };
+  }
+
+  return { status: "ok", successfulUploadCount };
+};

--- a/src/pages/about/about.handlers.js
+++ b/src/pages/about/about.handlers.js
@@ -1,18 +1,12 @@
-export const handleBeforeMount = () => {
-  // Initialize about page
-};
+export const handleBeforeMount = (deps) => {
+  const { appService, store } = deps;
 
-export const handleAfterMount = async (deps) => {
-  const { store, render, appService } = deps;
-
-  // Set app version from appService
   const appVersion = appService.getAppVersion();
   if (appVersion) {
     store.setAppVersion({ version: appVersion });
   }
-  const platform = appService.getPlatform();
-  store.setPlatform({ platform: platform });
-  render();
+
+  store.setPlatform({ platform: appService.getPlatform() });
 };
 
 export const handleDataChanged = () => {

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
+import { processWithConcurrency } from "../../internal/processWithConcurrency.js";
 import { createCharacterSpritesFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
 import {
   getResourcePageErrorMessage,
@@ -11,6 +12,27 @@ import { tap } from "rxjs";
 
 const EMPTY_TREE = { items: {}, tree: [] };
 const ACCEPTED_FILE_TYPES = ".jpg,.jpeg,.png,.webp";
+const MAX_PARALLEL_UPLOADS = 1;
+const CREATE_SPRITE_ABORT_ERROR = "create-sprite-abort";
+
+const createPendingUploads = ({ files, parentId } = {}) => {
+  if (!parentId) {
+    return [];
+  }
+
+  return (Array.isArray(files) ? files : []).map((file) => ({
+    id: `pending-sprite-${nanoid()}`,
+    file,
+    parentId,
+    name: file.name.replace(/\.[^.]+$/, ""),
+  }));
+};
+
+const createSpriteAbortError = () => {
+  const error = new Error(CREATE_SPRITE_ABORT_ERROR);
+  error.code = CREATE_SPRITE_ABORT_ERROR;
+  return error;
+};
 
 const getCharacterIdFromPayload = ({ appService }) => {
   return appService.getPayload().characterId;
@@ -102,14 +124,109 @@ const openEditDialogForSprite = ({
 const createSpritesFromFiles = async ({
   deps,
   files,
-  parentId = null,
+  parentId = undefined,
 } = {}) => {
-  const { appService, projectService, store } = deps;
-  let successfulUploads;
+  const { appService, projectService, store, render } = deps;
+  const characterId = store.selectCharacterId();
+  if (!characterId) {
+    appService.showToast("Character is missing.", { title: "Error" });
+    return;
+  }
+
+  const pendingUploads = createPendingUploads({ files, parentId });
+  const remainingPendingUploadIds = new Set(
+    pendingUploads.map((item) => item.id),
+  );
+  const pendingUploadIdByFile = new Map(
+    pendingUploads.map((item) => [item.file, item.id]),
+  );
+  const removePendingUploads = (itemIds) => {
+    const normalizedItemIds = (itemIds ?? []).filter((itemId) =>
+      remainingPendingUploadIds.has(itemId),
+    );
+    if (normalizedItemIds.length === 0) {
+      return;
+    }
+
+    store.removePendingUploads({ itemIds: normalizedItemIds });
+    normalizedItemIds.forEach((itemId) =>
+      remainingPendingUploadIds.delete(itemId),
+    );
+    render();
+  };
+
+  if (pendingUploads.length > 0) {
+    store.addPendingUploads({
+      items: pendingUploads.map((item) => ({
+        id: item.id,
+        parentId: item.parentId,
+        name: item.name,
+      })),
+    });
+    render();
+  }
+
+  let successfulUploadCount = 0;
+  let createdCount = 0;
 
   try {
-    successfulUploads = await projectService.uploadFiles(files);
+    await processWithConcurrency(
+      Array.isArray(files) ? files : [],
+      async (file) => {
+        const pendingUploadId = pendingUploadIdByFile.get(file);
+        const uploadResults = await projectService.uploadFiles([file]);
+        const uploadResult = uploadResults?.[0];
+
+        if (!uploadResult) {
+          removePendingUploads([pendingUploadId]);
+          return { ok: false, reason: "upload-failed" };
+        }
+
+        successfulUploadCount += 1;
+
+        const createAttempt = await runResourcePageMutation({
+          appService,
+          fallbackMessage: "Failed to create sprite.",
+          action: () =>
+            projectService.createCharacterSpriteItem({
+              characterId,
+              spriteId: nanoid(),
+              fileRecords: uploadResult.fileRecords,
+              parentId,
+              position: "last",
+              data: {
+                type: "image",
+                fileId: uploadResult.fileId,
+                name: uploadResult.displayName,
+                fileType: uploadResult.file.type,
+                fileSize: uploadResult.file.size,
+                width: uploadResult.dimensions.width,
+                height: uploadResult.dimensions.height,
+              },
+            }),
+        });
+
+        removePendingUploads([pendingUploadId]);
+
+        if (!createAttempt.ok) {
+          throw createSpriteAbortError();
+        }
+
+        createdCount += 1;
+        await refreshCharacterSpritesData(deps);
+        return { ok: true };
+      },
+      {
+        concurrency: MAX_PARALLEL_UPLOADS,
+        stopOnError: true,
+      },
+    );
   } catch (error) {
+    removePendingUploads([...remainingPendingUploadIds]);
+    if (error?.code === CREATE_SPRITE_ABORT_ERROR) {
+      return;
+    }
+
     showResourcePageError({
       appService,
       errorOrResult: error,
@@ -118,46 +235,14 @@ const createSpritesFromFiles = async ({
     return;
   }
 
-  if (!successfulUploads.length) {
+  if (successfulUploadCount === 0) {
     appService.showToast("Failed to upload sprites.", { title: "Error" });
     return;
   }
 
-  const characterId = store.selectCharacterId();
-  if (!characterId) {
-    appService.showToast("Character is missing.", { title: "Error" });
-    return;
+  if (createdCount > 0) {
+    await refreshCharacterSpritesData(deps);
   }
-
-  for (const result of successfulUploads) {
-    const createAttempt = await runResourcePageMutation({
-      appService,
-      fallbackMessage: "Failed to create sprite.",
-      action: () =>
-        projectService.createCharacterSpriteItem({
-          characterId,
-          spriteId: nanoid(),
-          fileRecords: result.fileRecords,
-          parentId,
-          position: "last",
-          data: {
-            type: "image",
-            fileId: result.fileId,
-            name: result.displayName,
-            fileType: result.file.type,
-            fileSize: result.file.size,
-            width: result.dimensions.width,
-            height: result.dimensions.height,
-          },
-        }),
-    });
-
-    if (!createAttempt.ok) {
-      return;
-    }
-  }
-
-  await refreshCharacterSpritesData(deps);
 };
 
 export const handleBeforeMount = (deps) => {

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -102,8 +102,25 @@ const matchesSearch = (item, searchQuery) => {
   return name.includes(searchQuery) || description.includes(searchQuery);
 };
 
+const buildMediaItem = (item) => ({
+  ...item,
+  cardKind: "image",
+  previewFileId: item.fileId,
+  canPreview: true,
+});
+
+const buildPendingMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "image",
+  isProcessing: true,
+  isInteractive: false,
+  canPreview: false,
+});
+
 export const createInitialState = () => ({
   spritesData: EMPTY_TREE,
+  pendingUploads: [],
   selectedItemId: undefined,
   characterId: undefined,
   characterName: undefined,
@@ -124,6 +141,25 @@ export const setItems = ({ state }, { spritesData } = {}) => {
   state.spritesData = spritesData ?? EMPTY_TREE;
 };
 
+export const addPendingUploads = ({ state }, { items } = {}) => {
+  if (!Array.isArray(items) || items.length === 0) {
+    return;
+  }
+
+  state.pendingUploads.push(...items);
+};
+
+export const removePendingUploads = ({ state }, { itemIds } = {}) => {
+  const idSet = new Set(Array.isArray(itemIds) ? itemIds : []);
+  if (idSet.size === 0) {
+    return;
+  }
+
+  state.pendingUploads = state.pendingUploads.filter(
+    (item) => !idSet.has(item.id),
+  );
+};
+
 export const setCharacterId = ({ state }, { characterId } = {}) => {
   state.characterId = characterId;
 };
@@ -135,6 +171,7 @@ export const setCharacterName = ({ state }, { characterName } = {}) => {
 export const clearCharacterSpritesView = ({ state }) => {
   state.characterName = undefined;
   state.spritesData = EMPTY_TREE;
+  state.pendingUploads = [];
   state.selectedItemId = undefined;
   state.isEditDialogOpen = false;
   state.editItemId = undefined;
@@ -225,23 +262,34 @@ export const selectViewData = ({ state }) => {
   );
   const rawFlatGroups = toFlatGroups(state.spritesData);
   const searchQuery = state.searchQuery.toLowerCase().trim();
+  const pendingByGroupId = new Map();
+
+  for (const pendingUpload of state.pendingUploads ?? []) {
+    const groupId = pendingUpload?.parentId;
+    if (!groupId) {
+      continue;
+    }
+
+    const existing = pendingByGroupId.get(groupId) ?? [];
+    existing.push(buildPendingMediaItem(pendingUpload));
+    pendingByGroupId.set(groupId, existing);
+  }
 
   const mediaGroups = rawFlatGroups
     .map((group) => {
-      const children = (group.children ?? []).filter((item) =>
-        matchesSearch(item, searchQuery),
+      const children = (group.children ?? [])
+        .filter((item) => matchesSearch(item, searchQuery))
+        .map(buildMediaItem);
+      const pendingChildren = (pendingByGroupId.get(group.id) ?? []).filter(
+        (item) => matchesSearch(item, searchQuery),
       );
-      const shouldDisplay = !searchQuery || children.length > 0;
+      const shouldDisplay =
+        !searchQuery || children.length > 0 || pendingChildren.length > 0;
 
       return {
         ...group,
-        children: children.map((item) => ({
-          ...item,
-          cardKind: "image",
-          previewFileId: item.fileId,
-          canPreview: true,
-        })),
-        hasChildren: children.length > 0,
+        children: [...children, ...pendingChildren],
+        hasChildren: children.length > 0 || pendingChildren.length > 0,
         shouldDisplay,
       };
     })

--- a/src/pages/colors/colors.store.js
+++ b/src/pages/colors/colors.store.js
@@ -29,7 +29,7 @@ const editForm = {
     {
       name: "hex",
       type: "color-picker",
-      label: "Hex Value",
+      label: "Color",
       required: true,
     },
   ],
@@ -57,7 +57,7 @@ const addForm = {
     {
       name: "hex",
       type: "color-picker",
-      label: "Hex Value",
+      label: "Color",
       required: true,
     },
   ],

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { createFontInfoExtractor } from "../../deps/fontInfoExtractor.js";
 import { getFileType } from "../../internal/fileTypes.js";
 import { recursivelyCheckResource } from "../../internal/project/projection.js";
+import { processWithConcurrency } from "../../internal/processWithConcurrency.js";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
 import {
@@ -10,6 +11,8 @@ import {
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const FONT_FILE_PATTERN = /\.(ttf|otf|woff|woff2|ttc|eot)$/i;
+const MAX_PARALLEL_UPLOADS = 1;
+const CREATE_FONT_ABORT_ERROR = "create-font-abort";
 
 const showInvalidFormatToast = (appService) => {
   appService.showToast(
@@ -31,16 +34,123 @@ const validateFontFiles = ({ appService, files } = {}) => {
   return true;
 };
 
+const createPendingUploads = ({ files, parentId } = {}) => {
+  if (!parentId) {
+    return [];
+  }
+
+  return (Array.isArray(files) ? files : []).map((file) => ({
+    id: `pending-font-${nanoid()}`,
+    file,
+    parentId,
+    name: file.name.replace(/\.[^.]+$/, ""),
+  }));
+};
+
+const createFontAbortError = () => {
+  const error = new Error(CREATE_FONT_ABORT_ERROR);
+  error.code = CREATE_FONT_ABORT_ERROR;
+  return error;
+};
+
 const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
-  const { appService, projectService } = deps;
+  const { appService, projectService, store, render } = deps;
   if (!validateFontFiles({ appService, files })) {
     return;
   }
 
-  let successfulUploads;
+  const pendingUploads = createPendingUploads({ files, parentId });
+  const remainingPendingUploadIds = new Set(
+    pendingUploads.map((item) => item.id),
+  );
+  const pendingUploadIdByFile = new Map(
+    pendingUploads.map((item) => [item.file, item.id]),
+  );
+  const removePendingUploads = (itemIds) => {
+    const normalizedItemIds = (itemIds ?? []).filter((itemId) =>
+      remainingPendingUploadIds.has(itemId),
+    );
+    if (normalizedItemIds.length === 0) {
+      return;
+    }
+
+    store.removePendingUploads({ itemIds: normalizedItemIds });
+    normalizedItemIds.forEach((itemId) =>
+      remainingPendingUploadIds.delete(itemId),
+    );
+    render();
+  };
+
+  if (pendingUploads.length > 0) {
+    store.addPendingUploads({
+      items: pendingUploads.map((item) => ({
+        id: item.id,
+        parentId: item.parentId,
+        name: item.name,
+      })),
+    });
+    render();
+  }
+
+  let successfulUploadCount = 0;
+  let createdCount = 0;
+
   try {
-    successfulUploads = await projectService.uploadFiles(files);
+    await processWithConcurrency(
+      Array.isArray(files) ? files : [],
+      async (file) => {
+        const pendingUploadId = pendingUploadIdByFile.get(file);
+        const uploadResults = await projectService.uploadFiles([file]);
+        const uploadResult = uploadResults?.[0];
+
+        if (!uploadResult) {
+          removePendingUploads([pendingUploadId]);
+          return { ok: false, reason: "upload-failed" };
+        }
+
+        successfulUploadCount += 1;
+
+        const createAttempt = await runResourcePageMutation({
+          appService,
+          fallbackMessage: "Failed to create font.",
+          action: () =>
+            projectService.createFont({
+              fontId: nanoid(),
+              fileRecords: uploadResult.fileRecords,
+              data: {
+                type: "font",
+                fileId: uploadResult.fileId,
+                name: uploadResult.displayName,
+                fontFamily: uploadResult.fontName,
+                fileType: getFileType(uploadResult),
+                fileSize: uploadResult.file.size,
+              },
+              parentId,
+              position: "last",
+            }),
+        });
+
+        removePendingUploads([pendingUploadId]);
+
+        if (!createAttempt.ok) {
+          throw createFontAbortError();
+        }
+
+        createdCount += 1;
+        await handleDataChanged(deps);
+        return { ok: true };
+      },
+      {
+        concurrency: MAX_PARALLEL_UPLOADS,
+        stopOnError: true,
+      },
+    );
   } catch (error) {
+    removePendingUploads([...remainingPendingUploadIds]);
+    if (error?.code === CREATE_FONT_ABORT_ERROR) {
+      return;
+    }
+
     showResourcePageError({
       appService,
       errorOrResult: error,
@@ -49,37 +159,14 @@ const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
     return;
   }
 
-  if (!successfulUploads.length) {
+  if (successfulUploadCount === 0) {
     appService.showToast("Failed to upload font.", { title: "Error" });
     return;
   }
 
-  for (const result of successfulUploads) {
-    const createAttempt = await runResourcePageMutation({
-      appService,
-      fallbackMessage: "Failed to create font.",
-      action: () =>
-        projectService.createFont({
-          fontId: nanoid(),
-          fileRecords: result.fileRecords,
-          data: {
-            type: "font",
-            fileId: result.fileId,
-            name: result.displayName,
-            fontFamily: result.fontName,
-            fileType: getFileType(result),
-            fileSize: result.file.size,
-          },
-          parentId,
-          position: "last",
-        }),
-    });
-    if (!createAttempt.ok) {
-      return;
-    }
+  if (createdCount > 0) {
+    await handleDataChanged(deps);
   }
-
-  await handleDataChanged(deps);
 };
 
 const {

--- a/src/pages/fonts/fonts.store.js
+++ b/src/pages/fonts/fonts.store.js
@@ -107,9 +107,20 @@ const buildMediaItem = (item) => ({
   fontFileId: item.fileId,
 });
 
+const buildPendingMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "font",
+  isProcessing: true,
+  isInteractive: false,
+  canPreview: false,
+});
+
 const {
   createInitialState: createMediaInitialState,
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   selectSelectedItem,
   selectItemById,
@@ -129,6 +140,7 @@ const {
   ],
   buildDetailFields,
   buildMediaItem,
+  buildPendingMediaItem,
   getSelectedPreviewFileId: (item) => item?.fileId,
   extendViewData: ({ state, selectedItem, baseViewData }) => {
     const selectedFontInfo = state.selectedFontInfo;
@@ -165,6 +177,8 @@ export const createInitialState = () => ({
 
 export {
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   selectSelectedItem,
   selectSelectedItemId,

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -1,10 +1,33 @@
 import { nanoid } from "nanoid";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
+import { processWithConcurrency } from "../../internal/processWithConcurrency.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
 import {
   runResourcePageMutation,
   showResourcePageError,
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
+
+const MAX_PARALLEL_UPLOADS = 1;
+const CREATE_IMAGE_ABORT_ERROR = "create-image-abort";
+
+const createPendingUploads = ({ files, parentId } = {}) => {
+  if (!parentId) {
+    return [];
+  }
+
+  return (Array.isArray(files) ? files : []).map((file) => ({
+    id: `pending-image-${nanoid()}`,
+    file,
+    parentId,
+    name: file.name.replace(/\.[^.]+$/, ""),
+  }));
+};
+
+const createImageAbortError = () => {
+  const error = new Error(CREATE_IMAGE_ABORT_ERROR);
+  error.code = CREATE_IMAGE_ABORT_ERROR;
+  return error;
+};
 
 const {
   refreshData: handleDataChanged,
@@ -37,12 +60,101 @@ export {
 };
 
 const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
-  const { appService, projectService } = deps;
-  let successfulUploads;
+  const { appService, projectService, store, render } = deps;
+  const pendingUploads = createPendingUploads({ files, parentId });
+  const remainingPendingUploadIds = new Set(
+    pendingUploads.map((item) => item.id),
+  );
+  const pendingUploadIdByFile = new Map(
+    pendingUploads.map((item) => [item.file, item.id]),
+  );
+  const removePendingUploads = (itemIds) => {
+    const normalizedItemIds = (itemIds ?? []).filter((itemId) =>
+      remainingPendingUploadIds.has(itemId),
+    );
+    if (normalizedItemIds.length === 0) {
+      return;
+    }
+
+    store.removePendingUploads({ itemIds: normalizedItemIds });
+    normalizedItemIds.forEach((itemId) =>
+      remainingPendingUploadIds.delete(itemId),
+    );
+    render();
+  };
+
+  if (pendingUploads.length > 0) {
+    store.addPendingUploads({
+      items: pendingUploads.map((item) => ({
+        id: item.id,
+        parentId: item.parentId,
+        name: item.name,
+      })),
+    });
+    render();
+  }
+
+  let successfulUploadCount = 0;
+  let createdCount = 0;
 
   try {
-    successfulUploads = await projectService.uploadFiles(files);
+    await processWithConcurrency(
+      Array.isArray(files) ? files : [],
+      async (file) => {
+        const pendingUploadId = pendingUploadIdByFile.get(file);
+        const uploadResults = await projectService.uploadFiles([file]);
+        const uploadResult = uploadResults?.[0];
+
+        if (!uploadResult) {
+          removePendingUploads([pendingUploadId]);
+          return { ok: false, reason: "upload-failed" };
+        }
+
+        successfulUploadCount += 1;
+
+        const createAttempt = await runResourcePageMutation({
+          appService,
+          fallbackMessage: "Failed to create image.",
+          action: () =>
+            projectService.createImage({
+              imageId: nanoid(),
+              fileRecords: uploadResult.fileRecords,
+              data: {
+                type: "image",
+                fileId: uploadResult.fileId,
+                thumbnailFileId: uploadResult.thumbnailFileId,
+                name: uploadResult.displayName,
+                fileType: uploadResult.file.type,
+                fileSize: uploadResult.file.size,
+                width: uploadResult.dimensions.width,
+                height: uploadResult.dimensions.height,
+              },
+              parentId,
+              position: "last",
+            }),
+        });
+
+        removePendingUploads([pendingUploadId]);
+
+        if (!createAttempt.ok) {
+          throw createImageAbortError();
+        }
+
+        createdCount += 1;
+        await handleDataChanged(deps);
+        return { ok: true };
+      },
+      {
+        concurrency: MAX_PARALLEL_UPLOADS,
+        stopOnError: true,
+      },
+    );
   } catch (error) {
+    removePendingUploads([...remainingPendingUploadIds]);
+    if (error?.code === CREATE_IMAGE_ABORT_ERROR) {
+      return;
+    }
+
     showResourcePageError({
       appService,
       errorOrResult: error,
@@ -51,7 +163,7 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
     return;
   }
 
-  if (!successfulUploads.length) {
+  if (successfulUploadCount === 0) {
     console.error("Failed to upload images: no successful uploads", {
       fileCount: Array.isArray(files) ? files.length : 0,
     });
@@ -59,35 +171,9 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
     return;
   }
 
-  for (const result of successfulUploads) {
-    const imageData = {
-      type: "image",
-      fileId: result.fileId,
-      thumbnailFileId: result.thumbnailFileId,
-      name: result.displayName,
-      fileType: result.file.type,
-      fileSize: result.file.size,
-      width: result.dimensions.width,
-      height: result.dimensions.height,
-    };
-    const createAttempt = await runResourcePageMutation({
-      appService,
-      fallbackMessage: "Failed to create image.",
-      action: () =>
-        projectService.createImage({
-          imageId: nanoid(),
-          fileRecords: result.fileRecords,
-          data: imageData,
-          parentId,
-          position: "last",
-        }),
-    });
-    if (!createAttempt.ok) {
-      return;
-    }
+  if (createdCount > 0) {
+    await handleDataChanged(deps);
   }
-
-  await handleDataChanged(deps);
 };
 
 export const handleUploadClick = async (deps, payload) => {

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -43,6 +43,15 @@ const buildMediaItem = (item) => ({
   canPreview: true,
 });
 
+const buildPendingMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "image",
+  isProcessing: true,
+  isInteractive: false,
+  canPreview: false,
+});
+
 const createEditForm = () => ({
   title: "Edit Image",
   fields: [
@@ -79,6 +88,8 @@ const createEditForm = () => ({
 const {
   createInitialState: createMediaInitialState,
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   openEditDialog,
   closeEditDialog,
@@ -98,6 +109,7 @@ const {
   showZoomControls: true,
   buildDetailFields,
   buildMediaItem,
+  buildPendingMediaItem,
   createEditForm,
   getSelectedPreviewFileId: (item) => item?.thumbnailFileId ?? item?.fileId,
   extendViewData: ({ state, baseViewData }) => ({
@@ -115,6 +127,8 @@ export const createInitialState = () => ({
 
 export {
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   openEditDialog,
   closeEditDialog,

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -363,7 +363,7 @@ export const handleBeforeMount = (deps) => {
     await flushSceneEditorDrafts(deps);
     const repository = await projectService.getRepository().catch(() => null);
     await repository?.clearActiveSceneId?.();
-    resetSceneEditorRuntime(deps);
+    await resetSceneEditorRuntime(deps);
   };
 };
 

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -4,6 +4,7 @@ import {
   matchesRemoteTargets,
 } from "../../internal/ui/collabRefresh.js";
 import { createScenesFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
+import { toFlatItems } from "../../internal/project/tree.js";
 import {
   SCENE_BOX_HEIGHT,
   SCENE_BOX_VIEWPORT_PADDING,
@@ -213,6 +214,43 @@ const getSceneItemById = ({ store, sceneId } = {}) => {
     return undefined;
   }
   return sceneItem;
+};
+
+const resolveSceneFormDefaultValues = ({ store } = {}) => {
+  const scenesData = store.selectScenesData() ?? { tree: [], items: {} };
+  const defaultFolderId = toFlatItems(scenesData).find(
+    (item) => item.type === "folder",
+  )?.id;
+
+  return {
+    name: "",
+    folderId: defaultFolderId,
+  };
+};
+
+const openSceneForm = ({
+  deps,
+  formPosition,
+  whiteboardPosition,
+  isWaitingForTransform = false,
+} = {}) => {
+  const { store, render, refs } = deps;
+  const sceneFormValues = resolveSceneFormDefaultValues({ store });
+
+  store.setSceneFormData({ data: sceneFormValues });
+  store.setSceneFormPosition({
+    position: formPosition,
+  });
+  store.setSceneWhiteboardPosition({
+    position: whiteboardPosition,
+  });
+  store.setWaitingForTransform({ isWaiting: isWaitingForTransform });
+  store.setShowSceneForm({ show: true });
+  render();
+
+  const { sceneForm } = refs;
+  sceneForm.reset();
+  sceneForm.setValues({ values: sceneFormValues });
 };
 
 const syncScenesState = async ({ store, projectService } = {}) => {
@@ -465,45 +503,28 @@ export const handleAddSceneClick = (deps) => {
 };
 
 export const handleWhiteboardClick = (deps, payload) => {
-  const { store, render } = deps;
+  const { store } = deps;
   const isWaitingForTransform = store.selectIsWaitingForTransform();
 
   if (isWaitingForTransform) {
     // Get click position relative to whiteboard
     const { formX, formY, whiteboardX, whiteboardY } = payload._event.detail;
-
-    // Reset form data
-    store.setSceneFormData({ data: { name: "", folderId: "_root" } });
-
-    // Show the form at the clicked position
-    store.setSceneFormPosition({
-      position: { x: formX, y: formY },
+    openSceneForm({
+      deps,
+      formPosition: { x: formX, y: formY },
+      whiteboardPosition: { x: whiteboardX, y: whiteboardY },
+      isWaitingForTransform: false,
     });
-    store.setSceneWhiteboardPosition({
-      position: { x: whiteboardX, y: whiteboardY },
-    });
-    store.setWaitingForTransform({ isWaiting: false });
-    store.setShowSceneForm({ show: true });
-    render();
   }
 };
 
 export const handleWhiteboardCanvasContextMenu = (deps, payload) => {
-  const { store, render } = deps;
   const { formX, formY, whiteboardX, whiteboardY } = payload._event.detail;
-
-  // Reset form data
-  store.setSceneFormData({ data: { name: "", folderId: "_root" } });
-
-  // Show the form at the right-clicked position
-  store.setSceneFormPosition({
-    position: { x: formX, y: formY },
+  openSceneForm({
+    deps,
+    formPosition: { x: formX, y: formY },
+    whiteboardPosition: { x: whiteboardX, y: whiteboardY },
   });
-  store.setSceneWhiteboardPosition({
-    position: { x: whiteboardX, y: whiteboardY },
-  });
-  store.setShowSceneForm({ show: true });
-  render();
 };
 
 export const handleSceneFormClose = (deps) => {
@@ -520,6 +541,10 @@ export const handleSceneFormAction = async (deps, payload) => {
     store.resetSceneForm();
     render();
   } else if (actionId === "submit") {
+    if (!store.getState().showSceneForm) {
+      return;
+    }
+
     const sceneWhiteboardPosition = store.selectSceneWhiteboardPosition() || {
       x: 0,
       y: 0,
@@ -527,6 +552,9 @@ export const handleSceneFormAction = async (deps, payload) => {
 
     // Get form values from the event detail (same pattern as text styles)
     const formData = payload._event.detail.values;
+
+    store.resetSceneForm();
+    render();
 
     // Use a simple ID generator instead of nanoid
     const newSceneId = `scene-${Date.now()}-${Math.random()
@@ -585,49 +613,56 @@ export const handleSceneFormAction = async (deps, payload) => {
       };
     }
 
-    await projectService.createSceneItem({
-      sceneId: newSceneId,
-      parentId: formData.folderId || null,
-      position: "last",
-      data: {
-        name: formData.name || `Scene ${new Date().toLocaleTimeString()}`,
-        position: {
+    try {
+      await projectService.createSceneItem({
+        sceneId: newSceneId,
+        parentId: formData.folderId || null,
+        position: "last",
+        data: {
+          name: formData.name || `Scene ${new Date().toLocaleTimeString()}`,
+          position: {
+            x: sceneWhiteboardPosition.x,
+            y: sceneWhiteboardPosition.y,
+          },
+        },
+      });
+      await projectService.createSectionItem({
+        sceneId: newSceneId,
+        sectionId,
+        position: "last",
+        data: {
+          name: "Section New",
+        },
+      });
+      await projectService.createLineItem({
+        sectionId,
+        lineId: stepId,
+        data: {
+          actions,
+        },
+        position: "last",
+      });
+
+      // Add to whiteboard items for visual display
+      store.addWhiteboardItem({
+        newItem: {
+          id: newSceneId,
+          name: formData.name,
           x: sceneWhiteboardPosition.x,
           y: sceneWhiteboardPosition.y,
         },
-      },
-    });
-    await projectService.createSectionItem({
-      sceneId: newSceneId,
-      sectionId,
-      position: "last",
-      data: {
-        name: "Section New",
-      },
-    });
-    await projectService.createLineItem({
-      sectionId,
-      lineId: stepId,
-      data: {
-        actions,
-      },
-      position: "last",
-    });
+      });
+      dismissMapAddHint({ store, appService });
 
-    // Add to whiteboard items for visual display
-    store.addWhiteboardItem({
-      newItem: {
-        id: newSceneId,
-        name: formData.name,
-        x: sceneWhiteboardPosition.x,
-        y: sceneWhiteboardPosition.y,
-      },
-    });
-    dismissMapAddHint({ store, appService });
-
-    // Reset form
-    store.resetSceneForm();
-    await refreshScenesData(deps);
+      await refreshScenesData(deps);
+      render();
+    } catch (error) {
+      appService.showToast(
+        getProjectErrorMessage(error, "Failed to create scene."),
+      );
+      await refreshScenesData(deps);
+      render();
+    }
   }
 };
 

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -36,7 +36,7 @@ export const createInitialState = () => ({
   showSceneForm: false,
   sceneFormPosition: { x: 0, y: 0 },
   sceneWhiteboardPosition: { x: 0, y: 0 },
-  sceneFormData: { name: "", folderId: "_root" },
+  sceneFormData: { name: "", folderId: undefined },
   // Dropdown menu state
   dropdownMenu: {
     isOpen: false,
@@ -200,7 +200,7 @@ export const resetSceneForm = ({ state }, _payload = {}) => {
   state.showSceneForm = false;
   state.isWaitingForTransform = false;
   state.sceneFormPosition = { x: 0, y: 0 };
-  state.sceneFormData = { name: "", folderId: "_root" };
+  state.sceneFormData = { name: "", folderId: undefined };
 };
 
 // Dropdown menu functions
@@ -336,38 +336,57 @@ export const selectViewData = ({ state }, payload) => {
   }
 
   // Get folder options for form
-  const folderOptions = [
-    { id: "_root", name: "Root Folder" },
-    ...flatItems
-      .filter((item) => item.type === "folder")
-      .map((folder) => ({ id: folder.id, name: folder.name || folder.id })),
-  ];
+  const folderOptions = flatItems
+    .filter((item) => item.type === "folder")
+    .map((folder) => ({ id: folder.id, name: folder.name || folder.id }));
+  const defaultSceneFolderId = folderOptions[0]?.id;
+  const hasSelectedSceneFolder = folderOptions.some(
+    (folder) => folder.id === state.sceneFormData.folderId,
+  );
+  const sceneFormDefaultValues = {
+    name: state.sceneFormData.name ?? "",
+    folderId: hasSelectedSceneFolder
+      ? state.sceneFormData.folderId
+      : defaultSceneFolderId,
+  };
+  const sceneFormKey = `${state.showSceneForm}-${sceneFormDefaultValues.folderId ?? "none"}-${folderOptions.length}`;
 
   // Define form fields
+  const sceneFormFieldsList = [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Scene Name",
+      description: "Enter the scene name",
+      required: true,
+    },
+  ];
+
+  if (folderOptions.length > 0) {
+    sceneFormFieldsList.push({
+      name: "folderId",
+      type: "select",
+      label: "Folder",
+      clearable: false,
+      options: folderOptions.map((option) => ({
+        value: option.id,
+        label: option.name,
+      })),
+      required: true,
+    });
+  }
+
   const sceneFormFields = {
     title: "Create New Scene",
-    fields: [
-      {
-        name: "name",
-        type: "input-text",
-        label: "Scene Name",
-        description: "Enter the scene name",
-        required: true,
-      },
-      {
-        name: "folderId",
-        type: "select",
-        label: "Folder",
-        options: folderOptions.map((option) => ({
-          value: option.id,
-          label: option.name,
-        })),
-        required: true,
-      },
-    ],
+    fields: sceneFormFieldsList,
     actions: {
       layout: "",
       buttons: [
+        {
+          id: "cancel",
+          variant: "se",
+          label: "Cancel",
+        },
         {
           id: "submit",
           variant: "pr",
@@ -422,8 +441,9 @@ export const selectViewData = ({ state }, payload) => {
     selectedSceneName,
     isWaitingForTransform: state.isWaitingForTransform,
     showSceneForm: state.showSceneForm,
+    sceneFormKey,
     sceneFormPosition: state.sceneFormPosition,
-    sceneFormData: state.sceneFormData,
+    sceneFormData: sceneFormDefaultValues,
     sceneFormFields,
     isEditDialogOpen: state.isEditDialogOpen,
     editDefaultValues: state.editDefaultValues,

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -121,7 +121,7 @@ template:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
       - rtgl-popover#sceneFormPopover ?open=${showSceneForm} x=${sceneFormPosition.x} y=${sceneFormPosition.y}:
-          - rtgl-form#sceneForm key=${showSceneForm} slot=content :form=sceneFormFields w=320: null
+          - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=sceneFormData :form=sceneFormFields w=320: null
       - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
           - rtgl-view slot=content g=md:
               - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=editDefaultValues :form=editForm w=f: null

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { filter, tap } from "rxjs";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
+import { processPendingUploads } from "../../internal/ui/resourcePages/media/processPendingUploads.js";
 import {
   getResourcePageErrorMessage,
   runResourcePageMutation,
@@ -56,52 +57,48 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
 
 const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
   const { appService, projectService } = deps;
-  let successfulUploads;
 
-  try {
-    successfulUploads = await projectService.uploadFiles(files);
-  } catch (error) {
-    await showUnsupportedFormatDialog(
-      appService,
-      getResourcePageErrorMessage(error, UNSUPPORTED_FORMAT_MESSAGE),
-    );
-    return;
-  }
+  await processPendingUploads({
+    deps,
+    files,
+    parentId,
+    pendingIdPrefix: "pending-sound",
+    refresh: handleDataChanged,
+    createItem: async ({ uploadResult }) => {
+      const createAttempt = await runResourcePageMutation({
+        appService,
+        fallbackMessage: "Failed to create sound.",
+        action: () =>
+          projectService.createSound({
+            soundId: nanoid(),
+            fileRecords: uploadResult.fileRecords,
+            data: {
+              type: "sound",
+              fileId: uploadResult.fileId,
+              name: uploadResult.displayName,
+              description: "",
+              fileType: uploadResult.file.type,
+              fileSize: uploadResult.file.size,
+              waveformDataFileId: uploadResult.waveformDataFileId,
+              duration: uploadResult.duration,
+            },
+            parentId,
+            position: "last",
+          }),
+      });
 
-  if (!successfulUploads.length) {
-    appService.showToast("Failed to upload sound.", { title: "Error" });
-    return;
-  }
-
-  for (const result of successfulUploads) {
-    const createAttempt = await runResourcePageMutation({
-      appService,
-      fallbackMessage: "Failed to create sound.",
-      action: () =>
-        projectService.createSound({
-          soundId: nanoid(),
-          fileRecords: result.fileRecords,
-          data: {
-            type: "sound",
-            fileId: result.fileId,
-            name: result.displayName,
-            description: "",
-            fileType: result.file.type,
-            fileSize: result.file.size,
-            waveformDataFileId: result.waveformDataFileId,
-            duration: result.duration,
-          },
-          parentId,
-          position: "last",
-        }),
-    });
-
-    if (!createAttempt.ok) {
-      return;
-    }
-  }
-
-  await handleDataChanged(deps);
+      return createAttempt.ok;
+    },
+    onUploadError: async ({ error }) => {
+      await showUnsupportedFormatDialog(
+        appService,
+        getResourcePageErrorMessage(error, UNSUPPORTED_FORMAT_MESSAGE),
+      );
+    },
+    onNoSuccessfulUploads: () => {
+      appService.showToast("Failed to upload sound.", { title: "Error" });
+    },
+  });
 };
 
 const handlePanelResize = (deps, payload) => {

--- a/src/pages/sounds/sounds.store.js
+++ b/src/pages/sounds/sounds.store.js
@@ -53,6 +53,15 @@ const buildMediaItem = (item) => ({
   canPreview: true,
 });
 
+const buildPendingMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "sound",
+  isProcessing: true,
+  isInteractive: false,
+  canPreview: false,
+});
+
 const createEditForm = () => ({
   title: "Edit Sound",
   fields: [
@@ -89,6 +98,8 @@ const createEditForm = () => ({
 const {
   createInitialState: createMediaInitialState,
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   openEditDialog,
   closeEditDialog,
@@ -108,6 +119,7 @@ const {
   previewMenuLabel: "Play",
   buildDetailFields,
   buildMediaItem,
+  buildPendingMediaItem,
   createEditForm,
   getSelectedPreviewFileId: (item) => item?.waveformDataFileId,
   extendViewData: ({ state, baseViewData }) => ({
@@ -132,6 +144,8 @@ export const createInitialState = () => ({
 
 export {
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   openEditDialog,
   closeEditDialog,

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -91,15 +91,30 @@ const buildTextStyleData = ({
   fontStyle,
   fontWeight,
   previewText,
-} = {}) => ({
-  name,
-  fontSize: Number(fontSize ?? 16),
-  lineHeight: Number(lineHeight ?? 1.5),
-  colorId: fontColor,
-  fontId: fontStyle,
-  fontWeight: String(fontWeight ?? "400"),
-  previewText: previewText ?? "",
-});
+  strokeColor,
+  strokeWidth,
+  clearOutlineColor = false,
+} = {}) => {
+  const hasStrokeColor = Boolean(strokeColor);
+  const textStyleData = {
+    name,
+    fontSize: Number(fontSize ?? 16),
+    lineHeight: Number(lineHeight ?? 1.5),
+    colorId: fontColor,
+    fontId: fontStyle,
+    fontWeight: String(fontWeight ?? "400"),
+    previewText: previewText ?? "",
+    strokeWidth: hasStrokeColor ? Number(strokeWidth ?? 0) : 0,
+  };
+
+  if (hasStrokeColor) {
+    textStyleData.strokeColorId = strokeColor;
+  } else if (clearOutlineColor) {
+    textStyleData.strokeColorId = undefined;
+  }
+
+  return textStyleData;
+};
 
 const handleTextStyleCreated = async (deps, payload) => {
   const { appService, projectService } = deps;
@@ -112,6 +127,8 @@ const handleTextStyleCreated = async (deps, payload) => {
     fontStyle,
     fontWeight,
     previewText,
+    strokeColor,
+    strokeWidth,
   } = payload._event.detail;
 
   const createAttempt = await runResourcePageMutation({
@@ -130,6 +147,8 @@ const handleTextStyleCreated = async (deps, payload) => {
             fontStyle,
             fontWeight,
             previewText,
+            strokeColor,
+            strokeWidth,
           }),
         },
         parentId: groupId,
@@ -156,6 +175,8 @@ const handleTextStyleUpdated = async (deps, payload) => {
     fontStyle,
     fontWeight,
     previewText,
+    strokeColor,
+    strokeWidth,
   } = payload._event.detail;
 
   const updateAttempt = await runResourcePageMutation({
@@ -172,6 +193,9 @@ const handleTextStyleUpdated = async (deps, payload) => {
           fontStyle,
           fontWeight,
           previewText,
+          strokeColor,
+          strokeWidth,
+          clearOutlineColor: true,
         }),
       }),
   });
@@ -235,9 +259,18 @@ export const handleTextStyleItemDoubleClick = (deps, payload) => {
 
 export const handleDialogFormChange = (deps, payload) => {
   const { store, render } = deps;
+  const { name, value, values } = payload._event.detail;
+
+  const formData = {
+    ...values,
+  };
+
+  if (name) {
+    formData[name] = value ?? "";
+  }
 
   // Update form values for preview
-  store.updateFormValues({ formData: payload._event.detail.values });
+  store.updateFormValues({ formData });
   render();
 };
 
@@ -260,7 +293,8 @@ export const handleFormActionClick = async (deps, payload) => {
   // Handle add option for color selector
   if (
     actionId === "select-options-add" &&
-    payload._event.detail.name === "fontColor"
+    (payload._event.detail.name === "fontColor" ||
+      payload._event.detail.name === "strokeColor")
   ) {
     // Open the add color dialog
     store.openAddColorDialog();
@@ -309,6 +343,17 @@ export const handleFormActionClick = async (deps, payload) => {
       return;
     }
 
+    const strokeWidth = Number(formData.strokeWidth ?? 0);
+    if (Number.isNaN(strokeWidth) || strokeWidth < 0) {
+      appService.showToast(
+        "Please enter a valid outline thickness (0 or greater)",
+        {
+          title: "Warning",
+        },
+      );
+      return;
+    }
+
     let submitResult;
 
     if (editMode && editingItemId) {
@@ -324,6 +369,8 @@ export const handleFormActionClick = async (deps, payload) => {
             fontStyle: formData.fontStyle,
             fontWeight: formData.fontWeight,
             previewText: formData.previewText,
+            strokeColor: formData.strokeColor,
+            strokeWidth: formData.strokeWidth,
           },
         },
       });
@@ -340,6 +387,8 @@ export const handleFormActionClick = async (deps, payload) => {
             fontStyle: formData.fontStyle,
             fontWeight: formData.fontWeight,
             previewText: formData.previewText,
+            strokeColor: formData.strokeColor,
+            strokeWidth: formData.strokeWidth,
           },
         },
       });

--- a/src/pages/textStyles/textStyles.store.js
+++ b/src/pages/textStyles/textStyles.store.js
@@ -117,18 +117,24 @@ export const createInitialState = () => ({
   currentFormValues: {
     name: "",
     fontColor: "",
+    strokeColor: "",
     fontStyle: "",
     fontSize: 16,
     lineHeight: 1.5,
     fontWeight: "400",
+    strokeWidth: 0,
     previewText: "",
   },
 
   defaultValues: {
     name: "",
+    fontColor: "",
+    strokeColor: "",
+    fontStyle: "",
     fontSize: 16,
     lineHeight: 1.5,
     fontWeight: "400",
+    strokeWidth: 0,
     previewText: "",
   },
 
@@ -194,10 +200,12 @@ export const resetFormValues = ({ state }, _payload = {}) => {
   state.currentFormValues = {
     name: "",
     fontColor: "",
+    strokeColor: "",
     fontStyle: "",
     fontSize: 16,
     lineHeight: 1.5,
     fontWeight: "400",
+    strokeWidth: 0,
     previewText: "",
   };
 };
@@ -209,10 +217,12 @@ export const setFormValuesFromItem = ({ state }, { item } = {}) => {
   state.currentFormValues = {
     name: item.name || "",
     fontColor: item.colorId || "",
+    strokeColor: item.strokeColorId || "",
     fontStyle: item.fontId || "",
     fontSize: item.fontSize,
     lineHeight: item.lineHeight,
     fontWeight: item.fontWeight,
+    strokeWidth: item.strokeWidth ?? 0,
     previewText: item.previewText || "",
   };
 };
@@ -374,6 +384,8 @@ export const selectViewData = ({ state }) => {
         fontStyle: fontData.fontFamily,
         fontFileId: fontData.fileId,
         color: getColorHex(item.colorId),
+        strokeColor: item.strokeColorId ? getColorHex(item.strokeColorId) : "",
+        strokeWidth: item.strokeColorId ? (item.strokeWidth ?? 0) : 0,
         previewText: getPreviewTextValue(item),
         selectedStyle:
           item.id === state.selectedItemId
@@ -433,6 +445,13 @@ export const selectViewData = ({ state }) => {
         },
         {
           type: "text",
+          label: "Outline Color",
+          value: selectedItem.strokeColorId
+            ? getColorName(selectedItem.strokeColorId)
+            : "",
+        },
+        {
+          type: "text",
           label: "Font",
           value: selectedItem.fontId ? getFontName(selectedItem.fontId) : "",
         },
@@ -440,6 +459,13 @@ export const selectViewData = ({ state }) => {
           type: "text",
           label: "Font Weight",
           value: String(selectedItem.fontWeight ?? ""),
+        },
+        {
+          type: "text",
+          label: "Outline Thickness",
+          value: String(
+            selectedItem.strokeColorId ? (selectedItem.strokeWidth ?? 0) : 0,
+          ),
         },
         {
           type: "text",
@@ -522,6 +548,25 @@ export const selectViewData = ({ state }) => {
         required: true,
       },
       {
+        name: "strokeColor",
+        type: "select",
+        label: "Outline Color",
+        placeholder: "Choose an outline color",
+        options: colorOptions,
+        addOption: { label: "Add new color" },
+        required: false,
+      },
+      {
+        name: "strokeWidth",
+        type: "slider-with-input",
+        label: "Outline Thickness",
+        min: 0,
+        max: 12,
+        step: 0.5,
+        unit: "px",
+        required: false,
+      },
+      {
         name: "fontStyle",
         type: "select",
         label: "Font Style",
@@ -592,10 +637,12 @@ export const selectViewData = ({ state }) => {
       ? {
           name: editingItem.name || "",
           fontColor: editingItem.colorId || "",
+          strokeColor: editingItem.strokeColorId || "",
           fontStyle: editingItem.fontId || "",
           fontSize: editingItem.fontSize,
           lineHeight: editingItem.lineHeight,
           fontWeight: editingItem.fontWeight,
+          strokeWidth: editingItem.strokeWidth ?? 0,
           previewText: editingItem.previewText ?? "",
         }
       : state.defaultValues;
@@ -646,6 +693,12 @@ export const selectViewData = ({ state }) => {
     detailPreviewColor: selectedItem?.colorId
       ? getColorHex(selectedItem.colorId)
       : undefined,
+    detailPreviewStrokeColor: selectedItem?.strokeColorId
+      ? getColorHex(selectedItem.strokeColorId)
+      : undefined,
+    detailPreviewStrokeWidth: selectedItem?.strokeColorId
+      ? (selectedItem?.strokeWidth ?? 0)
+      : 0,
     detailPreviewFontFamily: detailPreviewFontData.fontFamily,
     detailPreviewFontFileId: detailPreviewFontData.fileId,
     title: "Typography",
@@ -681,6 +734,12 @@ export const selectViewData = ({ state }) => {
     previewLineHeight: state.currentFormValues.lineHeight,
     previewFontWeight: state.currentFormValues.fontWeight,
     previewColor: getPreviewColor(),
+    previewStrokeColor: state.currentFormValues.strokeColor
+      ? getColorHex(state.currentFormValues.strokeColor)
+      : undefined,
+    previewStrokeWidth: state.currentFormValues.strokeColor
+      ? (state.currentFormValues.strokeWidth ?? 0)
+      : 0,
     previewFontFamily: previewFontData.fontFamily,
     previewFontFileId: previewFontData.fileId,
     searchQuery: state.searchQuery,

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -72,7 +72,7 @@ template:
                               - rtgl-text c=mu-fg: ${selectedItemName}
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=detailFields:
                               - rtgl-view#detailTextStylePreview slot="text-style-preview" p=md bw=xs bc=bo br=md cur=pointer:
-                                  - rvn-font-preview fontFamily=${detailPreviewFontFamily} previewText="${detailPreviewText}" fileId=${detailPreviewFontFileId} fontSize=${detailPreviewFontSize} lineHeight=${detailPreviewLineHeight} color=${detailPreviewColor} fontWeight=${detailPreviewFontWeight} width=220 showBorder=false: null
+                                  - rvn-font-preview fontFamily=${detailPreviewFontFamily} previewText="${detailPreviewText}" fileId=${detailPreviewFontFileId} fontSize=${detailPreviewFontSize} lineHeight=${detailPreviewLineHeight} color=${detailPreviewColor} strokeColor=${detailPreviewStrokeColor} strokeWidth=${detailPreviewStrokeWidth} fontWeight=${detailPreviewFontWeight} width=220 showBorder=false: null
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
@@ -83,7 +83,7 @@ template:
                   - rtgl-form#textStyleForm key=${formKey} :defaultValues=dialogDefaultValues :form=dialogForm w=f: null
               - rtgl-view w=1fg p=md bwl=xs d=v:
                   - rtgl-text s=lg fw=b mb=md: Preview
-                  - rvn-font-preview h=1fg fontFamily=${previewFontFamily} previewText="${previewText}" fileId=${previewFontFileId} fontSize=${previewFontSize} lineHeight=${previewLineHeight} color=${previewColor} fontWeight=${previewFontWeight} width=350 showBorder=true: null
+                  - rvn-font-preview h=1fg fontFamily=${previewFontFamily} previewText="${previewText}" fileId=${previewFontFileId} fontSize=${previewFontSize} lineHeight=${previewLineHeight} color=${previewColor} strokeColor=${previewStrokeColor} strokeWidth=${previewStrokeWidth} fontWeight=${previewFontWeight} width=350 showBorder=true: null
   - rtgl-dialog#addColorDialog ?open=${isAddColorDialogOpen} s=sm:
       - $if isAddColorDialogOpen:
           - rtgl-form#addColorForm slot=content :defaultValues=addColorDefaultValues :form=addColorForm w=f: null

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -1,10 +1,32 @@
 import { nanoid } from "nanoid";
 import { createMediaPageHandlers } from "../../internal/ui/resourcePages/media/createMediaPageHandlers.js";
 import { resolveResourceParentId } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
+import { processPendingUploads } from "../../internal/ui/resourcePages/media/processPendingUploads.js";
 import {
   runResourcePageMutation,
   showResourcePageError,
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
+
+const VIDEO_FILE_PATTERN = /\.(mp4)$/i;
+const INVALID_VIDEO_FORMAT_MESSAGE =
+  "Invalid file format. Please upload an MP4 video file.";
+
+const showInvalidFormatToast = (appService) => {
+  appService.showToast(INVALID_VIDEO_FORMAT_MESSAGE, { title: "Warning" });
+};
+
+const validateVideoFiles = ({ appService, files } = {}) => {
+  const invalidFiles = Array.from(files ?? []).filter(
+    (file) => !file.name.match(VIDEO_FILE_PATTERN),
+  );
+
+  if (invalidFiles.length > 0) {
+    showInvalidFormatToast(appService);
+    return false;
+  }
+
+  return true;
+};
 
 const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
   let file;
@@ -20,6 +42,10 @@ const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
 
   if (!file) {
     return { cancelled: true };
+  }
+
+  if (!validateVideoFiles({ appService, files: [file] })) {
+    return { errorType: "validation-failed" };
   }
 
   let uploadedFiles;
@@ -39,54 +65,54 @@ const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
 
 const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
   const { appService, projectService } = deps;
-  let successfulUploads;
 
-  try {
-    successfulUploads = await projectService.uploadFiles(files);
-  } catch (error) {
-    showResourcePageError({
-      appService,
-      errorOrResult: error,
-      fallbackMessage: "Failed to upload video.",
-    });
+  if (!validateVideoFiles({ appService, files })) {
     return;
   }
 
-  if (!successfulUploads.length) {
-    appService.showToast("Failed to upload video.", { title: "Error" });
-    return;
-  }
+  await processPendingUploads({
+    deps,
+    files,
+    parentId,
+    pendingIdPrefix: "pending-video",
+    refresh: handleDataChanged,
+    createItem: async ({ uploadResult }) => {
+      const createAttempt = await runResourcePageMutation({
+        appService,
+        fallbackMessage: "Failed to create video.",
+        action: () =>
+          projectService.createVideo({
+            videoId: nanoid(),
+            fileRecords: uploadResult.fileRecords,
+            data: {
+              type: "video",
+              fileId: uploadResult.fileId,
+              thumbnailFileId: uploadResult.thumbnailFileId,
+              name: uploadResult.displayName,
+              description: "",
+              fileType: uploadResult.file.type,
+              fileSize: uploadResult.file.size,
+              width: uploadResult.dimensions?.width,
+              height: uploadResult.dimensions?.height,
+            },
+            parentId,
+            position: "last",
+          }),
+      });
 
-  for (const result of successfulUploads) {
-    const createAttempt = await runResourcePageMutation({
-      appService,
-      fallbackMessage: "Failed to create video.",
-      action: () =>
-        projectService.createVideo({
-          videoId: nanoid(),
-          fileRecords: result.fileRecords,
-          data: {
-            type: "video",
-            fileId: result.fileId,
-            thumbnailFileId: result.thumbnailFileId,
-            name: result.displayName,
-            description: "",
-            fileType: result.file.type,
-            fileSize: result.file.size,
-            width: result.dimensions?.width,
-            height: result.dimensions?.height,
-          },
-          parentId,
-          position: "last",
-        }),
-    });
-
-    if (!createAttempt.ok) {
-      return;
-    }
-  }
-
-  await handleDataChanged(deps);
+      return createAttempt.ok;
+    },
+    onUploadError: ({ error }) => {
+      showResourcePageError({
+        appService,
+        errorOrResult: error,
+        fallbackMessage: "Failed to upload video.",
+      });
+    },
+    onNoSuccessfulUploads: () => {
+      appService.showToast("Failed to upload video.", { title: "Error" });
+    },
+  });
 };
 
 const openVideoPreviewById = async ({ deps, itemId } = {}) => {
@@ -185,6 +211,17 @@ export const handleFilesDropped = async (deps, payload) => {
   });
 };
 
+export const handleFilesDropRejected = (deps, payload) => {
+  const { appService } = deps;
+  const rejectedFiles = payload._event.detail?.rejectedFiles ?? [];
+
+  if (rejectedFiles.length === 0) {
+    return;
+  }
+
+  showInvalidFormatToast(appService);
+};
+
 export const handleFormExtraEvent = async (deps) => {
   const { appService, projectService, store } = deps;
   const selectedItem = store.selectSelectedItem();
@@ -203,6 +240,10 @@ export const handleFormExtraEvent = async (deps) => {
       errorOrResult: result.error,
       fallbackMessage: "Failed to select file.",
     });
+    return;
+  }
+
+  if (result.errorType === "validation-failed") {
     return;
   }
 
@@ -268,6 +309,10 @@ export const handleEditDialogVideoClick = async (deps) => {
       errorOrResult: result.error,
       fallbackMessage: "Failed to select file.",
     });
+    return;
+  }
+
+  if (result.errorType === "validation-failed") {
     return;
   }
 

--- a/src/pages/videos/videos.store.js
+++ b/src/pages/videos/videos.store.js
@@ -51,6 +51,15 @@ const buildMediaItem = (item) => ({
   canPreview: true,
 });
 
+const buildPendingMediaItem = (item) => ({
+  id: item.id,
+  name: item.name,
+  cardKind: "video",
+  isProcessing: true,
+  isInteractive: false,
+  canPreview: false,
+});
+
 const createEditForm = () => ({
   title: "Edit Video",
   fields: [
@@ -87,6 +96,8 @@ const createEditForm = () => ({
 const {
   createInitialState: createMediaInitialState,
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   openEditDialog,
   closeEditDialog,
@@ -105,6 +116,7 @@ const {
   acceptedFileTypes: [".mp4"],
   buildDetailFields,
   buildMediaItem,
+  buildPendingMediaItem,
   createEditForm,
   getSelectedPreviewFileId: (item) => item?.thumbnailFileId,
   extendViewData: ({ state, baseViewData }) => ({
@@ -122,6 +134,8 @@ export const createInitialState = () => ({
 
 export {
   setItems,
+  addPendingUploads,
+  removePendingUploads,
   setSelectedItemId,
   openEditDialog,
   closeEditDialog,

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -21,6 +21,8 @@ refs:
         handler: handleVideoItemEdit
       files-dropped:
         handler: handleFilesDropped
+      files-drop-rejected:
+        handler: handleFilesDropRejected
       upload-click:
         handler: handleUploadClick
       search-input:


### PR DESCRIPTION
## Summary
- improve asset upload UX and validation by serializing media uploads, showing processing placeholders, surfacing invalid drop/picker formats, and documenting the upload file-type policy
- optimize upload internals with shared concurrency helpers, audio byte reuse/timing logs, and media-page pending upload state
- add text style outline preview controls, adjust font preview rendering, and tweak related UI labels/resize affordances
- tighten shared editor behavior with safer resource deletion checks, scene form default handling, awaited scene editor reset, and a lighter historical repository replay path

## Testing
- `oxlint` on changed JS files
- `bun prettier --check` on changed JS/YAML/MD files
- `bun run build:tauri`
- pre-push hook: `oxlint && bun prettier --check src`
