### PR TITLE
fix: stabilize project runtime and import flow

### DIFF
--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -88,7 +88,7 @@ export const handleCommandLineSubmit = (deps, payload) => {
   store.updateActions(nextActions);
   dispatchEvent(
     new CustomEvent("actions-change", {
-      detail: nextActions,
+      detail: normalizeActionsObject(submittedActions),
     }),
   );
   store.hideActionsDialog();

--- a/src/deps/clients/tauri/db.js
+++ b/src/deps/clients/tauri/db.js
@@ -1,10 +1,9 @@
-// SQLite wrapper for Tauri - all SQLite access goes through this file
-import Database from "@tauri-apps/plugin-sql";
 import { join } from "@tauri-apps/api/path";
 import {
   SQLITE_BUSY_TIMEOUT_MS,
   withSqliteLockRetry,
 } from "../../../internal/sqliteLocking.js";
+import { getManagedSqliteConnection } from "./sqliteConnectionManager.js";
 
 /**
  * Create a database instance
@@ -21,146 +20,184 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
 
   let db = null;
   let initialized = false;
+  let resolvedDbPath;
+  let operationQueue = Promise.resolve();
+
+  const queueDbOperation = async (operation) => {
+    const nextOperation = operationQueue.then(async () => operation());
+    operationQueue = nextOperation.catch(() => {});
+    return nextOperation;
+  };
+
+  const ensureConnection = async () => {
+    if (initialized && db) {
+      return;
+    }
+
+    if (!resolvedDbPath) {
+      resolvedDbPath = path;
+      if (projectPath) {
+        const fullPath = await join(projectPath, "project.db");
+        resolvedDbPath = `sqlite:${fullPath}`;
+      }
+    }
+
+    db = getManagedSqliteConnection({
+      dbPath: resolvedDbPath,
+      busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS,
+      onConnect: async (connection) => {
+        await connection.execute(`
+            CREATE TABLE IF NOT EXISTS kv (
+              key TEXT PRIMARY KEY,
+              value TEXT
+            )
+          `);
+
+        if (withEvents) {
+          await connection.execute(`
+              CREATE TABLE IF NOT EXISTS events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                type TEXT NOT NULL,
+                payload TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+              )
+            `);
+        }
+      },
+    });
+
+    await db.init();
+
+    initialized = true;
+  };
 
   const instance = {
     async init() {
-      let dbPath = path;
-      if (projectPath) {
-        const fullPath = await join(projectPath, "project.db");
-        dbPath = `sqlite:${fullPath}`;
-      }
-
-      db = await Database.load(dbPath);
-      await withSqliteLockRetry(() =>
-        db.execute(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`),
-      );
-
-      // Initialize key-value table
-      await withSqliteLockRetry(() =>
-        db.execute(`
-          CREATE TABLE IF NOT EXISTS kv (
-            key TEXT PRIMARY KEY,
-            value TEXT
-          )
-        `),
-      );
-
-      // Initialize events table if needed
-      if (withEvents) {
-        await withSqliteLockRetry(() =>
-          db.execute(`
-            CREATE TABLE IF NOT EXISTS events (
-              id INTEGER PRIMARY KEY AUTOINCREMENT,
-              type TEXT NOT NULL,
-              payload TEXT,
-              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-          `),
-        );
-      }
-
-      initialized = true;
+      return queueDbOperation(async () => ensureConnection());
     },
 
     async get(key) {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      const result = await withSqliteLockRetry(() =>
-        db.select("SELECT value FROM kv WHERE key = $1", [key]),
-      );
-      if (result && result.length > 0) {
-        try {
-          return JSON.parse(result[0].value);
-        } catch {
-          return result[0].value;
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
         }
-      }
-      return null;
+        const result = await withSqliteLockRetry(() =>
+          db.select("SELECT value FROM kv WHERE key = $1", [key]),
+        );
+        if (result && result.length > 0) {
+          try {
+            return JSON.parse(result[0].value);
+          } catch {
+            return result[0].value;
+          }
+        }
+        return null;
+      });
     },
 
     async set(key, value) {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      const jsonValue = JSON.stringify(value);
-      await withSqliteLockRetry(() =>
-        db.execute("INSERT OR REPLACE INTO kv (key, value) VALUES ($1, $2)", [
-          key,
-          jsonValue,
-        ]),
-      );
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
+        }
+        const jsonValue = JSON.stringify(value);
+        await withSqliteLockRetry(() =>
+          db.execute("INSERT OR REPLACE INTO kv (key, value) VALUES ($1, $2)", [
+            key,
+            jsonValue,
+          ]),
+        );
+      });
     },
 
     async remove(key) {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      await withSqliteLockRetry(() =>
-        db.execute("DELETE FROM kv WHERE key = $1", [key]),
-      );
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
+        }
+        await withSqliteLockRetry(() =>
+          db.execute("DELETE FROM kv WHERE key = $1", [key]),
+        );
+      });
     },
   };
 
   // Add events methods if needed
   if (withEvents) {
     instance.getEvents = async (payload = {}) => {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      const { since } = payload;
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
+        }
+        const { since } = payload;
 
-      let query = "SELECT type, payload FROM events";
-      let params = [];
+        let query = "SELECT type, payload FROM events";
+        let params = [];
 
-      if (since !== undefined) {
-        query += " WHERE id > $1";
-        params.push(since);
-      }
+        if (since !== undefined) {
+          query += " WHERE id > $1";
+          params.push(since);
+        }
 
-      query += " ORDER BY id";
+        query += " ORDER BY id";
 
-      const results = await withSqliteLockRetry(() => db.select(query, params));
-      return results.map((row) => ({
-        type: row.type,
-        payload: row.payload ? JSON.parse(row.payload) : null,
-      }));
+        const results = await withSqliteLockRetry(() =>
+          db.select(query, params),
+        );
+        return results.map((row) => ({
+          type: row.type,
+          payload: row.payload ? JSON.parse(row.payload) : null,
+        }));
+      });
     };
 
     instance.appendEvent = async (event) => {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      await withSqliteLockRetry(() =>
-        db.execute("INSERT INTO events (type, payload) VALUES (?, ?)", [
-          event.type,
-          JSON.stringify(event.payload),
-        ]),
-      );
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
+        }
+        await withSqliteLockRetry(() =>
+          db.execute("INSERT INTO events (type, payload) VALUES (?, ?)", [
+            event.type,
+            JSON.stringify(event.payload),
+          ]),
+        );
+      });
     };
 
     // Snapshot support for fast initialization
     instance.getSnapshot = async () => {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      const result = await withSqliteLockRetry(() =>
-        db.select("SELECT value FROM kv WHERE key = $1", ["_eventsSnapshot"]),
-      );
-      if (result && result.length > 0) {
-        try {
-          return JSON.parse(result[0].value);
-        } catch {
-          return null;
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
         }
-      }
-      return null;
+        const result = await withSqliteLockRetry(() =>
+          db.select("SELECT value FROM kv WHERE key = $1", ["_eventsSnapshot"]),
+        );
+        if (result && result.length > 0) {
+          try {
+            return JSON.parse(result[0].value);
+          } catch {
+            return null;
+          }
+        }
+        return null;
+      });
     };
 
     instance.setSnapshot = async (snapshot) => {
-      if (!initialized)
-        throw new Error("Db not initialized. Call init() first.");
-      const jsonValue = JSON.stringify(snapshot);
-      await withSqliteLockRetry(() =>
-        db.execute("INSERT OR REPLACE INTO kv (key, value) VALUES ($1, $2)", [
-          "_eventsSnapshot",
-          jsonValue,
-        ]),
-      );
+      return queueDbOperation(async () => {
+        if (!initialized) {
+          throw new Error("Db not initialized. Call init() first.");
+        }
+        const jsonValue = JSON.stringify(snapshot);
+        await withSqliteLockRetry(() =>
+          db.execute("INSERT OR REPLACE INTO kv (key, value) VALUES ($1, $2)", [
+            "_eventsSnapshot",
+            jsonValue,
+          ]),
+        );
+      });
     };
   }
 

--- a/src/deps/clients/tauri/sqliteConnectionManager.js
+++ b/src/deps/clients/tauri/sqliteConnectionManager.js
@@ -1,0 +1,133 @@
+import Database from "@tauri-apps/plugin-sql";
+import {
+  SQLITE_BUSY_TIMEOUT_MS,
+  withSqliteLockRetry,
+} from "../../../internal/sqliteLocking.js";
+
+const connectionsByPath = new Map();
+
+const isClosedPoolError = (error) =>
+  String(error?.message || "")
+    .toLowerCase()
+    .includes("closed pool");
+
+const createManagedSqliteConnection = ({
+  dbPath,
+  busyTimeoutMs = SQLITE_BUSY_TIMEOUT_MS,
+  onConnect,
+}) => {
+  let db;
+  let connectPromise;
+
+  const connect = async ({ forceReload = false } = {}) => {
+    if (db && !forceReload) {
+      return db;
+    }
+
+    if (connectPromise && !forceReload) {
+      return connectPromise;
+    }
+
+    const nextConnectPromise = (async () => {
+      const nextDb = await Database.load(dbPath);
+      await withSqliteLockRetry(() =>
+        nextDb.execute(`PRAGMA busy_timeout=${busyTimeoutMs}`),
+      );
+      if (typeof onConnect === "function") {
+        await onConnect(nextDb);
+      }
+      db = nextDb;
+      return nextDb;
+    })();
+
+    const trackedConnectPromise = nextConnectPromise.finally(() => {
+      if (connectPromise === trackedConnectPromise) {
+        connectPromise = undefined;
+      }
+    });
+    connectPromise = trackedConnectPromise;
+
+    return trackedConnectPromise;
+  };
+
+  const withRecoveredConnection = async (operation) => {
+    let hasRetriedClosedPool = false;
+
+    while (true) {
+      const currentDb = await connect();
+
+      try {
+        return await operation(currentDb);
+      } catch (error) {
+        if (hasRetriedClosedPool || !isClosedPoolError(error)) {
+          throw error;
+        }
+
+        hasRetriedClosedPool = true;
+        if (typeof currentDb?.close === "function") {
+          try {
+            await currentDb.close(dbPath);
+          } catch {
+            // best-effort stale-handle disposal before reconnect
+          }
+        }
+        db = undefined;
+        connectPromise = undefined;
+      }
+    }
+  };
+
+  return {
+    dbPath,
+
+    async init() {
+      await connect();
+    },
+
+    async execute(sql, args = []) {
+      return withRecoveredConnection((currentDb) =>
+        currentDb.execute(sql, Array.isArray(args) ? args : []),
+      );
+    },
+
+    async select(sql, args = []) {
+      return withRecoveredConnection((currentDb) =>
+        currentDb.select(sql, Array.isArray(args) ? args : []),
+      );
+    },
+
+    async close() {
+      connectionsByPath.delete(dbPath);
+      const currentDb = db;
+      db = undefined;
+      connectPromise = undefined;
+
+      if (typeof currentDb?.close === "function") {
+        await currentDb.close(dbPath);
+      }
+    },
+  };
+};
+
+export const getManagedSqliteConnection = ({
+  dbPath,
+  busyTimeoutMs = SQLITE_BUSY_TIMEOUT_MS,
+  onConnect,
+}) => {
+  if (!dbPath) {
+    throw new Error("dbPath is required");
+  }
+
+  const existing = connectionsByPath.get(dbPath);
+  if (existing) {
+    return existing;
+  }
+
+  const connection = createManagedSqliteConnection({
+    dbPath,
+    busyTimeoutMs,
+    onConnect,
+  });
+  connectionsByPath.set(dbPath, connection);
+  return connection;
+};

--- a/src/deps/clients/web/fileProcessors.js
+++ b/src/deps/clients/web/fileProcessors.js
@@ -727,13 +727,7 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
       resolve(result);
     };
 
-    const logContext = {
-      fileName: videoFile?.name ?? "",
-      fileSize: videoFile?.size ?? 0,
-      sampleCount,
-    };
-
-    const refreshActivityTimeout = (stage = "unknown") => {
+    const refreshActivityTimeout = () => {
       if (settled) {
         return;
       }
@@ -743,19 +737,11 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
       }
 
       activityTimeoutId = window.setTimeout(() => {
-        console.warn("[videoThumbnail] extract.stalled", {
-          ...logContext,
-          stage,
-        });
         rejectOnce(new Error("Timed out while generating video thumbnail"));
       }, VIDEO_THUMBNAIL_ACTIVITY_TIMEOUT_MS);
     };
 
     video.onerror = (error) => {
-      console.warn("[videoThumbnail] load.failed", {
-        ...logContext,
-        error: error?.message || "Unknown error",
-      });
       rejectOnce(
         new Error(`Video load error: ${error.message || "Unknown error"}`),
       );
@@ -763,7 +749,7 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
 
     video.onloadedmetadata = async () => {
       try {
-        refreshActivityTimeout("metadata-loaded");
+        refreshActivityTimeout();
         const outputDimensions = getScaledThumbnailDimensions({
           sourceWidth: video.videoWidth,
           sourceHeight: video.videoHeight,
@@ -780,22 +766,15 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
           timeOffset,
           sampleCount,
         });
-        console.info("[videoThumbnail] metadata.loaded", {
-          ...logContext,
-          duration: video.duration,
-          sampleTimes,
-        });
 
         let bestCandidate;
         let bestFallbackCandidate;
-        let sampledFrameCount = 0;
-
         for (const sampleTime of sampleTimes) {
           if (settled) {
             return;
           }
 
-          refreshActivityTimeout(`sampling-${sampleTime}`);
+          refreshActivityTimeout();
 
           try {
             await captureVideoFrameAtTime({
@@ -805,12 +784,7 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
               height: analysisCanvas.height,
               time: sampleTime,
             });
-          } catch (error) {
-            console.warn("[videoThumbnail] sample.failed", {
-              ...logContext,
-              sampleTime,
-              error: error?.message ?? "Unknown error",
-            });
+          } catch {
             continue;
           }
 
@@ -818,9 +792,7 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
             return;
           }
 
-          refreshActivityTimeout(`sampled-${sampleTime}`);
-          sampledFrameCount += 1;
-
+          refreshActivityTimeout();
           const frameAnalysis = analyzeVideoFrame({
             ctx: analysisCtx,
             width: analysisCanvas.width,
@@ -862,28 +834,16 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
 
         const chosenCandidate = bestCandidate ?? bestFallbackCandidate;
         if (!chosenCandidate) {
-          console.warn("[videoThumbnail] sampling.empty", {
-            ...logContext,
-            sampleTimes,
-          });
-          refreshActivityTimeout("capturing-fallback-frame");
+          refreshActivityTimeout();
           await captureVideoFrameAtTime({
             video,
             ctx: fallbackCtx,
             width,
             height,
           });
-        } else {
-          console.info("[videoThumbnail] frame.selected", {
-            ...logContext,
-            sampledFrameCount,
-            selectedTime: chosenCandidate.time,
-            score: Number(chosenCandidate.score.toFixed(2)),
-            usedFallbackFrame: !bestCandidate,
-          });
         }
 
-        refreshActivityTimeout("encoding-thumbnail");
+        refreshActivityTimeout();
         const selectedCanvas = bestCandidate ? bestCanvas : fallbackCanvas;
         const blob = await canvasToBlob(selectedCanvas, format, quality);
         const dataUrl = selectedCanvas.toDataURL(format, quality);
@@ -901,15 +861,11 @@ const extractScoredVideoThumbnail = async (videoFile, options = {}) => {
           return;
         }
 
-        console.warn("[videoThumbnail] extract.failed", {
-          ...logContext,
-          error: error?.message ?? "Unknown error",
-        });
         rejectOnce(new Error(`Thumbnail extraction error: ${error.message}`));
       }
     };
 
-    refreshActivityTimeout("waiting-for-metadata");
+    refreshActivityTimeout();
     objectUrl = URL.createObjectURL(videoFile);
     video.src = objectUrl;
   });
@@ -986,12 +942,7 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
       resolve(result);
     };
 
-    const logContext = {
-      fileName: videoFile?.name ?? "",
-      fileSize: videoFile?.size ?? 0,
-    };
-
-    const refreshActivityTimeout = (stage = "unknown") => {
+    const refreshActivityTimeout = () => {
       if (settled) {
         return;
       }
@@ -1001,10 +952,6 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
       }
 
       activityTimeoutId = window.setTimeout(() => {
-        console.warn("[videoThumbnail] fallback.stalled", {
-          ...logContext,
-          stage,
-        });
         rejectOnce(
           new Error("Timed out while generating fallback video thumbnail"),
         );
@@ -1021,7 +968,7 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
 
     video.onloadedmetadata = async () => {
       try {
-        refreshActivityTimeout("fallback-metadata-loaded");
+        refreshActivityTimeout();
         const outputDimensions = getScaledThumbnailDimensions({
           sourceWidth: video.videoWidth,
           sourceHeight: video.videoHeight,
@@ -1046,13 +993,8 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
             height,
             time: fallbackTime > 0 ? fallbackTime : undefined,
           });
-        } catch (seekError) {
-          console.warn("[videoThumbnail] fallback.seek-failed", {
-            ...logContext,
-            fallbackTime,
-            error: seekError?.message ?? "Unknown error",
-          });
-          refreshActivityTimeout("fallback-current-frame");
+        } catch {
+          refreshActivityTimeout();
           await captureVideoFrameAtTime({
             video,
             ctx,
@@ -1061,7 +1003,7 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
           });
         }
 
-        refreshActivityTimeout("fallback-encoding-thumbnail");
+        refreshActivityTimeout();
         const blob = await canvasToBlob(canvas, format, quality);
         const dataUrl = canvas.toDataURL(format, quality);
 
@@ -1080,7 +1022,7 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
       }
     };
 
-    refreshActivityTimeout("fallback-waiting-for-metadata");
+    refreshActivityTimeout();
     objectUrl = URL.createObjectURL(videoFile);
     video.src = objectUrl;
   });
@@ -1089,12 +1031,7 @@ const extractInitialVideoThumbnail = async (videoFile, options = {}) => {
 export const extractVideoThumbnail = async (videoFile, options = {}) => {
   try {
     return await extractScoredVideoThumbnail(videoFile, options);
-  } catch (error) {
-    console.warn("[videoThumbnail] fallback.attempt", {
-      fileName: videoFile?.name ?? "",
-      fileSize: videoFile?.size ?? 0,
-      error: error?.message ?? "Unknown error",
-    });
+  } catch {
     return extractInitialVideoThumbnail(videoFile, options);
   }
 };

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -155,106 +155,48 @@ export const createProjectAssetService = ({
     }
 
     if (fileType === "audio") {
-      const totalStartedAt = getNow();
-      let readDurationMs = 0;
-      let waveformDurationMs = 0;
-      let storeAndHashDurationMs = 0;
-      let storeDurationMs = 0;
-      let hashDurationMs = 0;
-      let metadataDurationMs = 0;
+      const arrayBuffer = await file.arrayBuffer();
 
-      try {
-        const readStartedAt = getNow();
-        const arrayBuffer = await file.arrayBuffer();
-        readDurationMs = getDurationMs(readStartedAt);
+      const [waveformData, stored] = await Promise.all([
+        extractWaveformDataFromArrayBuffer(arrayBuffer),
+        storeFileWithRecord({
+          file,
+          bytes: arrayBuffer,
+          timings: {},
+        }),
+      ]);
 
-        const [waveformData, stored] = await Promise.all([
-          (async () => {
-            const waveformStartedAt = getNow();
-            const result =
-              await extractWaveformDataFromArrayBuffer(arrayBuffer);
-            waveformDurationMs = getDurationMs(waveformStartedAt);
-            return result;
-          })(),
-          (async () => {
-            const storeStartedAt = getNow();
-            const storeAndHashTimings = {};
-            const result = await storeFileWithRecord({
-              file,
-              bytes: arrayBuffer,
-              timings: storeAndHashTimings,
-            });
-            storeAndHashDurationMs = getDurationMs(storeStartedAt);
-            storeDurationMs = storeAndHashTimings.storeDurationMs ?? 0;
-            hashDurationMs = storeAndHashTimings.hashDurationMs ?? 0;
-            return result;
-          })(),
-        ]);
-
-        let waveformDataFileId = null;
-        let waveformResult = null;
-        if (waveformData) {
-          const compressedWaveformData = {
-            ...waveformData,
-            amplitudes: waveformData.amplitudes.map((value) =>
-              Math.round(value * 255),
-            ),
-          };
-          const metadataStartedAt = getNow();
-          waveformResult = await storeMetadata({
-            data: compressedWaveformData,
-            storeFile: (metadataFile) =>
-              storeFileWithRecord({
-                file: metadataFile,
-              }),
-            idGenerator,
-          });
-          metadataDurationMs = getDurationMs(metadataStartedAt);
-          waveformDataFileId = waveformResult.fileId;
-        }
-
-        console.info("[audioUpload] process.complete", {
-          fileName: file.name,
-          fileSize: file.size,
-          fileType: file.type,
-          readDurationMs,
-          waveformDurationMs,
-          storeAndHashDurationMs,
-          storeDurationMs,
-          hashDurationMs,
-          metadataDurationMs,
-          totalDurationMs: getDurationMs(totalStartedAt),
-          decodedDurationSeconds: waveformData?.duration,
-          waveformSampleCount: waveformData?.amplitudes?.length ?? 0,
-        });
-
-        return {
-          ...stored,
-          waveformDataFileId,
-          waveformData,
-          duration: waveformData?.duration,
-          type: "audio",
-          fileRecords: [
-            stored.fileRecord,
-            ...(waveformResult ? [waveformResult.fileRecord] : []),
-          ],
+      let waveformDataFileId = null;
+      let waveformResult = null;
+      if (waveformData) {
+        const compressedWaveformData = {
+          ...waveformData,
+          amplitudes: waveformData.amplitudes.map((value) =>
+            Math.round(value * 255),
+          ),
         };
-      } catch (error) {
-        console.warn("[audioUpload] process.failed", {
-          fileName: file.name,
-          fileSize: file.size,
-          fileType: file.type,
-          readDurationMs,
-          waveformDurationMs,
-          storeAndHashDurationMs,
-          storeDurationMs,
-          hashDurationMs,
-          metadataDurationMs,
-          totalDurationMs: getDurationMs(totalStartedAt),
-          error: error?.message ?? "Unknown error",
+        waveformResult = await storeMetadata({
+          data: compressedWaveformData,
+          storeFile: (metadataFile) =>
+            storeFileWithRecord({
+              file: metadataFile,
+            }),
+          idGenerator,
         });
-        throw error;
+        waveformDataFileId = waveformResult.fileId;
       }
+
+      return {
+        ...stored,
+        waveformDataFileId,
+        waveformData,
+        duration: waveformData?.duration,
+        type: "audio",
+        fileRecords: [
+          stored.fileRecord,
+          ...(waveformResult ? [waveformResult.fileRecord] : []),
+        ],
+      };
     }
 
     if (fileType === "video") {

--- a/src/deps/services/shared/projectEntriesService.js
+++ b/src/deps/services/shared/projectEntriesService.js
@@ -14,6 +14,26 @@ const normalizeLocalProjectEntry = (entry) => ({
   iconFileId: entry?.iconFileId ?? null,
 });
 
+const mergeProjectEntriesPreservingWorkingPath = (currentEntry, nextEntry) => {
+  const mergedEntry = {
+    ...currentEntry,
+    ...nextEntry,
+  };
+
+  if (
+    currentEntry?.id &&
+    nextEntry?.id &&
+    currentEntry.id === nextEntry.id &&
+    currentEntry?.projectPath &&
+    nextEntry?.projectPath &&
+    currentEntry.projectPath !== nextEntry.projectPath
+  ) {
+    mergedEntry.projectPath = currentEntry.projectPath;
+  }
+
+  return mergedEntry;
+};
+
 export const createProjectEntriesService = ({
   db,
   getCurrentProjectId,
@@ -256,10 +276,10 @@ export const createProjectEntriesService = ({
         continue;
       }
 
-      nextEntries[duplicateIndex] = {
-        ...nextEntries[duplicateIndex],
-        ...nextEntry,
-      };
+      nextEntries[duplicateIndex] = mergeProjectEntriesPreservingWorkingPath(
+        nextEntries[duplicateIndex],
+        nextEntry,
+      );
       didChange = true;
     }
 

--- a/src/deps/services/shared/projectEntriesService.js
+++ b/src/deps/services/shared/projectEntriesService.js
@@ -111,6 +111,27 @@ export const createProjectEntriesService = ({
 
   const addProjectEntry = async (entry) => {
     const entries = await getProjectEntries();
+    const existingEntryIndex = entries.findIndex(
+      (candidate) => candidate?.id && candidate.id === entry?.id,
+    );
+    if (existingEntryIndex !== -1) {
+      const existingEntry = entries[existingEntryIndex] || {};
+      entries[existingEntryIndex] = {
+        ...existingEntry,
+        ...entry,
+        createdAt: existingEntry.createdAt ?? entry?.createdAt,
+        lastOpenedAt: existingEntry.lastOpenedAt ?? entry?.lastOpenedAt,
+      };
+      await db.set("projectEntries", entries);
+      projectEntriesCache = structuredClone(entries);
+      if (entry?.id === getCurrentProjectId()) {
+        currentProjectEntry = normalizeLocalProjectEntry(
+          entries[existingEntryIndex],
+        );
+      }
+      return entries;
+    }
+
     const isDuplicate = platformAdapter.isDuplicateProjectEntry?.({
       entries,
       entry,
@@ -163,6 +184,94 @@ export const createProjectEntriesService = ({
     return entries;
   };
 
+  const removeProjectEntryByPath = async (projectPath) => {
+    if (!projectPath) {
+      return getProjectEntries();
+    }
+
+    const entries = await getProjectEntries();
+    const filtered = entries.filter(
+      (entry) => entry?.projectPath !== projectPath,
+    );
+    await db.set("projectEntries", filtered);
+    projectEntriesCache = structuredClone(filtered);
+
+    if (currentProjectEntry?.projectPath === projectPath) {
+      const routeProjectId = getCurrentProjectId();
+      currentProjectEntry = routeProjectId
+        ? createEmptyProjectEntry({ id: routeProjectId, source: "cloud" })
+        : createEmptyProjectEntry();
+    }
+
+    return filtered;
+  };
+
+  const repairProjectEntries = async (entries = []) => {
+    if (
+      typeof projectService?.getProjectInfoByPath !== "function" ||
+      !Array.isArray(entries) ||
+      entries.length === 0
+    ) {
+      return Array.isArray(entries) ? entries : [];
+    }
+
+    let didChange = false;
+    const nextEntries = [];
+
+    for (const entry of entries) {
+      let nextEntry = structuredClone(entry);
+
+      if (!nextEntry?.id && nextEntry?.projectPath) {
+        try {
+          const projectInfo = await projectService.getProjectInfoByPath(
+            nextEntry.projectPath,
+          );
+          if (projectInfo?.id) {
+            nextEntry.id = projectInfo.id;
+            nextEntry.name = projectInfo.name ?? nextEntry.name ?? "";
+            nextEntry.description =
+              projectInfo.description ?? nextEntry.description ?? "";
+            nextEntry.iconFileId =
+              projectInfo.iconFileId ?? nextEntry.iconFileId ?? null;
+            didChange = true;
+          }
+        } catch {
+          // Keep the stale entry visible so the user can remove it.
+        }
+      }
+
+      const duplicateIndex = nextEntries.findIndex((candidate) => {
+        if (nextEntry?.id && candidate?.id) {
+          return candidate.id === nextEntry.id;
+        }
+
+        return (
+          nextEntry?.projectPath &&
+          candidate?.projectPath === nextEntry.projectPath
+        );
+      });
+
+      if (duplicateIndex === -1) {
+        nextEntries.push(nextEntry);
+        continue;
+      }
+
+      nextEntries[duplicateIndex] = {
+        ...nextEntries[duplicateIndex],
+        ...nextEntry,
+      };
+      didChange = true;
+    }
+
+    if (!didChange) {
+      return nextEntries;
+    }
+
+    await db.set("projectEntries", nextEntries);
+    projectEntriesCache = structuredClone(nextEntries);
+    return nextEntries;
+  };
+
   return {
     async getProjectEntries() {
       return getProjectEntries();
@@ -176,12 +285,18 @@ export const createProjectEntriesService = ({
       return removeProjectEntry(projectId);
     },
 
+    async removeProjectEntryByPath(projectPath) {
+      return removeProjectEntryByPath(projectPath);
+    },
+
     async updateProjectEntry(projectId, updates) {
       return updateProjectEntry(projectId, updates);
     },
 
     async loadAllProjects() {
-      const projectEntries = await getProjectEntries();
+      const projectEntries = await repairProjectEntries(
+        await getProjectEntries(),
+      );
       const projectsWithFullData = await Promise.all(
         projectEntries.map(async (entry) => {
           // projectEntries cache the current projectInfo snapshot for fast

--- a/src/deps/services/shared/projectRepositoryService.js
+++ b/src/deps/services/shared/projectRepositoryService.js
@@ -21,6 +21,15 @@ const flushRepositoryMainCheckpoint = async (repository) => {
   }
 };
 
+const flushRepositoryForRelease = async (repository) => {
+  if (typeof repository?.flushMaterializedViews === "function") {
+    await repository.flushMaterializedViews();
+    return;
+  }
+
+  await flushRepositoryMainCheckpoint(repository);
+};
+
 const discardReusableMainCheckpoint = async (store) => {
   if (typeof store?.deleteMaterializedViewCheckpoint !== "function") {
     return;
@@ -167,6 +176,30 @@ export const createProjectRepositoryService = ({
     if (typeof storageAdapter?.evictStoreByReference === "function") {
       await storageAdapter.evictStoreByReference({ reference });
     }
+  };
+
+  const releaseRepositoryByReference = async (reference) => {
+    const cacheKey = reference?.cacheKey;
+    if (!cacheKey) {
+      return;
+    }
+
+    const repository = repositoriesByCacheKey.get(cacheKey);
+    if (repository) {
+      try {
+        await flushRepositoryForRelease(repository);
+      } catch {}
+    }
+
+    await evictCachedReference(reference);
+  };
+
+  const releaseCurrentRepository = async () => {
+    if (!currentReference) {
+      return;
+    }
+
+    await releaseRepositoryByReference(currentReference);
   };
 
   const withRecoveredStore = async (reference, run) => {
@@ -808,6 +841,7 @@ export const createProjectRepositoryService = ({
       return storesByProject.get(projectId);
     },
     getCurrentRepository: ensureRepository,
+    releaseCurrentRepository,
     getCachedRepository,
     getCachedStore,
     getCachedReference,

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -161,11 +161,26 @@ export const createProjectServiceCore = ({
     };
   };
 
+  const releaseProjectRuntime = async (projectId) => {
+    const targetProjectId =
+      projectId ||
+      repositoryService.getEnsuredProjectId() ||
+      router.getPayload()?.p;
+
+    if (targetProjectId) {
+      await collabService.stopCollabSession(targetProjectId);
+    }
+
+    await repositoryService.releaseCurrentRepository();
+  };
+
   return {
     getRepository: repositoryService.getRepository,
     getRepositoryById: repositoryService.getRepositoryById,
     getAdapterById: repositoryService.getAdapterById,
     getEnsuredProjectId: repositoryService.getEnsuredProjectId,
+    releaseCurrentRepository: repositoryService.releaseCurrentRepository,
+    releaseProjectRuntime,
     ensureRepository: repositoryService.ensureRepository,
     ensureProjectCompatibleById:
       repositoryService.ensureProjectCompatibleByProjectId,

--- a/src/deps/services/tauri/collabClientStore.js
+++ b/src/deps/services/tauri/collabClientStore.js
@@ -1,5 +1,4 @@
 import { join } from "@tauri-apps/api/path";
-import Database from "@tauri-apps/plugin-sql";
 import { createLibsqlClientStore } from "insieme/client";
 import { Subject, asyncScheduler, throttleTime } from "rxjs";
 import {
@@ -8,6 +7,7 @@ import {
   isSqliteNoActiveTransactionError,
   withSqliteLockRetry,
 } from "../../../internal/sqliteLocking.js";
+import { getManagedSqliteConnection } from "../../clients/tauri/sqliteConnectionManager.js";
 import {
   applyRepositoryEventsToRepositoryState,
   createProjectCreateRepositoryEvent,
@@ -31,6 +31,7 @@ const SQL_BYTES_DATA_KEY = "data";
 const WAL_CHECKPOINT_THROTTLE_MS = 20000;
 const ROUTEVN_CHECKPOINT_ENVELOPE_KEY = "__routevnCheckpoint";
 const ROUTEVN_CHECKPOINT_ENVELOPE_VERSION = 1;
+export const DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE = "snapshot_archive";
 
 const isReadQuery = (sql) => {
   const normalized = String(sql ?? "")
@@ -189,6 +190,21 @@ const normalizeHistoryStatValue = (value) => {
     return 0;
   }
   return Math.max(0, Math.floor(numericValue));
+};
+
+const isPlainObject = (value) =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const areJsonStatesEqual = (left, right) => {
+  if (!isPlainObject(left) || !isPlainObject(right)) {
+    return false;
+  }
+
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
 };
 
 const normalizeRepositoryHistoryStats = (stats = {}) => ({
@@ -441,6 +457,7 @@ export const loadRepositoryEvents = async ({
   store,
   projectId,
   onProgress,
+  draftHistoryMode,
 }) => {
   const committed = await store._debug.getCommitted();
   emitEventLoadProgress(onProgress, {
@@ -494,6 +511,22 @@ export const loadRepositoryEvents = async ({
     return events;
   }
 
+  const draftEvents = drafts.map((draft) => {
+    const nextEvent = toRepositoryEvent(draft, {
+      created: draft.createdAt,
+      projectId,
+    });
+    assertRepositoryEventShape(nextEvent);
+    return nextEvent;
+  });
+
+  if (draftHistoryMode === DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE) {
+    processedEventCount = totalEventCount;
+    reportProgress({ force: true });
+    await yieldForUiPaint();
+    return [...events, ...draftEvents];
+  }
+
   emitEventLoadProgress(onProgress, {
     phase: "replay_local_drafts",
     label: "Reading project events...",
@@ -505,15 +538,6 @@ export const loadRepositoryEvents = async ({
     repositoryState: initialProjectData,
     events,
     projectId,
-  });
-
-  const draftEvents = drafts.map((draft) => {
-    const nextEvent = toRepositoryEvent(draft, {
-      created: draft.createdAt,
-      projectId,
-    });
-    assertRepositoryEventShape(nextEvent);
-    return nextEvent;
   });
   const invalidDrafts = [];
   let remainingDraftEvents = draftEvents;
@@ -710,6 +734,20 @@ export const planBootstrapHistoryRepair = ({
     .map((event, index) => (isBootstrapRepositoryEvent(event) ? index : -1))
     .filter((index) => index >= 0);
 
+  const canonicalSnapshotDraftArchive =
+    committed.length === 0 &&
+    drafts.length > 1 &&
+    draftBootstrapIndexes.length === 1 &&
+    draftBootstrapIndexes[0] === 0 &&
+    areJsonStatesEqual(drafts[0]?.payload?.state, mainCheckpointState);
+
+  if (canonicalSnapshotDraftArchive) {
+    return {
+      changed: false,
+      reason: "canonical_snapshot_draft_history",
+    };
+  }
+
   if (
     committedBootstrapIndexes.length === 1 &&
     committedBootstrapIndexes[0] === 0 &&
@@ -824,10 +862,11 @@ export const createPersistedTauriProjectStore = async ({
   }
 
   const storePromise = (async () => {
-    const db = await Database.load(`sqlite:${dbPath}`);
-    await withSqliteLockRetry(() =>
-      db.execute(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`),
-    );
+    const db = getManagedSqliteConnection({
+      dbPath: `sqlite:${dbPath}`,
+      busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS,
+    });
+    await db.init();
 
     let operationQueue = Promise.resolve();
     const queueStoreOperation = async (labelOrOperation, maybeOperation) => {
@@ -928,6 +967,7 @@ export const createPersistedTauriProjectStore = async ({
     await store.init();
 
     let projectHistoryIntegrityPromise;
+    let draftHistoryMode;
     const loadAppValue = async (key) => {
       const rows = await runSelect(
         `SELECT value FROM ${APP_STATE_TABLE} WHERE key = $1`,
@@ -1009,6 +1049,10 @@ export const createPersistedTauriProjectStore = async ({
                 committedEventCount: committedEvents.length,
                 draftEventCount: draftEvents.length,
               });
+            }
+
+            if (repairPlan.reason === "canonical_snapshot_draft_history") {
+              draftHistoryMode = DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE;
             }
 
             return repairPlan;
@@ -1151,6 +1195,7 @@ export const createPersistedTauriProjectStore = async ({
               typeof payload?.onProgress === "function"
                 ? payload.onProgress
                 : undefined,
+            draftHistoryMode,
           }),
         );
         const since = Number(payload?.since);

--- a/src/deps/services/tauri/collabClientStore.js
+++ b/src/deps/services/tauri/collabClientStore.js
@@ -521,10 +521,88 @@ export const loadRepositoryEvents = async ({
   });
 
   if (draftHistoryMode === DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE) {
-    processedEventCount = totalEventCount;
+    const bootstrapEvent = draftEvents[0];
+    events.push(bootstrapEvent);
+    processedEventCount += 1;
     reportProgress({ force: true });
     await yieldForUiPaint();
-    return [...events, ...draftEvents];
+
+    if (draftEvents.length === 1) {
+      reportProgress({ force: true });
+      return events;
+    }
+
+    let repositoryState = structuredClone(
+      bootstrapEvent?.payload?.state ?? initialProjectData,
+    );
+    const invalidDrafts = [];
+    let remainingDraftEvents = draftEvents.slice(1);
+
+    while (remainingDraftEvents.length > 0) {
+      try {
+        repositoryState = applyRepositoryEventsToState({
+          repositoryState,
+          events: remainingDraftEvents,
+          projectId,
+        });
+        events.push(...remainingDraftEvents);
+        processedEventCount += remainingDraftEvents.length;
+        reportProgress({ force: true });
+        await yieldForUiPaint();
+        break;
+      } catch (error) {
+        const failedDraftIndex = Number(error?.details?.commandIndex);
+        const resolvedFailedDraftIndex =
+          Number.isInteger(failedDraftIndex) &&
+          failedDraftIndex >= 0 &&
+          failedDraftIndex < remainingDraftEvents.length
+            ? failedDraftIndex
+            : 0;
+        const acceptedPrefix = remainingDraftEvents.slice(
+          0,
+          resolvedFailedDraftIndex,
+        );
+
+        if (acceptedPrefix.length > 0) {
+          repositoryState = applyRepositoryEventsToState({
+            repositoryState,
+            events: acceptedPrefix,
+            projectId,
+          });
+          events.push(...acceptedPrefix);
+          processedEventCount += acceptedPrefix.length;
+          reportProgress({ force: true });
+          await yieldForUiPaint();
+        }
+
+        const failedDraft = remainingDraftEvents[resolvedFailedDraftIndex];
+        invalidDrafts.push({
+          id: failedDraft?.id,
+          code: error?.code || "validation_failed",
+          message: error?.message || "Invalid local draft",
+        });
+        processedEventCount += 1;
+        reportProgress({ force: true });
+        await yieldForUiPaint();
+        remainingDraftEvents = remainingDraftEvents.slice(
+          resolvedFailedDraftIndex + 1,
+        );
+      }
+    }
+
+    for (const invalidDraft of invalidDrafts) {
+      await store.applySubmitResult({
+        result: {
+          id: invalidDraft.id,
+          status: "rejected",
+          reason: invalidDraft.code,
+          message: invalidDraft.message,
+        },
+      });
+    }
+
+    reportProgress({ force: true });
+    return events;
   }
 
   emitEventLoadProgress(onProgress, {

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -1,7 +1,6 @@
 import { mkdir, writeFile, exists } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
-import Database from "@tauri-apps/plugin-sql";
 import JSZip from "jszip";
 import {
   loadTemplate,
@@ -28,14 +27,10 @@ import {
   resolveProjectResolutionForWrite,
   scaleTemplateProjectStateForResolution,
 } from "../../../internal/projectResolution.js";
-import {
-  SQLITE_BUSY_TIMEOUT_MS,
-  withSqliteLockRetry,
-} from "../../../internal/sqliteLocking.js";
+import { SQLITE_BUSY_TIMEOUT_MS } from "../../../internal/sqliteLocking.js";
 
 const PROJECT_INFO_KEY = "projectInfo";
 const CREATOR_VERSION_KEY = "creatorVersion";
-const APP_STATE_TABLE = "app_state";
 
 const normalizeProjectInfo = (projectInfo = {}) => ({
   id: projectInfo.id ?? "",
@@ -44,41 +39,6 @@ const normalizeProjectInfo = (projectInfo = {}) => ({
   description: projectInfo.description ?? "",
   iconFileId: projectInfo.iconFileId ?? null,
 });
-
-const parseStoredAppValue = (value) => {
-  if (typeof value !== "string" || value.length === 0) {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-};
-
-const getNow = () => {
-  if (
-    typeof performance !== "undefined" &&
-    typeof performance.now === "function"
-  ) {
-    return performance.now();
-  }
-
-  return Date.now();
-};
-
-const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
-
-const isAudioUploadFile = (file) =>
-  [
-    "audio/mpeg",
-    "audio/mp3",
-    "audio/wav",
-    "audio/x-wav",
-    "audio/wave",
-    "audio/ogg",
-  ].includes(file?.type);
 
 async function copyTemplateFiles(templateId, targetPath) {
   const templateFilesPath = `/templates/${templateId}/files/`;
@@ -108,32 +68,6 @@ export const createTauriProjectServiceAdapters = ({
 }) => {
   const filesPathByProjectPath = new Map();
   const fileUrlByCacheKey = new Map();
-
-  const readProjectAppValueByPath = async ({ projectPath, key }) => {
-    if (!projectPath || !key) {
-      return undefined;
-    }
-
-    try {
-      const dbPath = await join(projectPath, PROJECT_DB_NAME);
-      // plugin-sql pools connections by db path; closing a raw preflight handle
-      // here can tear down the shared pool used by the project store.
-      const projectDb = await Database.load(`sqlite:${dbPath}`);
-      await withSqliteLockRetry(() =>
-        projectDb.execute(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`),
-      );
-      const rows = await withSqliteLockRetry(() =>
-        projectDb.select(
-          `SELECT value FROM ${APP_STATE_TABLE} WHERE key = $1`,
-          [key],
-        ),
-      );
-      const row = Array.isArray(rows) ? rows[0] : undefined;
-      return parseStoredAppValue(row?.value);
-    } catch {
-      return undefined;
-    }
-  };
 
   const getReferenceFilesPath = async (reference) => {
     const projectPath = reference?.projectPath;
@@ -246,25 +180,6 @@ export const createTauriProjectServiceAdapters = ({
       repositoryProjectId: projectPath,
     }),
 
-    readCreatorVersionByReference: async ({ reference }) => {
-      const projectPath = reference?.projectPath;
-      const parsedValue = await readProjectAppValueByPath({
-        projectPath,
-        key: CREATOR_VERSION_KEY,
-      });
-      return Number.isFinite(parsedValue) ? parsedValue : undefined;
-    },
-
-    readProjectInfoByReference: async ({ reference }) => {
-      const projectPath = reference?.projectPath;
-      return normalizeProjectInfo(
-        await readProjectAppValueByPath({
-          projectPath,
-          key: PROJECT_INFO_KEY,
-        }),
-      );
-    },
-
     createStore: async ({ reference }) => {
       return createPersistedTauriProjectStore({
         projectPath: reference.projectPath,
@@ -356,59 +271,22 @@ export const createTauriProjectServiceAdapters = ({
           }
         : getCurrentReference();
       const fileId = idGenerator();
-      const totalStartedAt = getNow();
-      let uint8ArrayDurationMs = 0;
-      let writeFileDurationMs = 0;
+      const arrayBuffer = bytes ?? (await file.arrayBuffer());
+      const uint8Array = new Uint8Array(arrayBuffer);
 
-      try {
-        const arrayBuffer = bytes ?? (await file.arrayBuffer());
+      const filesPath = await getReferenceFilesPath(reference);
+      await mkdir(filesPath, { recursive: true });
+      const filePath = await join(filesPath, fileId);
 
-        const uint8ArrayStartedAt = getNow();
-        const uint8Array = new Uint8Array(arrayBuffer);
-        uint8ArrayDurationMs = getDurationMs(uint8ArrayStartedAt);
+      await writeFile(filePath, uint8Array);
 
-        const filesPath = await getReferenceFilesPath(reference);
-        await mkdir(filesPath, { recursive: true });
-        const filePath = await join(filesPath, fileId);
+      const fileUrl = convertFileSrc(filePath);
+      fileUrlByCacheKey.set(getFileUrlCacheKey(reference, fileId), fileUrl);
 
-        const writeFileStartedAt = getNow();
-        await writeFile(filePath, uint8Array);
-        writeFileDurationMs = getDurationMs(writeFileStartedAt);
-
-        if (isAudioUploadFile(file)) {
-          console.info("[audioUpload.store.tauri] complete", {
-            fileName: file.name,
-            fileSize: file.size,
-            fileType: file.type,
-            usedPreloadedBytes: bytes !== undefined,
-            uint8ArrayDurationMs,
-            writeFileDurationMs,
-            totalDurationMs: getDurationMs(totalStartedAt),
-          });
-        }
-
-        const fileUrl = convertFileSrc(filePath);
-        fileUrlByCacheKey.set(getFileUrlCacheKey(reference, fileId), fileUrl);
-
-        return {
-          fileId,
-          downloadUrl: fileUrl,
-        };
-      } catch (error) {
-        if (isAudioUploadFile(file)) {
-          console.warn("[audioUpload.store.tauri] failed", {
-            fileName: file.name,
-            fileSize: file.size,
-            fileType: file.type,
-            usedPreloadedBytes: bytes !== undefined,
-            uint8ArrayDurationMs,
-            writeFileDurationMs,
-            totalDurationMs: getDurationMs(totalStartedAt),
-            error: error?.message ?? "Unknown error",
-          });
-        }
-        throw error;
-      }
+      return {
+        fileId,
+        downloadUrl: fileUrl,
+      };
     },
 
     getFileContent: async ({ fileId, getCurrentReference }) => {

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -7,6 +7,7 @@ import {
   getTemplateFiles,
 } from "../../clients/web/templateLoader.js";
 import {
+  PROJECT_DB_NAME,
   createPersistedTauriProjectStore,
   evictPersistedTauriProjectStoreCache,
   toBootstrappedCommittedEvent,
@@ -26,6 +27,11 @@ import {
   resolveProjectResolutionForWrite,
   scaleTemplateProjectStateForResolution,
 } from "../../../internal/projectResolution.js";
+import {
+  SQLITE_BUSY_TIMEOUT_MS,
+  withSqliteLockRetry,
+} from "../../../internal/sqliteLocking.js";
+import { getManagedSqliteConnection } from "../../clients/tauri/sqliteConnectionManager.js";
 
 const PROJECT_INFO_KEY = "projectInfo";
 const CREATOR_VERSION_KEY = "creatorVersion";
@@ -37,6 +43,23 @@ const normalizeProjectInfo = (projectInfo = {}) => ({
   description: projectInfo.description ?? "",
   iconFileId: projectInfo.iconFileId ?? null,
 });
+
+const parseStoredAppValue = (value) => {
+  if (typeof value !== "string" || value.length === 0) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+const createProjectDatabaseOpenError = () =>
+  new Error(
+    "error returned from database: (code: 14) unable to open database file",
+  );
 
 async function copyTemplateFiles(templateId, targetPath) {
   const templateFilesPath = `/templates/${templateId}/files/`;
@@ -66,6 +89,41 @@ export const createTauriProjectServiceAdapters = ({
 }) => {
   const filesPathByProjectPath = new Map();
   const fileUrlByCacheKey = new Map();
+
+  const readProjectAppValueByReference = async ({ reference, key }) => {
+    const projectPath = reference?.projectPath;
+    if (!projectPath || !key) {
+      return undefined;
+    }
+
+    const dbFilePath = await join(projectPath, PROJECT_DB_NAME);
+    if (!(await exists(dbFilePath))) {
+      throw createProjectDatabaseOpenError();
+    }
+
+    const db = getManagedSqliteConnection({
+      dbPath: `sqlite:${dbFilePath}`,
+      busyTimeoutMs: SQLITE_BUSY_TIMEOUT_MS,
+    });
+    await db.init();
+
+    try {
+      const rows = await withSqliteLockRetry(() =>
+        db.select("SELECT value FROM app_state WHERE key = $1", [key]),
+      );
+      const row = Array.isArray(rows) ? rows[0] : undefined;
+      return parseStoredAppValue(row?.value);
+    } catch (error) {
+      const message = String(error?.message || "").toLowerCase();
+      if (
+        message.includes("no such table") ||
+        message.includes("no such column")
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  };
 
   const getReferenceFilesPath = async (reference) => {
     const projectPath = reference?.projectPath;
@@ -177,6 +235,23 @@ export const createTauriProjectServiceAdapters = ({
       cacheKey: projectPath,
       repositoryProjectId: projectPath,
     }),
+
+    readCreatorVersionByReference: async ({ reference }) => {
+      const creatorVersion = await readProjectAppValueByReference({
+        reference,
+        key: CREATOR_VERSION_KEY,
+      });
+      return Number.isFinite(creatorVersion) ? creatorVersion : 0;
+    },
+
+    readProjectInfoByReference: async ({ reference }) => {
+      return normalizeProjectInfo(
+        await readProjectAppValueByReference({
+          reference,
+          key: PROJECT_INFO_KEY,
+        }),
+      );
+    },
 
     createStore: async ({ reference }) => {
       return createPersistedTauriProjectStore({

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -7,7 +7,6 @@ import {
   getTemplateFiles,
 } from "../../clients/web/templateLoader.js";
 import {
-  PROJECT_DB_NAME,
   createPersistedTauriProjectStore,
   evictPersistedTauriProjectStoreCache,
   toBootstrappedCommittedEvent,
@@ -27,7 +26,6 @@ import {
   resolveProjectResolutionForWrite,
   scaleTemplateProjectStateForResolution,
 } from "../../../internal/projectResolution.js";
-import { SQLITE_BUSY_TIMEOUT_MS } from "../../../internal/sqliteLocking.js";
 
 const PROJECT_INFO_KEY = "projectInfo";
 const CREATOR_VERSION_KEY = "creatorVersion";

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -37,29 +37,6 @@ const countImageEntries = (imagesData) =>
 
 const INITIAL_REMOTE_SYNC_TIMEOUT_MS = 5_000;
 
-const getNow = () => {
-  if (
-    typeof performance !== "undefined" &&
-    typeof performance.now === "function"
-  ) {
-    return performance.now();
-  }
-
-  return Date.now();
-};
-
-const getDurationMs = (startedAt) => Number((getNow() - startedAt).toFixed(2));
-
-const isAudioUploadFile = (file) =>
-  [
-    "audio/mpeg",
-    "audio/mp3",
-    "audio/wav",
-    "audio/x-wav",
-    "audio/wave",
-    "audio/ogg",
-  ].includes(file?.type);
-
 export const createWebProjectServiceAdapters = ({
   onRemoteEvent,
   collabLog,
@@ -198,49 +175,12 @@ export const createWebProjectServiceAdapters = ({
         ? await getStoreByProject(projectId)
         : getCurrentStore();
       const fileId = idGenerator();
-      const totalStartedAt = getNow();
-      let blobBuildDurationMs = 0;
-      let adapterWriteDurationMs = 0;
+      const fileBlob = new Blob([bytes ?? (await file.arrayBuffer())], {
+        type: file.type,
+      });
+      await adapter.setFile(fileId, fileBlob);
 
-      try {
-        const blobBuildStartedAt = getNow();
-        const fileBlob = new Blob([bytes ?? (await file.arrayBuffer())], {
-          type: file.type,
-        });
-        blobBuildDurationMs = getDurationMs(blobBuildStartedAt);
-
-        const adapterWriteStartedAt = getNow();
-        await adapter.setFile(fileId, fileBlob);
-        adapterWriteDurationMs = getDurationMs(adapterWriteStartedAt);
-
-        if (isAudioUploadFile(file)) {
-          console.info("[audioUpload.store.web] complete", {
-            fileName: file.name,
-            fileSize: file.size,
-            fileType: file.type,
-            usedPreloadedBytes: bytes !== undefined,
-            blobBuildDurationMs,
-            adapterWriteDurationMs,
-            totalDurationMs: getDurationMs(totalStartedAt),
-          });
-        }
-
-        return { fileId };
-      } catch (error) {
-        if (isAudioUploadFile(file)) {
-          console.warn("[audioUpload.store.web] failed", {
-            fileName: file.name,
-            fileSize: file.size,
-            fileType: file.type,
-            usedPreloadedBytes: bytes !== undefined,
-            blobBuildDurationMs,
-            adapterWriteDurationMs,
-            totalDurationMs: getDurationMs(totalStartedAt),
-            error: error?.message ?? "Unknown error",
-          });
-        }
-        throw error;
-      }
+      return { fileId };
     },
 
     getFileContent: async ({ fileId, getCurrentStore }) => {

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -164,8 +164,11 @@ const createRouteTransitionRunner = (deps) => {
       canonicalPath,
       currentProjectId,
     );
-    const isAlreadyEnsured =
-      currentProjectId === projectService.getEnsuredProjectId();
+    const ensuredProjectId = projectService.getEnsuredProjectId();
+    const isAlreadyEnsured = currentProjectId === ensuredProjectId;
+    const shouldReleaseEnsuredRepository =
+      !!ensuredProjectId &&
+      (!needsRepository || ensuredProjectId !== currentProjectId);
     store.setCurrentRoute({ route: canonicalPath });
     store.setRepositoryLoading({
       isLoading: needsRepository && !isAlreadyEnsured,
@@ -176,6 +179,10 @@ const createRouteTransitionRunner = (deps) => {
       });
     }
     render();
+
+    if (shouldReleaseEnsuredRepository) {
+      await projectService.releaseProjectRuntime(ensuredProjectId);
+    }
 
     if (!needsRepository) {
       if (currentTransitionToken !== transitionToken) {

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -409,7 +409,12 @@ export const handleKeyboardActionsChange = async (deps, payload) => {
     return;
   }
 
-  const actions = payload._event.detail || {};
+  const control = getSelectedControl(store);
+  const currentActions = getKeyboardEntryActions(control, key);
+  const actions = {
+    ...currentActions,
+    ...(payload._event.detail || {}),
+  };
   const interaction = withInteractionPayload({}, { actions });
   const updated = await updateControlKeyboard({
     appService,

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -413,7 +413,7 @@ export const handleKeyboardActionsChange = async (deps, payload) => {
   const currentActions = getKeyboardEntryActions(control, key);
   const actions = {
     ...currentActions,
-    ...(payload._event.detail || {}),
+    ...payload._event.detail,
   };
   const interaction = withInteractionPayload({}, { actions });
   const updated = await updateControlKeyboard({

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -756,23 +756,18 @@ export const handleDeleteDialogConfirm = async (deps) => {
     return;
   }
 
-  let failedStage = "unknown";
-
   try {
     if (
       projectId &&
       typeof projectService?.releaseProjectRuntime === "function"
     ) {
-      failedStage = "release_project_runtime";
       await projectService.releaseProjectRuntime(projectId);
     }
 
     if (projectId) {
-      failedStage = "remove_project_entry";
       await appService.removeProjectEntry(projectId);
       store.removeProject({ projectId });
     } else {
-      failedStage = "remove_project_entry_by_path";
       await appService.removeProjectEntryByPath(projectPath);
       store.removeProject({ projectPath });
     }

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -92,6 +92,19 @@ const getProjectIdFromEvent = (event) => {
   return event?.currentTarget?.dataset?.projectId ?? "";
 };
 
+const getProjectPathFromEvent = (event) => {
+  return event?.currentTarget?.dataset?.projectPath ?? "";
+};
+
+const getProjectIndexFromEvent = (event) => {
+  const value = event?.currentTarget?.dataset?.projectIndex;
+  const index = Number(value);
+  if (!Number.isInteger(index) || index < 0) {
+    return undefined;
+  }
+  return index;
+};
+
 const showCreateProjectDialog = async (appService) => {
   return appService.showComponentDialog({
     component: PROJECT_CREATE_DIALOG_COMPONENT,
@@ -128,6 +141,44 @@ const getIncompatibleProjectMessage = (error) => {
   }
 
   return message;
+};
+
+const isMissingProjectResolutionError = (error) => {
+  const message = String(error?.message || "").toLowerCase();
+  return (
+    message.includes("project resolution is required") &&
+    message.includes("width") &&
+    message.includes("height")
+  );
+};
+
+const isProjectDatabaseOpenError = (error) => {
+  const message = String(error?.message || "").toLowerCase();
+  return (
+    message.includes("unable to open database file") ||
+    message.includes("(code: 14)")
+  );
+};
+
+const getProjectOpenErrorMessage = (error) => {
+  if (isMissingProjectResolutionError(error)) {
+    return "Project is missing required resolution settings.";
+  }
+
+  if (isProjectDatabaseOpenError(error)) {
+    return "Failed to open the project database. Make sure the project folder still exists and RouteVN can access it.";
+  }
+
+  const detail = typeof error?.message === "string" ? error.message.trim() : "";
+  if (!detail || detail === "Failed to open project.") {
+    return "Failed to open project. An unexpected error occurred while preparing the project.";
+  }
+
+  if (detail.toLowerCase().startsWith("failed to open project")) {
+    return detail;
+  }
+
+  return `Failed to open project. ${detail}`;
 };
 
 export const handleCreateButtonClick = async (deps) => {
@@ -313,12 +364,12 @@ export const handleOpenButtonClick = async (deps) => {
     }
 
     const importedProject = await appService.openExistingProject(selectedPath);
-
-    store.addProject({ project: importedProject });
+    const projects = await appService.loadAllProjects();
+    store.setProjects({ projects });
     render();
 
-    appService.showAlert({
-      message: `Project "${importedProject.name}" has been successfully imported.`,
+    appService.showToast({
+      message: `Project "${importedProject.name}" imported.`,
     });
   } catch (error) {
     appService.showAlert({
@@ -481,8 +532,14 @@ export const handleProjectsClick = async (deps, payload) => {
   const { appService, projectService, store } = deps;
   const id = getProjectIdFromEvent(payload._event);
   if (!id) {
+    appService.showAlert({
+      message:
+        "This project entry is invalid. Remove it from the list and import the project again.",
+    });
     return;
   }
+
+  const project = store.getState().projects.find((entry) => entry?.id === id);
 
   try {
     await projectService.ensureProjectCompatibleById(id);
@@ -497,12 +554,10 @@ export const handleProjectsClick = async (deps, payload) => {
     }
 
     appService.showAlert({
-      message: error?.message || "Failed to open project.",
+      message: getProjectOpenErrorMessage(error),
     });
     return;
   }
-
-  const project = store.getState().projects.find((entry) => entry?.id === id);
 
   if (project) {
     appService.setCurrentProjectEntry(project);
@@ -512,17 +567,33 @@ export const handleProjectsClick = async (deps, payload) => {
 };
 
 export const handleProjectContextMenu = (deps, payload) => {
-  const { store, render } = deps;
+  const { appService, store, render } = deps;
   payload._event.preventDefault();
 
   const projectId = getProjectIdFromEvent(payload._event);
-  if (!projectId) {
-    return;
-  }
   const projects = store.selectProjects();
-  const project = projects.find((p) => p.id === projectId);
+  const projectIndex = getProjectIndexFromEvent(payload._event);
+  const project =
+    projects.find((entry) => entry?.id === projectId) ??
+    (projectIndex === undefined ? undefined : projects[projectIndex]);
+  const projectPath =
+    project?.projectPath || getProjectPathFromEvent(payload._event);
+  if (!projectId) {
+    if (!projectPath) {
+      appService.showAlert({
+        message:
+          "This project entry is invalid. Refresh the projects page and try again.",
+      });
+      return;
+    }
 
-  if (!project) {
+    store.openDropdownMenu({
+      x: payload._event.clientX,
+      y: payload._event.clientY,
+      scope: "local",
+      projectPath,
+    });
+    render();
     return;
   }
 
@@ -531,16 +602,21 @@ export const handleProjectContextMenu = (deps, payload) => {
     y: payload._event.clientY,
     scope: "local",
     projectId: projectId,
+    projectPath,
   });
   render();
 };
 
 export const handleCloudProjectContextMenu = (deps, payload) => {
-  const { store, render } = deps;
+  const { appService, store, render } = deps;
   payload._event.preventDefault();
 
   const projectId = getProjectIdFromEvent(payload._event);
   if (!projectId) {
+    appService.showAlert({
+      message:
+        "This project entry is invalid. Refresh the projects page and try again.",
+    });
     return;
   }
 
@@ -671,17 +747,35 @@ export const handleAddMemberFormAction = async (deps, payload) => {
 };
 
 export const handleDeleteDialogConfirm = async (deps) => {
-  const { appService, store, render } = deps;
+  const { appService, projectService, store, render } = deps;
   const projectId = store.selectDeleteDialogProjectId();
-  if (!projectId) {
+  const projectPath = store.selectDeleteDialogProjectPath();
+  if (!projectId && !projectPath) {
     store.closeDeleteDialog();
     render();
     return;
   }
 
+  let failedStage = "unknown";
+
   try {
-    await appService.removeProjectEntry(projectId);
-    store.removeProject({ projectId });
+    if (
+      projectId &&
+      typeof projectService?.releaseProjectRuntime === "function"
+    ) {
+      failedStage = "release_project_runtime";
+      await projectService.releaseProjectRuntime(projectId);
+    }
+
+    if (projectId) {
+      failedStage = "remove_project_entry";
+      await appService.removeProjectEntry(projectId);
+      store.removeProject({ projectId });
+    } else {
+      failedStage = "remove_project_entry_by_path";
+      await appService.removeProjectEntryByPath(projectPath);
+      store.removeProject({ projectPath });
+    }
   } catch {
     appService.showAlert({
       message: "Failed to remove project. Please try again.",
@@ -699,6 +793,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   const item = detail.item || detail;
   const targetScope = store.selectDropdownMenuTargetScope();
   const projectId = store.selectDropdownMenuTargetProjectId();
+  const projectPath = store.selectDropdownMenuTargetProjectPath();
 
   if (item.value === "add-member" && targetScope === "cloud") {
     if (!projectId) {
@@ -730,25 +825,26 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
     return;
   }
 
-  if (!projectId) {
+  if (!projectId && !projectPath) {
     store.closeDropdownMenu();
     render();
     return;
   }
 
   const projects = store.selectProjects();
-  const project = projects.find((p) => p.id === projectId);
+  const project = projects.find((projectItem) => {
+    if (projectId && projectItem?.id === projectId) {
+      return true;
+    }
 
-  if (!project) {
-    store.closeDropdownMenu();
-    render();
-    return;
-  }
+    return projectPath && projectItem?.projectPath === projectPath;
+  });
 
   store.closeDropdownMenu();
   store.openDeleteDialog({
     projectId: projectId,
-    projectName: project.name || "",
+    projectPath,
+    projectName: project?.name || "",
   });
   render();
 };

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -5,7 +5,7 @@ export const createInitialState = () => ({
   loginButtonText: "Login",
   createButtonText: "Create",
   createCloudButtonText: "Create Cloud Project",
-  openButtonText: "Open",
+  openButtonText: "Import",
   isLoggedIn: false,
   userEmail: "",
   userName: "",
@@ -47,12 +47,14 @@ export const createInitialState = () => ({
     y: 0,
     targetScope: "local",
     targetProjectId: null,
+    targetProjectPath: "",
     items: [],
   },
 
   deleteDialog: {
     isOpen: false,
     projectId: null,
+    projectPath: "",
     projectName: "",
   },
 
@@ -81,7 +83,19 @@ export const setProjects = ({ state }, { projects } = {}) => {
 };
 
 export const addProject = ({ state }, { project } = {}) => {
-  state.projects.push(project);
+  if (!project?.id) {
+    return;
+  }
+
+  const existingIndex = state.projects.findIndex(
+    (entry) => entry?.id === project.id,
+  );
+  if (existingIndex === -1) {
+    state.projects.push(project);
+    return;
+  }
+
+  state.projects[existingIndex] = project;
 };
 
 export const setCloudProjects = ({ state }, { projects } = {}) => {
@@ -114,8 +128,18 @@ export const setAuthUser = ({ state }, { user } = {}) => {
   state.avatarInitial = initialSource[0].toUpperCase();
 };
 
-export const removeProject = ({ state }, { projectId } = {}) => {
-  state.projects = state.projects.filter((p) => p.id !== projectId);
+export const removeProject = ({ state }, { projectId, projectPath } = {}) => {
+  state.projects = state.projects.filter((project) => {
+    if (projectId && project?.id === projectId) {
+      return false;
+    }
+
+    if (projectPath && project?.projectPath === projectPath) {
+      return false;
+    }
+
+    return true;
+  });
 };
 
 export const openProfileMenu = ({ state }, { x, y } = {}) => {
@@ -207,6 +231,10 @@ export const selectDropdownMenuTargetProjectId = ({ state }) => {
   return state.dropdownMenu.targetProjectId;
 };
 
+export const selectDropdownMenuTargetProjectPath = ({ state }) => {
+  return state.dropdownMenu.targetProjectPath || "";
+};
+
 export const selectDropdownMenuTargetScope = ({ state }) => {
   return state.dropdownMenu.targetScope || "local";
 };
@@ -217,13 +245,14 @@ export const selectIsProjectDropdownMenuOpen = ({ state }) => {
 
 export const openDropdownMenu = (
   { state },
-  { x, y, scope = "local", projectId, items } = {},
+  { x, y, scope = "local", projectId, projectPath, items } = {},
 ) => {
   state.dropdownMenu.isOpen = true;
   state.dropdownMenu.x = x;
   state.dropdownMenu.y = y;
   state.dropdownMenu.targetScope = scope;
   state.dropdownMenu.targetProjectId = projectId;
+  state.dropdownMenu.targetProjectPath = projectPath ?? "";
   state.dropdownMenu.items = Array.isArray(items)
     ? items
     : [{ label: "Remove", type: "item", value: "delete" }];
@@ -235,26 +264,33 @@ export const closeDropdownMenu = ({ state }, _payload = {}) => {
   state.dropdownMenu.y = 0;
   state.dropdownMenu.targetScope = "local";
   state.dropdownMenu.targetProjectId = null;
+  state.dropdownMenu.targetProjectPath = "";
   state.dropdownMenu.items = [];
 };
 
 export const openDeleteDialog = (
   { state },
-  { projectId, projectName = "" } = {},
+  { projectId, projectPath, projectName = "" } = {},
 ) => {
   state.deleteDialog.isOpen = true;
   state.deleteDialog.projectId = projectId || null;
+  state.deleteDialog.projectPath = projectPath ?? "";
   state.deleteDialog.projectName = projectName;
 };
 
 export const closeDeleteDialog = ({ state }, _payload = {}) => {
   state.deleteDialog.isOpen = false;
   state.deleteDialog.projectId = null;
+  state.deleteDialog.projectPath = "";
   state.deleteDialog.projectName = "";
 };
 
 export const selectDeleteDialogProjectId = ({ state }) => {
   return state.deleteDialog.projectId;
+};
+
+export const selectDeleteDialogProjectPath = ({ state }) => {
+  return state.deleteDialog.projectPath || "";
 };
 
 export const selectIsDeleteDialogOpen = ({ state }) => {

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -128,7 +128,7 @@ template:
                                           - rtgl-text s=lg c=mu-fg: ${localEmptyMessage}
                                           - rtgl-text s=sm c=mu-fg: ${localEmptySubMessage}
                               - $for project, i in projects:
-                                  - rtgl-view#projectItem${i} data-project-id=${project.id} h=auto w=f bw=xs bc=bo h-bc=ac p=md cur=pointer d=h av=c g=md:
+                                  - rtgl-view#projectItem${i} data-project-id=${project.id} data-project-index=${i} h=auto w=f bw=xs bc=bo h-bc=ac p=md cur=pointer d=h av=c g=md:
                                       - $if project.iconUrl:
                                           - rtgl-image wh=56 src=${project.iconUrl} bw=xs bc=bo of=con br=md: null
                                         $else:

--- a/tests/appService/projectEntriesService.test.js
+++ b/tests/appService/projectEntriesService.test.js
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import { createProjectEntriesService } from "../../src/deps/services/shared/projectEntriesService.js";
+
+const createDb = (initialEntries = []) => {
+  let entries = structuredClone(initialEntries);
+
+  return {
+    get: vi.fn(async (key) => {
+      if (key !== "projectEntries") {
+        return undefined;
+      }
+
+      return structuredClone(entries);
+    }),
+    set: vi.fn(async (key, value) => {
+      if (key === "projectEntries") {
+        entries = structuredClone(value);
+      }
+    }),
+  };
+};
+
+const createService = (
+  initialEntries = [],
+  {
+    projectService = {},
+    platformAdapter = {
+      isDuplicateProjectEntry: ({ entries, entry }) => {
+        return entries.some(
+          (project) => project?.projectPath === entry?.projectPath,
+        );
+      },
+      mapProjectEntryToProject: (entry) => ({
+        projectPath: entry?.projectPath,
+      }),
+    },
+  } = {},
+) => {
+  const db = createDb(initialEntries);
+  const service = createProjectEntriesService({
+    db,
+    getCurrentProjectId: () => "",
+    projectService,
+    platformAdapter,
+  });
+
+  return { db, service };
+};
+
+describe("projectEntriesService", () => {
+  it("replaces an existing local project entry when the same project id is re-added from a new path", async () => {
+    const { service } = createService([
+      {
+        id: "project-1",
+        projectPath: "/old/DiaLune-migrated",
+        name: "DiaLune",
+        description: "old description",
+        iconFileId: "icon-old",
+        createdAt: 100,
+        lastOpenedAt: 200,
+      },
+    ]);
+
+    const entries = await service.addProjectEntry({
+      id: "project-1",
+      projectPath: "/new/DiaLune-migrated",
+      name: "DiaLune",
+      description: "new description",
+      iconFileId: "icon-new",
+      createdAt: 300,
+      lastOpenedAt: null,
+    });
+
+    expect(entries).toEqual([
+      {
+        id: "project-1",
+        projectPath: "/new/DiaLune-migrated",
+        name: "DiaLune",
+        description: "new description",
+        iconFileId: "icon-new",
+        createdAt: 100,
+        lastOpenedAt: 200,
+      },
+    ]);
+  });
+
+  it("still rejects adding a different project on an already imported path", async () => {
+    const { service } = createService([
+      {
+        id: "project-1",
+        projectPath: "/projects/DiaLune-migrated",
+        name: "DiaLune",
+      },
+    ]);
+
+    await expect(
+      service.addProjectEntry({
+        id: "project-2",
+        projectPath: "/projects/DiaLune-migrated",
+        name: "Another Project",
+      }),
+    ).rejects.toThrow("This project has already been added.");
+  });
+
+  it("repairs missing local project ids from the project path on load", async () => {
+    const getProjectInfoByPath = vi.fn(async (projectPath) => ({
+      id: "project-1",
+      name: "DiaLune",
+      description: "Recovered",
+      iconFileId: "icon-1",
+      projectPath,
+    }));
+    const { db, service } = createService(
+      [
+        {
+          id: "",
+          projectPath: "/projects/DiaLune-migrated",
+          name: "",
+          description: "",
+          iconFileId: null,
+        },
+      ],
+      {
+        projectService: {
+          getProjectInfoByPath,
+        },
+      },
+    );
+
+    const projects = await service.loadAllProjects();
+
+    expect(projects).toEqual([
+      expect.objectContaining({
+        id: "project-1",
+        name: "DiaLune",
+        description: "Recovered",
+        iconFileId: "icon-1",
+        projectPath: "/projects/DiaLune-migrated",
+      }),
+    ]);
+    expect(db.set).toHaveBeenCalledWith("projectEntries", [
+      {
+        id: "project-1",
+        projectPath: "/projects/DiaLune-migrated",
+        name: "DiaLune",
+        description: "Recovered",
+        iconFileId: "icon-1",
+      },
+    ]);
+  });
+
+  it("removes a stale local project entry by path when its id is missing", async () => {
+    const { service } = createService([
+      {
+        id: "",
+        projectPath: "/projects/DiaLune-migrated",
+        name: "Broken DiaLune",
+      },
+    ]);
+
+    const entries = await service.removeProjectEntryByPath(
+      "/projects/DiaLune-migrated",
+    );
+
+    expect(entries).toEqual([]);
+  });
+});

--- a/tests/appService/projectEntriesService.test.js
+++ b/tests/appService/projectEntriesService.test.js
@@ -149,6 +149,56 @@ describe("projectEntriesService", () => {
     ]);
   });
 
+  it("preserves the working path when duplicate repaired entries merge by project id", async () => {
+    const getProjectInfoByPath = vi.fn(async () => ({
+      id: "project-1",
+      name: "DiaLune",
+      description: "Recovered",
+      iconFileId: "icon-1",
+    }));
+    const { db, service } = createService(
+      [
+        {
+          id: "project-1",
+          projectPath: "/projects/working",
+          name: "DiaLune",
+          description: "Working",
+          iconFileId: "icon-working",
+        },
+        {
+          id: "",
+          projectPath: "/projects/stale",
+          name: "",
+          description: "",
+          iconFileId: null,
+        },
+      ],
+      {
+        projectService: {
+          getProjectInfoByPath,
+        },
+      },
+    );
+
+    const projects = await service.loadAllProjects();
+
+    expect(projects).toEqual([
+      expect.objectContaining({
+        id: "project-1",
+        projectPath: "/projects/working",
+      }),
+    ]);
+    expect(db.set).toHaveBeenCalledWith("projectEntries", [
+      {
+        id: "project-1",
+        projectPath: "/projects/working",
+        name: "DiaLune",
+        description: "Recovered",
+        iconFileId: "icon-1",
+      },
+    ]);
+  });
+
   it("removes a stale local project entry by path when its id is missing", async () => {
     const { service } = createService([
       {

--- a/tests/controls/controls.handlers.test.js
+++ b/tests/controls/controls.handlers.test.js
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { createControlTemplate } from "../../src/pages/controls/controls.handlers.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createControlTemplate,
+  handleKeyboardActionsChange,
+} from "../../src/pages/controls/controls.handlers.js";
 
 describe("createControlTemplate", () => {
   const projectResolution = {
@@ -17,6 +20,70 @@ describe("createControlTemplate", () => {
     itemEntries.forEach(([itemId, item]) => {
       expect(item.id).toBe(itemId);
       expect(item.name).toBeTruthy();
+    });
+  });
+});
+
+describe("handleKeyboardActionsChange", () => {
+  it("merges the submitted action delta with existing keyboard actions", async () => {
+    const updateControlItem = vi.fn(async () => ({}));
+    const deps = {
+      appService: {
+        showAlert: vi.fn(),
+      },
+      projectService: {
+        updateControlItem,
+        getRepositoryState: () => ({
+          controls: {
+            items: {},
+            tree: [],
+          },
+        }),
+      },
+      store: {
+        selectKeyboardEditorKey: () => "Enter",
+        selectSelectedItem: () => ({
+          id: "control-1",
+          type: "control",
+          keyboard: {
+            Enter: {
+              payload: {
+                actions: {
+                  toggleAutoMode: {},
+                },
+              },
+            },
+          },
+        }),
+        closeKeyboardEditor: vi.fn(),
+        setItems: vi.fn(),
+      },
+      render: vi.fn(),
+      refs: {},
+    };
+
+    await handleKeyboardActionsChange(deps, {
+      _event: {
+        detail: {
+          toggleSkipMode: {},
+        },
+      },
+    });
+
+    expect(updateControlItem).toHaveBeenCalledWith({
+      controlId: "control-1",
+      data: {
+        keyboard: {
+          Enter: {
+            payload: {
+              actions: {
+                toggleAutoMode: {},
+                toggleSkipMode: {},
+              },
+            },
+          },
+        },
+      },
     });
   });
 });

--- a/tests/projectService/projectServiceCore.releaseRuntime.test.js
+++ b/tests/projectService/projectServiceCore.releaseRuntime.test.js
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  repositoryService: {
+    getCachedStore: vi.fn(),
+    getCachedReference: vi.fn(),
+    getStoreByProject: vi.fn(),
+    getStoreByProjectSync: vi.fn(),
+    getCurrentRepository: vi.fn(),
+    getCachedRepository: vi.fn(),
+    getRepositoryByProject: vi.fn(),
+    getProjectInfoByProjectId: vi.fn(),
+    resolveProjectReferenceByProjectId: vi.fn(),
+    getRepository: vi.fn(),
+    getRepositoryById: vi.fn(),
+    getAdapterById: vi.fn(),
+    getEnsuredProjectId: vi.fn(),
+    releaseCurrentRepository: vi.fn(),
+    ensureRepository: vi.fn(),
+    ensureProjectCompatibleByProjectId: vi.fn(),
+    subscribeProjectState: vi.fn(),
+    getCurrentProjectInfo: vi.fn(),
+    updateCurrentProjectInfo: vi.fn(),
+    updateProjectInfoByProjectId: vi.fn(),
+  },
+  collabService: {
+    stopCollabSession: vi.fn(),
+    commandApi: {},
+    addVersionToProject: vi.fn(),
+    updateVersionInProject: vi.fn(),
+    deleteVersionFromProject: vi.fn(),
+    deleteImageIfUnused: vi.fn(),
+    deleteSoundIfUnused: vi.fn(),
+    deleteVideoIfUnused: vi.fn(),
+    createCollabSession: vi.fn(),
+    ensureCommandSessionForProject: vi.fn(),
+    getCollabSession: vi.fn(),
+    getCollabSessionMode: vi.fn(),
+    submitCommand: vi.fn(),
+  },
+  assetService: {
+    uploadFiles: vi.fn(),
+    storeFile: vi.fn(),
+    storeFileForProject: vi.fn(),
+    getFileContent: vi.fn(),
+    downloadMetadata: vi.fn(),
+    loadFontFile: vi.fn(),
+    detectFileType: vi.fn(),
+  },
+  exportService: {
+    createBundle: vi.fn(),
+    exportProject: vi.fn(),
+    downloadBundle: vi.fn(),
+    createDistributionZip: vi.fn(),
+    createDistributionZipStreamed: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/deps/services/shared/projectRepositoryService.js", () => ({
+  createProjectRepositoryService: vi.fn(() => mocked.repositoryService),
+}));
+
+vi.mock("../../src/deps/services/shared/projectCollabCore.js", () => ({
+  createProjectCollabCore: vi.fn(() => mocked.collabService),
+}));
+
+vi.mock("../../src/deps/services/shared/projectAssetService.js", () => ({
+  createProjectAssetService: vi.fn(() => mocked.assetService),
+}));
+
+vi.mock("../../src/deps/services/shared/projectExportService.js", () => ({
+  createProjectExportService: vi.fn(() => mocked.exportService),
+}));
+
+vi.mock("../../src/deps/services/shared/resourceImports.js", () => ({
+  importImageFile: vi.fn(),
+}));
+
+vi.mock("../../src/deps/services/shared/resourceUsage.js", () => ({
+  checkProjectResourceUsage: vi.fn(),
+  checkSceneDeleteUsage: vi.fn(),
+}));
+
+import { createProjectServiceCore } from "../../src/deps/services/shared/projectServiceCore.js";
+
+describe("projectServiceCore releaseProjectRuntime", () => {
+  beforeEach(() => {
+    mocked.repositoryService.getEnsuredProjectId.mockReset();
+    mocked.repositoryService.releaseCurrentRepository.mockReset();
+    mocked.collabService.stopCollabSession.mockReset();
+  });
+
+  it("stops the ensured collab session before releasing the current repository", async () => {
+    mocked.repositoryService.getEnsuredProjectId.mockReturnValue("project-1");
+    mocked.collabService.stopCollabSession.mockResolvedValue(undefined);
+    mocked.repositoryService.releaseCurrentRepository.mockResolvedValue(
+      undefined,
+    );
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-2" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+    });
+
+    await projectService.releaseProjectRuntime();
+
+    expect(mocked.collabService.stopCollabSession).toHaveBeenCalledWith(
+      "project-1",
+    );
+    expect(
+      mocked.repositoryService.releaseCurrentRepository,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      mocked.collabService.stopCollabSession.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocked.repositoryService.releaseCurrentRepository.mock
+        .invocationCallOrder[0],
+    );
+  });
+});

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -1,11 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleProjectsClick } from "../../src/pages/projects/projects.handlers.js";
+import {
+  handleDeleteDialogConfirm,
+  handleOpenButtonClick,
+  handleProjectContextMenu,
+  handleProjectsClick,
+} from "../../src/pages/projects/projects.handlers.js";
 
 const createDeps = ({
   ensureProjectCompatibleById = vi.fn(async () => {}),
 } = {}) => {
   const appService = {
+    getPlatform: vi.fn(() => "tauri"),
+    openFolderPicker: vi.fn(),
+    openExistingProject: vi.fn(),
+    loadAllProjects: vi.fn(async () => []),
     showAlert: vi.fn(),
+    showToast: vi.fn(),
     setCurrentProjectEntry: vi.fn(),
     navigate: vi.fn(),
   };
@@ -14,6 +24,7 @@ const createDeps = ({
     appService,
     projectService: {
       ensureProjectCompatibleById,
+      releaseProjectRuntime: vi.fn(async () => {}),
     },
     store: {
       getState: vi.fn(() => ({
@@ -24,7 +35,21 @@ const createDeps = ({
           },
         ],
       })),
+      setProjects: vi.fn(),
+      selectProjects: vi.fn(() => [
+        {
+          id: "project-1",
+          name: "Project One",
+          projectPath: "/projects/project-one",
+        },
+      ]),
+      openDropdownMenu: vi.fn(),
+      selectDeleteDialogProjectId: vi.fn(() => ""),
+      selectDeleteDialogProjectPath: vi.fn(() => ""),
+      closeDeleteDialog: vi.fn(),
+      removeProject: vi.fn(),
     },
+    render: vi.fn(),
   };
 };
 
@@ -75,7 +100,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later.",
+        "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -91,9 +116,44 @@ describe("projects.handleProjectsClick", () => {
     await handleProjectsClick(deps, createPayload());
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
-      message: "Failed to open project.",
+      message:
+        "Failed to open project. An unexpected error occurred while preparing the project.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("shows a clearer message for missing project resolution errors", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        throw new Error(
+          "Project resolution is required. Missing width and height.",
+        );
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message: "Project is missing required resolution settings.",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("shows a clearer message for missing project database file errors", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        throw new Error(
+          "error returned from database: (code: 14) unable to open database file",
+        );
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message:
+        "Failed to open the project database. Make sure the project folder still exists and RouteVN can access it.",
+    });
   });
 
   it("opens compatible projects normally", async () => {
@@ -107,6 +167,147 @@ describe("projects.handleProjectsClick", () => {
     });
     expect(deps.appService.navigate).toHaveBeenCalledWith("/project", {
       p: "project-1",
+    });
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects.handleOpenButtonClick", () => {
+  it("reloads the project list and shows a toast after a successful import", async () => {
+    const deps = createDeps();
+    deps.appService.openFolderPicker.mockResolvedValue(
+      "/projects/DiaLune-migrated",
+    );
+    deps.appService.openExistingProject.mockResolvedValue({
+      id: "project-2",
+      name: "DiaLune",
+      projectPath: "/projects/DiaLune-migrated",
+    });
+    deps.appService.loadAllProjects.mockResolvedValue([
+      {
+        id: "project-1",
+        name: "Project One",
+        projectPath: "/projects/project-one",
+      },
+      {
+        id: "project-2",
+        name: "DiaLune",
+        projectPath: "/projects/DiaLune-migrated",
+      },
+    ]);
+
+    await handleOpenButtonClick(deps);
+
+    expect(deps.store.setProjects).toHaveBeenCalledWith({
+      projects: [
+        {
+          id: "project-1",
+          name: "Project One",
+          projectPath: "/projects/project-one",
+        },
+        {
+          id: "project-2",
+          name: "DiaLune",
+          projectPath: "/projects/DiaLune-migrated",
+        },
+      ],
+    });
+    expect(deps.appService.showToast).toHaveBeenCalledWith({
+      message: 'Project "DiaLune" imported.',
+    });
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects.handleDeleteDialogConfirm", () => {
+  it("releases a local project runtime before removing its project entry", async () => {
+    const deps = createDeps();
+    deps.store.selectDeleteDialogProjectId.mockReturnValue("project-1");
+
+    deps.appService.removeProjectEntry = vi.fn(async () => {});
+
+    await handleDeleteDialogConfirm(deps);
+
+    expect(deps.projectService.releaseProjectRuntime).toHaveBeenCalledWith(
+      "project-1",
+    );
+    expect(deps.appService.removeProjectEntry).toHaveBeenCalledWith(
+      "project-1",
+    );
+    expect(deps.store.removeProject).toHaveBeenCalledWith({
+      projectId: "project-1",
+    });
+    expect(deps.store.closeDeleteDialog).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("projects.handleProjectContextMenu", () => {
+  it("shows an alert when the project item is missing its id", () => {
+    const deps = createDeps();
+
+    handleProjectsClick(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {},
+        },
+      },
+    });
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message:
+        "This project entry is invalid. Remove it from the list and import the project again.",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("opens the dropdown for a stale project row when only the path is available", () => {
+    const deps = createDeps();
+
+    handleProjectContextMenu(deps, {
+      _event: {
+        preventDefault: vi.fn(),
+        clientX: 10,
+        clientY: 20,
+        currentTarget: {
+          dataset: {
+            projectIndex: "0",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.openDropdownMenu).toHaveBeenCalledWith({
+      x: 10,
+      y: 20,
+      scope: "local",
+      projectPath: "/projects/project-one",
+    });
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
+  });
+
+  it("derives the project path from store for a normal local project row", () => {
+    const deps = createDeps();
+
+    handleProjectContextMenu(deps, {
+      _event: {
+        preventDefault: vi.fn(),
+        clientX: 10,
+        clientY: 20,
+        currentTarget: {
+          dataset: {
+            projectId: "project-1",
+            projectIndex: "0",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.openDropdownMenu).toHaveBeenCalledWith({
+      x: 10,
+      y: 20,
+      scope: "local",
+      projectId: "project-1",
+      projectPath: "/projects/project-one",
     });
     expect(deps.appService.showAlert).not.toHaveBeenCalled();
   });

--- a/tests/projects/projects.store.test.js
+++ b/tests/projects/projects.store.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  addProject,
+  createInitialState,
+} from "../../src/pages/projects/projects.store.js";
+
+describe("projects.store addProject", () => {
+  it("replaces an existing project with the same id instead of appending a duplicate", () => {
+    const state = createInitialState();
+
+    addProject(
+      {
+        state,
+      },
+      {
+        project: {
+          id: "project-1",
+          name: "DiaLune",
+          projectPath: "/old/DiaLune-migrated",
+        },
+      },
+    );
+
+    addProject(
+      {
+        state,
+      },
+      {
+        project: {
+          id: "project-1",
+          name: "DiaLune",
+          projectPath: "/new/DiaLune-migrated",
+        },
+      },
+    );
+
+    expect(state.projects).toEqual([
+      {
+        id: "project-1",
+        name: "DiaLune",
+        projectPath: "/new/DiaLune-migrated",
+      },
+    ]);
+  });
+});

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -11,7 +11,7 @@ import {
 } from "../../src/components/systemActions/systemActions.handlers.js";
 
 describe("systemActions.handlers", () => {
-  it("emits the full next action set when adding a new action", () => {
+  it("keeps local merged actions but emits only the submitted action delta", () => {
     const state = createInitialState();
     const dispatchedEvents = [];
     const stopPropagation = () => {};
@@ -51,8 +51,59 @@ describe("systemActions.handlers", () => {
     expect(dispatchedEvents).toHaveLength(1);
     expect(dispatchedEvents[0].type).toBe("actions-change");
     expect(dispatchedEvents[0].detail).toEqual({
-      toggleAutoMode: {},
       toggleSkipMode: {},
+    });
+  });
+
+  it("does not leak stale dialogue content when submitting an unrelated action", () => {
+    const state = createInitialState();
+    const dispatchedEvents = [];
+
+    updateActions(
+      { state },
+      {
+        dialogue: {
+          content: [{ text: "stale draft text" }],
+        },
+      },
+    );
+
+    const deps = {
+      store: {
+        selectAction: () => selectAction({ state }),
+        updateActions: (payload) => updateActions({ state }, payload),
+        hideActionsDialog: () => {},
+      },
+      render: () => {},
+      dispatchEvent: (event) => {
+        dispatchedEvents.push(event);
+      },
+    };
+
+    handleCommandLineSubmit(deps, {
+      _event: {
+        stopPropagation: () => {},
+        detail: {
+          background: {
+            resourceId: "bg-1",
+          },
+        },
+      },
+    });
+
+    expect(selectAction({ state })).toEqual({
+      dialogue: {
+        content: [{ text: "stale draft text" }],
+      },
+      background: {
+        resourceId: "bg-1",
+      },
+    });
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].detail).toEqual({
+      background: {
+        resourceId: "bg-1",
+      },
     });
   });
 

--- a/tests/tauri/collabClientStore.getEvents.test.js
+++ b/tests/tauri/collabClientStore.getEvents.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadRepositoryEvents } from "../../src/deps/services/tauri/collabClientStore.js";
+import {
+  DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE,
+  loadRepositoryEvents,
+} from "../../src/deps/services/tauri/collabClientStore.js";
 
 describe("loadRepositoryEvents", () => {
   it("skips committed replay when there are no drafts", async () => {
@@ -191,6 +194,83 @@ describe("loadRepositoryEvents", () => {
       phase: "read_project_events",
       current: 3,
       total: 3,
+    });
+  });
+
+  it("preserves canonical snapshot draft history without rejecting drafts", async () => {
+    const applySubmitResult = vi.fn(async () => {});
+    const progressUpdates = [];
+
+    const events = await loadRepositoryEvents({
+      projectId: "project-1",
+      draftHistoryMode: DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE,
+      onProgress: (payload) => {
+        progressUpdates.push(payload);
+      },
+      store: {
+        _debug: {
+          getCommitted: async () => [],
+          getDrafts: async () => [
+            {
+              id: "bootstrap-draft",
+              partition: "m",
+              projectId: "project-1",
+              userId: "user-1",
+              type: "project.create",
+              schemaVersion: 1,
+              payload: {
+                state: {
+                  scenes: {
+                    items: {
+                      "scene-1": {
+                        id: "scene-1",
+                        type: "scene",
+                        name: "Scene 1",
+                      },
+                    },
+                    tree: [{ id: "scene-1" }],
+                  },
+                },
+              },
+              clientTs: 1000,
+              createdAt: 1000,
+              meta: {},
+            },
+            {
+              id: "draft-2",
+              partition: "m",
+              projectId: "project-1",
+              userId: "user-1",
+              type: "character.create",
+              schemaVersion: 1,
+              payload: {
+                characterId: "character-1",
+                data: {
+                  type: "character",
+                  name: "Dia",
+                },
+                parentId: "characters-folder",
+                index: 0,
+              },
+              clientTs: 1001,
+              createdAt: 1001,
+              meta: {},
+            },
+          ],
+        },
+        applySubmitResult,
+      },
+    });
+
+    expect(events.map((event) => event.id)).toEqual([
+      "bootstrap-draft",
+      "draft-2",
+    ]);
+    expect(applySubmitResult).not.toHaveBeenCalled();
+    expect(progressUpdates.at(-1)).toMatchObject({
+      phase: "read_project_events",
+      current: 2,
+      total: 2,
     });
   });
 });

--- a/tests/tauri/collabClientStore.getEvents.test.js
+++ b/tests/tauri/collabClientStore.getEvents.test.js
@@ -3,6 +3,7 @@ import {
   DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE,
   loadRepositoryEvents,
 } from "../../src/deps/services/tauri/collabClientStore.js";
+import { initialProjectData } from "../../src/deps/services/shared/projectRepository.js";
 
 describe("loadRepositoryEvents", () => {
   it("skips committed replay when there are no drafts", async () => {
@@ -219,18 +220,7 @@ describe("loadRepositoryEvents", () => {
               type: "project.create",
               schemaVersion: 1,
               payload: {
-                state: {
-                  scenes: {
-                    items: {
-                      "scene-1": {
-                        id: "scene-1",
-                        type: "scene",
-                        name: "Scene 1",
-                      },
-                    },
-                    tree: [{ id: "scene-1" }],
-                  },
-                },
+                state: structuredClone(initialProjectData),
               },
               clientTs: 1000,
               createdAt: 1000,
@@ -238,19 +228,16 @@ describe("loadRepositoryEvents", () => {
             },
             {
               id: "draft-2",
-              partition: "m",
+              partition: "m:s:scene-1",
               projectId: "project-1",
               userId: "user-1",
-              type: "character.create",
+              type: "scene.create",
               schemaVersion: 1,
               payload: {
-                characterId: "character-1",
+                sceneId: "scene-1",
                 data: {
-                  type: "character",
-                  name: "Dia",
+                  name: "Scene 1",
                 },
-                parentId: "characters-folder",
-                index: 0,
               },
               clientTs: 1001,
               createdAt: 1001,
@@ -271,6 +258,69 @@ describe("loadRepositoryEvents", () => {
       phase: "read_project_events",
       current: 2,
       total: 2,
+    });
+  });
+
+  it("quarantines invalid drafts after the bootstrap snapshot in snapshot-archive mode", async () => {
+    const applySubmitResult = vi.fn(async () => {});
+
+    const events = await loadRepositoryEvents({
+      projectId: "project-1",
+      draftHistoryMode: DRAFT_HISTORY_MODE_SNAPSHOT_ARCHIVE,
+      store: {
+        _debug: {
+          getCommitted: async () => [],
+          getDrafts: async () => [
+            {
+              id: "bootstrap-draft",
+              partition: "m",
+              projectId: "project-1",
+              userId: "user-1",
+              type: "project.create",
+              schemaVersion: 1,
+              payload: {
+                state: structuredClone(initialProjectData),
+              },
+              clientTs: 1000,
+              createdAt: 1000,
+              meta: {},
+            },
+            {
+              id: "broken-draft",
+              partition: "m",
+              projectId: "project-1",
+              userId: "user-1",
+              type: "image.create",
+              schemaVersion: 1,
+              payload: {
+                imageId: "image-1",
+                data: {
+                  type: "image",
+                  name: "Broken image",
+                  fileId: "missing-file",
+                },
+                parentId: null,
+                position: "last",
+              },
+              clientTs: 1001,
+              createdAt: 1001,
+              meta: {},
+            },
+          ],
+        },
+        applySubmitResult,
+      },
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["bootstrap-draft"]);
+    expect(applySubmitResult).toHaveBeenCalledWith({
+      result: {
+        id: "broken-draft",
+        status: "rejected",
+        reason: "precondition_validation_failed",
+        message:
+          "payload.data.fileId must reference an existing non-folder file",
+      },
     });
   });
 });

--- a/tests/tauri/collabClientStore.historyRepair.test.js
+++ b/tests/tauri/collabClientStore.historyRepair.test.js
@@ -134,6 +134,55 @@ describe("planBootstrapHistoryRepair", () => {
     expect(repairPlan.draftEvents).toEqual([]);
   });
 
+  it("preserves canonical snapshot draft history without rewriting it", () => {
+    const snapshotState = {
+      scenes: {
+        items: {
+          "scene-1": {
+            id: "scene-1",
+            type: "scene",
+            name: "Scene 1",
+          },
+        },
+        tree: [{ id: "scene-1" }],
+      },
+    };
+    const repairPlan = planBootstrapHistoryRepair({
+      projectId,
+      committedEvents: [],
+      draftEvents: [
+        createDraftEvent({
+          id: "bootstrap-draft",
+          partition: "m",
+          type: "project.create",
+          payload: {
+            state: snapshotState,
+          },
+        }),
+        createDraftEvent({
+          id: "character-1",
+          partition: "m",
+          type: "character.create",
+          payload: {
+            characterId: "character-1",
+            data: {
+              type: "character",
+              name: "Dia",
+            },
+            parentId: "characters-folder",
+            index: 0,
+          },
+        }),
+      ],
+      mainCheckpointState: snapshotState,
+    });
+
+    expect(repairPlan).toEqual({
+      changed: false,
+      reason: "canonical_snapshot_draft_history",
+    });
+  });
+
   it("synthesizes a bootstrap event from the main checkpoint for line-only history", () => {
     const repairPlan = planBootstrapHistoryRepair({
       projectId,

--- a/tests/tauri/collabClientStore.locking.test.js
+++ b/tests/tauri/collabClientStore.locking.test.js
@@ -220,6 +220,38 @@ describe("tauri collab client store locking", () => {
     await store.close();
   }, 10000);
 
+  it("recovers a closed-pool project db handle by reopening it once", async () => {
+    const staleDb = {
+      execute: vi.fn(async () => ({ rowsAffected: 0 })),
+      select: vi.fn(async () => {
+        throw new Error("attempted to acquire a connection on a closed pool");
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const freshDb = {
+      execute: vi.fn(async () => ({ rowsAffected: 0 })),
+      select: vi.fn(async () => []),
+      close: vi.fn(async () => {}),
+    };
+    loadMock.mockResolvedValueOnce(staleDb).mockResolvedValueOnce(freshDb);
+    createLibsqlClientStoreMock.mockImplementation(createStoreMockFactory());
+
+    const { createPersistedTauriProjectStore } = await import(
+      "../../src/deps/services/tauri/collabClientStore.js"
+    );
+    const store = await createPersistedTauriProjectStore({
+      projectPath: "/projects/recover",
+      projectId: "project-recover",
+    });
+
+    expect(loadMock).toHaveBeenCalledTimes(2);
+    expect(staleDb.close).toHaveBeenCalledWith(
+      "sqlite:/projects/recover/project.db",
+    );
+
+    await store.close();
+  });
+
   it("recovers a commit retry that loses transaction state", async () => {
     vi.useFakeTimers();
     const fakeDb = {

--- a/tests/tauri/db.locking.test.js
+++ b/tests/tauri/db.locking.test.js
@@ -139,4 +139,114 @@ describe("tauri db lock handling", () => {
       ).length,
     ).toBe(2);
   });
+
+  it("serializes concurrent reads and writes on the same connection", async () => {
+    let activeOperations = 0;
+    let maxConcurrentOperations = 0;
+    const kv = new Map();
+
+    const fakeDb = {
+      execute: vi.fn(
+        async (sql, args = []) =>
+          new Promise((resolve) => {
+            activeOperations += 1;
+            maxConcurrentOperations = Math.max(
+              maxConcurrentOperations,
+              activeOperations,
+            );
+
+            globalThis.setTimeout(() => {
+              if (String(sql).includes("INSERT OR REPLACE INTO kv")) {
+                kv.set(args[0], args[1]);
+              }
+              activeOperations -= 1;
+              resolve({ rowsAffected: 1 });
+            }, 10);
+          }),
+      ),
+      select: vi.fn(
+        async (sql, args = []) =>
+          new Promise((resolve) => {
+            activeOperations += 1;
+            maxConcurrentOperations = Math.max(
+              maxConcurrentOperations,
+              activeOperations,
+            );
+
+            globalThis.setTimeout(() => {
+              const value = String(sql).includes("SELECT value FROM kv")
+                ? kv.get(args[0])
+                : undefined;
+              activeOperations -= 1;
+              resolve(value === undefined ? [] : [{ value }]);
+            }, 10);
+          }),
+      ),
+    };
+    loadMock.mockResolvedValue(fakeDb);
+
+    const { createDb } = await import("../../src/deps/clients/tauri/db.js");
+    const db = createDb({ path: "sqlite:app.db" });
+
+    const initPromise = db.init();
+    await vi.runAllTimersAsync();
+    await initPromise;
+
+    const setPromise = db.set("projectEntries", [{ id: "project-1" }]);
+    const getPromise = db.get("projectEntries");
+
+    await vi.runAllTimersAsync();
+
+    await expect(setPromise).resolves.toBeUndefined();
+    await expect(getPromise).resolves.toEqual([{ id: "project-1" }]);
+    expect(maxConcurrentOperations).toBe(1);
+  });
+
+  it("recovers from a closed-pool app db handle by reopening and retrying once", async () => {
+    const kv = new Map();
+    const staleDb = {
+      execute: vi.fn(async (sql, args = []) => {
+        if (String(sql).includes("PRAGMA busy_timeout")) {
+          return { rowsAffected: 0 };
+        }
+        if (String(sql).includes("CREATE TABLE IF NOT EXISTS kv")) {
+          return { rowsAffected: 0 };
+        }
+        if (String(sql).includes("INSERT OR REPLACE INTO kv")) {
+          throw new Error("attempted to acquire a connection on a closed pool");
+        }
+        return { rowsAffected: 0 };
+      }),
+      select: vi.fn(async (sql, args = []) => {
+        const value = kv.get(args[0]);
+        return value === undefined ? [] : [{ value }];
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const freshDb = {
+      execute: vi.fn(async (sql, args = []) => {
+        if (String(sql).includes("INSERT OR REPLACE INTO kv")) {
+          kv.set(args[0], args[1]);
+        }
+        return { rowsAffected: 1 };
+      }),
+      select: vi.fn(async (sql, args = []) => {
+        const value = kv.get(args[0]);
+        return value === undefined ? [] : [{ value }];
+      }),
+    };
+    loadMock.mockResolvedValueOnce(staleDb).mockResolvedValueOnce(freshDb);
+
+    const { createDb } = await import("../../src/deps/clients/tauri/db.js");
+    const db = createDb({ path: "sqlite:app.db" });
+
+    await db.init();
+    await db.set("projectEntries", [{ id: "project-1" }]);
+
+    await expect(db.get("projectEntries")).resolves.toEqual([
+      { id: "project-1" },
+    ]);
+    expect(loadMock).toHaveBeenCalledTimes(2);
+    expect(staleDb.close).toHaveBeenCalledWith("sqlite:app.db");
+  });
 });

--- a/tests/tauri/db.locking.test.js
+++ b/tests/tauri/db.locking.test.js
@@ -205,7 +205,7 @@ describe("tauri db lock handling", () => {
   it("recovers from a closed-pool app db handle by reopening and retrying once", async () => {
     const kv = new Map();
     const staleDb = {
-      execute: vi.fn(async (sql, args = []) => {
+      execute: vi.fn(async (sql, _args = []) => {
         if (String(sql).includes("PRAGMA busy_timeout")) {
           return { rowsAffected: 0 };
         }

--- a/tests/tauri/projectServiceAdapters.test.js
+++ b/tests/tauri/projectServiceAdapters.test.js
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  exists: vi.fn(),
+  join: vi.fn(),
+  connection: {
+    init: vi.fn(async () => {}),
+    select: vi.fn(async () => []),
+  },
+  getManagedSqliteConnection: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  mkdir: vi.fn(async () => {}),
+  writeFile: vi.fn(async () => {}),
+  exists: mocked.exists,
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  join: mocked.join,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn((value) => value),
+  invoke: vi.fn(async () => {}),
+}));
+
+vi.mock("../../src/deps/clients/tauri/sqliteConnectionManager.js", () => ({
+  getManagedSqliteConnection: mocked.getManagedSqliteConnection,
+}));
+
+vi.mock("../../src/deps/services/tauri/collabClientStore.js", () => ({
+  PROJECT_DB_NAME: "project.db",
+  createPersistedTauriProjectStore: vi.fn(),
+  evictPersistedTauriProjectStoreCache: vi.fn(async () => {}),
+  toBootstrappedCommittedEvent: vi.fn(),
+}));
+
+vi.mock(
+  "../../src/deps/services/shared/collab/createProjectCollabService.js",
+  () => ({
+    createProjectCollabService: vi.fn(),
+  }),
+);
+
+vi.mock("../../src/deps/services/shared/collab/projectorCache.js", () => ({
+  clearProjectionGap: vi.fn(),
+  saveProjectionGap: vi.fn(),
+}));
+
+vi.mock(
+  "../../src/deps/services/web/collab/createWebSocketTransport.js",
+  () => ({
+    createWebSocketTransport: vi.fn(),
+  }),
+);
+
+vi.mock("../../src/deps/services/shared/projectRepository.js", () => ({
+  applyCommandToRepository: vi.fn(),
+  assertSupportedProjectState: vi.fn(),
+  createProjectCreateRepositoryEvent: vi.fn(),
+}));
+
+vi.mock("../../src/deps/clients/web/templateLoader.js", () => ({
+  loadTemplate: vi.fn(),
+  getTemplateFiles: vi.fn(async () => []),
+}));
+
+vi.mock("../../src/internal/projectResolution.js", () => ({
+  resolveProjectResolutionForWrite: vi.fn(),
+  scaleTemplateProjectStateForResolution: vi.fn(),
+}));
+
+import { createTauriProjectServiceAdapters } from "../../src/deps/services/tauri/projectServiceAdapters.js";
+
+describe("tauri project service adapters preflight reads", () => {
+  beforeEach(() => {
+    mocked.exists.mockReset();
+    mocked.join.mockReset();
+    mocked.connection.init.mockClear();
+    mocked.connection.select.mockReset();
+    mocked.getManagedSqliteConnection.mockReset();
+
+    mocked.join.mockImplementation(async (...parts) => parts.join("/"));
+    mocked.getManagedSqliteConnection.mockReturnValue(mocked.connection);
+  });
+
+  it("reads creatorVersion from app_state without creating the project store", async () => {
+    mocked.exists.mockResolvedValue(true);
+    mocked.connection.select.mockResolvedValue([
+      {
+        value: "1",
+      },
+    ]);
+
+    const { storageAdapter } = createTauriProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+
+    const creatorVersion = await storageAdapter.readCreatorVersionByReference({
+      reference: {
+        projectPath: "/projects/dialune",
+      },
+    });
+
+    expect(creatorVersion).toBe(1);
+    expect(mocked.getManagedSqliteConnection).toHaveBeenCalledWith({
+      dbPath: "sqlite:/projects/dialune/project.db",
+      busyTimeoutMs: 15000,
+    });
+  });
+
+  it("treats missing creatorVersion metadata as project format 0", async () => {
+    mocked.exists.mockResolvedValue(true);
+    mocked.connection.select.mockResolvedValue([]);
+
+    const { storageAdapter } = createTauriProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+
+    const creatorVersion = await storageAdapter.readCreatorVersionByReference({
+      reference: {
+        projectPath: "/projects/legacy",
+      },
+    });
+
+    expect(creatorVersion).toBe(0);
+  });
+
+  it("throws a database-open error when project.db is missing", async () => {
+    mocked.exists.mockResolvedValue(false);
+
+    const { storageAdapter } = createTauriProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+
+    await expect(
+      storageAdapter.readCreatorVersionByReference({
+        reference: {
+          projectPath: "/projects/missing",
+        },
+      }),
+    ).rejects.toThrow("unable to open database file");
+    expect(mocked.getManagedSqliteConnection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- stabilize Tauri SQLite lifecycle with a shared per-path connection manager and scoped close/recovery behavior
- harden project import/open/remove flows, runtime release, and project entry rebinding for moved projects
- improve migrated-project loading, checkpoint reuse, and projects-page behavior, and rename the button label to Import

## Validation
- bunx vitest run tests/projects/projects.handlers.test.js tests/projectService/projectServiceCore.releaseRuntime.test.js tests/projectRepositoryService/projectRepositoryService.mainCheckpoint.test.js tests/tauri/db.locking.test.js tests/tauri/collabClientStore.locking.test.js
- bunx oxlint src/deps/services/tauri/projectServiceAdapters.js src/pages/projects/projects.handlers.js tests/tauri/db.locking.test.js
- bunx prettier --check src/pages/projects/projects.handlers.js src/deps/services/shared/projectRepositoryService.js tests/projects/projects.handlers.test.js src/deps/clients/tauri/db.js src/deps/clients/tauri/sqliteConnectionManager.js src/deps/services/tauri/collabClientStore.js src/pages/projects/projects.store.js src/pages/projects/projects.view.yaml
- push hook: oxlint && bun prettier --check src