### PR TITLE
feat: polish page layouts and detail interactions

### DIFF
--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -26,18 +26,18 @@ refs:
       contextmenu:
         handler: handleItemContextMenu
 template:
-  - 'rtgl-view w=f h=100vh g=lg style="min-width: 0;"':
+  - 'rtgl-view w=f h=100vh g=sm style="min-width: 0;"':
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if navTitle:
-                      - rtgl-text c=mu-fg: ${navTitle}
+                      - rtgl-text: ${navTitle}
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
       - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view w=f ph=md:
-                      - 'rtgl-view d=h w=f av=c style="position: sticky; top: 0px;"':
+                  - rtgl-view w=f ph=md pos=rel:
+                      - 'rtgl-view d=h w=f av=c bgc=bg z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:
                                   - rtgl-svg wh=16 svg=folderArrowRight: null

--- a/src/components/charactersResourcesView/charactersResourcesView.view.yaml
+++ b/src/components/charactersResourcesView/charactersResourcesView.view.yaml
@@ -30,18 +30,18 @@ refs:
       click:
         handler: handleSpritesButtonClick
 template:
-  - 'rtgl-view w=f h=100vh g=lg style="min-width: 0;"':
+  - 'rtgl-view w=f h=100vh g=sm style="min-width: 0;"':
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if navTitle:
-                      - rtgl-text c=mu-fg: ${navTitle}
+                      - rtgl-text: ${navTitle}
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
       - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view w=f ph=md:
-                      - 'rtgl-view d=h w=f av=c style="position: sticky; top: 0px;"':
+                  - rtgl-view w=f ph=md pos=rel:
+                      - 'rtgl-view d=h w=f av=c bgc=bg z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:
                                   - rtgl-svg wh=16 svg=folderArrowRight: null

--- a/src/components/groupVariablesView/groupVariablesView.view.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.view.yaml
@@ -44,8 +44,8 @@ refs:
       item-click:
         handler: handleContextMenuClickItem
 template:
-  - 'rtgl-view w=f h=100vh g=lg style="overflow-y: scroll;"':
-      - rtgl-view g=lg w=f h=f:
+  - 'rtgl-view w=f h=100vh g=sm style="overflow-y: scroll;"':
+      - rtgl-view g=sm w=f h=f:
           - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
               - rtgl-input#searchInput s=sm placeholder="Search variables..." value=${searchQuery}: null
           - $if flatGroups.length > 0:

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -26,7 +26,7 @@ refs:
       contextmenu:
         handler: handleItemContextMenu
 template:
-  - 'rtgl-view w=f h=100vh g=lg style="min-width: 0;"':
+  - 'rtgl-view w=f h=100vh g=sm style="min-width: 0;"':
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
@@ -36,8 +36,8 @@ template:
       - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view w=f ph=md:
-                      - 'rtgl-view d=h w=f av=c style="position: sticky; top: 0px;"':
+                  - rtgl-view w=f ph=md pos=rel:
+                      - 'rtgl-view d=h w=f av=c bgc=bg z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:
                                   - rtgl-svg wh=16 svg=folderArrowRight: null

--- a/src/pages/about/about.view.yaml
+++ b/src/pages/about/about.view.yaml
@@ -12,12 +12,12 @@ refs:
       click:
         handler: handleClickSocialButton
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
-          - rtgl-view w=1fg h=f p=lg d=v:
+          - 'rtgl-view w=1fg h=f p=lg d=v style="min-width: 0; min-height: 0;"':
               - rtgl-text s=h2: About
               - rtgl-view g=xl mt=lg h=1fg:
                   - rtgl-view g=lg:

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -136,6 +136,26 @@ export const handleAnimationItemDoubleClick = async (deps, payload) => {
   });
 };
 
+export const handleDetailHeaderClick = async (deps) => {
+  const { store } = deps;
+  const itemId = store.selectSelectedItemId();
+  if (!itemId) {
+    return;
+  }
+
+  const itemData = store.selectAnimationDisplayItemById({ itemId });
+  if (!itemData) {
+    return;
+  }
+
+  await openAnimationDialog({
+    deps,
+    editMode: true,
+    itemId,
+    itemData,
+  });
+};
+
 export const handleCloseDialog = (deps) => {
   const { render, store } = deps;
   store.closeDialog();

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -115,22 +115,27 @@ refs:
         handler: handleClosePopover
       item-click:
         handler: handleKeyframeDropdownItemClick
+  detailHeader:
+    eventListeners:
+      click:
+        handler: handleDetailHeaderClick
   canvas: {}
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorerPanel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} :groups=${catalogGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :addText=${addText} :itemContextMenuItems=${centerItemContextMenuItems}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rtgl-view d=v w=f h=1fg p=md g=md:
                               - rtgl-view d=v w=f g=xs:
                                   - rtgl-text c=mu-fg: Type

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -348,6 +348,15 @@ export const handleSpriteItemEdit = (deps, payload) => {
   });
 };
 
