### PR TITLE
Polish project UI, default layouts, and release assets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.4.2",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.2.4",
+        "@routevn/creator-model": "1.2.5",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -259,7 +259,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.2.4", "", {}, "sha512-wFyOtEg163Ch2fjFDDcsOrayp3062obfgIxk4fBttQY+AcprzU85u2J0nG1n6AmYAq3tuosasCAOLY+ijjx0kQ=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.2.5", "", {}, "sha512-RGISe4er4LwxIYSqO49PCX3Y2wvJrmapc5bvzfzr6udSpfUMIRtaacesOfF8m5bi4BS7MDtQ1MrIIoPQRVDR+g=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.4.2",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "1.2.4",
+    "@routevn/creator-model": "1.2.5",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -260,12 +260,12 @@ export const selectSelectedResource = ({ state }) => {
   }
 
   const layoutTypeLabels = {
-    normal: "Normal",
+    general: "General",
     "save-load": "Save / Load",
     confirmDialog: "Confirm Dialog",
     history: "History",
-    dialogue: "Dialogue",
-    nvl: "NVL",
+    "dialogue-adv": "Dialogue ADV",
+    "dialogue-nvl": "Dialogue NVL",
     choice: "Choice",
   };
 
@@ -310,7 +310,7 @@ export const selectViewData = ({ state }) => {
     .map((group) => {
       const children = group.children
         .filter(
-          (layout) => state.tab !== "layout" || layout.layoutType === "normal",
+          (layout) => state.tab !== "layout" || layout.layoutType === "general",
         )
         .filter(matchesSearch)
         .map((child) => {
@@ -318,12 +318,12 @@ export const selectViewData = ({ state }) => {
           const itemBorderColor = isSelected ? "pr" : "bo";
           const itemHoverBorderColor = isSelected ? "pr" : "ac";
           const layoutTypeLabels = {
-            normal: "Normal",
+            general: "General",
             "save-load": "Save / Load",
             confirmDialog: "Confirm Dialog",
             history: "History",
-            dialogue: "Dialogue",
-            nvl: "NVL",
+            "dialogue-adv": "Dialogue ADV",
+            "dialogue-nvl": "Dialogue NVL",
             choice: "Choice",
           };
 

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -3,7 +3,7 @@ const toBoolean = (value) => {
 };
 
 const getLayoutTypeByMode = (mode) => {
-  return mode === "nvl" ? "nvl" : "dialogue";
+  return mode === "nvl" ? "dialogue-nvl" : "dialogue-adv";
 };
 
 const resolveDialogueMode = ({ layouts, dialogue } = {}) => {
@@ -12,7 +12,7 @@ const resolveDialogueMode = ({ layouts, dialogue } = {}) => {
     (layout) => layout.id === resourceId,
   )?.layoutType;
 
-  if (dialogue?.mode === "nvl" || layoutType === "nvl") {
+  if (dialogue?.mode === "nvl" || layoutType === "dialogue-nvl") {
     return "nvl";
   }
 

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -1,5 +1,5 @@
 const getLayoutTypeByMode = (mode) => {
-  return mode === "nvl" ? "nvl" : "dialogue";
+  return mode === "nvl" ? "dialogue-nvl" : "dialogue-adv";
 };
 
 const getLayoutOptions = ({ layouts, mode } = {}) => {
@@ -168,7 +168,10 @@ export const selectViewData = ({ state, props }) => {
           ...field,
           options: layoutOptions,
           value: selectedResourceId,
-          label: selectedMode === "nvl" ? "NVL Layout" : "Dialogue Layout",
+          label:
+            selectedMode === "nvl"
+              ? "Dialogue NVL Layout"
+              : "Dialogue ADV Layout",
         };
       }
       if (field.name === "characterId") {

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -18,7 +18,7 @@ const getCollectionTree = (collection) => {
 };
 
 const isSelectableVisualResource = (resourceType, item) => {
-  return resourceType !== "layout" || item?.layoutType === "visual";
+  return resourceType !== "layout" || item?.layoutType === "general";
 };
 
 const prefixTreeNode = (node, resourceType, items) => {
@@ -256,7 +256,7 @@ export const selectResourceItemById = ({ state }, { resourceId } = {}) => {
   }
 
   const layoutData = state.layouts.items?.[resourceId];
-  if (layoutData?.layoutType === "visual") {
+  if (layoutData?.layoutType === "general") {
     return {
       ...layoutData,
       resourceType: "layout",
@@ -359,11 +359,11 @@ export const selectViewData = ({ state }) => {
     childFilter: () => true,
   });
 
-  // Add layouts (only visual type)
+  // Add layouts (only general type)
   const layoutGroups = buildResourceGroups({
     collection: state.layouts,
     resourceType: "layout",
-    childFilter: (child) => child.layoutType === "visual",
+    childFilter: (child) => child.layoutType === "general",
   });
 
   const resourceGroups = [...imageGroups, ...videoGroups, ...layoutGroups];

--- a/src/components/layoutEditorPreview/layoutEditorPreview.store.js
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.store.js
@@ -148,11 +148,11 @@ const resolvePreviewBackgroundFormTarget = ({
   hasPreviewVariables,
   hasSaveLoadPreview,
 } = {}) => {
-  if (layoutType === "dialogue") {
+  if (layoutType === "dialogue-adv") {
     return "dialogue";
   }
 
-  if (layoutType === "nvl") {
+  if (layoutType === "dialogue-nvl") {
     return "nvl";
   }
 

--- a/src/components/layoutEditorPreview/layoutEditorPreview.view.yaml
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.view.yaml
@@ -90,7 +90,7 @@ template:
                       - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=220 h=160 br=md: null
                     $else:
                       - rtgl-text c=mu-fg ta=c: Select image
-  - $if layoutType == 'dialogue':
+  - $if layoutType == 'dialogue-adv':
       - rtgl-form#dialogueForm key=${dialogueFormKey} w=f :form=${dialogueForm} :defaultValues=${dialogueDefaultValues}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
               - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c:
@@ -98,7 +98,7 @@ template:
                       - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=220 h=160 br=md: null
                     $else:
                       - rtgl-text c=mu-fg ta=c: Select image
-  - $if layoutType == 'nvl':
+  - $if layoutType == 'dialogue-nvl':
       - rtgl-form#nvlForm key=${nvlFormKey} w=f :form=${nvlForm} :defaultValues=${nvlDefaultValues} :context=${nvlContext}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
               - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c:
@@ -106,7 +106,7 @@ template:
                       - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=220 h=160 br=md: null
                     $else:
                       - rtgl-text c=mu-fg ta=c: Select image
-  - $if layoutType == 'dialogue':
+  - $if layoutType == 'dialogue-adv':
       - rtgl-view d=h av=c g=sm w=f ph=md pb=md:
           - rtgl-text s=sm c=mu-fg: Revealing Speed
           - rtgl-input#revealingSpeedInput type=number min=1 step=1 w=120 value=${previewRevealingSpeed}: null

--- a/src/components/layoutEditorPreview/support/layoutEditorPreviewDialogue.js
+++ b/src/components/layoutEditorPreview/support/layoutEditorPreviewDialogue.js
@@ -88,7 +88,7 @@ export const createDialoguePreviewData = ({
       },
       content: [{ text: dialogueContent }],
       lines:
-        layoutType === "nvl"
+        layoutType === "dialogue-nvl"
           ? createNvlLines(nvlDefaultValues)
           : createDialogueLines({
               characterName,

--- a/src/components/layoutEditorPreview/support/layoutEditorPreviewVariables.js
+++ b/src/components/layoutEditorPreview/support/layoutEditorPreviewVariables.js
@@ -8,7 +8,7 @@ import { visitLayoutItemsWithFragments } from "./layoutEditorPreviewFragments.js
 
 const PREVIEW_VARIABLE_TYPES = new Set(["boolean", "number", "string"]);
 const NORMAL_LIKE_LAYOUT_TYPES = new Set([
-  "normal",
+  "general",
   "save-load",
   "confirmDialog",
 ]);

--- a/src/components/projectCreateDialog/projectCreateDialog.store.js
+++ b/src/components/projectCreateDialog/projectCreateDialog.store.js
@@ -28,6 +28,7 @@ const createCreateProjectDefaultValues = (values = {}) => {
 };
 
 const form = {
+  title: "Create Project",
   fields: [
     {
       name: "name",
@@ -58,6 +59,8 @@ const form = {
       name: "resolution",
       type: "select",
       label: "Resolution",
+      description:
+        "Only 1920x1080 is supported for now, more options coming soon.",
       required: true,
       clearable: false,
       options: PROJECT_RESOLUTION_OPTIONS,

--- a/src/components/projectCreateDialog/projectCreateDialog.view.yaml
+++ b/src/components/projectCreateDialog/projectCreateDialog.view.yaml
@@ -1,12 +1,10 @@
 refs:
-  dialogBody:
-    eventListeners:
-      keydown:
-        handler: handleKeyDown
   createProjectForm:
     eventListeners:
       form-change:
         handler: handleFormChange
+      keydown:
+        handler: handleKeyDown
   browseButton:
     eventListeners:
       click:
@@ -26,21 +24,20 @@ refs:
       confirm:
         handler: handleIconCropDialogConfirm
 template:
-  - rtgl-view#dialogBody g=md w=f:
-      - rtgl-form#createProjectForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f:
-          - rtgl-view slot=project-icon-selector w=f:
-              - $if iconPreviewUrl:
-                  - rtgl-view w=120 h=120 av=c ah=c:
-                      - rtgl-image#iconPreview src=${iconPreviewUrl} w=120 h=120 of=cov bw=xs bc=bo br=md cur=pointer: null
-                $else:
-                  - rtgl-view w=120 h=120 av=c ah=c:
-                      - rtgl-view#iconPlaceholder w=120 h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
-                          - rtgl-text c=mu-fg s=sm: Click to Upload
-          - $if platform == 'tauri':
-              - rtgl-view slot=project-path-selector g=xs:
-                  - rtgl-view d=h g=sm av=c:
-                      - rtgl-input#pathInput w=f :value=${projectPathDisplay} disabled=true placeholder="No folder selected": null
-                      - rtgl-button#browseButton variant=se: Browse
-                  - $if validationErrors.projectPath:
-                      - rtgl-text s=sm c=de: ${validationErrors.projectPath}
+  - rtgl-form#createProjectForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f:
+      - rtgl-view slot=project-icon-selector w=f:
+          - $if iconPreviewUrl:
+              - rtgl-view w=120 h=120 av=c ah=c:
+                  - rtgl-image#iconPreview src=${iconPreviewUrl} w=120 h=120 of=cov bw=xs bc=bo br=md cur=pointer: null
+            $else:
+              - rtgl-view w=120 h=120 av=c ah=c:
+                  - rtgl-view#iconPlaceholder w=120 h=120 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer:
+                      - rtgl-text c=mu-fg s=sm: Click to Upload
+      - $if platform == 'tauri':
+          - rtgl-view slot=project-path-selector g=xs:
+              - rtgl-view d=h g=sm av=c:
+                  - rtgl-input#pathInput w=f :value=${projectPathDisplay} disabled=true placeholder="No folder selected": null
+                  - rtgl-button#browseButton variant=se: Browse
+              - $if validationErrors.projectPath:
+                  - rtgl-text s=sm c=de: ${validationErrors.projectPath}
   - rvn-square-image-crop-dialog#iconCropDialog :open=${isIconCropDialogOpen} :file=${iconCropFile}: null

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -59,7 +59,8 @@ export const selectViewData = ({ state, props, props: attrs }) => {
   const dialogueLayouts = Object.entries(repositoryState.layouts?.items || {})
     .filter(
       ([_, layout]) =>
-        layout.layoutType === "dialogue" || layout.layoutType === "nvl",
+        layout.layoutType === "dialogue-adv" ||
+        layout.layoutType === "dialogue-nvl",
     )
     .map(([id, layout]) => ({
       id,
@@ -168,7 +169,7 @@ const resolveDialogueModeLabel = (dialogue, layoutsItems) => {
 
   const layoutId = dialogue?.ui?.resourceId ?? dialogue?.gui?.resourceId;
   const layoutType = layoutsItems?.[layoutId]?.layoutType;
-  if (layoutType === "nvl") {
+  if (layoutType === "dialogue-nvl") {
     return "NVL";
   }
 

--- a/src/deps/services/shared/commandApi/layouts.js
+++ b/src/deps/services/shared/commandApi/layouts.js
@@ -12,7 +12,7 @@ const submitCreateLayoutItem = async ({
   context,
   layoutId,
   name,
-  layoutType = "normal",
+  layoutType = "general",
   elements = createTreeCollection(),
   parentId = null,
   position = "last",
@@ -72,7 +72,7 @@ export const createLayoutCommandApi = (shared) => ({
   async createLayoutItem({
     layoutId,
     name,
-    layoutType = "normal",
+    layoutType = "general",
     elements = createTreeCollection(),
     parentId = null,
     position = "last",
@@ -113,7 +113,7 @@ export const createLayoutCommandApi = (shared) => ({
 
     const {
       name,
-      layoutType = "normal",
+      layoutType = "general",
       elements = createTreeCollection(),
       ...data
     } = sourceLayoutClone;

--- a/src/internal/project/projection.js
+++ b/src/internal/project/projection.js
@@ -260,7 +260,7 @@ const projectRepositoryResources = ({ repositoryState }) => {
             `${resourceType === "controls" ? "Control" : "Layout"} ${resourceId}`,
           ...(resourceType === "layouts"
             ? {
-                layoutType: item?.layoutType || "normal",
+                layoutType: item?.layoutType || "general",
                 isFragment: isFragmentLayout(item),
               }
             : {}),
@@ -924,7 +924,7 @@ const alignDialogueModesWithLayouts = (story, layouts = {}) => {
         const layoutId = dialogue?.ui?.resourceId;
         const layoutType = layouts?.[layoutId]?.layoutType;
 
-        if (layoutType === "nvl") {
+        if (layoutType === "dialogue-nvl") {
           dialogue.mode = "nvl";
         }
       });

--- a/src/internal/projectResolution.js
+++ b/src/internal/projectResolution.js
@@ -7,33 +7,33 @@ export const DEFAULT_PROJECT_RESOLUTION = Object.freeze({
 
 export const PROJECT_RESOLUTION_PRESETS = Object.freeze([
   {
-    value: "1280x720",
-    label: "1280x720",
-    width: 1280,
-    height: 720,
-  },
-  {
     value: DEFAULT_PROJECT_RESOLUTION_PRESET,
     label: "1920x1080",
     width: 1920,
     height: 1080,
   },
-  {
-    value: "qhd",
-    label: "2560x1440 (QHD)",
-    width: 2560,
-    height: 1440,
-  },
-  {
-    value: "4k",
-    label: "3840x2160 (4K)",
-    width: 3840,
-    height: 2160,
-  },
-  {
-    value: CUSTOM_PROJECT_RESOLUTION_PRESET,
-    label: "Custom",
-  },
+  // {
+  //   value: "1280x720",
+  //   label: "1280x720",
+  //   width: 1280,
+  //   height: 720,
+  // },
+  // {
+  //   value: "qhd",
+  //   label: "2560x1440 (QHD)",
+  //   width: 2560,
+  //   height: 1440,
+  // },
+  // {
+  //   value: "4k",
+  //   label: "3840x2160 (4K)",
+  //   width: 3840,
+  //   height: 2160,
+  // },
+  // {
+  //   value: CUSTOM_PROJECT_RESOLUTION_PRESET,
+  //   label: "Custom",
+  // },
 ]);
 
 export const PROJECT_RESOLUTION_OPTIONS = PROJECT_RESOLUTION_PRESETS.map(

--- a/src/internal/ui/sceneEditor/lineOperations.js
+++ b/src/internal/ui/sceneEditor/lineOperations.js
@@ -50,7 +50,7 @@ const resolveEffectiveDialogueMode = ({ repositoryState, dialogue } = {}) => {
     return "nvl";
   }
 
-  if (getDialogueLayoutType({ repositoryState, dialogue }) === "nvl") {
+  if (getDialogueLayoutType({ repositoryState, dialogue }) === "dialogue-nvl") {
     return "nvl";
   }
 

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -189,7 +189,7 @@ const resolveDialogueModeLabel = (repositoryState, line) => {
 
   const layoutId = dialogue.ui?.resourceId ?? dialogue.gui?.resourceId;
   const layoutType = repositoryState?.layouts?.items?.[layoutId]?.layoutType;
-  if (layoutType === "nvl") {
+  if (layoutType === "dialogue-nvl") {
     return "NVL";
   }
 

--- a/src/internal/ui/sceneEditor/sectionOperations.js
+++ b/src/internal/ui/sceneEditor/sectionOperations.js
@@ -175,7 +175,7 @@ export const createSceneEditorSectionWithName = async (
 
   if (layouts?.items) {
     for (const [layoutId, layout] of Object.entries(layouts.items)) {
-      if (!dialogueLayoutId && layout.layoutType === "dialogue") {
+      if (!dialogueLayoutId && layout.layoutType === "dialogue-adv") {
         dialogueLayoutId = layoutId;
       }
       if (dialogueLayoutId) {

--- a/src/pages/characters/characters.store.js
+++ b/src/pages/characters/characters.store.js
@@ -63,6 +63,7 @@ export const createInitialState = () => ({
         name: "shortcut",
         type: "select",
         label: "Shortcut",
+        description: "Used for keyboard shortcut in scene editor",
         options: CHARACTER_SHORTCUT_OPTIONS,
         required: false,
       },

--- a/src/pages/layoutEditor/layoutEditor.constants.yaml
+++ b/src/pages/layoutEditor/layoutEditor.constants.yaml
@@ -17,7 +17,7 @@ contextMenuItems:
   - label: Slider
     type: item
     createType: slider
-  - "$when": 'layoutType == "normal"'
+  - "$when": 'layoutType == "general"'
     label: Fragment
     type: item
     createType: fragment-ref
@@ -37,23 +37,23 @@ contextMenuItems:
     label: Container (Confirm Cancel)
     type: item
     createType: container-confirm-dialog-cancel
-  - "$when": 'layoutType == "dialogue"'
+  - "$when": 'layoutType == "dialogue-adv"'
     label: Text (Dialogue Content)
     type: item
     createType: text-dialogue-content
-  - "$when": 'layoutType == "dialogue"'
+  - "$when": 'layoutType == "dialogue-adv"'
     label: Text (Character Name)
     type: item
     createType: text-character-name
-  - "$when": 'layoutType == "nvl"'
+  - "$when": 'layoutType == "dialogue-nvl"'
     label: Container (Dialogue Line)
     type: item
     createType: container-dialogue-line
-  - "$when": 'layoutType == "nvl"'
+  - "$when": 'layoutType == "dialogue-nvl"'
     label: Text (Line Character Name)
     type: item
     createType: text-dialogue-line-character-name
-  - "$when": 'layoutType == "nvl"'
+  - "$when": 'layoutType == "dialogue-nvl"'
     label: Text (Line Content)
     type: item
     createType: text-dialogue-line-content
@@ -115,7 +115,7 @@ emptyContextMenuItems:
   - label: Slider
     type: item
     createType: slider
-  - "$when": 'layoutType == "normal"'
+  - "$when": 'layoutType == "general"'
     label: Fragment
     type: item
     createType: fragment-ref
@@ -147,23 +147,23 @@ emptyContextMenuItems:
     label: Text (Save Date)
     type: item
     createType: text-save-load-slot-date
-  - "$when": 'layoutType == "dialogue"'
+  - "$when": 'layoutType == "dialogue-adv"'
     label: Text (Dialogue Content)
     type: item
     createType: text-dialogue-content
-  - "$when": 'layoutType == "dialogue"'
+  - "$when": 'layoutType == "dialogue-adv"'
     label: Text (Character Name)
     type: item
     createType: text-character-name
-  - "$when": 'layoutType == "nvl"'
+  - "$when": 'layoutType == "dialogue-nvl"'
     label: Container (Dialogue Line)
     type: item
     createType: container-dialogue-line
-  - "$when": 'layoutType == "nvl"'
+  - "$when": 'layoutType == "dialogue-nvl"'
     label: Text (Line Character Name)
     type: item
     createType: text-dialogue-line-character-name
-  - "$when": 'layoutType == "nvl"'
+  - "$when": 'layoutType == "dialogue-nvl"'
     label: Text (Line Content)
     type: item
     createType: text-dialogue-line-content

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -47,7 +47,7 @@ const getLayoutEditorLayoutType = (layoutType, resourceType) => {
     return "save-load";
   }
 
-  return layoutType ?? "normal";
+  return layoutType ?? "general";
 };
 
 const assignLayoutState = (state, { id, layout, resourceType } = {}) => {

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -175,7 +175,7 @@ const createLayoutElement = (id, data) => ({
 });
 
 export const createLayoutTemplate = (layoutType, projectResolution) => {
-  if (layoutType === "dialogue") {
+  if (layoutType === "dialogue-adv") {
     const containerId = nanoid();
     const nameTextId = nanoid();
     const contentTextId = nanoid();
@@ -250,7 +250,7 @@ export const createLayoutTemplate = (layoutType, projectResolution) => {
     );
   }
 
-  if (layoutType === "nvl") {
+  if (layoutType === "dialogue-nvl") {
     const nvlContainerId = nanoid();
     const nvlBackgroundId = nanoid();
     const nvlLinesId = nanoid();
@@ -829,7 +829,7 @@ export const createLayoutTemplate = (layoutType, projectResolution) => {
     );
   }
 
-  if (layoutType === "normal" || layoutType === "save-load") {
+  if (layoutType === "general" || layoutType === "save-load") {
     const rootId = nanoid();
     const textId = nanoid();
 
@@ -891,8 +891,8 @@ export const createLayoutTemplate = (layoutType, projectResolution) => {
 };
 
 const protectedLayoutTypeLabels = {
-  dialogue: "Dialogue",
-  nvl: "NVL",
+  "dialogue-adv": "Dialogue ADV",
+  "dialogue-nvl": "Dialogue NVL",
   choice: "Choice",
 };
 

--- a/src/pages/layouts/layouts.store.js
+++ b/src/pages/layouts/layouts.store.js
@@ -29,17 +29,17 @@ const layoutForm = {
       label: "Layout Type",
       required: true,
       options: [
-        { value: "normal", label: "Normal" },
+        { value: "general", label: "General" },
         { value: "save-load", label: "Save / Load" },
         { value: "confirmDialog", label: "Confirm Dialog" },
         { value: "history", label: "History" },
-        { value: "dialogue", label: "Dialogue" },
-        { value: "nvl", label: "NVL" },
+        { value: "dialogue-adv", label: "Dialogue ADV" },
+        { value: "dialogue-nvl", label: "Dialogue NVL" },
         { value: "choice", label: "Choice" },
       ],
       tooltip: {
         content:
-          "Normal is layout that can be used for background or menu pages. Save / Load is used for save-slot based save and load screens. Confirm Dialog is used for compact confirmation prompts with OK and Cancel areas. History is used for dialogue history layered views. Dialogue is used for ADV mode text dialogue layout. NVL is used for novel mode accumulated dialogue layout. Choice is used for the choices.",
+          "General is the flexible layout type for backgrounds, menus, and other all-purpose screens. Save / Load is used for save-slot based save and load screens. Confirm Dialog is used for compact confirmation prompts with OK and Cancel areas. History is used for dialogue history layered views. Dialogue ADV is used for ADV mode text dialogue layout. Dialogue NVL is used for novel mode accumulated dialogue layout. Choice is used for the choices.",
       },
     },
     layoutDescriptionField,
@@ -93,12 +93,12 @@ const layoutCenterItemContextMenuItems = [
 ];
 
 const layoutTypeLabels = {
-  normal: "Normal",
+  general: "General",
   "save-load": "Save / Load",
   confirmDialog: "Confirm Dialog",
   history: "History",
-  dialogue: "Dialogue",
-  nvl: "NVL",
+  "dialogue-adv": "Dialogue ADV",
+  "dialogue-nvl": "Dialogue NVL",
   choice: "Choice",
 };
 
@@ -177,7 +177,7 @@ const {
     layoutForm,
     layoutFormDefaults: {
       name: "",
-      layoutType: "normal",
+      layoutType: "general",
       description: "",
       isFragment: false,
     },

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -40,7 +40,10 @@ template:
                   - rtgl-text s=h3: ${projectName}
               - rtgl-view#projectDescription slot=project-description cur=pointer:
                   - rtgl-text c=mu-fg: ${projectDescription}
-              - rvn-file-image#projectImage slot=project-icon fileId=${projectIconFileId} w=128 h=128 bw=xs bc=bo br=md cur=pointer: null
+              - $if projectIconFileId:
+                  - rvn-file-image#projectImage slot=project-icon fileId=${projectIconFileId} w=128 h=128 bw=xs bc=bo br=md cur=pointer: null
+                $else:
+                  - rtgl-image#projectImage slot=project-icon src="/public/project_logo_placeholder.png" w=128 h=128 bw=xs bc=bo br=md cur=pointer: null
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} w=f:

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -95,7 +95,6 @@ const getProjectIdFromEvent = (event) => {
 const showCreateProjectDialog = async (appService) => {
   return appService.showComponentDialog({
     component: PROJECT_CREATE_DIALOG_COMPONENT,
-    title: "Create Project",
     size: "md",
     props: {
       platform: appService.getPlatform(),

--- a/src/pages/resourceTypes/resourceTypes.store.js
+++ b/src/pages/resourceTypes/resourceTypes.store.js
@@ -36,11 +36,13 @@ export const animatedAssetItems = [
     id: "particles",
     name: "Particles",
     path: "/project/particles",
+    hidden: true,
   },
   {
     id: "spritesheets",
     name: "Spritesheets",
     path: "/project/spritesheets",
+    hidden: true,
   },
 ];
 

--- a/src/pages/resources/resources.store.js
+++ b/src/pages/resources/resources.store.js
@@ -32,16 +32,16 @@ export const createInitialState = () => ({
       label: "Animations",
       route: "/project/animations",
     },
-    {
-      id: "particles",
-      label: "Particles",
-      route: "/project/particles",
-    },
-    {
-      id: "spritesheets",
-      label: "Spritesheets",
-      route: "/project/spritesheets",
-    },
+    // {
+    //   id: "particles",
+    //   label: "Particles",
+    //   route: "/project/particles",
+    // },
+    // {
+    //   id: "spritesheets",
+    //   label: "Spritesheets",
+    //   route: "/project/spritesheets",
+    // },
   ],
   ui: [
     {

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -578,7 +578,7 @@ export const handleSceneFormAction = async (deps, payload) => {
     if (layouts && layouts.items) {
       // Find first dialogue layout
       for (const [layoutId, layout] of Object.entries(layouts.items)) {
-        if (!dialogueLayoutId && layout.layoutType === "dialogue") {
+        if (!dialogueLayoutId && layout.layoutType === "dialogue-adv") {
           dialogueLayoutId = layoutId;
         }
         if (dialogueLayoutId) {

--- a/src/pages/sidebar/sidebar.store.js
+++ b/src/pages/sidebar/sidebar.store.js
@@ -31,7 +31,7 @@ export const createInitialState = () => ({
     },
     {
       title: "Animated Assets",
-      path: "/project/particles",
+      path: "/project/animations",
       icon: "animation",
     },
     {

--- a/src/pages/textStyles/textStyles.store.js
+++ b/src/pages/textStyles/textStyles.store.js
@@ -745,7 +745,7 @@ export const selectViewData = ({ state }) => {
       : 0,
     detailPreviewFontFamily: detailPreviewFontData.fontFamily,
     detailPreviewFontFileId: detailPreviewFontData.fileId,
-    title: "Typography",
+    title: "Text Styles",
     addText: "Add",
     folderContextMenuItems: state.folderContextMenuItems,
     itemContextMenuItems: state.itemContextMenuItems,

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -66,7 +66,6 @@ template:
                       - rtgl-form#transformForm :defaultValues=${dialogDefaultValues} :form=${transformForm} w=f: null
               - $if isPreviewOnlyDialog:
                   - rtgl-view w=f d=v g=md:
-                      - rtgl-text: Preview
                       - 'rtgl-view w=f bgc=fg pos=rel style="aspect-ratio: ${canvasAspectRatio};"':
                           - rtgl-view pos=abs cor=full:
                               - 'div#canvas style="width: 100%; height: 100%;display: flex; background-color: var(--muted);"': null

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -1018,20 +1018,20 @@
       "WkzTF7gNhJSnG4MnZTh2U": {
         "id": "WkzTF7gNhJSnG4MnZTh2U",
         "type": "textStyle",
-        "name": "Menu Text",
+        "name": "Menu Item",
         "fontSize": 36,
         "lineHeight": 1.5,
         "colorId": "yqk8aZABQccrrEZUSoAp2",
         "strokeColorId": "NqhJ2JeHjnPx8vg9zAJMb",
         "fontId": "WbhTa7gjrKgfgb7nYptFb",
         "fontWeight": "700",
-        "previewText": "Menu Text",
+        "previewText": "Menu Item",
         "strokeWidth": 4
       },
       "6wXcAmc_SmJHzMIeKp--Z": {
         "id": "6wXcAmc_SmJHzMIeKp--Z",
         "type": "textStyle",
-        "name": "Menu Text Selected",
+        "name": "Menu Item Selected",
         "fontSize": 36,
         "lineHeight": 1.5,
         "colorId": "WT1WD8x7KekvJaUrrf2p9",
@@ -1057,7 +1057,7 @@
       "a8u1N2rL7mV5pQ4tY6wZe": {
         "id": "a8u1N2rL7mV5pQ4tY6wZe",
         "type": "textStyle",
-        "name": "Menu Text Active",
+        "name": "Menu Item Active",
         "fontSize": 36,
         "lineHeight": 1.5,
         "colorId": "dL9Qd9q4mW9vM8kWv5wQe",
@@ -1093,11 +1093,11 @@
             "children": []
           },
           {
-            "id": "WTs4jkPjYmdsxZtz-O4CB",
+            "id": "a8u1N2rL7mV5pQ4tY6wZe",
             "children": []
           },
           {
-            "id": "a8u1N2rL7mV5pQ4tY6wZe",
+            "id": "WTs4jkPjYmdsxZtz-O4CB",
             "children": []
           }
         ]
@@ -1105,8 +1105,19 @@
     ]
   },
   "variables": {
-    "items": {},
-    "tree": []
+    "items": {
+      "3sXvM8qP2nL5kT7wR4yZa": {
+        "id": "3sXvM8qP2nL5kT7wR4yZa",
+        "type": "folder",
+        "name": "Default"
+      }
+    },
+    "tree": [
+      {
+        "id": "3sXvM8qP2nL5kT7wR4yZa",
+        "children": []
+      }
+    ]
   },
   "layouts": {
     "items": {
@@ -1119,7 +1130,7 @@
         "id": "HbESBAK58wzdbCozqzZvh",
         "type": "layout",
         "name": "Simple Dialogue",
-        "layoutType": "dialogue",
+        "layoutType": "dialogue-adv",
         "elements": {
           "items": {
             "NkJVi2XPTmoc7P9nbMtmU": {
@@ -1563,7 +1574,7 @@
         "id": "UMuPdCgtimWAid1xaaMoE",
         "type": "layout",
         "name": "Default NVL",
-        "layoutType": "nvl",
+        "layoutType": "dialogue-nvl",
         "elements": {
           "items": {
             "Y13kKD6mZLhLnHA6r9hQ2": {
@@ -1802,7 +1813,7 @@
         "id": "NeKtb7n888ErSpapP1diL",
         "type": "layout",
         "name": "Title",
-        "layoutType": "normal",
+        "layoutType": "general",
         "description": "",
         "isFragment": false,
         "elements": {
@@ -2054,7 +2065,7 @@
         "id": "Jy3Rayx5WJx1_D62TVi7f",
         "type": "layout",
         "name": "Menu",
-        "layoutType": "normal",
+        "layoutType": "general",
         "elements": {
           "items": {
             "1kDU76vm-kosdlt3bO1NQ": {
@@ -4379,7 +4390,7 @@
         "type": "layout",
         "name": "Options",
         "description": "",
-        "layoutType": "normal",
+        "layoutType": "general",
         "isFragment": true,
         "elements": {
           "items": {

--- a/svg/rocket.svg
+++ b/svg/rocket.svg
@@ -1,36 +1,22 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path
-    d="M14 3L20 9L14.5 14.5L10 16L8 14L9.5 9.5L14 3Z"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linejoin="round"
-  />
-  <circle
-    cx="14.5"
-    cy="9.5"
-    r="1.5"
-    stroke="currentColor"
-    stroke-width="2"
-  />
-  <path
-    d="M8 14L4.5 14L3 15.5L6.5 15.5"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M10 16V19.5L11.5 21L11.5 17.5"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M6.5 17.5L5 19L7 19"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(12 12) rotate(35) scale(1.06) translate(-12 -12)">
+    <path
+      fill="currentColor"
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M12 2.5C15.42 2.77 17.93 5.28 18.2 8.7C18.44 11.74 17.28 14.58 14.7 17.25L13.4 18.59V15.8C13.4 15.03 12.77 14.4 12 14.4C11.23 14.4 10.6 15.03 10.6 15.8V18.59L9.3 17.25C6.72 14.58 5.56 11.74 5.8 8.7C6.07 5.28 8.58 2.77 12 2.5ZM12 6.75C10.9 6.75 10 7.65 10 8.75C10 9.85 10.9 10.75 12 10.75C13.1 10.75 14 9.85 14 8.75C14 7.65 13.1 6.75 12 6.75Z"
+    />
+    <path
+      fill="currentColor"
+      d="M9.45 13.95L6.35 15.35L4.7 18.45L8.2 17.3L9.45 13.95Z"
+    />
+    <path
+      fill="currentColor"
+      d="M14.55 13.95L17.65 15.35L19.3 18.45L15.8 17.3L14.55 13.95Z"
+    />
+    <path
+      fill="currentColor"
+      d="M12 17.2L10.45 20.25L12 21.5L13.55 20.25L12 17.2Z"
+    />
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- simplify several project editor surfaces, including project creation, placeholders, helper copy, preview labels, and temporary animated-asset navigation
- rename layout types to `general`, `dialogue-adv`, and `dialogue-nvl`, update the layout editor and seeded repository template, and bump `@routevn/creator-model` to `1.2.5`
- refresh text-style/template defaults and replace the release sidebar rocket with a larger upper-right-tilted icon

## Testing
- bun run lint
- bun run build:web