### PR TITLE
fix: refine layout editor selectors and resource actions

### DIFF
--- a/src/components/groupVariablesView/groupVariablesView.handlers.js
+++ b/src/components/groupVariablesView/groupVariablesView.handlers.js
@@ -215,9 +215,16 @@ export const handleRowContextMenu = (deps, payload) => {
 export const handleContextMenuClickItem = (deps, payload) => {
   const { store, render, dispatchEvent } = deps;
   const item = payload._event.detail.item;
+  const itemId = store.selectTargetItemId();
+
+  store.hideContextMenu();
+
+  if (item && item.value === "edit-item") {
+    openEditDialogForItem({ deps, itemId });
+    return;
+  }
 
   if (item && item.value === "delete-item") {
-    const itemId = store.selectTargetItemId();
     dispatchEvent(
       new CustomEvent("variable-delete", {
         detail: { itemId },
@@ -227,7 +234,6 @@ export const handleContextMenuClickItem = (deps, payload) => {
     );
   }
 
-  store.hideContextMenu();
   render();
 };
 

--- a/src/components/groupVariablesView/groupVariablesView.store.js
+++ b/src/components/groupVariablesView/groupVariablesView.store.js
@@ -19,7 +19,10 @@ export const createInitialState = () => ({
     x: 0,
     y: 0,
     targetItemId: null,
-    items: [{ label: "Delete", type: "item", value: "delete-item" }],
+    items: [
+      { label: "Edit", type: "item", value: "edit-item" },
+      { label: "Delete", type: "item", value: "delete-item" },
+    ],
   },
 
   defaultValues: structuredClone(DEFAULT_FORM_VALUES),

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -7,7 +7,7 @@ refs:
       dblclick:
         handler: handleImageItemDoubleClick
 template:
-  - rtgl-view#container h=1fg sv g=lg:
+  - 'rtgl-view#container h=1fg sv g=lg style="outline: none;"':
       - $for group, i in groups:
           - 'rtgl-view#groupRef${i} data-group-id=${group.id} mb=sm w=f bgc=bg style="position: sticky; top: 0"':
               - rtgl-view d=h av=c g=md:

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -1274,6 +1274,27 @@ export const handleImageSelectorImageSelected = (deps, payload) => {
   });
 };
 
+export const handleImageSelectorImageDoubleClick = (deps, payload) => {
+  const imageId = payload?._event?.detail?.imageId;
+  if (!imageId) {
+    return;
+  }
+
+  deps.store.showFullImagePreview({ imageId });
+  deps.render();
+};
+
+export const handleImageSelectorFileExplorerClickItem = (deps, payload) => {
+  const itemId = payload?._event?.detail?.itemId;
+  if (!itemId) {
+    return;
+  }
+
+  deps.refs.imageSelector?.transformedHandlers?.handleScrollToItem?.({
+    itemId,
+  });
+};
+
 export const handleImageSelectorCancel = (deps) => {
   const { store, render } = deps;
   store.closeImageSelectorDialog();
@@ -1289,4 +1310,9 @@ export const handleImageSelectorSubmit = (deps) => {
     value: imageId,
     closeImageSelector: true,
   });
+};
+
+export const handlePreviewOverlayClick = (deps) => {
+  deps.store.hideFullImagePreview();
+  deps.render();
 };

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -1,6 +1,7 @@
 import { parseAndRender } from "jempl";
 import { getFirstTextStyleId } from "../../constants/textStyles.js";
 import { getVariableOptions } from "../../internal/project/projection.js";
+import { toFlatItems } from "../../internal/project/tree.js";
 import { getFragmentLayoutOptions } from "../../pages/layoutEditor/support/layoutFragments.js";
 import { getLayoutEditorElementDefinition } from "../../internal/layoutEditorElementRegistry.js";
 import { splitLayoutConditionFromWhen } from "../../internal/layoutConditions.js";
@@ -209,6 +210,8 @@ export const createInitialState = () => {
       open: false,
       name: undefined,
     },
+    fullImagePreviewVisible: false,
+    fullImagePreviewImageId: undefined,
     popover: {
       key: 0,
       x: undefined,
@@ -488,6 +491,8 @@ export const openImageSelectorDialog = ({ state }, { name } = {}) => {
     open: true,
     name,
   };
+  state.tempSelectedImageId =
+    typeof name === "string" ? state.values?.[name] : undefined;
 };
 
 export const closeImageSelectorDialog = ({ state }, _payload = {}) => {
@@ -496,6 +501,16 @@ export const closeImageSelectorDialog = ({ state }, _payload = {}) => {
     name: undefined,
   };
   state.tempSelectedImageId = undefined;
+};
+
+export const showFullImagePreview = ({ state }, { imageId } = {}) => {
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewImageId = imageId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
 };
 
 export const setValues = ({ state }, { values } = {}) => {
@@ -610,6 +625,9 @@ export const selectTextStyleOptions = ({ state }) => {
 export const selectViewData = ({ state, props, constants }) => {
   const textStyleItems = toTextStyleOptions(state.textStylesData);
   const imageItems = toImageOptions(state.imagesData);
+  const imageFolderItems = toFlatItems(state.imagesData).filter(
+    (item) => item.type === "folder",
+  );
   const firstTextStyleId = getFirstTextStyleId(state.textStylesData);
   const textStyleItemsWithNone = [
     { label: "None", value: "" },
@@ -831,5 +849,8 @@ export const selectViewData = ({ state, props, constants }) => {
     },
     imageSelectorDialog: state.imageSelectorDialog,
     tempSelectedImageId: state.tempSelectedImageId,
+    imageFolderItems,
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewImageId: state.fullImagePreviewImageId,
   };
 };

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -125,10 +125,16 @@ refs:
     eventListeners:
       close:
         handler: handleImageSelectorCancel
+  imageSelectorFileExplorer:
+    eventListeners:
+      item-click:
+        handler: handleImageSelectorFileExplorerClickItem
   imageSelector:
     eventListeners:
       image-selected:
         handler: handleImageSelectorImageSelected
+      image-dblclick:
+        handler: handleImageSelectorImageDoubleClick
   confirmImageSelection:
     eventListeners:
       click:
@@ -137,6 +143,10 @@ refs:
     eventListeners:
       click:
         handler: handleImageSelectorCancel
+  previewOverlay:
+    eventListeners:
+      click:
+        handler: handlePreviewOverlayClick
   listBarItem*:
     eventListeners:
       click:
@@ -264,9 +274,19 @@ template:
   - rtgl-dialog#conditionalOverrideAttributeDialog ?open=${conditionalOverrideAttributeDialog.open} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#conditionalOverrideAttributeForm key=${conditionalOverrideAttributeDialog.key} :form=${conditionalOverrideAttributeForm} :defaultValues=${conditionalOverrideAttributeDefaults} :context=${conditionalOverrideAttributeDialogContext} w=f: null
-  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open}:
-      - rtgl-view slot=content g=md:
-          - rvn-image-selector#imageSelector: null
+  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
+      - rtgl-view slot=content d=v w=f g=md:
+          - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
+              - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-image-selector#imageSelector selectedImageId=${tempSelectedImageId}: null
           - rtgl-view d=h g=sm w=f ah=e:
               - rtgl-button#cancelImageSelection variant=se: Cancel
               - rtgl-button#confirmImageSelection variant=pr: OK
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
+      - $if fullImagePreviewImageId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image imageId=${fullImagePreviewImageId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -277,6 +277,7 @@ const renderLayoutEditorCanvas = async (
   { clearFirst = false, updatedItem } = {},
 ) => {
   try {
+    await deps.graphicsService.waitUntilReady?.();
     const repositoryState = await getRepositoryState(deps);
     const layoutData = updatedItem
       ? createLayoutDataWithUpdatedItem(

--- a/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.handlers.js
+++ b/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.handlers.js
@@ -19,10 +19,22 @@ const createValidationErrors = (images = {}) => {
   return errors;
 };
 
+const syncImagesData = (deps) => {
+  deps.store.setImagesData({
+    imagesData: deps.projectService.getRepositoryState()?.images,
+  });
+};
+
 export const handleBeforeMount = (deps) => {
+  syncImagesData(deps);
   deps.store.syncFromProps({
     props: deps.props,
   });
+};
+
+export const handleAfterMount = (deps) => {
+  syncImagesData(deps);
+  deps.render();
 };
 
 export const handleOnUpdate = (deps, payload = {}) => {
@@ -86,6 +98,32 @@ export const handleImageSelectorSubmit = (deps) => {
   }
 
   deps.store.closeImageSelectorDialog();
+  deps.render();
+};
+
+export const handleImageDoubleClick = (deps, payload) => {
+  const imageId = payload?._event?.detail?.imageId;
+  if (!imageId) {
+    return;
+  }
+
+  deps.store.showFullImagePreview({ imageId });
+  deps.render();
+};
+
+export const handleFileExplorerClickItem = (deps, payload) => {
+  const itemId = payload?._event?.detail?.itemId;
+  if (!itemId) {
+    return;
+  }
+
+  deps.refs.imageSelector?.transformedHandlers?.handleScrollToItem?.({
+    itemId,
+  });
+};
+
+export const handlePreviewOverlayClick = (deps) => {
+  deps.store.hideFullImagePreview();
   deps.render();
 };
 

--- a/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js
+++ b/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js
@@ -1,3 +1,5 @@
+import { toFlatItems } from "../../internal/project/tree.js";
+
 const createEmptyImages = () => ({
   barImageId: undefined,
   thumbImageId: undefined,
@@ -39,6 +41,12 @@ export const createInitialState = () => {
       fieldName: undefined,
       selectedImageId: undefined,
     },
+    imagesData: {
+      items: {},
+      tree: [],
+    },
+    fullImagePreviewVisible: false,
+    fullImagePreviewImageId: undefined,
     validationErrors: {},
   };
 };
@@ -52,7 +60,16 @@ export const syncFromProps = ({ state }, { props } = {}) => {
     fieldName: undefined,
     selectedImageId: undefined,
   };
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
   state.validationErrors = {};
+};
+
+export const setImagesData = ({ state }, { imagesData } = {}) => {
+  state.imagesData = imagesData ?? {
+    items: {},
+    tree: [],
+  };
 };
 
 export const setImage = ({ state }, { fieldName, imageId } = {}) => {
@@ -95,6 +112,16 @@ export const setValidationErrors = ({ state }, { errors } = {}) => {
   state.validationErrors = errors ?? {};
 };
 
+export const showFullImagePreview = ({ state }, { imageId } = {}) => {
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewImageId = imageId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
+};
+
 export const selectImages = ({ state }) => {
   return state.images;
 };
@@ -104,12 +131,19 @@ export const selectImageSelectorDialog = ({ state }) => {
 };
 
 export const selectViewData = ({ state, constants }) => {
+  const fileExplorerItems = toFlatItems(state.imagesData).filter(
+    (item) => item.type === "folder",
+  );
+
   return {
     form: constants.sliderCreateForm,
     formKey: state.formKey,
     defaultValues: state.defaultValues,
     images: state.images,
     imageSelectorDialog: state.imageSelectorDialog,
+    fileExplorerItems,
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewImageId: state.fullImagePreviewImageId,
     validationErrors: state.validationErrors,
   };
 };

--- a/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml
+++ b/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml
@@ -12,10 +12,16 @@ refs:
     eventListeners:
       close:
         handler: handleImageSelectorCancel
+  baseFileExplorer:
+    eventListeners:
+      item-click:
+        handler: handleFileExplorerClickItem
   imageSelector:
     eventListeners:
       image-selected:
         handler: handleImageSelected
+      image-dblclick:
+        handler: handleImageDoubleClick
   confirmImageSelection:
     eventListeners:
       click:
@@ -24,6 +30,10 @@ refs:
     eventListeners:
       click:
         handler: handleImageSelectorCancel
+  previewOverlay:
+    eventListeners:
+      click:
+        handler: handlePreviewOverlayClick
 template:
   - rtgl-view g=md w=f:
       - rtgl-form#sliderCreateForm key=${formKey} :defaultValues=${defaultValues} :form=${form} w=f:
@@ -59,9 +69,19 @@ template:
                       - rtgl-text c=mu-fg ta=c: Select hover thumb image
               - $if images.hoverThumbImageId:
                   - rtgl-button#clearSliderCreateImageHoverThumb data-field-name=hoverThumbImageId variant=se size=sm: Clear
-  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open}:
-      - rtgl-view slot=content g=md:
-          - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
+  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
+      - rtgl-view slot=content d=v w=f g=md:
+          - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
+              - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
           - rtgl-view d=h g=sm w=f ah=e:
               - rtgl-button#cancelImageSelection variant=se: Cancel
               - rtgl-button#confirmImageSelection variant=pr: OK
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
+      - $if fullImagePreviewImageId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image imageId=${fullImagePreviewImageId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.handlers.js
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.handlers.js
@@ -12,10 +12,22 @@ const createValidationErrors = (imageId) => {
   return errors;
 };
 
+const syncImagesData = (deps) => {
+  deps.store.setImages({
+    images: deps.projectService.getRepositoryState()?.images,
+  });
+};
+
 export const handleBeforeMount = (deps) => {
+  syncImagesData(deps);
   deps.store.syncFromProps({
     props: deps.props,
   });
+};
+
+export const handleAfterMount = (deps) => {
+  syncImagesData(deps);
+  deps.render();
 };
 
 export const handleOnUpdate = (deps, payload = {}) => {
@@ -55,6 +67,32 @@ export const handleImageSelectorSubmit = (deps) => {
     imageId: imageSelectorDialog.selectedImageId,
   });
   deps.store.closeImageSelectorDialog();
+  deps.render();
+};
+
+export const handleImageDoubleClick = (deps, payload) => {
+  const imageId = payload?._event?.detail?.imageId;
+  if (!imageId) {
+    return;
+  }
+
+  deps.store.showFullImagePreview({ imageId });
+  deps.render();
+};
+
+export const handleFileExplorerClickItem = (deps, payload) => {
+  const itemId = payload?._event?.detail?.itemId;
+  if (!itemId) {
+    return;
+  }
+
+  deps.refs.imageSelector?.transformedHandlers?.handleScrollToItem?.({
+    itemId,
+  });
+};
+
+export const handlePreviewOverlayClick = (deps) => {
+  deps.store.hideFullImagePreview();
   deps.render();
 };
 

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js
@@ -1,3 +1,5 @@
+import { toFlatItems } from "../../internal/project/tree.js";
+
 const createDefaultValuesFromProps = (props = {}) => {
   const source = props.defaultValues ?? {};
 
@@ -15,6 +17,12 @@ export const createInitialState = () => {
       open: false,
       selectedImageId: undefined,
     },
+    images: {
+      items: {},
+      tree: [],
+    },
+    fullImagePreviewVisible: false,
+    fullImagePreviewImageId: undefined,
     validationErrors: {},
   };
 };
@@ -28,12 +36,21 @@ export const syncFromProps = ({ state }, { props } = {}) => {
     open: false,
     selectedImageId: undefined,
   };
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
   state.validationErrors = {};
 };
 
 export const setImageId = ({ state }, { imageId } = {}) => {
   state.imageId = imageId;
   delete state.validationErrors.imageId;
+};
+
+export const setImages = ({ state }, { images } = {}) => {
+  state.images = images ?? {
+    items: {},
+    tree: [],
+  };
 };
 
 export const openImageSelectorDialog = ({ state }, _payload = {}) => {
@@ -57,6 +74,16 @@ export const setValidationErrors = ({ state }, { errors } = {}) => {
   state.validationErrors = errors ?? {};
 };
 
+export const showFullImagePreview = ({ state }, { imageId } = {}) => {
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewImageId = imageId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
+};
+
 export const selectImageId = ({ state }) => {
   return state.imageId;
 };
@@ -66,12 +93,19 @@ export const selectImageSelectorDialog = ({ state }) => {
 };
 
 export const selectViewData = ({ state, constants }) => {
+  const fileExplorerItems = toFlatItems(state.images).filter(
+    (item) => item.type === "folder",
+  );
+
   return {
     form: constants.spriteCreateForm,
     formKey: state.formKey,
     defaultValues: state.defaultValues,
     imageId: state.imageId,
     imageSelectorDialog: state.imageSelectorDialog,
+    fileExplorerItems,
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewImageId: state.fullImagePreviewImageId,
     validationErrors: state.validationErrors,
   };
 };

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml
@@ -4,6 +4,10 @@ refs:
     eventListeners:
       click:
         handler: handleImageFieldClick
+  baseFileExplorer:
+    eventListeners:
+      item-click:
+        handler: handleFileExplorerClickItem
   imageSelectorDialog:
     eventListeners:
       close:
@@ -12,6 +16,8 @@ refs:
     eventListeners:
       image-selected:
         handler: handleImageSelected
+      image-dblclick:
+        handler: handleImageDoubleClick
   confirmImageSelection:
     eventListeners:
       click:
@@ -20,6 +26,10 @@ refs:
     eventListeners:
       click:
         handler: handleImageSelectorCancel
+  previewOverlay:
+    eventListeners:
+      click:
+        handler: handlePreviewOverlayClick
 template:
   - rtgl-view g=md w=f:
       - rtgl-form#spriteCreateForm key=${formKey} :defaultValues=${defaultValues} :form=${form} w=f:
@@ -31,9 +41,19 @@ template:
                       - rtgl-text c=mu-fg ta=c: Select image
               - $if validationErrors.imageId:
                   - rtgl-text s=sm c=de: ${validationErrors.imageId}
-  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open}:
-      - rtgl-view slot=content g=md:
-          - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
+  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
+      - rtgl-view slot=content d=v w=f g=md:
+          - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
+              - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
           - rtgl-view d=h g=sm w=f ah=e:
               - rtgl-button#cancelImageSelection variant=se: Cancel
               - rtgl-button#confirmImageSelection variant=pr: OK
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
+      - $if fullImagePreviewImageId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image imageId=${fullImagePreviewImageId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -236,25 +236,44 @@ const generateMinimapData = (items, pan, zoomLevel, containerSize) => {
     };
   }
 
-  let x_tl = Infinity;
-  let y_tl = Infinity;
-  let x_br = -Infinity;
-  let y_br = -Infinity;
-
-  items.forEach((item) => {
-    x_tl = Math.min(x_tl, item.x);
-    y_tl = Math.min(y_tl, item.y);
-    x_br = Math.max(x_br, item.x);
-    y_br = Math.max(y_br, item.y);
-  });
-
-  const minimapWidth = 200;
-  const minimapHeight = 150;
   const itemWidth = SCENE_BOX_WIDTH;
   const itemHeight = SCENE_BOX_HEIGHT;
+  const minimapWidth = 200;
+  const minimapHeight = 150;
   const padding = 30;
-  const standardWidth = x_br - x_tl + itemWidth + 60;
-  const standardHeight = y_br - y_tl + itemHeight + 60;
+  const viewportLeft = -pan.x / zoomLevel;
+  const viewportTop = -pan.y / zoomLevel;
+  const viewportRight = viewportLeft + containerSize.width / zoomLevel;
+  const viewportBottom = viewportTop + containerSize.height / zoomLevel;
+
+  let worldLeft = Infinity;
+  let worldTop = Infinity;
+  let worldRight = -Infinity;
+  let worldBottom = -Infinity;
+
+  items.forEach((item) => {
+    worldLeft = Math.min(worldLeft, item.x);
+    worldTop = Math.min(worldTop, item.y);
+    worldRight = Math.max(worldRight, item.x + itemWidth);
+    worldBottom = Math.max(worldBottom, item.y + itemHeight);
+  });
+
+  if (containerSize.width > 0 && containerSize.height > 0) {
+    // Keep the current viewport represented in the minimap even when the user
+    // pans into empty space beyond the scene-item bounds.
+    worldLeft = Math.min(worldLeft, viewportLeft);
+    worldTop = Math.min(worldTop, viewportTop);
+    worldRight = Math.max(worldRight, viewportRight);
+    worldBottom = Math.max(worldBottom, viewportBottom);
+  }
+
+  worldLeft -= padding;
+  worldTop -= padding;
+  worldRight += padding;
+  worldBottom += padding;
+
+  const standardWidth = Math.max(1, worldRight - worldLeft);
+  const standardHeight = Math.max(1, worldBottom - worldTop);
 
   const scale = Math.min(
     minimapWidth / standardWidth,
@@ -270,18 +289,12 @@ const generateMinimapData = (items, pan, zoomLevel, containerSize) => {
 
   const minimapItems = items.map((item) => ({
     id: item.id,
-    x: (item.x - x_tl + padding) * scale + offsetX,
-    y: (item.y - y_tl + padding) * scale + offsetY,
+    x: (item.x - worldLeft) * scale + offsetX,
+    y: (item.y - worldTop) * scale + offsetY,
   }));
 
   const scaledPanX = pan.x * scale;
   const scaledPanY = pan.y * scale;
-  const worldLeft = x_tl - padding;
-  const worldTop = y_tl - padding;
-  const viewportLeft = -pan.x / zoomLevel;
-  const viewportTop = -pan.y / zoomLevel;
-  const viewportRight = viewportLeft + containerSize.width / zoomLevel;
-  const viewportBottom = viewportTop + containerSize.height / zoomLevel;
   const rawViewportLeft = (viewportLeft - worldLeft) * scale + offsetX;
   const rawViewportTop = (viewportTop - worldTop) * scale + offsetY;
   const rawViewportRight = (viewportRight - worldLeft) * scale + offsetX;

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -279,6 +279,7 @@ installManagedAudioAsset();
 
 export const createGraphicsService = async ({ subject }) => {
   let routeGraphics;
+  let routeGraphicsInitPromise;
   let engine;
   let assetBufferManager;
   let loadedAssetTypes = new Map();
@@ -1060,116 +1061,137 @@ export const createGraphicsService = async ({ subject }) => {
     pendingClickInteractionTimeouts.set(interactionId, timeoutId);
   };
 
+  const waitUntilReady = async () => {
+    if (!routeGraphicsInitPromise) {
+      return;
+    }
+
+    await routeGraphicsInitPromise;
+  };
+
   return {
     init: async (options = {}) => {
+      if (routeGraphicsInitPromise) {
+        await routeGraphicsInitPromise;
+      }
+
       if (routeGraphics) {
         await destroyRuntime();
       }
 
-      ticker = new Ticker();
-      ticker.start();
-      const { canvas, beforeHandleActions: onBeforeHandleActions } = options;
-      const { width: renderWidth, height: renderHeight } =
-        requireProjectResolution(
-          {
-            width: options.width,
-            height: options.height,
-          },
-          "Graphics runtime resolution",
-        );
-      beforeHandleActions = onBeforeHandleActions;
-      actionQueue = Promise.resolve();
-      assetLoadQueue = Promise.resolve();
-      assetLoadRuntimeVersion += 1;
-      invalidateDeferredAudioRender();
-      clearAllPendingClickInteractions();
-      loadedAssetTypes = new Map();
-      assetBufferManager = createAssetBufferManager();
-      routeGraphics = createRouteGraphics();
+      routeGraphicsInitPromise = (async () => {
+        ticker = new Ticker();
+        ticker.start();
+        const { canvas, beforeHandleActions: onBeforeHandleActions } = options;
+        const { width: renderWidth, height: renderHeight } =
+          requireProjectResolution(
+            {
+              width: options.width,
+              height: options.height,
+            },
+            "Graphics runtime resolution",
+          );
+        beforeHandleActions = onBeforeHandleActions;
+        actionQueue = Promise.resolve();
+        assetLoadQueue = Promise.resolve();
+        assetLoadRuntimeVersion += 1;
+        invalidateDeferredAudioRender();
+        clearAllPendingClickInteractions();
+        loadedAssetTypes = new Map();
+        assetBufferManager = createAssetBufferManager();
+        routeGraphics = createRouteGraphics();
 
-      const plugins = await loadGraphicsEnginePlugins();
+        const plugins = await loadGraphicsEnginePlugins();
 
-      await routeGraphics.init({
-        width: renderWidth,
-        height: renderHeight,
-        plugins,
-        eventHandler: (eventName, payload) => {
-          const eventId = payload?._event?.id;
-          const layoutEditorDragTarget =
-            eventId === "selected-border" ||
-            eventId?.startsWith("selected-border-resize-");
-          if (eventName === "dragMove") {
-            if (layoutEditorDragTarget) {
-              subject.dispatch("border-drag-move", {
-                x: Math.round(payload._event.x),
-                y: Math.round(payload._event.y),
-                targetId: eventId,
-              });
+        await routeGraphics.init({
+          width: renderWidth,
+          height: renderHeight,
+          plugins,
+          eventHandler: (eventName, payload) => {
+            const eventId = payload?._event?.id;
+            const layoutEditorDragTarget =
+              eventId === "selected-border" ||
+              eventId?.startsWith("selected-border-resize-");
+            if (eventName === "dragMove") {
+              if (layoutEditorDragTarget) {
+                subject.dispatch("border-drag-move", {
+                  x: Math.round(payload._event.x),
+                  y: Math.round(payload._event.y),
+                  targetId: eventId,
+                });
+              }
+            } else if (eventName === "dragStart") {
+              if (layoutEditorDragTarget) {
+                subject.dispatch("border-drag-start", {
+                  targetId: eventId,
+                });
+              }
+            } else if (eventName === "dragEnd") {
+              if (layoutEditorDragTarget) {
+                subject.dispatch("border-drag-end", {
+                  targetId: eventId,
+                });
+              }
             }
-          } else if (eventName === "dragStart") {
-            if (layoutEditorDragTarget) {
-              subject.dispatch("border-drag-start", {
-                targetId: eventId,
-              });
-            }
-          } else if (eventName === "dragEnd") {
-            if (layoutEditorDragTarget) {
-              subject.dispatch("border-drag-end", {
-                targetId: eventId,
-              });
-            }
-          }
 
-          if (!engine) {
-            return;
-          }
-
-          if (eventName === "renderComplete") {
-            if (payload?.aborted === true) {
+            if (!engine) {
               return;
             }
-            engine.handleActions({
-              markLineCompleted: {},
-            });
-            return;
-          }
 
-          const actions = getRuntimeEventActions(payload);
+            if (eventName === "renderComplete") {
+              if (payload?.aborted === true) {
+                return;
+              }
+              engine.handleActions({
+                markLineCompleted: {},
+              });
+              return;
+            }
 
-          if (actions && engine) {
-            const eventContext = createRuntimeEventContext(payload);
+            const actions = getRuntimeEventActions(payload);
 
-            const interactionId = eventContext?._event?.id ?? "__unknown__";
+            if (actions && engine) {
+              const eventContext = createRuntimeEventContext(payload);
 
-            if (isRuntimeRightClickEvent(eventName)) {
-              clearPendingClickInteraction(interactionId);
+              const interactionId = eventContext?._event?.id ?? "__unknown__";
+
+              if (isRuntimeRightClickEvent(eventName)) {
+                clearPendingClickInteraction(interactionId);
+                enqueueInteractionActions(actions, eventContext);
+                return;
+              }
+
+              if (eventName === "click") {
+                scheduleClickInteraction(actions, eventContext);
+                return;
+              }
+
               enqueueInteractionActions(actions, eventContext);
-              return;
             }
+          },
+        });
 
-            if (eventName === "click") {
-              scheduleClickInteraction(actions, eventContext);
-              return;
-            }
-
-            enqueueInteractionActions(actions, eventContext);
+        if (canvas) {
+          if (canvas.children.length > 0) {
+            canvas.removeChild(canvas.children[0]);
           }
-        },
-      });
-
-      if (canvas) {
-        if (canvas.children.length > 0) {
-          canvas.removeChild(canvas.children[0]);
+          // Keep Pixi's internal render resolution synced to the project screen,
+          // then scale the displayed canvas to the container.
+          routeGraphics.canvas.style.width = "100%";
+          routeGraphics.canvas.style.height = "100%";
+          routeGraphics.canvas.style.display = "block";
+          canvas.appendChild(routeGraphics.canvas);
         }
-        // Keep Pixi's internal render resolution synced to the project screen,
-        // then scale the displayed canvas to the container.
-        routeGraphics.canvas.style.width = "100%";
-        routeGraphics.canvas.style.height = "100%";
-        routeGraphics.canvas.style.display = "block";
-        canvas.appendChild(routeGraphics.canvas);
+      })();
+
+      try {
+        await routeGraphicsInitPromise;
+      } finally {
+        routeGraphicsInitPromise = undefined;
       }
     },
     loadAssets: async (assets) => {
+      await waitUntilReady();
       const runtimeVersion = assetLoadRuntimeVersion;
       const queuedLoad = assetLoadQueue.then(() =>
         runAssetLoad(assets, runtimeVersion),
@@ -1287,6 +1309,7 @@ export const createGraphicsService = async ({ subject }) => {
     setAnimationTime: (timeMs) => {
       routeGraphics?.setAnimationTime?.(timeMs);
     },
+    waitUntilReady,
     render: (payload) => routeGraphics.render(payload),
     parse: (payload) => routeGraphics.parse(payload),
     destroy: destroyRuntime,

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -1136,6 +1136,27 @@ export const handleMaskImageSelected = (deps, payload) => {
   render();
 };
 
+export const handleMaskImageDoubleClick = (deps, payload) => {
+  const imageId = payload?._event?.detail?.imageId;
+  if (!imageId) {
+    return;
+  }
+
+  deps.store.showFullImagePreview({ imageId });
+  deps.render();
+};
+
+export const handleMaskImageFileExplorerClickItem = (deps, payload) => {
+  const itemId = payload?._event?.detail?.itemId;
+  if (!itemId) {
+    return;
+  }
+
+  deps.refs.imageSelector?.transformedHandlers?.handleScrollToItem?.({
+    itemId,
+  });
+};
+
 export const handleConfirmMaskImageSelection = (deps) => {
   const { render, store } = deps;
   const imageSelectorDialog = store.selectImageSelectorDialog();
@@ -1185,6 +1206,11 @@ export const handleCloseMaskImageSelectorDialog = (deps) => {
   const { render, store } = deps;
   store.hideImageSelectorDialog({});
   render();
+};
+
+export const handleMaskImagePreviewOverlayClick = (deps) => {
+  deps.store.hideFullImagePreview();
+  deps.render();
 };
 
 export const handleReplayAnimation = async (deps) => {

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -3,6 +3,7 @@ import {
   formatProjectResolutionAspectRatio,
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
+import { toFlatItems } from "../../internal/project/tree.js";
 import {
   compileTransitionMaskForRuntime,
   createDefaultTransitionMask,
@@ -574,6 +575,8 @@ export const createInitialState = () => ({
     formValues: {},
   },
   imageSelectorDialog: createInitialImageSelectorDialogState(),
+  fullImagePreviewVisible: false,
+  fullImagePreviewImageId: undefined,
 });
 
 export const setItems = ({ state }, { data } = {}) => {
@@ -1440,6 +1443,8 @@ export const showImageSelectorDialog = (
 
 export const hideImageSelectorDialog = ({ state }, _payload = {}) => {
   state.imageSelectorDialog = createInitialImageSelectorDialogState();
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
 };
 
 export const setImageSelectorSelectedImageId = (
@@ -1447,6 +1452,16 @@ export const setImageSelectorSelectedImageId = (
   { imageId } = {},
 ) => {
   state.imageSelectorDialog.selectedImageId = imageId;
+};
+
+export const showFullImagePreview = ({ state }, { imageId } = {}) => {
+  state.fullImagePreviewVisible = true;
+  state.fullImagePreviewImageId = imageId;
+};
+
+export const hideFullImagePreview = ({ state }, _payload = {}) => {
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewImageId = undefined;
 };
 
 export const selectImageSelectorDialog = ({ state }) => {
@@ -1638,6 +1653,9 @@ export const selectViewData = ({ state }) => {
     propertyFieldConfig,
   );
   const transitionMaskPanel = buildTransitionMaskPanelData(state);
+  const imageFolderItems = toFlatItems(state.imagesData).filter(
+    (item) => item.type === "folder",
+  );
 
   const keyframeDropdownItems = (() => {
     if (state.popover.mode !== "keyframeMenu") {
@@ -1773,5 +1791,8 @@ export const selectViewData = ({ state }) => {
       useInitialValue: false,
     },
     imageSelectorDialog: state.imageSelectorDialog,
+    imageFolderItems,
+    fullImagePreviewVisible: state.fullImagePreviewVisible,
+    fullImagePreviewImageId: state.fullImagePreviewImageId,
   };
 };

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -193,10 +193,16 @@ refs:
     eventListeners:
       close:
         handler: handleCloseMaskImageSelectorDialog
+  imageSelectorFileExplorer:
+    eventListeners:
+      item-click:
+        handler: handleMaskImageFileExplorerClickItem
   imageSelector:
     eventListeners:
       image-selected:
         handler: handleMaskImageSelected
+      image-dblclick:
+        handler: handleMaskImageDoubleClick
   confirmMaskImageSelection:
     eventListeners:
       click:
@@ -205,6 +211,10 @@ refs:
     eventListeners:
       click:
         handler: handleCancelMaskImageSelection
+  previewOverlay:
+    eventListeners:
+      click:
+        handler: handleMaskImagePreviewOverlayClick
   canvas: {}
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
@@ -273,7 +283,7 @@ template:
                               - $if transitionMaskPanel.kind == 'composite':
                                   - rtgl-view d=v g=xs:
                                       - rtgl-text s=sm c=mu-fg: Combine
-                                      - rtgl-select#maskCombineSelect w=f no-clear :selectedValue=${transitionMaskPanel.combineValue} :options=${maskCombineOptions}: null
+                                      - rtgl-segmented-control#maskCombineSelect w=f no-clear :selectedValue=${transitionMaskPanel.combineValue} :options=${maskCombineOptions}: null
                               - rtgl-view d=v g=xs:
                                   - rtgl-text s=sm c=mu-fg: Softness
                                   - rtgl-input#maskSoftnessInput type=number min=0 step=0.01 w=f value=${transitionMaskPanel.softness}: null
@@ -339,10 +349,10 @@ template:
                                                       - rtgl-button#compositeMaskRemoveButton${i} data-index=${item.index} s=sm v=se: Remove
                                                   - rtgl-view d=v g=xs:
                                                       - rtgl-text s=sm c=mu-fg: Channel
-                                                      - rtgl-select#compositeMaskChannelSelect${i} data-index=${item.index} w=f no-clear :selectedValue=${item.channelValue} :options=${maskChannelOptions}: null
+                                                      - rtgl-segmented-control#compositeMaskChannelSelect${i} data-index=${item.index} w=f no-clear :selectedValue=${item.channelValue} :options=${maskChannelOptions}: null
                                                   - rtgl-view d=v g=xs:
                                                       - rtgl-text s=sm c=mu-fg: Invert
-                                                      - rtgl-select#compositeMaskInvertSelect${i} data-index=${item.index} w=f no-clear :selectedValue=${item.invertValue} :options=${maskBooleanOptions}: null
+                                                      - rtgl-segmented-control#compositeMaskInvertSelect${i} data-index=${item.index} w=f no-clear :selectedValue=${item.invertValue} :options=${maskBooleanOptions}: null
                               - rtgl-view d=v g=xs:
                                   - rtgl-text s=sm c=mu-fg: Progress Duration (ms)
                                   - rtgl-input#maskProgressDurationInput type=number min=1 step=1 w=f value=${transitionMaskPanel.progressDuration}: null
@@ -367,9 +377,19 @@ template:
               - rtgl-form#editInitialValueForm :form=${editInitialValueForm} :defaultValues=${editInitialValueDefaultValues} :context=${editInitialValueContext}: null
   - rtgl-dropdown-menu#keyframeDropdownMenu :items=${keyframeDropdownItems} ?open=${popover.dropdownMenuIsOpen} x=${popover.x} y=${popover.y}: null
   - rtgl-dropdown-menu#addPropertySideMenu :items=${addPropertySideMenuItems} ?open=${popover.addPropertySideMenuIsOpen} x=${popover.x} y=${popover.y}: null
-  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open}:
-      - rtgl-view slot=content g=md:
-          - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
-          - rtgl-view d=h g=sm:
+  - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
+      - rtgl-view slot=content d=v w=f g=md:
+          - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
+              - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+                  - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
+          - rtgl-view d=h g=sm w=f ah=e:
               - rtgl-button#cancelMaskImageSelection variant=se: Cancel
               - rtgl-button#confirmMaskImageSelection variant=pr: OK
+  - $when: fullImagePreviewVisible
+    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+      - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
+      - $if fullImagePreviewImageId:
+          - rtgl-view pos=fix edge=f ah=c av=c z=3001:
+              - rvn-file-image imageId=${fullImagePreviewImageId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -174,14 +174,16 @@ export const handleDetailHeaderClick = (deps) => {
   openEditDialogWithValues({ deps, itemId: selectedItemId });
 };
 
-const createControlTemplate = (projectResolution) => {
+export const createControlTemplate = (projectResolution) => {
   const spriteId = nanoid();
 
   return scaleLayoutElementsForProjectResolution(
     {
       items: {
         [spriteId]: {
+          id: spriteId,
           type: "sprite",
+          name: "Control Sprite",
           anchorX: 0,
           anchorY: 0,
           click: {

--- a/src/pages/controls/controls.store.js
+++ b/src/pages/controls/controls.store.js
@@ -132,7 +132,7 @@ const {
   title: "Controls",
   selectedResourceId: "controls",
   resourceCategory: "systemConfig",
-  addText: "Add Control",
+  addText: "Add",
   matchesSearch,
   buildDetailFields,
   buildCatalogItem,

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -283,6 +283,7 @@ export const selectViewData = ({ state, constants }) => {
     previewData: state.previewData,
     projectResolution: state.projectResolution,
     layout,
+    imagesData: state.images,
     textStylesData: state.textStylesData,
     variablesData: state.variablesData,
     layoutsData: state.layoutsData,

--- a/src/pages/variables/variables.handlers.js
+++ b/src/pages/variables/variables.handlers.js
@@ -60,12 +60,41 @@ const refreshVariablesData = async (deps) => {
   render();
 };
 
-const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
-  createVariablesFileExplorerHandlers({
-    refresh: refreshVariablesData,
-  });
+const {
+  handleFileExplorerAction: handleVariablesFileExplorerAction,
+  handleFileExplorerTargetChanged,
+} = createVariablesFileExplorerHandlers({
+  refresh: refreshVariablesData,
+});
 
-export { handleFileExplorerAction, handleFileExplorerTargetChanged };
+const openVariableEditDialog = ({ deps, itemId } = {}) => {
+  const { refs, store, render } = deps;
+  if (!itemId) {
+    return;
+  }
+
+  refs.fileexplorer?.selectItem?.({ itemId });
+  store.setSelectedItemId({ itemId });
+  render();
+  refs.groupview?.openEditDialog?.({ itemId });
+};
+
+export const handleFileExplorerAction = async (deps, payload) => {
+  const detail = payload?._event?.detail ?? {};
+  const action = (detail.item || detail)?.value;
+
+  if (action === "edit-item") {
+    openVariableEditDialog({
+      deps,
+      itemId: detail.itemId,
+    });
+    return;
+  }
+
+  await handleVariablesFileExplorerAction(deps, payload);
+};
+
+export { handleFileExplorerTargetChanged };
 
 export const handleDataChanged = refreshVariablesData;
 
@@ -124,13 +153,13 @@ export const handleVariableItemClick = (deps, payload) => {
 };
 
 export const handleDetailHeaderClick = (deps) => {
-  const { refs, store } = deps;
+  const { store } = deps;
   const itemId = store.selectSelectedItemId();
   if (!itemId) {
     return;
   }
 
-  refs.groupview?.openEditDialog?.({ itemId });
+  openVariableEditDialog({ deps, itemId });
 };
 
 export const handleVariableCreated = async (deps, payload) => {

--- a/src/pages/variables/variables.store.js
+++ b/src/pages/variables/variables.store.js
@@ -1,16 +1,27 @@
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
 
+const folderContextMenuItems = [
+  { label: "New Folder", type: "item", value: "new-item" },
+  { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const itemContextMenuItems = [
+  { label: "Edit", type: "item", value: "edit-item" },
+  { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Delete", type: "item", value: "delete-item" },
+];
+
+const emptyContextMenuItems = [
+  { label: "New Folder", type: "item", value: "new-item" },
+];
+
 export const createInitialState = () => ({
   variablesData: { tree: [], items: {} },
   selectedItemId: undefined,
-  contextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-    { label: "Rename", type: "item", value: "rename-item" },
-    { label: "Delete", type: "item", value: "delete-item" },
-  ],
-  emptyContextMenuItems: [
-    { label: "New Folder", type: "item", value: "new-item" },
-  ],
+  folderContextMenuItems,
+  itemContextMenuItems,
+  emptyContextMenuItems,
 });
 
 export const setItems = ({ state }, { variablesData } = {}) => {
@@ -78,7 +89,8 @@ export const selectViewData = ({ state }) => {
     selectedItemId: state.selectedItemId,
     selectedItemName: selectedItem?.name ?? "",
     detailFields,
-    contextMenuItems: state.contextMenuItems,
+    folderContextMenuItems: state.folderContextMenuItems,
+    itemContextMenuItems: state.itemContextMenuItems,
     emptyContextMenuItems: state.emptyContextMenuItems,
   };
 };

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -29,7 +29,7 @@ template:
           - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
               - rtgl-view slot="content" w=f h=f:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
-                  - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+                  - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
           - 'rtgl-view d=v w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - rvn-group-variables-view#groupview w=f h=1fg navTitle=${title} :flatGroups=${flatGroups} :selectedItemId=${selectedItemId}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":

--- a/src/pages/versions/versions.view.yaml
+++ b/src/pages/versions/versions.view.yaml
@@ -70,7 +70,7 @@ template:
                               - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                               - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
-                              - rtgl-button#detailDownloadBtn slot=actions data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: Download Zip
+                              - rtgl-button#detailDownloadBtn slot=actions data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: Export Web
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection

--- a/tests/controls/controls.handlers.test.js
+++ b/tests/controls/controls.handlers.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createControlTemplate } from "../../src/pages/controls/controls.handlers.js";
+
+describe("createControlTemplate", () => {
+  const projectResolution = {
+    width: 1920,
+    height: 1080,
+  };
+
+  it("creates control elements with required ids and names", () => {
+    const template = createControlTemplate(projectResolution);
+    const itemEntries = Object.entries(template.items);
+
+    expect(Array.isArray(template.tree)).toBe(true);
+    expect(itemEntries.length).toBeGreaterThan(0);
+
+    itemEntries.forEach(([itemId, item]) => {
+      expect(item.id).toBe(itemId);
+      expect(item.name).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- update layout editor sprite, slider, and detail-panel image pickers to use the same split selector layout with folder explorer, preview overlay, and shared styling fixes
- expose image data correctly in the layout editor, keep selector folders populated, and prevent layout canvas parsing from racing graphics-service initialization
- add variable context-menu edit actions and complete the default control template with required nested sprite fields plus regression coverage

## Testing
- bunx oxlint src/components/groupVariablesView/groupVariablesView.handlers.js src/components/groupVariablesView/groupVariablesView.store.js src/components/imageSelector/imageSelector.view.yaml src/components/layoutEditPanel/layoutEditPanel.handlers.js src/components/layoutEditPanel/layoutEditPanel.store.js src/components/layoutEditPanel/layoutEditPanel.view.yaml src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.handlers.js src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.handlers.js src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml src/deps/services/graphicsService.js src/pages/controls/controls.handlers.js src/pages/controls/controls.store.js src/pages/layoutEditor/layoutEditor.store.js src/pages/variables/variables.handlers.js src/pages/variables/variables.store.js src/pages/variables/variables.view.yaml tests/controls/controls.handlers.test.js
- bunx prettier --check src/components/groupVariablesView/groupVariablesView.handlers.js src/components/groupVariablesView/groupVariablesView.store.js src/components/imageSelector/imageSelector.view.yaml src/components/layoutEditPanel/layoutEditPanel.handlers.js src/components/layoutEditPanel/layoutEditPanel.store.js src/components/layoutEditPanel/layoutEditPanel.view.yaml src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.handlers.js src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.handlers.js src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml src/deps/services/graphicsService.js src/pages/controls/controls.handlers.js src/pages/controls/controls.store.js src/pages/layoutEditor/layoutEditor.store.js src/pages/variables/variables.handlers.js src/pages/variables/variables.store.js src/pages/variables/variables.view.yaml tests/controls/controls.handlers.test.js
- bunx vitest run tests/controls/controls.handlers.test.js
- bun run build:web
- push hook: oxlint
- push hook: bun prettier --check src