+export const handleDetailHeaderClick = (deps) => {
+  const selectedItemId = deps.store.selectSelectedItemId();
+
+  openEditDialogForSprite({
+    deps,
+    itemId: selectedItemId,
+  });
+};
+
 export const handleUploadClick = async (deps, payload) => {
   const { appService } = deps;
   const { groupId } = payload._event.detail;

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -106,7 +106,7 @@ const buildMediaItem = (item) => ({
   ...item,
   cardKind: "image",
   previewFileId: item.fileId,
-  canPreview: true,
+  canPreview: false,
 });
 
 const buildPendingMediaItem = (item) => ({

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -53,6 +53,10 @@ refs:
     eventListeners:
       click:
         handler: handleFormExtraEvent
+  detailHeader:
+    eventListeners:
+      click:
+        handler: handleDetailHeaderClick
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -66,8 +70,9 @@ template:
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedPreviewFileId:
                                   - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} h=160 bw=xs bc=bo br=md cur=pointer: null

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -118,6 +118,15 @@ export const handleCharacterItemDoubleClick = async (deps, payload) => {
 
   const { fileExplorer } = refs;
   fileExplorer.selectItem({ itemId });
+  handleSpritesButtonClick(deps, payload);
+};
+
+export const handleDetailHeaderClick = (deps) => {
+  const { store } = deps;
+  const itemId = store.selectSelectedItemId();
+  if (!itemId) {
+    return;
+  }
 
   openEditDialogWithValues({ deps, itemId });
 };
@@ -193,84 +202,6 @@ export const handleSpritesButtonClick = (deps, payload) => {
   });
 
   render();
-};
-
-export const handleDetailPanelAvatarClick = async (deps) => {
-  const { appService, projectService, store } = deps;
-
-  // Get the currently selected item
-  const selectedItem = store.selectSelectedItem();
-  if (!selectedItem) {
-    console.warn("No item selected for image replacement");
-    return;
-  }
-
-  let file;
-  try {
-    file = await appService.pickFiles({
-      accept: "image/*",
-      multiple: false,
-      validations: [{ type: "square" }],
-    });
-  } catch (error) {
-    showResourcePageError({
-      appService,
-      errorOrResult: error,
-      fallbackMessage: "Failed to select avatar image.",
-    });
-    return;
-  }
-
-  if (!file) {
-    return; // User cancelled
-  }
-
-  try {
-    // Upload the new avatar file using projectService
-    const uploadedFiles = await projectService.uploadFiles([file]);
-
-    const uploadedFile = uploadedFiles?.[0];
-    if (!uploadedFile) {
-      showResourcePageError({
-        appService,
-        errorOrResult: "Failed to upload avatar image.",
-        fallbackMessage: "Failed to upload avatar image.",
-      });
-      return;
-    }
-
-    const updateData = {
-      fileId: uploadedFile.fileId,
-      fileType: file.type,
-      fileSize: file.size,
-    };
-    if (!selectedItem.name || selectedItem.name === "Untitled Character") {
-      updateData.name = file.name.replace(/\.[^/.]+$/, "");
-    }
-
-    const updateAttempt = await runResourcePageMutation({
-      appService,
-      fallbackMessage: "Failed to update character avatar.",
-      action: () =>
-        projectService.updateCharacter({
-          characterId: selectedItem.id,
-          fileRecords: uploadedFile.fileRecords,
-          data: updateData,
-        }),
-    });
-
-    if (!updateAttempt.ok) {
-      return;
-    }
-
-    await refreshCharactersData(deps);
-  } catch (error) {
-    showResourcePageError({
-      appService,
-      errorOrResult: error,
-      fallbackMessage: "Failed to upload avatar image.",
-    });
-  }
 };
 
 export const handleSearchInput = (deps, payload) => {

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -55,30 +55,31 @@ refs:
     eventListeners:
       form-action:
         handler: handleEditFormAction
-  detailPanelAvatar:
+  detailHeader:
     eventListeners:
       click:
-        handler: handleDetailPanelAvatarClick
+        handler: handleDetailHeaderClick
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorerPanel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-characters-resources-view#charactersView :navTitle=${title} :groups=${flatGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedAvatarFileId:
-                                  - rvn-file-image#detailPanelAvatar slot="avatar" cur=pointer w=128 h=128 br=f fileId="${selectedAvatarFileId}": null
+                                  - rvn-file-image slot="avatar" w=128 h=128 br=f fileId="${selectedAvatarFileId}": null
                                 $else:
-                                  - rtgl-view#detailPanelAvatar slot="avatar" w=128 h=128 av=c ah=c bgc=bg bc=bo bw=xs br=f cur=pointer:
+                                  - rtgl-view slot="avatar" w=128 h=128 av=c ah=c bgc=bg bc=bo bw=xs br=f:
                                       - rtgl-text c=mu-fg s=sm: No Avatar
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -36,13 +36,13 @@ refs:
       click:
         handler: handleFormExtraEvent
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorerPanel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-media-resources-view#groupview :navTitle=${title} :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :acceptedFileTypes=${acceptedFileTypes} :itemContextMenuItems=${centerItemContextMenuItems}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -37,13 +37,13 @@ refs:
       update:
         handler: handleLayoutEditorCanvasUpdate
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-      - rtgl-view w=1fg h=f:
+      - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 bwb=xs bc=bo d=h av=c w=f ph=md:
               - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
               - rtgl-view w=1fg:

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -82,13 +82,13 @@ refs:
       click:
         handler: handleMapAddHintClose
 template:
-  - rtgl-view d=h w=f h=f pos=rel:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f pos=rel style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rtgl-text ml=lg s=sm c=mu-fg mv=md: Scenes
                   - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f:
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
               - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":

--- a/src/pages/settingsUser/settingsUser.view.yaml
+++ b/src/pages/settingsUser/settingsUser.view.yaml
@@ -4,12 +4,12 @@ refs:
       data-changed:
         handler: handleDataChanged
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
-          - rtgl-view w=1fg h=f:
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
               - rtgl-view w=f h=f p=lg:
                   - rtgl-text s=h2: User Settings
                   - rtgl-view g=lg mt=lg:

--- a/src/pages/systemVariables/systemVariables.view.yaml
+++ b/src/pages/systemVariables/systemVariables.view.yaml
@@ -4,12 +4,12 @@ refs:
       variable-item-click:
         handler: handleSystemVariableItemClick
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=220 min-w=180 max-w=320 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-group-variables-view#groupview readonly :flatGroups=${flatGroups} :selectedItemId=${selectedItemId}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -58,13 +58,13 @@ refs:
       form-action:
         handler: handleAddFontFormAction
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorerPanel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-text-style-resources-view#typographyView :navTitle=${title} :groups=${flatGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :itemContextMenuItems=${centerItemContextMenuItems}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -192,6 +192,26 @@ export const handleTransformItemDoubleClick = async (deps, payload) => {
   });
 };
 
