### PR TITLE
feat: polish media upload validation and previews

### DIFF
--- a/docs/upload-file-types.md
+++ b/docs/upload-file-types.md
@@ -51,9 +51,10 @@ Pages must validate unsupported types and show a user-facing toast/dialog.
 
 Current explicit page validators:
 
+- `src/pages/images/images.handlers.js`
 - `src/pages/videos/videos.handlers.js`
 - `src/pages/fonts/fonts.handlers.js`
-- `src/pages/sounds/sounds.handlers.js` via decoder/upload failure dialog
+- `src/pages/sounds/sounds.handlers.js`
 
 ### 3. Shared Picker Validation
 
@@ -82,16 +83,22 @@ Supported processing buckets today:
 - font
 - generic
 
+Current shared type fallbacks are intentionally narrower than before:
+
+- images: `.jpg`, `.jpeg`, `.png`, `.webp`
+- audio: `.mp3`, `.wav`, `.ogg`
+- video: `.mp4`
+
 ## Current Upload Matrix
 
 ### Media Resource Pages
 
 | Surface                | Allowed file types                                | Extra validation              | Notes                                  |
 | ---------------------- | ------------------------------------------------- | ----------------------------- | -------------------------------------- |
-| Images page            | `.jpg`, `.jpeg`, `.png`, `.webp`                  | none                          | picker, center drag-drop, edit/replace |
+| Images page            | `.jpg`, `.jpeg`, `.png`, `.webp`                  | explicit invalid-format toast | picker, center drag-drop, edit/replace |
 | Character sprites page | `.jpg`, `.jpeg`, `.png`, `.webp`                  | none                          | picker, center drag-drop, edit/replace |
 | Videos page            | `.mp4`                                            | explicit invalid-format toast | picker, center drag-drop, edit/replace |
-| Sounds page            | `.mp3`, `.wav`, `.ogg`                            | upload/decode failure dialog  | picker, center drag-drop, edit/replace |
+| Sounds page            | `.mp3`, `.wav`, `.ogg`                            | explicit invalid-format toast | picker, center drag-drop, edit/replace |
 | Fonts page             | `.ttf`, `.otf`, `.woff`, `.woff2`, `.ttc`, `.eot` | explicit invalid-format toast | picker, center drag-drop, edit/replace |
 
 ### Dialog / Special Upload Surfaces
@@ -152,3 +159,5 @@ When adding or changing an uploadable file type:
   of an explicit extension list.
   If stricter control is required, those surfaces should be narrowed and
   documented here in the same change.
+- Sounds currently show copy that mentions `OGG (Windows only)`, but the upload
+  surface itself does not enforce a platform-specific OGG restriction.

