### PR TITLE
build: bump rettangoli ui to 1.0.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "dependencies": {
         "@rettangoli/fe": "1.1.0",
-        "@rettangoli/ui": "1.0.16",
+        "@rettangoli/ui": "1.0.18",
         "@rettangoli/vt": "1.0.2",
         "@routevn/creator-model": "1.1.4",
         "@tauri-apps/api": "^2.8.0",
@@ -205,7 +205,7 @@
 
     "@rettangoli/fe": ["@rettangoli/fe@1.1.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-rvSEQXbHt7jl9ewATduAuOUXVMO0ES8fG7i7cVpPR3SLSveKhG0k0X4v+v/SsdBEB+w2G6pfokG/atxwYfU9yw=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.0.16", "", { "dependencies": { "@rettangoli/fe": "1.1.0", "jempl": "1.0.1" } }, "sha512-sChzXgm2TsNmDrOM6ayqlXOOp75iAVSSitVqImK1nLYwEcdFwg/LfhpsiDcp9cCjWiD98w5ezUtCOp13udmJRA=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.0.18", "", { "dependencies": { "@rettangoli/fe": "1.1.1", "jempl": "1.0.1" } }, "sha512-48N9iYpjJzVXPi2Qx1SpPjDp6i/DPUu00n3JZ3+FGBmOcKYyvOUxLWcL+tXUtRXyuHiWanupqrerJfd9tZh/sA=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.2", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-QHweZ2BJFiQi0mc8KvSLiFjKTm9ovjs++x9cOTtN89AyK/Pn0acuD0mA+kjOu4zgPcaHvjOAINNqMFsqhx9Hgw=="],
 
@@ -856,6 +856,8 @@
     "@pixi/utils/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "@rettangoli/fe/jempl": ["jempl@1.0.1", "", {}, "sha512-aeOlPrZV1KVhwtMYidkH1vGLlLrCTZ8fk3LlDxLGyTFsZUMHDtvSuqmrCimJL0u2LZFg1rtoE4/1NzGjwmIoUw=="],
+
+    "@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.1.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-EW5+b2zz7//sO0MYN4PVVGjbkvm6fI2GObqK5NjpBR0anO3ihYCJeIOzF9gEfa3g9VRQMgSZDg2QNuGC614i9Q=="],
 
     "@rettangoli/ui/jempl": ["jempl@1.0.1", "", {}, "sha512-aeOlPrZV1KVhwtMYidkH1vGLlLrCTZ8fk3LlDxLGyTFsZUMHDtvSuqmrCimJL0u2LZFg1rtoE4/1NzGjwmIoUw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "dependencies": {
     "@rettangoli/fe": "1.1.0",
-    "@rettangoli/ui": "1.0.16",
+    "@rettangoli/ui": "1.0.18",
     "@rettangoli/vt": "1.0.2",
     "@routevn/creator-model": "1.1.4",
     "@tauri-apps/api": "^2.8.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ set -e
 
 BUILD_TYPE=${1:-web}
 SETUP_FILE="src/setup.${BUILD_TYPE}.js"
-RETTANGOLI_VERSION="1.0.16"
+RETTANGOLI_VERSION="1.0.18"
 RETTANGOLI_URL="https://cdn.jsdelivr.net/npm/@rettangoli/ui@${RETTANGOLI_VERSION}/dist/rettangoli-iife-ui.min.js"
 RETTANGOLI_DIR="static/public/@rettangoli/ui@${RETTANGOLI_VERSION}/dist"
 RETTANGOLI_FILE="${RETTANGOLI_DIR}/rettangoli-iife-ui.min.js"

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/public/theme.css">
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.0.3/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.0.18/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">


### PR DESCRIPTION
## Summary
- bump @rettangoli/ui to 1.0.18
- align scripts/build.sh with the new Rettangoli UI version
- update checked-in static HTML references to the new asset path

## Validation
- bun run build:web