### PR TITLE
refactor: extract shared graphics engine runtime helpers

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,26 +2,14 @@ import { fileTypeFromBuffer } from "file-type";
 import createRouteEngine, { createEffectsHandler } from "route-engine-js";
 import { Ticker } from "pixi.js";
 
-import createRouteGraphics, {
-  createAssetBufferManager,
-  textPlugin,
-  rectPlugin,
-  spritePlugin,
-  sliderPlugin,
-  containerPlugin,
-  textRevealingPlugin,
-  tweenPlugin,
-  soundPlugin,
-  videoPlugin,
-  particlesPlugin,
-  animatedSpritePlugin,
-} from "route-graphics";
+import createRouteGraphics, { createAssetBufferManager } from "route-graphics";
 import { prepareRenderStateKeyboardForGraphics } from "../src/internal/project/layout.js";
 import {
-  applyRuntimeActionContext,
-  captureCanvasThumbnailImage,
-  preloadRuntimeThumbnailImage,
-} from "../src/internal/ui/runtimeActionPreparation.js";
+  createRuntimeEventContext,
+  getRuntimeEventActions,
+  loadGraphicsEnginePlugins,
+  prepareRuntimeInteractionExecution,
+} from "../src/internal/runtime/graphicsEngineRuntime.js";
 import { BUNDLE_FORMAT_VERSION } from "../src/deps/services/shared/projectExportService.js";
 
 async function parseVNBundle(arrayBuffer) {
@@ -127,57 +115,8 @@ const preloadBundleData = async () => {
   return { jsonData, assetBufferMap };
 };
 
-const getEventActions = (payload = {}) => {
-  if (payload?.actions && typeof payload.actions === "object") {
-    return payload.actions;
-  }
-
-  if (
-    payload?.payload?.actions &&
-    typeof payload.payload.actions === "object"
-  ) {
-    return payload.payload.actions;
-  }
-
-  return undefined;
-};
-
-const hasSaveAction = (actions = {}) => {
-  if (!actions || typeof actions !== "object" || Array.isArray(actions)) {
-    return false;
-  }
-
-  if (actions.saveSlot || actions.saveSaveSlot) {
-    return true;
-  }
-
-  const confirmDialog = actions.showConfirmDialog;
-  if (!confirmDialog || typeof confirmDialog !== "object") {
-    return false;
-  }
-
-  return (
-    hasSaveAction(confirmDialog.confirmActions) ||
-    hasSaveAction(confirmDialog.cancelActions)
-  );
-};
-
 const prepareEngine = async ({ jsonData, assetBufferMap }) => {
-  const plugins = {
-    elements: [
-      textPlugin,
-      rectPlugin,
-      spritePlugin,
-      sliderPlugin,
-      containerPlugin,
-      textRevealingPlugin,
-      videoPlugin,
-      particlesPlugin,
-      animatedSpritePlugin,
-    ],
-    animations: [tweenPlugin],
-    audio: [soundPlugin],
-  };
+  const plugins = await loadGraphicsEnginePlugins();
 
   // Create dedicated ticker for auto mode
   const ticker = new Ticker();
@@ -239,39 +178,27 @@ const prepareEngine = async ({ jsonData, assetBufferMap }) => {
         return;
       }
 
-      const actions = getEventActions(payload);
+      const actions = getRuntimeEventActions(payload);
       if (!actions) {
         return;
       }
 
-      const eventData = payload._event ?? payload.event;
-      const eventContext = eventData
-        ? { _event: eventData }
-        : undefined;
-      const preparedActions = structuredClone(actions);
-      const shouldCaptureThumbnail = hasSaveAction(preparedActions);
-      let thumbnailImage;
+      const eventContext = createRuntimeEventContext(payload);
+      const { preparedActions, thumbnailPreloadError } =
+        await prepareRuntimeInteractionExecution({
+          actions,
+          eventContext,
+          graphicsService: routeGraphics,
+          canvasRoot: routeGraphics.canvas,
+          swallowThumbnailPreloadError: true,
+        });
 
-      if (shouldCaptureThumbnail) {
-        thumbnailImage = await captureCanvasThumbnailImage(
-          routeGraphics,
-          routeGraphics.canvas,
+      if (thumbnailPreloadError) {
+        console.warn(
+          "Failed to preload save thumbnail image.",
+          thumbnailPreloadError,
         );
-
-        if (thumbnailImage) {
-          try {
-            await preloadRuntimeThumbnailImage(routeGraphics, thumbnailImage);
-          } catch (error) {
-            console.warn("Failed to preload save thumbnail image.", error);
-          }
-        }
       }
-
-      applyRuntimeActionContext(preparedActions, {
-        slotBinding:
-          eventData?.slotId !== undefined ? "_event.slotId" : undefined,
-        thumbnailImage,
-      });
 
       engine.handleActions(preparedActions, eventContext);
     },

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -8,6 +8,7 @@ import {
   createRuntimeEventContext,
   getRuntimeEventActions,
   loadGraphicsEnginePlugins,
+  preloadRuntimeSaveSlotImages,
   prepareRuntimeInteractionExecution,
 } from "../src/internal/runtime/graphicsEngineRuntime.js";
 import { BUNDLE_FORMAT_VERSION } from "../src/deps/services/shared/projectExportService.js";
@@ -216,6 +217,16 @@ const prepareEngine = async ({ jsonData, assetBufferMap }) => {
     JSON.parse(localStorage.getItem("globalDeviceVariables")) || {};
   const globalAccountVariables =
     JSON.parse(localStorage.getItem("globalAccountVariables")) || {};
+  const preloadSaveSlotImagesResult = await preloadRuntimeSaveSlotImages(
+    routeGraphics,
+    saveSlots,
+  );
+
+  if (preloadSaveSlotImagesResult.failed > 0) {
+    console.warn(
+      `Failed to preload ${preloadSaveSlotImagesResult.failed} saved thumbnail image(s) during bundle startup.`,
+    );
+  }
 
   const startEngine = () => {
     engine.init({

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -3,7 +3,7 @@ import {
   DEFAULT_PROJECT_RESOLUTION,
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
-import { captureCanvasThumbnailImage } from "../../internal/ui/runtimeActionPreparation.js";
+import { captureCanvasThumbnailImage } from "../../internal/runtime/graphicsEngineRuntime.js";
 import {
   createLayoutEditorRenderedElements,
   loadLayoutEditorAssets,

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -9,12 +9,7 @@ import {
   extractTransitionTargetSceneIds,
   extractTransitionTargetSceneIdsFromActions,
 } from "../../internal/project/layout.js";
-import {
-  applyRuntimeActionContext,
-  captureCanvasThumbnailImage,
-  prepareRuntimeInteractionActions,
-  preloadRuntimeThumbnailImage,
-} from "../../internal/ui/runtimeActionPreparation.js";
+import { prepareRuntimeInteractionExecution } from "../../internal/runtime/graphicsEngineRuntime.js";
 import {
   collectSceneIdsFromValue,
   collectSectionIdsFromValue,
@@ -175,20 +170,14 @@ const createBeforeHandleActionsHook = (
   );
 
   return async (actions, eventContext) => {
-    const eventData = eventContext?._event;
-    const preparedActions = prepareRuntimeInteractionActions(
-      actions,
-      eventData,
-    );
-    const thumbnailImage = await captureCanvasThumbnailImage(
-      deps.graphicsService,
-      deps.refs?.canvas,
-    );
-    applyRuntimeActionContext(preparedActions, {
-      thumbnailImage,
-    });
-    await preloadRuntimeThumbnailImage(deps.graphicsService, thumbnailImage);
-    const resolvedActions = resolveEventBindings(preparedActions, eventData);
+    const { eventData, preparedActions, resolvedActions } =
+      await prepareRuntimeInteractionExecution({
+        actions,
+        eventContext,
+        graphicsService: deps.graphicsService,
+        canvasRoot: deps.refs?.canvas,
+        resolveEventBindings,
+      });
     const referencedSceneIds = collectSceneIdsFromValue(
       resolvedActions,
       eventData,

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -2,19 +2,16 @@ import createRouteGraphics, {
   Assets,
   AudioAsset,
   createAssetBufferManager,
-  textPlugin,
-  rectPlugin,
-  spritePlugin,
-  sliderPlugin,
-  containerPlugin,
-  textRevealingPlugin,
-  videoPlugin,
-  tweenPlugin,
-  soundPlugin,
 } from "route-graphics";
 import createRouteEngine, { createEffectsHandler } from "route-engine-js";
 import { Rectangle, Ticker } from "pixi.js";
 import { prepareRenderStateKeyboardForGraphics } from "../../internal/project/layout.js";
+import {
+  createRuntimeEventContext,
+  getRuntimeEventActions,
+  isRuntimeRightClickEvent,
+  loadGraphicsEnginePlugins,
+} from "../../internal/runtime/graphicsEngineRuntime.js";
 import { requireProjectResolution } from "../../internal/projectResolution.js";
 
 const cloneBufferForAudioDecode = (value) => {
@@ -292,7 +289,6 @@ const installManagedAudioAsset = () => {
 installManagedAudioAsset();
 
 export const createGraphicsService = async ({ subject }) => {
-  const RIGHT_CLICK_EVENT_NAMES = new Set(["rightclick", "rightClick"]);
   let routeGraphics;
   let engine;
   let assetBufferManager;
@@ -922,21 +918,6 @@ export const createGraphicsService = async ({ subject }) => {
     };
   };
 
-  const getEventActions = (payload) => {
-    if (payload?.actions && typeof payload.actions === "object") {
-      return payload.actions;
-    }
-
-    if (
-      payload?.payload?.actions &&
-      typeof payload.payload.actions === "object"
-    ) {
-      return payload.payload.actions;
-    }
-
-    return undefined;
-  };
-
   const renderEngineState = (renderState, options = {}) => {
     const { allowDeferredAudio = true } = options;
     let nextRenderState = prepareRenderStateKeyboardForGraphics({
@@ -1117,19 +1098,7 @@ export const createGraphicsService = async ({ subject }) => {
       assetBufferManager = createAssetBufferManager();
       routeGraphics = createRouteGraphics();
 
-      const plugins = {
-        elements: [
-          textPlugin,
-          rectPlugin,
-          spritePlugin,
-          sliderPlugin,
-          containerPlugin,
-          textRevealingPlugin,
-          videoPlugin,
-        ],
-        animations: [tweenPlugin],
-        audio: [soundPlugin],
-      };
+      const plugins = await loadGraphicsEnginePlugins();
 
       await routeGraphics.init({
         width: renderWidth,
@@ -1164,16 +1133,14 @@ export const createGraphicsService = async ({ subject }) => {
             return;
           }
 
-          const actions = getEventActions(payload);
+          const actions = getRuntimeEventActions(payload);
 
           if (actions && engine) {
-            const eventContext = payload._event
-              ? { _event: payload._event }
-              : undefined;
+            const eventContext = createRuntimeEventContext(payload);
 
             const interactionId = eventContext?._event?.id ?? "__unknown__";
 
-            if (RIGHT_CLICK_EVENT_NAMES.has(eventName)) {
+            if (isRuntimeRightClickEvent(eventName)) {
               clearPendingClickInteraction(interactionId);
               enqueueInteractionActions(actions, eventContext);
               return;

--- a/src/internal/runtime/graphicsEngineRuntime.js
+++ b/src/internal/runtime/graphicsEngineRuntime.js
@@ -10,10 +10,21 @@ let graphicsEnginePlugins;
 
 export const loadGraphicsEnginePlugins = async () => {
   if (!graphicsEnginePlugins) {
+    const routeGraphicsModule = await import("route-graphics");
+    const animatedSpritePlugin = Object.prototype.hasOwnProperty.call(
+      routeGraphicsModule,
+      "animatedSpritePlugin",
+    )
+      ? routeGraphicsModule.animatedSpritePlugin
+      : undefined;
+    const particlesPlugin = Object.prototype.hasOwnProperty.call(
+      routeGraphicsModule,
+      "particlesPlugin",
+    )
+      ? routeGraphicsModule.particlesPlugin
+      : undefined;
     const {
-      animatedSpritePlugin,
       containerPlugin,
-      particlesPlugin,
       rectPlugin,
       sliderPlugin,
       soundPlugin,
@@ -22,7 +33,7 @@ export const loadGraphicsEnginePlugins = async () => {
       textRevealingPlugin,
       tweenPlugin,
       videoPlugin,
-    } = await import("route-graphics");
+    } = routeGraphicsModule;
 
     graphicsEnginePlugins = {
       elements: [
@@ -35,7 +46,7 @@ export const loadGraphicsEnginePlugins = async () => {
         videoPlugin,
         particlesPlugin,
         animatedSpritePlugin,
-      ],
+      ].filter(Boolean),
       animations: [tweenPlugin],
       audio: [soundPlugin],
     };

--- a/src/internal/runtime/graphicsEngineRuntime.js
+++ b/src/internal/runtime/graphicsEngineRuntime.js
@@ -371,6 +371,43 @@ export const preloadRuntimeThumbnailImage = async (graphicsService, value) => {
   });
 };
 
+export const preloadRuntimeSaveSlotImages = async (
+  graphicsService,
+  saveSlots = {},
+) => {
+  if (!saveSlots || typeof saveSlots !== "object" || Array.isArray(saveSlots)) {
+    return {
+      attempted: 0,
+      failed: 0,
+    };
+  }
+
+  const images = Array.from(
+    new Set(
+      Object.values(saveSlots)
+        .map((saveSlot) => saveSlot?.image ?? saveSlot?.thumbnailImage)
+        .filter(
+          (value) => typeof value === "string" && value.startsWith("data:"),
+        ),
+    ),
+  );
+
+  let failed = 0;
+
+  for (const image of images) {
+    try {
+      await preloadRuntimeThumbnailImage(graphicsService, image);
+    } catch {
+      failed += 1;
+    }
+  }
+
+  return {
+    attempted: images.length,
+    failed,
+  };
+};
+
 export const prepareRuntimeInteractionExecution = async ({
   actions,
   eventContext,

--- a/src/internal/runtime/graphicsEngineRuntime.js
+++ b/src/internal/runtime/graphicsEngineRuntime.js
@@ -1,9 +1,106 @@
 const SAVE_ACTION_KEYS = new Set(["saveSlot", "saveSaveSlot"]);
 const LOAD_ACTION_KEYS = new Set(["loadSlot", "loadSaveSlot"]);
+const RIGHT_CLICK_EVENT_NAMES = new Set(["rightclick", "rightClick"]);
 const THUMBNAIL_MAX_WIDTH = 400;
 const THUMBNAIL_MAX_HEIGHT = 225;
 const THUMBNAIL_FORMAT = "image/jpeg";
 const THUMBNAIL_QUALITY = 0.75;
+
+let graphicsEnginePlugins;
+
+export const loadGraphicsEnginePlugins = async () => {
+  if (!graphicsEnginePlugins) {
+    const {
+      animatedSpritePlugin,
+      containerPlugin,
+      particlesPlugin,
+      rectPlugin,
+      sliderPlugin,
+      soundPlugin,
+      spritePlugin,
+      textPlugin,
+      textRevealingPlugin,
+      tweenPlugin,
+      videoPlugin,
+    } = await import("route-graphics");
+
+    graphicsEnginePlugins = {
+      elements: [
+        textPlugin,
+        rectPlugin,
+        spritePlugin,
+        sliderPlugin,
+        containerPlugin,
+        textRevealingPlugin,
+        videoPlugin,
+        particlesPlugin,
+        animatedSpritePlugin,
+      ],
+      animations: [tweenPlugin],
+      audio: [soundPlugin],
+    };
+  }
+
+  return {
+    elements: [...graphicsEnginePlugins.elements],
+    animations: [...graphicsEnginePlugins.animations],
+    audio: [...graphicsEnginePlugins.audio],
+  };
+};
+
+export const isRuntimeRightClickEvent = (eventName) => {
+  return RIGHT_CLICK_EVENT_NAMES.has(eventName);
+};
+
+export const getRuntimeEventActions = (payload = {}) => {
+  if (payload?.actions && typeof payload.actions === "object") {
+    return payload.actions;
+  }
+
+  if (
+    payload?.payload?.actions &&
+    typeof payload.payload.actions === "object"
+  ) {
+    return payload.payload.actions;
+  }
+
+  return undefined;
+};
+
+export const getRuntimeEventData = (payload = {}) => {
+  return payload?._event;
+};
+
+export const createRuntimeEventContext = (payload = {}) => {
+  const eventData = getRuntimeEventData(payload);
+  if (!eventData) {
+    return undefined;
+  }
+
+  return {
+    _event: eventData,
+  };
+};
+
+export const hasRuntimeSaveAction = (actions = {}) => {
+  if (!actions || typeof actions !== "object" || Array.isArray(actions)) {
+    return false;
+  }
+
+  if (actions.saveSlot || actions.saveSaveSlot) {
+    return true;
+  }
+
+  const confirmDialog = actions.showConfirmDialog;
+  if (!confirmDialog || typeof confirmDialog !== "object") {
+    return false;
+  }
+
+  return (
+    hasRuntimeSaveAction(confirmDialog.confirmActions) ||
+    hasRuntimeSaveAction(confirmDialog.cancelActions)
+  );
+};
 
 const getCanvasElement = (canvasRoot) => {
   if (!canvasRoot || typeof canvasRoot !== "object") {
@@ -272,4 +369,58 @@ export const preloadRuntimeThumbnailImage = async (graphicsService, value) => {
       type: getDataUrlMimeType(value) ?? "image/jpeg",
     },
   });
+};
+
+export const prepareRuntimeInteractionExecution = async ({
+  actions,
+  eventContext,
+  graphicsService,
+  canvasRoot,
+  resolveEventBindings,
+  captureThumbnail = "save-only",
+  swallowThumbnailPreloadError = false,
+} = {}) => {
+  const eventData = eventContext?._event;
+  const preparedActions = prepareRuntimeInteractionActions(actions, eventData);
+  const shouldCaptureThumbnail =
+    captureThumbnail === "always" ||
+    (captureThumbnail === "save-only" && hasRuntimeSaveAction(preparedActions));
+  let thumbnailImage;
+  let thumbnailPreloadError;
+
+  if (shouldCaptureThumbnail) {
+    thumbnailImage = await captureCanvasThumbnailImage(
+      graphicsService,
+      canvasRoot,
+    );
+  }
+
+  applyRuntimeActionContext(preparedActions, {
+    thumbnailImage,
+  });
+
+  if (thumbnailImage) {
+    try {
+      await preloadRuntimeThumbnailImage(graphicsService, thumbnailImage);
+    } catch (error) {
+      if (!swallowThumbnailPreloadError) {
+        throw error;
+      }
+
+      thumbnailPreloadError = error;
+    }
+  }
+
+  const resolvedActions =
+    typeof resolveEventBindings === "function"
+      ? resolveEventBindings(preparedActions, eventData)
+      : undefined;
+
+  return {
+    eventData,
+    preparedActions,
+    resolvedActions,
+    thumbnailImage,
+    thumbnailPreloadError,
+  };
 };

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -13,12 +13,7 @@ import {
   sanitizeProjectDataForRouteEngine,
   summarizeProjectDataForRouteEngine,
 } from "../../project/routeEngineProjectData.js";
-import {
-  applyRuntimeActionContext,
-  captureCanvasThumbnailImage,
-  prepareRuntimeInteractionActions,
-  preloadRuntimeThumbnailImage,
-} from "../runtimeActionPreparation.js";
+import { prepareRuntimeInteractionExecution } from "../../runtime/graphicsEngineRuntime.js";
 
 const createAssetLoadCache = () => ({
   sceneIds: new Set(),
@@ -352,20 +347,14 @@ const createBeforeHandleActionsHook = (deps) => {
 
   return async (actions, eventContext) => {
     const projectData = store.selectProjectData();
-    const eventData = eventContext?._event;
-    const preparedActions = prepareRuntimeInteractionActions(
-      actions,
-      eventData,
-    );
-    const thumbnailImage = await captureCanvasThumbnailImage(
-      deps.graphicsService,
-      deps.refs?.canvas,
-    );
-    applyRuntimeActionContext(preparedActions, {
-      thumbnailImage,
-    });
-    await preloadRuntimeThumbnailImage(deps.graphicsService, thumbnailImage);
-    const resolvedActions = resolveEventBindings(preparedActions, eventData);
+    const { eventData, preparedActions, resolvedActions } =
+      await prepareRuntimeInteractionExecution({
+        actions,
+        eventContext,
+        graphicsService: deps.graphicsService,
+        canvasRoot: deps.refs?.canvas,
+        resolveEventBindings,
+      });
     const layoutIds = Array.from(
       new Set([
         ...extractLayoutIdsFromValue(resolvedActions, projectData),

--- a/tests/internal/runtimeActionPreparation.test.js
+++ b/tests/internal/runtimeActionPreparation.test.js
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   captureCanvasThumbnailImage,
+  preloadRuntimeSaveSlotImages,
   prepareRuntimeInteractionExecution,
   prepareRuntimeInteractionActions,
 } from "../../src/internal/runtime/graphicsEngineRuntime.js";
@@ -228,5 +229,49 @@ describe("prepareRuntimeInteractionExecution", () => {
       },
     });
     expect(result.thumbnailPreloadError).toBeUndefined();
+  });
+});
+
+describe("preloadRuntimeSaveSlotImages", () => {
+  it("preloads unique saved thumbnail data urls from restored save slots", async () => {
+    const graphicsService = {
+      loadAssets: vi.fn(async () => {}),
+      hasLoadedAsset: vi.fn(() => false),
+    };
+
+    const result = await preloadRuntimeSaveSlotImages(graphicsService, {
+      "slot:1": {
+        image: "data:image/jpeg;base64,one",
+      },
+      "slot:2": {
+        image: "data:image/jpeg;base64,two",
+      },
+      "slot:3": {
+        image: "data:image/jpeg;base64,one",
+      },
+      "slot:4": {
+        image: "blob:https://example.com/not-a-data-url",
+      },
+    });
+
+    expect(graphicsService.loadAssets).toHaveBeenCalledTimes(2);
+    expect(graphicsService.loadAssets).toHaveBeenNthCalledWith(1, {
+      "data:image/jpeg;base64,one": {
+        source: "url",
+        url: "data:image/jpeg;base64,one",
+        type: "image/jpeg",
+      },
+    });
+    expect(graphicsService.loadAssets).toHaveBeenNthCalledWith(2, {
+      "data:image/jpeg;base64,two": {
+        source: "url",
+        url: "data:image/jpeg;base64,two",
+        type: "image/jpeg",
+      },
+    });
+    expect(result).toEqual({
+      attempted: 2,
+      failed: 0,
+    });
   });
 });

--- a/tests/internal/runtimeActionPreparation.test.js
+++ b/tests/internal/runtimeActionPreparation.test.js
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   captureCanvasThumbnailImage,
+  prepareRuntimeInteractionExecution,
   prepareRuntimeInteractionActions,
-} from "../../src/internal/ui/runtimeActionPreparation.js";
+} from "../../src/internal/runtime/graphicsEngineRuntime.js";
 
 const createThumbnailCanvas = (result) => {
   const context = {
@@ -168,5 +169,64 @@ describe("prepareRuntimeInteractionActions", () => {
         },
       },
     });
+  });
+});
+
+describe("prepareRuntimeInteractionExecution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("fills nested save actions and preloads thumbnail images through the shared runtime helper", async () => {
+    const thumbnailCanvas = createThumbnailCanvas(
+      "data:image/jpeg;base64,thumb-save",
+    );
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => thumbnailCanvas),
+    });
+    vi.stubGlobal("Image", FakeImage);
+
+    const graphicsService = {
+      extractBase64: vi.fn(async () => "data:image/png;base64,full-save"),
+      loadAssets: vi.fn(async () => {}),
+      hasLoadedAsset: vi.fn(() => false),
+    };
+
+    const result = await prepareRuntimeInteractionExecution({
+      actions: {
+        showConfirmDialog: {
+          confirmActions: {
+            saveSlot: {},
+          },
+        },
+      },
+      eventContext: {
+        _event: {
+          slotId: 7,
+        },
+      },
+      graphicsService,
+      captureThumbnail: "save-only",
+    });
+
+    expect(result.preparedActions).toEqual({
+      showConfirmDialog: {
+        confirmActions: {
+          saveSlot: {
+            slotId: 7,
+            thumbnailImage: "data:image/jpeg;base64,thumb-save",
+          },
+        },
+      },
+    });
+    expect(graphicsService.loadAssets).toHaveBeenCalledWith({
+      "data:image/jpeg;base64,thumb-save": {
+        source: "url",
+        url: "data:image/jpeg;base64,thumb-save",
+        type: "image/jpeg",
+      },
+    });
+    expect(result.thumbnailPreloadError).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- move the shared graphics/engine runtime helpers into `src/internal/runtime/graphicsEngineRuntime.js`
- rewire bundle, preview, scene editor, and layout editor screenshot capture to import from that shared runtime module
- share the runtime plugin manifest, event payload parsing, and interaction preparation path across bundle and preview/editor runtimes
- preload restored save slot screenshot data URLs during bundle startup so previously saved thumbnails are available on first render
- tolerate missing optional `route-graphics` plugin exports so existing graphicsService mocks and older plugin sets still initialize cleanly

## Testing
- `bun run lint`
- `bunx vitest run tests/internal/runtimeActionPreparation.test.js tests/sceneEditor/runtime.test.js tests/graphicsService/graphicsService.test.js`
- `bun run build:bundle`