### PR TITLE
refactor: align alerts and animation defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "dependencies": {
         "@rettangoli/fe": "1.1.3",
-        "@rettangoli/ui": "1.5.0",
+        "@rettangoli/ui": "1.6.0",
         "@rettangoli/vt": "1.0.2",
         "@routevn/creator-model": "1.2.7",
         "@tauri-apps/api": "^2.8.0",
@@ -205,7 +205,7 @@
 
     "@rettangoli/fe": ["@rettangoli/fe@1.1.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-/fia9Ir5x5NU7fjfXtuioCwbc4ELj939pM+/vB9R7bOAPVKosKTspyOuYqMrstysfT84xfLEcPidBrI5OY/l0g=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.5.0", "", { "dependencies": { "@rettangoli/fe": "1.1.3", "jempl": "1.0.1" } }, "sha512-UxKiCE9ZjtMSCQSNVgRbPAwE40PT/y3cB47Tg6Hd91To4uDRWeynx8IT/+KSv5LUub9YuA/dAJqXa0t/WH8g2A=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.6.0", "", { "dependencies": { "@rettangoli/fe": "1.1.3", "jempl": "1.0.1" } }, "sha512-sLe7HdRkTLNFuG1IKzJJmWGDCZqH2WODwwl2PZk45F5VDcQtFem7Wj4px6PAmqYdwx2tyjfiAYTyohX9nfzjcw=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.2", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-QHweZ2BJFiQi0mc8KvSLiFjKTm9ovjs++x9cOTtN89AyK/Pn0acuD0mA+kjOu4zgPcaHvjOAINNqMFsqhx9Hgw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "dependencies": {
     "@rettangoli/fe": "1.1.3",
-    "@rettangoli/ui": "1.5.0",
+    "@rettangoli/ui": "1.6.0",
     "@rettangoli/vt": "1.0.2",
     "@routevn/creator-model": "1.2.7",
     "@tauri-apps/api": "^2.8.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ set -e
 
 BUILD_TYPE=${1:-web}
 SETUP_FILE="src/setup.${BUILD_TYPE}.js"
-RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.5.0")
+RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.6.0")
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 RETTANGOLI_URL="https://cdn.jsdelivr.net/npm/@rettangoli/ui@${RETTANGOLI_VERSION}/dist/rettangoli-iife-ui.min.js"

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -282,7 +282,10 @@ export const handleButtonSelectClick = (deps) => {
     const tempSelectedSpriteId = store.selectTempSelectedSpriteId();
 
     if (!tempSelectedSpriteId) {
-      appService.showToast("A sprite is required.", { title: "Warning" });
+      appService.showAlert({
+        message: "A sprite is required.",
+        title: "Warning",
+      });
       return;
     }
 

--- a/src/components/commandLineChoices/commandLineChoices.handlers.js
+++ b/src/components/commandLineChoices/commandLineChoices.handlers.js
@@ -90,24 +90,34 @@ export const handleSaveChoiceClick = (deps) => {
   const editForm = store.selectEditForm();
 
   if (!editForm.content || editForm.content.trim() === "") {
-    appService.showToast("Choice content cannot be empty", {
+    appService.showAlert({
+      message: "Choice content cannot be empty",
       title: "Warning",
     });
     return;
   }
 
   if (!editForm.actionType) {
-    appService.showToast("Please select an action type", { title: "Warning" });
+    appService.showAlert({
+      message: "Please select an action type",
+      title: "Warning",
+    });
     return;
   }
 
   if (editForm.actionType === "sectionTransition") {
     if (!editForm.sceneId) {
-      appService.showToast("Please select a scene", { title: "Warning" });
+      appService.showAlert({
+        message: "Please select a scene",
+        title: "Warning",
+      });
       return;
     }
     if (!editForm.sectionId) {
-      appService.showToast("Please select a section", { title: "Warning" });
+      appService.showAlert({
+        message: "Please select a section",
+        title: "Warning",
+      });
       return;
     }
   }
@@ -160,7 +170,8 @@ export const handleSubmitClick = (deps) => {
   });
 
   if (!selectedResourceId) {
-    appService.showToast("Please select a choice layout", {
+    appService.showAlert({
+      message: "Please select a choice layout",
       title: "Warning",
     });
     return;

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.js
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.js
@@ -78,14 +78,16 @@ export const handleSubmitClick = (deps) => {
   const sectionId = formValues?.sectionId;
 
   if (!sceneId) {
-    appService.showToast("Please select a scene", {
+    appService.showAlert({
+      message: "Please select a scene",
       title: "Warning",
     });
     return;
   }
 
   if (!sectionId) {
-    appService.showToast("Please select a section", {
+    appService.showAlert({
+      message: "Please select a section",
       title: "Warning",
     });
     return;
@@ -95,7 +97,8 @@ export const handleSubmitClick = (deps) => {
   const selectedSection = selectedScene?.sections?.items?.[sectionId];
 
   if (!selectedScene || !selectedSection || !hasSectionId(scenes, sectionId)) {
-    appService.showToast("Please select a valid section for selected scene", {
+    appService.showAlert({
+      message: "Please select a valid section for selected scene",
       title: "Warning",
     });
     return;

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js
@@ -49,12 +49,18 @@ export const handleSubmitClick = (deps) => {
   const { formValues, scenes } = store.getState();
 
   if (!formValues?.sceneId) {
-    appService.showToast("Please select a scene", { title: "Warning" });
+    appService.showAlert({
+      message: "Please select a scene",
+      title: "Warning",
+    });
     return;
   }
 
   if (!formValues?.sectionId) {
-    appService.showToast("Please select a section", { title: "Warning" });
+    appService.showAlert({
+      message: "Please select a section",
+      title: "Warning",
+    });
     return;
   }
 
@@ -63,7 +69,8 @@ export const handleSubmitClick = (deps) => {
     selectedScene?.sections?.items?.[formValues.sectionId];
 
   if (!selectedScene || !selectedSection) {
-    appService.showToast("Please select a valid section for selected scene", {
+    appService.showAlert({
+      message: "Please select a valid section for selected scene",
       title: "Warning",
     });
     return;

--- a/src/components/commandLineUpdateVariable/commandLineUpdateVariable.handlers.js
+++ b/src/components/commandLineUpdateVariable/commandLineUpdateVariable.handlers.js
@@ -184,7 +184,8 @@ export const handleSubmitClick = (deps, payload) => {
     });
 
   if (validOperations.length === 0) {
-    appService.showToast("Please add at least one valid variable operation.", {
+    appService.showAlert({
+      message: "Please add at least one valid variable operation.",
       title: "Warning",
     });
     return;

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -181,7 +181,10 @@ export const handleButtonSelectClick = (deps) => {
 
   if (mode === "resource-select") {
     if (!tempSelectedResourceId) {
-      appService.showToast("A resource is required.", { title: "Warning" });
+      appService.showAlert({
+        message: "A resource is required.",
+        title: "Warning",
+      });
       return;
     }
 

--- a/src/components/groupVariablesView/groupVariablesView.handlers.js
+++ b/src/components/groupVariablesView/groupVariablesView.handlers.js
@@ -260,7 +260,10 @@ export const handleFormActionClick = (deps, payload) => {
 
     // Don't submit if name is not set
     if (!name) {
-      appService.showToast("Variable name is required.", { title: "Warning" });
+      appService.showAlert({
+        message: "Variable name is required.",
+        title: "Warning",
+      });
       return;
     }
 
@@ -275,17 +278,18 @@ export const handleFormActionClick = (deps, payload) => {
       formData.scope ?? storeState.defaultValues?.scope ?? "context";
     const type = formData.type ?? storeState.defaultValues?.type ?? "string";
     if (isEditMode && !editingItemId) {
-      appService.showToast(
-        "Unable to update variable. Please reopen the editor and try again.",
-        { title: "Warning" },
-      );
+      appService.showAlert({
+        message:
+          "Unable to update variable. Please reopen the editor and try again.",
+        title: "Warning",
+      });
       return;
     }
     if (!isEditMode && !targetGroupId) {
-      appService.showToast(
-        "Unable to add variable. Please select a group and try again.",
-        { title: "Warning" },
-      );
+      appService.showAlert({
+        message: "Unable to add variable. Please select a group and try again.",
+        title: "Warning",
+      });
       return;
     }
 
@@ -297,7 +301,8 @@ export const handleFormActionClick = (deps, payload) => {
           item.name === name && (!isEditMode || item.id !== editingItemId),
       );
     if (isDuplicateName) {
-      appService.showToast("Variable name must be unique.", {
+      appService.showAlert({
+        message: "Variable name must be unique.",
         title: "Warning",
       });
       return;

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -1062,7 +1062,9 @@ export const handleConditionalOverrideAddAttributeClick = (deps, payload) => {
   });
 
   if (availableAttributeOptions.length === 0) {
-    appService.showToast("All supported attributes are already added.");
+    appService.showAlert({
+      message: "All supported attributes are already added.",
+    });
     return;
   }
 

--- a/src/components/projectCreateDialog/projectCreateDialog.handlers.js
+++ b/src/components/projectCreateDialog/projectCreateDialog.handlers.js
@@ -79,7 +79,7 @@ export const handleBrowseButtonClick = async (deps) => {
     });
     render();
   } catch {
-    appService.showToast("Failed to select project location.");
+    appService.showAlert({ message: "Failed to select project location." });
   }
 };
 
@@ -121,7 +121,7 @@ export const handleProjectIconClick = async (deps) => {
       validations: ICON_VALIDATIONS,
     });
   } catch {
-    appService.showToast("Failed to select project icon.");
+    appService.showAlert({ message: "Failed to select project icon." });
     return;
   }
 
@@ -161,7 +161,7 @@ export const handleIconCropDialogConfirm = async (deps) => {
     store.closeIconCropDialog();
     render();
   } catch {
-    appService.showToast("Failed to crop project icon.");
+    appService.showAlert({ message: "Failed to crop project icon." });
   }
 };
 

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -100,7 +100,8 @@ async function loadAssetsForSceneIds(
       sceneIds: uniqueSceneIds,
     });
   } catch (error) {
-    appService?.showToast("Failed to load some preview assets", {
+    appService?.showAlert({
+      message: "Failed to load some preview assets",
       title: "Warning",
     });
     console.error("[vnPreview] Failed to load scene assets:", error);

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -82,20 +82,16 @@ export const createAppShellService = ({
 
     openUrl,
 
-    showToast(message, options = {}) {
-      const toastMessage =
-        typeof options.title === "string" && options.title.length > 0
-          ? `${options.title}: ${message}`
-          : message;
-
-      globalUI.showToast({
-        message: toastMessage,
-        size: options.size ?? options.s,
-      });
-    },
-
     showDialog(options) {
       return globalUI.showConfirm(options);
+    },
+
+    showAlert(options) {
+      return globalUI.showAlert(options);
+    },
+
+    showToast(options) {
+      return globalUI.showToast(options);
     },
 
     showFormDialog(options) {

--- a/src/internal/ui/fileExplorer.js
+++ b/src/internal/ui/fileExplorer.js
@@ -378,12 +378,12 @@ export const createResourceFileExplorerHandlers = ({
           itemId,
         });
         if (!deleteValidation.canDelete) {
-          appService.showToast(
-            getDeletionBlockedMessage({
+          appService.showAlert({
+            message: getDeletionBlockedMessage({
               itemType: currentItem?.type,
               reason: deleteValidation.reason,
             }),
-          );
+          });
           return;
         }
 
@@ -391,7 +391,7 @@ export const createResourceFileExplorerHandlers = ({
           [resourceApi.deleteField]: [itemId],
         });
         if (deleteResult?.valid === false) {
-          appService.showToast("Failed to delete resource.");
+          appService.showAlert({ message: "Failed to delete resource." });
           return;
         }
       } else if (action === "duplicate-item") {
@@ -409,15 +409,13 @@ export const createResourceFileExplorerHandlers = ({
           [resourceApi.idField]: itemId,
         });
         if (duplicateItemId?.valid === false) {
-          appService.showToast(
-            getResultErrorMessage(
+          appService.showAlert({
+            message: getResultErrorMessage(
               duplicateItemId,
               "Failed to duplicate resource.",
             ),
-            {
-              title: "Error",
-            },
-          );
+            title: "Error",
+          });
           return;
         }
 
@@ -527,9 +525,9 @@ export const createLayoutsFileExplorerHandlers = ({
         });
 
         if (usage.isUsed) {
-          appService.showToast(
-            "Cannot delete resource, it is currently in use.",
-          );
+          appService.showAlert({
+            message: "Cannot delete resource, it is currently in use.",
+          });
           return;
         }
 
@@ -545,15 +543,13 @@ export const createLayoutsFileExplorerHandlers = ({
           layoutId: itemId,
         });
         if (duplicateLayoutId?.valid === false) {
-          appService.showToast(
-            getResultErrorMessage(
+          appService.showAlert({
+            message: getResultErrorMessage(
               duplicateLayoutId,
               "Failed to duplicate layout.",
             ),
-            {
-              title: "Error",
-            },
-          );
+            title: "Error",
+          });
           return;
         }
 
@@ -646,9 +642,9 @@ export const createControlsFileExplorerHandlers = ({
         });
 
         if (usage.isUsed) {
-          appService.showToast(
-            "Cannot delete resource, it is currently in use.",
-          );
+          appService.showAlert({
+            message: "Cannot delete resource, it is currently in use.",
+          });
           return;
         }
 
@@ -697,9 +693,9 @@ export const createLayoutElementsFileExplorerHandlers = ({
       const resourceType = getResourceType(deps);
       const isControls = resourceType === "controls";
       if (!layoutId) {
-        appService.showToast(
-          isControls ? "Control is missing." : "Layout is missing.",
-        );
+        appService.showAlert({
+          message: isControls ? "Control is missing." : "Layout is missing.",
+        });
         return;
       }
 
@@ -795,12 +791,13 @@ export const createLayoutElementsFileExplorerHandlers = ({
           position: "last",
         });
         if (createResult?.valid === false) {
-          appService.showToast(
-            getResultErrorMessage(createResult, "Failed to create element."),
-            {
-              title: "Error",
-            },
-          );
+          appService.showAlert({
+            message: getResultErrorMessage(
+              createResult,
+              "Failed to create element.",
+            ),
+            title: "Error",
+          });
           console.error("Failed to create layout editor element:", {
             resourceType,
             layoutId,
@@ -826,9 +823,9 @@ export const createLayoutElementsFileExplorerHandlers = ({
       const resourceType = getResourceType(deps);
       const isControls = resourceType === "controls";
       if (!layoutId) {
-        appService.showToast(
-          isControls ? "Control is missing." : "Layout is missing.",
-        );
+        appService.showAlert({
+          message: isControls ? "Control is missing." : "Layout is missing.",
+        });
         return;
       }
 
@@ -955,7 +952,7 @@ export const createCharacterSpritesFileExplorerHandlers = ({
       const state = projectService.getState();
       const characterId = getCharacterId(deps);
       if (!characterId) {
-        appService.showToast("Character is missing.");
+        appService.showAlert({ message: "Character is missing." });
         return;
       }
 
@@ -1010,9 +1007,9 @@ export const createCharacterSpritesFileExplorerHandlers = ({
           checkTargets: ["scenes", "layouts"],
         });
         if (usage.isUsed) {
-          appService.showToast(
-            "Cannot delete resource, it is currently in use.",
-          );
+          appService.showAlert({
+            message: "Cannot delete resource, it is currently in use.",
+          });
           return;
         }
 
@@ -1051,7 +1048,7 @@ export const createCharacterSpritesFileExplorerHandlers = ({
 
       const characterId = getCharacterId(deps);
       if (!characterId) {
-        appService.showToast("Character is missing.");
+        appService.showAlert({ message: "Character is missing." });
         return;
       }
 

--- a/src/internal/ui/resourcePages/resourcePageErrors.js
+++ b/src/internal/ui/resourcePages/resourcePageErrors.js
@@ -22,7 +22,7 @@ export const showResourcePageError = ({
   title = "Error",
 } = {}) => {
   const message = getResourcePageErrorMessage(errorOrResult, fallbackMessage);
-  appService.showToast(message, { title });
+  appService.showAlert({ message: message, title });
   return message;
 };
 

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -247,7 +247,8 @@ async function loadAssetsForSceneIds(
     uniqueSceneIds.forEach((sceneId) => {
       assetLoadCache.pendingSceneIds.delete(sceneId);
     });
-    appService?.showToast("Failed to load some scene assets", {
+    appService?.showAlert({
+      message: "Failed to load some scene assets",
       title: "Warning",
     });
     console.error("[sceneEditor] Failed to load scene assets:", error);

--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -10,7 +10,6 @@ export const PREVIEW_UPDATE_ELEMENT_ID = "preview-element";
 export const PREVIEW_TRANSITION_ELEMENT_ID = "preview-transition-element";
 export const PREVIEW_TRANSITION_PREV_FILL = "#ffffff";
 export const PREVIEW_TRANSITION_NEXT_FILL = "#8fd3ff";
-export const PREVIEW_TRANSITION_OFFSET_X = 18;
 export const AUTO_TWEEN_DEFAULT_DURATION = 1000;
 export const AUTO_TWEEN_DEFAULT_EASING = "linear";
 

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -526,7 +526,7 @@ const syncEditorState = async ({ deps, repositoryState } = {}) => {
     });
 
     if (!itemData) {
-      appService.showToast("Animation not found.", { title: "Error" });
+      appService.showAlert({ message: "Animation not found.", title: "Error" });
       appService.navigate(
         getAnimationEditorBackPath(),
         createAnimationEditorPayload({

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -33,7 +33,6 @@ import {
   PREVIEW_BG_COLOR,
   PREVIEW_TRANSITION_NEXT_FILL,
   PREVIEW_TRANSITION_ELEMENT_ID,
-  PREVIEW_TRANSITION_OFFSET_X,
   PREVIEW_TRANSITION_PREV_FILL,
   PREVIEW_UPDATE_ELEMENT_ID,
   propertyNameDropdownItems,
@@ -171,7 +170,7 @@ const createAnimationResetState = (dialogType, projectResolution) => {
     elements.push(
       createPreviewRect({
         id: PREVIEW_TRANSITION_ELEMENT_ID,
-        x: centerX - PREVIEW_TRANSITION_OFFSET_X,
+        x: centerX,
         y: centerY,
         width,
         height,
@@ -1111,7 +1110,7 @@ const createAnimationRenderState = ({
       },
       createPreviewRect({
         id: PREVIEW_TRANSITION_ELEMENT_ID,
-        x: centerX + PREVIEW_TRANSITION_OFFSET_X,
+        x: centerX,
         y: centerY,
         width,
         height,

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -25,13 +25,26 @@ const navigateToAnimationEditor = ({
   });
 };
 
+const logSelectedAnimationData = ({ store, itemId } = {}) => {
+  if (!itemId) {
+    return;
+  }
+
+  const animationItem = store.selectAnimationItemById({ itemId });
+  if (!animationItem) {
+    return;
+  }
+
+  console.log("Selected animation data", animationItem);
+};
+
 const {
   handleBeforeMount: handleBeforeMountBase,
   refreshData: handleDataChanged,
-  handleFileExplorerSelectionChanged,
+  handleFileExplorerSelectionChanged: handleFileExplorerSelectionChangedBase,
   handleFileExplorerAction: handleFileExplorerActionBase,
   handleFileExplorerTargetChanged,
-  handleItemClick: handleAnimationItemClick,
+  handleItemClick: handleAnimationItemClickBase,
   handleSearchInput,
 } = createCatalogPageHandlers({
   resourceType: "animations",
@@ -39,14 +52,35 @@ const {
 
 export {
   handleDataChanged,
-  handleFileExplorerSelectionChanged,
   handleFileExplorerTargetChanged,
-  handleAnimationItemClick,
   handleSearchInput,
 };
 
 export const handleBeforeMount = (deps) => {
   return handleBeforeMountBase(deps);
+};
+
+export const handleFileExplorerSelectionChanged = (deps, payload) => {
+  handleFileExplorerSelectionChangedBase(deps, payload);
+
+  const { itemId, isFolder } = payload?._event?.detail ?? {};
+  if (isFolder || !itemId) {
+    return;
+  }
+
+  logSelectedAnimationData({
+    store: deps.store,
+    itemId,
+  });
+};
+
+export const handleAnimationItemClick = (deps, payload) => {
+  handleAnimationItemClickBase(deps, payload);
+
+  logSelectedAnimationData({
+    store: deps.store,
+    itemId: payload?._event?.detail?.itemId,
+  });
 };
 
 const openEditDialogWithValues = ({ deps, itemId } = {}) => {
@@ -185,7 +219,8 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Please enter an animation name.", {
+    appService.showAlert({
+      message: "Please enter an animation name.",
       title: "Warning",
     });
     return;
@@ -232,7 +267,8 @@ export const handleAddFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Please enter an animation name.", {
+    appService.showAlert({
+      message: "Please enter an animation name.",
       title: "Warning",
     });
     return;
@@ -286,7 +322,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     return;
   }
 

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -53,6 +53,14 @@ const isMissingProjectResolutionError = (error) => {
   );
 };
 
+const isProjectLoadDialogError = (error) => {
+  const message = String(error?.message || "");
+  return (
+    message.includes("incompatible project with version") ||
+    message.includes("requires reset for schema version")
+  );
+};
+
 const getProjectLoadErrorMessage = (error) => {
   if (isMissingProjectResolutionError(error)) {
     return "Project is missing required resolution settings.";
@@ -192,7 +200,15 @@ const createRouteTransitionRunner = (deps) => {
       }
 
       store.setRepositoryLoading({ isLoading: false });
-      appService.showToast(getProjectLoadErrorMessage(error));
+      if (isProjectLoadDialogError(error)) {
+        await appService.showAlert({
+          title: "Incompatible Project",
+          message: getProjectLoadErrorMessage(error),
+          status: "error",
+        });
+      } else {
+        appService.showAlert({ message: getProjectLoadErrorMessage(error) });
+      }
       appService.redirect("/projects");
       store.setCurrentRoute({ route: "/projects" });
       render();

--- a/src/pages/authenticate/authenticate.handlers.js
+++ b/src/pages/authenticate/authenticate.handlers.js
@@ -78,7 +78,7 @@ export const handleFormAction = async (deps, payload) => {
   if (detail.actionId === "request-otp") {
     const email = detail?.values?.email?.trim?.() || "";
     if (!email) {
-      appService.showToast("Email is required.");
+      appService.showAlert({ message: "Email is required." });
       return;
     }
 
@@ -87,7 +87,7 @@ export const handleFormAction = async (deps, payload) => {
       store.setOtpRequested({ email });
       render();
     } catch (error) {
-      appService.showToast(getErrorMessage(error));
+      appService.showAlert({ message: getErrorMessage(error) });
     }
     return;
   }
@@ -95,13 +95,13 @@ export const handleFormAction = async (deps, payload) => {
   if (detail.actionId === "next") {
     const otp = detail?.values?.otp?.trim?.() || "";
     if (!otp) {
-      appService.showToast("OTP is required.");
+      appService.showAlert({ message: "OTP is required." });
       return;
     }
 
     const email = store.selectRequestedEmail();
     if (!email) {
-      appService.showToast("Email is required.");
+      appService.showAlert({ message: "Email is required." });
       return;
     }
 
@@ -115,9 +115,9 @@ export const handleFormAction = async (deps, payload) => {
             ? authResult.registerCode
             : "";
         if (!registerCode) {
-          appService.showToast(
-            "Registration failed. Please request OTP again.",
-          );
+          appService.showAlert({
+            message: "Registration failed. Please request OTP again.",
+          });
           return;
         }
         store.setRegisterStep({ registerCode });
@@ -129,7 +129,7 @@ export const handleFormAction = async (deps, payload) => {
       appService.navigate("/projects");
       return;
     } catch (error) {
-      appService.showToast(getAuthenticateErrorMessage(error));
+      appService.showAlert({ message: getAuthenticateErrorMessage(error) });
     }
     return;
   }
@@ -139,14 +139,18 @@ export const handleFormAction = async (deps, payload) => {
     const acceptPrivacy = Boolean(detail?.values?.acceptPrivacy);
 
     if (!acceptTerms || !acceptPrivacy) {
-      appService.showToast("Please accept Terms and Privacy Policy.");
+      appService.showAlert({
+        message: "Please accept Terms and Privacy Policy.",
+      });
       return;
     }
 
     const email = store.selectRequestedEmail();
     const registerCode = store.selectRegisterCode();
     if (!email || !registerCode) {
-      appService.showToast("Registration session expired. Please login again.");
+      appService.showAlert({
+        message: "Registration session expired. Please login again.",
+      });
       return;
     }
 
@@ -159,7 +163,7 @@ export const handleFormAction = async (deps, payload) => {
       appService.navigate("/projects");
     } catch (error) {
       if (!shouldReissueRegisterCode(error)) {
-        appService.showToast(getRegisterErrorMessage(error));
+        appService.showAlert({ message: getRegisterErrorMessage(error) });
         return;
       }
 
@@ -170,9 +174,9 @@ export const handleFormAction = async (deps, payload) => {
         });
         const nextRegisterCode = extractRegisterCode(reissueResult);
         if (!nextRegisterCode) {
-          appService.showToast(
-            "Registration session expired. Please login again.",
-          );
+          appService.showAlert({
+            message: "Registration session expired. Please login again.",
+          });
           return;
         }
 
@@ -184,7 +188,9 @@ export const handleFormAction = async (deps, payload) => {
         persistAuthenticatedSession(appService, registerResult);
         appService.navigate("/projects");
       } catch (reissueError) {
-        appService.showToast(getRegisterErrorMessage(reissueError));
+        appService.showAlert({
+          message: getRegisterErrorMessage(reissueError),
+        });
       }
       return;
     }

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -65,13 +65,13 @@ const syncCharacterSpritesData = ({ deps, repositoryState } = {}) => {
   const state = repositoryState ?? projectService.getState();
 
   if (!characterId) {
-    appService.showToast("Character is missing.", { title: "Error" });
+    appService.showAlert({ message: "Character is missing.", title: "Error" });
     return false;
   }
 
   const character = state?.characters?.items?.[characterId];
   if (!character) {
-    appService.showToast("Character not found.", { title: "Error" });
+    appService.showAlert({ message: "Character not found.", title: "Error" });
     return false;
   }
 
@@ -169,7 +169,7 @@ const createSpritesFromFiles = async ({
   const { appService, projectService, store, render } = deps;
   const characterId = store.selectCharacterId();
   if (!characterId) {
-    appService.showToast("Character is missing.", { title: "Error" });
+    appService.showAlert({ message: "Character is missing.", title: "Error" });
     return;
   }
 
@@ -277,7 +277,10 @@ const createSpritesFromFiles = async ({
   }
 
   if (successfulUploadCount === 0) {
-    appService.showToast("Failed to upload sprites.", { title: "Error" });
+    appService.showAlert({
+      message: "Failed to upload sprites.",
+      title: "Error",
+    });
     return;
   }
 
@@ -579,14 +582,17 @@ export const handleFormExtraEvent = async (deps) => {
   }
 
   if (!(file.uploadSucessful && file.uploadResult)) {
-    appService.showToast("Failed to upload sprite.", { title: "Error" });
+    appService.showAlert({
+      message: "Failed to upload sprite.",
+      title: "Error",
+    });
     return;
   }
 
   const uploadResult = file.uploadResult;
   const characterId = store.selectCharacterId();
   if (!characterId) {
-    appService.showToast("Character is missing.", { title: "Error" });
+    appService.showAlert({ message: "Character is missing.", title: "Error" });
     return;
   }
 
@@ -647,7 +653,10 @@ export const handleEditDialogImageClick = async (deps) => {
   }
 
   if (!(file.uploadSucessful && file.uploadResult)) {
-    appService.showToast("Failed to upload sprite.", { title: "Error" });
+    appService.showAlert({
+      message: "Failed to upload sprite.",
+      title: "Error",
+    });
     return;
   }
 
@@ -668,7 +677,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Sprite name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Sprite name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -735,7 +747,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     return;
   }
 
@@ -745,10 +759,13 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (deleteResult?.valid === false) {
-    appService.showToast(
-      getResourcePageErrorMessage(deleteResult, "Failed to delete sprite."),
-      { title: "Error" },
-    );
+    appService.showAlert({
+      message: getResourcePageErrorMessage(
+        deleteResult,
+        "Failed to delete sprite.",
+      ),
+      title: "Error",
+    });
     return;
   }
 

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -282,7 +282,8 @@ export const handleDialogFormActionClick = async (deps, payload) => {
     const formData = payload._event.detail.values;
     const name = formData.name?.trim();
     if (!name) {
-      appService.showToast("Character name is required.", {
+      appService.showAlert({
+        message: "Character name is required.",
         title: "Warning",
       });
       return;
@@ -372,7 +373,9 @@ export const handleItemDelete = async (deps, payload) => {
   }
 
   if (isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }
@@ -431,7 +434,8 @@ export const handleAvatarCropDialogConfirm = async (deps) => {
   try {
     const croppedFile = await refs.avatarCropDialog?.getCroppedFile?.();
     if (!croppedFile) {
-      appService.showToast("Avatar crop is not ready yet.", {
+      appService.showAlert({
+        message: "Avatar crop is not ready yet.",
         title: "Warning",
       });
       return;

--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -103,7 +103,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Color name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Color name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -155,7 +158,10 @@ export const handleAddFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Color name cannot be empty.", { title: "Warning" });
+    appService.showAlert({
+      message: "Color name cannot be empty.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -194,7 +200,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -221,7 +221,10 @@ export const handleControlFormActionClick = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Please enter a control name", { title: "Warning" });
+    appService.showAlert({
+      message: "Please enter a control name",
+      title: "Warning",
+    });
     return;
   }
 
@@ -287,7 +290,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }
@@ -313,7 +318,8 @@ export const handleKeyboardAddClick = async (deps, payload) => {
   }));
 
   if (availableItems.length === 0) {
-    appService.showToast("All available keyboard keys are already assigned", {
+    appService.showAlert({
+      message: "All available keyboard keys are already assigned",
       title: "Warning",
     });
     return;

--- a/src/pages/fonts/fonts.handlers.js
+++ b/src/pages/fonts/fonts.handlers.js
@@ -16,10 +16,11 @@ const MAX_PARALLEL_UPLOADS = 1;
 const CREATE_FONT_ABORT_ERROR = "create-font-abort";
 
 const showInvalidFormatToast = (appService) => {
-  appService.showToast(
-    "Invalid file format. Please upload a font file (.ttf, .otf, .woff, .woff2, .ttc, or .eot)",
-    { title: "Warning" },
-  );
+  appService.showAlert({
+    message:
+      "Invalid file format. Please upload a font file (.ttf, .otf, .woff, .woff2, .ttc, or .eot)",
+    title: "Warning",
+  });
 };
 
 const validateFontFiles = ({ appService, files } = {}) => {
@@ -197,7 +198,7 @@ const createFontsFromFiles = async ({ deps, files, parentId } = {}) => {
   }
 
   if (successfulUploadCount === 0) {
-    appService.showToast("Failed to upload font.", { title: "Error" });
+    appService.showAlert({ message: "Failed to upload font.", title: "Error" });
     return;
   }
 
@@ -382,7 +383,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Font name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Font name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -461,7 +465,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -15,7 +15,10 @@ const INVALID_IMAGE_FORMAT_MESSAGE =
   "Only JPG/JPEG, PNG, and WEBP images are supported.";
 
 const showInvalidFormatToast = (appService) => {
-  appService.showToast(INVALID_IMAGE_FORMAT_MESSAGE, { title: "Warning" });
+  appService.showAlert({
+    message: INVALID_IMAGE_FORMAT_MESSAGE,
+    title: "Warning",
+  });
 };
 
 const validateImageFiles = ({ appService, files } = {}) => {
@@ -285,7 +288,10 @@ const createImagesFromFiles = async ({ deps, files, parentId } = {}) => {
     console.error("Failed to upload images: no successful uploads", {
       fileCount: Array.isArray(files) ? files.length : 0,
     });
-    appService.showToast("Failed to upload images.", { title: "Error" });
+    appService.showAlert({
+      message: "Failed to upload images.",
+      title: "Error",
+    });
     return;
   }
 
@@ -381,7 +387,10 @@ export const handleFormExtraEvent = async (deps) => {
   }
 
   if (result.errorType === "upload-failed") {
-    appService.showToast("Failed to upload image.", { title: "Error" });
+    appService.showAlert({
+      message: "Failed to upload image.",
+      title: "Error",
+    });
     return;
   }
 
@@ -559,7 +568,10 @@ export const handleEditDialogImageClick = async (deps) => {
   }
 
   if (result.errorType === "upload-failed") {
-    appService.showToast("Failed to upload image.", { title: "Error" });
+    appService.showAlert({
+      message: "Failed to upload image.",
+      title: "Error",
+    });
     return;
   }
 
@@ -580,7 +592,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Image name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Image name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -635,7 +650,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (!result.deleted) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -82,9 +82,7 @@ const showLayoutEditorError = ({
   const message = isSqliteLockError(error)
     ? lockedMessage
     : error?.message || fallbackMessage;
-  appService.showToast(message, {
-    title: "Error",
-  });
+  appService.showAlert({ message: message, title: "Error" });
 };
 
 const runLayoutEditorPersistence = (deps, task) => {
@@ -420,7 +418,8 @@ export const handleSaveButtonClick = async (deps) => {
     getLayoutEditorOwnerConfig(resourceType, projectService);
 
   if (!layoutId) {
-    appService.showToast(`${ownerLabel} is missing.`, {
+    appService.showAlert({
+      message: `${ownerLabel} is missing.`,
       title: "Error",
     });
     return;
@@ -430,12 +429,10 @@ export const handleSaveButtonClick = async (deps) => {
     const thumbnailImage =
       await refs.layoutEditorCanvas.captureThumbnailImage();
     if (!thumbnailImage) {
-      appService.showToast(
-        `Failed to capture ${ownerLabel.toLowerCase()} thumbnail.`,
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message: `Failed to capture ${ownerLabel.toLowerCase()} thumbnail.`,
+        title: "Error",
+      });
       return;
     }
 
@@ -453,26 +450,22 @@ export const handleSaveButtonClick = async (deps) => {
     });
 
     if (updateResult?.valid === false) {
-      appService.showToast(
-        `Failed to save ${ownerLabel.toLowerCase()} preview.`,
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message: `Failed to save ${ownerLabel.toLowerCase()} preview.`,
+        title: "Error",
+      });
       return;
     }
 
     await refreshLayoutEditorData(deps, {
       selectedItemId: store.selectSelectedItemId(),
     });
-    appService.showToast(`${ownerLabel} preview saved.`);
+    appService.showToast({ message: `${ownerLabel} preview saved.` });
   } catch {
-    appService.showToast(
-      `Failed to save ${ownerLabel.toLowerCase()} preview.`,
-      {
-        title: "Error",
-      },
-    );
+    appService.showAlert({
+      message: `Failed to save ${ownerLabel.toLowerCase()} preview.`,
+      title: "Error",
+    });
   }
 };
 
@@ -597,9 +590,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     const resourceType = store.selectLayoutResourceType();
 
     if (!layoutId || resourceType !== "layouts") {
-      appService.showToast("Layout is missing.", {
-        title: "Error",
-      });
+      appService.showAlert({ message: "Layout is missing.", title: "Error" });
       return;
     }
 
@@ -639,15 +630,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createContainerResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(
+      appService.showAlert({
+        message: getResultErrorMessage(
           createContainerResult,
           "Failed to create save/load slot.",
         ),
-        {
-          title: "Error",
-        },
-      );
+        title: "Error",
+      });
       return;
     }
 
@@ -660,15 +649,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createImageResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(
+      appService.showAlert({
+        message: getResultErrorMessage(
           createImageResult,
           "Failed to create save/load slot image.",
         ),
-        {
-          title: "Error",
-        },
-      );
+        title: "Error",
+      });
       return;
     }
 
@@ -681,15 +668,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createDateResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(
+      appService.showAlert({
+        message: getResultErrorMessage(
           createDateResult,
           "Failed to create save/load slot date.",
         ),
-        {
-          title: "Error",
-        },
-      );
+        title: "Error",
+      });
       return;
     }
 
@@ -709,7 +694,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     );
 
     if (fragmentLayoutOptions.length === 0) {
-      appService.showToast("Mark a layout as a fragment first.", {
+      appService.showAlert({
+        message: "Mark a layout as a fragment first.",
         title: "Warning",
       });
       return;
@@ -728,7 +714,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
 
     const fragmentLayoutId = dialogResult.values?.fragmentLayoutId;
     if (!fragmentLayoutId) {
-      appService.showToast("Fragment is required.", {
+      appService.showAlert({
+        message: "Fragment is required.",
         title: "Warning",
       });
       return;
@@ -740,7 +727,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       fragmentLayout?.type !== "layout" ||
       !isFragmentLayout(fragmentLayout)
     ) {
-      appService.showToast("Selected fragment is invalid.", {
+      appService.showAlert({
+        message: "Selected fragment is invalid.",
         title: "Error",
       });
       return;
@@ -748,9 +736,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
 
     const layoutId = store.selectLayoutId();
     if (!layoutId) {
-      appService.showToast("Layout is missing.", {
-        title: "Error",
-      });
+      appService.showAlert({ message: "Layout is missing.", title: "Error" });
       return;
     }
 
@@ -771,12 +757,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(createResult, "Failed to create fragment."),
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message: getResultErrorMessage(
+          createResult,
+          "Failed to create fragment.",
+        ),
+        title: "Error",
+      });
       return;
     }
 
@@ -795,7 +782,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       toSpritesheetAnimationSelectionItems(spritesheetsData);
 
     if (selectionItems.length === 0) {
-      appService.showToast("Import a spritesheet first.", {
+      appService.showAlert({
+        message: "Import a spritesheet first.",
         title: "Warning",
       });
       return;
@@ -816,7 +804,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
 
     const name = dialogResult.values?.name?.trim();
     if (!name) {
-      appService.showToast("Animation name is required.", {
+      appService.showAlert({
+        message: "Animation name is required.",
         title: "Warning",
       });
       return;
@@ -827,7 +816,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
         dialogResult.values?.spritesheetSelection,
       );
     if (!resourceId || !animationName) {
-      appService.showToast("Spritesheet animation is required.", {
+      appService.showAlert({
+        message: "Spritesheet animation is required.",
         title: "Warning",
       });
       return;
@@ -836,14 +826,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     const layoutId = store.selectLayoutId();
     const resourceType = store.selectLayoutResourceType();
     if (!layoutId) {
-      appService.showToast(
-        resourceType === "controls"
-          ? "Control is missing."
-          : "Layout is missing.",
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message:
+          resourceType === "controls"
+            ? "Control is missing."
+            : "Layout is missing.",
+        title: "Error",
+      });
       return;
     }
 
@@ -890,15 +879,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(
+      appService.showAlert({
+        message: getResultErrorMessage(
           createResult,
           "Failed to create spritesheet animation.",
         ),
-        {
-          title: "Error",
-        },
-      );
+        title: "Error",
+      });
       return;
     }
 
@@ -914,7 +901,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     const selectionItems = toParticleSelectionItems(particlesData);
 
     if (selectionItems.length === 0) {
-      appService.showToast("Create a particle effect first.", {
+      appService.showAlert({
+        message: "Create a particle effect first.",
         title: "Warning",
       });
       return;
@@ -934,7 +922,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
 
     const name = dialogResult.values?.name?.trim();
     if (!name) {
-      appService.showToast("Particle name is required.", {
+      appService.showAlert({
+        message: "Particle name is required.",
         title: "Warning",
       });
       return;
@@ -942,7 +931,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
 
     const particleId = dialogResult.values?.particleId;
     if (!particleId) {
-      appService.showToast("Particle is required.", {
+      appService.showAlert({
+        message: "Particle is required.",
         title: "Warning",
       });
       return;
@@ -951,14 +941,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     const layoutId = store.selectLayoutId();
     const resourceType = store.selectLayoutResourceType();
     if (!layoutId) {
-      appService.showToast(
-        resourceType === "controls"
-          ? "Control is missing."
-          : "Layout is missing.",
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message:
+          resourceType === "controls"
+            ? "Control is missing."
+            : "Layout is missing.",
+        title: "Error",
+      });
       return;
     }
 
@@ -1004,12 +993,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(createResult, "Failed to create particle."),
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message: getResultErrorMessage(
+          createResult,
+          "Failed to create particle.",
+        ),
+        title: "Error",
+      });
       return;
     }
 
@@ -1036,7 +1026,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
         spriteAction,
       );
     } catch {
-      appService.showToast("Failed to open sprite dialog.", {
+      appService.showAlert({
+        message: "Failed to open sprite dialog.",
         title: "Error",
       });
       return;
@@ -1049,7 +1040,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     const values = spriteDialogResult.values ?? {};
     const name = values.name?.trim();
     if (!name) {
-      appService.showToast("Sprite name is required.", {
+      appService.showAlert({
+        message: "Sprite name is required.",
         title: "Warning",
       });
       return;
@@ -1057,23 +1049,20 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
 
     const imageId = values.imageId;
     if (!imageId) {
-      appService.showToast("Image is required.", {
-        title: "Warning",
-      });
+      appService.showAlert({ message: "Image is required.", title: "Warning" });
       return;
     }
 
     const layoutId = store.selectLayoutId();
     const resourceType = store.selectLayoutResourceType();
     if (!layoutId) {
-      appService.showToast(
-        resourceType === "controls"
-          ? "Control is missing."
-          : "Layout is missing.",
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message:
+          resourceType === "controls"
+            ? "Control is missing."
+            : "Layout is missing.",
+        title: "Error",
+      });
       return;
     }
 
@@ -1116,12 +1105,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     });
 
     if (createResult?.valid === false) {
-      appService.showToast(
-        getResultErrorMessage(createResult, "Failed to create sprite."),
-        {
-          title: "Error",
-        },
-      );
+      appService.showAlert({
+        message: getResultErrorMessage(
+          createResult,
+          "Failed to create sprite.",
+        ),
+        title: "Error",
+      });
       return;
     }
 
@@ -1134,7 +1124,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
   try {
     dialogResult = await showSliderCreateDialog(appService, sliderAction);
   } catch {
-    appService.showToast("Failed to open slider dialog.", {
+    appService.showAlert({
+      message: "Failed to open slider dialog.",
       title: "Error",
     });
     return;
@@ -1147,7 +1138,8 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
   const values = dialogResult.values ?? {};
   const name = values.name?.trim();
   if (!name) {
-    appService.showToast("Slider name is required.", {
+    appService.showAlert({
+      message: "Slider name is required.",
       title: "Warning",
     });
     return;
@@ -1159,14 +1151,16 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
   const hoverThumbImageId = values.hoverThumbImageId;
 
   if (!barImageId) {
-    appService.showToast("Bar image is required.", {
+    appService.showAlert({
+      message: "Bar image is required.",
       title: "Warning",
     });
     return;
   }
 
   if (!thumbImageId) {
-    appService.showToast("Thumb image is required.", {
+    appService.showAlert({
+      message: "Thumb image is required.",
       title: "Warning",
     });
     return;
@@ -1176,14 +1170,13 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
   const layoutId = store.selectLayoutId();
   const resourceType = store.selectLayoutResourceType();
   if (!layoutId) {
-    appService.showToast(
-      resourceType === "controls"
-        ? "Control is missing."
-        : "Layout is missing.",
-      {
-        title: "Error",
-      },
-    );
+    appService.showAlert({
+      message:
+        resourceType === "controls"
+          ? "Control is missing."
+          : "Layout is missing.",
+      title: "Error",
+    });
     return;
   }
 
@@ -1220,12 +1213,10 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
   });
 
   if (createResult?.valid === false) {
-    appService.showToast(
-      getResultErrorMessage(createResult, "Failed to create slider."),
-      {
-        title: "Error",
-      },
-    );
+    appService.showAlert({
+      message: getResultErrorMessage(createResult, "Failed to create slider."),
+      title: "Error",
+    });
     return;
   }
 

--- a/src/pages/layoutEditor/support/layoutFragments.js
+++ b/src/pages/layoutEditor/support/layoutFragments.js
@@ -13,8 +13,8 @@ export const getFragmentLayoutItems = (
         item?.id !== excludeLayoutId,
     )
     .sort((left, right) =>
-      String(left.fullLabel || left.name || left.id).localeCompare(
-        String(right.fullLabel || right.name || right.id),
+      String(left.name || left.id).localeCompare(
+        String(right.name || right.id),
       ),
     );
 };
@@ -24,7 +24,7 @@ export const getFragmentLayoutOptions = (
   options = {},
 ) => {
   return getFragmentLayoutItems(layoutsData, options).map((item) => ({
-    label: item.fullLabel || item.name || item.id,
+    label: item.name || item.id,
     value: item.id,
   }));
 };

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -903,13 +903,19 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Please enter a layout name", { title: "Warning" });
+    appService.showAlert({
+      message: "Please enter a layout name",
+      title: "Warning",
+    });
     return;
   }
 
   const layoutType = values?.layoutType;
   if (!layoutType) {
-    appService.showToast("Please select a layout type", { title: "Warning" });
+    appService.showAlert({
+      message: "Please select a layout type",
+      title: "Warning",
+    });
     return;
   }
   const isFragment = values?.isFragment ?? false;
@@ -955,7 +961,10 @@ export const handleEditFormActionClick = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Please enter a layout name", { title: "Warning" });
+    appService.showAlert({
+      message: "Please enter a layout name",
+      title: "Warning",
+    });
     return;
   }
 
@@ -1010,15 +1019,17 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }
 
   if (!canDeleteLayoutItem(state.layouts, itemId)) {
-    appService.showToast(
-      `Cannot delete the last ${protectedLayoutTypeLabels[layoutType]} layout. At least one ${protectedLayoutTypeLabels[layoutType]} layout must remain.`,
-    );
+    appService.showAlert({
+      message: `Cannot delete the last ${protectedLayoutTypeLabels[layoutType]} layout. At least one ${protectedLayoutTypeLabels[layoutType]} layout must remain.`,
+    });
     render();
     return;
   }

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -384,7 +384,8 @@ export const handleAddParticleClick = async (deps, payload) => {
   );
 
   if (!isValidPreset) {
-    appService.showToast("Particle preset is required.", {
+    appService.showAlert({
+      message: "Particle preset is required.",
       title: "Warning",
     });
     return;
@@ -426,20 +427,25 @@ export const handleParticleFormActionClick = async (deps, payload) => {
   });
 
   if (!particleData.name) {
-    appService.showToast("Particle name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Particle name is required.",
+      title: "Warning",
+    });
     return;
   }
 
   const textureImageId = `${values?.textureImageId ?? ""}`.trim();
   if (!textureImageId) {
-    appService.showToast("Particle texture image is required.", {
+    appService.showAlert({
+      message: "Particle texture image is required.",
       title: "Warning",
     });
     return;
   }
 
   if (!store.selectImagesData()?.items?.[textureImageId]?.fileId) {
-    appService.showToast("Select a valid particle texture image.", {
+    appService.showAlert({
+      message: "Select a valid particle texture image.",
       title: "Warning",
     });
     return;

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -54,7 +54,8 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Project name is required.", {
+    appService.showAlert({
+      message: "Project name is required.",
       title: "Warning",
     });
     return;
@@ -98,9 +99,7 @@ export const handleEditDialogIconClick = async (deps) => {
       upload: true,
     });
   } catch {
-    appService.showToast("Failed to select file.", {
-      title: "Error",
-    });
+    appService.showAlert({ message: "Failed to select file.", title: "Error" });
     return;
   }
 
@@ -109,7 +108,8 @@ export const handleEditDialogIconClick = async (deps) => {
   }
 
   if (!file.uploadSucessful || !file.uploadResult) {
-    appService.showToast("Failed to upload project icon.", {
+    appService.showAlert({
+      message: "Failed to upload project icon.",
       title: "Error",
     });
     return;

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -76,9 +76,9 @@ export const handleAfterMount = async (deps) => {
           store,
           authToken: cloudSession.authToken,
         }).catch(() => {
-          appService.showToast(
-            "Failed to load cloud projects. Please try again later.",
-          );
+          appService.showAlert({
+            message: "Failed to load cloud projects. Please try again later.",
+          });
         })
       : Promise.resolve();
 
@@ -113,6 +113,14 @@ const showCreateProjectDialog = async (appService) => {
   });
 };
 
+const isIncompatibleProjectVersionError = (error) => {
+  return (
+    typeof error?.message === "string" &&
+    (error.message.includes("incompatible project with version") ||
+      error.message.includes("requires reset for schema version"))
+  );
+};
+
 export const handleCreateButtonClick = async (deps) => {
   const { appService, render, store } = deps;
   let dialogResult;
@@ -120,7 +128,7 @@ export const handleCreateButtonClick = async (deps) => {
   try {
     dialogResult = await showCreateProjectDialog(appService);
   } catch {
-    appService.showToast("Failed to open create project dialog.");
+    appService.showAlert({ message: "Failed to open create project dialog." });
     return;
   }
 
@@ -154,7 +162,7 @@ export const handleCreateButtonClick = async (deps) => {
         message = "Project Location is required.";
       }
 
-      appService.showToast(message);
+      appService.showAlert({ message: message });
       return;
     }
 
@@ -167,22 +175,22 @@ export const handleCreateButtonClick = async (deps) => {
     if (!projectResolution) {
       if (resolution === CUSTOM_PROJECT_RESOLUTION_PRESET) {
         if (!resolutionWidth) {
-          appService.showToast("Resolution Width is required.");
+          appService.showAlert({ message: "Resolution Width is required." });
           return;
         }
 
         if (!resolutionHeight) {
-          appService.showToast("Resolution Height is required.");
+          appService.showAlert({ message: "Resolution Height is required." });
           return;
         }
 
-        appService.showToast(
-          "Resolution Width and Height must be positive integers.",
-        );
+        appService.showAlert({
+          message: "Resolution Width and Height must be positive integers.",
+        });
         return;
       }
 
-      appService.showToast("Project Resolution is invalid.");
+      appService.showAlert({ message: "Project Resolution is invalid." });
       return;
     }
 
@@ -198,10 +206,11 @@ export const handleCreateButtonClick = async (deps) => {
     store.addProject({ project: newProject });
     render();
   } catch (error) {
-    appService.showToast(
-      error?.message ||
+    appService.showAlert({
+      message:
+        error?.message ||
         "Failed to create project. Please check the selected folder and try again.",
-    );
+    });
   }
 };
 
@@ -209,7 +218,9 @@ export const handleCloudCreateButtonClick = (deps) => {
   const { appService, store, render } = deps;
   const cloudSession = getAuthenticatedSession(appService);
   if (!cloudSession) {
-    appService.showToast("Please login to create a cloud project.");
+    appService.showAlert({
+      message: "Please login to create a cloud project.",
+    });
     return;
   }
 
@@ -243,14 +254,16 @@ export const handleCloudCreateFormAction = async (deps, payload) => {
 
   const cloudSession = getAuthenticatedSession(appService);
   if (!cloudSession) {
-    appService.showToast("Please login to create a cloud project.");
+    appService.showAlert({
+      message: "Please login to create a cloud project.",
+    });
     return;
   }
 
   const name = detail?.values?.name?.trim?.() || "";
   const description = detail?.values?.description?.trim?.() || "";
   if (!name) {
-    appService.showToast("Project Name is required.");
+    appService.showAlert({ message: "Project Name is required." });
     return;
   }
 
@@ -269,7 +282,9 @@ export const handleCloudCreateFormAction = async (deps, payload) => {
     store.closeCloudCreateDialog();
     render();
   } catch {
-    appService.showToast("Failed to create cloud project. Please try again.");
+    appService.showAlert({
+      message: "Failed to create cloud project. Please try again.",
+    });
   }
 };
 
@@ -293,14 +308,15 @@ export const handleOpenButtonClick = async (deps) => {
     store.addProject({ project: importedProject });
     render();
 
-    appService.showToast(
-      `Project "${importedProject.name}" has been successfully imported.`,
-    );
+    appService.showAlert({
+      message: `Project "${importedProject.name}" has been successfully imported.`,
+    });
   } catch (error) {
-    appService.showToast(
-      error?.message ||
+    appService.showAlert({
+      message:
+        error?.message ||
         "Failed to import project. Please select a valid project folder.",
-    );
+    });
   }
 };
 
@@ -363,7 +379,7 @@ export const handleProfileFormAction = (deps, payload) => {
   const existingUser = appService.getUserConfig("auth.user") || {};
   const email = existingUser?.email?.trim?.() || "";
   if (!email) {
-    appService.showToast("You are not logged in.");
+    appService.showAlert({ message: "You are not logged in." });
     return;
   }
 
@@ -397,7 +413,7 @@ export const handleSettingsFormAction = (deps, payload) => {
 
   const email = detail?.values?.email?.trim?.() || "";
   if (!email) {
-    appService.showToast("Email is required.");
+    appService.showAlert({ message: "Email is required." });
     return;
   }
 
@@ -462,7 +478,18 @@ export const handleProjectsClick = async (deps, payload) => {
   try {
     await projectService.ensureProjectCompatibleById(id);
   } catch (error) {
-    appService.showToast(error?.message || "Failed to open project.");
+    if (isIncompatibleProjectVersionError(error)) {
+      await appService.showAlert({
+        title: "Incompatible Project",
+        message: error.message,
+        status: "error",
+      });
+      return;
+    }
+
+    appService.showAlert({
+      message: error?.message || "Failed to open project.",
+    });
     return;
   }
 
@@ -577,19 +604,19 @@ export const handleAddMemberFormAction = async (deps, payload) => {
 
   const cloudSession = getAuthenticatedSession(appService);
   if (!cloudSession) {
-    appService.showToast("Please login to add a member.");
+    appService.showAlert({ message: "Please login to add a member." });
     return;
   }
 
   const projectId = store.selectAddMemberDialogProjectId();
   if (!projectId) {
-    appService.showToast("Cloud project is missing.");
+    appService.showAlert({ message: "Cloud project is missing." });
     return;
   }
 
   const email = detail?.values?.email?.trim?.() || "";
   if (!email) {
-    appService.showToast("Email is required.");
+    appService.showAlert({ message: "Email is required." });
     return;
   }
 
@@ -606,15 +633,17 @@ export const handleAddMemberFormAction = async (deps, payload) => {
     const cannotAddOwner = Number(result?.summary?.cannotAddOwner || 0);
 
     if (added > 0) {
-      appService.showToast("Member added.");
+      appService.showAlert({ message: "Member added." });
     } else if (alreadyMember > 0) {
-      appService.showToast("User is already a member.");
+      appService.showAlert({ message: "User is already a member." });
     } else if (userNotFound > 0) {
-      appService.showToast("User not found.");
+      appService.showAlert({ message: "User not found." });
     } else if (cannotAddOwner > 0) {
-      appService.showToast("Project owner cannot be added as a member.");
+      appService.showAlert({
+        message: "Project owner cannot be added as a member.",
+      });
     } else {
-      appService.showToast("No member was added.");
+      appService.showAlert({ message: "No member was added." });
     }
 
     await loadCloudProjects({
@@ -626,7 +655,9 @@ export const handleAddMemberFormAction = async (deps, payload) => {
     store.closeAddMemberDialog();
     render();
   } catch {
-    appService.showToast("Failed to add member. Please try again.");
+    appService.showAlert({
+      message: "Failed to add member. Please try again.",
+    });
   }
 };
 
@@ -643,7 +674,9 @@ export const handleDeleteDialogConfirm = async (deps) => {
     await appService.removeProjectEntry(projectId);
     store.removeProject({ projectId });
   } catch {
-    appService.showToast("Failed to remove project. Please try again.");
+    appService.showAlert({
+      message: "Failed to remove project. Please try again.",
+    });
   } finally {
     store.closeDeleteDialog();
     render();

--- a/src/pages/register/register.handlers.js
+++ b/src/pages/register/register.handlers.js
@@ -22,7 +22,9 @@ export const handleFormAction = (deps, payload) => {
   const acceptPrivacy = Boolean(detail?.values?.acceptPrivacy);
 
   if (!acceptTerms || !acceptPrivacy) {
-    appService.showToast("Please accept Terms and Privacy Policy.");
+    appService.showAlert({
+      message: "Please accept Terms and Privacy Policy.",
+    });
     return;
   }
 
@@ -34,7 +36,7 @@ export const handleFormAction = (deps, payload) => {
     "";
 
   if (!email) {
-    appService.showToast("Email is required.");
+    appService.showAlert({ message: "Email is required." });
     return;
   }
 

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -184,9 +184,7 @@ const assertSceneEditorCommandResult = (
   }
 
   const message = result?.error?.message || fallbackMessage;
-  appService?.showToast(message, {
-    title: "Error",
-  });
+  appService?.showAlert({ message: message, title: "Error" });
 
   const error = new Error(message);
   error.code = result?.error?.code || "validation_failed";
@@ -324,7 +322,8 @@ const flushSceneEditorDrafts = async (deps) => {
           revision: store.selectRepositoryRevision(),
           dirtyLineIds: dirtyLines.map(({ lineId }) => lineId),
         });
-        deps.appService?.showToast("Failed to save scene changes", {
+        deps.appService?.showAlert({
+          message: "Failed to save scene changes",
           title: "Error",
         });
         throw error;
@@ -439,7 +438,8 @@ export const handleAfterMount = async (deps) => {
       throw error;
     }
 
-    deps.appService?.showToast(MISSING_PROJECT_RESOLUTION_MESSAGE, {
+    deps.appService?.showAlert({
+      message: MISSING_PROJECT_RESOLUTION_MESSAGE,
       title: "Error",
     });
     deps.appService?.navigate("/projects");
@@ -524,7 +524,8 @@ export const handleCommandLineSubmit = async (deps, payload) => {
         "command line submit detail (sectionTransition)",
       );
     } catch {
-      appService?.showToast("Invalid action payload (non-serializable data)", {
+      appService?.showAlert({
+        message: "Invalid action payload (non-serializable data)",
         title: "Error",
       });
       return;
@@ -578,7 +579,8 @@ export const handleCommandLineSubmit = async (deps, payload) => {
         "command line submit detail (pushOverlay)",
       );
     } catch {
-      appService?.showToast("Invalid action payload (non-serializable data)", {
+      appService?.showAlert({
+        message: "Invalid action payload (non-serializable data)",
         title: "Error",
       });
       return;
@@ -626,7 +628,8 @@ export const handleCommandLineSubmit = async (deps, payload) => {
         "command line submit detail (popOverlay)",
       );
     } catch {
-      appService?.showToast("Invalid action payload (non-serializable data)", {
+      appService?.showAlert({
+        message: "Invalid action payload (non-serializable data)",
         title: "Error",
       });
       return;
@@ -686,7 +689,8 @@ export const handleCommandLineSubmit = async (deps, payload) => {
       "command line submit detail (general)",
     );
   } catch {
-    appService?.showToast("Invalid action payload (non-serializable data)", {
+    appService?.showAlert({
+      message: "Invalid action payload (non-serializable data)",
       title: "Error",
     });
     return;

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -663,9 +663,9 @@ export const handleSceneFormAction = async (deps, payload) => {
       await refreshScenesData(deps);
       render();
     } catch (error) {
-      appService.showToast(
-        getProjectErrorMessage(error, "Failed to create scene."),
-      );
+      appService.showAlert({
+        message: getProjectErrorMessage(error, "Failed to create scene."),
+      });
       await refreshScenesData(deps);
       render();
     }
@@ -791,7 +791,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Scene name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Scene name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -811,10 +814,10 @@ export const handleEditFormAction = async (deps, payload) => {
   });
 
   if (updateResult?.valid === false) {
-    appService.showToast(
-      getProjectErrorMessage(updateResult, "Failed to update scene."),
-      { title: "Error" },
-    );
+    appService.showAlert({
+      message: getProjectErrorMessage(updateResult, "Failed to update scene."),
+      title: "Error",
+    });
     return;
   }
 

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -19,9 +19,7 @@ const showUnsupportedFormatToast = (
   appService,
   message = UNSUPPORTED_FORMAT_MESSAGE,
 ) => {
-  appService.showToast(message, {
-    title: UNSUPPORTED_FORMAT_TITLE,
-  });
+  appService.showAlert({ message: message, title: UNSUPPORTED_FORMAT_TITLE });
 };
 
 const validateSoundFiles = ({ appService, files } = {}) => {
@@ -113,7 +111,10 @@ const createSoundsFromFiles = async ({ deps, files, parentId } = {}) => {
       );
     },
     onNoSuccessfulUploads: () => {
-      appService.showToast("Failed to upload sound.", { title: "Error" });
+      appService.showAlert({
+        message: "Failed to upload sound.",
+        title: "Error",
+      });
     },
   });
 };
@@ -405,7 +406,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Sound name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Sound name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -465,7 +469,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (!result.deleted) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }

--- a/src/pages/spritesheets/spritesheets.handlers.js
+++ b/src/pages/spritesheets/spritesheets.handlers.js
@@ -26,13 +26,15 @@ const INVALID_IMPORT_PAIR_MESSAGE =
   "Spritesheet import requires exactly one PNG image and one JSON atlas.";
 
 const showInvalidImportFormatToast = (appService) => {
-  appService.showToast(INVALID_IMPORT_FORMAT_MESSAGE, {
+  appService.showAlert({
+    message: INVALID_IMPORT_FORMAT_MESSAGE,
     title: "Warning",
   });
 };
 
 const showInvalidImportPairToast = (appService) => {
-  appService.showToast(INVALID_IMPORT_PAIR_MESSAGE, {
+  appService.showAlert({
+    message: INVALID_IMPORT_PAIR_MESSAGE,
     title: "Warning",
   });
 };
@@ -637,7 +639,8 @@ export const handleDialogFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Spritesheet name is required.", {
+    appService.showAlert({
+      message: "Spritesheet name is required.",
       title: "Warning",
     });
     return;
@@ -653,14 +656,16 @@ export const handleDialogFormAction = async (deps, payload) => {
     : undefined;
 
   if (dialogMode === "create" && !dialogSourceFiles?.pngFile) {
-    appService.showToast("Spritesheet image is required.", {
+    appService.showAlert({
+      message: "Spritesheet image is required.",
       title: "Warning",
     });
     return;
   }
 
   if (dialogMode === "create" && !dialogSourceFiles?.atlasFile) {
-    appService.showToast("Atlas JSON is required.", {
+    appService.showAlert({
+      message: "Atlas JSON is required.",
       title: "Warning",
     });
     return;
@@ -676,7 +681,8 @@ export const handleDialogFormAction = async (deps, payload) => {
   }
 
   if (dialogMode === "create" && !uploadResult) {
-    appService.showToast("Failed to upload spritesheet image.", {
+    appService.showAlert({
+      message: "Failed to upload spritesheet image.",
       title: "Error",
     });
     return;
@@ -721,7 +727,7 @@ export const handleDialogFormAction = async (deps, payload) => {
   }
 
   if (!dialogItemId || !existingItem) {
-    appService.showToast("Spritesheet not found.", { title: "Error" });
+    appService.showAlert({ message: "Spritesheet not found.", title: "Error" });
     return;
   }
 
@@ -784,7 +790,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     return;
   }
 

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -359,7 +359,8 @@ export const handleFormActionClick = async (deps, payload) => {
       !formData.fontStyle ||
       !formData.fontWeight
     ) {
-      appService.showToast("Please fill in all required fields", {
+      appService.showAlert({
+        message: "Please fill in all required fields",
         title: "Warning",
       });
       return;
@@ -367,7 +368,8 @@ export const handleFormActionClick = async (deps, payload) => {
 
     // Validate font size is a number
     if (isNaN(formData.fontSize) || parseInt(formData.fontSize) <= 0) {
-      appService.showToast("Please enter a valid font size (positive number)", {
+      appService.showAlert({
+        message: "Please enter a valid font size (positive number)",
         title: "Warning",
       });
       return;
@@ -375,12 +377,10 @@ export const handleFormActionClick = async (deps, payload) => {
 
     const strokeWidth = Number(formData.strokeWidth ?? 0);
     if (Number.isNaN(strokeWidth) || strokeWidth < 0) {
-      appService.showToast(
-        "Please enter a valid outline thickness (0 or greater)",
-        {
-          title: "Warning",
-        },
-      );
+      appService.showAlert({
+        message: "Please enter a valid outline thickness (0 or greater)",
+        title: "Warning",
+      });
       return;
     }
 
@@ -541,7 +541,10 @@ export const handleAddFontFormAction = async (deps, payload) => {
 
     // Check if a font file was selected and uploaded
     if (!fontData || !fontData.uploadResult) {
-      appService.showToast("Please select a font file", { title: "Warning" });
+      appService.showAlert({
+        message: "Please select a font file",
+        title: "Warning",
+      });
       return;
     }
 
@@ -599,7 +602,7 @@ export const handleItemDelete = async (deps, payload) => {
   const textStyleCount = getTextStyleCount(state.textStyles);
   const removalCount = getTextStyleRemovalCount(state.textStyles, itemId);
   if (textStyleCount - removalCount < 1) {
-    appService.showToast("At least one text style must remain.");
+    appService.showAlert({ message: "At least one text style must remain." });
     render();
     return;
   }
@@ -611,7 +614,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -264,7 +264,10 @@ export const handleTransformFormActionClick = async (deps, payload) => {
 
   const transformData = createTransformPayload(values);
   if (!transformData.name) {
-    appService.showToast("Transform name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Transform name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -336,7 +339,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (usage.isUsed) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     return;
   }
 

--- a/src/pages/versions/versions.handlers.js
+++ b/src/pages/versions/versions.handlers.js
@@ -147,7 +147,8 @@ export const handleVersionFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Version name is required.", {
+    appService.showAlert({
+      message: "Version name is required.",
       title: "Warning",
     });
     return;
@@ -202,14 +203,12 @@ export const handleVersionFormAction = async (deps, payload) => {
     store.closeVersionDialog();
     render();
   } catch {
-    appService.showToast(
-      editingVersionId
+    appService.showAlert({
+      message: editingVersionId
         ? "Failed to update version."
         : "Failed to create version.",
-      {
-        title: "Error",
-      },
-    );
+      title: "Error",
+    });
   }
 };
 
@@ -251,9 +250,7 @@ export const handleDownloadZipClick = async (deps, payload) => {
   const version = store.selectVersion(versionId);
 
   if (!version) {
-    appService.showToast("Version not found.", {
-      title: "Error",
-    });
+    appService.showAlert({ message: "Version not found.", title: "Error" });
     return;
   }
 
@@ -272,7 +269,8 @@ export const handleDownloadZipClick = async (deps, payload) => {
     try {
       outputPath = await projectService.promptDistributionZipPath(zipName);
     } catch (error) {
-      appService.showToast(`Failed to open save dialog: ${error.message}`, {
+      appService.showAlert({
+        message: `Failed to open save dialog: ${error.message}`,
         title: "Error",
       });
       return;
@@ -284,7 +282,8 @@ export const handleDownloadZipClick = async (deps, payload) => {
     }
   }
 
-  appService.showToast("Please wait while the bundle is being created...", {
+  appService.showAlert({
+    message: "Please wait while the bundle is being created...",
     title: "Bundle in progress",
   });
 
@@ -319,11 +318,13 @@ export const handleDownloadZipClick = async (deps, payload) => {
       return;
     }
 
-    appService.showToast(`ZIP export completed.\nSaved to: ${savedPath}`, {
+    appService.showAlert({
+      message: `ZIP export completed.\nSaved to: ${savedPath}`,
       title: "Export completed",
     });
   } catch (error) {
-    appService.showToast(`Failed to save ZIP file: ${error.message}`, {
+    appService.showAlert({
+      message: `Failed to save ZIP file: ${error.message}`,
       title: "Error",
     });
   }
@@ -360,7 +361,8 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
     render();
   } catch {
     render();
-    appService.showToast("Failed to delete version.", {
+    appService.showAlert({
+      message: "Failed to delete version.",
       title: "Error",
     });
   }

--- a/src/pages/videos/videos.handlers.js
+++ b/src/pages/videos/videos.handlers.js
@@ -11,7 +11,10 @@ const VIDEO_FILE_PATTERN = /\.(mp4)$/i;
 const INVALID_VIDEO_FORMAT_MESSAGE = "Only MP4 videos are supported.";
 
 const showInvalidFormatToast = (appService) => {
-  appService.showToast(INVALID_VIDEO_FORMAT_MESSAGE, { title: "Warning" });
+  appService.showAlert({
+    message: INVALID_VIDEO_FORMAT_MESSAGE,
+    title: "Warning",
+  });
 };
 
 const validateVideoFiles = ({ appService, files } = {}) => {
@@ -110,7 +113,10 @@ const createVideosFromFiles = async ({ deps, files, parentId } = {}) => {
       });
     },
     onNoSuccessfulUploads: () => {
-      appService.showToast("Failed to upload video.", { title: "Error" });
+      appService.showAlert({
+        message: "Failed to upload video.",
+        title: "Error",
+      });
     },
   });
 };
@@ -371,7 +377,10 @@ export const handleEditFormAction = async (deps, payload) => {
 
   const name = values?.name?.trim();
   if (!name) {
-    appService.showToast("Video name is required.", { title: "Warning" });
+    appService.showAlert({
+      message: "Video name is required.",
+      title: "Warning",
+    });
     return;
   }
 
@@ -427,7 +436,9 @@ export const handleItemDelete = async (deps, payload) => {
   });
 
   if (!result.deleted) {
-    appService.showToast("Cannot delete resource, it is currently in use.");
+    appService.showAlert({
+      message: "Cannot delete resource, it is currently in use.",
+    });
     render();
     return;
   }

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.5.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.6.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -923,12 +923,56 @@
       "kGfL2nQv8YpR4mTa6HsWx": {
         "id": "kGfL2nQv8YpR4mTa6HsWx",
         "type": "folder",
-        "name": "Default"
+        "name": "Transitions"
+      },
+      "-qYuYOXAq_wt9Pfp_2kIt": {
+        "id": "-qYuYOXAq_wt9Pfp_2kIt",
+        "type": "animation",
+        "name": "Fade 1s",
+        "description": "",
+        "animation": {
+          "type": "transition",
+          "prev": {
+            "tween": {
+              "alpha": {
+                "keyframes": [
+                  {
+                    "duration": 1000,
+                    "value": 0,
+                    "easing": "linear",
+                    "relative": false
+                  }
+                ],
+                "initialValue": 1
+              }
+            }
+          },
+          "next": {
+            "tween": {
+              "alpha": {
+                "keyframes": [
+                  {
+                    "duration": 1000,
+                    "value": 1,
+                    "easing": "linear",
+                    "relative": false
+                  }
+                ],
+                "initialValue": 0
+              }
+            }
+          }
+        }
       }
     },
     "tree": [
       {
-        "id": "kGfL2nQv8YpR4mTa6HsWx"
+        "id": "kGfL2nQv8YpR4mTa6HsWx",
+        "children": [
+          {
+            "id": "-qYuYOXAq_wt9Pfp_2kIt"
+          }
+        ]
       }
     ]
   },

--- a/tests/animations/animations.handlers.test.js
+++ b/tests/animations/animations.handlers.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAnimationItemClick,
+  handleFileExplorerSelectionChanged,
+} from "../../src/pages/animations/animations.handlers.js";
+
+describe("animations.handlers", () => {
+  it("logs full animation data when selecting an animation from the catalog", () => {
+    const animationItem = {
+      id: "animation-1",
+      type: "animation",
+      name: "Fade In",
+      animation: {
+        type: "update",
+        tween: {
+          alpha: {
+            keyframes: [
+              {
+                duration: 300,
+                value: 1,
+                easing: "linear",
+                relative: false,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const deps = {
+      store: {
+        setSelectedItemId: vi.fn(),
+        selectAnimationItemById: vi.fn(() => animationItem),
+      },
+      refs: {
+        fileExplorer: {
+          selectItem: vi.fn(),
+        },
+      },
+      render: vi.fn(),
+    };
+
+    handleAnimationItemClick(deps, {
+      _event: {
+        detail: {
+          itemId: "animation-1",
+        },
+      },
+    });
+
+    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: "animation-1",
+    });
+    expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
+      itemId: "animation-1",
+    });
+    expect(consoleLog).toHaveBeenCalledWith(
+      "Selected animation data",
+      animationItem,
+    );
+
+    consoleLog.mockRestore();
+  });
+
+  it("logs full animation data when selecting an animation from the file explorer", () => {
+    const animationItem = {
+      id: "animation-1",
+      type: "animation",
+      name: "Slide",
+      animation: {
+        type: "transition",
+      },
+    };
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const deps = {
+      store: {
+        setSelectedItemId: vi.fn(),
+        selectAnimationItemById: vi.fn(() => animationItem),
+      },
+      render: vi.fn(),
+    };
+
+    handleFileExplorerSelectionChanged(deps, {
+      _event: {
+        detail: {
+          itemId: "animation-1",
+          isFolder: false,
+        },
+      },
+    });
+
+    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: "animation-1",
+    });
+    expect(consoleLog).toHaveBeenCalledWith(
+      "Selected animation data",
+      animationItem,
+    );
+
+    consoleLog.mockRestore();
+  });
+});

--- a/tests/appService/appShellService.test.js
+++ b/tests/appService/appShellService.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAppShellService } from "../../src/deps/services/shared/appShellService.js";
+
+const createDeps = () => {
+  return {
+    router: {
+      getPayload: vi.fn(() => ({ p: "project-1" })),
+      getPathName: vi.fn(() => "/projects"),
+      redirect: vi.fn(),
+      replace: vi.fn(),
+      setPayload: vi.fn(),
+      back: vi.fn(),
+    },
+    subject: {
+      dispatch: vi.fn(),
+    },
+    globalUI: {
+      showConfirm: vi.fn(() => Promise.resolve(true)),
+      showAlert: vi.fn(() => Promise.resolve()),
+      showToast: vi.fn(() => Promise.resolve()),
+      showFormDialog: vi.fn(),
+      showComponentDialog: vi.fn(),
+      closeAll: vi.fn(),
+      showDropdownMenu: vi.fn(),
+    },
+    filePicker: {
+      openFolderPicker: vi.fn(),
+      openFilePicker: vi.fn(),
+      saveFilePicker: vi.fn(),
+    },
+    openUrl: vi.fn(),
+    appVersion: "1.0.0",
+    platform: "web",
+    updater: {},
+    audioService: {},
+  };
+};
+
+describe("appShellService", () => {
+  it("forwards alert dialogs through showAlert", async () => {
+    const deps = createDeps();
+    const service = createAppShellService(deps);
+    const options = {
+      message: "Upload failed",
+      title: "Error",
+      size: "sm",
+    };
+
+    await service.showAlert(options);
+
+    expect(deps.globalUI.showAlert).toHaveBeenCalledWith(options);
+  });
+
+  it("forwards toasts through showToast", async () => {
+    const deps = createDeps();
+    const service = createAppShellService(deps);
+    const options = {
+      message: "Layout preview saved.",
+      status: "success",
+    };
+
+    await service.showToast(options);
+
+    expect(deps.globalUI.showToast).toHaveBeenCalledWith(options);
+  });
+
+  it("forwards confirm dialogs through showDialog", async () => {
+    const deps = createDeps();
+    const service = createAppShellService(deps);
+    const options = {
+      title: "Logout",
+      message: "Are you sure?",
+      confirmText: "Logout",
+      cancelText: "Cancel",
+    };
+
+    const result = await service.showDialog(options);
+
+    expect(result).toBe(true);
+    expect(deps.globalUI.showConfirm).toHaveBeenCalledWith(options);
+  });
+});

--- a/tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.test.js
+++ b/tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.test.js
@@ -42,7 +42,7 @@ describe("commandLineResetStoryAtSection.handlers", () => {
 
     handleSubmitClick({
       appService: {
-        showToast: vi.fn(),
+        showAlert: vi.fn(),
       },
       dispatchEvent,
       store: {

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -49,6 +49,7 @@ const createLayoutEditorDeps = ({
       resourceType: "layouts",
     })),
     navigate: vi.fn(),
+    showAlert: vi.fn(),
     showToast: vi.fn(),
   };
 
@@ -169,7 +170,8 @@ describe("layoutEditor.handleBackClick", () => {
 
     await handleBackClick(deps);
 
-    expect(deps.appService.showToast).toHaveBeenCalledWith("save failed", {
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message: "save failed",
       title: "Error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -274,8 +276,8 @@ describe("layoutEditor.handleSaveButtonClick", () => {
       },
       fileRecords: [{ fileId: "file-layout-thumb" }],
     });
-    expect(deps.appService.showToast).toHaveBeenCalledWith(
-      "Layout preview saved.",
-    );
+    expect(deps.appService.showToast).toHaveBeenCalledWith({
+      message: "Layout preview saved.",
+    });
   });
 });

--- a/tests/layoutEditor/layoutFragments.test.js
+++ b/tests/layoutEditor/layoutFragments.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getFragmentLayoutOptions } from "../../src/pages/layoutEditor/support/layoutFragments.js";
+
+describe("layoutFragments", () => {
+  it("uses plain layout names for fragment selector options", () => {
+    const layoutsData = {
+      items: {
+        "folder-1": {
+          id: "folder-1",
+          type: "folder",
+          name: "Dialogs",
+        },
+        "fragment-1": {
+          id: "fragment-1",
+          type: "layout",
+          parentId: "folder-1",
+          name: "Choice Menu",
+          isFragment: true,
+        },
+        "fragment-2": {
+          id: "fragment-2",
+          type: "layout",
+          parentId: "folder-1",
+          name: "A Prompt",
+          isFragment: true,
+        },
+      },
+      tree: [
+        {
+          id: "folder-1",
+          children: [{ id: "fragment-1" }, { id: "fragment-2" }],
+        },
+      ],
+    };
+
+    expect(getFragmentLayoutOptions(layoutsData)).toEqual([
+      {
+        label: "A Prompt",
+        value: "fragment-2",
+      },
+      {
+        label: "Choice Menu",
+        value: "fragment-1",
+      },
+    ]);
+  });
+});

--- a/tests/layouts/layouts.fileExplorer.test.js
+++ b/tests/layouts/layouts.fileExplorer.test.js
@@ -7,7 +7,7 @@ describe("createLayoutsFileExplorerHandlers", () => {
     const duplicateLayoutItem = vi.fn(async () => "layout-copy");
     const deps = {
       appService: {
-        showToast: vi.fn(),
+        showAlert: vi.fn(),
       },
       projectService: {
         ensureRepository: vi.fn(async () => {}),
@@ -44,6 +44,6 @@ describe("createLayoutsFileExplorerHandlers", () => {
     expect(refresh).toHaveBeenCalledWith(deps, {
       selectedItemId: "layout-copy",
     });
-    expect(deps.appService.showToast).not.toHaveBeenCalled();
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
   });
 });

--- a/tests/layouts/layouts.handlers.test.js
+++ b/tests/layouts/layouts.handlers.test.js
@@ -91,7 +91,7 @@ describe("createLayoutTemplate", () => {
         }),
       },
       appService: {
-        showToast: vi.fn(),
+        showAlert: vi.fn(),
       },
       render: vi.fn(),
     };
@@ -158,7 +158,7 @@ describe("createLayoutTemplate", () => {
         }),
       },
       appService: {
-        showToast: vi.fn(),
+        showAlert: vi.fn(),
       },
       render: vi.fn(),
     };

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleProjectsClick } from "../../src/pages/projects/projects.handlers.js";
+
+const createDeps = ({
+  ensureProjectCompatibleById = vi.fn(async () => {}),
+} = {}) => {
+  const appService = {
+    showAlert: vi.fn(),
+    setCurrentProjectEntry: vi.fn(),
+    navigate: vi.fn(),
+  };
+
+  return {
+    appService,
+    projectService: {
+      ensureProjectCompatibleById,
+    },
+    store: {
+      getState: vi.fn(() => ({
+        projects: [
+          {
+            id: "project-1",
+            name: "Project One",
+          },
+        ],
+      })),
+    },
+  };
+};
+
+const createPayload = (projectId = "project-1") => {
+  return {
+    _event: {
+      currentTarget: {
+        dataset: {
+          projectId,
+        },
+      },
+    },
+  };
+};
+
+describe("projects.handleProjectsClick", () => {
+  it("shows an alert dialog for incompatible project versions", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        throw new Error(
+          "You're trying to open an incompatible project with version 1 using RouteVN Creator project format 2. For assistance, please reach out to RouteVN staff for support.",
+        );
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      title: "Incompatible Project",
+      message:
+        "You're trying to open an incompatible project with version 1 using RouteVN Creator project format 2. For assistance, please reach out to RouteVN staff for support.",
+      status: "error",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("shows an alert dialog for client store schema reset errors", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        throw new Error(
+          "Client store requires reset for schema version 2; runtime expects 6",
+        );
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      title: "Incompatible Project",
+      message:
+        "Client store requires reset for schema version 2; runtime expects 6",
+      status: "error",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("shows a generic alert for other open failures", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        throw new Error("Failed to open project.");
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message: "Failed to open project.",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("opens compatible projects normally", async () => {
+    const deps = createDeps();
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.setCurrentProjectEntry).toHaveBeenCalledWith({
+      id: "project-1",
+      name: "Project One",
+    });
+    expect(deps.appService.navigate).toHaveBeenCalledWith("/project", {
+      p: "project-1",
+    });
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/textStyles/textStyles.fileExplorer.test.js
+++ b/tests/textStyles/textStyles.fileExplorer.test.js
@@ -7,7 +7,7 @@ describe("createResourceFileExplorerHandlers", () => {
     const duplicateTextStyle = vi.fn(async () => "text-style-copy");
     const deps = {
       appService: {
-        showToast: vi.fn(),
+        showAlert: vi.fn(),
       },
       projectService: {
         ensureRepository: vi.fn(async () => {}),
@@ -47,6 +47,6 @@ describe("createResourceFileExplorerHandlers", () => {
     expect(refresh).toHaveBeenCalledWith(deps, {
       selectedItemId: "text-style-copy",
     });
-    expect(deps.appService.showToast).not.toHaveBeenCalled();
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
   });
 });

--- a/tests/textStyles/textStyles.handlers.test.js
+++ b/tests/textStyles/textStyles.handlers.test.js
@@ -45,7 +45,7 @@ describe("textStyles.handlers", () => {
         }),
       },
       appService: {
-        showToast: vi.fn(),
+        showAlert: vi.fn(),
       },
       render: vi.fn(),
     };


### PR DESCRIPTION
## Summary
- align app-shell feedback APIs around `showAlert`/`showToast` forwarding and update affected handlers and tests to the new call shape
- update the client to `@rettangoli/ui@1.6.0`, refresh the static Rettangoli asset URLs, and keep the build script fallback in sync
- refine animation and layout editor defaults by centering transition preview layers, simplifying fragment selector labels, logging selected animation data, and seeding a default `Fade 1s` transition in the `Transitions` folder template

## Testing
- `bun run lint`
- `bunx vitest run tests/animations/animations.handlers.test.js tests/appService/appShellService.test.js tests/projects/projects.handlers.test.js tests/layoutEditor/layoutFragments.test.js tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.test.js tests/layoutEditor/layoutEditor.handlers.test.js tests/layouts/layouts.fileExplorer.test.js tests/layouts/layouts.handlers.test.js tests/textStyles/textStyles.fileExplorer.test.js tests/textStyles/textStyles.handlers.test.js`
  - existing failure: `tests/layouts/layouts.handlers.test.js` -> `createLayoutTemplate > creates an NVL layout template without throwing`