### PR TITLE
feat(layout-editor): add visibility condition preview controls

### DIFF
--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -231,6 +231,11 @@ layoutSections:
             value: center
           - label: Right
             value: right
+  - label: Visibility
+    items:
+      - type: condition-summary
+        name: visibilityCondition
+        value: "${visibilityConditionSummary}"
   - "$when": "supportsActions"
     id: actions
     label: Actions
@@ -268,6 +273,11 @@ controlSections:
             name: height
             value: "${values.height}"
             popoverForm: *numberPopoverForm
+  - label: Visibility
+    items:
+      - type: condition-summary
+        name: visibilityCondition
+        value: "${visibilityConditionSummary}"
   - "$when": "supportsActions"
     id: actions
     label: Actions

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -2,6 +2,11 @@ import {
   getInteractionActions,
   getInteractionPayload,
 } from "../../internal/project/interactionPayload.js";
+import {
+  buildVisibilityConditionExpression,
+  mergeWhenExpressions,
+  splitVisibilityConditionFromWhen,
+} from "../../internal/layoutVisibilityCondition.js";
 
 const ACTION_INTERACTION_TYPES = ["click", "rightClick"];
 const EMPTY_TREE = { items: {}, tree: [] };
@@ -104,9 +109,45 @@ export const handleGroupItemClick = (deps, payload) => {
   render();
 };
 
+export const handleVisibilityConditionItemClick = (deps) => {
+  const { render, store } = deps;
+  const variableTypeById = store.selectVisibilityConditionVariableTypeById();
+  const currentVisibilityCondition = splitVisibilityConditionFromWhen(
+    store.selectValues()["$when"],
+  ).visibilityCondition;
+  const variableId = currentVisibilityCondition?.variableId;
+
+  store.setVisibilityConditionDialogSelectedVariableType({
+    selectedVariableType: variableId
+      ? (variableTypeById?.[variableId] ?? "string")
+      : undefined,
+  });
+  store.openVisibilityConditionDialog();
+  render();
+};
+
 export const handlePopverFormClose = (deps) => {
   const { render, store } = deps;
   store.closePopoverForm();
+  render();
+};
+
+export const handleVisibilityConditionDialogClose = (deps) => {
+  const { render, store } = deps;
+  store.closeVisibilityConditionDialog();
+  render();
+};
+
+export const handleVisibilityConditionFormChange = (deps, payload) => {
+  const { render, store } = deps;
+  const values = payload._event.detail?.values ?? {};
+  const variableTypeById = store.selectVisibilityConditionVariableTypeById();
+
+  store.setVisibilityConditionDialogSelectedVariableType({
+    selectedVariableType: values.variableId
+      ? (variableTypeById?.[values.variableId] ?? "string")
+      : undefined,
+  });
   render();
 };
 
@@ -190,6 +231,69 @@ export const handleFormActions = (deps, payload) => {
     value: _event.detail.values.value,
     closePopover: true,
   });
