### PR TITLE
docs: clarify version contracts

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -402,7 +402,11 @@ Exported `package.bin` files have two distinct version concepts:
   - currently includes:
     - `appName`
     - `appVersion`
+  - meanings:
+    - `appName`: which application produced the export
+    - `appVersion`: which released app build/version produced the export
   - used for provenance, debugging, and support
+  - these are not compatibility gates; they are exporter provenance only
 
 Do not collapse these into one field.
 

--- a/docs/platform/10-model-compatibility-and-upgrades.md
+++ b/docs/platform/10-model-compatibility-and-upgrades.md
@@ -29,7 +29,8 @@ Collaboration:
 1. Older client opening newer project:
    effectively not supported.
 2. Newer client opening older project:
-   not guaranteed.
+   partially supported only when the stored project format version still
+   matches and the latest model can still replay the older command/state data.
 
 ### Collaboration
 
@@ -62,55 +63,67 @@ validate under the new model.
 
 Current version-like fields:
 
-1. App-level `creatorVersion`
+1. Project format version (`creatorVersion` in project app-store metadata)
 2. Command envelope `schemaVersion`
-3. Model package `SCHEMA_VERSION`
+3. Model package version
+4. Model package `SCHEMA_VERSION`
 
 Current values in this repo:
 
-1. `creatorVersion = 1` when new projects are created:
+1. Project format version `creatorVersion = 1` when new projects are created:
    [webRepositoryAdapter.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/deps/clients/web/webRepositoryAdapter.js#L94)
    [projectServiceAdapters.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/deps/services/tauri/projectServiceAdapters.js#L254)
 2. Command envelope `schemaVersion = 1`:
    [commands.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/internal/project/commands.js#L1)
-3. Creator model `SCHEMA_VERSION = 2`:
+3. Installed creator model package version `1.1.12`:
+   [package.json](/home/tk/Code/yuusoft-org/routevn-creator-client/package.json#L22)
+4. Creator model `SCHEMA_VERSION = 1`:
    [model.js](/home/tk/Code/yuusoft-org/routevn-creator-model/src/model.js#L148)
 
 Problem:
 
-1. There is no single authoritative compatibility version.
-2. The client does not consume the model package `SCHEMA_VERSION`.
-3. It is easy to bump one version and forget the others.
+1. There is no single authoritative compatibility version because these values
+   answer different compatibility questions.
+2. The project format version, command envelope version, and model schema
+   version must remain intentionally separate.
+3. It is still easy to confuse them unless the distinction is documented
+   explicitly.
 
 Impact:
 
-1. Compatibility decisions are inconsistent.
-2. It is unclear which version governs project-open safety.
-3. It is unclear which version governs command replay safety.
+1. Project-open safety is governed by project format version.
+2. Mixed-version collab safety is governed first by command envelope version.
+3. Replay safety still depends on current model behavior and backward-compatible
+   validation.
 
-## Issue 2: Project Open Is Blocked By App Major Version Equality
+## Issue 2: Project Open Is Intentionally Coupled To App Major / Project Format
 
 The repository service currently requires the stored `creatorVersion` to equal
-the runtime `CURRENT_CREATOR_MAJOR_VERSION`.
+the runtime supported project format version.
 
 References:
 
-1. Current major version gate:
+1. Current project format gate:
    [projectRepositoryService.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/deps/services/shared/projectRepositoryService.js#L13)
 2. Equality check:
    [projectRepositoryService.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/deps/services/shared/projectRepositoryService.js#L186)
 
-Problem:
+Status update:
 
-1. If the app major version becomes `2`, a version `2` client will reject a
-   project stamped with `creatorVersion = 1`.
-2. That directly violates the desired one-way compatibility goal for
-   single-user upgrades.
+1. This is intentionally derived from app semver major.
+2. A normal app `2.x` release is therefore also a project format break and will
+   reject projects stamped with `creatorVersion = 1`.
+
+Remaining limitation:
+
+1. Cross-project-format opening is unsupported by design.
+2. Migration between project format generations must happen outside the app.
 
 Impact:
 
-1. Newer client opening older project is explicitly blocked before any
-   migration logic could run.
+1. Project format generations remain a hard compatibility boundary.
+2. One-way compatibility inside the same project format still depends on model
+   replay compatibility.
 
 ## Issue 3: Replay Uses The Current Model, So Validation Tightening Can Break Old Projects
 
@@ -170,7 +183,7 @@ Impact:
 1. Compatibility work scales poorly.
 2. Each schema change becomes a manual judgment call.
 
-## Issue 5: Command Envelope Schema Version Is Disconnected From Model Schema Version
+## Issue 5: Command Envelope Version And Model Schema Version Are Separate On Purpose
 
 Command transport uses the app repo command envelope schema version, not the
 creator model schema version.
@@ -185,17 +198,21 @@ References:
    supported schema version:
    [compatibility.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/deps/services/shared/collab/compatibility.js#L20)
 
-Problem:
+Status update:
 
-1. A command may be marked compatible at the envelope level even if the current
-   model meaning changed.
-2. The model repo `SCHEMA_VERSION` is documented as the source of truth for
-   persisted command compatibility, but the client does not use it.
+1. This is intentional now.
+2. The command envelope version is a client-owned collab wire compatibility
+   version and must stay stable unless the envelope itself changes.
+3. The model schema version is a model-owned persisted replay compatibility
+   version and should not be used directly for mixed-version collab gating.
 
 Impact:
 
-1. Compatibility signaling is weaker than it appears.
-2. The current `schemaVersion` does not fully describe model replay safety.
+1. Mixed-version collab avoids unnecessary projection gaps when the wire
+   envelope is still unchanged.
+2. Envelope compatibility and replay compatibility remain separate concerns.
+3. A command marked collab-compatible can still fail at replay/model level if
+   the current model no longer accepts the older persisted shape.
 
 ## Issue 6: Mixed-Version Collaboration Uses Projection Gaps, Not True Compatibility
 

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -2,22 +2,45 @@
 
 This folder defines the current platform for RouteVN Creator.
 
-Date baseline: February 24, 2026.
+Date baseline: April 9, 2026.
 
 ## Scope
 
 - The current platform is the only supported project and protocol format.
-- Older projects are not opened by the current runtime.
+- Projects are opened only when their stored project format version matches the
+  client-supported project format version.
 - All write operations must go through authoritative collaboration server validation.
 - The domain model and command schemas are owned by the model repo:
   `https://github.com/RouteVN/routevn-creator-model`
 
 ## Version Contract
 
-- `model_version = 2`
+- `project_format_version = 1`
+- `command_envelope_version = 1`
+- `model_package_version = "1.1.12"`
+- `model_schema_version = 1`
+- `bundle_format_version = 2`
 - `protocol_version = "1.0"`
 - `command_version = 1`
 - entity ids are base58 strings
+
+Notes:
+
+- project format version is derived from app semver major
+- a future app major release is therefore also a project-format boundary
+- the command envelope version is a client-owned collab wire version and is
+  intentionally separate from the model schema version
+- the bundle format version is the `package.bin` binary format version used by
+  exported runtime bundles and is intentionally separate from sync protocol and
+  collab command envelope version
+
+Bundle implementation points:
+
+- reader/runtime: [scripts/main.js](/home/tk/Code/yuusoft-org/routevn-creator-client/scripts/main.js)
+- writer/shared export service:
+  [projectExportService.js](/home/tk/Code/yuusoft-org/routevn-creator-client/src/deps/services/shared/projectExportService.js)
+- tauri streamed zip export:
+  [export_zip.rs](/home/tk/Code/yuusoft-org/routevn-creator-client/src-tauri/src/export_zip.rs)
 
 ## Spec Index
 

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -17,7 +17,6 @@ Date baseline: April 9, 2026.
 
 - `project_format_version = 1`
 - `command_envelope_version = 1`
-- `model_package_version = "1.1.12"`
 - `model_schema_version = 1`
 - `bundle_format_version = 2`
 - `protocol_version = "1.0"`

--- a/src/internal/projectCompatibility.js
+++ b/src/internal/projectCompatibility.js
@@ -1,2 +1,16 @@
 export const COMMAND_ENVELOPE_VERSION = 1;
-export const CREATOR_VERSION = 1;
+
+export const deriveProjectFormatVersionFromAppVersion = (appVersion) => {
+  if (typeof appVersion !== "string" || appVersion.length === 0) {
+    throw new Error("appVersion must be a non-empty string");
+  }
+
+  const match = appVersion.match(/^(\d+)\./);
+  if (!match) {
+    throw new Error(
+      `Cannot derive project format version from appVersion '${appVersion}'`,
+    );
+  }
+
+  return Number.parseInt(match[1], 10);
+};

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -19,7 +19,7 @@ import { createApiService } from "./deps/services/apiService";
 import Subject from "./deps/subject";
 import Router from "./deps/clients/router";
 import { createGraphicsService } from "./deps/services/graphicsService";
-import { CREATOR_VERSION } from "./internal/projectCompatibility.js";
+import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
 import { registerPrimitives } from "./primitives/registerPrimitives";
 
 registerPrimitives();
@@ -37,7 +37,7 @@ const audioService = createAudioService();
 
 // Get app version
 const appVersion = await getVersion();
-const creatorVersion = CREATOR_VERSION;
+const creatorVersion = deriveProjectFormatVersionFromAppVersion(appVersion);
 
 // Create updater
 const updater = createUpdater({ globalUI, keyValueStore: appDb });

--- a/src/setup.web.js
+++ b/src/setup.web.js
@@ -16,7 +16,7 @@ import { createAudioService } from "./deps/services/audioService.js";
 import Subject from "./deps/subject.js";
 import Router from "./deps/clients/router.js";
 import { createGraphicsService } from "./deps/services/graphicsService.js";
-import { CREATOR_VERSION } from "./internal/projectCompatibility.js";
+import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
 import { registerPrimitives } from "./primitives/registerPrimitives.js";
 import tauriConfig from "../src-tauri/tauri.conf.json";
 
@@ -36,7 +36,7 @@ const globalUI = createGlobalUI(globalUIElement);
 const audioService = createAudioService();
 
 const appVersion = tauriConfig.version;
-const creatorVersion = CREATOR_VERSION;
+const creatorVersion = deriveProjectFormatVersionFromAppVersion(appVersion);
 
 const updater = {
   checkForUpdates: async () => null,


### PR DESCRIPTION
## Summary
- derive project format version from app semver major again
- document the current separation between project format, command envelope, protocol, model, and bundle versions
- document that bundle app metadata is provenance only, not a compatibility gate

## Validation
- bunx oxlint src/internal/projectCompatibility.js src/setup.tauri.js src/setup.web.js
- bunx prettier --check docs/engineering.md docs/platform/README.md docs/platform/10-model-compatibility-and-upgrades.md src/internal/projectCompatibility.js src/setup.tauri.js src/setup.web.js