### PR TITLE
feat: improve layout editor preview flows

### DIFF
--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -99,7 +99,7 @@ layoutSections:
         value: "${values.direction}"
         options:
           - label: Absolute
-            value: ""
+            value: absolute
           - label: Horizontal
             value: horizontal
           - label: Vertical

--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -99,7 +99,6 @@ layoutSections:
         value: "${values.direction}"
         options:
           - label: Absolute
-            value: absolute
           - label: Horizontal
             value: horizontal
           - label: Vertical

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -292,7 +292,7 @@ const toInspectorValues = ({ values, firstTextStyleId }) => {
     ...values,
     revealEffect,
     variableId,
-    direction: values?.direction ?? "absolute",
+    direction: values?.direction,
     textStyleId: values?.textStyleId || firstTextStyleId || "",
     hoverTextStyleId: values?.hoverTextStyleId ?? "",
     clickTextStyleId: values?.clickTextStyleId ?? "",

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -292,7 +292,7 @@ const toInspectorValues = ({ values, firstTextStyleId }) => {
     ...values,
     revealEffect,
     variableId,
-    direction: values?.direction ?? "",
+    direction: values?.direction ?? "absolute",
     textStyleId: values?.textStyleId || firstTextStyleId || "",
     hoverTextStyleId: values?.hoverTextStyleId ?? "",
     clickTextStyleId: values?.clickTextStyleId ?? "",

--- a/src/internal/layoutEditorMutations.js
+++ b/src/internal/layoutEditorMutations.js
@@ -51,12 +51,13 @@ export const applyLayoutItemFieldChange = ({
   }
 
   const typeRules = getLayoutEditorTypeRules(item.type);
-  const normalizedValue =
-    typeRules.normalizeFieldValue?.({
-      item,
-      name,
-      value,
-    }) ?? value;
+  const normalizedValue = typeRules.normalizeFieldValue
+    ? typeRules.normalizeFieldValue({
+        item,
+        name,
+        value,
+      })
+    : value;
 
   const nextItem = structuredClone(item);
 

--- a/src/internal/layoutEditorPreview.js
+++ b/src/internal/layoutEditorPreview.js
@@ -50,7 +50,7 @@ const toPreviewVariableValue = (variable = {}) => {
 
 const createPreviewVariables = (variablesData = {}) => {
   const variableItems = {
-    ...(variablesData.items ?? {}),
+    ...variablesData.items,
     ...getSystemVariableItems(),
   };
 
@@ -73,7 +73,7 @@ const applyPreviewVariableOverrides = (
   previewVariableValues = {},
 ) => {
   const variableItems = {
-    ...(variablesData.items ?? {}),
+    ...variablesData.items,
     ...getSystemVariableItems(),
   };
   const nextPreviewVariables = {
@@ -125,8 +125,7 @@ const createDialogueLines = ({ characterName, dialogueContent }) => {
 
 const createNvlLines = (nvlDefaultValues = {}) => {
   const linesNum = Number(nvlDefaultValues.linesNum);
-  const lineCount =
-    Number.isFinite(linesNum) && linesNum > 0 ? linesNum : 0;
+  const lineCount = Number.isFinite(linesNum) && linesNum > 0 ? linesNum : 0;
   const sourceCharacterNames = Array.isArray(nvlDefaultValues.characterNames)
     ? nvlDefaultValues.characterNames
     : [];

--- a/src/internal/layoutEditorPreview.js
+++ b/src/internal/layoutEditorPreview.js
@@ -330,26 +330,6 @@ const resolveLayoutPreviewElements = ({ elements, previewData } = {}) => {
   );
 };
 
-const collectParsedElementCoordinates = (elements = [], parentId) => {
-  return toElementList(elements).flatMap((element) => {
-    const entry = {
-      id: element?.id,
-      type: element?.type,
-      parentId,
-      x: element?.x,
-      y: element?.y,
-      width: element?.width,
-      height: element?.height,
-      rotation: element?.rotation,
-    };
-
-    return [
-      entry,
-      ...collectParsedElementCoordinates(element?.children, element?.id),
-    ];
-  });
-};
-
 export const createLayoutEditorSelectionOverlay = ({
   parsedElements,
   selectedItemId,
@@ -521,10 +501,6 @@ export const renderLayoutEditorPreview = async (
 
     const parsedState = graphicsService.parse({
       elements: finalElements,
-    });
-    console.log("[layoutEditor.preview] parsedElementCoordinates", {
-      selectedItemId: selectedItem?.id,
-      coordinates: collectParsedElementCoordinates(parsedState.elements),
     });
     const overlayElements = createLayoutEditorSelectionOverlay({
       parsedElements: parsedState.elements,

--- a/src/internal/layoutEditorPreview.js
+++ b/src/internal/layoutEditorPreview.js
@@ -123,6 +123,31 @@ const createDialogueLines = ({ characterName, dialogueContent }) => {
   ];
 };
 
+const createNvlLines = (nvlDefaultValues = {}) => {
+  const linesNum = Number(nvlDefaultValues.linesNum);
+  const lineCount =
+    Number.isFinite(linesNum) && linesNum > 0 ? linesNum : 0;
+  const sourceCharacterNames = Array.isArray(nvlDefaultValues.characterNames)
+    ? nvlDefaultValues.characterNames
+    : [];
+  const sourceLines = Array.isArray(nvlDefaultValues.lines)
+    ? nvlDefaultValues.lines
+    : [];
+
+  return Array.from({ length: lineCount }, (_unused, index) => {
+    const characterName = sourceCharacterNames[index] ?? "";
+    const line = {
+      content: [{ text: sourceLines[index] ?? `Line ${index + 1}` }],
+    };
+
+    if (characterName) {
+      line.characterName = characterName;
+    }
+
+    return line;
+  });
+};
+
 const toElementList = (elements) => {
   if (Array.isArray(elements)) {
     return elements.filter(Boolean);
@@ -140,12 +165,7 @@ const isSelectableMatch = (elementId, selectedItemId) => {
     return true;
   }
 
-  if (!elementId.startsWith(`${selectedItemId}-`)) {
-    return false;
-  }
-
-  const repeatedInstanceSuffix = elementId.slice(selectedItemId.length + 1);
-  return /^\d+$/.test(repeatedInstanceSuffix);
+  return elementId === `${selectedItemId}-instance-0`;
 };
 
 const collectMatchingPaths = (
@@ -257,9 +277,11 @@ const buildOverlayTree = ({ path, overlayId, draggable }) => {
 };
 
 export const createLayoutEditorPreviewData = ({
+  layoutType,
   variablesData,
   previewVariableValues,
   dialogueDefaultValues,
+  nvlDefaultValues,
   previewRevealingSpeed,
   choicesData,
 } = {}) => {
@@ -289,10 +311,13 @@ export const createLayoutEditorPreviewData = ({
         name: characterName,
       },
       content: [{ text: dialogueContent }],
-      lines: createDialogueLines({
-        characterName,
-        dialogueContent,
-      }),
+      lines:
+        layoutType === "nvl"
+          ? createNvlLines(nvlDefaultValues)
+          : createDialogueLines({
+              characterName,
+              dialogueContent,
+            }),
     },
     choice: {
       items: createChoiceItems(choicesData),
@@ -304,6 +329,26 @@ const resolveLayoutPreviewElements = ({ elements, previewData } = {}) => {
   return toElementList(
     parseAndRender(toElementList(elements), previewData ?? {}),
   );
+};
+
+const collectParsedElementCoordinates = (elements = [], parentId) => {
+  return toElementList(elements).flatMap((element) => {
+    const entry = {
+      id: element?.id,
+      type: element?.type,
+      parentId,
+      x: element?.x,
+      y: element?.y,
+      width: element?.width,
+      height: element?.height,
+      rotation: element?.rotation,
+    };
+
+    return [
+      entry,
+      ...collectParsedElementCoordinates(element?.children, element?.id),
+    ];
+  });
 };
 
 export const createLayoutEditorSelectionOverlay = ({
@@ -325,18 +370,10 @@ export const createLayoutEditorSelectionOverlay = ({
 
   const primaryPath =
     matchingPaths.find(
-      (path) => path[path.length - 1]?.id === selectedItemId,
+      (path) =>
+        path[path.length - 1]?.id === selectedItemId ||
+        path[path.length - 1]?.id === `${selectedItemId}-instance-0`,
     ) ?? matchingPaths[0];
-  const secondaryPaths = matchingPaths.filter((path) => path !== primaryPath);
-  const secondaryOverlays = secondaryPaths
-    .map((path, index) => {
-      return buildOverlayTree({
-        path,
-        overlayId: `selected-border-preview-${index}`,
-        draggable: false,
-      });
-    })
-    .filter(Boolean);
   const primaryOverlay = buildOverlayTree({
     path: primaryPath,
     overlayId: "selected-border",
@@ -344,10 +381,10 @@ export const createLayoutEditorSelectionOverlay = ({
   });
 
   if (!primaryOverlay) {
-    return secondaryOverlays;
+    return [];
   }
 
-  return [...secondaryOverlays, primaryOverlay];
+  return [primaryOverlay];
 };
 
 const loadLayoutEditorAssets = async (deps, fileReferences, fontsItems) => {
@@ -473,9 +510,11 @@ export const renderLayoutEditorPreview = async (
     const finalElements = resolveLayoutPreviewElements({
       elements: renderStateElements,
       previewData: createLayoutEditorPreviewData({
+        layoutType: store.selectCurrentLayoutType(),
         variablesData,
         previewVariableValues: store.selectPreviewVariableValues(),
         dialogueDefaultValues: store.selectDialogueDefaultValues(),
+        nvlDefaultValues: store.selectNvlDefaultValues(),
         previewRevealingSpeed: store.selectPreviewRevealingSpeed(),
         choicesData: store.selectChoicesData(),
       }),
@@ -483,6 +522,10 @@ export const renderLayoutEditorPreview = async (
 
     const parsedState = graphicsService.parse({
       elements: finalElements,
+    });
+    console.log("[layoutEditor.preview] parsedElementCoordinates", {
+      selectedItemId: selectedItem?.id,
+      coordinates: collectParsedElementCoordinates(parsedState.elements),
     });
     const overlayElements = createLayoutEditorSelectionOverlay({
       parsedElements: parsedState.elements,

--- a/src/internal/layoutEditorTypes.js
+++ b/src/internal/layoutEditorTypes.js
@@ -398,10 +398,7 @@ const ITEM_TYPE_CAPABILITY_OVERRIDES = {
 const TYPE_RULES = {
   container: {
     normalizeFieldValue: ({ name, value }) => {
-      if (
-        name === "direction" &&
-        (value === null || value === "" || value === "absolute")
-      ) {
+      if (name === "direction" && (value === null || value === "")) {
         return undefined;
       }
 

--- a/src/internal/layoutEditorTypes.js
+++ b/src/internal/layoutEditorTypes.js
@@ -398,7 +398,10 @@ const ITEM_TYPE_CAPABILITY_OVERRIDES = {
 const TYPE_RULES = {
   container: {
     normalizeFieldValue: ({ name, value }) => {
-      if (name === "direction" && (value === null || value === "")) {
+      if (
+        name === "direction" &&
+        (value === null || value === "" || value === "absolute")
+      ) {
         return undefined;
       }
 

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -262,7 +262,7 @@ const updateChildrenIds = (children, indexVar) => {
   return children.map((child) => {
     const updatedChild = {
       ...child,
-      id: `${child.id}-\${${indexVar}}`,
+      id: `${child.id}-instance-\${${indexVar}}`,
     };
 
     if (updatedChild.children && updatedChild.children.length > 0) {
@@ -533,7 +533,7 @@ const applyContainerNode = ({ element, node }) => {
     ...nextElement,
     type: "container",
     $each: repeatingConfig.each,
-    id: `${node.id}-\${i}`,
+    id: `${node.id}-instance-\${i}`,
     ...(repeatingConfig.click
       ? {
           click: {

--- a/src/pages/layoutEditor/layoutEditor.constants.yaml
+++ b/src/pages/layoutEditor/layoutEditor.constants.yaml
@@ -104,6 +104,40 @@ dialogueForm:
       description: Dialogue Content
       type: input-text
 
+nvlForm:
+  title: Preview
+  description: Edit to see how the layout will look like with different content items
+  fields:
+    - name: linesNum
+      type: select
+      description: Number of Lines
+      options:
+        - label: "1"
+          value: 1
+        - label: "2"
+          value: 2
+        - label: "3"
+          value: 3
+        - label: "4"
+          value: 4
+        - label: "5"
+          value: 5
+        - label: "6"
+          value: 6
+      placeholder: Select number of lines
+      required: true
+    - "$each": 'line, i in lines'
+      type: section
+      fields:
+        - name: 'characterName${i}'
+          type: input-text
+          description: Character name
+          placeholder: Enter character name
+        - name: 'line${i}'
+          type: input-text
+          description: Line content text
+          placeholder: Enter line text
+
 choiceForm:
   title: Preview
   description: Edit to see how the layout will look like with different data
@@ -127,7 +161,7 @@ choiceForm:
       placeholder: Select number of choices
       required: true
     - "$each": 'choice, i in choices'
-      name: 'choices[${i}]'
+      name: 'choice${i}'
       type: input-text
       description: Choice content text
       placeholder: Enter choice text

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -251,6 +251,14 @@ export const handleDialogueFormChange = async (deps, payload) => {
   await rerenderLayoutEditorSurface(deps);
 };
 
+export const handleNvlFormChange = async (deps, payload) => {
+  const { store } = deps;
+  const { name, value: fieldValue } = payload._event.detail;
+
+  store.setNvlDefaultValue({ name, fieldValue });
+  await rerenderLayoutEditorSurface(deps);
+};
+
 export const handleChoiceFormChange = async (deps, payload) => {
   const { store } = deps;
   const { name, value: fieldValue } = payload._event.detail;

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -13,6 +13,7 @@ import {
 } from "../../internal/projectResolution.js";
 
 const PREVIEW_VARIABLE_TYPES = new Set(["boolean", "number", "string"]);
+const NORMAL_LIKE_LAYOUT_TYPES = new Set(["normal", "save-load"]);
 
 const PREVIEW_BOOLEAN_OPTIONS = [
   { label: "True", value: true },
@@ -42,7 +43,7 @@ const toPreviewVariableValue = ({ type, value } = {}) => {
 
 const getLayoutPreviewVariableItems = (layoutData = {}, variablesData = {}) => {
   const availableVariables = {
-    ...(variablesData.items ?? {}),
+    ...variablesData.items,
     ...getSystemVariableItems(),
   };
   const previewVariables = [];
@@ -129,6 +130,39 @@ const createPreviewVariableDefaultValues = (
   );
 };
 
+const createChoiceFormDefaultValues = (choiceDefaultValues = {}) => {
+  const choicesNum = Number(choiceDefaultValues.choicesNum);
+  const choiceCount =
+    Number.isFinite(choicesNum) && choicesNum > 0 ? choicesNum : 0;
+  const defaultValues = {
+    choicesNum: choiceCount,
+  };
+
+  for (let index = 0; index < choiceCount; index += 1) {
+    defaultValues[`choice${index}`] =
+      choiceDefaultValues.choices?.[index] ?? `Choice ${index + 1}`;
+  }
+
+  return defaultValues;
+};
+
+const createNvlFormDefaultValues = (nvlDefaultValues = {}) => {
+  const linesNum = Number(nvlDefaultValues.linesNum);
+  const lineCount = Number.isFinite(linesNum) && linesNum > 0 ? linesNum : 0;
+  const defaultValues = {
+    linesNum: lineCount,
+  };
+
+  for (let index = 0; index < lineCount; index += 1) {
+    defaultValues[`characterName${index}`] =
+      nvlDefaultValues.characterNames?.[index] ?? "";
+    defaultValues[`line${index}`] =
+      nvlDefaultValues.lines?.[index] ?? `This is sample NVL line ${index + 1}.`;
+  }
+
+  return defaultValues;
+};
+
 const toLayoutEditorContextMenuItems = (
   items = [],
   projectResolution = DEFAULT_PROJECT_RESOLUTION,
@@ -179,6 +213,15 @@ export const createInitialState = () => ({
   dialogueDefaultValues: {
     "dialogue-character-name": "Character",
     "dialogue-content": "This is a sample dialogue content.",
+  },
+  nvlDefaultValues: {
+    linesNum: 3,
+    characterNames: ["Character", "", "Narrator"],
+    lines: [
+      "This is the first sample NVL line.",
+      "This is the second sample NVL line.",
+      "This is the third sample NVL line.",
+    ],
   },
   previewRevealingSpeed: 50,
   choiceDefaultValues: {
@@ -350,6 +393,38 @@ export const setDialogueDefaultValue = (
   state.dialogueDefaultValues[name] = fieldValue;
 };
 
+export const setNvlDefaultValue = ({ state }, { name, fieldValue } = {}) => {
+  if (/^characterName\d+$/.test(name)) {
+    const index = Number.parseInt(name.slice("characterName".length), 10);
+    state.nvlDefaultValues.characterNames[index] = fieldValue;
+    return;
+  }
+
+  if (/^line\d+$/.test(name)) {
+    const index = Number.parseInt(name.slice("line".length), 10);
+    state.nvlDefaultValues.lines[index] = fieldValue;
+    return;
+  }
+
+  state.nvlDefaultValues[name] = fieldValue;
+
+  if (name !== "linesNum") {
+    return;
+  }
+
+  const lines = [];
+  const characterNames = [];
+  for (let index = 0; index < fieldValue; index += 1) {
+    characterNames.push(state.nvlDefaultValues.characterNames[index] ?? "");
+    lines.push(
+      state.nvlDefaultValues.lines[index] ||
+        `This is sample NVL line ${index + 1}.`,
+    );
+  }
+  state.nvlDefaultValues.characterNames = characterNames;
+  state.nvlDefaultValues.lines = lines;
+};
+
 export const setPreviewRevealingSpeed = ({ state }, { value } = {}) => {
   state.previewRevealingSpeed = value;
 };
@@ -436,8 +511,8 @@ export const setSliderCreateImageSelectorSelectedImageId = (
 };
 
 export const setChoiceDefaultValue = ({ state }, { name, fieldValue } = {}) => {
-  if (name.startsWith("choices[")) {
-    const index = Number.parseInt(name.match(/\d+/)[0], 10);
+  if (/^choice\d+$/.test(name)) {
+    const index = Number.parseInt(name.slice("choice".length), 10);
     state.choiceDefaultValues.choices[index] = fieldValue;
     return;
   }
@@ -489,6 +564,10 @@ export const selectCurrentLayoutType = ({ state }) => {
 
 export const selectDialogueDefaultValues = ({ state }) => {
   return state.dialogueDefaultValues;
+};
+
+export const selectNvlDefaultValues = ({ state }) => {
+  return state.nvlDefaultValues;
 };
 
 export const selectChoiceDefaultValues = ({ state }) => {
@@ -608,7 +687,7 @@ export const selectViewData = ({ state, constants }) => {
     { layoutType },
   );
   const previewVariableItems =
-    layoutType === "normal"
+    NORMAL_LIKE_LAYOUT_TYPES.has(layoutType)
       ? getLayoutPreviewVariableItems(state.layoutData, state.variablesData)
       : [];
   const previewVariablesDefaultValues = createPreviewVariableDefaultValues(
@@ -638,9 +717,16 @@ export const selectViewData = ({ state, constants }) => {
     ),
     dialogueForm: constants.dialogueForm,
     dialogueDefaultValues: state.dialogueDefaultValues,
+    nvlForm: constants.nvlForm,
+    nvlDefaultValues: createNvlFormDefaultValues(state.nvlDefaultValues),
+    nvlContext: {
+      ...state.nvlDefaultValues,
+    },
     previewRevealingSpeed: state.previewRevealingSpeed,
     choiceForm: constants.choiceForm,
-    choiceDefaultValues: state.choiceDefaultValues,
+    choiceDefaultValues: createChoiceFormDefaultValues(
+      state.choiceDefaultValues,
+    ),
     choicesContext: {
       ...state.choiceDefaultValues,
     },

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -157,7 +157,8 @@ const createNvlFormDefaultValues = (nvlDefaultValues = {}) => {
     defaultValues[`characterName${index}`] =
       nvlDefaultValues.characterNames?.[index] ?? "";
     defaultValues[`line${index}`] =
-      nvlDefaultValues.lines?.[index] ?? `This is sample NVL line ${index + 1}.`;
+      nvlDefaultValues.lines?.[index] ??
+      `This is sample NVL line ${index + 1}.`;
   }
 
   return defaultValues;
@@ -686,10 +687,9 @@ export const selectViewData = ({ state, constants }) => {
       : constants.emptyContextMenuItems,
     { layoutType },
   );
-  const previewVariableItems =
-    NORMAL_LIKE_LAYOUT_TYPES.has(layoutType)
-      ? getLayoutPreviewVariableItems(state.layoutData, state.variablesData)
-      : [];
+  const previewVariableItems = NORMAL_LIKE_LAYOUT_TYPES.has(layoutType)
+    ? getLayoutPreviewVariableItems(state.layoutData, state.variablesData)
+    : [];
   const previewVariablesDefaultValues = createPreviewVariableDefaultValues(
     previewVariableItems,
     state.previewVariableValues,

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -14,18 +14,30 @@ refs:
         handler: handleAddLayoutClick
   dialogueForm:
     eventListeners:
+      form-input:
+        handler: handleDialogueFormChange
       form-change:
         handler: handleDialogueFormChange
+  nvlForm:
+    eventListeners:
+      form-input:
+        handler: handleNvlFormChange
+      form-change:
+        handler: handleNvlFormChange
   revealingSpeedInput:
     eventListeners:
       value-input:
         handler: handlePreviewRevealingSpeedInput
   choiceForm:
     eventListeners:
+      form-input:
+        handler: handleChoiceFormChange
       form-change:
         handler: handleChoiceFormChange
   previewVariablesForm:
     eventListeners:
+      form-input:
+        handler: handlePreviewVariablesFormChange
       form-change:
         handler: handlePreviewVariablesFormChange
   sliderCreateDialog:
@@ -89,8 +101,10 @@ template:
               - 'rtgl-view w=f bgc=mu pos=rel bwb=xs style="margin-left: 1px; aspect-ratio: ${canvasAspectRatio};"':
                   - rtgl-view pos=abs cor=full:
                       - 'div#canvas style="width: 100%; height: 100%;display: flex; cursor: ${canvasCursor}"': null
-              - $if layout.layoutType == 'dialogue' || layout.layoutType == 'nvl':
+              - $if layout.layoutType == 'dialogue':
                   - rtgl-form#dialogueForm w=f :form=${dialogueForm} :defaultValues=${dialogueDefaultValues}: null
+              - $if layout.layoutType == 'nvl':
+                  - rtgl-form#nvlForm w=f :form=${nvlForm} :defaultValues=${nvlDefaultValues} :context=${nvlContext}: null
               - $if layout.layoutType == 'dialogue':
                   - rtgl-view d=h av=c g=sm w=f ph=md pb=md:
                       - rtgl-text s=sm c=mu-fg: Revealing Speed
@@ -98,7 +112,7 @@ template:
                       - rtgl-button#playPreviewButton v=ol: Play
               - $if layout.layoutType == 'choice':
                   - rtgl-form#choiceForm w=f :form=${choiceForm} :defaultValues=${choiceDefaultValues} :context=${choicesContext}: null
-              - $if layout.layoutType == 'normal' && hasPreviewVariables:
+              - $if (layout.layoutType == 'normal' || layout.layoutType == 'save-load') && hasPreviewVariables:
                   - rtgl-form#previewVariablesForm key=${previewVariablesFormKey} w=f :form=${previewVariablesForm} :defaultValues=${previewVariablesDefaultValues}: null
       - rvn-resizable-panel#resizableDetailPanel panel-type=detail-panel w=300 min-w=200 max-w=500 resize-side="left":
           - rtgl-view wh=f slot="content":

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -279,7 +279,7 @@ const createLayoutTemplate = (layoutType, projectResolution) => {
     );
   }
 
-  if (layoutType === "normal") {
+  if (layoutType === "normal" || layoutType === "save-load") {
     const rootId = nanoid();
     const textId = nanoid();
 

--- a/src/pages/layouts/layouts.store.js
+++ b/src/pages/layouts/layouts.store.js
@@ -17,13 +17,14 @@ const layoutForm = {
       required: true,
       options: [
         { value: "normal", label: "Normal" },
+        { value: "save-load", label: "Save/Load" },
         { value: "dialogue", label: "Dialogue" },
         { value: "nvl", label: "NVL" },
         { value: "choice", label: "Choice" },
       ],
       tooltip: {
         content:
-          "Normal is layout that can be used for background or menu pages. Dialogue is used for ADV mode text dialogue layout. NVL is used for novel mode accumulated dialogue layout. Choice is used for the choices.",
+          "Normal is layout that can be used for background or menu pages. Save/Load is a normal-style layout intended for save and load screens. Dialogue is used for ADV mode text dialogue layout. NVL is used for novel mode accumulated dialogue layout. Choice is used for the choices.",
       },
     },
   ],
@@ -41,6 +42,7 @@ const layoutForm = {
 
 const layoutTypeLabels = {
   normal: "Normal",
+  "save-load": "Save/Load",
   dialogue: "Dialogue",
   nvl: "NVL",
   choice: "Choice",

--- a/tests/layoutEditor/layoutEditorMutations.test.js
+++ b/tests/layoutEditor/layoutEditorMutations.test.js
@@ -47,6 +47,22 @@ describe("layoutEditorMutations", () => {
     expect(updatedItem.anchorY).toBe(1);
   });
 
+  it("normalizes absolute container direction to an unset saved value", () => {
+    const item = {
+      id: "choice-container-1",
+      type: "container-ref-choice-item",
+      direction: "vertical",
+    };
+
+    const updatedItem = applyLayoutItemFieldChange({
+      item,
+      name: "direction",
+      value: "absolute",
+    });
+
+    expect(updatedItem.direction).toBeUndefined();
+  });
+
   it("auto-sizes sprites from the selected image when width and height are unset", () => {
     const item = {
       id: "sprite-1",

--- a/tests/layoutEditor/layoutEditorMutations.test.js
+++ b/tests/layoutEditor/layoutEditorMutations.test.js
@@ -47,7 +47,7 @@ describe("layoutEditorMutations", () => {
     expect(updatedItem.anchorY).toBe(1);
   });
 
-  it("normalizes absolute container direction to an unset saved value", () => {
+  it("keeps cleared container direction unset in saved data", () => {
     const item = {
       id: "choice-container-1",
       type: "container-ref-choice-item",
@@ -57,7 +57,7 @@ describe("layoutEditorMutations", () => {
     const updatedItem = applyLayoutItemFieldChange({
       item,
       name: "direction",
-      value: "absolute",
+      value: undefined,
     });
 
     expect(updatedItem.direction).toBeUndefined();

--- a/tests/layoutEditor/layoutEditorPreview.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.test.js
@@ -51,6 +51,27 @@ describe("layoutEditorPreview", () => {
     ]);
   });
 
+  it("builds NVL preview lines from the editable content list", () => {
+    const previewData = createLayoutEditorPreviewData({
+      layoutType: "nvl",
+      nvlDefaultValues: {
+        linesNum: 2,
+        characterNames: ["Aki", ""],
+        lines: ["First NVL line", "Second NVL line"],
+      },
+    });
+
+    expect(previewData.dialogue.lines).toEqual([
+      {
+        characterName: "Aki",
+        content: [{ text: "First NVL line" }],
+      },
+      {
+        content: [{ text: "Second NVL line" }],
+      },
+    ]);
+  });
+
   it("includes system variables in preview data", () => {
     const previewData = createLayoutEditorPreviewData({
       variablesData: {
@@ -83,12 +104,12 @@ describe("layoutEditorPreview", () => {
     });
   });
 
-  it("creates a draggable primary overlay and non-draggable repeated overlays", () => {
+  it("creates a draggable overlay only for the first repeated instance", () => {
     const overlays = createLayoutEditorSelectionOverlay({
       selectedItemId: "target",
       parsedElements: [
         {
-          id: "target",
+          id: "target-instance-0",
           type: "rect",
           x: 10,
           y: 20,
@@ -96,7 +117,7 @@ describe("layoutEditorPreview", () => {
           height: 40,
         },
         {
-          id: "target-0",
+          id: "target-instance-1",
           type: "rect",
           x: 140,
           y: 20,
@@ -106,11 +127,9 @@ describe("layoutEditorPreview", () => {
       ],
     });
 
-    expect(overlays).toHaveLength(2);
-    expect(overlays[0].id).toBe("selected-border-preview-0");
-    expect(overlays[0].drag).toBeUndefined();
-    expect(overlays[1].id).toBe("selected-border");
-    expect(overlays[1].drag).toEqual({
+    expect(overlays).toHaveLength(1);
+    expect(overlays[0].id).toBe("selected-border");
+    expect(overlays[0].drag).toEqual({
       start: { payload: {} },
       move: { payload: {} },
       end: { payload: {} },


### PR DESCRIPTION
## Summary
- add NVL-specific preview editing with per-line character names and content
- improve layout editor preview behavior for repeated elements and preview variable editing
- add save/load as a normal-like layout type and fix absolute container direction persistence

## Validation
- bunx vitest run tests/layoutEditor/layoutEditorPreview.test.js tests/layoutEditor/layoutEditorMutations.test.js
- bunx oxlint && bun prettier --check src