### PR TITLE
fix: refine background gallery borders

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -252,6 +252,18 @@ export const handleImageSelected = async (deps, payload) => {
   render();
 };
 
+export const handleImageDoubleClick = (deps, payload) => {
+  const { store, render } = deps;
+  const { imageId } = payload._event.detail;
+
+  store.setTempSelectedResource({
+    resourceId: imageId,
+    resourceType: "image",
+  });
+  store.showFullImagePreview({ imageId });
+  render();
+};
+
 export const handleFormExtra = (deps) => {
   const { store, render } = deps;
   store.setMode({
@@ -348,10 +360,10 @@ export const handleFileExplorerClickItem = (deps, payload) => {
     return;
   }
 
-  const { id } = payload._event.detail;
+  const { itemId } = payload._event.detail;
   const imageSelector = refs["rvnImageSelector"];
   if (imageSelector?.transformedHandlers?.handleScrollToItem) {
-    imageSelector.transformedHandlers.handleScrollToItem({ id });
+    imageSelector.transformedHandlers.handleScrollToItem({ itemId });
   }
 };
 

--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -319,6 +319,12 @@ export const handleTabClick = (deps, payload) => {
   render();
 };
 
+export const handleSearchInput = (deps, payload) => {
+  const { store, render } = deps;
+  store.setSearchQuery({ value: payload._event.detail.value ?? "" });
+  render();
+};
+
 export const handleSubmitClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { dispatchEvent, store } = deps;

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -237,7 +237,11 @@ export const selectViewData = ({ state }) => {
           const itemHoverBorderColor = isSelected ? "pr" : "ac";
           const layoutTypeLabels = {
             normal: "Normal",
+            "save-load": "Save / Load",
+            confirmDialog: "Confirm Dialog",
+            history: "History",
             dialogue: "Dialogue",
+            nvl: "NVL",
             choice: "Choice",
           };
 
@@ -245,6 +249,7 @@ export const selectViewData = ({ state }) => {
             ...child,
             itemBorderColor,
             itemHoverBorderColor,
+            typeInfo: layoutTypeLabels[child.layoutType] ?? child.layoutType,
             layoutTypeDisplay: child.layoutType
               ? layoutTypeLabels[child.layoutType] || child.layoutType
               : "Layout",

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -201,6 +201,8 @@ export const selectViewData = ({ state }) => {
         )
         .map((child) => {
           const isSelected = child.id === state.tempSelectedResourceId;
+          const itemBorderColor = isSelected ? "pr" : "bo";
+          const itemHoverBorderColor = isSelected ? "pr" : "ac";
           const layoutTypeLabels = {
             normal: "Normal",
             dialogue: "Dialogue",
@@ -209,8 +211,8 @@ export const selectViewData = ({ state }) => {
 
           return {
             ...child,
-            bw: isSelected ? "md" : "xs",
-            bc: isSelected ? "pr" : "mu",
+            itemBorderColor,
+            itemHoverBorderColor,
             layoutTypeDisplay: child.layoutType
               ? layoutTypeLabels[child.layoutType] || child.layoutType
               : "Layout",

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -188,15 +188,24 @@ export const selectSelectedResource = ({ state }) => {
 
   const layoutTypeLabels = {
     normal: "Normal",
+    "save-load": "Save / Load",
+    confirmDialog: "Confirm Dialog",
+    history: "History",
     dialogue: "Dialogue",
+    nvl: "NVL",
     choice: "Choice",
   };
+
+  const typeInfo = layoutTypeLabels[item.layoutType] ?? item.layoutType;
 
   return {
     resourceId: state.selectedResourceId,
     resourceType: state.selectedResourceType,
     fileId: item.thumbnailFileId || item.fileId,
     name: item.name,
+    itemBorderColor: "bo",
+    itemHoverBorderColor: "ac",
+    typeInfo,
     layoutType: item.layoutType,
     layoutTypeDisplay: item.layoutType
       ? layoutTypeLabels[item.layoutType] || item.layoutType

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -45,6 +45,8 @@ export const createInitialState = () => ({
   selectedAnimationId: undefined,
   backgroundLoop: false,
   pendingResourceId: undefined,
+  fullImagePreviewVisible: false,
+  fullImagePreviewFileId: undefined,
 });
 
 export const selectTempSelectedResourceId = ({ state }) => {
@@ -96,6 +98,21 @@ export const selectPendingResourceId = ({ state }) => {
 
 export const clearPendingResourceId = ({ state }, _payload = {}) => {
   state.pendingResourceId = undefined;
+};
+
+export const showFullImagePreview = ({ state }, { imageId } = {}) => {
+  const item = state.imageItems.items[imageId];
+  if (!(item?.type === "image") || !item.fileId) {
+    return;
+  }
+
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewFileId = item.fileId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewFileId = undefined;
 };
 
 export const setSelectedAnimation = ({ state }, { animationId } = {}) => {
@@ -279,6 +296,8 @@ export const selectViewData = ({ state }) => {
     groups: flatGroups,
     tempSelectedResourceId: state.tempSelectedResourceId,
     selectedResource,
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewFileId: state.fullImagePreviewFileId,
     dialogueForm: {
       form,
       defaultValues,

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -47,6 +47,7 @@ export const createInitialState = () => ({
   pendingResourceId: undefined,
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
+  searchQuery: "",
 });
 
 export const selectTempSelectedResourceId = ({ state }) => {
@@ -113,6 +114,10 @@ export const showFullImagePreview = ({ state }, { imageId } = {}) => {
 export const hideFullImagePreview = ({ state }, _payload = {}) => {
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
+};
+
+export const setSearchQuery = ({ state }, { value } = {}) => {
+  state.searchQuery = value ?? "";
 };
 
 export const setSelectedAnimation = ({ state }, { animationId } = {}) => {
@@ -209,13 +214,23 @@ export const selectViewData = ({ state }) => {
   };
   const items = itemsMap[state.tab] || createEmptyCollection();
   const flatItems = toFlatItems(items).filter((item) => item.type === "folder");
-  const flatGroups = toFlatGroups(items).map((group) => {
-    return {
-      ...group,
-      children: group.children
+  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+  const matchesSearch = (item) => {
+    if (!searchQuery) {
+      return true;
+    }
+
+    const name = (item.name ?? "").toLowerCase();
+    const description = (item.description ?? "").toLowerCase();
+    return name.includes(searchQuery) || description.includes(searchQuery);
+  };
+  const flatGroups = toFlatGroups(items)
+    .map((group) => {
+      const children = group.children
         .filter(
           (layout) => state.tab !== "layout" || layout.layoutType === "normal",
         )
+        .filter(matchesSearch)
         .map((child) => {
           const isSelected = child.id === state.tempSelectedResourceId;
           const itemBorderColor = isSelected ? "pr" : "bo";
@@ -234,9 +249,16 @@ export const selectViewData = ({ state }) => {
               ? layoutTypeLabels[child.layoutType] || child.layoutType
               : "Layout",
           };
-        }),
-    };
-  });
+        });
+
+      return {
+        ...group,
+        children,
+        hasChildren: children.length > 0,
+        shouldDisplay: !searchQuery || children.length > 0,
+      };
+    })
+    .filter((group) => group.shouldDisplay);
 
   const selectedResource = selectSelectedResource({ state });
   const breadcrumb = selectBreadcrumb({ state });
@@ -298,6 +320,8 @@ export const selectViewData = ({ state }) => {
     selectedResource,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
+    searchQuery: state.searchQuery,
+    searchPlaceholder: "Search...",
     dialogueForm: {
       form,
       defaultValues,

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -25,6 +25,10 @@ refs:
     eventListeners:
       item-click:
         handler: handleTabClick
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
   form:
     eventListeners:
       form-field-event:
@@ -74,13 +78,16 @@ template:
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':
-          - rtgl-tabs#tabs selected-tab=${tab} :items=${tabs}: null
+          - rtgl-view d=h w=f av=c g=md:
+              - rtgl-tabs#tabs selected-tab=${tab} :items=${tabs}: null
+              - rtgl-view w=1fg: null
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
           - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
               - rtgl-view h=f w=2fg sv g=lg:
                   - $if tab == 'image':
-                      - rvn-image-selector#rvnImageSelector selectedImageId=${tempSelectedResourceId}: null
+                      - rvn-image-selector#rvnImageSelector selectedImageId=${tempSelectedResourceId} searchQuery=${searchQuery}: null
                     $elif tab == 'layout':
                       - $for group, i in groups:
                           - rtgl-view g=md:

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -91,8 +91,9 @@ template:
                               - rtgl-text: ${group.name}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
-                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 cur=pointer g=sm bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
-                                          - rvn-file-image w=f h=1fg fileId=${item.thumbnailFileId}: null
-                                          - rtgl-text s=sm ah=c: ${item.name}
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                          - rtgl-view p=md g=md br=md:
+                                              - rvn-file-image w=200 h=120 fileId=${item.thumbnailFileId}: null
+                                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -91,7 +91,9 @@ template:
                     $elif tab == 'layout':
                       - $for group, i in groups:
                           - rtgl-view g=md:
-                              - rtgl-text: ${group.name}
+                              - rtgl-view d=h av=c g=md:
+                                  - rtgl-svg svg=folder wh=16: null
+                                  - rtgl-text: ${group.fullLabel}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
                                       - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
@@ -108,7 +110,9 @@ template:
                     $elif tab == 'video':
                       - $for group, i in groups:
                           - rtgl-view g=md:
-                              - rtgl-text: ${group.name}
+                              - rtgl-view d=h av=c g=md:
+                                  - rtgl-svg svg=folder wh=16: null
+                                  - rtgl-text: ${group.fullLabel}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
                                       - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -57,17 +57,30 @@ template:
           - rtgl-form#form :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues}:
               - $if selectedResource:
                   - $if selectedResource.resourceType == 'image':
-                      - rvn-file-image#backgroundImage fileId=${selectedResource.fileId} w=355 h=200 slot=background cur=pointer: null
+                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
+                          - rtgl-view p=md g=md br=md:
+                              - rvn-file-image w=200 h=120 fileId=${selectedResource.fileId}: null
+                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
                     $elif selectedResource.resourceType == 'layout':
-                      - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background bw=xs bc=mu br=sm:
-                          - rtgl-view av=c ah=c:
-                              - rtgl-text s=lg: ${selectedResource.name}
-                              - rtgl-text s=sm c=mu-fg: ${selectedResource.layoutTypeDisplay}
+                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
+                          - 'rtgl-view w=225 br=md style="overflow: hidden;"':
+                              - $if selectedResource.item.thumbnailFileId:
+                                  - rvn-file-image fileId=${selectedResource.item.thumbnailFileId} w=225 h=120: null
+                                $else:
+                                  - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
+                                      - rtgl-text s=sm c=mu-fg: No thumbnail
+                              - rtgl-view d=v w=f g=xs ph=md pt=sm pb=md:
+                                  - rtgl-text s=sm ellipsis w=193: ${selectedResource.name}
+                                  - $if selectedResource.typeInfo:
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=193: ${selectedResource.typeInfo}
                     $elif selectedResource.resourceType == 'video':
-                      - rtgl-view#backgroundImage w=355 h=200 cur=pointer slot=background pos=rel:
-                          - rvn-file-image fileId=${selectedResource.item.thumbnailFileId} w=355 h=200: null
-                          - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
-                              - rtgl-icon icon=play s=xl c=fg: null
+                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
+                          - rtgl-view p=md g=md br=md:
+                              - rtgl-view pos=rel:
+                                  - rvn-file-image w=200 h=120 fileId=${selectedResource.item.thumbnailFileId}: null
+                                  - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
+                                      - rtgl-icon icon=play s=xl c=fg: null
+                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
                     $else:
                       - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
                           - rtgl-text s=md c=mu-fg: Select Background

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -81,7 +81,7 @@ template:
                               - rtgl-text: ${group.name}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
-                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 ah=c av=c bw=${item.bw} bc=${item.bc} br=sm cur=pointer:
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 ah=c av=c bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer:
                                           - rtgl-view av=c ah=c:
                                               - rtgl-text s=md: ${item.name}
                                               - rtgl-text s=sm c=mu-fg: ${item.layoutTypeDisplay}
@@ -91,8 +91,8 @@ template:
                               - rtgl-text: ${group.name}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
-                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 cur=pointer g=sm bw=${item.bw} bc=${item.bc} br=sm:
-                                          - rvn-file-image w=200 h=120 fileId=${item.thumbnailFileId}: null
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 cur=pointer g=sm bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                          - rvn-file-image w=f h=1fg fileId=${item.thumbnailFileId}: null
                                           - rtgl-text s=sm ah=c: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -94,10 +94,17 @@ template:
                               - rtgl-text: ${group.name}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
-                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 ah=c av=c bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer:
-                                          - rtgl-view av=c ah=c:
-                                              - rtgl-text s=md: ${item.name}
-                                              - rtgl-text s=sm c=mu-fg: ${item.layoutTypeDisplay}
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                          - 'rtgl-view w=225 br=md style="overflow: hidden;"':
+                                              - $if item.thumbnailFileId:
+                                                  - rvn-file-image fileId=${item.thumbnailFileId} w=225 h=120: null
+                                                $else:
+                                                  - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
+                                                      - rtgl-text s=sm c=mu-fg: No thumbnail
+                                              - rtgl-view d=v w=f g=xs ph=md pt=sm pb=md:
+                                                  - rtgl-text s=sm ellipsis w=193: ${item.name}
+                                                  - $if item.typeInfo:
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=193: ${item.typeInfo}
                     $elif tab == 'video':
                       - $for group, i in groups:
                           - rtgl-view g=md:

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -3,6 +3,8 @@ refs:
     eventListeners:
       image-selected:
         handler: handleImageSelected
+      image-dblclick:
+        handler: handleImageDoubleClick
   resourceItem*:
     eventListeners:
       click:
@@ -39,6 +41,10 @@ refs:
     eventListeners:
       item-click:
         handler: handleFileExplorerClickItem
+  previewOverlay:
+    eventListeners:
+      click:
+        action: hideFullImagePreview
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-view d=h g=md: null
@@ -97,3 +103,9 @@ template:
                                               - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: #000;"': null
+      - $if fullImagePreviewFileId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -94,6 +94,25 @@ export const handleResourceItemClick = (deps, payload) => {
   render();
 };
 
+export const handleResourceItemDoubleClick = (deps, payload) => {
+  const { store, render } = deps;
+  const resourceId = payload._event.currentTarget.dataset.resourceId;
+  const selectedItem = store.selectSoundItemById({ itemId: resourceId });
+
+  if (!selectedItem?.fileId) {
+    return;
+  }
+
+  store.setTempSelectedResource({
+    resourceId,
+  });
+  store.openAudioPlayer({
+    fileId: selectedItem.fileId,
+    fileName: selectedItem.name,
+  });
+  render();
+};
+
 export const handleFileExplorerItemClick = async (deps, payload) => {
   const { refs, store, render, downloadWaveformData, projectService } = deps;
   const { itemId, isFolder } = payload._event.detail;
@@ -133,6 +152,12 @@ export const handleFileExplorerItemClick = async (deps, payload) => {
 export const handleSearchInput = (deps, payload) => {
   const { store, render } = deps;
   store.setSearchQuery({ value: payload._event.detail.value ?? "" });
+  render();
+};
+
+export const handleAudioPlayerClose = (deps) => {
+  const { store, render } = deps;
+  store.closeAudioPlayer();
   render();
 };
 

--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -1,5 +1,49 @@
 import { toFlatItems } from "../../internal/project/tree.js";
 
+const openBgmGallery = ({ store, render }) => {
+  const selectedResource = store.selectSelectedResource();
+  if (selectedResource) {
+    store.setTempSelectedResource({
+      resourceId: selectedResource.resourceId,
+    });
+  }
+
+  store.setMode({
+    mode: "gallery",
+  });
+  render();
+};
+
+const showCurrentBgmDropdown = async (deps, event) => {
+  const { store, render, globalUI } = deps;
+  const selectedResource = store.selectSelectedResource();
+
+  if (!selectedResource) {
+    openBgmGallery({ store, render });
+    return;
+  }
+
+  const result = await globalUI.showDropdownMenu({
+    items: [
+      { type: "item", label: "Change", key: "change" },
+      { type: "item", label: "Remove", key: "remove" },
+    ],
+    x: event.clientX,
+    y: event.clientY,
+    place: "bs",
+  });
+
+  if (result?.item?.key === "change") {
+    openBgmGallery({ store, render });
+    return;
+  }
+
+  if (result?.item?.key === "remove") {
+    store.clearBgmAudio();
+    render();
+  }
+};
+
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
@@ -17,60 +61,23 @@ export const handleAfterMount = async (deps) => {
 };
 
 export const handleAudioWaveformRightClick = async (deps, payload) => {
-  const { store, render, globalUI } = deps;
   const { _event: event } = payload;
   event.preventDefault();
   event.stopPropagation();
 
-  if (!store.selectSelectedResource()) {
-    return;
-  }
-
-  const result = await globalUI.showDropdownMenu({
-    items: [{ type: "item", label: "Remove", key: "remove" }],
-    x: event.clientX,
-    y: event.clientY,
-    place: "bs",
-  });
-
-  if (result?.item?.key === "remove") {
-    store.clearBgmAudio();
-    render();
-  }
+  await showCurrentBgmDropdown(deps, event);
 };
 
-export const handleAudioWaveformClick = (deps) => {
-  const { store, render } = deps;
+export const handleAudioWaveformClick = async (deps, payload) => {
+  const { _event: event } = payload;
+  event.stopPropagation();
 
-  // When user clicks on waveform, open gallery
-  const selectedResource = store.selectSelectedResource();
-  if (selectedResource) {
-    store.setTempSelectedResource({
-      resourceId: selectedResource.resourceId,
-    });
-  }
-
-  store.setMode({
-    mode: "gallery",
-  });
-  render();
+  await showCurrentBgmDropdown(deps, event);
 };
 
 export const handleFormExtra = (deps, _payload) => {
   const { store, render } = deps;
-
-  // When user clicks on waveform field, open gallery
-  const selectedResource = store.selectSelectedResource();
-  if (selectedResource) {
-    store.setTempSelectedResource({
-      resourceId: selectedResource.resourceId,
-    });
-  }
-
-  store.setMode({
-    mode: "gallery",
-  });
-  render();
+  openBgmGallery({ store, render });
 };
 
 export const handleFormChange = (deps, payload) => {

--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -95,9 +95,18 @@ export const handleResourceItemClick = (deps, payload) => {
 };
 
 export const handleFileExplorerItemClick = async (deps, payload) => {
-  const { store, render, downloadWaveformData, projectService } = deps;
+  const { refs, store, render, downloadWaveformData, projectService } = deps;
+  const { itemId, isFolder } = payload._event.detail;
+
+  if (isFolder) {
+    const groupElement = refs.galleryScroll?.querySelector(
+      `[data-group-id="${itemId}"]`,
+    );
+    groupElement?.scrollIntoView?.({ block: "start" });
+    return;
+  }
+
   await projectService.ensureRepository();
-  const itemId = payload._event.detail.id;
   const { sounds } = projectService.getState();
 
   store.setTempSelectedResource({
@@ -119,6 +128,12 @@ export const handleFileExplorerItemClick = async (deps, payload) => {
       console.error("Failed to load waveform data:", error);
     }
   }
+};
+
+export const handleSearchInput = (deps, payload) => {
+  const { store, render } = deps;
+  store.setSearchQuery({ value: payload._event.detail.value ?? "" });
+  render();
 };
 
 export const handleSubmitClick = (deps, payload) => {

--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -20,6 +20,11 @@ export const handleAudioWaveformRightClick = async (deps, payload) => {
   const { store, render, globalUI } = deps;
   const { _event: event } = payload;
   event.preventDefault();
+  event.stopPropagation();
+
+  if (!store.selectSelectedResource()) {
+    return;
+  }
 
   const result = await globalUI.showDropdownMenu({
     items: [{ type: "item", label: "Remove", key: "remove" }],
@@ -28,11 +33,8 @@ export const handleAudioWaveformRightClick = async (deps, payload) => {
     place: "bs",
   });
 
-  if (result.item.key === "remove") {
-    store.setBgmAudio({
-      resourceId: undefined,
-    });
-
+  if (result?.item?.key === "remove") {
+    store.clearBgmAudio();
     render();
   }
 };

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -115,7 +115,11 @@ export const selectSelectedResource = ({ state }) => {
     name: item.name,
     itemBorderColor: "bo",
     itemHoverBorderColor: "ac",
-    item: item,
+    item: {
+      ...item,
+      itemBorderColor: "bo",
+      itemHoverBorderColor: "ac",
+    },
   };
 };
 

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -40,6 +40,7 @@ export const createInitialState = () => ({
   selectedResourceId: undefined,
   tempSelectedResourceId: undefined,
   bgm: normalizeBgm(),
+  searchQuery: "",
 });
 
 export const setBgmAudio = ({ state }, { resourceId } = {}) => {
@@ -71,6 +72,10 @@ export const selectTempSelectedResourceId = ({ state }) => {
 
 export const setTempSelectedResource = ({ state }, { resourceId } = {}) => {
   state.tempSelectedResourceId = resourceId;
+};
+
+export const setSearchQuery = ({ state }, { value } = {}) => {
+  state.searchQuery = value ?? "";
 };
 
 export const selectSelectedResource = ({ state }) => {
@@ -124,20 +129,36 @@ export const selectViewData = ({ state }) => {
   const flatItems = toFlatItems(state.items).filter(
     (item) => item.type === "folder",
   );
-  const flatGroups = toFlatGroups(state.items).map((group) => {
-    return {
-      ...group,
-      children: group.children.map((child) => {
+  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+  const matchesSearch = (item) => {
+    if (!searchQuery) {
+      return true;
+    }
+
+    const name = (item.name ?? "").toLowerCase();
+    const description = (item.description ?? "").toLowerCase();
+    return name.includes(searchQuery) || description.includes(searchQuery);
+  };
+  const flatGroups = toFlatGroups(state.items)
+    .map((group) => {
+      const children = group.children.filter(matchesSearch).map((child) => {
         const isSelected = child.id === state.tempSelectedResourceId;
         return {
           ...child,
-          bw: isSelected ? "md" : "",
-          bc: isSelected ? "fg" : "",
+          itemBorderColor: isSelected ? "pr" : "bo",
+          itemHoverBorderColor: isSelected ? "pr" : "ac",
           waveformDataFileId: child.waveformDataFileId,
         };
-      }),
-    };
-  });
+      });
+
+      return {
+        ...group,
+        children,
+        hasChildren: children.length > 0,
+        shouldDisplay: !searchQuery || children.length > 0,
+      };
+    })
+    .filter((group) => group.shouldDisplay);
 
   const selectedResource = selectSelectedResource({ state });
   const breadcrumb = selectBreadcrumb({ state });
@@ -155,6 +176,8 @@ export const selectViewData = ({ state }) => {
     items: flatItems,
     groups: flatGroups,
     tempSelectedResourceId: state.tempSelectedResourceId,
+    searchQuery: state.searchQuery,
+    searchPlaceholder: "Search...",
     breadcrumb,
     form,
     defaultValues,

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -41,6 +41,11 @@ export const createInitialState = () => ({
   tempSelectedResourceId: undefined,
   bgm: normalizeBgm(),
   searchQuery: "",
+  playingSound: {
+    title: "",
+    fileId: undefined,
+  },
+  showAudioPlayer: false,
 });
 
 export const setBgmAudio = ({ state }, { resourceId } = {}) => {
@@ -78,6 +83,20 @@ export const setSearchQuery = ({ state }, { value } = {}) => {
   state.searchQuery = value ?? "";
 };
 
+export const openAudioPlayer = ({ state }, { fileId, fileName } = {}) => {
+  state.playingSound.fileId = fileId;
+  state.playingSound.title = fileName;
+  state.showAudioPlayer = true;
+};
+
+export const closeAudioPlayer = ({ state }, _payload = {}) => {
+  state.showAudioPlayer = false;
+  state.playingSound = {
+    title: "",
+    fileId: undefined,
+  };
+};
+
 export const selectSelectedResource = ({ state }) => {
   if (!state.bgm.resourceId) {
     return null;
@@ -96,6 +115,10 @@ export const selectSelectedResource = ({ state }) => {
     name: item.name,
     item: item,
   };
+};
+
+export const selectSoundItemById = ({ state }, { itemId } = {}) => {
+  return toFlatItems(state.items).find((item) => item.id === itemId);
 };
 
 export const selectBreadcrumb = ({ state }) => {
@@ -178,6 +201,8 @@ export const selectViewData = ({ state }) => {
     tempSelectedResourceId: state.tempSelectedResourceId,
     searchQuery: state.searchQuery,
     searchPlaceholder: "Search...",
+    playingSound: state.playingSound,
+    showAudioPlayer: state.showAudioPlayer,
     breadcrumb,
     form,
     defaultValues,

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -113,6 +113,8 @@ export const selectSelectedResource = ({ state }) => {
     resourceId: state.bgm.resourceId,
     fileId: item.fileId,
     name: item.name,
+    itemBorderColor: "bo",
+    itemHoverBorderColor: "ac",
     item: item,
   };
 };

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -17,7 +17,7 @@ const form = {
     {
       name: "loop",
       description: "Loop",
-      type: "select",
+      type: "segmented-control",
       options: [
         { value: true, label: "Loop" },
         { value: false, label: "Don't Loop" },

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -55,6 +55,11 @@ export const setBgmAudio = ({ state }, { resourceId } = {}) => {
   };
 };
 
+export const clearBgmAudio = ({ state }, _payload = {}) => {
+  state.bgm.resourceId = undefined;
+  state.tempSelectedResourceId = undefined;
+};
+
 export const setBgm = ({ state }, { bgm } = {}) => {
   state.bgm = normalizeBgm(bgm);
 };

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -49,9 +49,10 @@ template:
       - $if mode == 'current':
           - rtgl-form#form key=${audio.id} :form=${form} :defaultValues=${defaultValues}:
               - $if defaultValues.audioWaveformDataFileId:
-                  - rtgl-view slot=audio:
-                      - rvn-waveform-visualizer#audioWaveform waveformDataFileId=${defaultValues.audioWaveformDataFileId} width=355 height=200 cur=pointer: null
-                      - rtgl-text s=sm ah=c: ${audio.name}
+                  - rtgl-view#audioWaveform slot=audio cur=pointer bw=xs bc=${audio.itemBorderColor} h-bc=${audio.itemHoverBorderColor} br=sm:
+                      - rtgl-view p=md g=md br=md:
+                          - rvn-waveform-visualizer waveformDataFileId=${defaultValues.audioWaveformDataFileId} w=200 h=120: null
+                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${audio.name}
                 $else:
                   - rtgl-view#audioWaveform w=250 h=150 bgc=mu av=c ah=c cur=pointer slot=audio:
                       - rtgl-text s=md c=mu-fg: Select BGM

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -9,6 +9,11 @@ refs:
     eventListeners:
       item-click:
         handler: handleFileExplorerItemClick
+  galleryScroll: {}
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
   resourceItem*:
     eventListeners:
       click:
@@ -48,21 +53,27 @@ template:
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':
+          - rtgl-view d=h w=f av=c g=md:
+              - rtgl-view w=1fg: null
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
           - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
-                  - rvn-base-file-explorer#baseFileExplorer :items=${items} no-empty-message: null
-              - rtgl-view h=f w=2fg sv g=lg:
+                  - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
+              - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                   - $for group, i in groups:
-                      - rtgl-view g=md:
-                          - rtgl-text: ${group.name}
+                      - rtgl-view data-group-id=${group.id} g=md:
+                          - rtgl-view d=h av=c g=md:
+                              - rtgl-svg svg=folder wh=16: null
+                              - rtgl-text: ${group.fullLabel}
                           - rtgl-view d=h w=f wrap g=lg:
                               - $for item, j in group.children:
-                                  - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=${item.bw} bc=${item.bc} g=sm:
-                                      - $if item.waveformDataFileId:
-                                          - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} width=225 h=120: null
-                                          - rtgl-text s=sm ah=c: ${item.name}
-                                        $else:
-                                          - rtgl-view w=225 h=120 av=c ah=c bgc=ac:
-                                              - rtgl-text s=sm c=mu-fg: No waveform
+                                  - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                      - rtgl-view p=md g=md br=md:
+                                          - $if item.waveformDataFileId:
+                                              - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=225 h=120: null
+                                            $else:
+                                              - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
+                                                  - rtgl-text s=sm c=mu-fg: No waveform
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=225: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -70,10 +70,10 @@ template:
                                   - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
                                       - rtgl-view p=md g=md br=md:
                                           - $if item.waveformDataFileId:
-                                              - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=225 h=120: null
+                                              - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=200 h=120: null
                                             $else:
-                                              - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
+                                              - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
                                                   - rtgl-text s=sm c=mu-fg: No waveform
-                                          - rtgl-text s=xs c=mu-fg ellipsis w=225: ${item.name}
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -18,6 +18,8 @@ refs:
     eventListeners:
       click:
         handler: handleResourceItemClick
+      dblclick:
+        handler: handleResourceItemDoubleClick
   submitButton:
     eventListeners:
       click:
@@ -36,6 +38,10 @@ refs:
         handler: handleAudioWaveformClick
       contextmenu:
         handler: handleAudioWaveformRightClick
+  rvnAudioPlayer:
+    eventListeners:
+      audio-player-close:
+        handler: handleAudioPlayerClose
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-view d=h g=md: null
@@ -77,3 +83,6 @@ template:
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select
+  - $if showAudioPlayer:
+      - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
+          - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -225,6 +225,20 @@ export const handleSpriteItemClick = (deps, payload) => {
   render();
 };
 
+export const handleSpriteItemDoubleClick = (deps, payload) => {
+  const { store, render } = deps;
+  const spriteId = payload._event.currentTarget.dataset.spriteId;
+  const sprite = store.selectCurrentSpriteItemById({ spriteId });
+
+  if (!sprite?.fileId) {
+    return;
+  }
+
+  store.setTempSelectedSpriteId({ spriteId });
+  store.showFullImagePreview({ fileId: sprite.fileId });
+  render();
+};
+
 export const handleButtonSelectClick = (deps) => {
   const { store, render, appService } = deps;
   const mode = store.selectMode();

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -62,16 +62,39 @@ export const handleCharacterContextMenu = (deps, payload) => {
 
 export const handleTransformChange = (deps, payload) => {
   const { store, render } = deps;
-  const id = payload._event.currentTarget?.id || payload._event.target?.id;
-  // Try both event structures (native change event and custom option-selected event)
-  const value =
-    payload._event.detail?.value ||
-    payload._event.currentTarget?.value ||
-    payload._event.target?.value;
-
-  // Extract index from ID (format: transform-{index})
-  const index = parseInt(id.replace("transform", ""));
+  const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
+  const value = payload._event.detail.value;
   store.updateCharacterTransform({ index, transform: value });
+  render();
+};
+
+export const handleFileExplorerItemClick = (deps, payload) => {
+  const { refs, store, render } = deps;
+  const { itemId, isFolder } = payload._event.detail;
+
+  if (isFolder) {
+    const groupElement = refs.galleryScroll?.querySelector(
+      `[data-group-id="${itemId}"]`,
+    );
+    groupElement?.scrollIntoView?.({ block: "start" });
+    return;
+  }
+
+  store.addCharacter({ id: itemId });
+
+  const currentCharacters = store.selectSelectedCharacters();
+  const newCharacterIndex = currentCharacters.length - 1;
+  store.setSelectedCharacterIndex({ index: newCharacterIndex });
+  store.setMode({
+    mode: "sprite-select",
+  });
+
+  render();
+};
+
+export const handleSearchInput = (deps, payload) => {
+  const { store, render } = deps;
+  store.setSearchQuery({ value: payload._event.detail.value ?? "" });
   render();
 };
 

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -71,12 +71,19 @@ export const handleTransformChange = (deps, payload) => {
 export const handleFileExplorerItemClick = (deps, payload) => {
   const { refs, store, render } = deps;
   const { itemId, isFolder } = payload._event.detail;
+  const mode = store.selectMode();
 
   if (isFolder) {
     const groupElement = refs.galleryScroll?.querySelector(
       `[data-group-id="${itemId}"]`,
     );
     groupElement?.scrollIntoView?.({ block: "start" });
+    return;
+  }
+
+  if (mode === "sprite-select") {
+    store.setTempSelectedSpriteId({ spriteId: itemId });
+    render();
     return;
   }
 

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -274,18 +274,25 @@ export const selectViewData = ({ state }) => {
         (item) => item.type === "folder",
       );
 
-      spriteGroups = toFlatGroups(enrichedSelectedChar.sprites).map((group) => {
-        return {
-          ...group,
-          children: group.children.map((child) => {
+      spriteGroups = toFlatGroups(enrichedSelectedChar.sprites)
+        .map((group) => {
+          const children = group.children.filter(matchesSearch).map((child) => {
             const isSelected = child.id === state.tempSelectedSpriteId;
             return {
               ...child,
-              bw: isSelected ? "md" : "",
+              itemBorderColor: isSelected ? "pr" : "bo",
+              itemHoverBorderColor: isSelected ? "pr" : "ac",
             };
-          }),
-        };
-      });
+          });
+
+          return {
+            ...group,
+            children,
+            hasChildren: children.length > 0,
+            shouldDisplay: !searchQuery || children.length > 0,
+          };
+        })
+        .filter((group) => group.shouldDisplay);
     }
   }
 

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -17,6 +17,7 @@ export const createInitialState = () => ({
   tempSelectedCharacterId: undefined,
   tempSelectedSpriteId: undefined,
   selectedCharacterIndex: undefined, // For sprite selection
+  searchQuery: "",
   dropdownMenu: {
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -97,6 +98,10 @@ export const setTempSelectedCharacterId = ({ state }, { characterId } = {}) => {
 
 export const setTempSelectedSpriteId = ({ state }, { spriteId } = {}) => {
   state.tempSelectedSpriteId = spriteId;
+};
+
+export const setSearchQuery = ({ state }, { value } = {}) => {
+  state.searchQuery = value ?? "";
 };
 
 export const setSelectedCharacterIndex = ({ state }, { index } = {}) => {
@@ -203,18 +208,35 @@ export const selectViewData = ({ state }) => {
   const flatItems = toFlatItems(state.items).filter(
     (item) => item.type === "folder",
   );
-  const flatGroups = toFlatGroups(state.items).map((group) => {
-    return {
-      ...group,
-      children: group.children.map((child) => {
+  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+  const matchesSearch = (item) => {
+    if (!searchQuery) {
+      return true;
+    }
+
+    const name = (item.name ?? "").toLowerCase();
+    const description = (item.description ?? "").toLowerCase();
+    return name.includes(searchQuery) || description.includes(searchQuery);
+  };
+  const flatGroups = toFlatGroups(state.items)
+    .map((group) => {
+      const children = group.children.filter(matchesSearch).map((child) => {
         const isSelected = child.id === state.tempSelectedCharacterId;
         return {
           ...child,
-          bw: isSelected ? "md" : "",
+          itemBorderColor: isSelected ? "pr" : "bo",
+          itemHoverBorderColor: isSelected ? "pr" : "ac",
         };
-      }),
-    };
-  });
+      });
+
+      return {
+        ...group,
+        children,
+        hasChildren: children.length > 0,
+        shouldDisplay: !searchQuery || children.length > 0,
+      };
+    })
+    .filter((group) => group.shouldDisplay);
 
   // Initialize sprite data (will be populated later after processedSelectedCharacters is defined)
   let spriteItems = [];
@@ -325,6 +347,8 @@ export const selectViewData = ({ state }) => {
     spriteItems,
     spriteGroups,
     selectedCharacterName,
+    searchQuery: state.searchQuery,
+    searchPlaceholder: "Search...",
     breadcrumb,
     form,
     defaultValues,

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -18,6 +18,8 @@ export const createInitialState = () => ({
   tempSelectedSpriteId: undefined,
   selectedCharacterIndex: undefined, // For sprite selection
   searchQuery: "",
+  fullImagePreviewVisible: false,
+  fullImagePreviewFileId: undefined,
   dropdownMenu: {
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -104,6 +106,20 @@ export const setSearchQuery = ({ state }, { value } = {}) => {
   state.searchQuery = value ?? "";
 };
 
+export const showFullImagePreview = ({ state }, { fileId } = {}) => {
+  if (!fileId) {
+    return;
+  }
+
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewFileId = fileId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewFileId = undefined;
+};
+
 export const setSelectedCharacterIndex = ({ state }, { index } = {}) => {
   state.selectedCharacterIndex = index;
 };
@@ -144,6 +160,16 @@ export const selectMode = ({ state }) => {
 
 export const selectSelectedCharacterIndex = ({ state }) => {
   return state.selectedCharacterIndex;
+};
+
+export const selectCurrentSpriteItemById = ({ state }, { spriteId } = {}) => {
+  const characters = selectCharactersWithRepositoryData({ state });
+  const character = characters[state.selectedCharacterIndex];
+  if (!character?.sprites) {
+    return undefined;
+  }
+
+  return toFlatItems(character.sprites).find((item) => item.id === spriteId);
 };
 
 export const setExistingCharacters = ({ state }, { characters } = {}) => {
@@ -356,6 +382,8 @@ export const selectViewData = ({ state }) => {
     selectedCharacterName,
     searchQuery: state.searchQuery,
     searchPlaceholder: "Search...",
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewFileId: state.fullImagePreviewFileId,
     breadcrumb,
     form,
     defaultValues,

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -110,18 +110,24 @@ template:
       - $if mode == 'sprite-select':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - 'rtgl-view d=h w=f g=lg h=1fg style="min-height: 0;"':
+          - rtgl-view d=h w=f av=c g=md:
+              - rtgl-view w=1fg: null
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${spriteItems}: null
-              - rtgl-view h=f w=2fg sv g=lg:
+              - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                   - $for group, i in spriteGroups:
-                      - rtgl-view g=md:
-                          - rtgl-text: ${group.name}
+                      - rtgl-view data-group-id=${group.id} g=md:
+                          - rtgl-view d=h av=c g=md:
+                              - rtgl-svg svg=folder wh=16: null
+                              - rtgl-text: ${group.fullLabel}
                           - rtgl-view d=h w=f wrap g=lg:
                               - $for item, j in group.children:
-                                  - rtgl-view#spriteItem${i}x${j} data-sprite-id=${item.id} w=200 h=150 cur=pointer key=${item.bw} bw=${item.bw} bc=pr br=sm g=sm:
-                                      - rvn-file-image fileId=${item.fileId} w=200 h=120: null
-                                      - rtgl-text s=sm ah=c: ${item.name}
+                                  - rtgl-view#spriteItem${i}x${j} data-sprite-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                      - rtgl-view p=md g=md br=md:
+                                          - rvn-file-image fileId=${item.fileId} w=200 h=120: null
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -58,7 +58,7 @@ template:
               - rtgl-form#form :form=${form} :defaultValues=${defaultValues}:
                   - rtgl-view#charactersContainer slot=characters g=md w=f cur=pointer:
                       - $for character, i in defaultValues.characters:
-                          - rtgl-view#character${i} data-index=${i} data-character-id=${character.id} d=h g=md av=t bgc=ac p=md br=md w=f:
+                          - rtgl-view#character${i} data-index=${i} data-character-id=${character.id} d=h g=md av=t p=md br=md w=f:
                               - rtgl-view g=sm:
                                   - $if character.spriteFileId:
                                       - rvn-file-image fileId=${character.spriteFileId} w=120 h=120 br=sm: null

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -59,13 +59,14 @@ template:
                   - rtgl-view#charactersContainer slot=characters g=md w=f:
                       - $for character, i in defaultValues.characters:
                           - rtgl-view#character${i} data-index=${i} data-character-id=${character.id} d=h g=md av=t p=md br=md w=f:
-                              - rtgl-view g=sm:
-                                  - $if character.spriteFileId:
-                                      - rvn-file-image fileId=${character.spriteFileId} w=120 h=120 br=sm: null
-                                    $else:
-                                      - rtgl-view w=120 h=120 av=c ah=c bgc=mu br=sm cur=pointer:
-                                          - rtgl-text s=sm c=mu-fg: No Sprite
-                                  - rtgl-text s=sm w=120 ah=c ellipsis=true: ${character.displayName}
+                              - rtgl-view cur=pointer bw=xs bc=bo h-bc=ac br=sm:
+                                  - rtgl-view p=md g=md br=md:
+                                      - $if character.spriteFileId:
+                                          - rvn-file-image fileId=${character.spriteFileId} w=200 h=120: null
+                                        $else:
+                                          - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                              - rtgl-text s=sm c=mu-fg: No Sprite
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=200: ${character.displayName}
                               - rtgl-view w=1fg g=sm:
                                   - rtgl-text s=sm c=mu-fg: Transform
                                   - rtgl-select#transform${i} :options=${defaultValues.transformOptions} :selectedValue=${defaultValues.characters[i].transformId} w=f: null

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -88,9 +88,9 @@ template:
           - rtgl-view d=h w=f av=c g=md:
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-          - 'rtgl-view d=h w=f g=lg h=1fg style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
-                  - rvn-base-file-explorer#baseFileExplorer :items=${items} no-empty-message: null
+                  - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
               - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                   - $for group, i in groups:
                       - rtgl-view data-group-id=${group.id} g=md:

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -26,6 +26,12 @@ refs:
     eventListeners:
       click:
         handler: handleSpriteItemClick
+      dblclick:
+        handler: handleSpriteItemDoubleClick
+  previewOverlay:
+    eventListeners:
+      click:
+        action: hideFullImagePreview
   submitButton:
     eventListeners:
       click:
@@ -131,3 +137,9 @@ template:
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: #000;"': null
+      - $if fullImagePreviewFileId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -13,6 +13,15 @@ refs:
         handler: handleCharacterClick
       contextmenu:
         handler: handleCharacterContextMenu
+  baseFileExplorer:
+    eventListeners:
+      item-click:
+        handler: handleFileExplorerItemClick
+  galleryScroll: {}
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
   spriteItem*:
     eventListeners:
       click:
@@ -69,30 +78,35 @@ template:
                                       - rtgl-text s=xs c=mu-fg ellipsis w=200: ${character.displayName}
                               - rtgl-view w=1fg g=sm:
                                   - rtgl-text s=sm c=mu-fg: Transform
-                                  - rtgl-select#transform${i} :options=${defaultValues.transformOptions} :selectedValue=${defaultValues.characters[i].transformId} w=f: null
+                                  - rtgl-select#transform${i} data-index=${i} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
                       - rtgl-button#addCharacterButton v=ol w=f mt=md: + Add Character
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#submitButton: Submit
       - $if mode == 'character-select':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
+          - rtgl-view d=h w=f av=c g=md:
+              - rtgl-view w=1fg: null
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
           - 'rtgl-view d=h w=f g=lg h=1fg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${items} no-empty-message: null
-              - rtgl-view h=f w=2fg sv g=lg:
+              - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                   - $for group, i in groups:
-                      - rtgl-view g=md:
-                          - rtgl-text: ${group.name}
+                      - rtgl-view data-group-id=${group.id} g=md:
+                          - rtgl-view d=h av=c g=md:
+                              - rtgl-svg svg=folder wh=16: null
+                              - rtgl-text: ${group.fullLabel}
                           - rtgl-view d=h w=f wrap g=lg:
                               - $for item, j in group.children:
-                                  - rtgl-view#characterItem${i}x${j} data-character-id=${item.id} w=200 h=150 p=sm bgc=mu br=md cur=pointer key=${item.bw} bw=${item.bw}:
-                                      - rtgl-view w=f h=f av=c ah=c g=sm:
+                                  - rtgl-view#characterItem${i}x${j} data-character-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                      - rtgl-view p=md g=md br=md:
                                           - $if item.fileId:
-                                              - rvn-file-image fileId=${item.fileId} w=80 h=80 br=f: null
+                                              - rvn-file-image fileId=${item.fileId} w=200 h=120: null
                                             $else:
-                                              - rtgl-view w=80 h=80 bgc=ac av=c ah=c br=f:
-                                                  - rtgl-text s=sm: No Avatar
-                                          - rtgl-text: ${item.name}
+                                              - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                                  - rtgl-text s=sm c=mu-fg: No Avatar
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
       - $if mode == 'sprite-select':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -56,7 +56,7 @@ template:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - rtgl-view h=1fg sv w=f:
               - rtgl-form#form :form=${form} :defaultValues=${defaultValues}:
-                  - rtgl-view#charactersContainer slot=characters g=md w=f cur=pointer:
+                  - rtgl-view#charactersContainer slot=characters g=md w=f:
                       - $for character, i in defaultValues.characters:
                           - rtgl-view#character${i} data-index=${i} data-character-id=${character.id} d=h g=md av=t p=md br=md w=f:
                               - rtgl-view g=sm:

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.handlers.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.handlers.js
@@ -142,6 +142,25 @@ export const handleSfxClick = (deps, payload) => {
   render();
 };
 
+export const handleSfxDoubleClick = (deps, payload) => {
+  const { store, render } = deps;
+  const sfxId = payload._event.currentTarget?.dataset?.sfxId;
+  const soundEffect = store.selectSfxs().find((item) => item.id === sfxId);
+  const soundItem = store.selectSoundItemById({
+    itemId: soundEffect?.resourceId,
+  });
+
+  if (!soundItem?.fileId) {
+    return;
+  }
+
+  store.openAudioPlayer({
+    fileId: soundItem.fileId,
+    fileName: soundItem.name,
+  });
+  render();
+};
+
 export const handleSfxContextMenu = (deps, payload) => {
   payload._event.preventDefault();
   const { store, render } = deps;
@@ -170,6 +189,51 @@ export const handleResourceItemClick = (deps, payload) => {
     resourceId: id,
   });
 
+  render();
+};
+
+export const handleResourceItemDoubleClick = (deps, payload) => {
+  const { store, render } = deps;
+  const resourceId = payload._event.currentTarget.dataset.resourceId;
+  const selectedItem = store.selectSoundItemById({ itemId: resourceId });
+
+  if (!selectedItem?.fileId) {
+    return;
+  }
+
+  store.setTempSelectedResourceId({
+    resourceId,
+  });
+  store.openAudioPlayer({
+    fileId: selectedItem.fileId,
+    fileName: selectedItem.name,
+  });
+  render();
+};
+
+export const handleFileExplorerItemClick = (deps, payload) => {
+  const { refs } = deps;
+  const { itemId, isFolder } = payload._event.detail;
+
+  if (!isFolder) {
+    return;
+  }
+
+  const groupElement = refs.galleryScroll?.querySelector(
+    `[data-group-id="${itemId}"]`,
+  );
+  groupElement?.scrollIntoView?.({ block: "start" });
+};
+
+export const handleSearchInput = (deps, payload) => {
+  const { store, render } = deps;
+  store.setSearchQuery({ value: payload._event.detail.value ?? "" });
+  render();
+};
+
+export const handleAudioPlayerClose = (deps) => {
+  const { store, render } = deps;
+  store.closeAudioPlayer();
   render();
 };
 

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
@@ -27,6 +27,12 @@ export const createInitialState = () => ({
   sfx: [],
   currentEditingId: null, // ID of sound effect being edited
   tempSelectedResourceId: undefined,
+  searchQuery: "",
+  playingSound: {
+    title: "",
+    fileId: undefined,
+  },
+  showAudioPlayer: false,
   // Dropdown menu state
   dropdownMenu: {
     isOpen: false,
@@ -46,6 +52,24 @@ export const setRepositoryState = ({ state }, { sounds } = {}) => {
 
 export const setTempSelectedResourceId = ({ state }, { resourceId } = {}) => {
   state.tempSelectedResourceId = resourceId;
+};
+
+export const setSearchQuery = ({ state }, { value } = {}) => {
+  state.searchQuery = value ?? "";
+};
+
+export const openAudioPlayer = ({ state }, { fileId, fileName } = {}) => {
+  state.playingSound.fileId = fileId;
+  state.playingSound.title = fileName;
+  state.showAudioPlayer = true;
+};
+
+export const closeAudioPlayer = ({ state }, _payload = {}) => {
+  state.showAudioPlayer = false;
+  state.playingSound = {
+    title: "",
+    fileId: undefined,
+  };
 };
 
 export const addSfx = ({ state }, { id } = {}) => {
@@ -126,6 +150,10 @@ export const selectCurrentEditingId = ({ state }) => {
   return state.currentEditingId;
 };
 
+export const selectSoundItemById = ({ state }, { itemId } = {}) => {
+  return toFlatItems(state.items).find((item) => item.id === itemId);
+};
+
 export const selectSfxWithSoundData = ({ state }) => {
   const flatSoundItems = toFlatItems(state.items);
 
@@ -134,7 +162,10 @@ export const selectSfxWithSoundData = ({ state }) => {
     return {
       ...sfx,
       name: soundItem?.name,
+      fileId: soundItem?.fileId,
       waveformDataFileId: soundItem?.waveformDataFileId,
+      itemBorderColor: "bo",
+      itemHoverBorderColor: "ac",
     };
   });
 };
@@ -170,20 +201,36 @@ export const selectViewData = ({ state }) => {
   const flatItems = toFlatItems(state.items).filter(
     (item) => item.type === "folder",
   );
-  const flatGroups = toFlatGroups(state.items).map((group) => {
-    return {
-      ...group,
-      children: group.children.map((child) => {
+  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+  const matchesSearch = (item) => {
+    if (!searchQuery) {
+      return true;
+    }
+
+    const name = (item.name ?? "").toLowerCase();
+    const description = (item.description ?? "").toLowerCase();
+    return name.includes(searchQuery) || description.includes(searchQuery);
+  };
+  const flatGroups = toFlatGroups(state.items)
+    .map((group) => {
+      const children = group.children.filter(matchesSearch).map((child) => {
         const isSelected = child.id === state.tempSelectedResourceId;
         return {
           ...child,
-          bw: isSelected ? "md" : "",
-          bc: isSelected ? "fg" : "",
+          itemBorderColor: isSelected ? "pr" : "bo",
+          itemHoverBorderColor: isSelected ? "pr" : "ac",
           waveformDataFileId: child.waveformDataFileId,
         };
-      }),
-    };
-  });
+      });
+
+      return {
+        ...group,
+        children,
+        hasChildren: children.length > 0,
+        shouldDisplay: !searchQuery || children.length > 0,
+      };
+    })
+    .filter((group) => group.shouldDisplay);
 
   const breadcrumb = selectBreadcrumb({ state });
   const sfxWithSoundData = selectSfxWithSoundData({ state });
@@ -199,6 +246,10 @@ export const selectViewData = ({ state }) => {
     groups: flatGroups,
     sfx: sfxWithSoundData,
     tempSelectedResourceId: state.tempSelectedResourceId,
+    searchQuery: state.searchQuery,
+    searchPlaceholder: "Search...",
+    playingSound: state.playingSound,
+    showAudioPlayer: state.showAudioPlayer,
     breadcrumb,
     loopOptions: LOOP_OPTIONS,
     defaultValues,

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -72,7 +72,7 @@ template:
                           - rtgl-text s=sm c=mu-fg: Loop
                           - rtgl-select#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
                           - rtgl-text s=sm c=mu-fg: Volume
-                          - rtgl-input#volumeInput${i} data-index=${i} type=number min=0 max=1000 step=1 w=f value=${sfx.volume}: null
+                          - rtgl-slider-input#volumeInput${i} data-index=${i} key=${sfx.id} min=0 max=1000 step=1 w=f value=${sfx.volume}: null
               - rtgl-button#addNewButton v=ol w=f mt=md: + Add New Sound Effect
           - rtgl-view h=1fg: null
           - rtgl-view d=h av=c ah=e w=f g=lg:

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -70,7 +70,7 @@ template:
                               - rtgl-text s=xs c=mu-fg ellipsis w=200: ${sfx.name}
                       - rtgl-view w=1fg g=sm:
                           - rtgl-text s=sm c=mu-fg: Loop
-                          - rtgl-select#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
+                          - rtgl-segmented-control#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
                           - rtgl-text s=sm c=mu-fg: Volume
                           - rtgl-slider-input#volumeInput${i} data-index=${i} key=${sfx.id} min=0 max=1000 step=1 w=f value=${sfx.volume}: null
               - rtgl-button#addNewButton v=ol w=f mt=md: + Add New Sound Effect

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -7,12 +7,21 @@ refs:
     eventListeners:
       click:
         handler: handleSfxClick
+      dblclick:
+        handler: handleSfxDoubleClick
       contextmenu:
         handler: handleSfxContextMenu
+  galleryScroll: {}
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
   resourceItem*:
     eventListeners:
       click:
         handler: handleResourceItemClick
+      dblclick:
+        handler: handleResourceItemDoubleClick
   submitButton:
     eventListeners:
       click:
@@ -39,6 +48,10 @@ refs:
         handler: handleDropdownMenuClose
       item-click:
         handler: handleDropdownMenuClickItem
+  rvnAudioPlayer:
+    eventListeners:
+      audio-player-close:
+        handler: handleAudioPlayerClose
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-view d=h g=md: null
@@ -47,10 +60,15 @@ template:
           - rtgl-view#soundEffectsContainer g=md:
               - $for sfx, i in defaultValues.sfx:
                   - rtgl-view d=h g=md av=t:
-                      - rtgl-view#soundEffectCard${i} data-sfx-id=${sfx.id} cur=pointer:
-                          - rvn-waveform-visualizer waveformDataFileId=${sfx.waveformDataFileId} width=355 height=150: null
+                      - rtgl-view#soundEffectCard${i} data-sfx-id=${sfx.id} cur=pointer bw=xs bc=${sfx.itemBorderColor} h-bc=${sfx.itemHoverBorderColor} br=sm:
+                          - rtgl-view p=md g=md br=md:
+                              - $if sfx.waveformDataFileId:
+                                  - rvn-waveform-visualizer waveformDataFileId=${sfx.waveformDataFileId} w=200 h=120: null
+                                $else:
+                                  - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                      - rtgl-text s=sm c=mu-fg: No waveform
+                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${sfx.name}
                       - rtgl-view w=1fg g=sm:
-                          - rtgl-text ellipsis=true s=sm c=mu-fg: ${sfx.name}
                           - rtgl-text s=sm c=mu-fg: Loop
                           - rtgl-select#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
                           - rtgl-text s=sm c=mu-fg: Volume
@@ -60,22 +78,31 @@ template:
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':
+          - rtgl-view d=h w=f av=c g=md:
+              - rtgl-view w=1fg: null
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
           - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
-                  - rvn-base-file-explorer#baseFileExplorer :items=${items} no-empty-message: null
-              - rtgl-view h=f w=2fg sv g=lg:
+                  - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
+              - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                   - $for group, i in groups:
-                      - rtgl-view g=md:
-                          - rtgl-text: ${group.name}
+                      - rtgl-view data-group-id=${group.id} g=md:
+                          - rtgl-view d=h av=c g=md:
+                              - rtgl-svg svg=folder wh=16: null
+                              - rtgl-text: ${group.fullLabel}
                           - rtgl-view d=h w=f wrap g=lg:
                               - $for item, j in group.children:
-                                  - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=${item.bw} bc=${item.bc} g=sm:
-                                      - $if item.waveformDataFileId:
-                                          - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} width=225 h=120: null
-                                          - rtgl-text s=sm ah=c: ${item.name}
-                                        $else:
-                                          - rtgl-view w=225 h=120 av=c ah=c bgc=ac:
-                                              - rtgl-text s=sm c=mu-fg: No waveform
+                                  - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                      - rtgl-view p=md g=md br=md:
+                                          - $if item.waveformDataFileId:
+                                              - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=200 h=120: null
+                                            $else:
+                                              - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                                  - rtgl-text s=sm c=mu-fg: No waveform
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
+  - $if showAudioPlayer:
+      - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
+          - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -57,9 +57,9 @@ template:
       - rtgl-view d=h g=md: null
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
-          - rtgl-view#soundEffectsContainer g=md:
+          - rtgl-view#soundEffectsContainer w=f g=md:
               - $for sfx, i in defaultValues.sfx:
-                  - rtgl-view d=h g=md av=t:
+                  - rtgl-view d=h w=f g=md av=t:
                       - rtgl-view#soundEffectCard${i} data-sfx-id=${sfx.id} cur=pointer bw=xs bc=${sfx.itemBorderColor} h-bc=${sfx.itemHoverBorderColor} br=sm:
                           - rtgl-view p=md g=md br=md:
                               - $if sfx.waveformDataFileId:

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -61,27 +61,54 @@ export const handleVisualContextMenu = (deps, payload) => {
 
 export const handleTransformChange = (deps, payload) => {
   const { store, render } = deps;
-  const id = payload._event.currentTarget?.id || payload._event.target?.id;
-  const value =
-    payload._event.detail?.value ||
-    payload._event.currentTarget?.value ||
-    payload._event.target?.value;
-
-  // Extract index from ID (format: transform-{index})
-  const index = parseInt(id.replace("transform", ""));
+  const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
+  const value = payload._event.detail.value;
   store.updateVisualTransform({ index, transform: value });
+  render();
+};
+
+export const handleFileExplorerItemClick = (deps, payload) => {
+  const { refs, store, render } = deps;
+  const { itemId, isFolder } = payload._event.detail;
+  const { resourceId } = store.selectResourceExplorerTarget({ itemId });
+
+  if (isFolder) {
+    const groupElement = refs.galleryScroll?.querySelector(
+      `[data-group-id="${itemId}"]`,
+    );
+    groupElement?.scrollIntoView?.({ block: "start" });
+    return;
+  }
+
+  store.setTempSelectedResourceId({ resourceId });
+  render();
+};
+
+export const handleSearchInput = (deps, payload) => {
+  const { store, render } = deps;
+  store.setSearchQuery({ value: payload._event.detail.value ?? "" });
   render();
 };
 
 export const handleResourceItemClick = (deps, payload) => {
   const { store, render } = deps;
-  const target = payload._event.currentTarget;
-  const resourceId =
-    target?.dataset?.resourceId ||
-    target?.id?.replace("resourceItem", "") ||
-    "";
+  const resourceId = payload._event.currentTarget.dataset.resourceId;
 
   store.setTempSelectedResourceId({ resourceId });
+  render();
+};
+
+export const handleResourceItemDoubleClick = (deps, payload) => {
+  const { store, render } = deps;
+  const resourceId = payload._event.currentTarget.dataset.resourceId;
+  const item = store.selectResourceItemById({ resourceId });
+
+  if (!item?.previewFileId) {
+    return;
+  }
+
+  store.setTempSelectedResourceId({ resourceId });
+  store.showFullImagePreview({ fileId: item.previewFileId });
   render();
 };
 

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -1,5 +1,90 @@
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
 
+const RESOURCE_TYPES = [
+  { type: "image", label: "Images" },
+  { type: "video", label: "Videos" },
+  { type: "layout", label: "Layouts" },
+];
+
+const getCollectionTree = (collection) => {
+  if (Array.isArray(collection?.tree)) {
+    return collection.tree;
+  }
+  if (Array.isArray(collection?.order)) {
+    return collection.order;
+  }
+
+  return Object.keys(collection?.items || {}).map((id) => ({ id }));
+};
+
+const isSelectableVisualResource = (resourceType, item) => {
+  return resourceType !== "layout" || item?.layoutType === "visual";
+};
+
+const prefixTreeNode = (node, resourceType, items) => {
+  const item = items[node.id];
+  if (
+    item?.type !== "folder" &&
+    !isSelectableVisualResource(resourceType, item)
+  ) {
+    return undefined;
+  }
+
+  const prefixedNode = { id: `${resourceType}:${node.id}` };
+  if (Array.isArray(node.children) && node.children.length > 0) {
+    const children = node.children
+      .map((child) => prefixTreeNode(child, resourceType, items))
+      .filter(Boolean);
+    if (children.length > 0) {
+      prefixedNode.children = children;
+    }
+  }
+  return prefixedNode;
+};
+
+const buildResourceExplorerItems = ({ images, videos, layouts } = {}) => {
+  const collections = { image: images, video: videos, layout: layouts };
+  const items = {};
+  const tree = [];
+
+  RESOURCE_TYPES.forEach(({ type, label }) => {
+    const collection = collections[type] || { items: {}, tree: [] };
+    const rootId = `${type}:root`;
+    const childNodes = getCollectionTree(collection)
+      .map((node) => prefixTreeNode(node, type, collection.items || {}))
+      .filter(Boolean);
+
+    items[rootId] = { type: "folder", name: label, resourceType: type };
+    Object.entries(collection.items || {}).forEach(([id, item]) => {
+      if (item.type !== "folder" && !isSelectableVisualResource(type, item)) {
+        return;
+      }
+
+      items[`${type}:${id}`] = {
+        ...item,
+        resourceId: id,
+        resourceType: type,
+      };
+    });
+
+    tree.push({ id: rootId, children: childNodes });
+  });
+
+  return { items, tree };
+};
+
+const parseResourceExplorerId = (itemId = "") => {
+  const separatorIndex = itemId.indexOf(":");
+  if (separatorIndex === -1) {
+    return { resourceType: undefined, resourceId: itemId };
+  }
+
+  return {
+    resourceType: itemId.slice(0, separatorIndex),
+    resourceId: itemId.slice(separatorIndex + 1),
+  };
+};
+
 export const createInitialState = () => ({
   mode: "current",
   images: { items: {}, tree: [] },
@@ -17,6 +102,9 @@ export const createInitialState = () => ({
   selectedVisuals: [],
   tempSelectedResourceId: undefined,
   selectedVisualIndex: undefined,
+  searchQuery: "",
+  fullImagePreviewVisible: false,
+  fullImagePreviewFileId: undefined,
   dropdownMenu: {
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -87,6 +175,24 @@ export const setTempSelectedResourceId = ({ state }, { resourceId } = {}) => {
   state.tempSelectedResourceId = resourceId;
 };
 
+export const setSearchQuery = ({ state }, { value } = {}) => {
+  state.searchQuery = value ?? "";
+};
+
+export const showFullImagePreview = ({ state }, { fileId } = {}) => {
+  if (!fileId) {
+    return;
+  }
+
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewFileId = fileId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewFileId = undefined;
+};
+
 export const setSelectedVisualIndex = ({ state }, { index } = {}) => {
   state.selectedVisualIndex = index;
 };
@@ -122,8 +228,43 @@ export const selectSelectedVisualIndex = ({ state }) => {
   return state.selectedVisualIndex;
 };
 
+export const selectResourceExplorerTarget = (_deps, { itemId } = {}) => {
+  return parseResourceExplorerId(itemId);
+};
+
 export const setExistingVisuals = ({ state }, { visuals } = {}) => {
   state.selectedVisuals = visuals;
+};
+
+export const selectResourceItemById = ({ state }, { resourceId } = {}) => {
+  const imageData = state.images.items?.[resourceId];
+  if (imageData) {
+    return {
+      ...imageData,
+      resourceType: "image",
+      previewFileId: imageData.thumbnailFileId || imageData.fileId,
+    };
+  }
+
+  const videoData = state.videos.items?.[resourceId];
+  if (videoData) {
+    return {
+      ...videoData,
+      resourceType: "video",
+      previewFileId: videoData.thumbnailFileId || videoData.fileId,
+    };
+  }
+
+  const layoutData = state.layouts.items?.[resourceId];
+  if (layoutData?.layoutType === "visual") {
+    return {
+      ...layoutData,
+      resourceType: "layout",
+      previewFileId: layoutData.thumbnailFileId || layoutData.fileId,
+    };
+  }
+
+  return undefined;
 };
 
 export const selectVisualsWithRepositoryData = ({ state }) => {
@@ -165,47 +306,72 @@ export const selectVisualsWithRepositoryData = ({ state }) => {
 };
 
 export const selectViewData = ({ state }) => {
+  const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
+  const matchesSearch = (item) => {
+    if (!searchQuery) {
+      return true;
+    }
+
+    const name = (item.name ?? "").toLowerCase();
+    const description = (item.description ?? "").toLowerCase();
+    return name.includes(searchQuery) || description.includes(searchQuery);
+  };
+  const buildResourceGroups = ({ collection, resourceType, childFilter }) => {
+    return toFlatGroups(collection)
+      .map((group) => {
+        const children = group.children
+          .filter(childFilter)
+          .filter(matchesSearch)
+          .map((child) => {
+            const isSelected = child.id === state.tempSelectedResourceId;
+            return {
+              ...child,
+              resourceType,
+              previewFileId: child.thumbnailFileId || child.fileId,
+              itemBorderColor: isSelected ? "pr" : "bo",
+              itemHoverBorderColor: isSelected ? "pr" : "ac",
+            };
+          });
+
+        return {
+          ...group,
+          resourceType,
+          groupId: `${resourceType}:${group.id}`,
+          children,
+          hasChildren: children.length > 0,
+          shouldDisplay: !searchQuery || children.length > 0,
+        };
+      })
+      .filter((group) => group.shouldDisplay);
+  };
+
   // Add images
-  const imageGroups = toFlatGroups(state.images).map((group) => ({
-    ...group,
+  const imageGroups = buildResourceGroups({
+    collection: state.images,
     resourceType: "image",
-    children: group.children.map((child) => ({
-      ...child,
-      resourceType: "image",
-      previewFileId: child.thumbnailFileId || child.fileId,
-      bw: child.id === state.tempSelectedResourceId ? "md" : "",
-    })),
-  }));
+    childFilter: () => true,
+  });
 
   // Add videos
-  const videoGroups = toFlatGroups(state.videos).map((group) => ({
-    ...group,
+  const videoGroups = buildResourceGroups({
+    collection: state.videos,
     resourceType: "video",
-    children: group.children.map((child) => ({
-      ...child,
-      resourceType: "video",
-      previewFileId: child.thumbnailFileId || child.fileId,
-      bw: child.id === state.tempSelectedResourceId ? "md" : "",
-    })),
-  }));
+    childFilter: () => true,
+  });
 
   // Add layouts (only visual type)
-  const layoutGroups = toFlatGroups(state.layouts)
-    .map((group) => ({
-      ...group,
-      resourceType: "layout",
-      children: group.children
-        .filter((child) => child.layoutType === "visual")
-        .map((child) => ({
-          ...child,
-          resourceType: "layout",
-          previewFileId: child.thumbnailFileId || child.fileId,
-          bw: child.id === state.tempSelectedResourceId ? "md" : "",
-        })),
-    }))
-    .filter((group) => group.children.length > 0);
+  const layoutGroups = buildResourceGroups({
+    collection: state.layouts,
+    resourceType: "layout",
+    childFilter: (child) => child.layoutType === "visual",
+  });
 
   const resourceGroups = [...imageGroups, ...videoGroups, ...layoutGroups];
+  const resourceItems = buildResourceExplorerItems({
+    images: state.images,
+    videos: state.videos,
+    layouts: state.layouts,
+  });
 
   // Get transform options
   const transformItems = toFlatItems(state.transforms).filter(
@@ -258,9 +424,14 @@ export const selectViewData = ({ state }) => {
 
   return {
     mode: state.mode,
+    resourceItems,
     resourceGroups,
     selectedVisuals: processedSelectedVisuals,
     transformOptions,
+    searchQuery: state.searchQuery,
+    searchPlaceholder: "Search...",
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewFileId: state.fullImagePreviewFileId,
     breadcrumb,
     defaultValues,
     dropdownMenu: state.dropdownMenu,

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -17,6 +17,21 @@ refs:
     eventListeners:
       click:
         handler: handleResourceItemClick
+      dblclick:
+        handler: handleResourceItemDoubleClick
+  baseFileExplorer:
+    eventListeners:
+      item-click:
+        handler: handleFileExplorerItemClick
+  galleryScroll: {}
+  searchInput:
+    eventListeners:
+      value-input:
+        handler: handleSearchInput
+  previewOverlay:
+    eventListeners:
+      click:
+        action: hideFullImagePreview
   submitButton:
     eventListeners:
       click:
@@ -47,39 +62,52 @@ template:
           - rtgl-view h=1fg sv w=f:
               - rtgl-view g=md w=f:
                   - $for visual, i in defaultValues.visuals:
-                      - rtgl-view#visual${i} data-index=${i} data-visual-id=${visual.id} d=h g=md av=t bgc=ac p=md br=md w=f:
-                          - rtgl-view g=sm:
-                              - $if visual.fileId:
-                                  - rvn-file-image fileId=${visual.fileId} w=120 h=120 br=sm: null
-                                $else:
-                                  - rtgl-view w=120 h=120 av=c ah=c bgc=mu br=sm cur=pointer:
-                                      - rtgl-text s=sm c=mu-fg: No Resource
-                              - rtgl-text s=sm w=120 ah=c ellipsis=true: ${visual.displayName}
-                              - $if visual.resourceType:
-                                  - rtgl-text s=xs c=mu-fg ah=c: (${visual.resourceType})
+                      - rtgl-view#visual${i} data-index=${i} data-visual-id=${visual.id} d=h g=md av=t p=md br=md w=f:
+                          - rtgl-view cur=pointer bw=xs bc=bo h-bc=ac br=sm:
+                              - rtgl-view p=md g=md br=md:
+                                  - $if visual.fileId:
+                                      - rvn-file-image fileId=${visual.fileId} w=200 h=120: null
+                                    $else:
+                                      - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                          - rtgl-text s=sm c=mu-fg: No Resource
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${visual.displayName}
                           - rtgl-view w=1fg g=sm:
                               - rtgl-text s=sm c=mu-fg: Transform
-                              - rtgl-select#transform${i} :options=${defaultValues.transformOptions} :selectedValue=${defaultValues.visuals[i].transformId} w=f: null
+                              - rtgl-select#transform${i} data-index=${i} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear: null
                   - rtgl-button#addVisualButton v=ol w=f mt=md: + Add Visual
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#submitButton: Submit
       - $if mode == 'resource-select':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - 'rtgl-view d=h w=f g=lg h=1fg style="min-height: 0;"':
-              - rtgl-view h=f w=1fg sv g=lg:
+          - rtgl-view d=h w=f av=c g=md:
+              - rtgl-view w=1fg: null
+              - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
+              - rtgl-view h=f w=1fg sv:
+                  - rvn-base-file-explorer#baseFileExplorer :items=${resourceItems}: null
+              - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                   - $for group, i in resourceGroups:
-                      - rtgl-view g=md:
-                          - rtgl-text: ${group.name}
+                      - rtgl-view data-group-id=${group.groupId} g=md:
+                          - rtgl-view d=h av=c g=md:
+                              - rtgl-svg svg=folder wh=16: null
+                              - rtgl-text: ${group.fullLabel}
                           - rtgl-view d=h w=f wrap g=lg:
                               - $for item, j in group.children:
-                                  - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} w=200 h=150 cur=pointer key=${item.bw} bw=${item.bw} bc=pr br=sm g=sm:
-                                      - $if item.previewFileId:
-                                          - rvn-file-image fileId=${item.previewFileId} w=200 h=120: null
-                                        $else:
-                                          - rtgl-view w=200 h=120 bgc=mu av=c ah=c:
-                                              - rtgl-text s=sm c=mu-fg: ${item.resourceType}
-                                      - rtgl-text s=sm ah=c ellipsis=true: ${item.name}
+                                  - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} data-resource-type=${item.resourceType} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
+                                      - rtgl-view p=md g=md br=md:
+                                          - $if item.previewFileId:
+                                              - rvn-file-image fileId=${item.previewFileId} w=200 h=120: null
+                                            $else:
+                                              - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                                  - rtgl-text s=sm c=mu-fg: ${item.resourceType}
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: #000;"': null
+      - $if fullImagePreviewFileId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/imageSelector/imageSelector.handlers.js
+++ b/src/components/imageSelector/imageSelector.handlers.js
@@ -50,11 +50,27 @@ export const handleImageItemClick = (deps, payload) => {
   render();
 };
 
+export const handleImageItemDoubleClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  const imageId = payload._event.currentTarget?.dataset?.itemId;
+  if (!imageId) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("image-dblclick", {
+      detail: {
+        imageId,
+      },
+    }),
+  );
+};
+
 export const handleScrollToItem = (deps, payload) => {
   const { refs } = deps;
 
   const { container } = refs;
-  const { id } = payload;
+  const id = payload.itemId ?? payload.id;
 
   // Find the group element by stable data attribute.
   const groupElement = container.querySelector(`[data-group-id="${id}"]`);

--- a/src/components/imageSelector/imageSelector.handlers.js
+++ b/src/components/imageSelector/imageSelector.handlers.js
@@ -71,6 +71,9 @@ export const handleScrollToItem = (deps, payload) => {
 
   const { container } = refs;
   const id = payload.itemId ?? payload.id;
+  if (!container || !id) {
+    return;
+  }
 
   // Find the group element by stable data attribute.
   const groupElement = container.querySelector(`[data-group-id="${id}"]`);

--- a/src/components/imageSelector/imageSelector.schema.yaml
+++ b/src/components/imageSelector/imageSelector.schema.yaml
@@ -4,3 +4,5 @@ propsSchema:
   properties:
     selectedImageId:
       type: string
+    searchQuery:
+      type: string

--- a/src/components/imageSelector/imageSelector.store.js
+++ b/src/components/imageSelector/imageSelector.store.js
@@ -31,13 +31,12 @@ export const selectViewData = ({ state }) => {
       ...group,
       children: group.children.map((child) => {
         const isSelected = child.id === selectedImageId;
+        const itemBorderColor = isSelected ? "pr" : "bo";
+        const itemHoverBorderColor = isSelected ? "pr" : "ac";
         return {
           ...child,
-          bw: isSelected ? "md" : "xs",
-          bc: isSelected ? "pr" : "mu",
-          selectedStyle: isSelected
-            ? "outline: 2px solid var(--color-pr); outline-offset: 2px;"
-            : "",
+          itemBorderColor,
+          itemHoverBorderColor,
         };
       }),
     };

--- a/src/components/imageSelector/imageSelector.store.js
+++ b/src/components/imageSelector/imageSelector.store.js
@@ -21,26 +21,45 @@ export const setImages = ({ state }, { images } = {}) => {
   state.images = images;
 };
 
-export const selectViewData = ({ state }) => {
+const matchesSearch = (item, searchQuery) => {
+  if (!searchQuery) {
+    return true;
+  }
+
+  const name = (item.name ?? "").toLowerCase();
+  const description = (item.description ?? "").toLowerCase();
+  return name.includes(searchQuery) || description.includes(searchQuery);
+};
+
+export const selectViewData = ({ state, props = {} }) => {
   const images = state.images || { items: {}, tree: [] }; // Raw data from state
   const selectedImageId = state.selectedImageId; // Use state instead of props
+  const searchQuery = (props.searchQuery ?? "").toLowerCase().trim();
 
   // Process images into groups here, like in commandLineBackground
-  const groups = toFlatGroups(images).map((group) => {
-    return {
-      ...group,
-      children: group.children.map((child) => {
-        const isSelected = child.id === selectedImageId;
-        const itemBorderColor = isSelected ? "pr" : "bo";
-        const itemHoverBorderColor = isSelected ? "pr" : "ac";
-        return {
-          ...child,
-          itemBorderColor,
-          itemHoverBorderColor,
-        };
-      }),
-    };
-  });
+  const groups = toFlatGroups(images)
+    .map((group) => {
+      const children = group.children
+        .filter((child) => matchesSearch(child, searchQuery))
+        .map((child) => {
+          const isSelected = child.id === selectedImageId;
+          const itemBorderColor = isSelected ? "pr" : "bo";
+          const itemHoverBorderColor = isSelected ? "pr" : "ac";
+          return {
+            ...child,
+            itemBorderColor,
+            itemHoverBorderColor,
+          };
+        });
+
+      return {
+        ...group,
+        children,
+        hasChildren: children.length > 0,
+        shouldDisplay: !searchQuery || children.length > 0,
+      };
+    })
+    .filter((group) => group.shouldDisplay);
 
   return {
     groups: groups, // Processed groups for template

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -10,7 +10,7 @@ template:
               - rtgl-text: ${group.name}
           - rtgl-view d=h w=f wrap g=lg:
               - $for item, j in group.children:
-                  - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} w=200 h=150 bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer key=${item.id}:
-                      - rtgl-view p=md g=md br=md w=f h=f:
-                          - rvn-file-image w=f h=1fg imageId=${item.id} source="thumbnail": null
-                          - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
+                  - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer key=${item.id}:
+                      - rtgl-view p=md g=md br=md:
+                          - rvn-file-image w=200 h=120 imageId=${item.id} source="thumbnail": null
+                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -3,11 +3,15 @@ refs:
     eventListeners:
       click:
         handler: handleImageItemClick
+      dblclick:
+        handler: handleImageItemDoubleClick
 template:
   - rtgl-view#container h=1fg sv g=lg:
       - $for group, i in groups:
           - 'rtgl-view#groupRef${i} data-group-id=${group.id} mb=sm w=f bgc=bg style="position: sticky; top: 0"':
-              - rtgl-text: ${group.name}
+              - rtgl-view d=h av=c g=md:
+                  - rtgl-svg svg=folder wh=16: null
+                  - rtgl-text: ${group.fullLabel}
           - rtgl-view d=h w=f wrap g=lg:
               - $for item, j in group.children:
                   - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer key=${item.id}:

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -1,4 +1,5 @@
 refs:
+  container: {}
   imageItem*:
     eventListeners:
       click:

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -10,5 +10,5 @@ template:
               - rtgl-text: ${group.name}
           - rtgl-view d=h w=f wrap g=lg:
               - $for item, j in group.children:
-                  - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} w=200 h=150 bw=${item.bw} bc=${item.bc} br=sm cur=pointer style="${item.selectedStyle}" key=${item.id}:
-                      - rvn-file-image w=200 h=150 imageId=${item.id} source="thumbnail": null
+                  - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} w=200 h=150 bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer key=${item.id}:
+                      - rvn-file-image w=f h=f imageId=${item.id} source="thumbnail": null

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -11,4 +11,6 @@ template:
           - rtgl-view d=h w=f wrap g=lg:
               - $for item, j in group.children:
                   - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} w=200 h=150 bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm cur=pointer key=${item.id}:
-                      - rvn-file-image w=f h=f imageId=${item.id} source="thumbnail": null
+                      - rtgl-view p=md g=md br=md w=f h=f:
+                          - rvn-file-image w=f h=1fg imageId=${item.id} source="thumbnail": null
+                          - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -89,6 +89,18 @@ template:
                                   - $if line.characterSprites.changeType == "delete":
                                       - rtgl-view pos=abs cor=full bgc=danger av=c ah=c:
                                           - rtgl-svg svg=x wh=16 c=white: null
+                          - $if line.visual:
+                              - rtgl-view#previewVisual data-type="visual" data-id="${line.id}" pos=rel mr=sm:
+                                  - $if line.visual.items && line.visual.items.length > 0:
+                                      - rtgl-view d=h:
+                                          - $for visual in line.visual.items:
+                                              - rvn-file-image fileId=${visual.fileId} w=36 h=24: null
+                                    $else:
+                                      - rtgl-view w=36 h=24 av=c ah=c:
+                                          - rtgl-svg svg=image wh=24: null
+                                  - $if line.visual.changeType == "delete":
+                                      - rtgl-view pos=abs cor=full bgc=danger av=c ah=c:
+                                          - rtgl-svg svg=x wh=16 c=white: null
                           - $if line.hasDialogueLayout:
                               - rtgl-view#previewDialogue data-type="dialogue" data-id="${line.id}" d=h av=c g=xs mr=sm:
                                   - rtgl-view pos=rel w=24 h=24 av=c ah=c:

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -429,9 +429,11 @@ export const selectActionsData = ({ props, state }) => {
         const imageData = images[item.resourceId];
         const videoData = videos[item.resourceId];
         const layoutData = layoutsItems[item.resourceId];
+        const resource = imageData || videoData || layoutData;
         return {
           ...item,
-          resource: imageData || videoData || layoutData,
+          resource,
+          previewFileId: resource?.thumbnailFileId || resource?.fileId,
           resourceType: imageData ? "image" : videoData ? "video" : "layout",
         };
       }),

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -69,7 +69,10 @@ template:
               - $if preview.visual:
                   - rtgl-view#actionItemVisual data-mode=visual g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=image wh=24: null
-                      - rtgl-text s=sm: ${preview.visual.count} visual(s)
+                      - rtgl-view d=h g=sm av=c:
+                          - $for visualData, i in preview.visual.items:
+                              - $if visualData.previewFileId:
+                                  - rvn-file-image fileId=${visualData.previewFileId} w=32 h=32: null
               - $if preview.sectionTransition:
                   - rtgl-view#actionItemSectionTransition data-mode=sectionTransition g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg="transition" wh=24: null

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -111,6 +111,57 @@ const buildCharacterSpritePreview = (
   };
 };
 
+const resolveVisualPreviewFileId = ({ repositoryState, resourceId }) => {
+  if (!resourceId) {
+    return undefined;
+  }
+
+  const image = repositoryState?.images?.items?.[resourceId];
+  if (image) {
+    return image.thumbnailFileId || image.fileId;
+  }
+
+  const video = repositoryState?.videos?.items?.[resourceId];
+  if (video) {
+    return video.thumbnailFileId || video.fileId;
+  }
+
+  const layout = repositoryState?.layouts?.items?.[resourceId];
+  if (layout) {
+    return layout.thumbnailFileId || layout.fileId;
+  }
+
+  return undefined;
+};
+
+const buildVisualPreview = (repositoryState, changes) => {
+  if (!changes.visual) {
+    return undefined;
+  }
+
+  const visualData = changes.visual.data || {};
+  if (!Array.isArray(visualData.items) || visualData.items.length === 0) {
+    return {
+      changeType: changes.visual.changeType,
+      items: [],
+    };
+  }
+
+  return {
+    changeType: changes.visual.changeType,
+    items: visualData.items
+      .map((visualChange) => ({
+        visualId: visualChange.id,
+        resourceId: visualChange.resourceId,
+        fileId: resolveVisualPreviewFileId({
+          repositoryState,
+          resourceId: visualChange.resourceId,
+        }),
+      }))
+      .filter((item) => item.fileId),
+  };
+};
+
 const buildSectionTransitionPreview = (line, sceneLookups) => {
   const lineActions = normalizeLineActions(line.actions || {});
   const transitionData = lineActions?.sectionTransition;
@@ -236,6 +287,7 @@ export const buildSceneEditorLineViewModels = ({
         changes,
         characterLookups.characterItems,
       ),
+      visual: buildVisualPreview(repositoryState, changes),
       sectionTransition: transitionPreview.sectionTransition,
       transitionTarget: transitionPreview.transitionTarget,
       hasChoices: choicesPreview.hasChoices,


### PR DESCRIPTION
## Summary
- keep gallery selection borders at a constant width and switch only border color for default, hover, and selected states
- update the shared image selector so command-line background image choices no longer use the thick selected border/outline
- remove fixed numeric dimensions from the thumbnail image elements inside the gallery cards

## Testing
- bun prettier --check src/components/commandLineBackground/commandLineBackground.view.yaml src/components/commandLineBackground/commandLineBackground.store.js src/components/imageSelector/imageSelector.view.yaml src/components/imageSelector/imageSelector.store.js
- bunx oxlint src/components/commandLineBackground/commandLineBackground.store.js src/components/imageSelector/imageSelector.store.js
- git diff --check -- src/components/commandLineBackground/commandLineBackground.view.yaml src/components/commandLineBackground/commandLineBackground.store.js src/components/imageSelector/imageSelector.view.yaml src/components/imageSelector/imageSelector.store.js
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src