+};
+
+export const handleVisibilityConditionFormAction = (deps, payload) => {
+  const { store, render } = deps;
+  const detail = payload._event.detail || {};
+  const { actionId, values = {} } = detail;
+  const currentWhen = store.selectValues()["$when"];
+  const { baseWhen } = splitVisibilityConditionFromWhen(currentWhen);
+
+  if (actionId === "cancel") {
+    store.closeVisibilityConditionDialog();
+    render();
+    return;
+  }
+
+  if (actionId === "clear") {
+    applyPanelValueUpdate(deps, {
+      name: "$when",
+      value: baseWhen,
+    });
+    store.closeVisibilityConditionDialog();
+    render();
+    return;
+  }
+
+  if (actionId !== "submit") {
+    return;
+  }
+
+  const variableId = values.variableId;
+  if (!variableId) {
+    applyPanelValueUpdate(deps, {
+      name: "$when",
+      value: baseWhen,
+    });
+    store.closeVisibilityConditionDialog();
+    render();
+    return;
+  }
+
+  const variableType =
+    store.selectVisibilityConditionVariableTypeById()?.[variableId] || "string";
+
+  let conditionValue = values.stringValue ?? "";
+  if (variableType === "boolean") {
+    conditionValue = values.booleanValue === true;
+  } else if (variableType === "number") {
+    const parsedNumber = Number(values.numberValue);
+    conditionValue = Number.isFinite(parsedNumber) ? parsedNumber : 0;
+  }
+
+  const nextVisibilityWhen = buildVisibilityConditionExpression({
+    variableId,
+    op: values.op ?? "eq",
+    value: conditionValue,
+  });
+
+  applyPanelValueUpdate(deps, {
+    name: "$when",
+    value: mergeWhenExpressions(baseWhen, nextVisibilityWhen),
+  });
+  store.closeVisibilityConditionDialog();
+  render();
 };
 
 export const handleActionsChange = (deps, payload) => {

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -2,18 +2,20 @@ import { parseAndRender } from "jempl";
 import { toFlatGroups } from "../../internal/project/tree.js";
 import { getFirstTextStyleId } from "../../constants/textStyles.js";
 import { getVariableOptions } from "../../internal/project/projection.js";
+import { getSystemVariableItems } from "../../internal/systemVariables.js";
 import {
   getInteractionActions,
   getInteractionPayload,
 } from "../../internal/project/interactionPayload.js";
 import { getLayoutEditorItemCapabilities } from "../../internal/layoutEditorTypes.js";
+import { splitVisibilityConditionFromWhen } from "../../internal/layoutVisibilityCondition.js";
 
 const ACTION_INTERACTION_LABELS = {
   click: "Click",
   rightClick: "Right Click",
 };
 
-const HIDDEN_LAYOUT_ACTION_MODES = new Set(["updateVariable"]);
+const HIDDEN_LAYOUT_ACTION_MODES = new Set();
 
 const ACTION_LABELS = {
   nextLine: "Next Line",
@@ -33,6 +35,19 @@ const REVEAL_EFFECT_OPTIONS = [
   { label: "Soft Wipe", value: "softWipe" },
   { label: "None", value: "none" },
 ];
+
+const VISIBILITY_CONDITION_OP_OPTIONS = [{ label: "Equals", value: "eq" }];
+
+const VISIBILITY_BOOLEAN_OPTIONS = [
+  { label: "True", value: true },
+  { label: "False", value: false },
+];
+
+const SUPPORTED_VISIBILITY_VARIABLE_TYPES = new Set([
+  "boolean",
+  "number",
+  "string",
+]);
 
 const getLayoutInteractionActions = (values, interactionType) => {
   return getInteractionActions(values?.[interactionType]);
@@ -90,6 +105,153 @@ const createDefaultValues = () => ({
   gap: 0,
   actions: {},
 });
+
+const getScalarVariableItems = (variablesData = {}) => {
+  const projectVariables = Object.entries(variablesData?.items || {}).filter(
+    ([, item]) =>
+      item?.type !== "folder" &&
+      SUPPORTED_VISIBILITY_VARIABLE_TYPES.has(
+        String(item?.type || "string").toLowerCase(),
+      ),
+  );
+  const systemVariables = Object.entries(getSystemVariableItems()).filter(
+    ([, item]) =>
+      SUPPORTED_VISIBILITY_VARIABLE_TYPES.has(
+        String(item?.type || "string").toLowerCase(),
+      ),
+  );
+
+  return Object.fromEntries([...projectVariables, ...systemVariables]);
+};
+
+const toVisibilityConditionVariableOptions = (variablesData = {}) => {
+  return Object.entries(getScalarVariableItems(variablesData)).map(
+    ([id, variable]) => ({
+      label: `${variable.name} (${String(variable.type || "string").toLowerCase()})`,
+      value: id,
+    }),
+  );
+};
+
+const toVisibilityConditionVariableTypeById = (variablesData = {}) => {
+  return Object.fromEntries(
+    Object.entries(getScalarVariableItems(variablesData)).map(
+      ([id, variable]) => [id, String(variable.type || "string").toLowerCase()],
+    ),
+  );
+};
+
+const getVisibilityConditionSummary = (
+  visibilityCondition,
+  variablesData = {},
+) => {
+  if (!visibilityCondition?.variableId || visibilityCondition?.op !== "eq") {
+    return "Always visible";
+  }
+
+  const variable =
+    getScalarVariableItems(variablesData)[visibilityCondition.variableId];
+  const variableName = variable?.name ?? visibilityCondition.variableId;
+  const value =
+    typeof visibilityCondition.value === "string"
+      ? `"${visibilityCondition.value}"`
+      : String(visibilityCondition.value);
+
+  return `${variableName} == ${value}`;
+};
+
+const createVisibilityConditionDialogDefaults = (
+  visibilityCondition,
+  variableTypeById,
+) => {
+  const variableId = visibilityCondition?.variableId ?? "";
+  const selectedVariableType = variableId
+    ? (variableTypeById[variableId] ?? "string")
+    : undefined;
+  const rawValue = visibilityCondition?.value;
+  const parsedNumberValue = Number(rawValue);
+
+  return {
+    variableId,
+    op: visibilityCondition?.op ?? "eq",
+    booleanValue: rawValue === true,
+    numberValue: Number.isFinite(parsedNumberValue) ? parsedNumberValue : 0,
+    stringValue: typeof rawValue === "string" ? rawValue : "",
+    selectedVariableType,
+  };
+};
+
+const createVisibilityConditionForm = ({
+  hasCondition,
+  variableOptions,
+} = {}) => {
+  return {
+    title: "Visibility Condition",
+    fields: [
+      {
+        name: "variableId",
+        type: "select",
+        label: "Variable",
+        required: false,
+        options: variableOptions,
+      },
+      {
+        $when: "variableId",
+        name: "op",
+        type: "select",
+        label: "Operation",
+        required: true,
+        clearable: false,
+        options: VISIBILITY_CONDITION_OP_OPTIONS,
+      },
+      {
+        $when: "variableId && selectedVariableType == 'boolean'",
+        name: "booleanValue",
+        type: "select",
+        label: "Value",
+        required: true,
+        clearable: false,
+        options: VISIBILITY_BOOLEAN_OPTIONS,
+      },
+      {
+        $when: "variableId && selectedVariableType == 'number'",
+        name: "numberValue",
+        type: "input-number",
+        label: "Value",
+        required: true,
+      },
+      {
+        $when: "variableId && selectedVariableType == 'string'",
+        name: "stringValue",
+        type: "input-text",
+        label: "Value",
+        required: true,
+      },
+    ],
+    actions: {
+      layout: "",
+      buttons: [
+        {
+          id: "clear",
+          align: "left",
+          variant: "se",
+          label: "Clear",
+          disabled: !hasCondition,
+        },
+        {
+          id: "cancel",
+          variant: "se",
+          label: "Cancel",
+        },
+        {
+          id: "submit",
+          variant: "pr",
+          label: "Save",
+        },
+      ],
+    },
+  };
+};
 
 const toTextStyleOptions = (textStylesData = {}) => {
   const textStyleGroups = toFlatGroups(textStylesData);
@@ -154,6 +316,11 @@ export const createInitialState = () => {
       name: undefined,
       form: undefined,
       context: {},
+    },
+    visibilityConditionDialog: {
+      open: false,
+      key: 0,
+      selectedVariableType: undefined,
     },
     textStylesData: { tree: [], items: {} },
     variablesData: { tree: [], items: {} },
@@ -245,6 +412,31 @@ export const closePopoverForm = ({ state }, _payload = {}) => {
   };
 };
 
+export const openVisibilityConditionDialog = ({ state }, _payload = {}) => {
+  state.visibilityConditionDialog = {
+    open: true,
+    key: state.visibilityConditionDialog.key + 1,
+    selectedVariableType: state.visibilityConditionDialog.selectedVariableType,
+  };
+};
+
+export const closeVisibilityConditionDialog = ({ state }, _payload = {}) => {
+  state.visibilityConditionDialog = {
+    ...state.visibilityConditionDialog,
+    open: false,
+  };
+};
+
+export const setVisibilityConditionDialogSelectedVariableType = (
+  { state },
+  { selectedVariableType } = {},
+) => {
+  state.visibilityConditionDialog = {
+    ...state.visibilityConditionDialog,
+    selectedVariableType: selectedVariableType ?? "string",
+  };
+};
+
 export const selectFieldPopoverForm = ({ constants, props }, { name } = {}) => {
   if (!name) {
     return undefined;
@@ -320,6 +512,14 @@ export const selectTempSelectedImageId = ({ state }) => {
   return state.tempSelectedImageId;
 };
 
+export const selectVisibilityConditionDialog = ({ state }) => {
+  return state.visibilityConditionDialog;
+};
+
+export const selectVisibilityConditionVariableTypeById = ({ state }) => {
+  return toVisibilityConditionVariableTypeById(state.variablesData);
+};
+
 export const selectViewData = ({ state, props, constants }) => {
   const textStyleItems = toTextStyleOptions(state.textStylesData);
   const firstTextStyleId = getFirstTextStyleId(state.textStylesData);
@@ -331,6 +531,10 @@ export const selectViewData = ({ state, props, constants }) => {
     type: "number",
     includeSystem: true,
   });
+  const visibilityConditionVariableOptions =
+    toVisibilityConditionVariableOptions(state.variablesData);
+  const visibilityConditionVariableTypeById =
+    toVisibilityConditionVariableTypeById(state.variablesData);
   const variableOptionsWithNone = [
     { label: "None", value: "" },
     ...variableOptions,
@@ -339,6 +543,9 @@ export const selectViewData = ({ state, props, constants }) => {
     values: state.values,
     firstTextStyleId,
   });
+  const currentVisibilityCondition = splitVisibilityConditionFromWhen(
+    values["$when"],
+  ).visibilityCondition;
   const capabilities = getLayoutEditorItemCapabilities(props.itemType);
   const sections = parseAndRender(
     getLayoutEditPanelSections({
@@ -353,6 +560,10 @@ export const selectViewData = ({ state, props, constants }) => {
       textStyleItemsWithNone,
       variableOptionsWithNone,
       values,
+      visibilityConditionSummary: getVisibilityConditionSummary(
+        currentVisibilityCondition,
+        state.variablesData,
+      ),
       canAddSpriteImageVariant:
         !values.imageId || !values.hoverImageId || !values.clickImageId,
       showsGapField:
@@ -361,6 +572,14 @@ export const selectViewData = ({ state, props, constants }) => {
       ...capabilities,
     },
   );
+  const visibilityConditionDialogDefaults =
+    createVisibilityConditionDialogDefaults(
+      currentVisibilityCondition,
+      visibilityConditionVariableTypeById,
+    );
+  const selectedVisibilityConditionVariableType =
+    state.visibilityConditionDialog.selectedVariableType ??
+    visibilityConditionDialogDefaults.selectedVariableType;
 
   return {
     values: state.values,
@@ -375,6 +594,15 @@ export const selectViewData = ({ state, props, constants }) => {
     revealEffectOptions: REVEAL_EFFECT_OPTIONS,
     revealEffectValue: values.revealEffect,
     popover: state.popover,
+    visibilityConditionDialog: state.visibilityConditionDialog,
+    visibilityConditionDialogDefaults,
+    visibilityConditionDialogForm: createVisibilityConditionForm({
+      hasCondition: !!currentVisibilityCondition?.variableId,
+      variableOptions: visibilityConditionVariableOptions,
+    }),
+    visibilityConditionDialogContext: {
+      selectedVariableType: selectedVisibilityConditionVariableType,
+    },
     imageSelectorDialog: state.imageSelectorDialog,
     tempSelectedImageId: state.tempSelectedImageId,
   };

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -1,4 +1,8 @@
 refs:
+  conditionItem*:
+    eventListeners:
+      click:
+        handler: handleVisibilityConditionItemClick
   groupItem*:
     eventListeners:
       click:
@@ -11,12 +15,22 @@ refs:
     eventListeners:
       close:
         handler: handlePopverFormClose
+  visibilityConditionDialog:
+    eventListeners:
+      close:
+        handler: handleVisibilityConditionDialogClose
   form:
     eventListeners:
       form-action:
         handler: handleFormActions
       form-change:
         handler: handlePopoverFormChange
+  visibilityConditionForm:
+    eventListeners:
+      form-action:
+        handler: handleVisibilityConditionFormAction
+      form-change:
+        handler: handleVisibilityConditionFormChange
   sectionAction*:
     eventListeners:
       click:
@@ -103,11 +117,17 @@ template:
                 $elif item.type == 'popover-input':
                   - rtgl-view#groupItem${i}x${j} data-name=${item.name} d=h pv=sm ph=md bgc=mu br=md av=c g=md cur=pointer bw=xs bc=bg h-bc=ac h=32 w=1fg:
                       - rtgl-text s=sm: ${item.value}
+                $elif item.type == 'condition-summary':
+                  - rtgl-view#conditionItem${i}x${j} data-name=${item.name} d=h pv=sm ph=md bgc=mu br=md av=c g=md cur=pointer bw=xs bc=bg h-bc=ac h=32 w=1fg:
+                      - rtgl-text s=sm: ${item.value}
   - rtgl-view h=1 w=f bgc=mu mv=lg: null
   - rvn-system-actions#systemActions :actions=${actionsData} actionType=system :hiddenModes=${hiddenSystemActionModes}: null
   - rtgl-popover#popoverForm ?open=${popover.open} place=b x=${popover.x} y=${popover.y}:
       - $if popover.open:
           - rtgl-form#form autofocus key=${popover.key} slot=content :form=${popover.form} :defaultValues=${popover.defaultValues} :context=${popover.context}: null
+  - rtgl-dialog#visibilityConditionDialog ?open=${visibilityConditionDialog.open} s=md:
+      - rtgl-view slot=content g=md:
+          - rtgl-form#visibilityConditionForm key=${visibilityConditionDialog.key} :form=${visibilityConditionDialogForm} :defaultValues=${visibilityConditionDialogDefaults} :context=${visibilityConditionDialogContext} w=f: null
   - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open}:
       - rtgl-view slot=content g=md:
           - rvn-image-selector#imageSelector: null

--- a/src/internal/layoutEditorPreview.js
+++ b/src/internal/layoutEditorPreview.js
@@ -4,6 +4,7 @@ import {
   extractFileIdsFromRenderState,
 } from "./project/layout.js";
 import { toHierarchyStructure } from "./project/tree.js";
+import { getSystemVariableItems } from "./systemVariables.js";
 
 const DEFAULT_DIALOGUE_CHARACTER_NAME = "Character";
 const DEFAULT_DIALOGUE_CONTENT = "This is a sample dialogue content.";
@@ -48,7 +49,12 @@ const toPreviewVariableValue = (variable = {}) => {
 };
 
 const createPreviewVariables = (variablesData = {}) => {
-  return Object.entries(variablesData.items ?? {}).reduce(
+  const variableItems = {
+    ...(variablesData.items ?? {}),
+    ...getSystemVariableItems(),
+  };
+
+  return Object.entries(variableItems).reduce(
     (variables, [variableId, variable]) => {
       if (!variableId || variable?.type === "folder") {
         return variables;
@@ -59,6 +65,31 @@ const createPreviewVariables = (variablesData = {}) => {
     },
     {},
   );
+};
+
+const applyPreviewVariableOverrides = (
+  previewVariables,
+  variablesData = {},
+  previewVariableValues = {},
+) => {
+  const variableItems = {
+    ...(variablesData.items ?? {}),
+    ...getSystemVariableItems(),
+  };
+  const nextPreviewVariables = {
+    ...previewVariables,
+  };
+
+  for (const [variableId, value] of Object.entries(previewVariableValues)) {
+    const variable = variableItems[variableId];
+
+    nextPreviewVariables[variableId] = toPreviewVariableValue({
+      ...variable,
+      value,
+    });
+  }
+
+  return nextPreviewVariables;
 };
 
 const createChoiceItems = (choicesData = {}) => {
@@ -227,6 +258,7 @@ const buildOverlayTree = ({ path, overlayId, draggable }) => {
 
 export const createLayoutEditorPreviewData = ({
   variablesData,
+  previewVariableValues,
   dialogueDefaultValues,
   previewRevealingSpeed,
   choicesData,
@@ -245,7 +277,11 @@ export const createLayoutEditorPreviewData = ({
 
   return {
     variables: {
-      ...createPreviewVariables(variablesData),
+      ...applyPreviewVariableOverrides(
+        createPreviewVariables(variablesData),
+        variablesData,
+        previewVariableValues,
+      ),
       _dialogueTextSpeed: dialogueRevealingSpeed,
     },
     dialogue: {
@@ -438,6 +474,7 @@ export const renderLayoutEditorPreview = async (
       elements: renderStateElements,
       previewData: createLayoutEditorPreviewData({
         variablesData,
+        previewVariableValues: store.selectPreviewVariableValues(),
         dialogueDefaultValues: store.selectDialogueDefaultValues(),
         previewRevealingSpeed: store.selectPreviewRevealingSpeed(),
         choicesData: store.selectChoicesData(),

--- a/src/internal/layoutVisibilityCondition.js
+++ b/src/internal/layoutVisibilityCondition.js
@@ -1,0 +1,231 @@
+const trimOuterParentheses = (value) => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  let nextValue = value.trim();
+
+  while (nextValue.startsWith("(") && nextValue.endsWith(")")) {
+    let depth = 0;
+    let isBalanced = true;
+
+    for (let index = 0; index < nextValue.length; index += 1) {
+      const char = nextValue[index];
+      if (char === "(") {
+        depth += 1;
+      } else if (char === ")") {
+        depth -= 1;
+        if (depth === 0 && index < nextValue.length - 1) {
+          isBalanced = false;
+          break;
+        }
+      }
+
+      if (depth < 0) {
+        isBalanced = false;
+        break;
+      }
+    }
+
+    if (!isBalanced || depth !== 0) {
+      break;
+    }
+
+    nextValue = nextValue.slice(1, -1).trim();
+  }
+
+  return nextValue;
+};
+
+const splitTopLevelAndExpressions = (expression) => {
+  if (typeof expression !== "string" || expression.trim().length === 0) {
+    return [];
+  }
+
+  const parts = [];
+  let current = "";
+  let depth = 0;
+  let quote;
+
+  for (let index = 0; index < expression.length; index += 1) {
+    const char = expression[index];
+    const nextChar = expression[index + 1];
+
+    if (quote) {
+      current += char;
+      if (char === "\\" && nextChar) {
+        current += nextChar;
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === "(") {
+      depth += 1;
+      current += char;
+      continue;
+    }
+
+    if (char === ")") {
+      depth -= 1;
+      current += char;
+      continue;
+    }
+
+    if (depth === 0 && char === "&" && nextChar === "&") {
+      parts.push(trimOuterParentheses(current));
+      current = "";
+      index += 1;
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim().length > 0) {
+    parts.push(trimOuterParentheses(current));
+  }
+
+  return parts.filter((part) => part.length > 0);
+};
+
+const parseConditionValue = (value) => {
+  const normalizedValue = value.trim();
+
+  if (normalizedValue === "true") {
+    return true;
+  }
+
+  if (normalizedValue === "false") {
+    return false;
+  }
+
+  if (/^-?\d+(?:\.\d+)?$/.test(normalizedValue)) {
+    const parsedNumber = Number(normalizedValue);
+    if (Number.isFinite(parsedNumber)) {
+      return parsedNumber;
+    }
+  }
+
+  if (normalizedValue.startsWith('"') && normalizedValue.endsWith('"')) {
+    try {
+      return JSON.parse(normalizedValue);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+};
+
+export const buildVisibilityConditionExpression = (visibilityCondition) => {
+  if (
+    !visibilityCondition?.variableId ||
+    typeof visibilityCondition.variableId !== "string"
+  ) {
+    return undefined;
+  }
+
+  if (visibilityCondition.op !== "eq") {
+    return undefined;
+  }
+
+  const variableAccess = `variables[${JSON.stringify(visibilityCondition.variableId)}]`;
+  const conditionValue = visibilityCondition.value;
+
+  if (typeof conditionValue === "number" && Number.isFinite(conditionValue)) {
+    return `${variableAccess} == ${conditionValue}`;
+  }
+
+  if (typeof conditionValue === "boolean") {
+    return `${variableAccess} == ${conditionValue}`;
+  }
+
+  return `${variableAccess} == ${JSON.stringify(String(conditionValue ?? ""))}`;
+};
+
+export const mergeWhenExpressions = (...expressions) => {
+  const normalizedExpressions = expressions.filter(
+    (expression) => typeof expression === "string" && expression.length > 0,
+  );
+
+  if (normalizedExpressions.length === 0) {
+    return undefined;
+  }
+
+  if (normalizedExpressions.length === 1) {
+    return normalizedExpressions[0];
+  }
+
+  return normalizedExpressions
+    .map((expression) => `(${expression})`)
+    .join(" && ");
+};
+
+export const splitVisibilityConditionFromWhen = (expression) => {
+  const clauses = splitTopLevelAndExpressions(expression);
+  if (clauses.length === 0) {
+    return {
+      baseWhen: undefined,
+      visibilityCondition: undefined,
+    };
+  }
+
+  let visibilityClauseIndex = -1;
+  let visibilityCondition;
+
+  for (let index = 0; index < clauses.length; index += 1) {
+    const clause = clauses[index];
+    const match = clause.match(/^variables\[(.+)\]\s*==\s*(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    try {
+      const variableId = JSON.parse(match[1].trim());
+      const value = parseConditionValue(match[2]);
+
+      if (
+        typeof variableId === "string" &&
+        variableId.length > 0 &&
+        value !== undefined
+      ) {
+        visibilityClauseIndex = index;
+        visibilityCondition = {
+          variableId,
+          op: "eq",
+          value,
+        };
+        break;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  if (!visibilityCondition) {
+    return {
+      baseWhen: typeof expression === "string" ? expression : undefined,
+      visibilityCondition: undefined,
+    };
+  }
+
+  const remainingClauses = clauses.filter(
+    (_clause, index) => index !== visibilityClauseIndex,
+  );
+
+  return {
+    baseWhen: mergeWhenExpressions(...remainingClauses),
+    visibilityCondition,
+  };
+};

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -19,6 +19,11 @@ const TEXT_NODE_TYPES = new Set([
   "text-ref-dialogue-line-content",
 ]);
 
+import {
+  buildVisibilityConditionExpression,
+  mergeWhenExpressions,
+} from "../layoutVisibilityCondition.js";
+
 const TEXT_CONTENT_BY_TYPE = {
   "text-ref-character-name": "${dialogue.character.name}",
   "text-revealing-ref-dialogue-content": "${dialogue.content[0].text}",
@@ -305,8 +310,12 @@ const buildBaseElement = (node) => {
     rightClick: normalizeEngineActions(node.rightClick),
   };
 
-  if (node["$when"]) {
-    element["$when"] = node["$when"];
+  const whenExpression = mergeWhenExpressions(
+    node["$when"],
+    buildVisibilityConditionExpression(node.visibilityCondition),
+  );
+  if (whenExpression) {
+    element["$when"] = whenExpression;
   }
 
   if (node["$each"]) {

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -259,6 +259,14 @@ export const handleChoiceFormChange = async (deps, payload) => {
   await rerenderLayoutEditorSurface(deps);
 };
 
+export const handlePreviewVariablesFormChange = async (deps, payload) => {
+  const { store } = deps;
+  const { name, value: fieldValue } = payload._event.detail;
+
+  store.setPreviewVariableValue({ name, fieldValue });
+  await rerenderLayoutEditorSurface(deps);
+};
+
 export const handleSliderCreateDialogClose = (deps) => {
   const { store, render } = deps;
   store.closeSliderCreateDialog();

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -4,11 +4,130 @@ import {
   createLayoutEditorItemTemplate,
   isLayoutEditorContainerItemType,
 } from "../../internal/layoutEditorTypes.js";
+import { getSystemVariableItems } from "../../internal/systemVariables.js";
+import { splitVisibilityConditionFromWhen } from "../../internal/layoutVisibilityCondition.js";
 import {
   DEFAULT_PROJECT_RESOLUTION,
   formatProjectResolutionAspectRatio,
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
+
+const PREVIEW_VARIABLE_TYPES = new Set(["boolean", "number", "string"]);
+
+const PREVIEW_BOOLEAN_OPTIONS = [
+  { label: "True", value: true },
+  { label: "False", value: false },
+];
+
+const toPreviewVariableValue = ({ type, value } = {}) => {
+  if (type === "number") {
+    const parsedValue = Number(value);
+    return Number.isFinite(parsedValue) ? parsedValue : 0;
+  }
+
+  if (type === "boolean") {
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      return value === "true";
+    }
+
+    return Boolean(value);
+  }
+
+  return value ?? "";
+};
+
+const getLayoutPreviewVariableItems = (layoutData = {}, variablesData = {}) => {
+  const availableVariables = {
+    ...(variablesData.items ?? {}),
+    ...getSystemVariableItems(),
+  };
+  const previewVariables = [];
+  const addedVariableIds = new Set();
+
+  for (const item of Object.values(layoutData?.items ?? {})) {
+    const visibilityCondition = splitVisibilityConditionFromWhen(
+      item?.["$when"],
+    ).visibilityCondition;
+    const variableId = visibilityCondition?.variableId;
+
+    if (!variableId || addedVariableIds.has(variableId)) {
+      continue;
+    }
+
+    const variable = availableVariables[variableId];
+    const type = String(variable?.type ?? "string").toLowerCase();
+
+    if (!PREVIEW_VARIABLE_TYPES.has(type)) {
+      continue;
+    }
+
+    addedVariableIds.add(variableId);
+    previewVariables.push({
+      id: variableId,
+      name: variable?.name ?? variableId,
+      type,
+      source: variable?.source,
+      description: variable?.description,
+      defaultValue: toPreviewVariableValue({
+        type,
+        value: variable?.value ?? variable?.default,
+      }),
+    });
+  }
+
+  return previewVariables.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+};
+
+const createPreviewVariablesForm = (previewVariableItems = []) => ({
+  title: "Preview",
+  description: "Edit visibility variables to preview conditional elements",
+  fields: previewVariableItems.map((variable) => {
+    const sourceLabel =
+      variable.source === "system" ? "System variable" : "Variable";
+    const descriptionParts = [
+      `${sourceLabel} (${variable.type})`,
+      variable.description,
+    ].filter(Boolean);
+
+    if (variable.type === "boolean") {
+      return {
+        name: variable.id,
+        type: "select",
+        label: variable.name,
+        clearable: false,
+        options: PREVIEW_BOOLEAN_OPTIONS,
+        description: descriptionParts.join(" • "),
+      };
+    }
+
+    return {
+      name: variable.id,
+      type: variable.type === "number" ? "input-number" : "input-text",
+      label: variable.name,
+      description: descriptionParts.join(" • "),
+    };
+  }),
+});
+
+const createPreviewVariableDefaultValues = (
+  previewVariableItems = [],
+  previewVariableValues = {},
+) => {
+  return Object.fromEntries(
+    previewVariableItems.map((variable) => [
+      variable.id,
+      Object.hasOwn(previewVariableValues, variable.id)
+        ? previewVariableValues[variable.id]
+        : variable.defaultValue,
+    ]),
+  );
+};
 
 const toLayoutEditorContextMenuItems = (
   items = [],
@@ -66,6 +185,7 @@ export const createInitialState = () => ({
     choicesNum: 2,
     choices: ["Choice 1", "Choice 2"],
   },
+  previewVariableValues: {},
   projectResolution: DEFAULT_PROJECT_RESOLUTION,
   sliderCreateDialog: {
     open: false,
@@ -94,6 +214,7 @@ export const setItems = ({ state }, { layoutData } = {}) => {
 
 export const setLayout = ({ state }, payload = {}) => {
   const { id, layout, resourceType } = payload || {};
+  const nextResourceType = resourceType || layout?.resourceType || "layouts";
 
   if (!layout && !id) {
     state.layout = undefined;
@@ -103,7 +224,11 @@ export const setLayout = ({ state }, payload = {}) => {
   state.layout = {
     ...layout,
     id: id || layout?.id || undefined,
-    resourceType: resourceType || layout?.resourceType || "layouts",
+    resourceType: nextResourceType,
+    layoutType:
+      nextResourceType === "controls"
+        ? layout?.layoutType
+        : (layout?.layoutType ?? "normal"),
   };
 };
 
@@ -332,6 +457,17 @@ export const setChoiceDefaultValue = ({ state }, { name, fieldValue } = {}) => {
   state.choiceDefaultValues.choices = choices;
 };
 
+export const setPreviewVariableValue = (
+  { state },
+  { name, fieldValue } = {},
+) => {
+  if (!name) {
+    return;
+  }
+
+  state.previewVariableValues[name] = fieldValue;
+};
+
 export const selectDragging = ({ state }) => {
   return {
     isDragging: state.isDragging,
@@ -433,6 +569,10 @@ export const selectChoicesData = ({ state }) => {
   };
 };
 
+export const selectPreviewVariableValues = ({ state }) => {
+  return state.previewVariableValues;
+};
+
 export const selectItems = ({ state }) => {
   return state.layoutData;
 };
@@ -467,6 +607,18 @@ export const selectViewData = ({ state, constants }) => {
       : constants.emptyContextMenuItems,
     { layoutType },
   );
+  const previewVariableItems =
+    layoutType === "normal"
+      ? getLayoutPreviewVariableItems(state.layoutData, state.variablesData)
+      : [];
+  const previewVariablesDefaultValues = createPreviewVariableDefaultValues(
+    previewVariableItems,
+    state.previewVariableValues,
+  );
+  const previewVariablesFormKey =
+    previewVariableItems.length > 0
+      ? previewVariableItems.map((item) => item.id).join("|")
+      : "empty";
 
   return {
     item,
@@ -492,6 +644,10 @@ export const selectViewData = ({ state, constants }) => {
     choicesContext: {
       ...state.choiceDefaultValues,
     },
+    previewVariablesForm: createPreviewVariablesForm(previewVariableItems),
+    previewVariablesDefaultValues,
+    previewVariablesFormKey,
+    hasPreviewVariables: previewVariableItems.length > 0,
     sliderCreateForm: constants.sliderCreateForm,
     sliderCreateDialog: state.sliderCreateDialog,
     sliderCreateImageSelectorDialog: state.sliderCreateImageSelectorDialog,

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -24,6 +24,10 @@ refs:
     eventListeners:
       form-change:
         handler: handleChoiceFormChange
+  previewVariablesForm:
+    eventListeners:
+      form-change:
+        handler: handlePreviewVariablesFormChange
   sliderCreateDialog:
     eventListeners:
       close:
@@ -94,6 +98,8 @@ template:
                       - rtgl-button#playPreviewButton v=ol: Play
               - $if layout.layoutType == 'choice':
                   - rtgl-form#choiceForm w=f :form=${choiceForm} :defaultValues=${choiceDefaultValues} :context=${choicesContext}: null
+              - $if layout.layoutType == 'normal' && hasPreviewVariables:
+                  - rtgl-form#previewVariablesForm key=${previewVariablesFormKey} w=f :form=${previewVariablesForm} :defaultValues=${previewVariablesDefaultValues}: null
       - rvn-resizable-panel#resizableDetailPanel panel-type=detail-panel w=300 min-w=200 max-w=500 resize-side="left":
           - rtgl-view wh=f slot="content":
               - $if selectedItemId:

--- a/tests/layoutEditor/layoutEditorPreview.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.test.js
@@ -3,6 +3,7 @@ import {
   createLayoutEditorPreviewData,
   createLayoutEditorSelectionOverlay,
 } from "../../src/internal/layoutEditorPreview.js";
+import { getSystemVariableItems } from "../../src/internal/systemVariables.js";
 
 describe("layoutEditorPreview", () => {
   it("builds stable preview data from variables, dialogue defaults, and choices", () => {
@@ -23,7 +24,7 @@ describe("layoutEditorPreview", () => {
       },
     });
 
-    expect(previewData.variables).toEqual({
+    expect(previewData.variables).toMatchObject({
       numberVar: 7,
       boolVar: true,
       _dialogueTextSpeed: 50,
@@ -48,6 +49,38 @@ describe("layoutEditorPreview", () => {
         },
       },
     ]);
+  });
+
+  it("includes system variables in preview data", () => {
+    const previewData = createLayoutEditorPreviewData({
+      variablesData: {
+        items: {},
+      },
+    });
+    const [firstSystemVariableId] = Object.keys(getSystemVariableItems());
+
+    expect(firstSystemVariableId).toBeTruthy();
+    expect(previewData.variables).toHaveProperty(firstSystemVariableId);
+  });
+
+  it("overrides preview variables with edited values", () => {
+    const previewData = createLayoutEditorPreviewData({
+      variablesData: {
+        items: {
+          score: { type: "number", default: 1 },
+          enabled: { type: "boolean", default: false },
+        },
+      },
+      previewVariableValues: {
+        score: 42,
+        enabled: true,
+      },
+    });
+
+    expect(previewData.variables).toMatchObject({
+      score: 42,
+      enabled: true,
+    });
   });
 
   it("creates a draggable primary overlay and non-draggable repeated overlays", () => {

--- a/tests/layoutEditor/layoutVisibilityCondition.test.js
+++ b/tests/layoutEditor/layoutVisibilityCondition.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildLayoutElements } from "../../src/internal/project/layout.js";
+import { splitVisibilityConditionFromWhen } from "../../src/internal/layoutVisibilityCondition.js";
+
+describe("layout visibility conditions", () => {
+  it("compiles a structured visibility condition into $when", () => {
+    const { elements } = buildLayoutElements(
+      [
+        {
+          id: "rect-1",
+          type: "rect",
+          visibilityCondition: {
+            variableId: "score",
+            op: "eq",
+            value: 10,
+          },
+        },
+      ],
+      {},
+      { items: {}, tree: [] },
+      { items: {}, tree: [] },
+      { items: {}, tree: [] },
+      { layoutId: "layout-1" },
+    );
+
+    expect(elements[0].$when).toBe('variables["score"] == 10');
+  });
+
+  it("combines a visibility condition with an existing $when", () => {
+    const { elements } = buildLayoutElements(
+      [
+        {
+          id: "rect-1",
+          type: "rect",
+          $when: "dialogue.character.name",
+          visibilityCondition: {
+            variableId: "flag-enabled",
+            op: "eq",
+            value: true,
+          },
+        },
+      ],
+      {},
+      { items: {}, tree: [] },
+      { items: {}, tree: [] },
+      { items: {}, tree: [] },
+      { layoutId: "layout-1" },
+    );
+
+    expect(elements[0].$when).toBe(
+      '(dialogue.character.name) && (variables["flag-enabled"] == true)',
+    );
+  });
+
+  it("extracts a saved visibility condition from $when", () => {
+    expect(
+      splitVisibilityConditionFromWhen(
+        '(line.characterName) && (variables["flag-enabled"] == true)',
+      ),
+    ).toEqual({
+      baseWhen: "line.characterName",
+      visibilityCondition: {
+        variableId: "flag-enabled",
+        op: "eq",
+        value: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add visibility condition editing for layout/control elements
- persist visibility rules through saved `` expressions instead of a custom field
- add normal-layout preview controls for variables used by visibility conditions, including system variables

## Testing
- bunx vitest run tests/layoutEditor/layoutEditorPreview.test.js tests/layoutEditor/layoutVisibilityCondition.test.js
- bun run build:web