--- a/src/components/fileImage/fileImage.handlers.js
+++ b/src/components/fileImage/fileImage.handlers.js
@@ -1,5 +1,9 @@
 const getFileIdFromProps = (attrs, projectService) => {
   if (attrs.fileId && attrs.imageId) {
+    console.warn("[fileImage] invalid-props", {
+      fileId: attrs.fileId,
+      imageId: attrs.imageId,
+    });
     return;
   }
 
@@ -25,22 +29,34 @@ const getFileIdFromProps = (attrs, projectService) => {
   return;
 };
 
+const revokeBlobUrl = (src) => {
+  if (typeof src !== "string" || !src.startsWith("blob:")) {
+    return;
+  }
+
+  URL.revokeObjectURL(src);
+};
+
 export const handleAfterMount = async (deps) => {
   const { store, props: attrs, projectService, render } = deps;
 
   await projectService.ensureRepository();
   const fileId = getFileIdFromProps(attrs, projectService);
+  const currentSrc = store.selectSrc();
 
   if (!fileId) {
+    store.setLoadedFileId({ fileId: undefined });
     return;
   }
 
   try {
     const { url } = await projectService.getFileContent(fileId);
+    revokeBlobUrl(currentSrc);
     store.setSrc({ src: url });
+    store.setLoadedFileId({ fileId });
     render();
   } catch (error) {
-    console.error("Failed to load image:", error);
+    console.error(error);
   } finally {
     store.setIsLoading({ isLoading: false });
     render();
@@ -53,21 +69,34 @@ export const handleOnUpdate = async (deps, payload) => {
   await projectService.ensureRepository();
   const { newProps: attrs } = payload;
   const fileId = getFileIdFromProps(attrs, projectService);
+  const loadedFileId = store.selectLoadedFileId();
+  const currentSrc = store.selectSrc();
+
+  if (fileId && fileId === loadedFileId) {
+    return;
+  }
 
   if (!fileId) {
+    revokeBlobUrl(currentSrc);
     store.setSrc({ src: "/public/project_logo_placeholder.png" });
     store.setIsLoading({ isLoading: false });
+    store.setLoadedFileId({ fileId: undefined });
     render();
     return;
   }
 
+  store.setIsLoading({ isLoading: true });
+
   try {
     const { url } = await projectService.getFileContent(fileId);
+    revokeBlobUrl(currentSrc);
     store.setSrc({ src: url });
+    store.setLoadedFileId({ fileId });
     render();
   } catch (error) {
-    console.error("Failed to load image:", error);
+    console.error(error);
   } finally {
     store.setIsLoading({ isLoading: false });
+    render();
   }
 };

--- a/src/components/fileImage/fileImage.store.js
+++ b/src/components/fileImage/fileImage.store.js
@@ -27,6 +27,7 @@ const stringifyAttrs = (attrs) => {
 export const createInitialState = () => ({
   src: "/public/project_logo_placeholder.png",
   isLoading: true,
+  loadedFileId: undefined,
 });
 
 export const setSrc = ({ state }, { src } = {}) => {
@@ -37,12 +38,20 @@ export const setIsLoading = ({ state }, { isLoading } = {}) => {
   state.isLoading = isLoading;
 };
 
+export const setLoadedFileId = ({ state }, { fileId } = {}) => {
+  state.loadedFileId = fileId;
+};
+
 export const selectSrc = ({ state }) => {
   return state.src;
 };
 
 export const selectIsLoading = ({ state }) => {
   return state.isLoading;
+};
+
+export const selectLoadedFileId = ({ state }) => {
+  return state.loadedFileId;
 };
 
 export const selectViewData = ({ state, props: attrs }) => {

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -109,6 +109,10 @@ export const handleDrop = (deps, payload) => {
     );
   }
 
+  if (!files.length) {
+    return;
+  }
+
   dispatchEvent(
     new CustomEvent("files-dropped", {
       detail: {
@@ -120,10 +124,6 @@ export const handleDrop = (deps, payload) => {
       composed: true,
     }),
   );
-
-  if (!files.length) {
-    return;
-  }
 };
 
 export const handleGroupClick = (deps, payload) => {

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -7,6 +7,12 @@ const getDataAttribute = (event, name) => {
   return event?.currentTarget?.getAttribute?.(name) ?? undefined;
 };
 
+const hasPreviewableItems = (groups = []) => {
+  return groups.some((group) =>
+    (group?.children ?? []).some((item) => item?.canPreview),
+  );
+};
+
 export const handleSearchInput = (deps, payload) => {
   const { dispatchEvent } = deps;
   const value = payload._event.detail.value ?? "";
@@ -103,20 +109,21 @@ export const handleDrop = (deps, payload) => {
     );
   }
 
-  if (!files.length) {
-    return;
-  }
-
   dispatchEvent(
     new CustomEvent("files-dropped", {
       detail: {
         files,
+        rejectedFiles,
         targetGroupId,
       },
       bubbles: true,
       composed: true,
     }),
   );
+
+  if (!files.length) {
+    return;
+  }
 };
 
 export const handleGroupClick = (deps, payload) => {
@@ -147,7 +154,11 @@ export const handleItemClick = (deps, payload) => {
 };
 
 export const handleItemMouseEnter = (deps, payload) => {
-  const { store, render } = deps;
+  const { store, render, props } = deps;
+  if (!hasPreviewableItems(props.groups)) {
+    return;
+  }
+
   const itemId = getDataAttribute(payload._event, "data-item-id");
   if (!itemId || store.selectHoveredItemId() === itemId) {
     return;
@@ -158,7 +169,11 @@ export const handleItemMouseEnter = (deps, payload) => {
 };
 
 export const handleItemMouseLeave = (deps) => {
-  const { store, render } = deps;
+  const { store, render, props } = deps;
+  if (!hasPreviewableItems(props.groups)) {
+    return;
+  }
+
   if (store.selectHoveredItemId() === undefined) {
     return;
   }

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -81,10 +81,6 @@ template:
           - $if groups.length > 0:
               - $for group, gIndex in groups:
                   - rtgl-view#groupDropRef${gIndex} data-group-id=${group.id} w=f ph=md pos=rel:
-                      - $if draggingGroupId == group.id:
-                          - 'rtgl-view d=h av=c pos=abs w=f h=f bw=md bc=pr bgc=se op="0.5" style="top: 0; bottom: 0; left: 0; right: 0;"':
-                              - rtgl-view w=f h=f av=c ah=c:
-                                  - rtgl-text s=lg: Drag file to this area to upload
                       - 'rtgl-view d=h w=f av=c bgc=bg z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:
@@ -96,69 +92,75 @@ template:
                           - rtgl-view w=1fg: null
                           - $if canUpload:
                               - rtgl-button#uploadBtnHeaderRef${gIndex} data-group-id=${group.id} s=sm w=1fg pre=upload: ${uploadText}
-                      - $if !group.isCollapsed:
-                          - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
-                              - $if group.hasChildren:
-                                  - $for item, itemIndex in group.children:
-                                      - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.domItemId} cur=${item.cursor} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
-                                          - $if item.cardKind == 'image':
-                                              - 'rtgl-view p=md g=md br=md w=${maxWidth} pos=rel style="max-width: 100%;"':
-                                                  - $if item.isProcessing:
-                                                      - rtgl-view w=f h=${imageHeight} br=md bw=xs bc=bo av=c ah=c:
-                                                          - rtgl-text s=sm c=mu-fg: Processing...
-                                                    $else:
-                                                      - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} key=${item.previewFileId}-${imageHeight}x${maxWidth}: null
-                                                  - $if item.showPreviewIcon:
-                                                      - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
-                                                          - rtgl-svg svg=zoomIn wh=22 c=white: null
-                                                  - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
-                                            $elif item.cardKind == 'video':
-                                              - 'rtgl-view p=md g=md br=md pos=rel':
-                                                  - $if item.isProcessing:
-                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
-                                                          - rtgl-text s=sm c=mu-fg: Processing...
-                                                    $elif item.thumbnailFileId:
-                                                      - rvn-file-image br=md w=${mediaWidth} h=${mediaHeight} fileId=${item.thumbnailFileId}: null
-                                                    $else:
-                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
-                                                          - rtgl-text s=xs c=mu-fg: No thumbnail
-                                                  - $if item.showPreviewIcon:
-                                                      - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
-                                                          - rtgl-svg svg=play wh=24 c=white: null
-                                                  - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
-                                            $elif item.cardKind == 'sound':
-                                              - 'rtgl-view p=md g=md br=md pos=rel':
-                                                  - $if item.isProcessing:
-                                                      - rtgl-view g=md:
+                      - rtgl-view w=f pos=rel:
+                          - $if !group.isCollapsed:
+                              - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
+                                  - $if group.hasChildren:
+                                      - $for item, itemIndex in group.children:
+                                          - rtgl-view#itemRef${gIndex}x${itemIndex} key=${item.id} data-item-id=${item.domItemId} cur=${item.cursor} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                              - $if item.cardKind == 'image':
+                                                  - 'rtgl-view p=md g=md br=md w=${maxWidth} pos=rel style="max-width: 100%;"':
+                                                      - $if item.isProcessing:
+                                                          - rtgl-view w=f h=${imageHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                              - rtgl-text s=sm c=mu-fg: Processing...
+                                                        $else:
+                                                          - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} key=${item.previewFileId}-${imageHeight}x${maxWidth}: null
+                                                      - $if item.showPreviewIcon:
+                                                          - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
+                                                              - rtgl-svg svg=zoomIn wh=22 c=white: null
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
+                                                $elif item.cardKind == 'video':
+                                                  - 'rtgl-view p=md g=md br=md pos=rel':
+                                                      - $if item.isProcessing:
                                                           - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=sm c=mu-fg: Processing...
-                                                          - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
-                                                    $elif item.waveformDataFileId:
-                                                      - rtgl-view g=md:
-                                                          - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=${mediaWidth} h=${mediaHeight}: null
-                                                          - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
-                                                    $else:
-                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
-                                                          - rtgl-text s=xs c=mu-fg: No waveform
-                                                  - $if item.showPreviewIcon:
-                                                      - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
-                                                          - rtgl-svg svg=play wh=24 c=white: null
-                                            $elif item.cardKind == 'font':
-                                              - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
-                                                  - $if item.isProcessing:
-                                                      - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
-                                                          - rtgl-text s=sm c=mu-fg: Processing...
-                                                    $else:
-                                                      - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=${mediaWidth} height=${mediaHeight} av=c ah=c: null
-                                                  - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
-                                            $else:
-                                              - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
-                                                  - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
-                                $else:
-                                  - $if canUpload:
-                                      - rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=sm cur=pointer:
-                                          - rtgl-svg svg=upload wh=32: null
-                                          - rtgl-text: ${uploadText}
+                                                        $elif item.thumbnailFileId:
+                                                          - rvn-file-image br=md w=${mediaWidth} h=${mediaHeight} fileId=${item.thumbnailFileId}: null
+                                                        $else:
+                                                          - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                              - rtgl-text s=xs c=mu-fg: No thumbnail
+                                                      - $if item.showPreviewIcon:
+                                                          - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
+                                                              - rtgl-svg svg=play wh=24 c=white: null
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                $elif item.cardKind == 'sound':
+                                                  - 'rtgl-view p=md g=md br=md pos=rel':
+                                                      - $if item.isProcessing:
+                                                          - rtgl-view g=md:
+                                                              - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                                  - rtgl-text s=sm c=mu-fg: Processing...
+                                                              - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                        $elif item.waveformDataFileId:
+                                                          - rtgl-view g=md:
+                                                              - rvn-waveform-visualizer key=${item.waveformDataFileId}-${mediaWidth}x${mediaHeight} waveformDataFileId=${item.waveformDataFileId} w=${mediaWidth} h=${mediaHeight}: null
+                                                              - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                        $else:
+                                                          - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                              - rtgl-text s=xs c=mu-fg: No waveform
+                                                      - $if item.showPreviewIcon:
+                                                          - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
+                                                              - rtgl-svg svg=play wh=24 c=white: null
+                                                $elif item.cardKind == 'font':
+                                                  - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
+                                                      - $if item.isProcessing:
+                                                          - rtgl-view w=${mediaWidth} h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                              - rtgl-text s=sm c=mu-fg: Processing...
+                                                        $else:
+                                                          - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=${mediaWidth} height=${mediaHeight} av=c ah=c: null
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                $else:
+                                                  - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                    $else:
+                                      - $if canUpload:
+                                          - rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=sm cur=pointer:
+                                              - rtgl-svg svg=upload wh=32: null
+                                              - rtgl-text: ${uploadText}
+                          - $if draggingGroupId == group.id:
+                              - 'rtgl-view d=h av=c pos=abs w=f h=f bw=md bc=pr style="top: 0; bottom: 0; left: 0; right: 0;"':
+                                  - 'rtgl-view pos=abs w=f h=f bgc=se op="0.5" style="top: 0; bottom: 0; left: 0; right: 0;"': null
+                                  - rtgl-view w=f h=f av=c ah=c pos=rel z=1:
+                                      - rtgl-text s=lg: Drop files to upload to ${group.fullLabel}
             $elif searchQuery:
               - rtgl-view w=f h=400 av=c ah=c:
                   - rtgl-text s=lg c=mu-fg: ${emptyMessage}

--- a/src/components/waveformVisualizer/waveformVisualizer.view.yaml
+++ b/src/components/waveformVisualizer/waveformVisualizer.view.yaml
@@ -4,5 +4,6 @@ refs:
   canvas:
     selector: canvas
 template:
-  - $if waveformData:
-      - rtgl-waveform :waveformData=${waveformData} w=${w} h=${h}: null
+  - rtgl-view w=${w} h=${h}:
+      - $if waveformData:
+          - rtgl-waveform :waveformData=${waveformData} w=${w} h=${h}: null

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -1008,6 +1008,7 @@ export const detectFileType = (file) => {
   if (
     [
       "audio/mpeg",
+      "audio/x-mpeg",
       "audio/mp3",
       "audio/wav",
       "audio/x-wav",
@@ -1017,9 +1018,6 @@ export const detectFileType = (file) => {
   ) {
     return "audio";
   }
-  if (file.type.startsWith("audio/")) return "generic";
-  if (file.type.startsWith("image/")) return "generic";
-  if (file.type.startsWith("video/")) return "generic";
 
   // Fallback to extension check (mainly for fonts which often have no MIME type)
   if (!ext) return "generic";

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -994,22 +994,42 @@ export const extractVideoThumbnail = async (videoFile, options = {}) => {
 
 // File type detection utility
 export const detectFileType = (file) => {
+  const ext = file.name.split(".").pop()?.toLowerCase();
+
   // Check MIME type first
-  if (file.type.startsWith("image/")) return "image";
-  if (file.type.startsWith("audio/")) return "audio";
-  if (file.type.startsWith("video/")) return "video";
+  if (file.type === "video/mp4") return "video";
+  if (
+    ["image/jpeg", "image/png", "image/webp"].includes(file.type) ||
+    (file.type.startsWith("image/") &&
+      ["jpg", "jpeg", "png", "webp"].includes(ext))
+  ) {
+    return "image";
+  }
+  if (
+    [
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/wav",
+      "audio/x-wav",
+      "audio/wave",
+      "audio/ogg",
+    ].includes(file.type)
+  ) {
+    return "audio";
+  }
+  if (file.type.startsWith("audio/")) return "generic";
+  if (file.type.startsWith("image/")) return "generic";
+  if (file.type.startsWith("video/")) return "generic";
 
   // Fallback to extension check (mainly for fonts which often have no MIME type)
-  const ext = file.name.split(".").pop()?.toLowerCase();
   if (!ext) return "generic";
 
   if (["ttf", "otf", "woff", "woff2", "ttc"].includes(ext)) return "font";
 
   // Additional fallbacks for common formats with unreliable MIME types
-  if (["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp"].includes(ext))
-    return "image";
-  if (["mp3", "wav", "ogg", "aac", "m4a", "flac"].includes(ext)) return "audio";
-  if (["mp4", "webm", "avi", "mov", "mkv"].includes(ext)) return "video";
+  if (["jpg", "jpeg", "png", "webp"].includes(ext)) return "image";
+  if (["mp3", "wav", "ogg"].includes(ext)) return "audio";
+  if (ext === "mp4") return "video";
 
   return "generic";
 };

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -36,11 +36,15 @@ const TAURI_ASSET_URL_PREFIXES = [
 
 const SUPPORTED_AUDIO_MIME_TYPES = new Set([
   "audio/mpeg",
+  "audio/x-mpeg",
   "audio/mp3",
   "audio/wav",
   "audio/x-wav",
   "audio/wave",
+  "audio/vnd.wave",
   "audio/ogg",
+  "audio/x-ogg",
+  "application/ogg",
 ]);
 
 // Keep this in sync with src-tauri/src/project_file_protocol.rs.

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -34,36 +34,21 @@ const TAURI_ASSET_URL_PREFIXES = [
   "asset://localhost/",
 ];
 
+const SUPPORTED_AUDIO_MIME_TYPES = new Set([
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/wave",
+  "audio/ogg",
+]);
+
 // Keep this in sync with src-tauri/src/project_file_protocol.rs.
 const PIXI_EXTENSION_BY_MIME_TYPE = {
-  "image/apng": "apng",
   "image/png": "png",
   "image/jpeg": "jpg",
   "image/webp": "webp",
-  "image/avif": "avif",
-  "image/gif": "gif",
-  "image/bmp": "bmp",
-  "image/x-ms-bmp": "bmp",
-  "image/svg+xml": "svg",
-  "image/tiff": "tif",
-  "image/heic": "heic",
-  "image/heif": "heif",
-  "image/vnd.microsoft.icon": "ico",
-  "image/x-icon": "ico",
-  "image/jxl": "jxl",
   "video/mp4": "mp4",
-  "video/x-m4v": "m4v",
-  "video/webm": "webm",
-  "video/ogg": "ogv",
-  "video/quicktime": "mov",
-  "video/x-msvideo": "avi",
-  "video/avi": "avi",
-  "video/x-ms-wmv": "wmv",
-  "video/mpeg": "mpeg",
-  "video/mp2t": "ts",
-  "video/3gpp": "3gp",
-  "video/3gpp2": "3g2",
-  "video/x-matroska": "mkv",
 };
 
 const isTauriAssetUrl = (url) => {
@@ -312,7 +297,7 @@ export const createGraphicsService = async ({ subject }) => {
       return "texture";
     }
 
-    if (mimeType.startsWith("audio/")) {
+    if (SUPPORTED_AUDIO_MIME_TYPES.has(mimeType)) {
       return "audio";
     }
 
@@ -328,7 +313,7 @@ export const createGraphicsService = async ({ subject }) => {
       return "font";
     }
 
-    if (mimeType.startsWith("video/")) {
+    if (mimeType === "video/mp4") {
       return "video";
     }
 

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -45,7 +45,15 @@ const getNow = () => {
 
 const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
 
-const isAudioUploadFile = (file) => file?.type?.startsWith("audio/");
+const isAudioUploadFile = (file) =>
+  [
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/wave",
+    "audio/ogg",
+  ].includes(file?.type);
 
 async function copyTemplateFiles(templateId, targetPath) {
   const templateFilesPath = `/templates/${templateId}/files/`;

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -50,7 +50,15 @@ const getNow = () => {
 
 const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
 
-const isAudioUploadFile = (file) => file?.type?.startsWith("audio/");
+const isAudioUploadFile = (file) =>
+  [
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/wave",
+    "audio/ogg",
+  ].includes(file?.type);
 
 export const createWebProjectServiceAdapters = ({
   onRemoteEvent,

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -9,6 +9,62 @@ import {
 
 const MAX_PARALLEL_UPLOADS = 1;
 const CREATE_IMAGE_ABORT_ERROR = "create-image-abort";
+const IMAGE_FILE_PATTERN = /\.(jpg|jpeg|png|webp)$/i;
+const IMAGE_FILE_ACCEPT = ".jpg,.jpeg,.png,.webp";
+const INVALID_IMAGE_FORMAT_MESSAGE =
+  "Only JPG/JPEG, PNG, and WEBP images are supported.";
+
+const showInvalidFormatToast = (appService) => {
+  appService.showToast(INVALID_IMAGE_FORMAT_MESSAGE, { title: "Warning" });
+};
+
+const validateImageFiles = ({ appService, files } = {}) => {
+  const invalidFiles = Array.from(files ?? []).filter(
+    (file) => !file.name.match(IMAGE_FILE_PATTERN),
+  );
+
+  if (invalidFiles.length === 0) {
+    return true;
+  }
+
+  showInvalidFormatToast(appService);
+  return false;
+};
+
+const pickAndUploadImage = async ({ appService, projectService } = {}) => {
+  let file;
+
+  try {
+    file = await appService.pickFiles({
+      accept: IMAGE_FILE_ACCEPT,
+      multiple: false,
+    });
+  } catch (error) {
+    return { error, errorType: "pick-failed" };
+  }
+
+  if (!file) {
+    return { cancelled: true };
+  }
+
+  if (!validateImageFiles({ appService, files: [file] })) {
+    return { errorType: "validation-failed" };
+  }
+
+  let uploadedFiles;
+  try {
+    uploadedFiles = await projectService.uploadFiles([file]);
+  } catch (error) {
+    return { error, errorType: "upload-failed" };
+  }
+
+  const uploadResult = uploadedFiles?.[0];
+  if (!uploadResult) {
+    return { error: "upload-failed" };
+  }
+
+  return { uploadResult };
+};
 
 const createPendingUploads = ({ files, parentId } = {}) => {
   if (!parentId) {
@@ -94,6 +150,11 @@ export const handleDetailHeaderClick = (deps) => {
 
 const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
   const { appService, projectService, store, render } = deps;
+
+  if (!validateImageFiles({ appService, files })) {
+    return;
+  }
+
   const pendingUploads = createPendingUploads({ files, parentId });
   const remainingPendingUploadIds = new Set(
     pendingUploads.map((item) => item.id),
@@ -216,7 +277,7 @@ export const handleUploadClick = async (deps, payload) => {
 
   try {
     files = await appService.pickFiles({
-      accept: ".jpg,.jpeg,.png,.webp",
+      accept: IMAGE_FILE_ACCEPT,
       multiple: true,
     });
   } catch (error) {
@@ -232,6 +293,10 @@ export const handleUploadClick = async (deps, payload) => {
     return;
   }
 
+  if (!validateImageFiles({ appService, files })) {
+    return;
+  }
+
   await createImagesFromFiles({
     deps,
     files,
@@ -240,7 +305,14 @@ export const handleUploadClick = async (deps, payload) => {
 };
 
 export const handleFilesDropped = async (deps, payload) => {
-  const { files, targetGroupId } = payload._event.detail;
+  const { appService } = deps;
+  const { files, rejectedFiles, targetGroupId } = payload._event.detail;
+
+  if ((!files || files.length === 0) && (rejectedFiles?.length ?? 0) > 0) {
+    showInvalidFormatToast(appService);
+    return;
+  }
+
   await createImagesFromFiles({
     deps,
     files,
@@ -248,41 +320,48 @@ export const handleFilesDropped = async (deps, payload) => {
   });
 };
 
+export const handleFilesDropRejected = (deps, payload) => {
+  const { appService } = deps;
+  const rejectedFiles = payload._event.detail?.rejectedFiles ?? [];
+
+  if (rejectedFiles.length === 0) {
+    return;
+  }
+
+  showInvalidFormatToast(appService);
+};
+
 export const handleFormExtraEvent = async (deps) => {
   const { appService, projectService, store } = deps;
-  let file;
-
   const selectedItem = store.selectSelectedItem();
   if (!selectedItem) {
     return;
   }
 
-  try {
-    file = await appService.pickFiles({
-      accept: ".jpg,.jpeg,.png,.webp",
-      multiple: false,
-      upload: true,
-    });
-  } catch (error) {
+  const result = await pickAndUploadImage({ appService, projectService });
+  if (result.cancelled) {
+    return;
+  }
+
+  if (result.errorType === "pick-failed") {
     showResourcePageError({
       appService,
-      errorOrResult: error,
+      errorOrResult: result.error,
       fallbackMessage: "Failed to select file.",
     });
     return;
   }
 
-  if (!file) {
+  if (result.errorType === "validation-failed") {
     return;
   }
 
-  if (!(file.uploadSucessful && file.uploadResult)) {
-    console.error("Failed to upload image:", file);
+  if (result.errorType === "upload-failed") {
     appService.showToast("Failed to upload image.", { title: "Error" });
     return;
   }
 
-  const uploadResult = file.uploadResult;
+  const { uploadResult } = result;
   const updateAttempt = await runResourcePageMutation({
     appService,
     fallbackMessage: "Failed to update image.",
@@ -322,38 +401,35 @@ export const handleEditDialogClose = (deps) => {
 };
 
 export const handleEditDialogImageClick = async (deps) => {
-  const { appService, store, render } = deps;
-  let file;
+  const { appService, projectService, store, render } = deps;
 
-  try {
-    file = await appService.pickFiles({
-      accept: ".jpg,.jpeg,.png,.webp",
-      multiple: false,
-      upload: true,
-    });
-  } catch (error) {
+  const result = await pickAndUploadImage({ appService, projectService });
+  if (result.cancelled) {
+    return;
+  }
+
+  if (result.errorType === "pick-failed") {
     showResourcePageError({
       appService,
-      errorOrResult: error,
+      errorOrResult: result.error,
       fallbackMessage: "Failed to select file.",
     });
     return;
   }
 
-  if (!file) {
+  if (result.errorType === "validation-failed") {
     return;
   }
 
-  if (!(file.uploadSucessful && file.uploadResult)) {
-    console.error("Failed to upload image:", file);
+  if (result.errorType === "upload-failed") {
     appService.showToast("Failed to upload image.", { title: "Error" });
     return;
   }
 
   store.setEditUpload({
-    uploadResult: file.uploadResult,
+    uploadResult: result.uploadResult,
     previewFileId:
-      file.uploadResult.thumbnailFileId ?? file.uploadResult.fileId,
+      result.uploadResult.thumbnailFileId ?? result.uploadResult.fileId,
   });
   render();
 };

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -60,7 +60,7 @@ const pickAndUploadImage = async ({ appService, projectService } = {}) => {
 
   const uploadResult = uploadedFiles?.[0];
   if (!uploadResult) {
-    return { error: "upload-failed" };
+    return { error: "upload-failed", errorType: "upload-failed" };
   }
 
   return { uploadResult };

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -21,6 +21,8 @@ refs:
         handler: handleImageItemEdit
       files-dropped:
         handler: handleFilesDropped
+      files-drop-rejected:
+        handler: handleFilesDropRejected
       upload-click:
         handler: handleUploadClick
       search-input:

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -66,7 +66,7 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
 
   const uploadResult = uploadedFiles?.[0];
   if (!uploadResult) {
-    return { error: "upload-failed" };
+    return { error: "upload-failed", errorType: "upload-failed" };
   }
 
   return { uploadResult };

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -12,16 +12,29 @@ import {
 const UNSUPPORTED_FORMAT_TITLE = "Unsupported Format";
 const UNSUPPORTED_FORMAT_MESSAGE =
   "The audio file format is not supported. Please use MP3, WAV, or OGG (Windows only) files.";
+const SOUND_FILE_PATTERN = /\.(mp3|wav|ogg)$/i;
+const SOUND_FILE_ACCEPT = ".mp3,.wav,.ogg";
 
-const showUnsupportedFormatDialog = async (
+const showUnsupportedFormatToast = (
   appService,
   message = UNSUPPORTED_FORMAT_MESSAGE,
 ) => {
-  await appService.showDialog({
+  appService.showToast(message, {
     title: UNSUPPORTED_FORMAT_TITLE,
-    message,
-    confirmText: "OK",
   });
+};
+
+const validateSoundFiles = ({ appService, files } = {}) => {
+  const invalidFiles = Array.from(files ?? []).filter(
+    (file) => !file.name.match(SOUND_FILE_PATTERN),
+  );
+
+  if (invalidFiles.length === 0) {
+    return true;
+  }
+
+  showUnsupportedFormatToast(appService);
+  return false;
 };
 
 const pickAndUploadSound = async ({ appService, projectService } = {}) => {
@@ -29,7 +42,7 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
 
   try {
     file = await appService.pickFiles({
-      accept: ".mp3,.wav,.ogg",
+      accept: SOUND_FILE_ACCEPT,
       multiple: false,
     });
   } catch (error) {
@@ -38,6 +51,10 @@ const pickAndUploadSound = async ({ appService, projectService } = {}) => {
 
   if (!file) {
     return { cancelled: true };
+  }
+
+  if (!validateSoundFiles({ appService, files: [file] })) {
+    return { errorType: "validation-failed" };
   }
 
   let uploadedFiles;
@@ -89,8 +106,8 @@ const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
 
       return createAttempt.ok;
     },
-    onUploadError: async ({ error }) => {
-      await showUnsupportedFormatDialog(
+    onUploadError: ({ error }) => {
+      showUnsupportedFormatToast(
         appService,
         getResourcePageErrorMessage(error, UNSUPPORTED_FORMAT_MESSAGE),
       );
@@ -225,7 +242,7 @@ export const handleUploadClick = async (deps, payload) => {
 
   try {
     files = await appService.pickFiles({
-      accept: ".mp3,.wav,.ogg",
+      accept: SOUND_FILE_ACCEPT,
       multiple: true,
     });
   } catch (error) {
@@ -241,6 +258,10 @@ export const handleUploadClick = async (deps, payload) => {
     return;
   }
 
+  if (!validateSoundFiles({ appService, files })) {
+    return;
+  }
+
   await createSoundsFromFiles({
     deps,
     files,
@@ -249,13 +270,30 @@ export const handleUploadClick = async (deps, payload) => {
 };
 
 export const handleFilesDropped = async (deps, payload) => {
-  const { files, targetGroupId } = payload._event.detail;
+  const { appService } = deps;
+  const { files, rejectedFiles, targetGroupId } = payload._event.detail;
+
+  if ((!files || files.length === 0) && (rejectedFiles?.length ?? 0) > 0) {
+    showUnsupportedFormatToast(appService);
+    return;
+  }
 
   await createSoundsFromFiles({
     deps,
     files,
     parentId: targetGroupId ?? undefined,
   });
+};
+
+export const handleFilesDropRejected = (deps, payload) => {
+  const { appService } = deps;
+  const rejectedFiles = payload._event.detail?.rejectedFiles ?? [];
+
+  if (rejectedFiles.length === 0) {
+    return;
+  }
+
+  showUnsupportedFormatToast(appService);
 };
 
 export const handleFormExtraEvent = async (deps) => {
@@ -279,8 +317,12 @@ export const handleFormExtraEvent = async (deps) => {
     return;
   }
 
+  if (result.errorType === "validation-failed") {
+    return;
+  }
+
   if (result.errorType === "upload-failed") {
-    await showUnsupportedFormatDialog(
+    showUnsupportedFormatToast(
       appService,
       getResourcePageErrorMessage(result.error, UNSUPPORTED_FORMAT_MESSAGE),
     );
@@ -335,8 +377,12 @@ export const handleEditDialogSoundClick = async (deps) => {
     return;
   }
 
+  if (result.errorType === "validation-failed") {
+    return;
+  }
+
   if (result.errorType === "upload-failed") {
-    await showUnsupportedFormatDialog(
+    showUnsupportedFormatToast(
       appService,
       getResourcePageErrorMessage(result.error, UNSUPPORTED_FORMAT_MESSAGE),
     );

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -21,6 +21,8 @@ refs:
         handler: handleSoundItemEdit
       files-dropped:
         handler: handleFilesDropped
+      files-drop-rejected:
+        handler: handleFilesDropRejected
       upload-click:
         handler: handleUploadClick
       search-input:

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -56,7 +56,7 @@ const pickAndUploadVideo = async ({ appService, projectService } = {}) => {
 
   const uploadResult = uploadedFiles?.[0];
   if (!uploadResult) {
-    return { error: "upload-failed" };
+    return { error: "upload-failed", errorType: "upload-failed" };
   }
 
   return { uploadResult };

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -8,8 +8,7 @@ import {
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 
 const VIDEO_FILE_PATTERN = /\.(mp4)$/i;
-const INVALID_VIDEO_FORMAT_MESSAGE =
-  "Invalid file format. Please upload an MP4 video file.";
+const INVALID_VIDEO_FORMAT_MESSAGE = "Only MP4 videos are supported.";
 
 const showInvalidFormatToast = (appService) => {
   appService.showToast(INVALID_VIDEO_FORMAT_MESSAGE, { title: "Warning" });
@@ -225,7 +224,13 @@ export const handleUploadClick = async (deps, payload) => {
 };
 
 export const handleFilesDropped = async (deps, payload) => {
-  const { files, targetGroupId } = payload._event.detail;
+  const { appService } = deps;
+  const { files, rejectedFiles, targetGroupId } = payload._event.detail;
+
+  if ((!files || files.length === 0) && (rejectedFiles?.length ?? 0) > 0) {
+    showInvalidFormatToast(appService);
+    return;
+  }
 
   await createVideosFromFiles({
     deps,


### PR DESCRIPTION
## Summary
- tighten media upload acceptance and shared runtime detection so images are limited to jpg/jpeg/png/webp, sounds to mp3/wav/ogg, and videos to mp4
- add explicit invalid-format feedback for image and sound picker/drop flows and update the upload-file-types documentation to match
- stabilize media card previews during drag and hover updates, and refine the group drop overlay so it only highlights the content area with clearer messaging

## Validation
- bun run lint
- bun run build:web