### PR TITLE
feat: add transition animation tween editor

### DIFF
--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -69,7 +69,19 @@ template:
                                             $elif item.cardKind == 'animation':
                                               - rtgl-view w=f h=1fg bgc=bg br=md p=md:
                                                   - rtgl-text s=h4 mb=md: ${item.name}
-                                                  - rvn-keyframe-timeline :properties=#{item.properties}: null
+                                                  - $if item.animationType == 'transition':
+                                                      - rtgl-view d=v w=f g=md:
+                                                          - rtgl-view d=h w=f:
+                                                              - rtgl-view w=f ah=e:
+                                                                  - rtgl-text s=sm c=mu-fg: 'Total duration: ${item.duration}ms'
+                                                          - rtgl-view d=v w=f g=xs:
+                                                              - rtgl-text s=xs c=mu-fg: Previous
+                                                              - rvn-keyframe-timeline w=f ?showTotalDuration=false timelineDuration=${item.transitionTimelineDuration} :properties=#{item.prevProperties}: null
+                                                          - rtgl-view d=v w=f g=xs:
+                                                              - rtgl-text s=xs c=mu-fg: Next
+                                                              - rvn-keyframe-timeline w=f ?showTotalDuration=false timelineDuration=${item.transitionTimelineDuration} :properties=#{item.nextProperties}: null
+                                                    $else:
+                                                      - rvn-keyframe-timeline w=f :properties=#{item.updateProperties}: null
                                             $else:
                                               - rtgl-view w=225 h=152 d=v ah=c av=c br=md p=md g=sm:
                                                   - rtgl-text s=md ellipsis w=f: ${item.name}

