### PR TITLE
build: bump tauri app version to 1.0.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.0.0-rc6",
+  "version": "1.0.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump the Tauri app version in `src-tauri/tauri.conf.json` from `1.0.0-rc6` to `1.0.0`

## Validation
- bunx prettier --check src-tauri/tauri.conf.json
- JSON parse check for src-tauri/tauri.conf.json
- git push hook: oxlint && bun prettier --check src
