### PR TITLE
fix: open version ZIP save dialog before export work

### DIFF
--- a/src/deps/services/shared/projectExportService.js
+++ b/src/deps/services/shared/projectExportService.js
@@ -155,5 +155,36 @@ export const createProjectExportService = ({
         getFileContent,
       });
     },
+
+    ...(typeof fileAdapter.promptDistributionZipPath === "function"
+      ? {
+          async promptDistributionZipPath(zipName, options = {}) {
+            return fileAdapter.promptDistributionZipPath({
+              zipName,
+              options,
+              filePicker,
+            });
+          },
+        }
+      : {}),
+
+    ...(typeof fileAdapter.createDistributionZipStreamedToPath === "function"
+      ? {
+          async createDistributionZipStreamedToPath(
+            projectData,
+            fileIds,
+            outputPath,
+          ) {
+            return fileAdapter.createDistributionZipStreamedToPath({
+              projectData,
+              fileIds,
+              outputPath,
+              staticFiles: await getBundleStaticFiles(),
+              getCurrentReference,
+              getFileContent,
+            });
+          },
+        }
+      : {}),
   };
 };

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -184,5 +184,16 @@ export const createProjectServiceCore = ({
     downloadBundle: exportService.downloadBundle,
     createDistributionZip: exportService.createDistributionZip,
     createDistributionZipStreamed: exportService.createDistributionZipStreamed,
+    ...("promptDistributionZipPath" in exportService
+      ? {
+          promptDistributionZipPath: exportService.promptDistributionZipPath,
+        }
+      : {}),
+    ...("createDistributionZipStreamedToPath" in exportService
+      ? {
+          createDistributionZipStreamedToPath:
+            exportService.createDistributionZipStreamedToPath,
+        }
+      : {}),
   };
 };

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -101,6 +101,76 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
     return `${projectKey}:${fileId ?? ""}`;
   };
 
