### PR TITLE
Fix scene editor draft overwrite flow

### DIFF
--- a/src/components/linesEditor/linesEditor.handlers.js
+++ b/src/components/linesEditor/linesEditor.handlers.js
@@ -1658,6 +1658,13 @@ export const handleLineBlur = (deps, payload) => {
     deps.props.lines,
   );
 
+  if (
+    shouldPreserveLiveContent &&
+    !shouldIgnoreElementContentSync(blurredElement)
+  ) {
+    dispatchEditorDataChanged(dispatchEvent, blurredElement);
+  }
+
   // Check if we're navigating between lines - if so, don't switch to block mode
   if (store.selectIsNavigating()) {
     return;

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -74,12 +74,13 @@ export const handleActionClicked = (deps, payload) => {
 export const handleCommandLineSubmit = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { store, render, dispatchEvent } = deps;
-  const nextActions = mergeActions(store.selectAction(), payload._event.detail);
+  const submittedActions = payload?._event?.detail || {};
+  const nextActions = mergeActions(store.selectAction(), submittedActions);
 
   store.updateActions(nextActions);
   dispatchEvent(
     new CustomEvent("actions-change", {
-      detail: nextActions,
+      detail: submittedActions,
     }),
   );
   store.hideActionsDialog();

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -664,7 +664,7 @@ export const handleCommandLineSubmit = async (deps, payload) => {
     return;
   }
 
-  let submissionData = payload._event.detail;
+  let submissionData = payload?._event?.detail || {};
 
   // Dialogue updates replace the full dialogue action, so keep content here.
   if (submissionData.dialogue) {


### PR DESCRIPTION
## Summary
- stop system action dialogs from resubmitting a stale merged full action object
- keep scene editor command-line submits working from the current live line data shape
- sync the last edited line text on blur only for ordinary text edits, so action clicks do not drop pending text

## Validation
- `node --check src/components/linesEditor/linesEditor.handlers.js`
- `node --check src/components/systemActions/systemActions.handlers.js`
- `node --check src/pages/sceneEditor/sceneEditor.handlers.js`
- push hook: `oxlint && bun prettier --check src`

`bun run build:web` was not run.