### PR TITLE
fix: harden uploads and scene projection recovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "jsdom": "^26.1.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.5",
-        "route-engine-js": "1.1.0",
+        "route-engine-js": "1.2.0",
         "route-graphics": "1.8.1",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
@@ -687,7 +687,7 @@
 
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
 
-    "route-engine-js": ["route-engine-js@1.1.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-LCOtfEz5kc+xFU2xZindEcaru62NztMBqi4Je3/p+9FprEoitCA0iKDwyamWBa+nAyw7jIhIvtkJSNY2E0T46Q=="],
+    "route-engine-js": ["route-engine-js@1.2.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-0d3HgHjl3BAJkTSqcJReoHTDEAEIzp7V0NOZ/X+F8Xnk7ZG8yUlEa365n28yy+Y3xd3s2CEmbrB/RegrWUCdVg=="],
 
     "route-graphics": ["route-graphics@1.8.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-L1z2B16E448dvvXDPjO9gss7c8qM/dAUJKs48ZTkFC/+V2Y8w2K7ZhnmhzVa/4BhU93cwCa3qYCrtte2U+N7OQ=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsdom": "^26.1.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.5",
-    "route-engine-js": "1.1.0",
+    "route-engine-js": "1.2.0",
     "route-graphics": "1.8.1",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",

--- a/src/deps/services/shared/collab/projectorCache.js
+++ b/src/deps/services/shared/collab/projectorCache.js
@@ -6,10 +6,11 @@ import {
 } from "./compatibility.js";
 import { committedEventToCommand } from "./mappers.js";
 
-export const PROJECTOR_CACHE_VERSION = "1";
+export const PROJECTOR_CACHE_VERSION = "2";
 
 const PROJECTOR_CACHE_VERSION_KEY = "projectorCacheVersion";
 const PROJECTOR_GAP_KEY = "projectorGap";
+const PROJECT_CREATE_COMMAND_TYPE = "project.create";
 
 const readAppValue = async (store, key) => {
   if (!store?.app || typeof store.app.get !== "function") return undefined;
@@ -32,6 +33,22 @@ const getRepositoryEvents = async (repositoryStore) => {
   }
   const events = await repositoryStore.getEvents();
   return Array.isArray(events) ? events : [];
+};
+
+const getCommandTypeFromEvent = (event) => {
+  return committedEventToCommand(event)?.type;
+};
+
+const hasProjectCreateEvent = (events = []) => {
+  return (events || []).some(
+    (event) => getCommandTypeFromEvent(event) === PROJECT_CREATE_COMMAND_TYPE,
+  );
+};
+
+const findProjectCreateEvent = (events = []) => {
+  return (events || []).find(
+    (event) => getCommandTypeFromEvent(event) === PROJECT_CREATE_COMMAND_TYPE,
+  );
 };
 
 export const listCommittedEvents = async (rawClientStore) => {
@@ -122,9 +139,19 @@ export const ensureRawCommittedLogBootstrapped = async ({
 export const buildRepositoryProjectionFromCommittedEvents = ({
   committedEvents,
   supportedSchemaVersion,
+  fallbackRepositoryEvents = [],
 }) => {
   const repositoryEvents = [];
   let projectionGap;
+
+  if (!hasProjectCreateEvent(committedEvents)) {
+    const fallbackProjectCreateEvent = findProjectCreateEvent(
+      fallbackRepositoryEvents,
+    );
+    if (fallbackProjectCreateEvent) {
+      repositoryEvents.push(structuredClone(fallbackProjectCreateEvent));
+    }
+  }
 
   for (const committedEvent of committedEvents || []) {
     if (projectionGap) break;
@@ -189,9 +216,11 @@ export const rebuildRepositoryProjectionCache = async ({
   rawClientStore,
 }) => {
   const committedEvents = await listCommittedEvents(rawClientStore);
+  const fallbackRepositoryEvents = await getRepositoryEvents(repositoryStore);
   const { repositoryEvents, projectionGap } =
     buildRepositoryProjectionFromCommittedEvents({
       committedEvents,
+      fallbackRepositoryEvents,
     });
 
   await clearDerivedRepositoryState(repositoryStore);

--- a/src/deps/services/shared/commandApi/characterSprites.js
+++ b/src/deps/services/shared/commandApi/characterSprites.js
@@ -12,14 +12,10 @@ export const createCharacterSpriteCommandApi = (shared) => ({
     index,
   }) {
     const context = await shared.ensureCommandContext();
-    const ensureFilesResult = await shared.ensureFilesExist({
+    const fileCommands = shared.buildMissingFileCommands({
       context,
       fileRecords,
     });
-    if (ensureFilesResult?.valid === false) {
-      return ensureFilesResult;
-    }
-
     const nextSpriteId = spriteId || shared.createId();
     const character = context.state?.characters?.items?.[characterId];
     const resolvedIndex = shared.resolveCharacterSpriteIndex({
@@ -34,22 +30,27 @@ export const createCharacterSpriteCommandApi = (shared) => ({
       "characters",
     );
 
-    const submitResult = await shared.submitCommandWithContext({
+    const submitResult = await shared.submitCommandsWithContext({
       context,
-      scope: "resources",
-      basePartition: resourcePartition,
-      type: COMMAND_TYPES.CHARACTER_SPRITE_CREATE,
-      payload: {
-        characterId,
-        spriteId: nextSpriteId,
-        data: structuredClone(data || {}),
-        ...shared.buildPlacementPayload({
-          parentId,
-          index: resolvedIndex,
-          position,
-          positionTargetId,
-        }),
-      },
+      commands: [
+        ...fileCommands,
+        {
+          scope: "resources",
+          basePartition: resourcePartition,
+          type: COMMAND_TYPES.CHARACTER_SPRITE_CREATE,
+          payload: {
+            characterId,
+            spriteId: nextSpriteId,
+            data: structuredClone(data || {}),
+            ...shared.buildPlacementPayload({
+              parentId,
+              index: resolvedIndex,
+              position,
+              positionTargetId,
+            }),
+          },
+        },
+      ],
     });
 
     if (submitResult?.valid === false) {
@@ -66,29 +67,31 @@ export const createCharacterSpriteCommandApi = (shared) => ({
     fileRecords = [],
   }) {
     const context = await shared.ensureCommandContext();
-    const ensureFilesResult = await shared.ensureFilesExist({
+    const fileCommands = shared.buildMissingFileCommands({
       context,
       fileRecords,
     });
-    if (ensureFilesResult?.valid === false) {
-      return ensureFilesResult;
-    }
 
     const resourcePartition = shared.resourceTypePartitionFor(
       context.projectId,
       "characters",
     );
 
-    return shared.submitCommandWithContext({
+    return shared.submitCommandsWithContext({
       context,
-      scope: "resources",
-      basePartition: resourcePartition,
-      type: COMMAND_TYPES.CHARACTER_SPRITE_UPDATE,
-      payload: {
-        characterId,
-        spriteId,
-        data: structuredClone(data || {}),
-      },
+      commands: [
+        ...fileCommands,
+        {
+          scope: "resources",
+          basePartition: resourcePartition,
+          type: COMMAND_TYPES.CHARACTER_SPRITE_UPDATE,
+          payload: {
+            characterId,
+            spriteId,
+            data: structuredClone(data || {}),
+          },
+        },
+      ],
     });
   },
 

--- a/src/deps/services/shared/commandApi/controls.js
+++ b/src/deps/services/shared/commandApi/controls.js
@@ -77,27 +77,29 @@ export const createControlCommandApi = (shared) => ({
 
   async updateControlItem({ controlId, data, fileRecords = [] }) {
     const context = await shared.ensureCommandContext();
-    const ensureFilesResult = await shared.ensureFilesExist({
+    const fileCommands = shared.buildMissingFileCommands({
       context,
       fileRecords,
     });
-    if (ensureFilesResult?.valid === false) {
-      return ensureFilesResult;
-    }
     const resourcePartition = shared.resourceTypePartitionFor(
       context.projectId,
       "controls",
     );
 
-    return shared.submitCommandWithContext({
+    return shared.submitCommandsWithContext({
       context,
-      scope: "resources",
-      basePartition: resourcePartition,
-      type: COMMAND_TYPES.CONTROL_UPDATE,
-      payload: {
-        controlId,
-        data: structuredClone(data || {}),
-      },
+      commands: [
+        ...fileCommands,
+        {
+          scope: "resources",
+          basePartition: resourcePartition,
+          type: COMMAND_TYPES.CONTROL_UPDATE,
+          payload: {
+            controlId,
+            data: structuredClone(data || {}),
+          },
+        },
+      ],
     });
   },
 

--- a/src/deps/services/shared/commandApi/layouts.js
+++ b/src/deps/services/shared/commandApi/layouts.js
@@ -151,24 +151,26 @@ export const createLayoutCommandApi = (shared) => ({
 
   async updateLayoutItem({ layoutId, data, fileRecords = [] }) {
     const context = await shared.ensureCommandContext();
-    const ensureFilesResult = await shared.ensureFilesExist({
+    const fileCommands = shared.buildMissingFileCommands({
       context,
       fileRecords,
     });
-    if (ensureFilesResult?.valid === false) {
-      return ensureFilesResult;
-    }
     const resourcePartition = getLayoutsResourcePartition({ shared, context });
 
-    return shared.submitCommandWithContext({
+    return shared.submitCommandsWithContext({
       context,
-      scope: "resources",
-      basePartition: resourcePartition,
-      type: COMMAND_TYPES.LAYOUT_UPDATE,
-      payload: {
-        layoutId,
-        data: structuredClone(data || {}),
-      },
+      commands: [
+        ...fileCommands,
+        {
+          scope: "resources",
+          basePartition: resourcePartition,
+          type: COMMAND_TYPES.LAYOUT_UPDATE,
+          payload: {
+            layoutId,
+            data: structuredClone(data || {}),
+          },
+        },
+      ],
     });
   },
 

--- a/src/deps/services/shared/commandApi/resources/shared.js
+++ b/src/deps/services/shared/commandApi/resources/shared.js
@@ -16,14 +16,10 @@ export const submitCreateResourceCommand = async ({
   fileRecords = [],
 }) => {
   const context = await shared.ensureCommandContext();
-  const ensureFilesResult = await shared.ensureFilesExist({
+  const fileCommands = shared.buildMissingFileCommands({
     context,
     fileRecords,
   });
-  if (ensureFilesResult?.valid === false) {
-    return ensureFilesResult;
-  }
-
   const nextResourceId = idValue ?? shared.createId();
   const resolvedIndex = shared.resolveResourceIndex({
     state: context.state,
@@ -34,25 +30,30 @@ export const submitCreateResourceCommand = async ({
     index,
   });
 
-  const submitResult = await shared.submitCommandWithContext({
+  const submitResult = await shared.submitCommandsWithContext({
     context,
-    scope: "resources",
-    basePartition: createResourcePartition({
-      shared,
-      context,
-      resourceType,
-    }),
-    type,
-    payload: {
-      [idField]: nextResourceId,
-      data: structuredClone(data),
-      ...shared.buildPlacementPayload({
-        parentId,
-        index: resolvedIndex,
-        position,
-        positionTargetId,
-      }),
-    },
+    commands: [
+      ...fileCommands,
+      {
+        scope: "resources",
+        basePartition: createResourcePartition({
+          shared,
+          context,
+          resourceType,
+        }),
+        type,
+        payload: {
+          [idField]: nextResourceId,
+          data: structuredClone(data),
+          ...shared.buildPlacementPayload({
+            parentId,
+            index: resolvedIndex,
+            position,
+            positionTargetId,
+          }),
+        },
+      },
+    ],
   });
 
   if (submitResult?.valid === false) {
@@ -72,27 +73,29 @@ export const submitUpdateResourceCommand = async ({
   fileRecords = [],
 }) => {
   const context = await shared.ensureCommandContext();
-  const ensureFilesResult = await shared.ensureFilesExist({
+  const fileCommands = shared.buildMissingFileCommands({
     context,
     fileRecords,
   });
-  if (ensureFilesResult?.valid === false) {
-    return ensureFilesResult;
-  }
 
-  return shared.submitCommandWithContext({
+  return shared.submitCommandsWithContext({
     context,
-    scope: "resources",
-    basePartition: createResourcePartition({
-      shared,
-      context,
-      resourceType,
-    }),
-    type,
-    payload: {
-      [idField]: idValue,
-      data: structuredClone(data),
-    },
+    commands: [
+      ...fileCommands,
+      {
+        scope: "resources",
+        basePartition: createResourcePartition({
+          shared,
+          context,
+          resourceType,
+        }),
+        type,
+        payload: {
+          [idField]: idValue,
+          data: structuredClone(data),
+        },
+      },
+    ],
   });
 };
 

--- a/src/deps/services/shared/commandApi/shared.js
+++ b/src/deps/services/shared/commandApi/shared.js
@@ -285,16 +285,16 @@ export const createCommandApiShared = ({
     };
   };
 
-  const ensureFilesExist = async ({ context, fileRecords = [] } = {}) => {
+  const buildMissingFileCommands = ({ context, fileRecords = [] } = {}) => {
     const normalizedFileRecords = Array.isArray(fileRecords) ? fileRecords : [];
     if (normalizedFileRecords.length === 0) {
-      return { valid: true, createdCount: 0 };
+      return [];
     }
 
     const knownFileIds = new Set(
       Object.keys(context.state?.files?.items || {}),
     );
-    let createdCount = 0;
+    const commands = [];
 
     for (const fileRecord of normalizedFileRecords) {
       if (
@@ -319,8 +319,7 @@ export const createCommandApiShared = ({
         );
       }
 
-      const submitResult = await submitCommandWithContext({
-        context,
+      commands.push({
         scope: "resources",
         basePartition: filePartitionFor(context.projectId),
         type: COMMAND_TYPES.FILE_CREATE,
@@ -333,15 +332,34 @@ export const createCommandApiShared = ({
           },
         },
       });
-      if (submitResult?.valid === false) {
-        return submitResult;
-      }
 
       knownFileIds.add(fileRecord.id);
-      createdCount += 1;
     }
 
-    return { valid: true, createdCount };
+    return commands;
+  };
+
+  const ensureFilesExist = async ({ context, fileRecords = [] } = {}) => {
+    const commands = buildMissingFileCommands({
+      context,
+      fileRecords,
+    });
+    if (commands.length === 0) {
+      return { valid: true, createdCount: 0 };
+    }
+
+    const submitResult = await submitCommandsWithContext({
+      context,
+      commands,
+    });
+    if (submitResult?.valid === false) {
+      return submitResult;
+    }
+
+    return {
+      valid: true,
+      createdCount: commands.length,
+    };
   };
 
   const buildPlacementPayload = ({
@@ -503,6 +521,7 @@ export const createCommandApiShared = ({
     createId,
     getCurrentProjectId,
     ensureCommandContext,
+    buildMissingFileCommands,
     ensureFilesExist,
     createCommandWithContext,
     submitCommandWithContext,

--- a/src/deps/services/shared/projectRepositoryViews/sceneStateView.js
+++ b/src/deps/services/shared/projectRepositoryViews/sceneStateView.js
@@ -1,4 +1,8 @@
-import { scenePartitionFor } from "../collab/partitions.js";
+import {
+  mainScenePartitionFor,
+  scenePartitionFor,
+} from "../collab/partitions.js";
+import { committedEventToCommand } from "../collab/mappers.js";
 import {
   SCENE_VIEW_NAME,
   SCENE_VIEW_VERSION,
@@ -10,6 +14,233 @@ import {
 } from "./shared.js";
 
 const getScenePartition = (sceneId) => scenePartitionFor(sceneId);
+const getMainScenePartition = (sceneId) => mainScenePartitionFor(sceneId);
+
+const getSceneProjectionDebugDetails = (event) => {
+  const command = committedEventToCommand(event);
+  const payload = command?.payload || {};
+  const lineId =
+    typeof payload.lineId === "string"
+      ? payload.lineId
+      : Array.isArray(payload.lineIds) && payload.lineIds.length > 0
+        ? payload.lineIds[0]
+        : undefined;
+  const sectionId =
+    typeof payload.sectionId === "string"
+      ? payload.sectionId
+      : typeof payload.toSectionId === "string"
+        ? payload.toSectionId
+        : undefined;
+
+  return {
+    command,
+    payload,
+    lineId,
+    sectionId,
+  };
+};
+
+const formatLineLocation = (location) => {
+  if (!location) {
+    return undefined;
+  }
+
+  return {
+    sceneId: location.sceneId,
+    sectionId: location.sectionId,
+  };
+};
+
+const formatSectionLocation = (location) => {
+  if (!location) {
+    return undefined;
+  }
+
+  return {
+    sceneId: location.sceneId,
+    sectionId: location.section?.id,
+  };
+};
+
+const formatSceneProjectionDebugEntry = (event, repositoryState) => {
+  const { command, lineId, sectionId } = getSceneProjectionDebugDetails(event);
+
+  return {
+    eventId: event?.id,
+    partition: event?.partition,
+    commandType: command?.type,
+    lineId,
+    sectionId,
+    linePresent: lineId
+      ? Boolean(findLineLocationInState(repositoryState, lineId))
+      : undefined,
+    sectionPresent: sectionId
+      ? Boolean(findSectionLocationInState(repositoryState, sectionId))
+      : undefined,
+  };
+};
+
+const summarizeSceneProjectionLifecycle = ({ events, lineId, sectionId }) => {
+  if (!lineId && !sectionId) {
+    return [];
+  }
+
+  const lifecycle = [];
+  for (const event of events) {
+    const {
+      command,
+      payload,
+      lineId: eventLineId,
+      sectionId: eventSectionId,
+    } = getSceneProjectionDebugDetails(event);
+
+    if (command?.type === "project.create") {
+      const seededState = payload?.state;
+      const seededLineLocation = lineId
+        ? findLineLocationInState(seededState, lineId)
+        : null;
+      const seededSectionLocation = sectionId
+        ? findSectionLocationInState(seededState, sectionId)
+        : null;
+
+      if (!seededLineLocation && !seededSectionLocation) {
+        continue;
+      }
+
+      lifecycle.push({
+        eventId: event?.id,
+        partition: event?.partition,
+        commandType: command?.type,
+        seededLineLocation: formatLineLocation(seededLineLocation),
+        seededSectionLocation: formatSectionLocation(seededSectionLocation),
+      });
+      continue;
+    }
+
+    const lineIds = Array.isArray(payload?.lineIds) ? payload.lineIds : [];
+    const sectionIds = Array.isArray(payload?.sectionIds)
+      ? payload.sectionIds
+      : [];
+    const touchesLine =
+      Boolean(lineId) && (eventLineId === lineId || lineIds.includes(lineId));
+    const touchesSection =
+      Boolean(sectionId) &&
+      (eventSectionId === sectionId || sectionIds.includes(sectionId));
+
+    if (!touchesLine && !touchesSection) {
+      continue;
+    }
+
+    lifecycle.push({
+      eventId: event?.id,
+      partition: event?.partition,
+      commandType: command?.type,
+      lineId: eventLineId,
+      lineIds: lineIds.length > 0 ? lineIds : undefined,
+      sectionId: eventSectionId,
+      sectionIds: sectionIds.length > 0 ? sectionIds : undefined,
+    });
+  }
+
+  return lifecycle;
+};
+
+const logSceneProjectionReplayFailure = ({
+  sceneId,
+  event,
+  index,
+  events,
+  mainState,
+  bootstrapProjection,
+  initialWorkingState,
+  repositoryState,
+  error,
+}) => {
+  const relevantHistory = [];
+  const startIndex = Math.max(0, index - 8);
+  const failedEvent = formatSceneProjectionDebugEntry(event, repositoryState);
+
+  for (
+    let historyIndex = startIndex;
+    historyIndex <= index;
+    historyIndex += 1
+  ) {
+    const historyEvent = events[historyIndex];
+    if (!isRelevantSceneProjectionEvent({ event: historyEvent, sceneId })) {
+      continue;
+    }
+
+    relevantHistory.push(
+      formatSceneProjectionDebugEntry(historyEvent, repositoryState),
+    );
+  }
+
+  console.error("[sceneProjection] replay failed", {
+    sceneId,
+    index,
+    error: error?.message || "unknown",
+    failedEvent,
+    mainStateLineLocation: failedEvent.lineId
+      ? formatLineLocation(
+          findLineLocationInState(mainState, failedEvent.lineId),
+        )
+      : undefined,
+    initialWorkingStateLineLocation: failedEvent.lineId
+      ? formatLineLocation(
+          findLineLocationInState(initialWorkingState, failedEvent.lineId),
+        )
+      : undefined,
+    bootstrapProjectionLineLocation: failedEvent.lineId
+      ? formatLineLocation(
+          findLineLocationInState(bootstrapProjection, failedEvent.lineId),
+        )
+      : undefined,
+    mainStateSectionLocation: failedEvent.sectionId
+      ? formatSectionLocation(
+          findSectionLocationInState(mainState, failedEvent.sectionId),
+        )
+      : undefined,
+    initialWorkingStateSectionLocation: failedEvent.sectionId
+      ? formatSectionLocation(
+          findSectionLocationInState(
+            initialWorkingState,
+            failedEvent.sectionId,
+          ),
+        )
+      : undefined,
+    bootstrapProjectionSectionLocation: failedEvent.sectionId
+      ? formatSectionLocation(
+          findSectionLocationInState(
+            bootstrapProjection,
+            failedEvent.sectionId,
+          ),
+        )
+      : undefined,
+    lineLifecycle: summarizeSceneProjectionLifecycle({
+      events,
+      lineId: failedEvent.lineId,
+      sectionId: failedEvent.sectionId,
+    }),
+    relevantHistory,
+  });
+};
+
+const isRelevantSceneProjectionEvent = ({ event, sceneId }) => {
+  if (!event || !isNonEmptyString(sceneId)) {
+    return false;
+  }
+
+  if (event.partition === getScenePartition(sceneId)) {
+    return true;
+  }
+
+  if (event.partition !== getMainScenePartition(sceneId)) {
+    return false;
+  }
+
+  const command = committedEventToCommand(event);
+  return typeof command?.type === "string" && command.type.startsWith("line.");
+};
 
 const hasOnlySceneTopLevelState = (value) => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -195,6 +426,25 @@ export const isSceneProjectionCheckpointShapeValid = ({ value, sceneId }) => {
   return sceneIds.length === 1 && sceneIds[0] === sceneId;
 };
 
+const hasSceneSeedInProjectCreateEvents = ({ events = [], sceneId }) => {
+  if (!isNonEmptyString(sceneId)) {
+    return false;
+  }
+
+  for (const event of events || []) {
+    const { command, payload } = getSceneProjectionDebugDetails(event);
+    if (command?.type !== "project.create") {
+      continue;
+    }
+
+    if (payload?.state?.scenes?.items?.[sceneId]) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 export const loadSceneProjectionState = async ({
   store,
   mainState,
@@ -223,6 +473,10 @@ export const loadSceneProjectionState = async ({
     store,
     sceneId,
   });
+  const hasProjectCreateSeed = hasSceneSeedInProjectCreateEvents({
+    events,
+    sceneId,
+  });
 
   if (!sceneExists) {
     if (checkpoint) {
@@ -245,34 +499,54 @@ export const loadSceneProjectionState = async ({
   }
 
   let bootstrapProjection;
+  let replayStartIndex = 0;
+  if (
+    checkpoint &&
+    isSceneProjectionCheckpointShapeValid({
+      value: checkpoint?.value,
+      sceneId,
+    }) &&
+    !hasProjectCreateSeed
+  ) {
+    bootstrapProjection = cloneState(checkpoint.value, emptyProjection);
+    replayStartIndex = Math.max(
+      0,
+      Number.isFinite(Number(checkpoint?.lastCommittedId))
+        ? Math.floor(Number(checkpoint.lastCommittedId))
+        : 0,
+    );
+  }
+
   if (typeof createInitialState === "function") {
     let bootstrapState = createInitialState();
-    const committedEvents = Array.isArray(events) ? events : [];
-    for (let index = 0; index < committedEvents.length; index += 1) {
-      const event = committedEvents[index];
-      if (!event) {
-        continue;
+    if (!bootstrapProjection) {
+      const committedEvents = Array.isArray(events) ? events : [];
+      for (let index = 0; index < committedEvents.length; index += 1) {
+        const event = committedEvents[index];
+        if (!event) {
+          continue;
+        }
+
+        if (event.type !== "project.create") {
+          continue;
+        }
+
+        const nextState = reduceEventToState({
+          repositoryState: bootstrapState,
+          event,
+        });
+        if (nextState !== undefined) {
+          bootstrapState = nextState;
+        }
+
+        break;
       }
 
-      if (event.type !== "project.create") {
-        continue;
-      }
-
-      const nextState = reduceEventToState({
-        repositoryState: bootstrapState,
-        event,
-      });
-      if (nextState !== undefined) {
-        bootstrapState = nextState;
-      }
-
-      break;
+      bootstrapProjection = createSceneProjectionState(
+        bootstrapState,
+        scenePartition,
+      );
     }
-
-    bootstrapProjection = createSceneProjectionState(
-      bootstrapState,
-      scenePartition,
-    );
   }
 
   let workingState = composeRepositoryState({
@@ -280,19 +554,39 @@ export const loadSceneProjectionState = async ({
     activeSceneId: sceneId,
     activeSceneState: bootstrapProjection || null,
   });
+  const initialWorkingState = workingState;
   const committedEvents = Array.isArray(events) ? events : [];
-  for (let index = 0; index < committedEvents.length; index += 1) {
+  for (
+    let index = replayStartIndex;
+    index < committedEvents.length;
+    index += 1
+  ) {
     const event = committedEvents[index];
-    if (!event || event.partition !== scenePartition) {
+    if (!isRelevantSceneProjectionEvent({ event, sceneId })) {
       continue;
     }
 
-    const nextState = reduceEventToState({
-      repositoryState: workingState,
-      event,
-    });
-    if (nextState !== undefined) {
-      workingState = nextState;
+    try {
+      const nextState = reduceEventToState({
+        repositoryState: workingState,
+        event,
+      });
+      if (nextState !== undefined) {
+        workingState = nextState;
+      }
+    } catch (error) {
+      logSceneProjectionReplayFailure({
+        sceneId,
+        event,
+        index,
+        events: committedEvents,
+        mainState,
+        bootstrapProjection,
+        initialWorkingState,
+        repositoryState: workingState,
+        error,
+      });
+      throw error;
     }
   }
 
@@ -334,17 +628,30 @@ export const applySceneEventsToLoadedProjection = ({
   });
 
   const committedEvents = Array.isArray(sourceEvents) ? sourceEvents : [];
-  for (const event of committedEvents) {
-    if (!event || event.partition !== scenePartition) {
+  for (let index = 0; index < committedEvents.length; index += 1) {
+    const event = committedEvents[index];
+    if (!isRelevantSceneProjectionEvent({ event, sceneId })) {
       continue;
     }
 
-    const nextState = reduceEventToState({
-      repositoryState: workingState,
-      event,
-    });
-    if (nextState !== undefined) {
-      workingState = nextState;
+    try {
+      const nextState = reduceEventToState({
+        repositoryState: workingState,
+        event,
+      });
+      if (nextState !== undefined) {
+        workingState = nextState;
+      }
+    } catch (error) {
+      logSceneProjectionReplayFailure({
+        sceneId,
+        event,
+        index,
+        events: committedEvents,
+        repositoryState: workingState,
+        error,
+      });
+      throw error;
     }
   }
 

--- a/src/deps/services/shared/projectRepositoryViews/shared.js
+++ b/src/deps/services/shared/projectRepositoryViews/shared.js
@@ -4,13 +4,14 @@ import {
   scenePartitionFor,
   scenePartitionTokenFor,
 } from "../collab/partitions.js";
+import { committedEventToCommand } from "../collab/mappers.js";
 
 export const MAIN_VIEW_NAME = "project_repository_main_state";
 export const SCENE_VIEW_NAME = "project_repository_scene_state";
 export const SCENE_OVERVIEW_VIEW_NAME =
   "project_repository_scene_overview_state";
 export const MAIN_VIEW_VERSION = "1";
-export const SCENE_VIEW_VERSION = "1";
+export const SCENE_VIEW_VERSION = "2";
 export const SCENE_OVERVIEW_VIEW_VERSION = "1";
 export const VIEW_CHECKPOINT = {
   mode: "debounce",
@@ -117,10 +118,23 @@ export const getLatestSceneProjectionRevision = ({ events = [], sceneId }) => {
   }
 
   const scenePartition = scenePartitionFor(sceneId);
+  const mainScenePartition = mainScenePartitionFor(sceneId);
   let latestRevision = 0;
 
   for (let index = 0; index < events.length; index += 1) {
-    if (events[index]?.partition === scenePartition) {
+    const event = events[index];
+    const partition = event?.partition;
+    if (partition === scenePartition) {
+      latestRevision = index + 1;
+      continue;
+    }
+
+    if (partition !== mainScenePartition) {
+      continue;
+    }
+
+    const command = committedEventToCommand(event);
+    if (typeof command?.type === "string" && command.type.startsWith("line.")) {
       latestRevision = index + 1;
     }
   }

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -1709,6 +1709,28 @@ const dedupeFileReferences = (fileReferences = []) => {
   return Array.from(dedupedReferences.values());
 };
 
+const resolveTargetSceneIdFromActionEntry = (allScenes, entry) => {
+  if (!entry || typeof entry !== "object") {
+    return undefined;
+  }
+
+  if (typeof entry.sceneId === "string" && allScenes[entry.sceneId]) {
+    return entry.sceneId;
+  }
+
+  if (typeof entry.sectionId !== "string" || entry.sectionId.length === 0) {
+    return undefined;
+  }
+
+  for (const [sceneId, scene] of Object.entries(allScenes)) {
+    if (scene?.sections?.[entry.sectionId]) {
+      return sceneId;
+    }
+  }
+
+  return undefined;
+};
+
 export const extractTransitionTargetSceneIds = (projectData, sceneId) => {
   const scene = projectData?.story?.scenes?.[sceneId];
   const allScenes = projectData?.story?.scenes || {};
@@ -1720,15 +1742,16 @@ export const extractTransitionTargetSceneIds = (projectData, sceneId) => {
   const sceneIds = new Set();
 
   traverseScene(scene, (key, entry) => {
-    if (key !== "sectionTransition" || typeof entry !== "object" || !entry) {
+    if (key !== "sectionTransition" && key !== "resetStoryAtSection") {
       return;
     }
 
-    if (typeof entry.sceneId !== "string" || !allScenes[entry.sceneId]) {
+    const targetSceneId = resolveTargetSceneIdFromActionEntry(allScenes, entry);
+    if (!targetSceneId) {
       return;
     }
 
-    sceneIds.add(entry.sceneId);
+    sceneIds.add(targetSceneId);
   });
 
   return Array.from(sceneIds);
@@ -1745,15 +1768,16 @@ export const extractTransitionTargetSceneIdsFromActions = (
 
   const sceneIds = new Set();
   traverseScene(actions, (key, entry) => {
-    if (key !== "sectionTransition" || typeof entry !== "object" || !entry) {
+    if (key !== "sectionTransition" && key !== "resetStoryAtSection") {
       return;
     }
 
-    if (typeof entry.sceneId !== "string" || !allScenes[entry.sceneId]) {
+    const targetSceneId = resolveTargetSceneIdFromActionEntry(allScenes, entry);
+    if (!targetSceneId) {
       return;
     }
 
-    sceneIds.add(entry.sceneId);
+    sceneIds.add(targetSceneId);
   });
 
   return Array.from(sceneIds);

--- a/tests/collab/projectorCache.rebuild.test.js
+++ b/tests/collab/projectorCache.rebuild.test.js
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProjectCreateRepositoryEvent,
+  createRepositoryCommandEvent,
+  repositoryEventToCommand,
+} from "../../src/deps/services/shared/projectRepository.js";
+import { rebuildRepositoryProjectionCache } from "../../src/deps/services/shared/collab/projectorCache.js";
+import { scenePartitionFor } from "../../src/deps/services/shared/collab/partitions.js";
+import { COMMAND_TYPES } from "../../src/internal/project/commands.js";
+
+const projectId = "project-1";
+const sceneId = "scene-1";
+const sectionId = "section-1";
+const lineId = "line-1";
+
+const createProjectState = () => ({
+  project: {
+    resolution: {
+      width: 1920,
+      height: 1080,
+    },
+  },
+  story: {
+    initialSceneId: sceneId,
+  },
+  files: {
+    items: {},
+    tree: [],
+  },
+  images: {
+    items: {},
+    tree: [],
+  },
+  spritesheets: {
+    items: {},
+    tree: [],
+  },
+  sounds: {
+    items: {},
+    tree: [],
+  },
+  videos: {
+    items: {},
+    tree: [],
+  },
+  animations: {
+    items: {},
+    tree: [],
+  },
+  particles: {
+    items: {},
+    tree: [],
+  },
+  characters: {
+    items: {},
+    tree: [],
+  },
+  fonts: {
+    items: {},
+    tree: [],
+  },
+  transforms: {
+    items: {},
+    tree: [],
+  },
+  colors: {
+    items: {},
+    tree: [],
+  },
+  textStyles: {
+    items: {},
+    tree: [],
+  },
+  variables: {
+    items: {},
+    tree: [],
+  },
+  layouts: {
+    items: {},
+    tree: [],
+  },
+  controls: {
+    items: {},
+    tree: [],
+  },
+  scenes: {
+    items: {
+      [sceneId]: {
+        id: sceneId,
+        type: "scene",
+        name: "Scene 1",
+        sections: {
+          items: {
+            [sectionId]: {
+              id: sectionId,
+              name: "Section 1",
+              lines: {
+                items: {
+                  [lineId]: {
+                    id: lineId,
+                    actions: {},
+                  },
+                },
+                tree: [{ id: lineId }],
+              },
+            },
+          },
+          tree: [{ id: sectionId }],
+        },
+      },
+    },
+    tree: [{ id: sceneId }],
+  },
+});
+
+const createLineUpdateEvent = () =>
+  createRepositoryCommandEvent({
+    command: {
+      id: "line-update-1",
+      projectId,
+      partition: scenePartitionFor(sceneId),
+      type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+      payload: {
+        lineId,
+        data: {
+          resetStoryAtSection: {
+            sectionId,
+          },
+        },
+        replace: false,
+      },
+      actor: {
+        userId: "user-1",
+        clientId: "client-1",
+      },
+      clientTs: 1,
+      schemaVersion: 1,
+    },
+  });
+
+const createRepositoryStore = (events = []) => {
+  const state = {
+    events: structuredClone(events),
+    appValues: new Map(),
+  };
+
+  return {
+    app: {
+      get: async (key) => state.appValues.get(key),
+      set: async (key, value) => state.appValues.set(key, value),
+      remove: async (key) => state.appValues.delete(key),
+    },
+    async getEvents() {
+      return structuredClone(state.events);
+    },
+    async clearEvents() {
+      state.events = [];
+    },
+    async clearMaterializedViewCheckpoints() {},
+    async appendEvent(event) {
+      state.events.push(structuredClone(event));
+    },
+  };
+};
+
+describe("projector cache rebuild", () => {
+  it("preserves the local project.create seed when committed history lacks it", async () => {
+    const projectCreateEvent = createProjectCreateRepositoryEvent({
+      projectId,
+      state: createProjectState(),
+    });
+    const lineUpdateEvent = createLineUpdateEvent();
+    const repositoryStore = createRepositoryStore([projectCreateEvent]);
+    const rawClientStore = {
+      _debug: {
+        getCommitted: async () => [
+          {
+            ...structuredClone(lineUpdateEvent),
+            committedId: 1,
+            serverTs: 1,
+          },
+        ],
+      },
+    };
+
+    await rebuildRepositoryProjectionCache({
+      repositoryStore,
+      rawClientStore,
+    });
+
+    const rebuiltEvents = await repositoryStore.getEvents();
+    expect(rebuiltEvents).toHaveLength(2);
+    expect(
+      rebuiltEvents.map((event) => repositoryEventToCommand(event)?.type),
+    ).toEqual([
+      COMMAND_TYPES.PROJECT_CREATE,
+      COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+    ]);
+  });
+});

--- a/tests/commandApi/resourceFileBatching.test.js
+++ b/tests/commandApi/resourceFileBatching.test.js
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  submitCreateResourceCommand,
+  submitUpdateResourceCommand,
+} from "../../src/deps/services/shared/commandApi/resources/shared.js";
+import { COMMAND_TYPES } from "../../src/internal/project/commands.js";
+
+const createShared = ({
+  fileCommands = [],
+  submitResult = { valid: true, commandIds: [] },
+} = {}) => {
+  const context = {
+    projectId: "project-1",
+    state: {
+      files: {
+        items: {},
+      },
+    },
+  };
+
+  const shared = {
+    ensureCommandContext: vi.fn().mockResolvedValue(context),
+    buildMissingFileCommands: vi.fn().mockReturnValue(fileCommands),
+    createId: vi.fn().mockReturnValue("generated-resource-id"),
+    resolveResourceIndex: vi.fn().mockReturnValue(4),
+    buildPlacementPayload: vi
+      .fn()
+      .mockReturnValue({ parentId: "folder-1", index: 4 }),
+    submitCommandsWithContext: vi.fn().mockResolvedValue(submitResult),
+    resourceTypePartitionFor: vi.fn().mockReturnValue("main"),
+  };
+
+  return { context, shared };
+};
+
+describe("resource command file batching", () => {
+  it("submits missing file records with image creation in one batch", async () => {
+    const fileCommands = [
+      {
+        scope: "resources",
+        type: COMMAND_TYPES.FILE_CREATE,
+        payload: {
+          fileId: "file-1",
+        },
+      },
+      {
+        scope: "resources",
+        type: COMMAND_TYPES.FILE_CREATE,
+        payload: {
+          fileId: "file-2",
+        },
+      },
+    ];
+    const { context, shared } = createShared({ fileCommands });
+
+    const result = await submitCreateResourceCommand({
+      shared,
+      resourceType: "images",
+      type: COMMAND_TYPES.IMAGE_CREATE,
+      idField: "imageId",
+      data: {
+        fileId: "file-1",
+        thumbnailFileId: "file-2",
+      },
+      parentId: "folder-1",
+      position: "last",
+    });
+
+    expect(result).toBe("generated-resource-id");
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledTimes(1);
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+      context,
+      commands: [
+        ...fileCommands,
+        {
+          scope: "resources",
+          basePartition: "main",
+          type: COMMAND_TYPES.IMAGE_CREATE,
+          payload: {
+            imageId: "generated-resource-id",
+            data: {
+              fileId: "file-1",
+              thumbnailFileId: "file-2",
+            },
+            parentId: "folder-1",
+            index: 4,
+          },
+        },
+      ],
+    });
+  });
+
+  it("submits missing file records with image updates in one batch", async () => {
+    const fileCommands = [
+      {
+        scope: "resources",
+        type: COMMAND_TYPES.FILE_CREATE,
+        payload: {
+          fileId: "file-3",
+        },
+      },
+    ];
+    const submitResult = { valid: true, commandIds: ["cmd-1", "cmd-2"] };
+    const { context, shared } = createShared({
+      fileCommands,
+      submitResult,
+    });
+
+    const result = await submitUpdateResourceCommand({
+      shared,
+      resourceType: "images",
+      type: COMMAND_TYPES.IMAGE_UPDATE,
+      idField: "imageId",
+      idValue: "image-1",
+      data: {
+        fileId: "file-3",
+      },
+      fileRecords: [
+        {
+          id: "file-3",
+        },
+      ],
+    });
+
+    expect(result).toBe(submitResult);
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledTimes(1);
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+      context,
+      commands: [
+        ...fileCommands,
+        {
+          scope: "resources",
+          basePartition: "main",
+          type: COMMAND_TYPES.IMAGE_UPDATE,
+          payload: {
+            imageId: "image-1",
+            data: {
+              fileId: "file-3",
+            },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/tests/project/layout.transitionTargets.test.js
+++ b/tests/project/layout.transitionTargets.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractTransitionTargetSceneIds,
+  extractTransitionTargetSceneIdsFromActions,
+} from "../../src/internal/project/layout.js";
+
+const createProjectData = () => ({
+  story: {
+    scenes: {
+      "scene-1": {
+        id: "scene-1",
+        sections: {
+          "section-1": {
+            id: "section-1",
+            lines: [
+              {
+                id: "line-1",
+                actions: {
+                  resetStoryAtSection: {
+                    sectionId: "section-2",
+                  },
+                },
+              },
+              {
+                id: "line-2",
+                actions: {
+                  sectionTransition: {
+                    sectionId: "section-3",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      "scene-2": {
+        id: "scene-2",
+        sections: {
+          "section-2": {
+            id: "section-2",
+            lines: [],
+          },
+        },
+      },
+      "scene-3": {
+        id: "scene-3",
+        sections: {
+          "section-3": {
+            id: "section-3",
+            lines: [],
+          },
+        },
+      },
+    },
+  },
+});
+
+describe("transition target scene extraction", () => {
+  it("resolves target scenes from scene actions that only reference section ids", () => {
+    const projectData = createProjectData();
+
+    expect(extractTransitionTargetSceneIds(projectData, "scene-1")).toEqual([
+      "scene-2",
+      "scene-3",
+    ]);
+  });
+
+  it("resolves target scenes from standalone actions for resetStoryAtSection", () => {
+    const projectData = createProjectData();
+
+    expect(
+      extractTransitionTargetSceneIdsFromActions(
+        {
+          resetStoryAtSection: {
+            sectionId: "section-2",
+          },
+          sectionTransition: {
+            sectionId: "section-3",
+          },
+        },
+        projectData,
+      ),
+    ).toEqual(["scene-2", "scene-3"]);
+  });
+});

--- a/tests/project/sceneProjectionCompatibility.test.js
+++ b/tests/project/sceneProjectionCompatibility.test.js
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProjectCreateRepositoryEvent,
+  applyCommandToRepositoryState,
+  initialProjectData,
+  repositoryEventToCommand,
+  createRepositoryCommandEvent,
+} from "../../src/deps/services/shared/projectRepository.js";
+import { loadSceneProjectionState } from "../../src/deps/services/shared/projectRepositoryViews/sceneStateView.js";
+import {
+  SCENE_VIEW_VERSION,
+  createMainProjectionState,
+  createSceneProjectionState,
+} from "../../src/deps/services/shared/projectRepositoryViews/shared.js";
+import {
+  mainScenePartitionFor,
+  scenePartitionFor,
+} from "../../src/deps/services/shared/collab/partitions.js";
+import { COMMAND_TYPES } from "../../src/internal/project/commands.js";
+
+const projectId = "project-1";
+const sceneId = "scene-1";
+const sectionId = "section-1";
+const targetSectionId = "section-2";
+const lineId = "line-1";
+
+const createCommandEvent = ({ id, partition, type, payload, clientTs }) =>
+  createRepositoryCommandEvent({
+    command: {
+      id,
+      projectId,
+      partition,
+      type,
+      payload,
+      actor: {
+        userId: "user-1",
+        clientId: "client-1",
+      },
+      clientTs,
+      schemaVersion: 1,
+    },
+  });
+
+const reduceEventToState = ({ repositoryState, event }) => {
+  const applyResult = applyCommandToRepositoryState({
+    repositoryState,
+    command: repositoryEventToCommand(event),
+    projectId,
+  });
+
+  if (!applyResult.valid) {
+    throw new Error(applyResult.error?.message || "Failed to apply event");
+  }
+
+  return applyResult.repositoryState;
+};
+
+const createRepositoryState = () => {
+  const state = structuredClone(initialProjectData);
+  state.project.resolution = {
+    width: 1920,
+    height: 1080,
+  };
+  state.story.initialSceneId = sceneId;
+  state.scenes = {
+    items: {
+      [sceneId]: {
+        id: sceneId,
+        type: "scene",
+        name: "Scene 1",
+        sections: {
+          items: {
+            [sectionId]: {
+              id: sectionId,
+              name: "Section 1",
+              lines: {
+                items: {},
+                tree: [],
+              },
+            },
+            [targetSectionId]: {
+              id: targetSectionId,
+              name: "Section 2",
+              lines: {
+                items: {},
+                tree: [],
+              },
+            },
+          },
+          tree: [{ id: sectionId }, { id: targetSectionId }],
+        },
+      },
+    },
+    tree: [{ id: sceneId }],
+  };
+  return state;
+};
+
+describe("scene projection compatibility", () => {
+  it("replays legacy line commands from main-scene partitions", async () => {
+    const initialState = createRepositoryState();
+    const events = [
+      createProjectCreateRepositoryEvent({
+        projectId,
+        state: initialState,
+      }),
+      createCommandEvent({
+        id: "line-create-1",
+        partition: mainScenePartitionFor(sceneId),
+        type: COMMAND_TYPES.LINE_CREATE,
+        payload: {
+          sectionId,
+          lines: [
+            {
+              lineId,
+              data: {
+                actions: {},
+              },
+            },
+          ],
+          index: 0,
+        },
+        clientTs: 1,
+      }),
+      createCommandEvent({
+        id: "line-update-1",
+        partition: scenePartitionFor(sceneId),
+        type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+        payload: {
+          lineId,
+          data: {
+            resetStoryAtSection: {
+              sectionId: targetSectionId,
+            },
+          },
+          replace: false,
+        },
+        clientTs: 2,
+      }),
+    ];
+
+    const projection = await loadSceneProjectionState({
+      store: {},
+      mainState: createMainProjectionState(initialState),
+      events,
+      createInitialState: () => structuredClone(initialProjectData),
+      reduceEventToState,
+      sceneId,
+    });
+
+    expect(
+      projection.scenes.items[sceneId].sections.items[sectionId].lines.items[
+        lineId
+      ].actions,
+    ).toMatchObject({
+      resetStoryAtSection: {
+        sectionId: targetSectionId,
+      },
+    });
+  });
+
+  it("falls back to a stale scene checkpoint when project.create seed is missing", async () => {
+    const initialState = createRepositoryState();
+    initialState.scenes.items[sceneId].sections.items[sectionId].lines.items[
+      lineId
+    ] = {
+      id: lineId,
+      actions: {},
+    };
+    initialState.scenes.items[sceneId].sections.items[sectionId].lines.tree = [
+      { id: lineId },
+    ];
+
+    const events = [
+      createCommandEvent({
+        id: "line-update-only",
+        partition: scenePartitionFor(sceneId),
+        type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+        payload: {
+          lineId,
+          data: {
+            resetStoryAtSection: {
+              sectionId: targetSectionId,
+            },
+          },
+          replace: false,
+        },
+        clientTs: 1,
+      }),
+    ];
+
+    const projection = await loadSceneProjectionState({
+      store: {
+        async loadMaterializedViewCheckpoint() {
+          return {
+            viewVersion: String(Number(SCENE_VIEW_VERSION) - 1),
+            lastCommittedId: 0,
+            value: createSceneProjectionState(
+              initialState,
+              scenePartitionFor(sceneId),
+            ),
+          };
+        },
+        async saveMaterializedViewCheckpoint() {},
+        async deleteMaterializedViewCheckpoint() {},
+      },
+      mainState: createMainProjectionState(initialState),
+      events,
+      createInitialState: () => structuredClone(initialProjectData),
+      reduceEventToState,
+      sceneId,
+    });
+
+    expect(
+      projection.scenes.items[sceneId].sections.items[sectionId].lines.items[
+        lineId
+      ].actions,
+    ).toMatchObject({
+      resetStoryAtSection: {
+        sectionId: targetSectionId,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- batch missing file creation with resource/image writes so multi-upload does not race on file ids
- preload resetStoryAtSection targets like section transitions and harden scene projection/cache recovery on refresh
- include regression coverage for upload batching, preview target extraction, projector cache rebuild, and scene projection compatibility
- bump route-engine-js to 1.2.0

## Testing
- bunx vitest run tests/commandApi/resourceFileBatching.test.js tests/project/layout.transitionTargets.test.js tests/project/sceneProjectionCompatibility.test.js tests/collab/projectorCache.rebuild.test.js
- bun prettier --check src/deps/services/shared/commandApi/characterSprites.js src/deps/services/shared/commandApi/controls.js src/deps/services/shared/commandApi/layouts.js src/deps/services/shared/commandApi/resources/shared.js src/deps/services/shared/commandApi/shared.js src/internal/project/layout.js src/deps/services/shared/projectRepositoryViews/shared.js src/deps/services/shared/projectRepositoryViews/sceneStateView.js src/deps/services/shared/collab/projectorCache.js tests/commandApi/resourceFileBatching.test.js tests/project/layout.transitionTargets.test.js tests/project/sceneProjectionCompatibility.test.js tests/collab/projectorCache.rebuild.test.js