+export const handleDetailHeaderClick = async (deps) => {
+  const { store } = deps;
+  const itemId = store.selectSelectedItemId();
+  if (!itemId) {
+    return;
+  }
+
+  const itemData = store.selectTransformItemById({ itemId });
+  if (!itemData) {
+    return;
+  }
+
+  await openTransformDialog({
+    deps,
+    editMode: true,
+    itemId,
+    itemData,
+  });
+};
+
 export const handleAddTransformClick = async (deps, payload) => {
   const { groupId } = payload._event.detail;
 

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -31,22 +31,27 @@ refs:
         handler: handleTransformFormActionClick
       form-change:
         handler: handleTransformFormChange
+  detailHeader:
+    eventListeners:
+      click:
+        handler: handleDetailHeaderClick
   canvas: {}
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorerPanel w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} :groups=${catalogGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :emptyMessage=${emptyMessage} :addText=${addText} :itemContextMenuItems=${centerItemContextMenuItems}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
                       - rtgl-view d=v w=f h=f:
-                          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-                              - rtgl-text c=mu-fg: ${selectedItemName}
+                          - rtgl-view#detailHeader h=48 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
+                              - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
+                              - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedItem:
                                   - rvn-transform-thumbnail slot="transform-preview" :item=${selectedItem} :resolution=${projectResolution} canvas-aspect-ratio="${canvasAspectRatio}" w=f h=180: null

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -20,13 +20,13 @@ refs:
       variable-delete:
         handler: handleVariableDelete
 template:
-  - rtgl-view d=h w=f h=f:
-      - rtgl-view d=h h=f w=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - rtgl-view w=1fg h=f pl=sm:
+          - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-group-variables-view#groupview :flatGroups=${flatGroups} :selectedItemId=${selectedItemId}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":

--- a/src/pages/versions/versions.view.yaml
+++ b/src/pages/versions/versions.view.yaml
@@ -30,11 +30,11 @@ refs:
       item-click:
         handler: handleDropdownMenuClickItem
 template:
-  - rtgl-view d=h w=f h=f:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
           - rtgl-view slot="content" w=f h=f:
               - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
-      - rtgl-view w=1fg p=lg d=v g=lg:
+      - 'rtgl-view w=1fg p=lg d=v g=lg style="min-width: 0; min-height: 0;"':
           - rtgl-text s=h2: Versions
           - rtgl-button#saveVersionBtn v=pr s=md: Create new version
           - rtgl-view w=f g=md h=1fg oy=a:


### PR DESCRIPTION
## Summary
- tighten page and center-panel layout wrappers across several editor pages to avoid min-size overflow issues
- polish shared resource list/group headers with smaller spacing and sticky background treatment
- add clickable detail headers with edit affordances for characters, character sprites, animations, and transforms, and remove direct avatar interaction from the characters right panel

## Validation
- bun run lint
- bun run build:web