--- a/src/components/keyframeTimeline/keyframeTimeline.handlers.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.handlers.js
@@ -14,16 +14,18 @@ export const handleMouseLeave = (deps, _payload) => {
 };
 
 export const handleAddKeyframe = (deps, payload) => {
-  const { dispatchEvent } = deps;
+  const { dispatchEvent, props } = deps;
   const target = payload._event.currentTarget;
   const property =
     target?.dataset?.property || target?.id?.replace("addKeyframe", "") || "";
+  const side = props?.side;
 
   // Dispatch event to parent to add keyframe - let the parent get the context
   dispatchEvent(
     new CustomEvent("add-keyframe", {
       detail: {
         property,
+        side,
         x: payload._event.clientX,
         y: payload._event.clientY,
       },
@@ -34,9 +36,10 @@ export const handleAddKeyframe = (deps, payload) => {
 };
 
 export const handleKeyframeRightClick = (deps, payload) => {
-  const { dispatchEvent } = deps;
+  const { dispatchEvent, props } = deps;
   const property = payload._event.currentTarget.dataset.property;
   const index = payload._event.currentTarget.dataset.index;
+  const side = props?.side;
 
   payload._event.preventDefault();
 
@@ -46,6 +49,7 @@ export const handleKeyframeRightClick = (deps, payload) => {
       detail: {
         property,
         index,
+        side,
         x: payload._event.clientX,
         y: payload._event.clientY,
       },
@@ -56,10 +60,11 @@ export const handleKeyframeRightClick = (deps, payload) => {
 };
 
 export const handlePropertyNameRightClick = (deps, payload) => {
-  const { dispatchEvent } = deps;
+  const { dispatchEvent, props } = deps;
   const target = payload._event.currentTarget;
   const property =
     target?.dataset?.property || target?.id?.replace("propertyName", "") || "";
+  const side = props?.side;
 
   payload._event.preventDefault();
 
@@ -68,6 +73,7 @@ export const handlePropertyNameRightClick = (deps, payload) => {
     new CustomEvent("propertyNameright-click", {
       detail: {
         property,
+        side,
         x: payload._event.clientX,
         y: payload._event.clientY,
       },
@@ -78,15 +84,17 @@ export const handlePropertyNameRightClick = (deps, payload) => {
 };
 
 export const handleInitialValueClick = (deps, payload) => {
-  const { dispatchEvent } = deps;
+  const { dispatchEvent, props } = deps;
   const target = payload._event.currentTarget;
   const property =
     target?.dataset?.property || target?.id?.replace("initialValue", "") || "";
+  const side = props?.side;
 
   dispatchEvent(
     new CustomEvent("initialValueclick", {
       detail: {
         property,
+        side,
         x: payload._event.clientX,
         y: payload._event.clientY,
       },

--- a/src/components/keyframeTimeline/keyframeTimeline.schema.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.schema.yaml
@@ -18,6 +18,18 @@ propsSchema:
     properties:
       type: object
       description: Animation properties object with initialValue and keyframes
+    defaultValues:
+      type: object
+      description: Property default values used to determine default-value display
+    timelineDuration:
+      type: number
+      description: Optional shared duration in milliseconds used for timeline sizing
+    showTotalDuration:
+      type: boolean
+      description: Whether the timeline should render its duration header
+    side:
+      type: string
+      description: Optional timeline context key included in emitted events
     tracks:
       type: array
       description: Array of animation tracks

--- a/src/components/keyframeTimeline/keyframeTimeline.store.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.store.js
@@ -14,17 +14,18 @@ export const hideTimelineLine = ({ state }, _payload = {}) => {
 
 export const selectViewData = ({ state, props, props: attrs }) => {
   let selectedProperties = [];
+  const defaultValues = props.defaultValues ?? {
+    x: 0,
+    y: 0,
+    alpha: 1,
+    scaleX: 1,
+    scaleY: 1,
+    rotation: 0,
+    translateX: 0,
+    translateY: 0,
+  };
 
   if (props.properties) {
-    const defaultValues = {
-      x: 0,
-      y: 0,
-      alpha: 1,
-      scaleX: 1,
-      scaleY: 1,
-      rotation: 0,
-    };
-
     selectedProperties = Object.keys(props.properties).map((propertyName) => {
       const value = props.properties[propertyName].initialValue;
       const isDefault = value === defaultValues[propertyName];
@@ -49,10 +50,15 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       }
     });
   }
-  const totalDuration = maxDuration > 0 ? `${maxDuration}ms` : "0ms";
+  const resolvedTimelineDuration =
+    Number(props.timelineDuration) > 0
+      ? Number(props.timelineDuration)
+      : maxDuration;
+  const totalDuration =
+    resolvedTimelineDuration > 0 ? `${resolvedTimelineDuration}ms` : "0ms";
 
   // Parse duration to calculate time at mouse position
-  const durationValue = maxDuration / 1000;
+  const durationValue = resolvedTimelineDuration / 1000;
 
   // Calculate time based on mouse position (assuming timeline width is around 400px)
   const timelineWidth = 400; // approximate width
@@ -60,7 +66,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
   const timeDisplay = Math.round(timeAtMouse * 10) / 10; // round to 1 decimal
 
   // Process keyframes to add width percentages
-  if (selectedProperties.length > 0 && maxDuration > 0) {
+  if (selectedProperties.length > 0 && resolvedTimelineDuration > 0) {
     selectedProperties = selectedProperties.map((property) => {
       if (property.keyframes && property.keyframes.length > 0) {
         const propertyTotalDuration = property.keyframes.reduce(
@@ -70,12 +76,12 @@ export const selectViewData = ({ state, props, props: attrs }) => {
 
         // Calculate property's total width percentage relative to max duration
         const propertyWidthPercent =
-          (propertyTotalDuration / maxDuration) * 100;
+          (propertyTotalDuration / resolvedTimelineDuration) * 100;
 
         // Calculate width percentage for each keyframe based on max duration
         const keyframesWithWidth = property.keyframes.map((keyframe) => {
           const duration = parseFloat(keyframe.duration) || 1000;
-          const widthPercent = (duration / maxDuration) * 100;
+          const widthPercent = (duration / resolvedTimelineDuration) * 100;
           // Add prefix for relative values
           let displayValue = keyframe.value;
           if (keyframe.relative) {
@@ -112,6 +118,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     mouseX: state.mouseX,
     timeDisplay,
     showHoverLine: state.showHoverLine,
+    showTotalDuration: attrs.showTotalDuration !== false,
     editable: attrs.editable,
   };
 

--- a/src/components/keyframeTimeline/keyframeTimeline.view.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.view.yaml
@@ -23,9 +23,10 @@ refs:
         handler: handleInitialValueClick
 template:
   - rtgl-view#timelineContainer g=md w=f pos=rel:
-      - rtgl-view d=h w=f mb=sm:
-          - rtgl-view w=f ah=e:
-              - rtgl-text s=sm: 'Total duration: ${totalDuration}'
+      - $if showTotalDuration:
+          - rtgl-view d=h w=f mb=sm:
+              - rtgl-view w=f ah=e:
+                  - rtgl-text s=sm: 'Total duration: ${totalDuration}'
       - $if selectedProperties.length > 0:
           - $for property, pIndex in selectedProperties:
               - rtgl-view d=h w=f av=c:

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -10,27 +10,30 @@ const defaultInitialValues = {
   alpha: 1,
   scaleX: 1,
   scaleY: 1,
-  rotation: 0,
+  translateX: 0,
+  translateY: 0,
 };
 
-const normalizeUpdateTween = (properties = {}) => {
+const normalizeTween = (properties = {}) => {
   return Object.fromEntries(
-    Object.entries(properties).map(([property, config]) => {
-      const normalizedConfig = {
-        keyframes: (config?.keyframes ?? []).map((keyframe) => ({
-          duration: Number(keyframe.duration) || 0,
-          value: Number(keyframe.value) || 0,
-          easing: keyframe.easing ?? "linear",
-          relative: keyframe.relative ?? false,
-        })),
-      };
+    Object.entries(properties)
+      .filter(([, config]) => (config?.keyframes ?? []).length > 0)
+      .map(([property, config]) => {
+        const normalizedConfig = {
+          keyframes: (config?.keyframes ?? []).map((keyframe) => ({
+            duration: Number(keyframe.duration) || 0,
+            value: Number(keyframe.value) || 0,
+            easing: keyframe.easing ?? "linear",
+            relative: keyframe.relative ?? false,
+          })),
+        };
 
-      if (config?.initialValue !== undefined && config.initialValue !== "") {
-        normalizedConfig.initialValue = Number(config.initialValue) || 0;
-      }
+        if (config?.initialValue !== undefined && config.initialValue !== "") {
+          normalizedConfig.initialValue = Number(config.initialValue) || 0;
+        }
 
-      return [property, normalizedConfig];
-    }),
+        return [property, normalizedConfig];
+      }),
   );
 };
 
@@ -40,14 +43,19 @@ const openAnimationDialog = async ({
   itemId,
   itemData,
   targetGroupId,
+  dialogType,
 } = {}) => {
   const { graphicsService, refs, render, store } = deps;
+  const resolvedDialogType =
+    dialogType ??
+    (itemData?.animation?.type === "transition" ? "transition" : "update");
 
   store.openDialog({
     editMode,
     itemId,
     itemData,
     targetGroupId,
+    dialogType: resolvedDialogType,
   });
   render();
 
@@ -58,6 +66,10 @@ const openAnimationDialog = async ({
         name: itemData.name ?? "",
       },
     });
+  }
+
+  if (resolvedDialogType !== "update") {
+    return;
   }
 
   const { canvas } = refs;
@@ -135,25 +147,21 @@ export const handleCloseCreateTypeMenu = (deps) => {
 };
 
 export const handleCreateTypeMenuItemClick = async (deps, payload) => {
-  const { appService, render, store } = deps;
+  const { render, store } = deps;
   const type = payload._event.detail.item?.value;
   const targetGroupId = store.selectCreateTypeMenuTargetGroupId();
 
   store.closeCreateTypeMenu();
   render();
 
-  if (type !== "update") {
-    await appService.showDialog({
-      title: "Coming Soon",
-      message: "Not implemented yet. Coming soon.",
-      confirmText: "OK",
-    });
+  if (type !== "update" && type !== "transition") {
     return;
   }
 
   await openAnimationDialog({
     deps,
     targetGroupId,
+    dialogType: type,
   });
 };
 
@@ -176,9 +184,54 @@ export const handleFormActionClick = async (deps, payload) => {
     return;
   }
 
-  const tween = normalizeUpdateTween(store.selectProperties());
+  const dialogType = store.selectDialogType();
   const editMode = store.selectEditMode();
   const editItemId = store.selectEditItemId();
+  let animationData;
+
+  if (dialogType === "transition") {
+    const prevTween = normalizeTween(store.selectProperties({ side: "prev" }));
+    const nextTween = normalizeTween(store.selectProperties({ side: "next" }));
+    const hasPrev = Object.keys(prevTween).length > 0;
+    const hasNext = Object.keys(nextTween).length > 0;
+
+    if (!hasPrev && !hasNext) {
+      appService.showToast("Add at least one property to Previous or Next.", {
+        title: "Warning",
+      });
+      return;
+    }
+
+    animationData = {
+      type: "transition",
+    };
+
+    if (hasPrev) {
+      animationData.prev = {
+        tween: prevTween,
+      };
+    }
+
+    if (hasNext) {
+      animationData.next = {
+        tween: nextTween,
+      };
+    }
+  } else {
+    const tween = normalizeTween(store.selectProperties({ side: "update" }));
+
+    if (Object.keys(tween).length === 0) {
+      appService.showToast("Add at least one animation property.", {
+        title: "Warning",
+      });
+      return;
+    }
+
+    animationData = {
+      type: "update",
+      tween,
+    };
+  }
 
   if (editMode && editItemId) {
     const updateAttempt = await runResourcePageMutation({
@@ -189,10 +242,7 @@ export const handleFormActionClick = async (deps, payload) => {
           animationId: editItemId,
           data: {
             name,
-            animation: {
-              type: "update",
-              tween,
-            },
+            animation: animationData,
           },
         }),
     });
@@ -210,10 +260,7 @@ export const handleFormActionClick = async (deps, payload) => {
           data: {
             type: "animation",
             name,
-            animation: {
-              type: "update",
-              tween,
-            },
+            animation: animationData,
           },
           parentId: store.selectTargetGroupId(),
           position: "last",
@@ -231,17 +278,26 @@ export const handleFormActionClick = async (deps, payload) => {
 
 export const handleAddPropertiesClick = (deps, payload) => {
   const { render, store } = deps;
+  const side =
+    payload._event.currentTarget?.dataset?.side ??
+    (store.selectDialogType() === "transition" ? "prev" : "update");
 
   store.setPopover({
     mode: "addProperty",
     x: payload._event.clientX,
     y: payload._event.clientY,
+    payload: {
+      side,
+    },
   });
   render();
 };
 
 export const handleAddPropertyFormSubmit = (deps, payload) => {
   const { render, store } = deps;
+  const {
+    payload: { side },
+  } = store.selectPopover();
   const { property, initialValue, useInitialValue } =
     payload._event.detail.values;
 
@@ -251,19 +307,27 @@ export const handleAddPropertyFormSubmit = (deps, payload) => {
       : (defaultInitialValues[property] ?? 0)
     : (defaultInitialValues[property] ?? 0);
 
-  store.addProperty({ property, initialValue: finalInitialValue });
+  store.addProperty({
+    side,
+    property,
+    initialValue: finalInitialValue,
+  });
   store.closePopover();
   render();
 };
 
 export const handleAddKeyframeInDialog = (deps, payload) => {
   const { render, store } = deps;
+  const side =
+    payload._event.detail.side ??
+    (store.selectDialogType() === "transition" ? "prev" : "update");
 
   store.setPopover({
     mode: "addKeyframe",
     x: payload._event.detail.x,
     y: payload._event.detail.y,
     payload: {
+      side,
       property: payload._event.detail.property,
     },
   });
@@ -273,16 +337,20 @@ export const handleAddKeyframeInDialog = (deps, payload) => {
 export const handleAddKeyframeFormSubmit = (deps, payload) => {
   const { render, store } = deps;
   const {
-    payload: { property, index },
+    payload: { side, property, index },
   } = store.selectPopover();
 
-  const formValues = payload._event.detail.values;
+  const formValues = {
+    ...payload._event.detail.values,
+  };
+
   if (formValues.duration < 1) {
     formValues.duration = 1;
   }
 
   store.addKeyframe({
     ...formValues,
+    side,
     property,
     index,
   });
@@ -297,6 +365,7 @@ export const handleKeyframeRightClick = (deps, payload) => {
     x: payload._event.detail.x,
     y: payload._event.detail.y,
     payload: {
+      side: payload._event.detail.side,
       property: payload._event.detail.property,
       index: payload._event.detail.index,
     },
@@ -311,6 +380,7 @@ export const handlePropertyNameRightClick = (deps, payload) => {
     x: payload._event.detail.x,
     y: payload._event.detail.y,
     payload: {
+      side: payload._event.detail.side,
       property: payload._event.detail.property,
     },
   });
@@ -320,7 +390,7 @@ export const handlePropertyNameRightClick = (deps, payload) => {
 export const handleKeyframeDropdownItemClick = (deps, payload) => {
   const { render, store } = deps;
   const popover = store.selectPopover();
-  const { property, index } = popover.payload;
+  const { side, property, index } = popover.payload;
   const { x, y } = popover;
   const value = payload._event.detail.item.value;
 
@@ -330,15 +400,16 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
       x,
       y,
       payload: {
+        side,
         property,
         index,
       },
     });
   } else if (value === "delete-property") {
-    store.deleteProperty({ property });
+    store.deleteProperty({ side, property });
     store.closePopover();
   } else if (value === "delete-keyframe") {
-    store.deleteKeyframe({ property, index });
+    store.deleteKeyframe({ side, property, index });
     store.closePopover();
   } else if (value === "add-right") {
     store.setPopover({
@@ -346,8 +417,9 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
       x,
       y,
       payload: {
+        side,
         property,
-        index: index + 1,
+        index: Number(index) + 1,
       },
     });
   } else if (value === "add-left") {
@@ -356,15 +428,16 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
       x,
       y,
       payload: {
+        side,
         property,
         index,
       },
     });
   } else if (value === "move-right") {
-    store.moveKeyframeRight({ property, index });
+    store.moveKeyframeRight({ side, property, index });
     store.closePopover();
   } else if (value === "move-left") {
-    store.moveKeyframeLeft({ property, index });
+    store.moveKeyframeLeft({ side, property, index });
     store.closePopover();
   }
 
@@ -374,16 +447,20 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
 export const handleEditKeyframeFormSubmit = (deps, payload) => {
   const { render, store } = deps;
   const {
-    payload: { property, index },
+    payload: { side, property, index },
   } = store.selectPopover();
 
-  const formValues = payload._event.detail.values;
+  const formValues = {
+    ...payload._event.detail.values,
+  };
+
   if (formValues.duration < 1) {
     formValues.duration = 1;
   }
 
   store.updateKeyframe({
     keyframe: formValues,
+    side,
     index,
     property,
   });
@@ -398,6 +475,7 @@ export const handleInitialValueClick = (deps, payload) => {
     x: payload._event.detail.x,
     y: payload._event.detail.y,
     payload: {
+      side: payload._event.detail.side,
       property: payload._event.detail.property,
     },
   });
@@ -435,7 +513,7 @@ export const handleEditInitialValueFormChange = (deps, payload) => {
 
 export const handleReplayAnimation = async (deps) => {
   const { graphicsService, store } = deps;
-  if (!graphicsService) {
+  if (!graphicsService || store.selectDialogType() !== "update") {
     return;
   }
 
@@ -449,7 +527,7 @@ export const handleReplayAnimation = async (deps) => {
 export const handleEditInitialValueFormSubmit = (deps, payload) => {
   const { render, store } = deps;
   const {
-    payload: { property },
+    payload: { side, property },
   } = store.selectPopover();
 
   const { initialValue, valueSource } = payload._event.detail.values;
@@ -459,6 +537,7 @@ export const handleEditInitialValueFormSubmit = (deps, payload) => {
       : initialValue;
 
   store.updateInitialValue({
+    side,
     property,
     initialValue: finalInitialValue,
   });

--- a/src/pages/animations/animations.store.js
+++ b/src/pages/animations/animations.store.js
@@ -3,84 +3,216 @@ import { applyFolderRequiredRootDragOptions } from "../../internal/fileExplorerD
 import { createCatalogPageStore } from "../../internal/ui/resourcePages/catalog/createCatalogPageStore.js";
 import { resetState } from "./animations.constants";
 
-const createAddKeyframeForm = (property) => {
-  if (!property) {
-    return {};
-  }
-
-  const sliderConfig = {
-    x: {
-      min: 0,
-      max: 1920,
-    },
-    y: {
-      min: 0,
-      max: 1920,
-    },
-    alpha: {
+const PROPERTY_FIELD_CONFIG = {
+  alpha: {
+    label: "Alpha",
+    defaultValue: 1,
+    slider: {
       min: 0,
       max: 1,
       step: 0.01,
     },
-    scaleX: {
+  },
+  x: {
+    label: "Position X",
+    defaultValue: 960,
+    slider: {
+      min: 0,
+      max: 1920,
+    },
+  },
+  y: {
+    label: "Position Y",
+    defaultValue: 540,
+    slider: {
+      min: 0,
+      max: 1080,
+    },
+  },
+  scaleX: {
+    label: "Scale X",
+    defaultValue: 1,
+    slider: {
       min: 0.1,
       max: 5,
       step: 0.1,
     },
-    scaleY: {
+  },
+  scaleY: {
+    label: "Scale Y",
+    defaultValue: 1,
+    slider: {
       min: 0.1,
       max: 5,
       step: 0.1,
     },
+  },
+  translateX: {
+    label: "Translate X",
+    defaultValue: 0,
+    slider: {
+      min: -2,
+      max: 2,
+      step: 0.05,
+    },
+    tooltip: {
+      content:
+        "Uses viewport-width units. 1 moves by one full screen width, -1 moves by one full screen width to the left.",
+    },
+  },
+  translateY: {
+    label: "Translate Y",
+    defaultValue: 0,
+    slider: {
+      min: -2,
+      max: 2,
+      step: 0.05,
+    },
+    tooltip: {
+      content:
+        "Uses viewport-height units. 1 moves by one full screen height, -1 moves by one full screen height upward.",
+    },
+  },
+};
+
+const UPDATE_PROPERTY_KEYS = ["alpha", "x", "y", "scaleX", "scaleY"];
+const TRANSITION_PROPERTY_KEYS = [
+  "translateX",
+  "translateY",
+  "alpha",
+  "scaleX",
+  "scaleY",
+];
+
+const buildPropertyOptions = (propertyKeys) => {
+  return propertyKeys.map((property) => ({
+    label: PROPERTY_FIELD_CONFIG[property]?.label ?? property,
+    value: property,
+  }));
+};
+
+const updatePropertyOptions = buildPropertyOptions(UPDATE_PROPERTY_KEYS);
+const transitionPropertyOptions = buildPropertyOptions(
+  TRANSITION_PROPERTY_KEYS,
+);
+
+const defaultInitialValuesByProperty = Object.fromEntries(
+  Object.entries(PROPERTY_FIELD_CONFIG).map(([property, config]) => [
+    property,
+    config.defaultValue,
+  ]),
+);
+
+const updateTimelineDefaultValues = Object.fromEntries(
+  UPDATE_PROPERTY_KEYS.map((property) => [
+    property,
+    defaultInitialValuesByProperty[property],
+  ]),
+);
+
+const transitionTimelineDefaultValues = Object.fromEntries(
+  TRANSITION_PROPERTY_KEYS.map((property) => [
+    property,
+    defaultInitialValuesByProperty[property],
+  ]),
+);
+
+const createSliderField = ({
+  property,
+  name,
+  label,
+  required = false,
+  fallbackLabel = "Value",
+} = {}) => {
+  const config = PROPERTY_FIELD_CONFIG[property];
+
+  if (!config) {
+    return {
+      name,
+      type: "input-text",
+      label: label ?? fallbackLabel,
+      required,
+    };
+  }
+
+  const field = {
+    name,
+    type: "slider-with-input",
+    label: label ?? fallbackLabel,
   };
+
+  Object.assign(field, config.slider);
+
+  if (required) {
+    field.required = true;
+  }
+
+  if (config.tooltip) {
+    field.tooltip = config.tooltip;
+  }
+
+  return field;
+};
+
+const createAddKeyframeForm = (property, { includeDuration = true } = {}) => {
+  if (!property) {
+    return {};
+  }
+
+  const fields = [];
+
+  if (includeDuration) {
+    fields.push({
+      name: "duration",
+      type: "input-text",
+      label: "Duration (ms)",
+      required: true,
+      placeholder: "Duration in milliseconds",
+      tooltip: {
+        content:
+          "The time it takes for the animation keyframe to move from previous value to next value",
+      },
+    });
+  }
+
+  fields.push(
+    {
+      ...createSliderField({
+        property,
+        name: "value",
+        label: "Value",
+        required: true,
+      }),
+      tooltip: {
+        content: "The final value of the property at the end of the animation",
+      },
+    },
+    {
+      name: "relative",
+      type: "select",
+      label: "Value type",
+      options: [
+        { label: "Absolute", value: false },
+        { label: "Relative", value: true },
+      ],
+      required: true,
+      tooltip: {
+        content:
+          "Relative will add the value to the previous value. Absolute will set the property value to exactly the specified value",
+      },
+    },
+    {
+      name: "easing",
+      type: "select",
+      label: "Easing",
+      options: [{ label: "Linear", value: "linear" }],
+      required: true,
+    },
+  );
 
   return {
     title: "Add Keyframe",
-    fields: [
-      {
-        name: "duration",
-        type: "input-text",
-        label: "Duration (ms)",
-        required: true,
-        placeholder: "Duration in milliseconds",
-        tooltip: {
-          content:
-            "The time it takes for the animation keyframe to move from previous value to next value",
-        },
-      },
-      {
-        name: "value",
-        type: "slider-with-input",
-        ...sliderConfig[property],
-        label: "Value",
-        required: true,
-        tooltip: {
-          content:
-            "The final value of the property at the end of the animation",
-        },
-      },
-      {
-        name: "relative",
-        type: "select",
-        label: "Value type",
-        options: [
-          { label: "Absolute", value: false },
-          { label: "Relative", value: true },
-        ],
-        required: true,
-        tooltip: {
-          content:
-            "Relative will add the value to the previous value. Absolute will set the property value to exactly the specified value",
-        },
-      },
-      {
-        name: "easing",
-        type: "select",
-        label: "Easing",
-        options: [{ label: "Linear", value: "linear" }],
-        required: true,
-      },
-    ],
+    fields,
     actions: {
       layout: "",
       buttons: [
@@ -101,9 +233,9 @@ const addKeyframeDefaultValues = {
   easing: "linear",
 };
 
-const createUpdateKeyframeForm = (property) => {
+const createUpdateKeyframeForm = (property, options = {}) => {
   return {
-    ...createAddKeyframeForm(property),
+    ...createAddKeyframeForm(property, options),
     title: "Edit Keyframe",
     actions: {
       layout: "",
@@ -151,15 +283,19 @@ const editInitialValueForm = {
   },
 };
 
-const propertyOptions = [
-  { label: "Alpha", value: "alpha" },
-  { label: "Position X", value: "x" },
-  { label: "Position Y", value: "y" },
-  { label: "Scale X", value: "scaleX" },
-  { label: "Scale Y", value: "scaleY" },
-];
-
 const createAddPropertyForm = (availableProperties) => {
+  const initialValueFields = Object.keys(PROPERTY_FIELD_CONFIG).map(
+    (property) => {
+      const field = createSliderField({
+        property,
+        name: "initialValue",
+        label: "Initial value",
+      });
+      field.$when = `property == "${property}"`;
+      return field;
+    },
+  );
+
   return {
     title: "Add animation property",
     fields: [
@@ -190,42 +326,7 @@ const createAddPropertyForm = (availableProperties) => {
         ],
       },
       {
-        "$if useInitialValue == true": [
-          {
-            $when: 'property == "x"',
-            name: "initialValue",
-            type: "slider-with-input",
-            min: 0,
-            max: 1920,
-            label: "Initial value",
-          },
-          {
-            $when: 'property == "y"',
-            name: "initialValue",
-            type: "slider-with-input",
-            min: 0,
-            max: 1080,
-            label: "Initial value",
-          },
-          {
-            $when: 'property == "alpha"',
-            name: "initialValue",
-            type: "slider-with-input",
-            step: 0.01,
-            min: 0,
-            max: 1,
-            label: "Initial value",
-          },
-          {
-            $when: 'property == "scaleX" || property == "scaleY"',
-            name: "initialValue",
-            type: "slider-with-input",
-            min: 0.1,
-            max: 5,
-            step: 0.1,
-            label: "Initial value",
-          },
-        ],
+        "$if useInitialValue == true": initialValueFields,
       },
     ],
     actions: {
@@ -295,86 +396,123 @@ const createTypeMenuItems = [
   },
 ];
 
-const addAnimationForm = {
+const createAnimationForm = ({
+  title,
+  buttonLabel,
+  typeLabel,
+  timelineFields,
+} = {}) => {
+  return {
+    title,
+    fields: [
+      {
+        type: "read-only-text",
+        content: `Type: ${typeLabel}`,
+      },
+      {
+        name: "name",
+        type: "input-text",
+        label: "Name",
+        required: true,
+      },
+      ...timelineFields,
+    ],
+    actions: {
+      layout: "",
+      buttons: [
+        {
+          id: "submit",
+          variant: "pr",
+          label: buttonLabel,
+        },
+      ],
+    },
+  };
+};
+
+const updateTimelineFields = [
+  {
+    name: "properties",
+    type: "slot",
+    slot: "timeline",
+    label: "Animation timeline",
+  },
+];
+
+const transitionTimelineFields = [
+  {
+    name: "previous",
+    type: "slot",
+    slot: "previousTimeline",
+    label: "Previous",
+  },
+  {
+    name: "next",
+    type: "slot",
+    slot: "nextTimeline",
+    label: "Next",
+  },
+];
+
+const addUpdateAnimationForm = createAnimationForm({
   title: "Add Animation",
-  fields: [
-    {
-      type: "read-only-text",
-      content: "Type: Update",
-    },
-    {
-      name: "name",
-      type: "input-text",
-      label: "Name",
-      required: true,
-    },
-    {
-      name: "properties",
-      type: "slot",
-      slot: "timeline",
-      label: "Animation timeline",
-    },
-  ],
-  actions: {
-    layout: "",
-    buttons: [
-      {
-        id: "submit",
-        variant: "pr",
-        label: "Add Animation",
-      },
-    ],
-  },
-};
+  buttonLabel: "Add Animation",
+  typeLabel: "Update",
+  timelineFields: updateTimelineFields,
+});
 
-const editAnimationForm = {
+const editUpdateAnimationForm = createAnimationForm({
   title: "Edit Animation",
-  fields: [
-    {
-      type: "read-only-text",
-      content: "Type: Update",
-    },
-    {
-      name: "name",
-      type: "input-text",
-      label: "Name",
-      required: true,
-    },
-    {
-      name: "properties",
-      type: "slot",
-      slot: "timeline",
-      label: "Animation timeline",
-    },
-  ],
-  actions: {
-    layout: "",
-    buttons: [
-      {
-        id: "submit",
-        variant: "pr",
-        label: "Update Animation",
-      },
-    ],
-  },
+  buttonLabel: "Update Animation",
+  typeLabel: "Update",
+  timelineFields: updateTimelineFields,
+});
+
+const addTransitionAnimationForm = createAnimationForm({
+  title: "Add Animation",
+  buttonLabel: "Add Animation",
+  typeLabel: "Transition",
+  timelineFields: transitionTimelineFields,
+});
+
+const editTransitionAnimationForm = createAnimationForm({
+  title: "Edit Animation",
+  buttonLabel: "Update Animation",
+  typeLabel: "Transition",
+  timelineFields: transitionTimelineFields,
+});
+
+const getDialogForm = (dialogType, editMode = false) => {
+  if (dialogType === "transition") {
+    return editMode ? editTransitionAnimationForm : addTransitionAnimationForm;
+  }
+
+  return editMode ? editUpdateAnimationForm : addUpdateAnimationForm;
 };
 
-const defaultInitialValuesByProperty = {
-  x: 960,
-  y: 540,
-  alpha: 1,
-  scaleX: 1,
-  scaleY: 1,
-  rotation: 0,
+const getDialogType = (animationType) => {
+  return animationType === "transition" ? "transition" : "update";
 };
 
-const getAnimationTween = (item = {}) => {
+const getUpdateAnimationTween = (item = {}) => {
   if (
     (item?.animation?.type === "live" || item?.animation?.type === "update") &&
     item.animation.tween &&
     typeof item.animation.tween === "object"
   ) {
     return item.animation.tween;
+  }
+
+  return {};
+};
+
+const getTransitionSideTween = (item = {}, side) => {
+  if (
+    item?.animation?.type === "transition" &&
+    item.animation?.[side]?.tween &&
+    typeof item.animation[side].tween === "object"
+  ) {
+    return item.animation[side].tween;
   }
 
   return {};
@@ -393,13 +531,65 @@ const getAnimationDuration = (tween = {}) => {
   }, 0);
 };
 
+const getAnimationDisplayProperties = (item = {}) => {
+  const dialogType = getDialogType(item?.animation?.type);
+
+  return dialogType === "transition"
+    ? {}
+    : structuredClone(getUpdateAnimationTween(item));
+};
+
+const getAnimationDisplayDuration = (item = {}) => {
+  const dialogType = getDialogType(item?.animation?.type);
+
+  if (dialogType === "transition") {
+    return Math.max(
+      getAnimationDuration(getTransitionSideTween(item, "prev")),
+      getAnimationDuration(getTransitionSideTween(item, "next")),
+    );
+  }
+
+  return getAnimationDuration(getUpdateAnimationTween(item));
+};
+
+const getTransitionTimelineDuration = ({
+  prevProperties = {},
+  nextProperties = {},
+} = {}) => {
+  return Math.max(
+    getAnimationDuration(prevProperties),
+    getAnimationDuration(nextProperties),
+  );
+};
+
 const toAnimationDisplayItem = (item) => {
-  const properties = structuredClone(getAnimationTween(item));
+  const animationType = getDialogType(item?.animation?.type);
+  const properties = getAnimationDisplayProperties(item);
+  const prevProperties = structuredClone(getTransitionSideTween(item, "prev"));
+  const nextProperties = structuredClone(getTransitionSideTween(item, "next"));
+  const updateProperties = structuredClone(getUpdateAnimationTween(item));
+  const propertyCount =
+    animationType === "transition"
+      ? Object.keys(prevProperties).length + Object.keys(nextProperties).length
+      : Object.keys(updateProperties).length;
+  const transitionTimelineDuration =
+    animationType === "transition"
+      ? getTransitionTimelineDuration({
+          prevProperties,
+          nextProperties,
+        })
+      : 0;
 
   return {
     ...item,
+    animationType,
     properties,
-    duration: getAnimationDuration(properties),
+    updateProperties,
+    prevProperties,
+    nextProperties,
+    transitionTimelineDuration,
+    propertyCount,
+    duration: getAnimationDisplayDuration(item),
     cardKind: "animation",
     itemWidth: "f",
   };
@@ -415,6 +605,28 @@ const matchesSearch = (item, searchQuery) => {
   const name = (item.name ?? "").toLowerCase();
   const description = (item.description ?? "").toLowerCase();
   return name.includes(searchQuery) || description.includes(searchQuery);
+};
+
+const createEmptyTweenBySection = () => ({
+  update: {},
+  prev: {},
+  next: {},
+});
+
+const getSectionProperties = (state, side) => {
+  return state.tweenBySection?.[side] ?? {};
+};
+
+const getPropertyOptionsForSide = (side) => {
+  return side === "update" ? updatePropertyOptions : transitionPropertyOptions;
+};
+
+const getAvailableProperties = (state, side) => {
+  const currentProperties = getSectionProperties(state, side);
+
+  return getPropertyOptionsForSide(side).filter((item) => {
+    return !Object.keys(currentProperties).includes(item.value);
+  });
 };
 
 const {
@@ -439,21 +651,29 @@ const {
     const selectedAnimationItem = selectedItem
       ? toAnimationDisplayItem(selectedItem)
       : undefined;
-    const selectedAnimationPropertyCount = Object.keys(
-      selectedAnimationItem?.properties ?? {},
-    ).length;
-
-    const availableProperties = propertyOptions.filter(
-      (item) => !Object.keys(state.properties).includes(item.value),
-    );
+    const selectedAnimationPropertyCount =
+      selectedAnimationItem?.propertyCount ?? 0;
+    const dialogType = state.dialogType;
+    const updateProperties = getSectionProperties(state, "update");
+    const previousProperties = getSectionProperties(state, "prev");
+    const nextProperties = getSectionProperties(state, "next");
+    const transitionTimelineDuration = getTransitionTimelineDuration({
+      prevProperties: previousProperties,
+      nextProperties,
+    });
+    const addPropertySide =
+      state.popover.payload?.side ??
+      (dialogType === "transition" ? "prev" : "update");
+    const addPropertyOptions = getAvailableProperties(state, addPropertySide);
 
     const keyframeDropdownItems = (() => {
       if (state.popover.mode !== "keyframeMenu") {
         return propertyNameDropdownItems;
       }
 
-      const { property, index } = state.popover.payload;
-      const keyframes = state.properties[property]?.keyframes ?? [];
+      const { side, property, index } = state.popover.payload;
+      const keyframes =
+        getSectionProperties(state, side)[property]?.keyframes ?? [];
       const currentIndex = Number(index);
       const isFirstKeyframe = currentIndex === 0;
       const isLastKeyframe = currentIndex === keyframes.length - 1;
@@ -479,8 +699,9 @@ const {
     }
 
     if (state.popover.mode === "editKeyframe") {
-      const { property, index } = state.popover.payload;
-      const currentKeyframe = state.properties[property]?.keyframes?.[index];
+      const { side, property, index } = state.popover.payload;
+      const currentKeyframe = getSectionProperties(state, side)[property]
+        ?.keyframes?.[index];
 
       if (currentKeyframe) {
         editKeyframeDefaultValues = {
@@ -493,8 +714,9 @@ const {
     }
 
     if (state.popover.mode === "editInitialValue") {
-      const { property } = state.popover.payload;
-      const currentInitialValue = state.properties[property]?.initialValue;
+      const { side, property } = state.popover.payload;
+      const currentInitialValue = getSectionProperties(state, side)[property]
+        ?.initialValue;
       const defaultValue = defaultInitialValuesByProperty[property] ?? 0;
       const isUsingDefault = currentInitialValue === defaultValue;
 
@@ -515,10 +737,18 @@ const {
       selectedAnimationPropertyCount,
       createTypeMenu: state.createTypeMenu,
       isDialogOpen: state.isDialogOpen,
+      dialogType,
       dialogDefaultValues: state.dialogDefaultValues,
       dialogForm: state.dialogForm,
-      properties: state.properties,
-      addPropertyForm: createAddPropertyForm(availableProperties),
+      dialogFormKey: `${dialogType}-${state.editMode ? "edit" : "add"}-${state.editItemId ?? "new"}-${state.isDialogOpen ? "open" : "closed"}`,
+      transitionTimelineDuration,
+      transitionTimelineDurationLabel: `${transitionTimelineDuration}ms`,
+      updateProperties,
+      previousProperties,
+      nextProperties,
+      updateTimelineDefaultValues,
+      transitionTimelineDefaultValues,
+      addPropertyForm: createAddPropertyForm(addPropertyOptions),
       addPropertyContext,
       addKeyframeForm: createAddKeyframeForm(state.popover.payload?.property),
       addKeyframeDefaultValues,
@@ -530,7 +760,12 @@ const {
       editKeyframeDefaultValues,
       editInitialValueDefaultValues,
       keyframeDropdownItems,
-      addPropertyButtonVisible: availableProperties.length > 0,
+      updateAddPropertyButtonVisible:
+        getAvailableProperties(state, "update").length > 0,
+      previousAddPropertyButtonVisible:
+        getAvailableProperties(state, "prev").length > 0,
+      nextAddPropertyButtonVisible:
+        getAvailableProperties(state, "next").length > 0,
       popover: {
         ...state.popover,
         popoverIsOpen: [
@@ -553,12 +788,13 @@ const {
 export const createInitialState = () => ({
   ...createCatalogInitialState(),
   isDialogOpen: false,
+  dialogType: "update",
   targetGroupId: undefined,
-  properties: {},
+  tweenBySection: createEmptyTweenBySection(),
   dialogDefaultValues: {
     name: "",
   },
-  dialogForm: addAnimationForm,
+  dialogForm: addUpdateAnimationForm,
   editMode: false,
   editItemId: undefined,
   createTypeMenu: {
@@ -594,21 +830,45 @@ export const selectAnimationDisplayItemById = ({ state }, { itemId } = {}) => {
   return rawItem ? toAnimationDisplayItem(rawItem) : undefined;
 };
 
+const cloneTweenBySectionFromItem = (itemData, dialogType) => {
+  const tweenBySection = createEmptyTweenBySection();
+
+  if (dialogType === "transition") {
+    tweenBySection.prev = structuredClone(
+      itemData?.animation?.prev?.tween ?? {},
+    );
+    tweenBySection.next = structuredClone(
+      itemData?.animation?.next?.tween ?? {},
+    );
+    return tweenBySection;
+  }
+
+  tweenBySection.update = structuredClone(getUpdateAnimationTween(itemData));
+  return tweenBySection;
+};
+
 export const openDialog = (
   { state },
-  { editMode, itemId, itemData, targetGroupId } = {},
+  { editMode, itemId, itemData, targetGroupId, dialogType } = {},
 ) => {
+  const resolvedDialogType =
+    dialogType ?? getDialogType(itemData?.animation?.type);
+
   state.isDialogOpen = true;
+  state.dialogType = resolvedDialogType;
   state.editMode = Boolean(editMode);
   state.editItemId = itemId;
 
   if (editMode && itemData) {
     state.targetGroupId = itemData.parentId ?? undefined;
-    state.dialogForm = editAnimationForm;
+    state.dialogForm = getDialogForm(resolvedDialogType, true);
     state.dialogDefaultValues = {
       name: itemData.name ?? "",
     };
-    state.properties = structuredClone(itemData.properties ?? {});
+    state.tweenBySection = cloneTweenBySectionFromItem(
+      itemData,
+      resolvedDialogType,
+    );
     return;
   }
 
@@ -616,23 +876,24 @@ export const openDialog = (
     targetGroupId === "_root"
       ? undefined
       : (targetGroupId ?? itemData?.parentId ?? undefined);
-  state.dialogForm = addAnimationForm;
+  state.dialogForm = getDialogForm(resolvedDialogType, false);
   state.dialogDefaultValues = {
     name: "",
   };
-  state.properties = {};
+  state.tweenBySection = createEmptyTweenBySection();
 };
 
 export const closeDialog = ({ state }, _payload = {}) => {
   state.isDialogOpen = false;
+  state.dialogType = "update";
   state.targetGroupId = undefined;
   state.editMode = false;
   state.editItemId = undefined;
   state.dialogDefaultValues = {
     name: "",
   };
-  state.dialogForm = addAnimationForm;
-  state.properties = {};
+  state.dialogForm = addUpdateAnimationForm;
+  state.tweenBySection = createEmptyTweenBySection();
 };
 
 export const openCreateTypeMenu = ({ state }, { x, y, targetGroupId } = {}) => {
@@ -670,8 +931,24 @@ export const selectEditItemId = ({ state }) => {
   return state.editItemId;
 };
 
-export const selectProperties = ({ state }) => {
-  return state.properties;
+export const selectDialogType = ({ state }) => {
+  return state.dialogType;
+};
+
+const resolveDialogSide = (state, side) => {
+  if (side) {
+    return side;
+  }
+
+  return state.dialogType === "transition" ? "prev" : "update";
+};
+
+const getMutableSectionProperties = (state, side) => {
+  return state.tweenBySection[resolveDialogSide(state, side)];
+};
+
+export const selectProperties = ({ state }, { side } = {}) => {
+  return getMutableSectionProperties(state, side) ?? {};
 };
 
 export const setPopover = ({ state }, { mode, x, y, payload } = {}) => {
@@ -748,19 +1025,24 @@ const createAnimationRenderState = (properties, includeAnimations = true) => {
 };
 
 export const selectAnimationRenderState = ({ state }) => {
-  return createAnimationRenderState(state.properties, false);
+  return createAnimationRenderState(state.tweenBySection.update, false);
 };
 
 export const selectAnimationRenderStateWithAnimations = ({ state }) => {
-  return createAnimationRenderState(state.properties, true);
+  return createAnimationRenderState(state.tweenBySection.update, true);
 };
 
-export const addProperty = ({ state }, { property, initialValue } = {}) => {
-  if (!property || state.properties[property]) {
+export const addProperty = (
+  { state },
+  { side, property, initialValue } = {},
+) => {
+  const properties = getMutableSectionProperties(state, side);
+
+  if (!property || !properties || properties[property]) {
     return;
   }
 
-  state.properties[property] = {
+  properties[property] = {
     initialValue,
     keyframes: [],
   };
@@ -771,7 +1053,8 @@ export const addKeyframe = ({ state }, keyframe = {}) => {
     return;
   }
 
-  const keyframes = state.properties[keyframe.property]?.keyframes;
+  const properties = getMutableSectionProperties(state, keyframe.side);
+  const keyframes = properties?.[keyframe.property]?.keyframes;
   if (!Array.isArray(keyframes)) {
     return;
   }
@@ -787,8 +1070,9 @@ export const addKeyframe = ({ state }, keyframe = {}) => {
   });
 };
 
-export const deleteKeyframe = ({ state }, { property, index } = {}) => {
-  const keyframes = state.properties[property]?.keyframes;
+export const deleteKeyframe = ({ state }, { side, property, index } = {}) => {
+  const properties = getMutableSectionProperties(state, side);
+  const keyframes = properties?.[property]?.keyframes;
   if (!Array.isArray(keyframes)) {
     return;
   }
@@ -796,17 +1080,23 @@ export const deleteKeyframe = ({ state }, { property, index } = {}) => {
   keyframes.splice(index, 1);
 };
 
-export const deleteProperty = ({ state }, { property } = {}) => {
-  if (!property) {
+export const deleteProperty = ({ state }, { side, property } = {}) => {
+  const properties = getMutableSectionProperties(state, side);
+
+  if (!property || !properties) {
     return;
   }
 
-  delete state.properties[property];
+  delete properties[property];
 };
 
-export const moveKeyframeRight = ({ state }, { property, index } = {}) => {
+export const moveKeyframeRight = (
+  { state },
+  { side, property, index } = {},
+) => {
   const numIndex = Number(index);
-  const keyframes = state.properties[property]?.keyframes;
+  const properties = getMutableSectionProperties(state, side);
+  const keyframes = properties?.[property]?.keyframes;
   if (!Array.isArray(keyframes) || numIndex >= keyframes.length - 1) {
     return;
   }
@@ -816,9 +1106,10 @@ export const moveKeyframeRight = ({ state }, { property, index } = {}) => {
   keyframes[numIndex + 1] = current;
 };
 
-export const moveKeyframeLeft = ({ state }, { property, index } = {}) => {
+export const moveKeyframeLeft = ({ state }, { side, property, index } = {}) => {
   const numIndex = Number(index);
-  const keyframes = state.properties[property]?.keyframes;
+  const properties = getMutableSectionProperties(state, side);
+  const keyframes = properties?.[property]?.keyframes;
   if (!Array.isArray(keyframes) || numIndex <= 0) {
     return;
   }
@@ -830,9 +1121,10 @@ export const moveKeyframeLeft = ({ state }, { property, index } = {}) => {
 
 export const updateKeyframe = (
   { state },
-  { property, index, keyframe } = {},
+  { side, property, index, keyframe } = {},
 ) => {
-  const keyframes = state.properties[property]?.keyframes;
+  const properties = getMutableSectionProperties(state, side);
+  const keyframes = properties?.[property]?.keyframes;
   if (!Array.isArray(keyframes) || !keyframe) {
     return;
   }
@@ -847,13 +1139,15 @@ export const updateKeyframe = (
 
 export const updateInitialValue = (
   { state },
-  { property, initialValue } = {},
+  { side, property, initialValue } = {},
 ) => {
-  if (!property || !state.properties[property]) {
+  const properties = getMutableSectionProperties(state, side);
+
+  if (!property || !properties?.[property]) {
     return;
   }
 
-  state.properties[property].initialValue = initialValue;
+  properties[property].initialValue = initialValue;
 };
 
 export const selectViewData = (context) => {

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -39,7 +39,35 @@ refs:
     eventListeners:
       click:
         handler: handleAddPropertiesClick
-  dialogTimeline:
+  previousAddPropertiesButton:
+    eventListeners:
+      click:
+        handler: handleAddPropertiesClick
+  nextAddPropertiesButton:
+    eventListeners:
+      click:
+        handler: handleAddPropertiesClick
+  updateTimeline:
+    eventListeners:
+      add-keyframe:
+        handler: handleAddKeyframeInDialog
+      keyframe-right-click:
+        handler: handleKeyframeRightClick
+      property-name-right-click:
+        handler: handlePropertyNameRightClick
+      initial-value-click:
+        handler: handleInitialValueClick
+  previousTimeline:
+    eventListeners:
+      add-keyframe:
+        handler: handleAddKeyframeInDialog
+      keyframe-right-click:
+        handler: handleKeyframeRightClick
+      property-name-right-click:
+        handler: handlePropertyNameRightClick
+      initial-value-click:
+        handler: handleInitialValueClick
+  nextTimeline:
     eventListeners:
       add-keyframe:
         handler: handleAddKeyframeInDialog
@@ -117,20 +145,41 @@ template:
   - rtgl-dialog#addAnimationDialog ?open=${isDialogOpen} s=lg:
       - rtgl-view slot=content d=h lg-d=v g=md:
           - rtgl-view w=4fg lg-w=f:
-              - rtgl-form#animationForm key=${isDialogOpen} :defaultValues=dialogDefaultValues :form=dialogForm w=f:
-                  - rtgl-view slot=timeline w=f:
-                      - rvn-keyframe-timeline#dialogTimeline editable=true :properties=properties: null
-                      - rtgl-view d=h g=md av=c mb=md w=f mt=lg:
-                          - $if addPropertyButtonVisible:
-                              - rtgl-button#addPropertiesButton w=f v=se s=sm: + Add animation property
+              - rtgl-form#animationForm key=${dialogFormKey} :defaultValues=dialogDefaultValues :form=dialogForm w=f:
+                  - $if dialogType == 'update':
+                      - rtgl-view slot=timeline w=f:
+                          - rvn-keyframe-timeline#updateTimeline editable=true side=update :properties=updateProperties :defaultValues=updateTimelineDefaultValues: null
+                          - rtgl-view d=h g=md av=c mb=md w=f mt=lg:
+                              - $if updateAddPropertyButtonVisible:
+                                  - rtgl-button#addPropertiesButton data-side=update w=f v=se s=sm: + Add animation property
+                  - $if dialogType == 'transition':
+                      - rtgl-view slot=previousTimeline d=v w=f g=sm:
+                          - rtgl-view d=h w=f:
+                              - rtgl-view w=f ah=e:
+                                  - rtgl-text s=sm: 'Total duration: ${transitionTimelineDurationLabel}'
+                          - rvn-keyframe-timeline#previousTimeline editable=true side=prev ?showTotalDuration=false timelineDuration=${transitionTimelineDuration} :properties=previousProperties :defaultValues=transitionTimelineDefaultValues: null
+                          - rtgl-view d=h g=md av=c mb=md w=f mt=lg:
+                              - $if previousAddPropertyButtonVisible:
+                                  - rtgl-button#previousAddPropertiesButton data-side=prev w=f v=se s=sm: + Add animation property
+                      - rtgl-view slot=nextTimeline w=f:
+                          - rvn-keyframe-timeline#nextTimeline editable=true side=next ?showTotalDuration=false timelineDuration=${transitionTimelineDuration} :properties=nextProperties :defaultValues=transitionTimelineDefaultValues: null
+                          - rtgl-view d=h g=md av=c mb=md w=f mt=lg:
+                              - $if nextAddPropertyButtonVisible:
+                                  - rtgl-button#nextAddPropertiesButton data-side=next w=f v=se s=sm: + Add animation property
               - rtgl-view h=128: null
           - rtgl-view w=6fg lg-w=f:
-              - rtgl-view d=h av=c ah=sb mb=md:
-                  - rtgl-text: Preview
-                  - rtgl-button#replayButton s=sm ml=md: Play Animation
-              - 'rtgl-view w=f bgc=fg pos=rel style="aspect-ratio: 16/9;"':
-                  - rtgl-view pos=abs cor=full:
-                      - 'div#canvas style="width: 100%; height: 100%;display: flex;"': null
+              - $if dialogType == 'update':
+                  - rtgl-view d=h av=c ah=sb mb=md:
+                      - rtgl-text: Preview
+                      - rtgl-button#replayButton s=sm ml=md: Play Animation
+                  - 'rtgl-view w=f bgc=fg pos=rel style="aspect-ratio: 16/9;"':
+                      - rtgl-view pos=abs cor=full:
+                          - 'div#canvas style="width: 100%; height: 100%;display: flex;"': null
+                $else:
+                  - rtgl-view d=h av=c ah=sb mb=md:
+                      - rtgl-text: Preview
+                  - 'rtgl-view w=f bgc=fg pos=rel style="aspect-ratio: 16/9;"':
+                      - rtgl-view pos=abs cor=full: null
           - rtgl-popover#addPropertyPopover ?open=${popover.popoverIsOpen} x=${popover.x} y=${popover.y}:
               - $if popover.mode == 'addProperty':
                   - rtgl-form#addPropertyForm slot=content :form=addPropertyForm :context=addPropertyContext :defaultValues=addPropertyFormDefaultValues: null


### PR DESCRIPTION
## Summary
- add transition animation editing to the animations page with separate Previous and Next tween sections
- reuse the keyframe timeline editor across update and transition flows, including side-aware property/keyframe actions
- align transition previews and catalog cards to one shared total duration based on the longer side, with filler on the shorter side

## Testing
- bunx oxlint src/pages/animations/animations.store.js src/pages/animations/animations.handlers.js src/components/keyframeTimeline/keyframeTimeline.store.js
- bun prettier --check src/pages/animations/animations.store.js src/pages/animations/animations.handlers.js src/pages/animations/animations.view.yaml src/components/keyframeTimeline/keyframeTimeline.store.js src/components/keyframeTimeline/keyframeTimeline.view.yaml src/components/keyframeTimeline/keyframeTimeline.schema.yaml src/components/catalogResourcesView/catalogResourcesView.view.yaml
- git diff --check -- src/pages/animations/animations.store.js src/pages/animations/animations.handlers.js src/pages/animations/animations.view.yaml src/components/keyframeTimeline/keyframeTimeline.store.js src/components/keyframeTimeline/keyframeTimeline.view.yaml src/components/keyframeTimeline/keyframeTimeline.schema.yaml src/components/catalogResourcesView/catalogResourcesView.view.yaml
- bun run build:tauri