+  const promptDistributionZipPath = async ({
+    zipName,
+    options = {},
+    filePicker,
+  }) => {
+    return filePicker.saveFilePicker({
+      title: options.title || "Save Distribution ZIP",
+      defaultPath: `${zipName}.zip`,
+      filters: [{ name: "ZIP Archive", extensions: ["zip"] }],
+    });
+  };
+
+  const collectDistributionZipAssets = async ({
+    fileIds,
+    getCurrentReference,
+  }) => {
+    const reference = getCurrentReference();
+    const filesPath = await join(reference.projectPath, "files");
+    const uniqueFileIds = [];
+    const seenFileIds = new Set();
+
+    for (const fileId of fileIds || []) {
+      if (!fileId || seenFileIds.has(fileId)) continue;
+      seenFileIds.add(fileId);
+      uniqueFileIds.push(fileId);
+    }
+
+    const assets = [];
+    for (const fileId of uniqueFileIds) {
+      const filePath = await join(filesPath, fileId);
+      const fileExists = await exists(filePath);
+      if (!fileExists) {
+        console.warn(`Skipping missing file during export: ${fileId}`);
+        continue;
+      }
+      assets.push({
+        id: fileId,
+        path: filePath,
+        mime: "application/octet-stream",
+      });
+    }
+
+    return assets;
+  };
+
+  const createDistributionZipStreamedToPath = async ({
+    projectData,
+    fileIds,
+    outputPath,
+    staticFiles,
+    options = {},
+    getCurrentReference,
+  }) => {
+    const assets = await collectDistributionZipAssets({
+      fileIds,
+      getCurrentReference,
+    });
+
+    await invoke("create_distribution_zip_streamed", {
+      outputPath,
+      assets,
+      instructionsJson: JSON.stringify(projectData),
+      indexHtml: staticFiles.indexHtml || null,
+      mainJs: staticFiles.mainJs || null,
+      usePartFile: options.usePartFile ?? true,
+    });
+
+    return outputPath;
+  };
+
   const storageAdapter = {
     resolveProjectReferenceByProjectId: async ({ db, projectId }) => {
       const projects = (await db.get("projectEntries")) || [];
@@ -338,52 +408,24 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
       getCurrentReference,
     }) => {
       try {
-        const selectedPath = await filePicker.saveFilePicker({
-          title: options.title || "Save Distribution ZIP",
-          defaultPath: `${zipName}.zip`,
-          filters: [{ name: "ZIP Archive", extensions: ["zip"] }],
+        const selectedPath = await promptDistributionZipPath({
+          zipName,
+          options,
+          filePicker,
         });
 
         if (!selectedPath) {
           return null;
         }
 
-        const reference = getCurrentReference();
-        const filesPath = await join(reference.projectPath, "files");
-        const uniqueFileIds = [];
-        const seenFileIds = new Set();
-
-        for (const fileId of fileIds || []) {
-          if (!fileId || seenFileIds.has(fileId)) continue;
-          seenFileIds.add(fileId);
-          uniqueFileIds.push(fileId);
-        }
-
-        const assets = [];
-        for (const fileId of uniqueFileIds) {
-          const filePath = await join(filesPath, fileId);
-          const fileExists = await exists(filePath);
-          if (!fileExists) {
-            console.warn(`Skipping missing file during export: ${fileId}`);
-            continue;
-          }
-          assets.push({
-            id: fileId,
-            path: filePath,
-            mime: "application/octet-stream",
-          });
-        }
-
-        await invoke("create_distribution_zip_streamed", {
+        return createDistributionZipStreamedToPath({
+          projectData,
+          fileIds,
           outputPath: selectedPath,
-          assets,
-          instructionsJson: JSON.stringify(projectData),
-          indexHtml: staticFiles.indexHtml || null,
-          mainJs: staticFiles.mainJs || null,
-          usePartFile: options.usePartFile ?? true,
+          staticFiles,
+          options,
+          getCurrentReference,
         });
-
-        return selectedPath;
       } catch (error) {
         console.error(
           "Error saving streamed distribution ZIP with dialog:",
@@ -392,6 +434,9 @@ export const createTauriProjectServiceAdapters = ({ collabLog }) => {
         throw error;
       }
     },
+
+    promptDistributionZipPath,
+    createDistributionZipStreamedToPath,
   };
 
   const collabAdapter = {

--- a/src/pages/versions/versions.handlers.js
+++ b/src/pages/versions/versions.handlers.js
@@ -71,6 +71,20 @@ const resolveVersionIdFromPayload = (payload = {}) => {
   return payload?._event?.currentTarget?.dataset?.versionId ?? "";
 };
 
+const getVersionZipName = ({ appService, projectId, version } = {}) => {
+  const currentProjectEntry =
+    typeof appService?.getCurrentProjectEntry === "function"
+      ? appService.getCurrentProjectEntry()
+      : undefined;
+  const entryName =
+    currentProjectEntry?.id === projectId
+      ? currentProjectEntry?.name?.trim?.()
+      : "";
+  const projectName = entryName || "project";
+
+  return `${projectName}_${version?.name ?? "version"}`;
+};
+
 export const handleAfterMount = async (deps) => {
   await refreshVersionsData(deps);
 };
@@ -233,10 +247,6 @@ export const handleDownloadZipClick = async (deps, payload) => {
   const currentPayload = appService.getPayload();
   const projectId = currentPayload.p ?? "";
 
-  appService.showToast("Please wait while the bundle is being created...", {
-    title: "Bundle in progress",
-  });
-
   const versionId = resolveVersionIdFromPayload(payload);
   const version = store.selectVersion(versionId);
 
@@ -251,46 +261,65 @@ export const handleDownloadZipClick = async (deps, payload) => {
   store.setSelectedItemId({ itemId: versionId });
   render();
 
-  const repository = await projectService.getRepository();
-  const repositoryState = repository.getState(version.actionIndex);
-  const usage = collectUsedResourcesForExport(repositoryState);
-  const filteredState = buildFilteredStateForExport(repositoryState, usage);
-  const constructedProjectData = constructProjectData(filteredState);
-  const transformedData = createBundleInstructions({
-    projectData: constructedProjectData,
-    bundler: {
-      appVersion: appService.getAppVersion(),
-    },
+  const zipName = getVersionZipName({
+    appService,
+    projectId,
+    version,
   });
-  const fileIds = usage.fileIds;
-  let projectName = "project";
+  let outputPath;
 
-  if (projectId && typeof appService.getProjectEntries === "function") {
-    const entries = await appService.getProjectEntries();
-    const projectEntry = Array.isArray(entries)
-      ? entries.find((entry) => entry?.id === projectId)
-      : undefined;
-    const entryName = projectEntry?.name?.trim?.();
-    if (entryName) {
-      projectName = entryName;
+  if (typeof projectService.promptDistributionZipPath === "function") {
+    try {
+      outputPath = await projectService.promptDistributionZipPath(zipName);
+    } catch (error) {
+      appService.showToast(`Failed to open save dialog: ${error.message}`, {
+        title: "Error",
+      });
+      return;
     }
-  }
-
-  const zipName = `${projectName}_${version.name}`;
-
-  try {
-    const outputPath = await projectService.createDistributionZipStreamed(
-      transformedData,
-      fileIds,
-      zipName,
-    );
 
     if (!outputPath) {
       appService.closeAll();
       return;
     }
+  }
 
-    appService.showToast(`ZIP export completed.\nSaved to: ${outputPath}`, {
+  appService.showToast("Please wait while the bundle is being created...", {
+    title: "Bundle in progress",
+  });
+
+  try {
+    const repository = await projectService.getRepository();
+    const repositoryState = repository.getState(version.actionIndex);
+    const usage = collectUsedResourcesForExport(repositoryState);
+    const filteredState = buildFilteredStateForExport(repositoryState, usage);
+    const constructedProjectData = constructProjectData(filteredState);
+    const transformedData = createBundleInstructions({
+      projectData: constructedProjectData,
+      bundler: {
+        appVersion: appService.getAppVersion(),
+      },
+    });
+    const savedPath =
+      outputPath &&
+      typeof projectService.createDistributionZipStreamedToPath === "function"
+        ? await projectService.createDistributionZipStreamedToPath(
+            transformedData,
+            usage.fileIds,
+            outputPath,
+          )
+        : await projectService.createDistributionZipStreamed(
+            transformedData,
+            usage.fileIds,
+            zipName,
+          );
+
+    if (!savedPath) {
+      appService.closeAll();
+      return;
+    }
+
+    appService.showToast(`ZIP export completed.\nSaved to: ${savedPath}`, {
       title: "Export completed",
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- prompt for the version ZIP save path before replaying repository state and preparing export data
- add optional export service hooks so Tauri can reuse a preselected output path for streamed ZIP export
- keep the existing fallback export flow for platforms that cannot preselect a save path

## Testing
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`
- `bunx oxlint src/pages/versions/versions.handlers.js src/deps/services/shared/projectExportService.js src/deps/services/shared/projectServiceCore.js src/deps/services/tauri/projectServiceAdapters.js`
- `bunx prettier --check src/pages/versions/versions.handlers.js src/deps/services/shared/projectExportService.js src/deps/services/shared/projectServiceCore.js src/deps/services/tauri/projectServiceAdapters.js`