### PR TITLE
feat: update media resource previews and thumbnails

### DIFF
--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -82,11 +82,7 @@ const parseBooleanProp = (value, fallback = false) => {
   return Boolean(value);
 };
 
-const resolveDefaultBorderColor = (cardKind) => {
-  if (cardKind === "sound" || cardKind === "video") {
-    return "tr";
-  }
-
+const resolveDefaultBorderColor = () => {
   return "bo";
 };
 
@@ -113,7 +109,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       isCollapsed,
       children: children.map((item) => {
         const isSelected = item.id === props.selectedItemId;
-        const defaultBorderColor = resolveDefaultBorderColor(item.cardKind);
+        const defaultBorderColor = resolveDefaultBorderColor();
         const isInteractive = item.isInteractive !== false;
 
         return {

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -62,14 +62,14 @@ refs:
       click:
         handler: handlePreviewActionClick
 template:
-  - 'rtgl-view w=f h=100vh g=lg style="min-width: 0;"':
+  - 'rtgl-view w=f h=100vh g=sm style="min-width: 0;"':
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if showBackButton:
                       - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
                   - $if navTitle:
-                      - rtgl-text c=mu-fg: ${navTitle}
+                      - rtgl-text: ${navTitle}
               - rtgl-view d=h av=c g=md:
                   - $if showZoomControls:
                       - rtgl-view d=h av=c g=sm:
@@ -85,7 +85,7 @@ template:
                           - 'rtgl-view d=h av=c pos=abs w=f h=f bw=md bc=pr bgc=se op="0.5" style="top: 0; bottom: 0; left: 0; right: 0;"':
                               - rtgl-view w=f h=f av=c ah=c:
                                   - rtgl-text s=lg: Drag file to this area to upload
-                      - 'rtgl-view d=h w=f av=c style="position: sticky; top: 0px;"':
+                      - 'rtgl-view d=h w=f av=c bgc=bg z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:
                                   - rtgl-svg wh=16 svg=folderArrowRight: null

--- a/src/components/resizablePanel/resizablePanel.view.yaml
+++ b/src/components/resizablePanel/resizablePanel.view.yaml
@@ -10,10 +10,10 @@ refs:
 template:
   - 'rtgl-view h=f w=${panelWidth} d=h pos=rel style="overflow: visible;"':
       - $if resizeSide=="left":
-          - 'rtgl-view#resizeHandle h=f ph=md style="cursor: col-resize; background: transparent; margin-left: calc(var(--spacing-md) * -1); margin-right: calc(var(--spacing-md) * -1);"':
+          - 'rtgl-view#resizeHandle pos=abs d=h ah=c h=f style="cursor: col-resize; background: transparent; top: 0; bottom: 0; left: calc(var(--spacing-sm) * -1); width: calc(var(--spacing-sm) * 2); z-index: 10;"':
               - rtgl-view w=1 h=f bgc=${dividerColor}: null
       - rtgl-view h=f w=f:
           - slot name="content": null
       - $if resizeSide=="right":
-          - 'rtgl-view#resizeHandle pos=abs d=h h=f style="cursor: col-resize; background: transparent; top: 0; bottom: 0; right: calc(var(--spacing-md) * -2); width: calc(var(--spacing-md) * 2); z-index: 10;"':
+          - 'rtgl-view#resizeHandle pos=abs d=h ah=c h=f style="cursor: col-resize; background: transparent; top: 0; bottom: 0; right: calc(var(--spacing-sm) * -1); width: calc(var(--spacing-sm) * 2); z-index: 10;"':
               - rtgl-view w=1 h=f bgc=${dividerColor}: null

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -56,6 +56,24 @@ const canvasToBlob = (canvas, type, quality) => {
   });
 };
 
+const getScaledThumbnailDimensions = ({
+  sourceWidth,
+  sourceHeight,
+  maxWidth = 320,
+  maxHeight = 320,
+} = {}) => {
+  if (!(sourceWidth > 0) || !(sourceHeight > 0)) {
+    throw new Error("Unable to read source dimensions");
+  }
+
+  const scale = Math.min(maxWidth / sourceWidth, maxHeight / sourceHeight, 1);
+
+  return {
+    width: Math.max(1, Math.round(sourceWidth * scale)),
+    height: Math.max(1, Math.round(sourceHeight * scale)),
+  };
+};
+
 export const extractImageThumbnail = async (imageFile, options = {}) => {
   const {
     maxWidth = 320,
@@ -229,91 +247,749 @@ export const extractWaveformData = async (audioFile, samples = 1000) => {
   return extractWaveformDataFromArrayBuffer(arrayBuffer, samples);
 };
 
+const VIDEO_THUMBNAIL_EVENT_TIMEOUT_MS = 1000;
+const VIDEO_THUMBNAIL_ACTIVITY_TIMEOUT_MS = 2000;
+
+const clampNumber = (value, min, max) => {
+  return Math.min(max, Math.max(min, value));
+};
+
+const drawVideoFrameToCanvas = ({ ctx, video, width, height } = {}) => {
+  const videoAspectRatio = video.videoWidth / video.videoHeight;
+  const canvasAspectRatio = width / height;
+
+  let drawWidth;
+  let drawHeight;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (videoAspectRatio > canvasAspectRatio) {
+    drawHeight = height;
+    drawWidth = height * videoAspectRatio;
+    offsetX = (width - drawWidth) / 2;
+  } else {
+    drawWidth = width;
+    drawHeight = width / videoAspectRatio;
+    offsetY = (height - drawHeight) / 2;
+  }
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.drawImage(video, offsetX, offsetY, drawWidth, drawHeight);
+};
+
+const buildVideoThumbnailSampleTimes = ({
+  duration,
+  timeOffset = 0,
+  sampleCount = 7,
+} = {}) => {
+  const safeDuration = Number.isFinite(duration) ? Math.max(duration, 0) : 0;
+  const maxSeekTime = Math.max(0, safeDuration - 0.1);
+
+  if (maxSeekTime === 0) {
+    return [0];
+  }
+
+  const preferredOffset = clampNumber(
+    Math.min(timeOffset, maxSeekTime * 0.5),
+    0,
+    maxSeekTime,
+  );
+  const leadingSkip = Math.min(
+    Math.max(safeDuration * 0.1, 0.2),
+    maxSeekTime * 0.5,
+  );
+  const trailingSkip = Math.min(
+    Math.max(safeDuration * 0.1, 0.2),
+    maxSeekTime * 0.5,
+  );
+  const rangeStart = clampNumber(
+    Math.max(preferredOffset, leadingSkip),
+    0,
+    maxSeekTime,
+  );
+  const rangeEnd = clampNumber(
+    maxSeekTime - trailingSkip,
+    rangeStart,
+    maxSeekTime,
+  );
+  const normalizedSampleCount = Math.max(1, Math.round(sampleCount));
+
+  if (normalizedSampleCount === 1 || rangeStart === rangeEnd) {
+    return [rangeStart];
+  }
+
+  const step = (rangeEnd - rangeStart) / (normalizedSampleCount - 1);
+  const sampleTimes = [];
+
+  for (let index = 0; index < normalizedSampleCount; index += 1) {
+    sampleTimes.push(Number((rangeStart + step * index).toFixed(3)));
+  }
+
+  return [...new Set(sampleTimes)];
+};
+
+const analyzeVideoFrame = ({ ctx, width, height } = {}) => {
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const pixels = imageData.data;
+  const brightnessByColumn = new Float32Array(width);
+
+  let brightnessSum = 0;
+  let brightnessSquaredSum = 0;
+  let colorfulnessSum = 0;
+  let edgeSum = 0;
+  let edgeCount = 0;
+  let pixelCount = 0;
+
+  for (let y = 0; y < height; y += 1) {
+    let leftBrightness;
+
+    for (let x = 0; x < width; x += 1) {
+      const pixelIndex = (y * width + x) * 4;
+      const red = pixels[pixelIndex];
+      const green = pixels[pixelIndex + 1];
+      const blue = pixels[pixelIndex + 2];
+      const brightness = red * 0.2126 + green * 0.7152 + blue * 0.0722;
+      const rg = red - green;
+      const yb = (red + green) * 0.5 - blue;
+      const colorfulness = Math.sqrt(rg * rg + yb * yb);
+
+      brightnessSum += brightness;
+      brightnessSquaredSum += brightness * brightness;
+      colorfulnessSum += colorfulness;
+      pixelCount += 1;
+
+      if (x > 0) {
+        edgeSum += Math.abs(brightness - leftBrightness);
+        edgeCount += 1;
+      }
+
+      if (y > 0) {
+        edgeSum += Math.abs(brightness - brightnessByColumn[x]);
+        edgeCount += 1;
+      }
+
+      leftBrightness = brightness;
+      brightnessByColumn[x] = brightness;
+    }
+  }
+
+  const brightnessMean = pixelCount > 0 ? brightnessSum / pixelCount : 0;
+  const brightnessVariance =
+    pixelCount > 0
+      ? Math.max(
+          0,
+          brightnessSquaredSum / pixelCount - brightnessMean * brightnessMean,
+        )
+      : 0;
+  const brightnessStdDev = Math.sqrt(brightnessVariance);
+  const colorfulnessMean = pixelCount > 0 ? colorfulnessSum / pixelCount : 0;
+  const edgeStrength = edgeCount > 0 ? edgeSum / edgeCount : 0;
+  const isTooDark = brightnessMean < 35 && edgeStrength < 24;
+  const isTooFlat =
+    brightnessStdDev < 18 && edgeStrength < 20 && colorfulnessMean < 18;
+  const isLowValueFrame = isTooDark || isTooFlat;
+  const exposureScore = Math.max(0, 255 - Math.abs(brightnessMean - 128) * 1.5);
+  const score =
+    brightnessStdDev * 3 +
+    edgeStrength * 4 +
+    colorfulnessMean * 0.25 +
+    exposureScore;
+
+  return {
+    score,
+    isLowValueFrame,
+  };
+};
+
+const waitForVideoFrame = async (
+  video,
+  { timeoutMs = VIDEO_THUMBNAIL_EVENT_TIMEOUT_MS } = {},
+) => {
+  if (typeof video.requestVideoFrameCallback === "function") {
+    await new Promise((resolve) => {
+      let settled = false;
+      const timeoutId = window.setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        resolve();
+      }, timeoutMs);
+
+      video.requestVideoFrameCallback(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        window.clearTimeout(timeoutId);
+        resolve();
+      });
+    });
+    return;
+  }
+
+  await new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+};
+
+const waitForVideoLoadedData = async (
+  video,
+  { timeoutMs = VIDEO_THUMBNAIL_EVENT_TIMEOUT_MS } = {},
+) => {
+  if (video.readyState >= 2) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for video frame data"));
+    }, timeoutMs);
+    const handleLoadedData = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = () => {
+      cleanup();
+      reject(new Error("Failed to load video frame data"));
+    };
+    const cleanup = () => {
+      window.clearTimeout(timeoutId);
+      video.removeEventListener("loadeddata", handleLoadedData);
+      video.removeEventListener("error", handleError);
+    };
+
+    video.addEventListener("loadeddata", handleLoadedData);
+    video.addEventListener("error", handleError);
+  });
+};
+
+const seekVideoToTime = async (
+  video,
+  targetTime,
+  { timeoutMs = VIDEO_THUMBNAIL_EVENT_TIMEOUT_MS } = {},
+) => {
+  const maxSeekTime = Math.max(0, (video.duration || 0) - 0.1);
+  const normalizedTime = clampNumber(targetTime, 0, maxSeekTime);
+
+  await waitForVideoLoadedData(video, { timeoutMs });
+
+  if (Math.abs(video.currentTime - normalizedTime) < 0.001) {
+    await waitForVideoFrame(video, { timeoutMs });
+    return normalizedTime;
+  }
+
+  await new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out seeking video while generating thumbnail (${normalizedTime}s)`,
+        ),
+      );
+    }, timeoutMs);
+    const handleSeeked = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = () => {
+      cleanup();
+      reject(new Error("Failed to seek video while generating thumbnail"));
+    };
+    const cleanup = () => {
+      window.clearTimeout(timeoutId);
+      video.removeEventListener("seeked", handleSeeked);
+      video.removeEventListener("error", handleError);
+    };
+
+    video.addEventListener("seeked", handleSeeked);
+    video.addEventListener("error", handleError);
+    video.currentTime = normalizedTime;
+  });
+
+  await waitForVideoFrame(video, { timeoutMs });
+  return normalizedTime;
+};
+
+const captureVideoFrameAtTime = async ({
+  video,
+  ctx,
+  width,
+  height,
+  time,
+  timeoutMs = VIDEO_THUMBNAIL_EVENT_TIMEOUT_MS,
+} = {}) => {
+  if (time !== undefined) {
+    await seekVideoToTime(video, time, { timeoutMs });
+  } else {
+    await waitForVideoLoadedData(video, { timeoutMs });
+    await waitForVideoFrame(video, { timeoutMs });
+  }
+
+  drawVideoFrameToCanvas({
+    ctx,
+    video,
+    width,
+    height,
+  });
+};
+
 // Video thumbnail extraction
-export const extractVideoThumbnail = async (videoFile, options = {}) => {
+const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
   const {
     timeOffset = 2,
-    width = 320,
-    height = 240,
+    maxWidth = 320,
+    maxHeight = 320,
+    format = "image/jpeg",
+    quality = 0.8,
+    sampleCount = 7,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const video = document.createElement("video");
+    video.preload = "auto";
+    video.muted = true;
+    video.playsInline = true;
+
+    const bestCanvas = document.createElement("canvas");
+    const bestCtx = bestCanvas.getContext("2d");
+    const fallbackCanvas = document.createElement("canvas");
+    const fallbackCtx = fallbackCanvas.getContext("2d");
+    const analysisCanvas = document.createElement("canvas");
+    const analysisCtx = analysisCanvas.getContext("2d", {
+      willReadFrequently: true,
+    });
+
+    analysisCanvas.width = 48;
+    analysisCanvas.height = 27;
+
+    if (!bestCtx || !fallbackCtx || !analysisCtx) {
+      reject(new Error("Unable to create video thumbnail canvas context"));
+      return;
+    }
+
+    let objectUrl;
+    let settled = false;
+    let activityTimeoutId;
+
+    const cleanup = () => {
+      video.onloadedmetadata = null;
+      video.onerror = null;
+
+      try {
+        video.pause();
+        video.removeAttribute("src");
+        video.load();
+      } catch {
+        // Ignore cleanup errors from partially initialized media elements.
+      }
+
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+      if (activityTimeoutId) {
+        window.clearTimeout(activityTimeoutId);
+      }
+
+      video.remove();
+      bestCanvas.remove();
+      fallbackCanvas.remove();
+      analysisCanvas.remove();
+    };
+
+    const rejectOnce = (error) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const resolveOnce = (result) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const logContext = {
+      fileName: videoFile?.name ?? "",
+      fileSize: videoFile?.size ?? 0,
+      sampleCount,
+    };
+
+    const refreshActivityTimeout = (stage = "unknown") => {
+      if (settled) {
+        return;
+      }
+
+      if (activityTimeoutId) {
+        window.clearTimeout(activityTimeoutId);
+      }
+
+      activityTimeoutId = window.setTimeout(() => {
+        console.warn("[videoThumbnail] extract.stalled", {
+          ...logContext,
+          stage,
+        });
+        rejectOnce(new Error("Timed out while generating video thumbnail"));
+      }, VIDEO_THUMBNAIL_ACTIVITY_TIMEOUT_MS);
+    };
+
+    video.onerror = (error) => {
+      console.warn("[videoThumbnail] load.failed", {
+        ...logContext,
+        error: error?.message || "Unknown error",
+      });
+      rejectOnce(
+        new Error(`Video load error: ${error.message || "Unknown error"}`),
+      );
+    };
+
+    video.onloadedmetadata = async () => {
+      try {
+        refreshActivityTimeout("metadata-loaded");
+        const outputDimensions = getScaledThumbnailDimensions({
+          sourceWidth: video.videoWidth,
+          sourceHeight: video.videoHeight,
+          maxWidth,
+          maxHeight,
+        });
+        const { width, height } = outputDimensions;
+        bestCanvas.width = width;
+        bestCanvas.height = height;
+        fallbackCanvas.width = width;
+        fallbackCanvas.height = height;
+        const sampleTimes = buildVideoThumbnailSampleTimes({
+          duration: video.duration,
+          timeOffset,
+          sampleCount,
+        });
+        console.info("[videoThumbnail] metadata.loaded", {
+          ...logContext,
+          duration: video.duration,
+          sampleTimes,
+        });
+
+        let bestCandidate;
+        let bestFallbackCandidate;
+        let sampledFrameCount = 0;
+
+        for (const sampleTime of sampleTimes) {
+          if (settled) {
+            return;
+          }
+
+          refreshActivityTimeout(`sampling-${sampleTime}`);
+
+          try {
+            await captureVideoFrameAtTime({
+              video,
+              ctx: analysisCtx,
+              width: analysisCanvas.width,
+              height: analysisCanvas.height,
+              time: sampleTime,
+            });
+          } catch (error) {
+            console.warn("[videoThumbnail] sample.failed", {
+              ...logContext,
+              sampleTime,
+              error: error?.message ?? "Unknown error",
+            });
+            continue;
+          }
+
+          if (settled) {
+            return;
+          }
+
+          refreshActivityTimeout(`sampled-${sampleTime}`);
+          sampledFrameCount += 1;
+
+          const frameAnalysis = analyzeVideoFrame({
+            ctx: analysisCtx,
+            width: analysisCanvas.width,
+            height: analysisCanvas.height,
+          });
+          const candidate = {
+            time: sampleTime,
+            score: frameAnalysis.score,
+            isLowValueFrame: frameAnalysis.isLowValueFrame,
+          };
+
+          if (
+            !bestFallbackCandidate ||
+            candidate.score > bestFallbackCandidate.score
+          ) {
+            bestFallbackCandidate = candidate;
+            drawVideoFrameToCanvas({
+              ctx: fallbackCtx,
+              video,
+              width,
+              height,
+            });
+          }
+
+          if (candidate.isLowValueFrame) {
+            continue;
+          }
+
+          if (!bestCandidate || candidate.score > bestCandidate.score) {
+            bestCandidate = candidate;
+            drawVideoFrameToCanvas({
+              ctx: bestCtx,
+              video,
+              width,
+              height,
+            });
+          }
+        }
+
+        const chosenCandidate = bestCandidate ?? bestFallbackCandidate;
+        if (!chosenCandidate) {
+          console.warn("[videoThumbnail] sampling.empty", {
+            ...logContext,
+            sampleTimes,
+          });
+          refreshActivityTimeout("capturing-fallback-frame");
+          await captureVideoFrameAtTime({
+            video,
+            ctx: fallbackCtx,
+            width,
+            height,
+          });
+        } else {
+          console.info("[videoThumbnail] frame.selected", {
+            ...logContext,
+            sampledFrameCount,
+            selectedTime: chosenCandidate.time,
+            score: Number(chosenCandidate.score.toFixed(2)),
+            usedFallbackFrame: !bestCandidate,
+          });
+        }
+
+        refreshActivityTimeout("encoding-thumbnail");
+        const selectedCanvas = bestCandidate ? bestCanvas : fallbackCanvas;
+        const blob = await canvasToBlob(selectedCanvas, format, quality);
+        const dataUrl = selectedCanvas.toDataURL(format, quality);
+
+        resolveOnce({
+          blob,
+          dataUrl,
+          width,
+          height,
+          format,
+          selectedTime: chosenCandidate?.time ?? 0,
+        });
+      } catch (error) {
+        if (settled) {
+          return;
+        }
+
+        console.warn("[videoThumbnail] extract.failed", {
+          ...logContext,
+          error: error?.message ?? "Unknown error",
+        });
+        rejectOnce(new Error(`Thumbnail extraction error: ${error.message}`));
+      }
+    };
+
+    refreshActivityTimeout("waiting-for-metadata");
+    objectUrl = URL.createObjectURL(videoFile);
+    video.src = objectUrl;
+  });
+};
+
+const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
+  const {
+    timeOffset = 1,
+    maxWidth = 320,
+    maxHeight = 320,
     format = "image/jpeg",
     quality = 0.8,
   } = options;
 
   return new Promise((resolve, reject) => {
     const video = document.createElement("video");
-    video.preload = "metadata";
+    video.preload = "auto";
     video.muted = true;
     video.playsInline = true;
 
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");
 
-    canvas.width = width;
-    canvas.height = height;
+    if (!ctx) {
+      reject(new Error("Unable to create fallback video thumbnail canvas"));
+      return;
+    }
+
+    let objectUrl;
+    let settled = false;
+    let activityTimeoutId;
+
+    const cleanup = () => {
+      video.onloadedmetadata = null;
+      video.onerror = null;
+
+      try {
+        video.pause();
+        video.removeAttribute("src");
+        video.load();
+      } catch {
+        // Ignore cleanup errors from partially initialized media elements.
+      }
+
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+
+      if (activityTimeoutId) {
+        window.clearTimeout(activityTimeoutId);
+      }
+
+      video.remove();
+      canvas.remove();
+    };
+
+    const rejectOnce = (error) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const resolveOnce = (result) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const logContext = {
+      fileName: videoFile?.name ?? "",
+      fileSize: videoFile?.size ?? 0,
+    };
+
+    const refreshActivityTimeout = (stage = "unknown") => {
+      if (settled) {
+        return;
+      }
+
+      if (activityTimeoutId) {
+        window.clearTimeout(activityTimeoutId);
+      }
+
+      activityTimeoutId = window.setTimeout(() => {
+        console.warn("[videoThumbnail] fallback.stalled", {
+          ...logContext,
+          stage,
+        });
+        rejectOnce(
+          new Error("Timed out while generating fallback video thumbnail"),
+        );
+      }, VIDEO_THUMBNAIL_ACTIVITY_TIMEOUT_MS);
+    };
 
     video.onerror = (error) => {
-      reject(
-        new Error(`Video load error: ${error.message || "Unknown error"}`),
+      rejectOnce(
+        new Error(
+          `Fallback video load error: ${error?.message || "Unknown error"}`,
+        ),
       );
     };
 
-    video.onloadedmetadata = () => {
-      const seekTime = Math.min(timeOffset, video.duration - 0.1);
-      video.currentTime = seekTime;
-    };
-
-    video.onseeked = () => {
+    video.onloadedmetadata = async () => {
       try {
-        const videoAspectRatio = video.videoWidth / video.videoHeight;
-        const canvasAspectRatio = width / height;
+        refreshActivityTimeout("fallback-metadata-loaded");
+        const outputDimensions = getScaledThumbnailDimensions({
+          sourceWidth: video.videoWidth,
+          sourceHeight: video.videoHeight,
+          maxWidth,
+          maxHeight,
+        });
+        const { width, height } = outputDimensions;
+        canvas.width = width;
+        canvas.height = height;
+        const maxSeekTime = Math.max(0, (video.duration || 0) - 0.1);
+        const fallbackTime = clampNumber(
+          Math.min(timeOffset, maxSeekTime),
+          0,
+          maxSeekTime,
+        );
 
-        let drawWidth,
-          drawHeight,
-          offsetX = 0,
-          offsetY = 0;
-
-        if (videoAspectRatio > canvasAspectRatio) {
-          drawHeight = height;
-          drawWidth = height * videoAspectRatio;
-          offsetX = (width - drawWidth) / 2;
-        } else {
-          drawWidth = width;
-          drawHeight = width / videoAspectRatio;
-          offsetY = (height - drawHeight) / 2;
+        try {
+          await captureVideoFrameAtTime({
+            video,
+            ctx,
+            width,
+            height,
+            time: fallbackTime > 0 ? fallbackTime : undefined,
+          });
+        } catch (seekError) {
+          console.warn("[videoThumbnail] fallback.seek-failed", {
+            ...logContext,
+            fallbackTime,
+            error: seekError?.message ?? "Unknown error",
+          });
+          refreshActivityTimeout("fallback-current-frame");
+          await captureVideoFrameAtTime({
+            video,
+            ctx,
+            width,
+            height,
+          });
         }
 
-        ctx.drawImage(video, offsetX, offsetY, drawWidth, drawHeight);
+        refreshActivityTimeout("fallback-encoding-thumbnail");
+        const blob = await canvasToBlob(canvas, format, quality);
+        const dataUrl = canvas.toDataURL(format, quality);
 
-        canvas.toBlob(
-          (blob) => {
-            if (blob) {
-              const dataUrl = canvas.toDataURL(format, quality);
-
-              video.remove();
-              canvas.remove();
-              URL.revokeObjectURL(video.src);
-
-              resolve({
-                blob,
-                dataUrl,
-                width,
-                height,
-                format,
-              });
-            } else {
-              reject(new Error("Failed to create thumbnail blob"));
-            }
-          },
+        resolveOnce({
+          blob,
+          dataUrl,
+          width,
+          height,
           format,
-          quality,
-        );
+          selectedTime: fallbackTime,
+        });
       } catch (error) {
-        reject(new Error(`Thumbnail extraction error: ${error.message}`));
+        rejectOnce(
+          new Error(`Fallback thumbnail extraction error: ${error.message}`),
+        );
       }
     };
 
-    video.src = URL.createObjectURL(videoFile);
+    refreshActivityTimeout("fallback-waiting-for-metadata");
+    objectUrl = URL.createObjectURL(videoFile);
+    video.src = objectUrl;
   });
+};
+
+export const extractVideoThumbnail = async (videoFile, options = {}) => {
+  try {
+    return await extractScoredVideoThumbnail(videoFile, options);
+  } catch (error) {
+    console.warn("[videoThumbnail] fallback.attempt", {
+      fileName: videoFile?.name ?? "",
+      fileSize: videoFile?.size ?? 0,
+      error: error?.message ?? "Unknown error",
+    });
+    return extractInitialVideoThumbnail(videoFile, options);
+  }
 };
 
 // File type detection utility

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -245,29 +245,49 @@ export const createProjectAssetService = ({
     }
 
     if (fileType === "video") {
-      const [dimensions, thumbnailData] = await Promise.all([
-        getVideoDimensions(file),
-        extractVideoThumbnail(file, {
-          timeOffset: 1,
-          width: 240,
-          height: 135,
-          format: "image/jpeg",
-          quality: 0.8,
-        }),
-      ]);
-      const [videoResult, thumbnailResult] = await Promise.all([
+      const [videoResult, dimensions, thumbnailPayload] = await Promise.all([
         storeFileWithRecord({ file }),
-        storeFileWithRecord({
-          file: thumbnailData.blob,
-        }),
+        getVideoDimensions(file),
+        (async () => {
+          try {
+            const thumbnailData = await extractVideoThumbnail(file, {
+              timeOffset: 1,
+              maxWidth: IMAGE_THUMBNAIL_MAX_WIDTH,
+              maxHeight: IMAGE_THUMBNAIL_MAX_HEIGHT,
+              format: "image/jpeg",
+              quality: 0.8,
+            });
+            const thumbnailResult = await storeFileWithRecord({
+              file: thumbnailData.blob,
+            });
+            return {
+              thumbnailData,
+              thumbnailResult,
+            };
+          } catch (error) {
+            console.warn("[videoUpload] thumbnail.failed", {
+              fileName: file.name,
+              fileSize: file.size,
+              fileType: file.type,
+              error: error?.message ?? "Unknown error",
+            });
+            return undefined;
+          }
+        })(),
       ]);
+
       return {
         ...videoResult,
-        thumbnailFileId: thumbnailResult.fileId,
-        thumbnailData,
+        thumbnailFileId: thumbnailPayload?.thumbnailResult?.fileId,
+        thumbnailData: thumbnailPayload?.thumbnailData,
         dimensions,
         type: "video",
-        fileRecords: [videoResult.fileRecord, thumbnailResult.fileRecord],
+        fileRecords: [
+          videoResult.fileRecord,
+          ...(thumbnailPayload?.thumbnailResult
+            ? [thumbnailPayload.thumbnailResult.fileRecord]
+            : []),
+        ],
       };
     }
 

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -30,15 +30,14 @@ const createImageAbortError = () => {
 };
 
 const {
+  openEditDialogWithValues,
   refreshData: handleDataChanged,
   handleBeforeMount,
   handleFileExplorerSelectionChanged,
-  handleFileExplorerDoubleClick,
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleSearchInput,
   handleItemClick: handleImageItemClick,
-  handleItemDoubleClick: handleImageItemDoubleClick,
   handleItemEdit: handleImageItemEdit,
 } = createMediaPageHandlers({
   resourceType: "images",
@@ -49,14 +48,48 @@ const {
 export {
   handleBeforeMount,
   handleFileExplorerSelectionChanged,
-  handleFileExplorerDoubleClick,
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleDataChanged,
   handleSearchInput,
   handleImageItemClick,
-  handleImageItemDoubleClick,
   handleImageItemEdit,
+};
+
+const openImagePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { refs, store, render } = deps;
+  const item = store.selectImageItemById({ itemId });
+  if (!itemId || !item) {
+    return;
+  }
+
+  store.setSelectedItemId({ itemId });
+
+  if (syncExplorer) {
+    refs.fileExplorer.selectItem({ itemId });
+  }
+
+  store.showFullImagePreview({ itemId });
+  render();
+};
+
+export const handleFileExplorerDoubleClick = (deps, payload) => {
+  const { itemId, isFolder } = payload._event.detail;
+  if (isFolder) {
+    return;
+  }
+
+  openImagePreviewById({ deps, itemId });
+};
+
+export const handleImageItemDoubleClick = (deps, payload) => {
+  const { itemId } = payload._event.detail;
+  openImagePreviewById({ deps, itemId, syncExplorer: true });
+};
+
+export const handleDetailHeaderClick = (deps) => {
+  const selectedItemId = deps.store.selectSelectedItemId();
+  openEditDialogWithValues({ deps, itemId: selectedItemId });
 };
 
 const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -40,7 +40,7 @@ const buildMediaItem = (item) => ({
   name: item.name,
   cardKind: "image",
   previewFileId: item.thumbnailFileId ?? item.fileId,
-  canPreview: true,
+  canPreview: false,
 });
 
 const buildPendingMediaItem = (item) => ({
@@ -104,7 +104,7 @@ const {
   resourceType: "images",
   title: "Images",
   selectedResourceId: "images",
-  uploadText: "Upload Image",
+  uploadText: "Upload",
   acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
   showZoomControls: true,
   buildDetailFields,

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -51,6 +51,10 @@ refs:
     eventListeners:
       click:
         handler: handleFormExtraEvent
+  detailHeader:
+    eventListeners:
+      click:
+        handler: handleDetailHeaderClick
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -64,8 +68,9 @@ template:
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedPreviewFileId:
                                   - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} h=160 bw=xs bc=bo br=md cur=pointer: null

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -117,15 +117,14 @@ const handlePanelResize = (deps, payload) => {
 };
 
 const {
+  openEditDialogWithValues,
   handleBeforeMount: handleMediaBeforeMount,
   refreshData: handleDataChanged,
   handleFileExplorerSelectionChanged,
-  handleFileExplorerDoubleClick,
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleSearchInput,
   handleItemClick: handleSoundItemClick,
-  handleItemDoubleClick: handleSoundItemDoubleClick,
   handleItemEdit: handleSoundItemEdit,
 } = createMediaPageHandlers({
   resourceType: "sounds",
@@ -164,18 +163,15 @@ export const handleBeforeMount = (deps) => {
 export {
   handleDataChanged,
   handleFileExplorerSelectionChanged,
-  handleFileExplorerDoubleClick,
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleSearchInput,
   handleSoundItemClick,
-  handleSoundItemDoubleClick,
   handleSoundItemEdit,
 };
 
-export const handleSoundItemPreview = (deps, payload) => {
-  const { store, render } = deps;
-  const { itemId } = payload._event.detail;
+const openSoundPreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { refs, store, render } = deps;
   if (!itemId) {
     return;
   }
@@ -185,11 +181,41 @@ export const handleSoundItemPreview = (deps, payload) => {
     return;
   }
 
+  store.setSelectedItemId({ itemId });
+
+  if (syncExplorer) {
+    refs.fileExplorer.selectItem({ itemId });
+  }
+
   store.openAudioPlayer({
     fileId: soundItem.fileId,
     fileName: soundItem.name,
   });
   render();
+};
+
+export const handleFileExplorerDoubleClick = (deps, payload) => {
+  const { itemId, isFolder } = payload._event.detail;
+  if (isFolder) {
+    return;
+  }
+
+  openSoundPreviewById({ deps, itemId });
+};
+
+export const handleSoundItemDoubleClick = (deps, payload) => {
+  const { itemId } = payload._event.detail;
+  openSoundPreviewById({ deps, itemId, syncExplorer: true });
+};
+
+export const handleDetailHeaderClick = (deps) => {
+  const selectedItemId = deps.store.selectSelectedItemId();
+  openEditDialogWithValues({ deps, itemId: selectedItemId });
+};
+
+export const handleSoundItemPreview = (deps, payload) => {
+  const { itemId } = payload._event.detail;
+  openSoundPreviewById({ deps, itemId });
 };
 
 export const handleUploadClick = async (deps, payload) => {

--- a/src/pages/sounds/sounds.store.js
+++ b/src/pages/sounds/sounds.store.js
@@ -50,7 +50,7 @@ const buildMediaItem = (item) => ({
   name: item.name,
   cardKind: "sound",
   waveformDataFileId: item.waveformDataFileId,
-  canPreview: true,
+  canPreview: false,
 });
 
 const buildPendingMediaItem = (item) => ({
@@ -114,7 +114,7 @@ const {
   resourceType: "sounds",
   title: "Sounds",
   selectedResourceId: "sounds",
-  uploadText: "Upload Sound",
+  uploadText: "Upload",
   acceptedFileTypes: [".mp3", ".wav", ".ogg"],
   previewMenuLabel: "Play",
   buildDetailFields,

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -39,6 +39,10 @@ refs:
     eventListeners:
       click:
         handler: handleFormExtraEvent
+  detailHeader:
+    eventListeners:
+      click:
+        handler: handleDetailHeaderClick
   editDialog:
     eventListeners:
       close:
@@ -68,8 +72,9 @@ template:
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedPreviewFileId:
                                   - rtgl-view slot="sound-waveform" p=sm bw=xs bc=bo br=md cur=pointer:

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -137,15 +137,14 @@ const openVideoPreviewById = async ({ deps, itemId } = {}) => {
 };
 
 const {
+  openEditDialogWithValues,
   handleBeforeMount,
   refreshData: handleDataChanged,
   handleFileExplorerSelectionChanged,
-  handleFileExplorerDoubleClick,
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleSearchInput,
   handleItemClick: handleVideoItemClick,
-  handleItemDoubleClick: handleVideoItemDoubleClick,
   handleItemEdit: handleVideoItemEdit,
 } = createMediaPageHandlers({
   resourceType: "videos",
@@ -157,13 +156,37 @@ export {
   handleBeforeMount,
   handleDataChanged,
   handleFileExplorerSelectionChanged,
-  handleFileExplorerDoubleClick,
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleSearchInput,
   handleVideoItemClick,
-  handleVideoItemDoubleClick,
   handleVideoItemEdit,
+};
+
+export const handleFileExplorerDoubleClick = async (deps, payload) => {
+  const { itemId, isFolder } = payload._event.detail;
+  if (isFolder) {
+    return;
+  }
+
+  await openVideoPreviewById({ deps, itemId });
+};
+
+export const handleVideoItemDoubleClick = async (deps, payload) => {
+  const { itemId } = payload._event.detail;
+  const { refs, store } = deps;
+  if (!itemId) {
+    return;
+  }
+
+  store.setSelectedItemId({ itemId });
+  refs.fileExplorer.selectItem({ itemId });
+  await openVideoPreviewById({ deps, itemId });
+};
+
+export const handleDetailHeaderClick = (deps) => {
+  const selectedItemId = deps.store.selectSelectedItemId();
+  openEditDialogWithValues({ deps, itemId: selectedItemId });
 };
 
 export const handleVideoItemPreview = async (deps, payload) => {

--- a/src/pages/videos/videos.store.js
+++ b/src/pages/videos/videos.store.js
@@ -48,7 +48,7 @@ const buildMediaItem = (item) => ({
   name: item.name,
   cardKind: "video",
   thumbnailFileId: item.thumbnailFileId,
-  canPreview: true,
+  canPreview: false,
 });
 
 const buildPendingMediaItem = (item) => ({
@@ -112,7 +112,7 @@ const {
   resourceType: "videos",
   title: "Videos",
   selectedResourceId: "videos",
-  uploadText: "Upload Video",
+  uploadText: "Upload",
   acceptedFileTypes: [".mp4"],
   buildDetailFields,
   buildMediaItem,

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -41,6 +41,10 @@ refs:
     eventListeners:
       click:
         handler: handleFormExtraEvent
+  detailHeader:
+    eventListeners:
+      click:
+        handler: handleDetailHeaderClick
   editDialog:
     eventListeners:
       close:
@@ -70,8 +74,9 @@ template:
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedPreviewFileId:
                                   - rvn-file-image#detailThumbnail slot="video-thumbnail-file-id" fileId=${selectedPreviewFileId} h=135 bw=xs bc=bo br=md cur=pointer: null
@@ -89,12 +94,11 @@ template:
                 $else:
                   - rtgl-view#editDialogThumbnailPlaceholder slot="video-slot" w=f h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                       - rtgl-text c=mu-fg s=sm: Click to Upload
-  - rtgl-dialog#videoPreviewDialog ?open=${videoVisible}:
-      - rtgl-view#dialogContainer slot=content bw=xs bgc=bg w=80vw h=80vh br=sm av=c ah=c:
-          - $if selectedVideo:
-              - $if selectedVideo.url:
-                  - video controls=true autoplay=true style="height:100%; width:100%;":
-                      - source src=${selectedVideo.url} type=${selectedVideo.fileType}: null
-                $else:
-                  - rtgl-view w=f h=f av=c ah=c:
-                      - rtgl-text s=lg c=mu-fg: Loading video...
+  - rtgl-dialog#videoPreviewDialog ?open=${videoVisible} s=lg:
+      - $if selectedVideo:
+          - $if selectedVideo.url:
+              - 'video slot=content controls=true autoplay=true style="width: 100%; height: 80vh; object-fit: contain; display: block; background-color: #000;"':
+                  - source src=${selectedVideo.url} type=${selectedVideo.fileType}: null
+            $else:
+              - rtgl-view slot=content w=f h=80vh av=c ah=c:
+                  - rtgl-text s=lg c=mu-fg: Loading video...

--- a/svg/edit.svg
+++ b/svg/edit.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 20H8L18.5 9.5C19.3284 8.67157 19.3284 7.32843 18.5 6.5C17.6716 5.67157 16.3284 5.67157 15.5 6.5L5 17V20Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 8.5L16.5 11.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- update image, sound, and video resource pages so double-click opens preview, detail headers expose edit affordances, and upload labels are simplified
- refine shared media UI behavior with sticky group headers, adjusted resize handles, and video preview layout cleanup
- improve video thumbnail generation with smarter frame sampling, fallback capture, non-blocking upload behavior on thumbnail failure, matched thumbnail sizing, and tighter timeouts

## Testing
- bun run lint
- bun run build:tauri