### PR TITLE
feat: update default scenes viewport and animation template

### DIFF
--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -14,9 +14,9 @@ import {
 const DEAD_END_TOOLTIP_CONTENT =
   "This section has no transition to another section.";
 const DEFAULT_SCENES_MAP_VIEWPORT = {
-  zoomLevel: 1.5,
-  panX: -120,
-  panY: -200,
+  zoomLevel: 1,
+  panX: -80,
+  panY: -40,
 };
 
 const getProjectErrorMessage = (result, fallbackMessage) => {

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -935,6 +935,11 @@
         "type": "folder",
         "name": "Transitions"
       },
+      "cB4d0iQ31SxN": {
+        "id": "cB4d0iQ31SxN",
+        "type": "folder",
+        "name": "Updates"
+      },
       "-qYuYOXAq_wt9Pfp_2kIt": {
         "id": "-qYuYOXAq_wt9Pfp_2kIt",
         "type": "animation",
@@ -973,6 +978,29 @@
             }
           }
         }
+      },
+      "z8EhCjJBErGf": {
+        "id": "z8EhCjJBErGf",
+        "type": "animation",
+        "name": "Position auto 0.3s",
+        "description": "",
+        "animation": {
+          "type": "update",
+          "tween": {
+            "x": {
+              "auto": {
+                "duration": 300,
+                "easing": "linear"
+              }
+            },
+            "y": {
+              "auto": {
+                "duration": 300,
+                "easing": "linear"
+              }
+            }
+          }
+        }
       }
     },
     "tree": [
@@ -981,6 +1009,14 @@
         "children": [
           {
             "id": "-qYuYOXAq_wt9Pfp_2kIt"
+          }
+        ]
+      },
+      {
+        "id": "cB4d0iQ31SxN",
+        "children": [
+          {
+            "id": "z8EhCjJBErGf"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- update the default scenes page viewport for new projects to use a zoom level of 1 with pan offsets of -80 and -40
- add a new `Updates` folder to the default template animations and place the `Position auto 0.3s` animation inside it

## Validation
- bunx prettier --check src/pages/scenes/scenes.handlers.js static/templates/default/repository.json
- bunx vitest run tests/scenes/scenes.handlers.test.js
- git push hook: oxlint && bun prettier --check src
