### PR TITLE
Improve media resource preview navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,8 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rettangoli/fe": "1.1.2",
-        "@rettangoli/ui": "1.4.1",
+        "@rettangoli/fe": "1.1.3",
+        "@rettangoli/ui": "1.4.2",
         "@rettangoli/vt": "1.0.2",
         "@routevn/creator-model": "1.2.2",
         "@tauri-apps/api": "^2.8.0",
@@ -203,9 +203,9 @@
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
-    "@rettangoli/fe": ["@rettangoli/fe@1.1.2", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-1HLVsSXaerxROJoi+XqNkDuYWVVFIdkqoEdPCqtoaUMeSFDN7jNwkXeiWktb0PxbzzB+lgGl+eCm0hzrKnyweg=="],
+    "@rettangoli/fe": ["@rettangoli/fe@1.1.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-/fia9Ir5x5NU7fjfXtuioCwbc4ELj939pM+/vB9R7bOAPVKosKTspyOuYqMrstysfT84xfLEcPidBrI5OY/l0g=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.4.1", "", { "dependencies": { "@rettangoli/fe": "1.1.2", "jempl": "1.0.1" } }, "sha512-PDU0ECa219GudPO40CLj33pwfRtLz45vV9Gsc7e73ngiHz5diRCusUcbrxNA5UPayducQpkObFTr/RPnM7xilQ=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.4.2", "", { "dependencies": { "@rettangoli/fe": "1.1.3", "jempl": "1.0.1" } }, "sha512-Tjns/M7PmDVZ38NNL/Zte0eDsBguUOQVLtIXfRoUIHZsekMPHls+jvKjnaq5xj2zOAr6P4lKtPyXrB+pSZqvWQ=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.2", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-QHweZ2BJFiQi0mc8KvSLiFjKTm9ovjs++x9cOTtN89AyK/Pn0acuD0mA+kjOu4zgPcaHvjOAINNqMFsqhx9Hgw=="],
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "type": "module",
   "dependencies": {
-    "@rettangoli/fe": "1.1.2",
-    "@rettangoli/ui": "1.4.1",
+    "@rettangoli/fe": "1.1.3",
+    "@rettangoli/ui": "1.4.2",
     "@rettangoli/vt": "1.0.2",
     "@routevn/creator-model": "1.2.2",
     "@tauri-apps/api": "^2.8.0",

--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -84,6 +84,40 @@ const getVisibleItems = (allItems, collapsedIds) => {
   });
 };
 
+const emitItemClick = ({ dispatchEvent, item } = {}) => {
+  if (!item) {
+    return;
+  }
+
+  const isFolder = item?.type === "folder";
+
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: {
+        id: item.id,
+        itemId: item.id,
+        item,
+        isFolder,
+      },
+    }),
+  );
+};
+
+const selectVisibleItem = ({ deps, item, emitSelectionEvent = false } = {}) => {
+  const { dispatchEvent, store, render } = deps;
+  if (!item?.id) {
+    return undefined;
+  }
+
+  store.expandItemAncestors({ itemId: item.id });
+  store.setSelectedItemId({ itemId: item.id });
+  render();
+  if (emitSelectionEvent) {
+    emitItemClick({ dispatchEvent, item });
+  }
+  return item;
+};
+
 const resolveDropTargetItem = ({ visibleItems, targetIndex, dropPosition }) => {
   if (dropPosition === "above" && targetIndex === -1) {
     return visibleItems[0];
@@ -668,29 +702,18 @@ export const handleItemContextMenu = (deps, payload) => {
 };
 
 export const handleItemClick = (deps, payload) => {
-  const { dispatchEvent, store, render, props } = deps;
+  const { store, render, props } = deps;
   const itemId = getItemIdFromEvent(payload._event);
   if (!itemId) {
     return;
   }
   const item = props.items?.find((entry) => entry.id === itemId);
-  const isFolder = item?.type === "folder";
 
   // Update selected item
   store.clearPendingDrag();
   store.setSelectedItemId({ itemId: itemId });
   render();
-
-  dispatchEvent(
-    new CustomEvent("item-click", {
-      detail: {
-        id: itemId,
-        itemId,
-        item,
-        isFolder,
-      },
-    }),
-  );
+  emitItemClick({ dispatchEvent: deps.dispatchEvent, item });
 };
 
 export const handleItemDblClick = (deps, payload) => {
@@ -715,12 +738,125 @@ export const handleItemDblClick = (deps, payload) => {
 };
 
 export const handlePageItemClick = (deps, payload) => {
-  const { store, render } = deps;
   const { itemId } = payload._event.detail; // Extract from forwarded event
+  const item = deps.props.items?.find((entry) => entry.id === itemId);
 
-  store.expandItemAncestors({ itemId });
-  store.setSelectedItemId({ itemId: itemId });
+  selectVisibleItem({ deps, item, emitSelectionEvent: false });
+};
+
+export const handleGetSelectedItem = (deps) => {
+  const { props, store } = deps;
+  const itemId = store.selectSelectedItemId();
+  if (!itemId) {
+    return undefined;
+  }
+
+  const item = props.items?.find((entry) => entry.id === itemId);
+  if (!item) {
+    return undefined;
+  }
+
+  return {
+    itemId: item.id,
+    item,
+    isFolder: item.type === "folder",
+    isCollapsed:
+      item.type === "folder" && store.selectCollapsedIds().includes(item.id),
+  };
+};
+
+export const handleNavigateSelection = (deps, payload) => {
+  const { props, store } = deps;
+  const { direction } = payload._event.detail ?? {};
+  const step =
+    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
+  if (!step) {
+    return undefined;
+  }
+
+  const visibleItems = getVisibleItems(
+    props.items ?? [],
+    store.selectCollapsedIds(),
+  );
+  if (visibleItems.length === 0) {
+    return undefined;
+  }
+
+  const selectedItemId = store.selectSelectedItemId();
+  const currentIndex = visibleItems.findIndex(
+    (item) => item.id === selectedItemId,
+  );
+  const nextItem =
+    currentIndex === -1
+      ? step > 0
+        ? visibleItems[0]
+        : visibleItems[visibleItems.length - 1]
+      : visibleItems[currentIndex + step];
+
+  if (!nextItem) {
+    return undefined;
+  }
+
+  const selectedItem = selectVisibleItem({
+    deps,
+    item: nextItem,
+    emitSelectionEvent: true,
+  });
+  if (!selectedItem) {
+    return undefined;
+  }
+
+  return {
+    itemId: selectedItem.id,
+    item: selectedItem,
+    isFolder: selectedItem.type === "folder",
+    isCollapsed:
+      selectedItem.type === "folder" &&
+      store.selectCollapsedIds().includes(selectedItem.id),
+  };
+};
+
+export const handleSetSelectedFolderExpanded = (deps, payload) => {
+  const { render, store, props } = deps;
+  const { expanded } = payload._event.detail ?? {};
+  const selectedItemId = store.selectSelectedItemId();
+  if (!selectedItemId) {
+    return undefined;
+  }
+
+  const item = props.items?.find((entry) => entry.id === selectedItemId);
+  if (!item || item.type !== "folder" || !item.hasChildren) {
+    return undefined;
+  }
+
+  const isCollapsed = store.selectCollapsedIds().includes(item.id);
+  if (expanded === true && !isCollapsed) {
+    return {
+      itemId: item.id,
+      item,
+      isFolder: true,
+      isCollapsed,
+    };
+  }
+
+  if (expanded === false && isCollapsed) {
+    return {
+      itemId: item.id,
+      item,
+      isFolder: true,
+      isCollapsed,
+    };
+  }
+
+  store.toggleFolderExpand({ folderId: item.id });
   render();
+
+  return {
+    itemId: item.id,
+    item,
+    isFolder: true,
+    isCollapsed: store.selectCollapsedIds().includes(item.id),
+  };
 };
 
 export const handleArrowClick = (deps, payload) => {

--- a/src/components/baseFileExplorer/baseFileExplorer.methods.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.methods.js
@@ -9,3 +9,27 @@ export function selectItem(payload = {}) {
     },
   });
 }
+
+export function getSelectedItem(payload = {}) {
+  return this.transformedHandlers.handleGetSelectedItem({
+    _event: {
+      detail: payload,
+    },
+  });
+}
+
+export function navigateSelection(payload = {}) {
+  return this.transformedHandlers.handleNavigateSelection({
+    _event: {
+      detail: payload,
+    },
+  });
+}
+
+export function setSelectedFolderExpanded(payload = {}) {
+  return this.transformedHandlers.handleSetSelectedFolderExpanded({
+    _event: {
+      detail: payload,
+    },
+  });
+}

--- a/src/components/baseFileExplorer/baseFileExplorer.schema.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.schema.yaml
@@ -59,3 +59,15 @@ methods:
       description: Selects an item by id in the explorer list.
       params: []
       returns: void
+    getSelectedItem:
+      description: Returns the currently selected explorer item and folder state.
+      params: []
+      returns: object
+    navigateSelection:
+      description: Moves explorer selection to the previous or next visible item.
+      params: []
+      returns: object
+    setSelectedFolderExpanded:
+      description: Expands or collapses the selected folder item when possible.
+      params: []
+      returns: object

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -535,9 +535,10 @@ export const handleUploadButtonClick = (deps, payload) => {
 
 export const handleZoomChange = (deps, payload) => {
   const { store, render } = deps;
-  const zoomLevel = parseFloat(
+  const nextZoomLevel = parseFloat(
     payload._event.detail?.value ?? payload._event.target?.value ?? 1,
   );
+  const zoomLevel = Math.min(2, Math.max(0.5, nextZoomLevel));
 
   store.setZoomLevel({ zoomLevel });
   render();
@@ -545,7 +546,7 @@ export const handleZoomChange = (deps, payload) => {
 
 export const handleZoomIn = (deps) => {
   const { store, render } = deps;
-  const zoomLevel = Math.min(4, store.selectZoomLevel() + 0.1);
+  const zoomLevel = Math.min(2, store.selectZoomLevel() + 0.1);
   store.setZoomLevel({ zoomLevel });
   render();
 };

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -16,9 +16,9 @@ refs:
         handler: handleContextMenuClickItem
   zoomSlider:
     eventListeners:
-      change:
+      value-change:
         handler: handleZoomChange
-      input:
+      value-input:
         handler: handleZoomChange
   zoomOut:
     eventListeners:
@@ -75,7 +75,7 @@ template:
                   - $if showZoomControls:
                       - rtgl-view d=h av=c g=sm:
                           - rtgl-button#zoomOut sq v="gh" s=sm: '-'
-                          - input#zoomSlider type="range" w=120 min="0.5" max="4.0" step="0.1" value="${zoomLevel}": null
+                          - rtgl-slider#zoomSlider w=120 min="0.5" max="2.0" step="0.1" value="${zoomLevel}": null
                           - rtgl-button#zoomIn sq v="gh" s=sm: +
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
       - 'rtgl-view#scrollContainer h=1fg w=f sv style="min-width: 0;"':

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -444,7 +444,7 @@ export const handleGroupViewKeyDown = (deps, payload) => {
   const selectedExplorerItem = refs.fileExplorer?.getSelectedItem?.();
   const selectedItemId = selectedExplorerItem?.isFolder
     ? undefined
-    : selectedExplorerItem?.itemId ?? store.selectSelectedItemId();
+    : (selectedExplorerItem?.itemId ?? store.selectSelectedItemId());
 
   if (event.key === "Enter") {
     if (!selectedItemId) {

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -40,6 +40,24 @@ const getCharacterIdFromPayload = ({ appService }) => {
   return appService.getPayload().characterId;
 };
 
+const isTextEntryKeyEvent = (event) => {
+  const target = event?.composedPath?.()?.[0] ?? event?.target;
+  const tagName = String(target?.tagName ?? "").toLowerCase();
+  return tagName === "input" || tagName === "textarea";
+};
+
+const focusGroupView = ({ refs } = {}) => {
+  requestAnimationFrame(() => {
+    refs.groupviewKeyboardScope?.focus?.();
+  });
+};
+
+const focusPreviewOverlay = ({ refs } = {}) => {
+  requestAnimationFrame(() => {
+    refs.previewOverlay?.focus?.();
+  });
+};
+
 const syncCharacterSpritesData = ({ deps, repositoryState } = {}) => {
   const { appService, projectService, store } = deps;
   const characterId =
@@ -93,6 +111,26 @@ const selectSprite = ({ deps, itemId, syncExplorer = false } = {}) => {
   }
 
   render();
+  refs.groupview?.scrollItemIntoView?.({ itemId });
+};
+
+const openSpritePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { refs, render, store } = deps;
+  const item = store.selectSpriteItemById({ itemId });
+
+  if (!itemId || !item) {
+    return;
+  }
+
+  store.setSelectedItemId({ itemId });
+  if (syncExplorer) {
+    refs.fileExplorer?.selectItem?.({ itemId });
+  }
+
+  store.showFullImagePreview({ itemId });
+  render();
+  refs.groupview?.scrollItemIntoView?.({ itemId });
+  focusPreviewOverlay(deps);
 };
 
 const openEditDialogForSprite = ({
@@ -297,15 +335,13 @@ export const handleFileExplorerSelectionChanged = async (deps, payload) => {
 };
 
 export const handleFileExplorerDoubleClick = (deps, payload) => {
-  const { render, store } = deps;
   const { itemId, isFolder } = payload._event.detail;
 
   if (isFolder || !itemId) {
     return;
   }
 
-  store.showFullImagePreview({ itemId });
-  render();
+  openSpritePreviewById({ deps, itemId });
 };
 
 export const handleSpriteItemClick = async (deps, payload) => {
@@ -316,30 +352,142 @@ export const handleSpriteItemClick = async (deps, payload) => {
     itemId,
     syncExplorer: true,
   });
+  focusGroupView(deps);
 };
 
 export const handleSpriteItemDoubleClick = (deps, payload) => {
-  const { render, store } = deps;
   const { itemId } = payload._event.detail;
 
   if (!itemId) {
     return;
   }
 
-  store.showFullImagePreview({ itemId });
-  render();
+  openSpritePreviewById({ deps, itemId, syncExplorer: true });
 };
 
 export const handleSpriteItemPreview = (deps, payload) => {
-  const { render, store } = deps;
   const { itemId } = payload._event.detail;
 
   if (!itemId) {
     return;
   }
 
-  store.showFullImagePreview({ itemId });
+  openSpritePreviewById({ deps, itemId, syncExplorer: true });
+};
+
+export const handlePreviewOverlayClick = (deps) => {
+  const { store, render } = deps;
+  store.hideFullImagePreview();
   render();
+  focusGroupView(deps);
+};
+
+export const handlePreviewOverlayKeyDown = (deps, payload) => {
+  const { store } = deps;
+  const event = payload._event;
+
+  if (!store.getState().fullImagePreviewVisible) {
+    return;
+  }
+
+  if (event.key === "Escape" || event.key === "Enter") {
+    event.preventDefault();
+    event.stopPropagation();
+    store.hideFullImagePreview();
+    deps.render();
+    focusGroupView(deps);
+    return;
+  }
+
+  let direction;
+  if (event.key === "ArrowDown") {
+    direction = "next";
+  } else if (event.key === "ArrowUp") {
+    direction = "previous";
+  }
+
+  if (!direction) {
+    return;
+  }
+
+  const selectedItemId = store.selectSelectedItemId();
+  if (!selectedItemId) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+
+  const nextItemId = store.selectAdjacentSpriteItemId({
+    itemId: selectedItemId,
+    direction,
+  });
+  if (!nextItemId) {
+    return;
+  }
+
+  openSpritePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
+};
+
+export const handleGroupViewKeyDown = (deps, payload) => {
+  const { refs, store } = deps;
+  const event = payload._event;
+
+  if (store.getState().fullImagePreviewVisible || isTextEntryKeyEvent(event)) {
+    return;
+  }
+
+  if (event.altKey || event.ctrlKey || event.metaKey) {
+    return;
+  }
+
+  const selectedExplorerItem = refs.fileExplorer?.getSelectedItem?.();
+  const selectedItemId = selectedExplorerItem?.isFolder
+    ? undefined
+    : selectedExplorerItem?.itemId ?? store.selectSelectedItemId();
+
+  if (event.key === "Enter") {
+    if (!selectedItemId) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    openSpritePreviewById({ deps, itemId: selectedItemId, syncExplorer: true });
+    return;
+  }
+
+  let direction;
+  if (event.key === "ArrowDown") {
+    direction = "next";
+  } else if (event.key === "ArrowUp") {
+    direction = "previous";
+  } else if (event.key === "ArrowRight") {
+    event.preventDefault();
+    event.stopPropagation();
+    refs.fileExplorer?.setSelectedFolderExpanded?.({ expanded: true });
+    return;
+  } else if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    event.stopPropagation();
+    refs.fileExplorer?.setSelectedFolderExpanded?.({ expanded: false });
+    return;
+  }
+
+  if (!direction) {
+    return;
+  }
+
+  const nextSelection = refs.fileExplorer?.navigateSelection?.({
+    direction,
+  });
+  if (!nextSelection?.itemId) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  focusGroupView(deps);
 };
 
 export const handleSpriteItemEdit = (deps, payload) => {

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -9,6 +9,8 @@ import {
 const EMPTY_TREE = { tree: [], items: {} };
 const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
+const IMAGE_CARD_MAX_WIDTH = 400;
+const IMAGE_CARD_HEIGHT = 225;
 
 const folderContextMenuItems = [
   { label: "New Folder", type: "item", value: "new-child-folder" },
@@ -250,6 +252,62 @@ export const selectCharacterId = ({ state }) => {
   return state.characterId;
 };
 
+export const selectAdjacentSpriteItemId = (
+  { state },
+  { itemId, direction } = {},
+) => {
+  const step =
+    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
+  if (!step) {
+    return undefined;
+  }
+
+  const rawFlatGroups = toFlatGroups(state.spritesData);
+  const searchQuery = state.searchQuery.toLowerCase().trim();
+  const pendingByGroupId = new Map();
+
+  for (const pendingUpload of state.pendingUploads ?? []) {
+    const groupId = pendingUpload?.parentId;
+    if (!groupId) {
+      continue;
+    }
+
+    const existing = pendingByGroupId.get(groupId) ?? [];
+    existing.push(buildPendingMediaItem(pendingUpload));
+    pendingByGroupId.set(groupId, existing);
+  }
+
+  const visibleSpriteIds = rawFlatGroups
+    .map((group) => {
+      const children = (group.children ?? [])
+        .filter((item) => matchesSearch(item, searchQuery))
+        .map(buildMediaItem);
+      const pendingChildren = (pendingByGroupId.get(group.id) ?? []).filter(
+        (item) => matchesSearch(item, searchQuery),
+      );
+
+      return [...children, ...pendingChildren];
+    })
+    .flatMap((children) =>
+      children
+        .map((child) => child.id)
+        .filter((childItemId) => state.spritesData.items?.[childItemId]?.type === "image"),
+    );
+
+  if (visibleSpriteIds.length === 0) {
+    return undefined;
+  }
+
+  const currentIndex = visibleSpriteIds.indexOf(itemId);
+  if (currentIndex === -1) {
+    return step > 0
+      ? visibleSpriteIds[0]
+      : visibleSpriteIds[visibleSpriteIds.length - 1];
+  }
+
+  return visibleSpriteIds[currentIndex + step];
+};
+
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {
   const item = state.spritesData.items?.[itemId];
 
@@ -321,6 +379,8 @@ export const selectViewData = ({ state }) => {
     searchQuery: state.searchQuery,
     uploadText: "Upload Sprite",
     acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
+    imageHeight: IMAGE_CARD_HEIGHT,
+    maxWidth: IMAGE_CARD_MAX_WIDTH,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
     folderContextMenuItems,

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -291,7 +291,10 @@ export const selectAdjacentSpriteItemId = (
     .flatMap((children) =>
       children
         .map((child) => child.id)
-        .filter((childItemId) => state.spritesData.items?.[childItemId]?.type === "image"),
+        .filter(
+          (childItemId) =>
+            state.spritesData.items?.[childItemId]?.type === "image",
+        ),
     );
 
   if (visibleSpriteIds.length === 0) {

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -29,10 +29,16 @@ refs:
         handler: handleItemDelete
       back-click:
         handler: handleBackClick
+  groupviewKeyboardScope:
+    eventListeners:
+      keydown:
+        handler: handleGroupViewKeyDown
   previewOverlay:
     eventListeners:
       click:
-        action: hideFullImagePreview
+        handler: handlePreviewOverlayClick
+      keydown:
+        handler: handlePreviewOverlayKeyDown
   editDialog:
     eventListeners:
       close:
@@ -65,7 +71,8 @@ template:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
           - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
-              - rvn-media-resources-view#groupview w=f h=f show-back-button show-zoom-controls progressive-render lazy-image-cards :navTitle=${title} :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :acceptedFileTypes=${acceptedFileTypes} :itemContextMenuItems=${centerItemContextMenuItems}: null
+              - 'div#groupviewKeyboardScope tabindex=0 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
+                  - rvn-media-resources-view#groupview w=f h=f show-back-button show-zoom-controls progressive-render lazy-image-cards :navTitle=${title} :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :acceptedFileTypes=${acceptedFileTypes} :imageHeight=${imageHeight} :maxWidth=${maxWidth} :itemContextMenuItems=${centerItemContextMenuItems}: null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
@@ -75,7 +82,7 @@ template:
                               - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedPreviewFileId:
-                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} h=160 bw=xs bc=bo br=md cur=pointer: null
+                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} w=f h=160 bw=xs bc=bo br=md cur=pointer: null
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
@@ -90,7 +97,7 @@ template:
                       - rtgl-view#editDialogImagePlaceholder w=120 h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                           - rtgl-text c=mu-fg s=sm: Click to Upload
   - $when: fullImagePreviewVisible
-    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: pointer; outline: none;"':
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
       - $if fullImagePreviewFileId:
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -93,7 +93,7 @@ const {
   handleFileExplorerAction,
   handleFileExplorerTargetChanged,
   handleSearchInput,
-  handleItemClick: handleImageItemClick,
+  handleItemClick: handleBaseImageItemClick,
   handleItemEdit: handleImageItemEdit,
 } = createMediaPageHandlers({
   resourceType: "images",
@@ -108,8 +108,43 @@ export {
   handleFileExplorerTargetChanged,
   handleDataChanged,
   handleSearchInput,
-  handleImageItemClick,
   handleImageItemEdit,
+};
+
+const isTextEntryKeyEvent = (event) => {
+  const target = event?.composedPath?.()?.[0] ?? event?.target;
+  const tagName = String(target?.tagName ?? "").toLowerCase();
+  return tagName === "input" || tagName === "textarea";
+};
+
+const focusGroupView = ({ refs } = {}) => {
+  requestAnimationFrame(() => {
+    refs.groupviewKeyboardScope?.focus?.();
+  });
+};
+
+const focusPreviewOverlay = ({ refs } = {}) => {
+  requestAnimationFrame(() => {
+    refs.previewOverlay?.focus?.();
+  });
+};
+
+const selectImageById = ({ deps, itemId, syncExplorer = false } = {}) => {
+  const { refs, store, render } = deps;
+  const item = store.selectImageItemById({ itemId });
+  if (!itemId || !item) {
+    return false;
+  }
+
+  store.setSelectedItemId({ itemId });
+
+  if (syncExplorer) {
+    refs.fileExplorer?.selectItem?.({ itemId });
+  }
+
+  render();
+  refs.groupview?.scrollItemIntoView?.({ itemId });
+  return true;
 };
 
 const openImagePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
@@ -127,6 +162,8 @@ const openImagePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
 
   store.showFullImagePreview({ itemId });
   render();
+  refs.groupview?.scrollItemIntoView?.({ itemId });
+  focusPreviewOverlay(deps);
 };
 
 export const handleFileExplorerDoubleClick = (deps, payload) => {
@@ -141,6 +178,11 @@ export const handleFileExplorerDoubleClick = (deps, payload) => {
 export const handleImageItemDoubleClick = (deps, payload) => {
   const { itemId } = payload._event.detail;
   openImagePreviewById({ deps, itemId, syncExplorer: true });
+};
+
+export const handleImageItemClick = (deps, payload) => {
+  handleBaseImageItemClick(deps, payload);
+  focusGroupView(deps);
 };
 
 export const handleDetailHeaderClick = (deps) => {
@@ -388,10 +430,123 @@ export const handleFormExtraEvent = async (deps) => {
 };
 
 export const handleImageItemPreview = (deps, payload) => {
-  const { store, render } = deps;
   const { itemId } = payload._event.detail;
-  store.showFullImagePreview({ itemId });
+  openImagePreviewById({ deps, itemId, syncExplorer: true });
+};
+
+export const handlePreviewOverlayClick = (deps) => {
+  const { store, render } = deps;
+  store.hideFullImagePreview();
   render();
+  focusGroupView(deps);
+};
+
+export const handlePreviewOverlayKeyDown = (deps, payload) => {
+  const { store } = deps;
+  const event = payload._event;
+
+  if (!store.getState().fullImagePreviewVisible) {
+    return;
+  }
+
+  if (event.key === "Escape" || event.key === "Enter") {
+    event.preventDefault();
+    event.stopPropagation();
+    store.hideFullImagePreview();
+    deps.render();
+    focusGroupView(deps);
+    return;
+  }
+
+  const selectedItemId = store.selectSelectedItemId();
+  if (!selectedItemId) {
+    return;
+  }
+
+  let direction;
+  if (event.key === "ArrowDown") {
+    direction = "next";
+  } else if (event.key === "ArrowUp") {
+    direction = "previous";
+  }
+
+  if (!direction) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+
+  const nextItemId = store.selectAdjacentImageItemId({
+    itemId: selectedItemId,
+    direction,
+  });
+  if (!nextItemId) {
+    return;
+  }
+
+  openImagePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
+};
+
+export const handleGroupViewKeyDown = (deps, payload) => {
+  const { refs, store } = deps;
+  const event = payload._event;
+
+  if (store.getState().fullImagePreviewVisible || isTextEntryKeyEvent(event)) {
+    return;
+  }
+
+  if (event.altKey || event.ctrlKey || event.metaKey) {
+    return;
+  }
+
+  const selectedExplorerItem = refs.fileExplorer?.getSelectedItem?.();
+  const selectedItemId = selectedExplorerItem?.isFolder
+    ? undefined
+    : selectedExplorerItem?.itemId ?? store.selectSelectedItemId();
+
+  if (event.key === "Enter") {
+    if (!selectedItemId) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    openImagePreviewById({ deps, itemId: selectedItemId, syncExplorer: true });
+    return;
+  }
+
+  let direction;
+  if (event.key === "ArrowDown") {
+    direction = "next";
+  } else if (event.key === "ArrowUp") {
+    direction = "previous";
+  } else if (event.key === "ArrowRight") {
+    event.preventDefault();
+    event.stopPropagation();
+    refs.fileExplorer?.setSelectedFolderExpanded?.({ expanded: true });
+    return;
+  } else if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    event.stopPropagation();
+    refs.fileExplorer?.setSelectedFolderExpanded?.({ expanded: false });
+    return;
+  }
+
+  if (!direction) {
+    return;
+  }
+
+  const nextSelection = refs.fileExplorer?.navigateSelection?.({
+    direction,
+  });
+  if (!nextSelection?.itemId) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  focusGroupView(deps);
 };
 
 export const handleEditDialogClose = (deps) => {

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -129,24 +129,6 @@ const focusPreviewOverlay = ({ refs } = {}) => {
   });
 };
 
-const selectImageById = ({ deps, itemId, syncExplorer = false } = {}) => {
-  const { refs, store, render } = deps;
-  const item = store.selectImageItemById({ itemId });
-  if (!itemId || !item) {
-    return false;
-  }
-
-  store.setSelectedItemId({ itemId });
-
-  if (syncExplorer) {
-    refs.fileExplorer?.selectItem?.({ itemId });
-  }
-
-  render();
-  refs.groupview?.scrollItemIntoView?.({ itemId });
-  return true;
-};
-
 const openImagePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
   const { refs, store, render } = deps;
   const item = store.selectImageItemById({ itemId });
@@ -503,7 +485,7 @@ export const handleGroupViewKeyDown = (deps, payload) => {
   const selectedExplorerItem = refs.fileExplorer?.getSelectedItem?.();
   const selectedItemId = selectedExplorerItem?.isFolder
     ? undefined
-    : selectedExplorerItem?.itemId ?? store.selectSelectedItemId();
+    : (selectedExplorerItem?.itemId ?? store.selectSelectedItemId());
 
   if (event.key === "Enter") {
     if (!selectedItemId) {

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -8,6 +8,8 @@ import {
 
 const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
+const IMAGE_CARD_MAX_WIDTH = 400;
+const IMAGE_CARD_HEIGHT = 225;
 
 const buildDetailFields = (item) => {
   if (!item) {
@@ -113,6 +115,8 @@ const {
   selectedResourceId: "images",
   uploadText: "Upload",
   acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp"],
+  imageHeight: IMAGE_CARD_HEIGHT,
+  maxWidth: IMAGE_CARD_MAX_WIDTH,
   showZoomControls: true,
   buildDetailFields,
   buildMediaItem,
@@ -146,6 +150,38 @@ export {
 };
 
 export const selectImageItemById = selectItemById;
+
+export const selectAdjacentImageItemId = (
+  context,
+  { itemId, direction } = {},
+) => {
+  const step =
+    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
+  if (!step) {
+    return undefined;
+  }
+
+  const viewData = selectMediaViewData(context);
+  const items = context.state.data?.items ?? {};
+  const visibleImageIds = (viewData.mediaGroups ?? []).flatMap((group) =>
+    (group.children ?? [])
+      .map((child) => child.id)
+      .filter((childItemId) => items[childItemId]?.type === "image"),
+  );
+
+  if (visibleImageIds.length === 0) {
+    return undefined;
+  }
+
+  const currentIndex = visibleImageIds.indexOf(itemId);
+  if (currentIndex === -1) {
+    return step > 0
+      ? visibleImageIds[0]
+      : visibleImageIds[visibleImageIds.length - 1];
+  }
+
+  return visibleImageIds[currentIndex + step];
+};
 
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {
   const item = state.data?.items?.[itemId];

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -29,10 +29,16 @@ refs:
         handler: handleSearchInput
       item-delete:
         handler: handleItemDelete
+  groupviewKeyboardScope:
+    eventListeners:
+      keydown:
+        handler: handleGroupViewKeyDown
   previewOverlay:
     eventListeners:
       click:
-        action: hideFullImagePreview
+        handler: handlePreviewOverlayClick
+      keydown:
+        handler: handlePreviewOverlayKeyDown
   editDialog:
     eventListeners:
       close:
@@ -65,7 +71,8 @@ template:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
           - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
-              - rvn-media-resources-view#groupview w=f h=f :navTitle=${title} show-zoom-controls progressive-render lazy-image-cards :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :acceptedFileTypes=${acceptedFileTypes} :imageHeight=${imageHeight} :maxWidth=${maxWidth} :itemContextMenuItems=${centerItemContextMenuItems}: null
+              - 'div#groupviewKeyboardScope tabindex=0 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
+                  - 'rvn-media-resources-view#groupview w=f h=f :navTitle=${title} show-zoom-controls progressive-render lazy-image-cards :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :acceptedFileTypes=${acceptedFileTypes} :imageHeight=${imageHeight} :maxWidth=${maxWidth} :itemContextMenuItems=${centerItemContextMenuItems}': null
           - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - $if selectedItemId:
@@ -75,7 +82,7 @@ template:
                               - rtgl-svg svg=edit wh=16: null
                           - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                               - $if selectedPreviewFileId:
-                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} h=160 bw=xs bc=bo br=md cur=pointer: null
+                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} w=f h=160 bw=xs bc=bo br=md cur=pointer: null
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
@@ -90,7 +97,7 @@ template:
                       - rtgl-view#editDialogImagePlaceholder w=120 h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
                           - rtgl-text c=mu-fg s=sm: Click to Upload
   - $when: fullImagePreviewVisible
-    rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
+    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: pointer; outline: none;"':
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
       - $if fullImagePreviewFileId:
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.4.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.4.2/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">


### PR DESCRIPTION
## Summary
- add keyboard-driven selection and fullscreen preview navigation for images and character sprites
- let closed-preview navigation follow the file explorer tree, including folder expand/collapse
- switch the shared media zoom control to `rtgl-slider`, clamp it to `0.5x..2x`, and keep media cards at a 16:9 preview box
- update `@rettangoli/ui` to `1.4.2`, `@rettangoli/fe` to `1.1.3`, and refresh the static UI bundle URLs

## Validation
- `bun prettier --check src/components/mediaResourcesView/mediaResourcesView.handlers.js src/components/mediaResourcesView/mediaResourcesView.view.yaml src/pages/characterSprites/characterSprites.handlers.js src/pages/characterSprites/characterSprites.store.js src/pages/images/images.handlers.js`
- `bunx oxlint src/components/mediaResourcesView/mediaResourcesView.handlers.js src/pages/characterSprites/characterSprites.handlers.js src/pages/characterSprites/characterSprites.store.js src/pages/images/images.handlers.js`
- `node --check src/components/mediaResourcesView/mediaResourcesView.handlers.js`
- `node --check src/pages/characterSprites/characterSprites.handlers.js`
- `node --check src/pages/characterSprites/characterSprites.store.js`
- `node --check src/pages/images/images.handlers.js`

`bun run build:web` was not run.