### PR TITLE
Improve animation flows and video metadata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.4.2",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.2.2",
+        "@routevn/creator-model": "1.2.3",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -259,7 +259,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.2.2", "", {}, "sha512-iohN7hskleNAJkCVkJEWJEKbabbaesY0s11Dz1pLSDEifU5xFbsVt5xkEFS60pli9aIvCuvSpdfQLkyh7oyScg=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.2.3", "", {}, "sha512-OOXvxxsixZDp6Y8R7QtEIw5csK/goLEh1Cxq885CFfpB4DzZnuxBUuX0fACWfbZp+LZd0mfg8k/HqWthzoC3nw=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.4.2",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "1.2.2",
+    "@routevn/creator-model": "1.2.3",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/src/components/linesEditor/linesEditor.view.yaml
+++ b/src/components/linesEditor/linesEditor.view.yaml
@@ -47,7 +47,7 @@ template:
                       - $if showLineNumbers:
                           - rtgl-view h=f w=32 ah=e mr=md pt=sm:
                               - rtgl-text s=sm c=${line.lineColor}: ${line.lineNumber}
-                      - rtgl-view wh=24 br=f mr=lg:
+                      - rtgl-view wh=24 br=f mr=sm:
                           - $if line.characterFileId:
                               - rvn-file-image fileId=${line.characterFileId} w=24 h=24 br=f: null
                       - rtgl-view d=h w=f:

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -143,7 +143,11 @@ export const getVideoDimensions = (file) => {
 
     video.onloadedmetadata = () => {
       URL.revokeObjectURL(url); // Clean up memory
-      resolve({ width: video.videoWidth, height: video.videoHeight });
+      resolve({
+        width: video.videoWidth,
+        height: video.videoHeight,
+        duration: video.duration,
+      });
     };
 
     video.onerror = () => {

--- a/src/deps/services/shared/commandApi/resources/catalog.js
+++ b/src/deps/services/shared/commandApi/resources/catalog.js
@@ -1,10 +1,16 @@
 import { COMMAND_TYPES } from "../../../../../internal/project/commands.js";
+import { toFlatItems } from "../../../../../internal/project/tree.js";
 import {
   submitCreateResourceCommand,
   submitDeleteResourceCommand,
   submitMoveResourceCommand,
   submitUpdateResourceCommand,
 } from "./shared.js";
+
+const resolveCatalogResourceParentId = (collection, itemId) => {
+  const flatItems = toFlatItems(collection);
+  return flatItems.find((item) => item.id === itemId)?.parentId ?? null;
+};
 
 export const createCatalogResourceCommandApi = (shared) => ({
   createAnimation: async ({
@@ -62,6 +68,37 @@ export const createCatalogResourceCommandApi = (shared) => ({
       deleteField: "animationIds",
       ids: animationIds,
     }),
+  async duplicateAnimation({ animationId }) {
+    const context = await shared.ensureCommandContext();
+    const sourceAnimation = context.state?.animations?.items?.[animationId];
+
+    if (!sourceAnimation || sourceAnimation.type !== "animation") {
+      return {
+        valid: false,
+        error: {
+          message: "Animation not found.",
+        },
+      };
+    }
+
+    const nextData = structuredClone(sourceAnimation);
+    delete nextData.id;
+    delete nextData.parentId;
+
+    return submitCreateResourceCommand({
+      shared,
+      resourceType: "animations",
+      type: COMMAND_TYPES.ANIMATION_CREATE,
+      idField: "animationId",
+      data: nextData,
+      parentId: resolveCatalogResourceParentId(
+        context.state?.animations,
+        animationId,
+      ),
+      position: "after",
+      positionTargetId: animationId,
+    });
+  },
   createParticle: async ({
     particleId,
     data,
@@ -363,7 +400,10 @@ export const createCatalogResourceCommandApi = (shared) => ({
       type: COMMAND_TYPES.TEXTSTYLE_CREATE,
       idField: "textStyleId",
       data: nextData,
-      parentId: sourceTextStyle.parentId ?? null,
+      parentId: resolveCatalogResourceParentId(
+        context.state?.textStyles,
+        textStyleId,
+      ),
       position: "after",
       positionTargetId: textStyleId,
     });

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -258,7 +258,7 @@ export const createProjectAssetService = ({
     }
 
     if (fileType === "video") {
-      const [videoResult, dimensions, thumbnailPayload] = await Promise.all([
+      const [videoResult, videoMetadata, thumbnailPayload] = await Promise.all([
         storeFileWithRecord({ file }),
         getVideoDimensions(file),
         (async () => {
@@ -293,7 +293,13 @@ export const createProjectAssetService = ({
         ...videoResult,
         thumbnailFileId: thumbnailPayload?.thumbnailResult?.fileId,
         thumbnailData: thumbnailPayload?.thumbnailData,
-        dimensions,
+        dimensions: videoMetadata
+          ? {
+              width: videoMetadata.width,
+              height: videoMetadata.height,
+            }
+          : undefined,
+        duration: videoMetadata?.duration,
         type: "video",
         fileRecords: [
           videoResult.fileRecord,

--- a/src/internal/animationEditorRoute.js
+++ b/src/internal/animationEditorRoute.js
@@ -10,10 +10,14 @@ export const resolveAnimationEditorPayload = (payload = {}) => {
     getPayloadString(payload, "ag") ?? getPayloadString(payload, "groupId");
   const dialogType =
     getPayloadString(payload, "at") === "transition" ? "transition" : "update";
+  const name = getPayloadString(payload, "anm");
+  const description = getPayloadString(payload, "ads");
 
   return {
     animationId,
     dialogType,
+    name,
+    description,
     targetGroupId: targetGroupId === "_root" ? undefined : targetGroupId,
   };
 };
@@ -23,6 +27,8 @@ export const createAnimationEditorPayload = ({
   animationId,
   dialogType,
   targetGroupId,
+  name,
+  description,
 } = {}) => {
   const nextPayload = { ...payload };
   delete nextPayload.animationId;
@@ -30,6 +36,8 @@ export const createAnimationEditorPayload = ({
   delete nextPayload.an;
   delete nextPayload.at;
   delete nextPayload.ag;
+  delete nextPayload.anm;
+  delete nextPayload.ads;
 
   if (animationId) {
     nextPayload.an = animationId;
@@ -42,6 +50,14 @@ export const createAnimationEditorPayload = ({
 
   if (targetGroupId) {
     nextPayload.ag = targetGroupId;
+  }
+
+  if (name) {
+    nextPayload.anm = name;
+  }
+
+  if (description) {
+    nextPayload.ads = description;
   }
 
   return nextPayload;

--- a/src/internal/ui/fileExplorer.js
+++ b/src/internal/ui/fileExplorer.js
@@ -132,6 +132,7 @@ const RESOURCE_FILE_EXPLORER_API = Object.freeze({
     updateMethod: "updateAnimation",
     moveMethod: "moveAnimation",
     deleteMethod: "deleteAnimations",
+    duplicateMethod: "duplicateAnimation",
     idField: "animationId",
     deleteField: "animationIds",
   },

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -506,7 +506,7 @@ const syncEditorState = async ({ deps, repositoryState } = {}) => {
   const { appService, projectService, render, store } = deps;
   const resolvedRepositoryState =
     repositoryState ?? projectService.getRepositoryState();
-  const { animationId, dialogType, targetGroupId } =
+  const { animationId, dialogType, targetGroupId, name, description } =
     getEditorPayload(appService);
 
   store.setItems({
@@ -551,7 +551,10 @@ const syncEditorState = async ({ deps, repositoryState } = {}) => {
       dialogType,
     });
     store.setAnimationName({
-      name: DEFAULT_NEW_ANIMATION_NAME,
+      name: name ?? DEFAULT_NEW_ANIMATION_NAME,
+    });
+    store.setAnimationDescription({
+      description: description ?? "",
     });
   }
 

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -8,6 +8,8 @@ const navigateToAnimationEditor = ({
   animationId,
   dialogType,
   targetGroupId,
+  name,
+  description,
 } = {}) => {
   const currentPayload = appService.getPayload() || {};
   appService.navigate("/project/animation-editor", {
@@ -16,6 +18,8 @@ const navigateToAnimationEditor = ({
       animationId,
       dialogType,
       targetGroupId,
+      name,
+      description,
     }),
   });
 };
@@ -105,13 +109,8 @@ export const handleFileExplorerAction = async (deps, payload) => {
 
 export const handleAddAnimationClick = async (deps, payload) => {
   const { render, store } = deps;
-  const { groupId, x, y } = payload._event.detail;
-
-  store.openCreateTypeMenu({
-    x,
-    y,
-    targetGroupId: groupId,
-  });
+  const { groupId } = payload._event.detail;
+  store.openAddDialog({ groupId });
   render();
 };
 
@@ -190,28 +189,40 @@ export const handleEditFormAction = async (deps, payload) => {
   await handleDataChanged(deps, { selectedItemId: editItemId });
 };
 
-export const handleCloseCreateTypeMenu = (deps) => {
+export const handleAddDialogClose = (deps) => {
   const { render, store } = deps;
-  store.closeCreateTypeMenu();
+  store.closeAddDialog();
   render();
 };
 
-export const handleCreateTypeMenuItemClick = async (deps, payload) => {
+export const handleAddFormAction = async (deps, payload) => {
   const { appService, render, store } = deps;
-  const type = payload._event.detail.item?.value;
-  const targetGroupId = store.selectCreateTypeMenuTargetGroupId();
-
-  store.closeCreateTypeMenu();
-  render();
-
-  if (type !== "update" && type !== "transition") {
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
     return;
   }
+
+  const name = values?.name?.trim();
+  if (!name) {
+    appService.showToast("Please enter an animation name.", {
+      title: "Warning",
+    });
+    return;
+  }
+
+  const dialogType =
+    values?.dialogType === "transition" ? "transition" : "update";
+  const targetGroupId = store.selectTargetGroupId();
+
+  store.closeAddDialog();
+  render();
 
   navigateToAnimationEditor({
     appService,
     targetGroupId,
-    dialogType: type,
+    dialogType,
+    name,
+    description: values?.description ?? "",
   });
 };
 
@@ -238,4 +249,28 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   await handleDataChanged(deps);
+};
+
+export const handleItemDuplicate = async (deps, payload) => {
+  const { appService, projectService } = deps;
+  const { itemId } = payload._event.detail;
+  if (!itemId) {
+    return;
+  }
+
+  const duplicateAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to duplicate animation.",
+    action: () =>
+      projectService.duplicateAnimation({
+        animationId: itemId,
+      }),
+  });
+  if (!duplicateAttempt.ok) {
+    return;
+  }
+
+  await handleDataChanged(deps, {
+    selectedItemId: duplicateAttempt.result,
+  });
 };

--- a/src/pages/animations/animations.store.js
+++ b/src/pages/animations/animations.store.js
@@ -34,27 +34,61 @@ const editForm = {
   },
 };
 
-const createTypeMenuItems = [
-  {
-    label: "Update",
-    type: "item",
-    value: "update",
+const addForm = {
+  title: "Add Animation",
+  fields: [
+    {
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      required: true,
+    },
+    {
+      name: "description",
+      type: "input-textarea",
+      label: "Description",
+      required: false,
+    },
+    {
+      name: "dialogType",
+      type: "segmented-control",
+      label: "Type",
+      noClear: true,
+      required: true,
+      options: [
+        {
+          label: "Update",
+          value: "update",
+        },
+        {
+          label: "Transition",
+          value: "transition",
+        },
+      ],
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Continue",
+      },
+    ],
   },
-  {
-    label: "Transition",
-    type: "item",
-    value: "transition",
-  },
-];
+};
 
 const animationExplorerItemContextMenuItems = [
   { label: "Edit", type: "item", value: "edit-item" },
   { label: "Rename", type: "item", value: "rename-item" },
+  { label: "Duplicate", type: "item", value: "duplicate-item" },
   { label: "Delete", type: "item", value: "delete-item" },
 ];
 
 const animationCenterItemContextMenuItems = [
   { label: "Edit", type: "item", value: "edit-item" },
+  { label: "Duplicate", type: "item", value: "duplicate-item" },
   { label: "Delete", type: "item", value: "delete-item" },
 ];
 
@@ -98,6 +132,13 @@ const {
 
     return {
       ...baseViewData,
+      isAddDialogOpen: state.isAddDialogOpen,
+      addForm,
+      addFormDefaults: {
+        name: "",
+        description: "",
+        dialogType: "update",
+      },
       isEditDialogOpen: state.isEditDialogOpen,
       editForm,
       editDefaultValues: state.editDefaultValues,
@@ -108,25 +149,19 @@ const {
       selectedItemDuration: formatAnimationDurationLabel(
         selectedAnimationItem?.duration,
       ),
-      createTypeMenu: state.createTypeMenu,
     };
   },
 });
 
 export const createInitialState = () => ({
   ...createCatalogInitialState(),
+  isAddDialogOpen: false,
+  targetGroupId: undefined,
   isEditDialogOpen: false,
   editItemId: undefined,
   editDefaultValues: {
     name: "",
     description: "",
-  },
-  createTypeMenu: {
-    isOpen: false,
-    x: 0,
-    y: 0,
-    targetGroupId: undefined,
-    items: createTypeMenuItems,
   },
 });
 
@@ -147,6 +182,20 @@ export const selectAnimationDisplayItemById = ({ state }, { itemId } = {}) => {
   return rawItem ? toAnimationDisplayItem(rawItem) : undefined;
 };
 
+export const openAddDialog = ({ state }, { groupId } = {}) => {
+  state.isAddDialogOpen = true;
+  state.targetGroupId = groupId === "_root" ? undefined : groupId;
+};
+
+export const closeAddDialog = ({ state }) => {
+  state.isAddDialogOpen = false;
+  state.targetGroupId = undefined;
+};
+
+export const selectTargetGroupId = ({ state }) => {
+  return state.targetGroupId;
+};
+
 export const openEditDialog = ({ state }, { itemId, defaultValues } = {}) => {
   state.isEditDialogOpen = true;
   state.editItemId = itemId;
@@ -163,25 +212,6 @@ export const closeEditDialog = ({ state }) => {
     name: "",
     description: "",
   };
-};
-
-export const openCreateTypeMenu = ({ state }, { x, y, targetGroupId } = {}) => {
-  state.createTypeMenu.isOpen = true;
-  state.createTypeMenu.x = x ?? 0;
-  state.createTypeMenu.y = y ?? 0;
-  state.createTypeMenu.targetGroupId =
-    targetGroupId === "_root" ? undefined : targetGroupId;
-};
-
-export const closeCreateTypeMenu = ({ state }) => {
-  state.createTypeMenu.isOpen = false;
-  state.createTypeMenu.x = 0;
-  state.createTypeMenu.y = 0;
-  state.createTypeMenu.targetGroupId = undefined;
-};
-
-export const selectCreateTypeMenuTargetGroupId = ({ state }) => {
-  return state.createTypeMenu.targetGroupId;
 };
 
 export const selectViewData = (context) => {

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -23,12 +23,16 @@ refs:
         handler: handleSearchInput
       item-delete:
         handler: handleItemDelete
-  createTypeMenu:
+      item-duplicate:
+        handler: handleItemDuplicate
+  addDialog:
     eventListeners:
       close:
-        handler: handleCloseCreateTypeMenu
-      item-click:
-        handler: handleCreateTypeMenuItemClick
+        handler: handleAddDialogClose
+  addForm:
+    eventListeners:
+      form-action:
+        handler: handleAddFormAction
   detailHeader:
     eventListeners:
       click:
@@ -71,6 +75,7 @@ template:
                     $else:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: No selection
+  - rtgl-dialog#addDialog ?open=${isAddDialogOpen} s=md:
+      - rtgl-form#addForm key=${isAddDialogOpen} slot=content :defaultValues=${addFormDefaults} :form=${addForm} w=f: null
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-form#editForm key=${isEditDialogOpen} slot=content :defaultValues=${editDefaultValues} :form=${editForm} w=f: null
-  - rtgl-dropdown-menu#createTypeMenu :items=${createTypeMenu.items} ?open=${createTypeMenu.isOpen} x=${createTypeMenu.x} y=${createTypeMenu.y}: null

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -91,6 +91,7 @@ const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
               description: "",
               fileType: uploadResult.file.type,
               fileSize: uploadResult.file.size,
+              duration: uploadResult.duration,
               width: uploadResult.dimensions?.width,
               height: uploadResult.dimensions?.height,
             },
@@ -298,6 +299,7 @@ export const handleFormExtraEvent = async (deps) => {
           name: uploadResult.displayName,
           fileType: uploadResult.file.type,
           fileSize: uploadResult.file.size,
+          duration: uploadResult.duration,
           width: uploadResult.dimensions?.width,
           height: uploadResult.dimensions?.height,
         },
@@ -386,6 +388,7 @@ export const handleEditFormAction = async (deps, payload) => {
         thumbnailFileId: editUploadResult.thumbnailFileId,
         fileType: editUploadResult.file.type,
         fileSize: editUploadResult.file.size,
+        duration: editUploadResult.duration,
         width: editUploadResult.dimensions?.width,
         height: editUploadResult.dimensions?.height,
       }

--- a/src/pages/videos/videos.store.js
+++ b/src/pages/videos/videos.store.js
@@ -10,6 +10,25 @@ const formatDimensions = (item) => {
   return `${item.width} × ${item.height}`;
 };
 
+const formatDuration = (duration) => {
+  if (!Number.isFinite(duration) || duration < 0) {
+    return "Unknown";
+  }
+
+  const totalSeconds = Math.floor(duration);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds
+      .toString()
+      .padStart(2, "0")}`;
+  }
+
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
 const buildDetailFields = (item) => {
   if (!item) {
     return [];
@@ -39,6 +58,11 @@ const buildDetailFields = (item) => {
       type: "text",
       label: "Dimensions",
       value: formatDimensions(item),
+    },
+    {
+      type: "text",
+      label: "Duration",
+      value: formatDuration(item.duration),
     },
   ];
 };


### PR DESCRIPTION
## Summary
- replace the animation type context menu with an add dialog that collects name, description, and type before opening the editor
- add animation duplication support through the resource command API and file explorer integration
- carry video duration through upload processing and show it in the videos detail panel
- keep a few related UI polish updates, including tighter line icon spacing in the scene editor

## Validation
- `node --check src/deps/clients/web/fileProcessors.js`
- `node --check src/deps/services/shared/commandApi/resources/catalog.js`
- `node --check src/deps/services/shared/projectAssetService.js`
- `node --check src/internal/animationEditorRoute.js`
- `node --check src/internal/ui/fileExplorer.js`
- `node --check src/pages/animationEditor/animationEditor.handlers.js`
- `node --check src/pages/animations/animations.handlers.js`
- `node --check src/pages/animations/animations.store.js`
- `node --check src/pages/videos/videos.handlers.js`
- `node --check src/pages/videos/videos.store.js`
- `bun prettier --check src/components/linesEditor/linesEditor.view.yaml src/deps/clients/web/fileProcessors.js src/deps/services/shared/commandApi/resources/catalog.js src/deps/services/shared/projectAssetService.js src/internal/animationEditorRoute.js src/internal/ui/fileExplorer.js src/pages/animationEditor/animationEditor.handlers.js src/pages/animations/animations.handlers.js src/pages/animations/animations.store.js src/pages/animations/animations.view.yaml src/pages/videos/videos.handlers.js src/pages/videos/videos.store.js`
- push hook: `oxlint && bun prettier --check src`

`bun run build:web` was not run.

## Note
- local-only `@routevn/creator-model: file:../routevn-creator-model` changes in `package.json` and `bun.lock` were intentionally left out of this PR.