### PR TITLE
Fix preview audio behavior and incremental scene loading

### DIFF
--- a/src-tauri/src/project_media_server.rs
+++ b/src-tauri/src/project_media_server.rs
@@ -1,16 +1,20 @@
+use std::sync::Arc;
+
+#[cfg(any(target_os = "macos", test))]
+use std::{fs, path::PathBuf};
+#[cfg(target_os = "macos")]
 use std::{
-    fs,
     fs::File,
     io::{Read, Seek, SeekFrom, Write},
     net::{TcpListener, TcpStream},
-    path::PathBuf,
-    sync::Arc,
     thread,
 };
 
 use tauri::State;
+#[cfg(target_os = "macos")]
 use url::Url;
 
+#[cfg(target_os = "macos")]
 const MEDIA_MIME_BY_EXTENSION: &[(&str, &str)] = &[
     (".apng", "image/apng"),
     (".png", "image/png"),
@@ -75,9 +79,7 @@ pub fn get_project_media_server_origin(
 
 fn start_project_media_server() -> Option<String> {
     #[cfg(not(target_os = "macos"))]
-    {
-        None
-    }
+    return None;
 
     #[cfg(target_os = "macos")]
     {
@@ -97,6 +99,7 @@ fn start_project_media_server() -> Option<String> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
     let request = read_request_head(&mut stream)?;
     let mut lines = request.split("\r\n");
@@ -228,6 +231,7 @@ fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
 fn read_request_head(stream: &mut TcpStream) -> std::io::Result<String> {
     let mut buffer = [0_u8; 4096];
     let mut request = Vec::new();
@@ -247,6 +251,7 @@ fn read_request_head(stream: &mut TcpStream) -> std::io::Result<String> {
     Ok(String::from_utf8_lossy(&request).into_owned())
 }
 
+#[cfg(target_os = "macos")]
 fn parse_byte_range(header: Option<&str>, file_size: u64) -> Result<Option<(u64, u64)>, ()> {
     let Some(header) = header else {
         return Ok(None);
@@ -282,6 +287,7 @@ fn parse_byte_range(header: Option<&str>, file_size: u64) -> Result<Option<(u64,
     Ok(Some((start, end.min(file_size - 1))))
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn resolve_allowed_project_file_path(path: &str) -> Option<PathBuf> {
     let canonical_path = fs::canonicalize(path).ok()?;
     if !canonical_path.is_file() {
@@ -302,6 +308,7 @@ fn resolve_allowed_project_file_path(path: &str) -> Option<PathBuf> {
         .then_some(canonical_path)
 }
 
+#[cfg(target_os = "macos")]
 fn get_media_mime_from_request_path(path: &str) -> Option<&'static str> {
     let normalized_path = path.to_ascii_lowercase();
 
@@ -310,6 +317,7 @@ fn get_media_mime_from_request_path(path: &str) -> Option<&'static str> {
         .find_map(|(extension, mime)| normalized_path.ends_with(extension).then_some(*mime))
 }
 
+#[cfg(target_os = "macos")]
 fn write_headers(
     stream: &mut TcpStream,
     status_code: u16,
@@ -340,6 +348,7 @@ fn write_headers(
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
 fn write_simple_response(
     stream: &mut TcpStream,
     status_code: u16,

--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -14,7 +14,7 @@ const openBgmGallery = ({ store, render }) => {
   render();
 };
 
-const showCurrentBgmDropdown = async (deps, event) => {
+const showCurrentBgmContextMenu = async (deps, event) => {
   const { store, render, globalUI } = deps;
   const selectedResource = store.selectSelectedResource();
 
@@ -24,19 +24,11 @@ const showCurrentBgmDropdown = async (deps, event) => {
   }
 
   const result = await globalUI.showDropdownMenu({
-    items: [
-      { type: "item", label: "Change", key: "change" },
-      { type: "item", label: "Remove", key: "remove" },
-    ],
+    items: [{ type: "item", label: "Remove", key: "remove" }],
     x: event.clientX,
     y: event.clientY,
     place: "bs",
   });
-
-  if (result?.item?.key === "change") {
-    openBgmGallery({ store, render });
-    return;
-  }
 
   if (result?.item?.key === "remove") {
     store.clearBgmAudio();
@@ -65,14 +57,15 @@ export const handleAudioWaveformRightClick = async (deps, payload) => {
   event.preventDefault();
   event.stopPropagation();
 
-  await showCurrentBgmDropdown(deps, event);
+  await showCurrentBgmContextMenu(deps, event);
 };
 
-export const handleAudioWaveformClick = async (deps, payload) => {
+export const handleAudioWaveformClick = (deps, payload) => {
+  const { store, render } = deps;
   const { _event: event } = payload;
   event.stopPropagation();
 
-  await showCurrentBgmDropdown(deps, event);
+  openBgmGallery({ store, render });
 };
 
 export const handleFormExtra = (deps, _payload) => {

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -10,11 +10,18 @@ import {
 } from "../../internal/layoutEditorElementRegistry.js";
 import { captureCanvasThumbnailImage } from "../../internal/runtime/graphicsEngineRuntime.js";
 import {
+  debugLog,
+  getDebugDurationMs,
+  getDebugNow,
+  isDebugEnabled,
+} from "../../deps/services/shared/debugLog.js";
+import {
   createLayoutEditorRenderedElements,
   loadLayoutEditorAssets,
 } from "./support/layoutEditorCanvasRender.js";
 
 const KEYBOARD_SAVE_DELAY = 1000;
+const LAYOUT_EDITOR_PERF_SCOPE = "layout-editor-perf";
 
 const KEYBOARD_UNITS = {
   NORMAL: 1,
@@ -304,9 +311,26 @@ const renderLayoutEditorCanvas = async (
     return;
   }
 
+  const perfEnabled = isDebugEnabled(LAYOUT_EDITOR_PERF_SCOPE);
+  const renderStartedAt = perfEnabled ? getDebugNow() : 0;
+  let assets = {};
+  let layoutElements = [];
+  let fileReferences = [];
+  let selectedElementMetrics;
+  let assetRetryCount = 0;
+
   try {
+    const waitUntilReadyStartedAt = perfEnabled ? getDebugNow() : 0;
     await deps.graphicsService.waitUntilReady?.();
+    const waitUntilReadyDurationMs = perfEnabled
+      ? getDebugDurationMs(waitUntilReadyStartedAt)
+      : undefined;
+
+    const repositoryStateStartedAt = perfEnabled ? getDebugNow() : 0;
     const repositoryState = await getRepositoryState(deps);
+    const repositoryStateDurationMs = perfEnabled
+      ? getDebugDurationMs(repositoryStateStartedAt)
+      : undefined;
     const layoutData = updatedItem
       ? createLayoutDataWithUpdatedItem(
           props.layoutState?.elements,
@@ -318,16 +342,23 @@ const renderLayoutEditorCanvas = async (
       layoutType: props.layoutState?.layoutType,
       elements: layoutData,
     };
-    const { elements, fileReferences, selectedElementMetrics } =
-      createLayoutEditorRenderedElements({
-        layoutState,
-        repositoryState,
-        previewData: props.previewData,
-        resolution: props.resolution,
-        selectedItemId: props.selectedItemId,
-        disableMoveDrag: props.disableMoveDrag === true,
-        graphicsService: deps.graphicsService,
-      });
+    const renderStateBuildStartedAt = perfEnabled ? getDebugNow() : 0;
+    ({
+      elements: layoutElements,
+      fileReferences,
+      selectedElementMetrics,
+    } = createLayoutEditorRenderedElements({
+      layoutState,
+      repositoryState,
+      previewData: props.previewData,
+      resolution: props.resolution,
+      selectedItemId: props.selectedItemId,
+      disableMoveDrag: props.disableMoveDrag === true,
+      graphicsService: deps.graphicsService,
+    }));
+    const renderStateBuildDurationMs = perfEnabled
+      ? getDebugDurationMs(renderStateBuildStartedAt)
+      : undefined;
 
     deps.dispatchEvent(
       new CustomEvent("selected-element-metrics-change", {
@@ -339,15 +370,21 @@ const renderLayoutEditorCanvas = async (
       }),
     );
 
+    let clearFirstDurationMs = 0;
     if (clearFirst) {
+      const clearFirstStartedAt = perfEnabled ? getDebugNow() : 0;
       deps.graphicsService.render({
         id: generatePrefixedId("layout-editor-preview-clear-"),
         elements: [],
         animations: [],
       });
+      if (perfEnabled) {
+        clearFirstDurationMs = getDebugDurationMs(clearFirstStartedAt);
+      }
     }
 
-    let assets = await loadLayoutEditorAssets({
+    const assetPreparationStartedAt = perfEnabled ? getDebugNow() : 0;
+    assets = await loadLayoutEditorAssets({
       projectService: deps.projectService,
       selectCachedFileContent: deps.store.selectCachedFileContent,
       clearCachedFileContent: deps.store.clearCachedFileContent,
@@ -355,10 +392,23 @@ const renderLayoutEditorCanvas = async (
       fileReferences,
       fontsItems: repositoryState?.fonts?.items || {},
     });
+    let assetPreparationDurationMs = perfEnabled
+      ? getDebugDurationMs(assetPreparationStartedAt)
+      : undefined;
+
+    let graphicsAssetLoadDurationMs = 0;
     try {
+      const graphicsAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
       await deps.graphicsService.loadAssets(assets);
+      if (perfEnabled) {
+        graphicsAssetLoadDurationMs = getDebugDurationMs(
+          graphicsAssetLoadStartedAt,
+        );
+      }
     } catch {
+      assetRetryCount += 1;
       deps.store.clearFileContentCache();
+      const retryAssetPreparationStartedAt = perfEnabled ? getDebugNow() : 0;
       assets = await loadLayoutEditorAssets({
         projectService: deps.projectService,
         selectCachedFileContent: deps.store.selectCachedFileContent,
@@ -367,14 +417,63 @@ const renderLayoutEditorCanvas = async (
         fileReferences,
         fontsItems: repositoryState?.fonts?.items || {},
       });
+      if (perfEnabled) {
+        assetPreparationDurationMs += getDebugDurationMs(
+          retryAssetPreparationStartedAt,
+        );
+      }
+      const retryGraphicsAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
       await deps.graphicsService.loadAssets(assets);
+      if (perfEnabled) {
+        graphicsAssetLoadDurationMs += getDebugDurationMs(
+          retryGraphicsAssetLoadStartedAt,
+        );
+      }
     }
 
+    const graphicsRenderStartedAt = perfEnabled ? getDebugNow() : 0;
     deps.graphicsService.render({
-      elements,
+      elements: layoutElements,
       animations: [],
     });
+    const graphicsRenderDurationMs = perfEnabled
+      ? getDebugDurationMs(graphicsRenderStartedAt)
+      : undefined;
+
+    if (perfEnabled) {
+      debugLog(LAYOUT_EDITOR_PERF_SCOPE, "canvas-render.complete", {
+        durationMs: getDebugDurationMs(renderStartedAt),
+        clearFirst,
+        updatedItemId: updatedItem?.id,
+        selectedItemId: props.selectedItemId,
+        waitUntilReadyDurationMs,
+        repositoryStateDurationMs,
+        renderStateBuildDurationMs,
+        clearFirstDurationMs,
+        assetPreparationDurationMs,
+        graphicsAssetLoadDurationMs,
+        graphicsRenderDurationMs,
+        elementCount: layoutElements.length,
+        fileReferenceCount: fileReferences.length,
+        assetCount: Object.keys(assets).length,
+        assetRetryCount,
+        selectedElementMetricsId: selectedElementMetrics?.id,
+      });
+    }
   } catch (error) {
+    if (perfEnabled) {
+      debugLog(LAYOUT_EDITOR_PERF_SCOPE, "canvas-render.failed", {
+        durationMs: getDebugDurationMs(renderStartedAt),
+        clearFirst,
+        updatedItemId: updatedItem?.id,
+        selectedItemId: props.selectedItemId,
+        elementCount: layoutElements.length,
+        fileReferenceCount: fileReferences.length,
+        assetCount: Object.keys(assets).length,
+        assetRetryCount,
+        error: error?.message || String(error),
+      });
+    }
     console.error("[layoutEditorCanvas] Failed to render canvas", error);
   }
 };

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -10,18 +10,11 @@ import {
 } from "../../internal/layoutEditorElementRegistry.js";
 import { captureCanvasThumbnailImage } from "../../internal/runtime/graphicsEngineRuntime.js";
 import {
-  debugLog,
-  getDebugDurationMs,
-  getDebugNow,
-  isDebugEnabled,
-} from "../../deps/services/shared/debugLog.js";
-import {
   createLayoutEditorRenderedElements,
   loadLayoutEditorAssets,
 } from "./support/layoutEditorCanvasRender.js";
 
 const KEYBOARD_SAVE_DELAY = 1000;
-const LAYOUT_EDITOR_PERF_SCOPE = "layout-editor-perf";
 
 const KEYBOARD_UNITS = {
   NORMAL: 1,
@@ -311,26 +304,9 @@ const renderLayoutEditorCanvas = async (
     return;
   }
 
-  const perfEnabled = isDebugEnabled(LAYOUT_EDITOR_PERF_SCOPE);
-  const renderStartedAt = perfEnabled ? getDebugNow() : 0;
-  let assets = {};
-  let layoutElements = [];
-  let fileReferences = [];
-  let selectedElementMetrics;
-  let assetRetryCount = 0;
-
   try {
-    const waitUntilReadyStartedAt = perfEnabled ? getDebugNow() : 0;
     await deps.graphicsService.waitUntilReady?.();
-    const waitUntilReadyDurationMs = perfEnabled
-      ? getDebugDurationMs(waitUntilReadyStartedAt)
-      : undefined;
-
-    const repositoryStateStartedAt = perfEnabled ? getDebugNow() : 0;
     const repositoryState = await getRepositoryState(deps);
-    const repositoryStateDurationMs = perfEnabled
-      ? getDebugDurationMs(repositoryStateStartedAt)
-      : undefined;
     const layoutData = updatedItem
       ? createLayoutDataWithUpdatedItem(
           props.layoutState?.elements,
@@ -342,23 +318,16 @@ const renderLayoutEditorCanvas = async (
       layoutType: props.layoutState?.layoutType,
       elements: layoutData,
     };
-    const renderStateBuildStartedAt = perfEnabled ? getDebugNow() : 0;
-    ({
-      elements: layoutElements,
-      fileReferences,
-      selectedElementMetrics,
-    } = createLayoutEditorRenderedElements({
-      layoutState,
-      repositoryState,
-      previewData: props.previewData,
-      resolution: props.resolution,
-      selectedItemId: props.selectedItemId,
-      disableMoveDrag: props.disableMoveDrag === true,
-      graphicsService: deps.graphicsService,
-    }));
-    const renderStateBuildDurationMs = perfEnabled
-      ? getDebugDurationMs(renderStateBuildStartedAt)
-      : undefined;
+    const { elements, fileReferences, selectedElementMetrics } =
+      createLayoutEditorRenderedElements({
+        layoutState,
+        repositoryState,
+        previewData: props.previewData,
+        resolution: props.resolution,
+        selectedItemId: props.selectedItemId,
+        disableMoveDrag: props.disableMoveDrag === true,
+        graphicsService: deps.graphicsService,
+      });
 
     deps.dispatchEvent(
       new CustomEvent("selected-element-metrics-change", {
@@ -370,21 +339,15 @@ const renderLayoutEditorCanvas = async (
       }),
     );
 
-    let clearFirstDurationMs = 0;
     if (clearFirst) {
-      const clearFirstStartedAt = perfEnabled ? getDebugNow() : 0;
       deps.graphicsService.render({
         id: generatePrefixedId("layout-editor-preview-clear-"),
         elements: [],
         animations: [],
       });
-      if (perfEnabled) {
-        clearFirstDurationMs = getDebugDurationMs(clearFirstStartedAt);
-      }
     }
 
-    const assetPreparationStartedAt = perfEnabled ? getDebugNow() : 0;
-    assets = await loadLayoutEditorAssets({
+    let assets = await loadLayoutEditorAssets({
       projectService: deps.projectService,
       selectCachedFileContent: deps.store.selectCachedFileContent,
       clearCachedFileContent: deps.store.clearCachedFileContent,
@@ -392,23 +355,10 @@ const renderLayoutEditorCanvas = async (
       fileReferences,
       fontsItems: repositoryState?.fonts?.items || {},
     });
-    let assetPreparationDurationMs = perfEnabled
-      ? getDebugDurationMs(assetPreparationStartedAt)
-      : undefined;
-
-    let graphicsAssetLoadDurationMs = 0;
     try {
-      const graphicsAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
       await deps.graphicsService.loadAssets(assets);
-      if (perfEnabled) {
-        graphicsAssetLoadDurationMs = getDebugDurationMs(
-          graphicsAssetLoadStartedAt,
-        );
-      }
     } catch {
-      assetRetryCount += 1;
       deps.store.clearFileContentCache();
-      const retryAssetPreparationStartedAt = perfEnabled ? getDebugNow() : 0;
       assets = await loadLayoutEditorAssets({
         projectService: deps.projectService,
         selectCachedFileContent: deps.store.selectCachedFileContent,
@@ -417,63 +367,14 @@ const renderLayoutEditorCanvas = async (
         fileReferences,
         fontsItems: repositoryState?.fonts?.items || {},
       });
-      if (perfEnabled) {
-        assetPreparationDurationMs += getDebugDurationMs(
-          retryAssetPreparationStartedAt,
-        );
-      }
-      const retryGraphicsAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
       await deps.graphicsService.loadAssets(assets);
-      if (perfEnabled) {
-        graphicsAssetLoadDurationMs += getDebugDurationMs(
-          retryGraphicsAssetLoadStartedAt,
-        );
-      }
     }
 
-    const graphicsRenderStartedAt = perfEnabled ? getDebugNow() : 0;
     deps.graphicsService.render({
-      elements: layoutElements,
+      elements,
       animations: [],
     });
-    const graphicsRenderDurationMs = perfEnabled
-      ? getDebugDurationMs(graphicsRenderStartedAt)
-      : undefined;
-
-    if (perfEnabled) {
-      debugLog(LAYOUT_EDITOR_PERF_SCOPE, "canvas-render.complete", {
-        durationMs: getDebugDurationMs(renderStartedAt),
-        clearFirst,
-        updatedItemId: updatedItem?.id,
-        selectedItemId: props.selectedItemId,
-        waitUntilReadyDurationMs,
-        repositoryStateDurationMs,
-        renderStateBuildDurationMs,
-        clearFirstDurationMs,
-        assetPreparationDurationMs,
-        graphicsAssetLoadDurationMs,
-        graphicsRenderDurationMs,
-        elementCount: layoutElements.length,
-        fileReferenceCount: fileReferences.length,
-        assetCount: Object.keys(assets).length,
-        assetRetryCount,
-        selectedElementMetricsId: selectedElementMetrics?.id,
-      });
-    }
   } catch (error) {
-    if (perfEnabled) {
-      debugLog(LAYOUT_EDITOR_PERF_SCOPE, "canvas-render.failed", {
-        durationMs: getDebugDurationMs(renderStartedAt),
-        clearFirst,
-        updatedItemId: updatedItem?.id,
-        selectedItemId: props.selectedItemId,
-        elementCount: layoutElements.length,
-        fileReferenceCount: fileReferences.length,
-        assetCount: Object.keys(assets).length,
-        assetRetryCount,
-        error: error?.message || String(error),
-      });
-    }
     console.error("[layoutEditorCanvas] Failed to render canvas", error);
   }
 };

--- a/src/components/vnPreview/support/vnPreviewProjectData.js
+++ b/src/components/vnPreview/support/vnPreviewProjectData.js
@@ -73,6 +73,20 @@ export const hasPreviewSceneLines = (projectData, sceneId) => {
   );
 };
 
+export const hasPreviewSceneEntryLines = (projectData, sceneId) => {
+  if (!sceneId) {
+    return false;
+  }
+
+  const scene = projectData?.story?.scenes?.[sceneId];
+  const initialSectionId = scene?.initialSectionId;
+  if (!initialSectionId) {
+    return false;
+  }
+
+  return hasPreviewSectionLines(projectData, initialSectionId);
+};
+
 export const hasPreviewSectionLines = (projectData, sectionId) => {
   const sceneId = resolveSceneIdForSectionId(projectData, sectionId);
   if (!sceneId) {
@@ -103,7 +117,7 @@ export const collectPreviewMissingTargets = ({
 
     if (
       !knownLoadedSceneIds.has(sceneId) ||
-      !hasPreviewSceneLines(projectData, sceneId)
+      !hasPreviewSceneEntryLines(projectData, sceneId)
     ) {
       missingSceneIds.add(sceneId);
     }
@@ -128,7 +142,7 @@ export const collectPreviewMissingTargets = ({
 
     if (
       !knownLoadedSceneIds.has(sceneId) ||
-      !hasPreviewSceneLines(projectData, sceneId)
+      !hasPreviewSceneEntryLines(projectData, sceneId)
     ) {
       missingSceneIds.add(sceneId);
     }
@@ -184,7 +198,7 @@ export const ensurePreviewProjectDataTargets = async ({
   const missingSceneIds = nextSceneIds.filter(
     (sceneId) =>
       !knownLoadedSceneIds.includes(sceneId) ||
-      !hasPreviewSceneLines(projectData, sceneId),
+      !hasPreviewSceneEntryLines(projectData, sceneId),
   );
 
   if (missingSceneIds.length === 0 && nextSectionIds.length === 0) {

--- a/src/components/vnPreview/support/vnPreviewProjectData.js
+++ b/src/components/vnPreview/support/vnPreviewProjectData.js
@@ -182,7 +182,9 @@ export const ensurePreviewProjectDataTargets = async ({
   const nextSceneIds = Array.from(new Set(sceneIds)).filter(Boolean);
   const nextSectionIds = Array.from(new Set(sectionIds)).filter(Boolean);
   const missingSceneIds = nextSceneIds.filter(
-    (sceneId) => !knownLoadedSceneIds.includes(sceneId),
+    (sceneId) =>
+      !knownLoadedSceneIds.includes(sceneId) ||
+      !hasPreviewSceneLines(projectData, sceneId),
   );
 
   if (missingSceneIds.length === 0 && nextSectionIds.length === 0) {

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -294,7 +294,7 @@ const createBeforeHandleActionsHook = (
 };
 
 export const handleBeforeMount = (deps) => {
-  const { dispatchEvent, store } = deps;
+  const { dispatchEvent, store, graphicsService } = deps;
   function handleKeyDown(event) {
     if (event.key === "Escape") {
       dispatchEvent(new CustomEvent("close"));
@@ -305,6 +305,7 @@ export const handleBeforeMount = (deps) => {
   return () => {
     store.setAssetLoading({ isLoading: false });
     resetAssetLoadCache(store);
+    void graphicsService.destroy?.();
     window.removeEventListener("keydown", handleKeyDown);
   };
 };
@@ -313,6 +314,7 @@ export const handleAfterMount = async (deps) => {
   const { projectService, graphicsService, refs, props: attrs, store } = deps;
   const repository = await projectService.ensureRepository();
   const { canvas } = refs;
+  graphicsService.setEngineAudioMuted?.(false);
 
   const sceneId = attrs.sceneId;
   const sectionId = attrs.sectionId;

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -15,6 +15,7 @@ import {
   collectSceneIdsFromValue,
   collectSectionIdsFromValue,
   ensurePreviewProjectDataTargets,
+  resolveSceneIdForSectionId,
   withPreviewEntryPoint,
 } from "./support/vnPreviewProjectData.js";
 
@@ -159,26 +160,163 @@ const preloadLayoutAssetsByIds = async (deps, projectData, layoutIds) => {
   });
 };
 
+const applyHydrationResult = (deps, runtime, hydrationResult) => {
+  if (!hydrationResult?.didLoad) {
+    return false;
+  }
+
+  runtime.projectData = hydrationResult.projectData;
+  runtime.loadedSceneIds = new Set(hydrationResult.loadedSceneIds);
+  deps.graphicsService.engineHandleActions(
+    {
+      updateProjectData: {
+        projectData: runtime.projectData,
+      },
+    },
+    undefined,
+    {
+      suppressRenderEffects: true,
+    },
+  );
+  return true;
+};
+
+const hydratePreviewTargets = async (
+  deps,
+  {
+    repository,
+    runtime,
+    sceneIds = [],
+    sectionIds = [],
+    initialSceneId,
+    initialSectionId,
+    initialLineId,
+    showLoading = false,
+  } = {},
+) => {
+  const { missingSceneIds, missingSectionIds } = collectPreviewMissingTargets({
+    projectData: runtime.projectData,
+    loadedSceneIds: Array.from(runtime.loadedSceneIds),
+    sceneIds,
+    sectionIds,
+  });
+  const hasMissingTargets =
+    missingSceneIds.length > 0 || missingSectionIds.length > 0;
+
+  if (!hasMissingTargets) {
+    return {
+      didLoad: false,
+      projectData: runtime.projectData,
+      loadedSceneIds: Array.from(runtime.loadedSceneIds),
+      missingSceneIds,
+      missingSectionIds,
+    };
+  }
+
+  if (showLoading) {
+    setAssetLoading(deps, true);
+  }
+
+  try {
+    const hydrationResult = await ensurePreviewProjectDataTargets({
+      repository,
+      projectData: runtime.projectData,
+      loadedSceneIds: Array.from(runtime.loadedSceneIds),
+      sceneIds: missingSceneIds,
+      sectionIds: missingSectionIds,
+      initialSceneId,
+      initialSectionId,
+      initialLineId,
+    });
+    applyHydrationResult(deps, runtime, hydrationResult);
+    return hydrationResult;
+  } finally {
+    if (showLoading) {
+      setAssetLoading(deps, false);
+    }
+  }
+};
+
+const selectCurrentSectionId = (systemState = {}) => {
+  const contexts = Array.isArray(systemState?.contexts)
+    ? systemState.contexts
+    : [];
+  const currentContext = contexts[contexts.length - 1];
+  const currentPointerMode = currentContext?.currentPointerMode;
+
+  if (!currentPointerMode) {
+    return undefined;
+  }
+
+  return currentContext?.pointers?.[currentPointerMode]?.sectionId;
+};
+
+const createSceneTargetPrefetcher = (
+  deps,
+  {
+    repository,
+    runtime,
+    initialSceneId,
+    initialSectionId,
+    initialLineId,
+  } = {},
+) => {
+  const prefetchedSceneIds = new Set();
+  let prefetchQueue = Promise.resolve();
+
+  return (sceneId) => {
+    if (!sceneId || prefetchedSceneIds.has(sceneId)) {
+      return;
+    }
+
+    prefetchedSceneIds.add(sceneId);
+    prefetchQueue = prefetchQueue
+      .then(async () => {
+        const transitionSceneIds = extractTransitionTargetSceneIds(
+          runtime.projectData,
+          sceneId,
+        );
+
+        if (transitionSceneIds.length === 0) {
+          return;
+        }
+
+        await hydratePreviewTargets(deps, {
+          repository,
+          runtime,
+          sceneIds: transitionSceneIds,
+          sectionIds: [],
+          initialSceneId,
+          initialSectionId,
+          initialLineId,
+          showLoading: false,
+        });
+        await loadAssetsForSceneIds(deps, runtime.projectData, transitionSceneIds, {
+          showLoading: false,
+        });
+        await preloadDirectTransitionScenes(
+          deps,
+          runtime.projectData,
+          transitionSceneIds,
+        );
+      })
+      .catch((error) => {
+        prefetchedSceneIds.delete(sceneId);
+        console.error("[vnPreview] Failed to prefetch scene targets:", error);
+      });
+  };
+};
+
 const createBeforeHandleActionsHook = (
   deps,
   {
     repository,
-    projectData,
-    loadedSceneIds: initialLoadedSceneIds = [],
+    runtime,
     sceneId,
     sectionId,
     lineId,
   } = {},
 ) => {
-  let currentProjectData = projectData;
-  let loadedSceneIds = new Set(
-    initialLoadedSceneIds.length > 0
-      ? initialLoadedSceneIds
-      : typeof sceneId === "string" && sceneId.length > 0
-        ? [sceneId]
-        : Object.keys(projectData?.story?.scenes || {}),
-  );
-
   return async (actions, eventContext) => {
     const { eventData, preparedActions, resolvedActions } =
       await prepareRuntimeInteractionExecution({
@@ -196,100 +334,56 @@ const createBeforeHandleActionsHook = (
       resolvedActions,
       eventData,
     );
-    const { missingSceneIds, missingSectionIds } = collectPreviewMissingTargets(
-      {
-        projectData: currentProjectData,
-        loadedSceneIds: Array.from(loadedSceneIds),
-        sceneIds: referencedSceneIds,
-        sectionIds: referencedSectionIds,
-      },
+
+    await hydratePreviewTargets(deps, {
+      repository,
+      runtime,
+      sceneIds: referencedSceneIds,
+      sectionIds: referencedSectionIds,
+      initialSceneId: sceneId,
+      initialSectionId: sectionId,
+      initialLineId: lineId,
+      showLoading: true,
+    });
+
+    const layoutIds = Array.from(
+      new Set([
+        ...extractLayoutIdsFromValue(resolvedActions, runtime.projectData),
+        ...extractLayoutIdsFromValue(eventData, runtime.projectData),
+      ]),
+    );
+    if (layoutIds.length > 0) {
+      await preloadLayoutAssetsByIds(deps, runtime.projectData, layoutIds);
+    }
+
+    const transitionSceneIds = Array.from(
+      new Set([
+        ...extractTransitionTargetSceneIdsFromActions(
+          resolvedActions,
+          runtime.projectData,
+        ),
+        ...extractTransitionTargetSceneIdsFromActions(
+          eventData,
+          runtime.projectData,
+        ),
+        ...extractSceneIdsFromValue(resolvedActions, runtime.projectData),
+        ...extractSceneIdsFromValue(eventData, runtime.projectData),
+      ]),
     );
 
-    const shouldShowLoading =
-      missingSceneIds.length > 0 || missingSectionIds.length > 0;
-
-    if (shouldShowLoading) {
-      setAssetLoading(deps, true);
-    }
-
-    try {
-      if (shouldShowLoading) {
-        const hydrationResult = await ensurePreviewProjectDataTargets({
-          repository,
-          projectData: currentProjectData,
-          loadedSceneIds: Array.from(loadedSceneIds),
-          sceneIds: missingSceneIds,
-          sectionIds: missingSectionIds,
-          initialSceneId: sceneId,
-          initialSectionId: sectionId,
-          initialLineId: lineId,
-        });
-
-        if (hydrationResult.didLoad) {
-          currentProjectData = hydrationResult.projectData;
-          loadedSceneIds = new Set(hydrationResult.loadedSceneIds);
-          deps.graphicsService.engineHandleActions(
-            {
-              updateProjectData: {
-                projectData: currentProjectData,
-              },
-            },
-            undefined,
-            {
-              suppressRenderEffects: true,
-            },
-          );
-        }
-      }
-
-      const layoutIds = Array.from(
-        new Set([
-          ...extractLayoutIdsFromValue(resolvedActions, currentProjectData),
-          ...extractLayoutIdsFromValue(eventData, currentProjectData),
-        ]),
-      );
-      if (layoutIds.length > 0) {
-        await preloadLayoutAssetsByIds(deps, currentProjectData, layoutIds);
-      }
-
-      const transitionSceneIds = Array.from(
-        new Set([
-          ...extractTransitionTargetSceneIdsFromActions(
-            resolvedActions,
-            currentProjectData,
-          ),
-          ...extractTransitionTargetSceneIdsFromActions(
-            eventData,
-            currentProjectData,
-          ),
-          ...extractSceneIdsFromValue(resolvedActions, currentProjectData),
-          ...extractSceneIdsFromValue(eventData, currentProjectData),
-        ]),
-      );
-
-      if (transitionSceneIds.length === 0) {
-        return preparedActions;
-      }
-
-      await loadAssetsForSceneIds(
-        deps,
-        currentProjectData,
-        transitionSceneIds,
-        {
-          showLoading: false,
-        },
-      );
-      await preloadDirectTransitionScenes(
-        deps,
-        currentProjectData,
-        transitionSceneIds,
-      );
+    if (transitionSceneIds.length === 0) {
       return preparedActions;
-    } finally {
-      if (shouldShowLoading) {
-        setAssetLoading(deps, false);
-      }
     }
+
+    await loadAssetsForSceneIds(deps, runtime.projectData, transitionSceneIds, {
+      showLoading: false,
+    });
+    await preloadDirectTransitionScenes(
+      deps,
+      runtime.projectData,
+      transitionSceneIds,
+    );
+    return preparedActions;
   };
 };
 
@@ -361,14 +455,25 @@ export const handleAfterMount = async (deps) => {
     }
   }
 
+  const runtime = {
+    projectData: projectDataWithInitial,
+    loadedSceneIds: new Set(loadedSceneIds),
+  };
   const beforeHandleActions = createBeforeHandleActionsHook(deps, {
     repository,
-    projectData: projectDataWithInitial,
-    loadedSceneIds,
+    runtime,
     sceneId,
     sectionId,
     lineId,
   });
+  const scheduleSceneTargetPrefetch = createSceneTargetPrefetcher(deps, {
+    repository,
+    runtime,
+    initialSceneId: sceneId,
+    initialSectionId: sectionId,
+    initialLineId: lineId,
+  });
+  let lastRenderedSceneId;
   const previewWidth = projectDataWithInitial?.screen?.width;
   const previewHeight = projectDataWithInitial?.screen?.height;
   store.setProjectResolution({
@@ -395,7 +500,21 @@ export const handleAfterMount = async (deps) => {
     projectDataWithInitial,
     initialSceneIds,
   );
-  await graphicsService.initRouteEngine(projectDataWithInitial, {
+  await graphicsService.initRouteEngine(runtime.projectData, {
     handleEffects: true,
+    onRenderState: ({ systemState }) => {
+      const currentSectionId = selectCurrentSectionId(systemState);
+      const currentSceneId = resolveSceneIdForSectionId(
+        runtime.projectData,
+        currentSectionId,
+      );
+
+      if (!currentSceneId || currentSceneId === lastRenderedSceneId) {
+        return;
+      }
+
+      lastRenderedSceneId = currentSceneId;
+      scheduleSceneTargetPrefetch(currentSceneId);
+    },
   });
 };

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -253,13 +253,7 @@ const selectCurrentSectionId = (systemState = {}) => {
 
 const createSceneTargetPrefetcher = (
   deps,
-  {
-    repository,
-    runtime,
-    initialSceneId,
-    initialSectionId,
-    initialLineId,
-  } = {},
+  { repository, runtime, initialSceneId, initialSectionId, initialLineId } = {},
 ) => {
   const prefetchedSceneIds = new Set();
   let prefetchQueue = Promise.resolve();
@@ -291,9 +285,14 @@ const createSceneTargetPrefetcher = (
           initialLineId,
           showLoading: false,
         });
-        await loadAssetsForSceneIds(deps, runtime.projectData, transitionSceneIds, {
-          showLoading: false,
-        });
+        await loadAssetsForSceneIds(
+          deps,
+          runtime.projectData,
+          transitionSceneIds,
+          {
+            showLoading: false,
+          },
+        );
         await preloadDirectTransitionScenes(
           deps,
           runtime.projectData,
@@ -309,13 +308,7 @@ const createSceneTargetPrefetcher = (
 
 const createBeforeHandleActionsHook = (
   deps,
-  {
-    repository,
-    runtime,
-    sceneId,
-    sectionId,
-    lineId,
-  } = {},
+  { repository, runtime, sceneId, sectionId, lineId } = {},
 ) => {
   return async (actions, eventContext) => {
     const { eventData, preparedActions, resolvedActions } =

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -1039,9 +1039,7 @@ export const createGraphicsService = async ({
     let missingAudioKeys = [];
 
     if (allowDeferredAudio && !effectiveSkipAudio) {
-      const splitAudio = splitRenderableAudio(
-        nextRenderState.audio,
-      );
+      const splitAudio = splitRenderableAudio(nextRenderState.audio);
       const { renderableAudio } = splitAudio;
       missingAudioKeys = splitAudio.missingAudioKeys;
 

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -360,6 +360,7 @@ export const createGraphicsService = async ({
   let deferredAudioRenderToken = 0;
   let deferredAudioRenderKeySignature = "";
   let suppressedEngineRenderEffects = 0;
+  let isEngineAudioMuted = false;
 
   const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
 
@@ -429,6 +430,19 @@ export const createGraphicsService = async ({
   const invalidateDeferredAudioRender = () => {
     deferredAudioRenderToken += 1;
     deferredAudioRenderKeySignature = "";
+  };
+
+  const setEngineAudioMuted = (value) => {
+    const nextIsMuted = value === true;
+
+    if (isEngineAudioMuted === nextIsMuted) {
+      return;
+    }
+
+    isEngineAudioMuted = nextIsMuted;
+    if (nextIsMuted) {
+      invalidateDeferredAudioRender();
+    }
   };
 
   const getRenderStateAudioKeys = (renderState) => {
@@ -1001,18 +1015,35 @@ export const createGraphicsService = async ({
   };
 
   const renderEngineState = (renderState, options = {}) => {
-    const { allowDeferredAudio = true } = options;
+    const { allowDeferredAudio = true, skipAudio = false } = options;
     let nextRenderState = prepareRenderStateKeyboardForGraphics({
       renderState,
       enableGlobalKeyboardBindings,
     });
+    const effectiveSkipAudio = skipAudio || isEngineAudioMuted;
+
+    if (
+      effectiveSkipAudio &&
+      Array.isArray(nextRenderState?.audio) &&
+      nextRenderState.audio.length > 0
+    ) {
+      invalidateDeferredAudioRender();
+      nextRenderState = {
+        ...nextRenderState,
+        audio: [],
+      };
+    }
+
     const requestedAudioKeys = getRenderStateAudioKeys(nextRenderState);
     let retainedAudioKeys = requestedAudioKeys;
+    let missingAudioKeys = [];
 
-    if (allowDeferredAudio) {
-      const { renderableAudio, missingAudioKeys } = splitRenderableAudio(
+    if (allowDeferredAudio && !effectiveSkipAudio) {
+      const splitAudio = splitRenderableAudio(
         nextRenderState.audio,
       );
+      const { renderableAudio } = splitAudio;
+      missingAudioKeys = splitAudio.missingAudioKeys;
 
       if (missingAudioKeys.length > 0) {
         nextRenderState = {
@@ -1432,13 +1463,8 @@ export const createGraphicsService = async ({
         return;
       }
       const { skipAudio = false, skipAnimations = false } = options;
-      if (skipAudio) {
-        invalidateDeferredAudioRender();
-      }
+      const effectiveSkipAudio = skipAudio || isEngineAudioMuted;
       let renderState = engine.selectRenderState();
-      if (skipAudio) {
-        renderState = { ...renderState, audio: [] };
-      }
       if (skipAnimations) {
         renderState = {
           ...renderState,
@@ -1446,7 +1472,9 @@ export const createGraphicsService = async ({
           elements: disableTextRevealingEffects(renderState?.elements),
         };
       }
-      renderEngineState(renderState);
+      renderEngineState(renderState, {
+        skipAudio: effectiveSkipAudio,
+      });
     },
 
     engineHandleActions: (actions, eventContext, options = {}) => {
@@ -1460,6 +1488,7 @@ export const createGraphicsService = async ({
       }
       engine.handleActions(actions, eventContext);
     },
+    setEngineAudioMuted,
 
     setAnimationPlaybackMode: (mode) => {
       routeGraphics?.setAnimationPlaybackMode?.(mode);

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -13,12 +13,6 @@ import {
   loadGraphicsEnginePlugins,
 } from "../../internal/runtime/graphicsEngineRuntime.js";
 import { requireProjectResolution } from "../../internal/projectResolution.js";
-import {
-  debugLog,
-  getDebugDurationMs,
-  getDebugNow,
-  isDebugEnabled,
-} from "./shared/debugLog.js";
 
 const cloneBufferForAudioDecode = (value) => {
   if (value instanceof ArrayBuffer) {
@@ -75,7 +69,6 @@ const PIXI_EXTENSION_BY_MIME_TYPE = {
   "image/webp": "webp",
   "video/mp4": "mp4",
 };
-const GRAPHICS_PERF_SCOPE = "graphics-perf";
 
 const isTauriAssetUrl = (url) => {
   return (
@@ -898,8 +891,6 @@ export const createGraphicsService = async ({
       return;
     }
 
-    const perfEnabled = isDebugEnabled(GRAPHICS_PERF_SCOPE);
-    const loadStartedAt = perfEnabled ? getDebugNow() : 0;
     const normalizedAssetEntries = Object.entries(assets || {}).map(
       ([key, asset]) => [
         key,
@@ -939,14 +930,9 @@ export const createGraphicsService = async ({
       .map(([, asset]) => asset?.url)
       .filter(isBlobUrl);
 
-    let bufferLoadDurationMs = 0;
     try {
       if (bufferedAssetEntries.length > 0) {
-        const bufferLoadStartedAt = perfEnabled ? getDebugNow() : 0;
         await loadBuffersWithRetry(activeBufferManager, bufferedAssets);
-        if (perfEnabled) {
-          bufferLoadDurationMs = getDebugDurationMs(bufferLoadStartedAt);
-        }
       }
     } finally {
       blobUrlsToRevoke.forEach((url) => {
@@ -981,56 +967,25 @@ export const createGraphicsService = async ({
     );
     const renderAssetBufferMap = Object.fromEntries(renderAssetEntries);
 
-    let routeGraphicsAssetLoadDurationMs = 0;
     if (Object.keys(renderAssetBufferMap).length > 0) {
       if (!routeGraphics) {
         return;
       }
-      const routeGraphicsAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
       await routeGraphics.loadAssets(renderAssetBufferMap);
-      if (perfEnabled) {
-        routeGraphicsAssetLoadDurationMs = getDebugDurationMs(
-          routeGraphicsAssetLoadStartedAt,
-        );
-      }
     }
 
     newAssetEntries.forEach(([key, asset]) => {
       loadedAssetTypes.set(key, classifyAsset(asset?.type));
     });
-
-    if (perfEnabled) {
-      debugLog(GRAPHICS_PERF_SCOPE, "assets.load.complete", {
-        durationMs: getDebugDurationMs(loadStartedAt),
-        requestedAssetCount: normalizedAssetEntries.length,
-        newAssetCount: newAssetEntries.length,
-        bufferedAssetCount: bufferedAssetEntries.length,
-        dataUrlAssetCount: dataUrlAssetEntries.length,
-        renderAssetCount: renderAssetEntries.length,
-        audioAssetCount:
-          Object.keys(deltaBufferMap).length - renderAssetEntries.length,
-        bufferLoadDurationMs,
-        routeGraphicsAssetLoadDurationMs,
-      });
-    }
   };
 
   const runInteractionActions = async (actions, eventContext) => {
-    const perfEnabled = isDebugEnabled(GRAPHICS_PERF_SCOPE);
-    const interactionStartedAt = perfEnabled ? getDebugNow() : 0;
     let nextActions = actions;
-    let beforeHandleActionsDurationMs = 0;
 
     if (beforeHandleActions) {
-      const beforeHandleActionsStartedAt = perfEnabled ? getDebugNow() : 0;
       const preparedActions = await beforeHandleActions(actions, eventContext);
       if (preparedActions !== undefined) {
         nextActions = preparedActions;
-      }
-      if (perfEnabled) {
-        beforeHandleActionsDurationMs = getDebugDurationMs(
-          beforeHandleActionsStartedAt,
-        );
       }
     }
 
@@ -1038,21 +993,7 @@ export const createGraphicsService = async ({
       return;
     }
 
-    const engineHandleActionsStartedAt = perfEnabled ? getDebugNow() : 0;
     engine.handleActions(nextActions, eventContext);
-    const engineHandleActionsDurationMs = perfEnabled
-      ? getDebugDurationMs(engineHandleActionsStartedAt)
-      : undefined;
-    if (perfEnabled) {
-      debugLog(GRAPHICS_PERF_SCOPE, "interaction-actions.complete", {
-        durationMs: getDebugDurationMs(interactionStartedAt),
-        beforeHandleActionsDurationMs,
-        engineHandleActionsDurationMs,
-        actionKeys: Object.keys(nextActions || {}),
-        eventId: eventContext?._event?.id,
-        eventType: eventContext?._event?.type,
-      });
-    }
     return {
       actions: nextActions,
       eventContext,
@@ -1060,8 +1001,6 @@ export const createGraphicsService = async ({
   };
 
   const renderEngineState = (renderState, options = {}) => {
-    const perfEnabled = isDebugEnabled(GRAPHICS_PERF_SCOPE);
-    const renderStartedAt = perfEnabled ? getDebugNow() : 0;
     const { allowDeferredAudio = true } = options;
     let nextRenderState = prepareRenderStateKeyboardForGraphics({
       renderState,
@@ -1069,13 +1008,11 @@ export const createGraphicsService = async ({
     });
     const requestedAudioKeys = getRenderStateAudioKeys(nextRenderState);
     let retainedAudioKeys = requestedAudioKeys;
-    let missingAudioCount = 0;
 
     if (allowDeferredAudio) {
       const { renderableAudio, missingAudioKeys } = splitRenderableAudio(
         nextRenderState.audio,
       );
-      missingAudioCount = missingAudioKeys.length;
 
       if (missingAudioKeys.length > 0) {
         nextRenderState = {
@@ -1091,37 +1028,9 @@ export const createGraphicsService = async ({
       ...nextRenderState,
       animations: nextRenderState?.animations || [],
     };
-    const routeGraphicsRenderStartedAt = perfEnabled ? getDebugNow() : 0;
     routeGraphics.render(nextRenderState);
-    const routeGraphicsRenderDurationMs = perfEnabled
-      ? getDebugDurationMs(routeGraphicsRenderStartedAt)
-      : undefined;
-    const hitAreaStartedAt = perfEnabled ? getDebugNow() : 0;
     applyInteractiveContainerHitAreas(nextRenderState.elements);
-    const hitAreaDurationMs = perfEnabled
-      ? getDebugDurationMs(hitAreaStartedAt)
-      : undefined;
     void pruneDecodedAudioCache(retainedAudioKeys);
-    if (perfEnabled) {
-      debugLog(GRAPHICS_PERF_SCOPE, "render-engine-state.complete", {
-        durationMs: getDebugDurationMs(renderStartedAt),
-        allowDeferredAudio,
-        routeGraphicsRenderDurationMs,
-        hitAreaDurationMs,
-        elementCount: Array.isArray(nextRenderState?.elements)
-          ? nextRenderState.elements.length
-          : 0,
-        animationCount: Array.isArray(nextRenderState?.animations)
-          ? nextRenderState.animations.length
-          : 0,
-        audioCount: Array.isArray(nextRenderState?.audio)
-          ? nextRenderState.audio.length
-          : 0,
-        requestedAudioCount: requestedAudioKeys.length,
-        retainedAudioCount: retainedAudioKeys.length,
-        missingAudioCount,
-      });
-    }
   };
 
   const disableTextRevealingEffects = (elements = []) => {

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -1382,6 +1382,10 @@ export const createGraphicsService = async ({
       enableGlobalKeyboardBindings =
         options.enableGlobalKeyboardBindings ?? true;
       const suppressRenderEffects = options.suppressRenderEffects === true;
+      const onRenderState =
+        typeof options.onRenderState === "function"
+          ? options.onRenderState
+          : undefined;
       const initialGlobal = options.initialGlobal ?? {};
       const namespace =
         typeof options.namespace === "string" && options.namespace.length > 0
@@ -1401,6 +1405,10 @@ export const createGraphicsService = async ({
               return;
             }
             renderEngineState(renderState);
+            onRenderState?.({
+              renderState,
+              systemState: engine?.selectSystemState?.(),
+            });
           },
         },
         namespace,

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -13,6 +13,12 @@ import {
   loadGraphicsEnginePlugins,
 } from "../../internal/runtime/graphicsEngineRuntime.js";
 import { requireProjectResolution } from "../../internal/projectResolution.js";
+import {
+  debugLog,
+  getDebugDurationMs,
+  getDebugNow,
+  isDebugEnabled,
+} from "./shared/debugLog.js";
 
 const cloneBufferForAudioDecode = (value) => {
   if (value instanceof ArrayBuffer) {
@@ -69,6 +75,7 @@ const PIXI_EXTENSION_BY_MIME_TYPE = {
   "image/webp": "webp",
   "video/mp4": "mp4",
 };
+const GRAPHICS_PERF_SCOPE = "graphics-perf";
 
 const isTauriAssetUrl = (url) => {
   return (
@@ -891,6 +898,8 @@ export const createGraphicsService = async ({
       return;
     }
 
+    const perfEnabled = isDebugEnabled(GRAPHICS_PERF_SCOPE);
+    const loadStartedAt = perfEnabled ? getDebugNow() : 0;
     const normalizedAssetEntries = Object.entries(assets || {}).map(
       ([key, asset]) => [
         key,
@@ -930,9 +939,14 @@ export const createGraphicsService = async ({
       .map(([, asset]) => asset?.url)
       .filter(isBlobUrl);
 
+    let bufferLoadDurationMs = 0;
     try {
       if (bufferedAssetEntries.length > 0) {
+        const bufferLoadStartedAt = perfEnabled ? getDebugNow() : 0;
         await loadBuffersWithRetry(activeBufferManager, bufferedAssets);
+        if (perfEnabled) {
+          bufferLoadDurationMs = getDebugDurationMs(bufferLoadStartedAt);
+        }
       }
     } finally {
       blobUrlsToRevoke.forEach((url) => {
@@ -967,25 +981,56 @@ export const createGraphicsService = async ({
     );
     const renderAssetBufferMap = Object.fromEntries(renderAssetEntries);
 
+    let routeGraphicsAssetLoadDurationMs = 0;
     if (Object.keys(renderAssetBufferMap).length > 0) {
       if (!routeGraphics) {
         return;
       }
+      const routeGraphicsAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
       await routeGraphics.loadAssets(renderAssetBufferMap);
+      if (perfEnabled) {
+        routeGraphicsAssetLoadDurationMs = getDebugDurationMs(
+          routeGraphicsAssetLoadStartedAt,
+        );
+      }
     }
 
     newAssetEntries.forEach(([key, asset]) => {
       loadedAssetTypes.set(key, classifyAsset(asset?.type));
     });
+
+    if (perfEnabled) {
+      debugLog(GRAPHICS_PERF_SCOPE, "assets.load.complete", {
+        durationMs: getDebugDurationMs(loadStartedAt),
+        requestedAssetCount: normalizedAssetEntries.length,
+        newAssetCount: newAssetEntries.length,
+        bufferedAssetCount: bufferedAssetEntries.length,
+        dataUrlAssetCount: dataUrlAssetEntries.length,
+        renderAssetCount: renderAssetEntries.length,
+        audioAssetCount:
+          Object.keys(deltaBufferMap).length - renderAssetEntries.length,
+        bufferLoadDurationMs,
+        routeGraphicsAssetLoadDurationMs,
+      });
+    }
   };
 
   const runInteractionActions = async (actions, eventContext) => {
+    const perfEnabled = isDebugEnabled(GRAPHICS_PERF_SCOPE);
+    const interactionStartedAt = perfEnabled ? getDebugNow() : 0;
     let nextActions = actions;
+    let beforeHandleActionsDurationMs = 0;
 
     if (beforeHandleActions) {
+      const beforeHandleActionsStartedAt = perfEnabled ? getDebugNow() : 0;
       const preparedActions = await beforeHandleActions(actions, eventContext);
       if (preparedActions !== undefined) {
         nextActions = preparedActions;
+      }
+      if (perfEnabled) {
+        beforeHandleActionsDurationMs = getDebugDurationMs(
+          beforeHandleActionsStartedAt,
+        );
       }
     }
 
@@ -993,7 +1038,21 @@ export const createGraphicsService = async ({
       return;
     }
 
+    const engineHandleActionsStartedAt = perfEnabled ? getDebugNow() : 0;
     engine.handleActions(nextActions, eventContext);
+    const engineHandleActionsDurationMs = perfEnabled
+      ? getDebugDurationMs(engineHandleActionsStartedAt)
+      : undefined;
+    if (perfEnabled) {
+      debugLog(GRAPHICS_PERF_SCOPE, "interaction-actions.complete", {
+        durationMs: getDebugDurationMs(interactionStartedAt),
+        beforeHandleActionsDurationMs,
+        engineHandleActionsDurationMs,
+        actionKeys: Object.keys(nextActions || {}),
+        eventId: eventContext?._event?.id,
+        eventType: eventContext?._event?.type,
+      });
+    }
     return {
       actions: nextActions,
       eventContext,
@@ -1001,6 +1060,8 @@ export const createGraphicsService = async ({
   };
 
   const renderEngineState = (renderState, options = {}) => {
+    const perfEnabled = isDebugEnabled(GRAPHICS_PERF_SCOPE);
+    const renderStartedAt = perfEnabled ? getDebugNow() : 0;
     const { allowDeferredAudio = true } = options;
     let nextRenderState = prepareRenderStateKeyboardForGraphics({
       renderState,
@@ -1008,11 +1069,13 @@ export const createGraphicsService = async ({
     });
     const requestedAudioKeys = getRenderStateAudioKeys(nextRenderState);
     let retainedAudioKeys = requestedAudioKeys;
+    let missingAudioCount = 0;
 
     if (allowDeferredAudio) {
       const { renderableAudio, missingAudioKeys } = splitRenderableAudio(
         nextRenderState.audio,
       );
+      missingAudioCount = missingAudioKeys.length;
 
       if (missingAudioKeys.length > 0) {
         nextRenderState = {
@@ -1028,9 +1091,37 @@ export const createGraphicsService = async ({
       ...nextRenderState,
       animations: nextRenderState?.animations || [],
     };
+    const routeGraphicsRenderStartedAt = perfEnabled ? getDebugNow() : 0;
     routeGraphics.render(nextRenderState);
+    const routeGraphicsRenderDurationMs = perfEnabled
+      ? getDebugDurationMs(routeGraphicsRenderStartedAt)
+      : undefined;
+    const hitAreaStartedAt = perfEnabled ? getDebugNow() : 0;
     applyInteractiveContainerHitAreas(nextRenderState.elements);
+    const hitAreaDurationMs = perfEnabled
+      ? getDebugDurationMs(hitAreaStartedAt)
+      : undefined;
     void pruneDecodedAudioCache(retainedAudioKeys);
+    if (perfEnabled) {
+      debugLog(GRAPHICS_PERF_SCOPE, "render-engine-state.complete", {
+        durationMs: getDebugDurationMs(renderStartedAt),
+        allowDeferredAudio,
+        routeGraphicsRenderDurationMs,
+        hitAreaDurationMs,
+        elementCount: Array.isArray(nextRenderState?.elements)
+          ? nextRenderState.elements.length
+          : 0,
+        animationCount: Array.isArray(nextRenderState?.animations)
+          ? nextRenderState.animations.length
+          : 0,
+        audioCount: Array.isArray(nextRenderState?.audio)
+          ? nextRenderState.audio.length
+          : 0,
+        requestedAudioCount: requestedAudioKeys.length,
+        retainedAudioCount: retainedAudioKeys.length,
+        missingAudioCount,
+      });
+    }
   };
 
   const disableTextRevealingEffects = (elements = []) => {

--- a/src/deps/services/shared/debugLog.js
+++ b/src/deps/services/shared/debugLog.js
@@ -28,6 +28,21 @@ export const previewDebugText = (value, maxLength = 120) => {
   return `${text.slice(0, maxLength)}...`;
 };
 
+export const getDebugNow = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+export const getDebugDurationMs = (startedAt) => {
+  return Number((getDebugNow() - startedAt).toFixed(2));
+};
+
 export const debugLog = (scope, event, data = {}) => {
   if (!isDebugEnabled(scope)) {
     return;
@@ -36,7 +51,7 @@ export const debugLog = (scope, event, data = {}) => {
   debugSequence += 1;
   const timestamp =
     typeof performance !== "undefined" && typeof performance.now === "function"
-      ? Number(performance.now().toFixed(2))
+      ? Number(getDebugNow().toFixed(2))
       : Date.now();
 
   console.log(`[rvn.debug.${scope}]`, {

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -14,7 +14,15 @@ import {
   summarizeProjectDataForRouteEngine,
 } from "../../project/routeEngineProjectData.js";
 import { prepareRuntimeInteractionExecution } from "../../runtime/graphicsEngineRuntime.js";
+import {
+  debugLog,
+  getDebugDurationMs,
+  getDebugNow,
+  isDebugEnabled,
+} from "../../../deps/services/shared/debugLog.js";
+
 const NO_PENDING_CANVAS_RENDER = Symbol("no-pending-canvas-render");
+const SCENE_EDITOR_PERF_SCOPE = "scene-editor-perf";
 
 const waitForNextFrame = () =>
   new Promise((resolve) => {
@@ -515,25 +523,52 @@ const initRouteEngineWithDiagnostics = (
 export const renderSceneEditorState = async (deps, payload = {}) => {
   const { store, graphicsService } = deps;
   const { skipAnimations = false, skipCanvasPaint = false } = payload;
+  const perfEnabled = isDebugEnabled(SCENE_EDITOR_PERF_SCOPE);
+  const renderStartedAt = perfEnabled ? getDebugNow() : 0;
   const sceneId = store.selectSceneId();
   const sectionId = store.selectSelectedSectionId();
   const lineId = store.selectSelectedLineId();
+  const projectDataProjectionStartedAt = perfEnabled ? getDebugNow() : 0;
+  const projectedProjectData = store.selectProjectData();
+  const projectDataProjectionDurationMs = perfEnabled
+    ? getDebugDurationMs(projectDataProjectionStartedAt)
+    : undefined;
+  const projectDataSelectionStartedAt = perfEnabled ? getDebugNow() : 0;
   const projectData = createProjectDataWithSelectedEntryPoint(
-    store.selectProjectData(),
+    projectedProjectData,
     {
       sceneId,
       sectionId,
       lineId,
     },
   );
+  const projectDataSelectionDurationMs = perfEnabled
+    ? getDebugDurationMs(projectDataSelectionStartedAt)
+    : undefined;
   const isMuted = store.selectIsMuted();
 
+  const engineInitStartedAt = perfEnabled ? getDebugNow() : 0;
   initRouteEngineWithDiagnostics(graphicsService, projectData, {
     enableGlobalKeyboardBindings: false,
     suppressRenderEffects: true,
   });
+  const engineInitDurationMs = perfEnabled
+    ? getDebugDurationMs(engineInitStartedAt)
+    : undefined;
+  const renderStateSelectStartedAt = perfEnabled ? getDebugNow() : 0;
   const currentRenderState = graphicsService.engineSelectRenderState();
+  const renderStateSelectDurationMs = perfEnabled
+    ? getDebugDurationMs(renderStateSelectStartedAt)
+    : undefined;
   if (!currentRenderState) {
+    if (perfEnabled) {
+      debugLog(SCENE_EDITOR_PERF_SCOPE, "render-state.missing-render-state", {
+        durationMs: getDebugDurationMs(renderStartedAt),
+        sceneId,
+        sectionId,
+        lineId,
+      });
+    }
     return;
   }
 
@@ -543,14 +578,25 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
       : (currentRenderState.audio || [])
           .map((audioElement) => audioElement?.src)
           .filter(Boolean);
+  const audioLoadStartedAt = perfEnabled ? getDebugNow() : 0;
   await graphicsService.ensureAudioAssetsLoaded(activeAudioFileIds);
+  const audioLoadDurationMs = perfEnabled
+    ? getDebugDurationMs(audioLoadStartedAt)
+    : undefined;
 
+  let canvasPaintDurationMs = 0;
   if (!skipCanvasPaint) {
+    const canvasPaintStartedAt = perfEnabled ? getDebugNow() : 0;
     graphicsService.engineRenderCurrentState({
       skipAudio: isMuted,
       skipAnimations,
     });
+    if (perfEnabled) {
+      canvasPaintDurationMs = getDebugDurationMs(canvasPaintStartedAt);
+    }
   }
+
+  const nextLineConfigStartedAt = perfEnabled ? getDebugNow() : 0;
   graphicsService.engineHandleActions(
     {
       setNextLineConfig: {
@@ -564,11 +610,47 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
       suppressRenderEffects: true,
     },
   );
+  const nextLineConfigDurationMs = perfEnabled
+    ? getDebugDurationMs(nextLineConfigStartedAt)
+    : undefined;
 
+  const presentationStateStartedAt = perfEnabled ? getDebugNow() : 0;
   const presentationState = graphicsService.engineSelectPresentationState();
   store.setPresentationState({
     presentationState,
   });
+  const presentationStateDurationMs = perfEnabled
+    ? getDebugDurationMs(presentationStateStartedAt)
+    : undefined;
+
+  if (perfEnabled) {
+    debugLog(SCENE_EDITOR_PERF_SCOPE, "render-state.complete", {
+      durationMs: getDebugDurationMs(renderStartedAt),
+      sceneId,
+      sectionId,
+      lineId,
+      skipAnimations,
+      skipCanvasPaint,
+      isMuted,
+      projectDataProjectionDurationMs,
+      projectDataSelectionDurationMs,
+      engineInitDurationMs,
+      renderStateSelectDurationMs,
+      audioLoadDurationMs,
+      canvasPaintDurationMs,
+      nextLineConfigDurationMs,
+      presentationStateDurationMs,
+      elementCount: Array.isArray(currentRenderState?.elements)
+        ? currentRenderState.elements.length
+        : 0,
+      animationCount: Array.isArray(currentRenderState?.animations)
+        ? currentRenderState.animations.length
+        : 0,
+      audioCount: Array.isArray(currentRenderState?.audio)
+        ? currentRenderState.audio.length
+        : 0,
+    });
+  }
 };
 
 export const updateSceneEditorSectionChanges = async (deps) => {
@@ -722,6 +804,8 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
     return;
   }
 
+  const perfEnabled = isDebugEnabled(SCENE_EDITOR_PERF_SCOPE);
+  const renderStartedAt = perfEnabled ? getDebugNow() : 0;
   const sceneId = store.selectSceneId();
   const sectionId = store.selectSelectedSectionId();
   const lineId = store.selectSelectedLineId();
@@ -735,16 +819,50 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
   );
   const sceneIdsToLoad = extractInitialHybridSceneIds(projectData, sceneId);
 
+  const sceneAssetLoadStartedAt = perfEnabled ? getDebugNow() : 0;
   await loadAssetsForSceneIds(deps, projectData, sceneIdsToLoad, {
     showLoading: false,
   });
+  const sceneAssetLoadDurationMs = perfEnabled
+    ? getDebugDurationMs(sceneAssetLoadStartedAt)
+    : undefined;
   void preloadDirectTransitionScenes(deps, projectData, sceneIdsToLoad);
 
+  const renderSceneStateStartedAt = perfEnabled ? getDebugNow() : 0;
   await renderSceneEditorState(deps, payload);
+  const renderSceneStateDurationMs = perfEnabled
+    ? getDebugDurationMs(renderSceneStateStartedAt)
+    : undefined;
+  const sectionChangesStartedAt = perfEnabled ? getDebugNow() : 0;
   await updateSceneEditorSectionChanges(deps);
+  const sectionChangesDurationMs = perfEnabled
+    ? getDebugDurationMs(sectionChangesStartedAt)
+    : undefined;
 
+  let uiRenderDurationMs = 0;
   if (!payload?.skipRender) {
+    const uiRenderStartedAt = perfEnabled ? getDebugNow() : 0;
     render();
+    if (perfEnabled) {
+      uiRenderDurationMs = getDebugDurationMs(uiRenderStartedAt);
+    }
+  }
+
+  if (perfEnabled) {
+    debugLog(SCENE_EDITOR_PERF_SCOPE, "render-canvas.complete", {
+      durationMs: getDebugDurationMs(renderStartedAt),
+      sceneId,
+      sectionId,
+      lineId,
+      skipRender: payload?.skipRender === true,
+      skipAnimations: payload?.skipAnimations === true,
+      skipCanvasPaint: payload?.skipCanvasPaint === true,
+      sceneAssetLoadDurationMs,
+      renderSceneStateDurationMs,
+      sectionChangesDurationMs,
+      uiRenderDurationMs,
+      sceneIdsToLoad,
+    });
   }
 };
 

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -546,6 +546,7 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     ? getDebugDurationMs(projectDataSelectionStartedAt)
     : undefined;
   const isMuted = store.selectIsMuted();
+  graphicsService.setEngineAudioMuted?.(isMuted);
 
   const engineInitStartedAt = perfEnabled ? getDebugNow() : 0;
   initRouteEngineWithDiagnostics(graphicsService, projectData, {

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -46,6 +46,7 @@ const STRUCTURE_DRAFT_SAVE_DEBOUNCE_MS = 900;
 const DRAFT_SAVE_MIN_INTERVAL_MS = 1000;
 const DRAFT_SAVE_MAX_INTERVAL_MS = 3000;
 const SHOW_LINE_NUMBERS_CONFIG_KEY = "sceneEditor.showLineNumbers";
+const IS_MUTED_CONFIG_KEY = "sceneEditor.isMuted";
 const nowMs = () => {
   if (
     typeof performance !== "undefined" &&
@@ -404,8 +405,10 @@ export const handleBeforeMount = (deps) => {
   store.setScenePageLoading({ isLoading: true });
   const showLineNumbers =
     appService.getUserConfig(SHOW_LINE_NUMBERS_CONFIG_KEY) ?? true;
+  const isMuted = appService.getUserConfig(IS_MUTED_CONFIG_KEY) ?? false;
   store.setSceneSettings({
     showLineNumbers,
+    isMuted,
   });
 
   const cleanupRuntimeSubscriptions = mountSceneEditorSubscriptions(deps);
@@ -1271,7 +1274,7 @@ export const handleSceneSettingsDialogClose = (deps) => {
 };
 
 export const handleSceneSettingsFormAction = (deps, payload) => {
-  const { store, render, appService, refs } = deps;
+  const { store, render, appService, refs, subject } = deps;
   const detail = payload._event.detail || {};
   const action = detail.actionId;
 
@@ -1285,17 +1288,25 @@ export const handleSceneSettingsFormAction = (deps, payload) => {
     return;
   }
 
+  const previousIsMuted = store.selectIsMuted();
   const showLineNumbers = detail.values?.showLineNumbers ?? true;
+  const isMuted = detail.values?.isMuted ?? false;
   store.setSceneSettings({
     showLineNumbers,
+    isMuted,
   });
   appService.setUserConfig(SHOW_LINE_NUMBERS_CONFIG_KEY, showLineNumbers);
+  appService.setUserConfig(IS_MUTED_CONFIG_KEY, isMuted);
   store.hideSceneSettingsDialog();
   render();
 
   requestAnimationFrame(() => {
     refs.linesEditor?.hardRefresh?.();
   });
+
+  if (previousIsMuted !== isMuted) {
+    subject.dispatch("sceneEditor.renderCanvas", {});
+  }
 };
 
 export const handleSectionCreateFormActionClick = async (deps, payload) => {
@@ -1624,13 +1635,5 @@ export const handleSystemActionsActionDelete = async (deps, payload) => {
   // Trigger re-render
   render();
 
-  subject.dispatch("sceneEditor.renderCanvas", {});
-};
-
-export const handleMuteToggle = (deps) => {
-  const { store, render, subject } = deps;
-  store.toggleMute();
-  render();
-  // Re-render canvas with new mute state
   subject.dispatch("sceneEditor.renderCanvas", {});
 };

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -268,6 +268,7 @@ export const createInitialState = () => ({
     formKey: 0,
     defaultValues: {
       showLineNumbers: true,
+      isMuted: false,
     },
   },
   repositoryState: {},
@@ -758,6 +759,7 @@ export const showSceneSettingsDialog = ({ state }, _payload = {}) => {
   state.sceneSettingsDialog.formKey += 1;
   state.sceneSettingsDialog.defaultValues = {
     showLineNumbers: state.sceneSettings.showLineNumbers,
+    isMuted: state.isMuted,
   };
 };
 
@@ -765,8 +767,13 @@ export const hideSceneSettingsDialog = ({ state }, _payload = {}) => {
   state.sceneSettingsDialog.isOpen = false;
 };
 
-export const setSceneSettings = ({ state }, { showLineNumbers } = {}) => {
-  state.sceneSettings.showLineNumbers = showLineNumbers ?? true;
+export const setSceneSettings = (
+  { state },
+  { showLineNumbers, isMuted } = {},
+) => {
+  state.sceneSettings.showLineNumbers =
+    showLineNumbers ?? state.sceneSettings.showLineNumbers;
+  state.isMuted = isMuted ?? state.isMuted;
 };
 
 export const selectProjectData = ({ state }) => {
@@ -957,6 +964,17 @@ export const selectViewData = ({ state }) => {
           { value: true, label: "Show" },
         ],
       },
+      {
+        name: "isMuted",
+        type: "segmented-control",
+        label: "Preview audio",
+        required: true,
+        clearable: false,
+        options: [
+          { value: false, label: "On" },
+          { value: true, label: "Muted" },
+        ],
+      },
     ],
     actions: {
       buttons: [
@@ -1015,8 +1033,6 @@ export const selectViewData = ({ state }) => {
       : "line-numbers-hide",
     sceneSettingsDialog: state.sceneSettingsDialog,
     sceneSettingsForm,
-    isMuted: state.isMuted,
-    muteIcon: state.isMuted ? "mute" : "unmute",
     isScenePageLoading: state.isScenePageLoading,
     isSceneAssetLoading: state.isSceneAssetLoading,
     deadEndTooltip: state.deadEndTooltip,
@@ -1136,10 +1152,6 @@ export const selectSectionTransitionsDAG = ({ state }) => {
     edges,
     adjacencyList,
   };
-};
-
-export const toggleMute = ({ state }, _payload = {}) => {
-  state.isMuted = !state.isMuted;
 };
 
 export const selectIsMuted = ({ state }) => {

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -119,10 +119,6 @@ refs:
     eventListeners:
       click:
         handler: handlePreviewClick
-  muteToggle:
-    eventListeners:
-      click:
-        handler: handleMuteToggle
   vnPreview:
     eventListeners:
       close:
@@ -165,7 +161,6 @@ template:
           - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':
               - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h jc=e g=sm:
                   - rtgl-button#previewButton: Preview
-                  - rtgl-button#muteToggle sq v="gh" pre="${muteIcon}": null
               - rtgl-view w=f h=1fg:
                   - rtgl-view:
                       - 'rtgl-view w=700 pos=rel style="aspect-ratio: ${canvasAspectRatio}; max-width: 100%;"':

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAudioWaveformClick,
+  handleAudioWaveformRightClick,
+} from "../../src/components/commandLineBgm/commandLineBgm.handlers.js";
+import {
+  clearBgmAudio,
+  createInitialState,
+  selectSelectedResource,
+  selectTempSelectedResourceId,
+  setBgm,
+  setMode,
+  setRepositoryState,
+  setTempSelectedResource,
+} from "../../src/components/commandLineBgm/commandLineBgm.store.js";
+
+const sounds = {
+  items: {
+    "folder-bgm": {
+      id: "folder-bgm",
+      type: "folder",
+      name: "BGM",
+    },
+    "sound-calm-theme": {
+      id: "sound-calm-theme",
+      type: "sound",
+      name: "Calm Theme",
+      fileId: "file-calm-theme",
+      waveformDataFileId: "waveform-calm-theme",
+      parentId: "folder-bgm",
+    },
+  },
+  tree: [
+    {
+      id: "folder-bgm",
+      children: [{ id: "sound-calm-theme" }],
+    },
+  ],
+};
+
+const createStoreDeps = (state) => ({
+  selectSelectedResource: () => selectSelectedResource({ state }),
+  selectTempSelectedResourceId: () => selectTempSelectedResourceId({ state }),
+  setTempSelectedResource: (payload) =>
+    setTempSelectedResource({ state }, payload),
+  setMode: (payload) => setMode({ state }, payload),
+  clearBgmAudio: (payload) => clearBgmAudio({ state }, payload),
+});
+
+describe("commandLineBgm.handlers", () => {
+  it("opens the gallery when the current BGM is clicked", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const stopPropagation = vi.fn();
+
+    setRepositoryState({ state }, { sounds });
+    setBgm(
+      { state },
+      {
+        bgm: {
+          resourceId: "sound-calm-theme",
+        },
+      },
+    );
+
+    handleAudioWaveformClick(
+      {
+        store: createStoreDeps(state),
+        render,
+      },
+      {
+        _event: {
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(selectTempSelectedResourceId({ state })).toBe("sound-calm-theme");
+    expect(state.mode).toBe("gallery");
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the context menu and removes the current BGM on right click", async () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const showDropdownMenu = vi.fn().mockResolvedValue({
+      item: {
+        key: "remove",
+      },
+    });
+
+    setRepositoryState({ state }, { sounds });
+    setBgm(
+      { state },
+      {
+        bgm: {
+          resourceId: "sound-calm-theme",
+        },
+      },
+    );
+    setTempSelectedResource(
+      { state },
+      {
+        resourceId: "sound-calm-theme",
+      },
+    );
+
+    await handleAudioWaveformRightClick(
+      {
+        store: createStoreDeps(state),
+        render,
+        globalUI: {
+          showDropdownMenu,
+        },
+      },
+      {
+        _event: {
+          clientX: 120,
+          clientY: 240,
+          preventDefault,
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(showDropdownMenu).toHaveBeenCalledWith({
+      items: [{ type: "item", label: "Remove", key: "remove" }],
+      x: 120,
+      y: 240,
+      place: "bs",
+    });
+    expect(state.bgm.resourceId).toBeUndefined();
+    expect(selectTempSelectedResourceId({ state })).toBeUndefined();
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -492,6 +492,99 @@ describe("graphicsService", () => {
     );
   });
 
+  it("notifies initRouteEngine render callbacks after engine-driven renders", async () => {
+    let effectsHandlerOptions;
+    createEffectsHandlerMock.mockImplementation((options) => {
+      effectsHandlerOptions = options;
+      return vi.fn();
+    });
+
+    createRouteEngineMock.mockReturnValue({
+      init: vi.fn(),
+      selectRenderState: vi.fn(() => ({
+        id: "render-1",
+        elements: [],
+        audio: [],
+        animations: [],
+      })),
+      selectPresentationState: vi.fn(() => undefined),
+      selectPresentationChanges: vi.fn(() => undefined),
+      selectSectionLineChanges: vi.fn(() => []),
+      selectSystemState: vi.fn(() => ({
+        contexts: [
+          {
+            currentPointerMode: "read",
+            pointers: {
+              read: {
+                sectionId: "section-1",
+              },
+            },
+          },
+        ],
+      })),
+      handleActions: vi.fn(),
+    });
+
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+
+    const onRenderState = vi.fn();
+    service.initRouteEngine(
+      {
+        screen: { width: 1920, height: 1080 },
+        story: { scenes: {} },
+        resources: {},
+      },
+      {
+        onRenderState,
+      },
+    );
+
+    effectsHandlerOptions.routeGraphics.render({
+      id: "render-2",
+      elements: [],
+      audio: [],
+      animations: [],
+    });
+
+    expect(onRenderState).toHaveBeenCalledWith({
+      renderState: {
+        id: "render-2",
+        elements: [],
+        audio: [],
+        animations: [],
+      },
+      systemState: {
+        contexts: [
+          {
+            currentPointerMode: "read",
+            pointers: {
+              read: {
+                sectionId: "section-1",
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
   it("keeps engine-driven follow-up renders muted after renderComplete", async () => {
     let effectsHandlerOptions;
     createEffectsHandlerMock.mockImplementation((options) => {

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -491,4 +491,89 @@ describe("graphicsService", () => {
       }),
     );
   });
+
+  it("keeps engine-driven follow-up renders muted after renderComplete", async () => {
+    let effectsHandlerOptions;
+    createEffectsHandlerMock.mockImplementation((options) => {
+      effectsHandlerOptions = options;
+      return vi.fn();
+    });
+
+    const handleActions = vi.fn((actions) => {
+      if (actions?.markLineCompleted) {
+        effectsHandlerOptions.routeGraphics.render({
+          id: "render-2",
+          elements: [],
+          audio: [
+            {
+              id: "bgm",
+              src: "file-1",
+              type: "sound",
+              loop: true,
+            },
+          ],
+          animations: [],
+        });
+      }
+    });
+
+    createRouteEngineMock.mockReturnValue({
+      init: vi.fn(),
+      selectRenderState: vi.fn(() => ({
+        id: "render-1",
+        elements: [],
+        audio: [
+          {
+            id: "bgm",
+            src: "file-1",
+            type: "sound",
+            loop: true,
+          },
+        ],
+        animations: [],
+      })),
+      selectPresentationState: vi.fn(() => undefined),
+      selectPresentationChanges: vi.fn(() => undefined),
+      selectSectionLineChanges: vi.fn(() => []),
+      handleActions,
+    });
+
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+
+    service.setEngineAudioMuted(true);
+    service.initRouteEngine({
+      screen: { width: 1920, height: 1080 },
+      story: { scenes: {} },
+      resources: {},
+    });
+    routeGraphicsInstance.render.mockClear();
+
+    routeGraphicsInitOptions.eventHandler("renderComplete", {});
+
+    expect(handleActions).toHaveBeenCalledWith({
+      markLineCompleted: {},
+    });
+    expect(routeGraphicsInstance.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audio: [],
+      }),
+    );
+  });
 });

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -102,6 +102,7 @@ const createProjectData = () => {
 
 const createGraphicsService = () => {
   let engine;
+  const setEngineAudioMuted = vi.fn();
 
   return {
     initRouteEngine: (projectData) => {
@@ -122,6 +123,7 @@ const createGraphicsService = () => {
       engine?.handleActions(actions, eventContext, options);
     },
     engineSelectPresentationState: () => engine?.selectPresentationState(),
+    setEngineAudioMuted,
   };
 };
 
@@ -242,5 +244,35 @@ describe("renderSceneEditorState", () => {
     });
 
     expect(engineRenderCurrentState).toHaveBeenCalledTimes(1);
+  });
+
+  it("syncs the graphics engine audio mute state from scene editor settings", async () => {
+    const projectData = createProjectData();
+    const graphicsService = createGraphicsService();
+    const store = {
+      selectSceneId: () => "scene-1",
+      selectSelectedSectionId: () => "section-1",
+      selectSelectedLineId: () => "line-2",
+      selectProjectData: () => projectData,
+      selectPreviewRuntimeGlobal: () => ({
+        dialogueTextSpeed: 100,
+      }),
+      selectIsMuted: () => true,
+      setPresentationState: ({ presentationState }) => {
+        store.presentationState = presentationState;
+      },
+      presentationState: undefined,
+    };
+
+    graphicsService.initRouteEngine(projectData, {
+      enableGlobalKeyboardBindings: false,
+    });
+
+    await renderSceneEditorState({
+      store,
+      graphicsService,
+    });
+
+    expect(graphicsService.setEngineAudioMuted).toHaveBeenCalledWith(true);
   });
 });

--- a/tests/vnPreview/vnPreview.handlers.test.js
+++ b/tests/vnPreview/vnPreview.handlers.test.js
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const constructProjectDataMock = vi.fn();
 const extractInitialHybridSceneIdsMock = vi.fn(() => []);
+const extractTransitionTargetSceneIdsMock = vi.fn(() => []);
 const withPreviewEntryPointMock = vi.fn((projectData) => projectData);
+const collectPreviewMissingTargetsMock = vi.fn(() => ({
+  missingSceneIds: [],
+  missingSectionIds: [],
+}));
 const ensurePreviewProjectDataTargetsMock = vi.fn(
   async ({ projectData, loadedSceneIds }) => ({
     didLoad: false,
@@ -10,6 +15,7 @@ const ensurePreviewProjectDataTargetsMock = vi.fn(
     loadedSceneIds,
   }),
 );
+const resolveSceneIdForSectionIdMock = vi.fn(() => undefined);
 
 vi.mock("../../src/internal/project/projection.js", () => ({
   constructProjectData: constructProjectDataMock,
@@ -22,7 +28,7 @@ vi.mock("../../src/internal/project/layout.js", () => ({
   extractInitialHybridSceneIds: extractInitialHybridSceneIdsMock,
   extractLayoutIdsFromValue: vi.fn(() => []),
   resolveEventBindings: vi.fn(() => ({})),
-  extractTransitionTargetSceneIds: vi.fn(() => []),
+  extractTransitionTargetSceneIds: extractTransitionTargetSceneIdsMock,
   extractTransitionTargetSceneIdsFromActions: vi.fn(() => []),
 }));
 
@@ -35,13 +41,11 @@ vi.mock("../../src/internal/runtime/graphicsEngineRuntime.js", () => ({
 }));
 
 vi.mock("../../src/components/vnPreview/support/vnPreviewProjectData.js", () => ({
-  collectPreviewMissingTargets: vi.fn(() => ({
-    missingSceneIds: [],
-    missingSectionIds: [],
-  })),
+  collectPreviewMissingTargets: collectPreviewMissingTargetsMock,
   collectSceneIdsFromValue: vi.fn(() => []),
   collectSectionIdsFromValue: vi.fn(() => []),
   ensurePreviewProjectDataTargets: ensurePreviewProjectDataTargetsMock,
+  resolveSceneIdForSectionId: resolveSceneIdForSectionIdMock,
   withPreviewEntryPoint: withPreviewEntryPointMock,
 }));
 
@@ -53,8 +57,11 @@ describe("vnPreview.handlers", () => {
   beforeEach(() => {
     constructProjectDataMock.mockReset();
     extractInitialHybridSceneIdsMock.mockReset();
+    extractTransitionTargetSceneIdsMock.mockReset();
+    collectPreviewMissingTargetsMock.mockReset();
     withPreviewEntryPointMock.mockClear();
     ensurePreviewProjectDataTargetsMock.mockClear();
+    resolveSceneIdForSectionIdMock.mockReset();
 
     constructProjectDataMock.mockReturnValue({
       screen: {
@@ -66,6 +73,12 @@ describe("vnPreview.handlers", () => {
       },
     });
     extractInitialHybridSceneIdsMock.mockReturnValue([]);
+    extractTransitionTargetSceneIdsMock.mockReturnValue([]);
+    collectPreviewMissingTargetsMock.mockReturnValue({
+      missingSceneIds: [],
+      missingSectionIds: [],
+    });
+    resolveSceneIdForSectionIdMock.mockReturnValue(undefined);
   });
 
   it("clears the scene editor mute override when mounting full-screen preview", async () => {
@@ -105,6 +118,86 @@ describe("vnPreview.handlers", () => {
 
     expect(deps.graphicsService.setEngineAudioMuted).toHaveBeenCalledWith(
       false,
+    );
+  });
+
+  it("prefetches direct transition targets after preview renders a different scene", async () => {
+    const { handleAfterMount } = await import(
+      "../../src/components/vnPreview/vnPreview.handlers.js"
+    );
+
+    const repository = {
+      getContextState: vi.fn(async () => ({})),
+    };
+    const initRouteEngine = vi.fn(async (_projectData, options) => {
+      await options.onRenderState?.({
+        systemState: {
+          contexts: [
+            {
+              currentPointerMode: "read",
+              pointers: {
+                read: {
+                  sectionId: "scene-2-section-1",
+                },
+              },
+            },
+          ],
+        },
+      });
+    });
+    extractTransitionTargetSceneIdsMock.mockImplementation((_projectData, sceneId) => {
+      if (sceneId === "scene-2") {
+        return ["scene-3"];
+      }
+      return [];
+    });
+    resolveSceneIdForSectionIdMock.mockImplementation((_projectData, sectionId) => {
+      if (sectionId === "scene-2-section-1") {
+        return "scene-2";
+      }
+      return undefined;
+    });
+    collectPreviewMissingTargetsMock.mockImplementation(({ sceneIds = [] }) => ({
+      missingSceneIds: sceneIds,
+      missingSectionIds: [],
+    }));
+
+    const deps = {
+      projectService: {
+        ensureRepository: vi.fn(async () => repository),
+        getRepositoryState: vi.fn(() => ({})),
+      },
+      graphicsService: {
+        setEngineAudioMuted: vi.fn(),
+        init: vi.fn(async () => {}),
+        initRouteEngine,
+        loadAssets: vi.fn(async () => {}),
+        engineHandleActions: vi.fn(),
+      },
+      refs: {
+        canvas: {},
+      },
+      props: {
+        sceneId: "scene-1",
+      },
+      store: {
+        setProjectResolution: vi.fn(),
+        setAssetLoading: vi.fn(),
+        resetAssetLoadCache: vi.fn(),
+        selectHasLoadedAssetFileId: vi.fn(() => false),
+        selectHasLoadedAssetSceneId: vi.fn(() => false),
+        markAssetFileIdsLoaded: vi.fn(),
+        markAssetSceneIdsLoaded: vi.fn(),
+      },
+      render: vi.fn(),
+    };
+
+    await handleAfterMount(deps);
+
+    expect(ensurePreviewProjectDataTargetsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sceneIds: ["scene-3"],
+      }),
     );
   });
 

--- a/tests/vnPreview/vnPreview.handlers.test.js
+++ b/tests/vnPreview/vnPreview.handlers.test.js
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const constructProjectDataMock = vi.fn();
+const extractInitialHybridSceneIdsMock = vi.fn(() => []);
+const withPreviewEntryPointMock = vi.fn((projectData) => projectData);
+const ensurePreviewProjectDataTargetsMock = vi.fn(
+  async ({ projectData, loadedSceneIds }) => ({
+    didLoad: false,
+    projectData,
+    loadedSceneIds,
+  }),
+);
+
+vi.mock("../../src/internal/project/projection.js", () => ({
+  constructProjectData: constructProjectDataMock,
+}));
+
+vi.mock("../../src/internal/project/layout.js", () => ({
+  extractFileIdsForLayouts: vi.fn(() => []),
+  extractSceneIdsFromValue: vi.fn(() => []),
+  extractFileIdsForScenes: vi.fn(() => []),
+  extractInitialHybridSceneIds: extractInitialHybridSceneIdsMock,
+  extractLayoutIdsFromValue: vi.fn(() => []),
+  resolveEventBindings: vi.fn(() => ({})),
+  extractTransitionTargetSceneIds: vi.fn(() => []),
+  extractTransitionTargetSceneIdsFromActions: vi.fn(() => []),
+}));
+
+vi.mock("../../src/internal/runtime/graphicsEngineRuntime.js", () => ({
+  prepareRuntimeInteractionExecution: vi.fn(async ({ actions }) => ({
+    eventData: {},
+    preparedActions: actions,
+    resolvedActions: actions,
+  })),
+}));
+
+vi.mock("../../src/components/vnPreview/support/vnPreviewProjectData.js", () => ({
+  collectPreviewMissingTargets: vi.fn(() => ({
+    missingSceneIds: [],
+    missingSectionIds: [],
+  })),
+  collectSceneIdsFromValue: vi.fn(() => []),
+  collectSectionIdsFromValue: vi.fn(() => []),
+  ensurePreviewProjectDataTargets: ensurePreviewProjectDataTargetsMock,
+  withPreviewEntryPoint: withPreviewEntryPointMock,
+}));
+
+describe("vnPreview.handlers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    constructProjectDataMock.mockReset();
+    extractInitialHybridSceneIdsMock.mockReset();
+    withPreviewEntryPointMock.mockClear();
+    ensurePreviewProjectDataTargetsMock.mockClear();
+
+    constructProjectDataMock.mockReturnValue({
+      screen: {
+        width: 1280,
+        height: 720,
+      },
+      story: {
+        scenes: {},
+      },
+    });
+    extractInitialHybridSceneIdsMock.mockReturnValue([]);
+  });
+
+  it("clears the scene editor mute override when mounting full-screen preview", async () => {
+    const { handleAfterMount } = await import(
+      "../../src/components/vnPreview/vnPreview.handlers.js"
+    );
+
+    const deps = {
+      projectService: {
+        ensureRepository: vi.fn(async () => ({})),
+        getRepositoryState: vi.fn(() => ({})),
+      },
+      graphicsService: {
+        setEngineAudioMuted: vi.fn(),
+        init: vi.fn(async () => {}),
+        initRouteEngine: vi.fn(async () => {}),
+        loadAssets: vi.fn(async () => {}),
+        engineHandleActions: vi.fn(),
+      },
+      refs: {
+        canvas: {},
+      },
+      props: {},
+      store: {
+        setProjectResolution: vi.fn(),
+        setAssetLoading: vi.fn(),
+        resetAssetLoadCache: vi.fn(),
+        selectHasLoadedAssetFileId: vi.fn(() => false),
+        selectHasLoadedAssetSceneId: vi.fn(() => false),
+        markAssetFileIdsLoaded: vi.fn(),
+        markAssetSceneIdsLoaded: vi.fn(),
+      },
+      render: vi.fn(),
+    };
+
+    await handleAfterMount(deps);
+
+    expect(deps.graphicsService.setEngineAudioMuted).toHaveBeenCalledWith(
+      false,
+    );
+  });
+
+  it("destroys the preview graphics runtime during unmount cleanup", async () => {
+    const { handleBeforeMount } = await import(
+      "../../src/components/vnPreview/vnPreview.handlers.js"
+    );
+
+    const removeEventListener = vi.fn();
+    const addEventListener = vi.fn();
+    vi.stubGlobal("window", {
+      addEventListener,
+      removeEventListener,
+    });
+
+    const deps = {
+      dispatchEvent: vi.fn(),
+      graphicsService: {
+        destroy: vi.fn(),
+      },
+      store: {
+        setAssetLoading: vi.fn(),
+        resetAssetLoadCache: vi.fn(),
+      },
+    };
+
+    const cleanup = handleBeforeMount(deps);
+    cleanup();
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      "keydown",
+      expect.any(Function),
+    );
+    expect(deps.graphicsService.destroy).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "keydown",
+      expect.any(Function),
+    );
+  });
+});

--- a/tests/vnPreview/vnPreviewProjectData.test.js
+++ b/tests/vnPreview/vnPreviewProjectData.test.js
@@ -5,6 +5,7 @@ import {
   collectSceneIdsFromValue,
   collectSectionIdsFromValue,
   ensurePreviewProjectDataTargets,
+  hasPreviewSceneEntryLines,
   hasPreviewSceneLines,
   hasPreviewSectionLines,
   withPreviewEntryPoint,
@@ -150,11 +151,61 @@ describe("vnPreview project data helpers", () => {
     });
 
     expect(hasPreviewSceneLines(projectData, "scene-1")).toBe(true);
+    expect(hasPreviewSceneEntryLines(projectData, "scene-1")).toBe(true);
     expect(hasPreviewSectionLines(projectData, "scene-1-section-1")).toBe(true);
     expect(hasPreviewSceneLines(projectData, "scene-2")).toBe(false);
+    expect(hasPreviewSceneEntryLines(projectData, "scene-2")).toBe(false);
     expect(hasPreviewSectionLines(projectData, "scene-2-section-1")).toBe(
       false,
     );
+  });
+
+  it("treats a target scene as missing when only non-entry sections still have lines", () => {
+    const initialState = createRepositoryState({
+      sceneIds: ["scene-1", "scene-2"],
+    });
+    initialState.scenes.items["scene-2"].sections.items[
+      "scene-2-section-1"
+    ].lines = {
+      items: {},
+      tree: [],
+    };
+    initialState.scenes.items["scene-2"].sections.items[
+      "scene-2-section-2"
+    ] = {
+      id: "scene-2-section-2",
+      name: "Section 2",
+      lines: {
+        items: {
+          "scene-2-line-2": {
+            id: "scene-2-line-2",
+            actions: {},
+          },
+        },
+        tree: [{ id: "scene-2-line-2" }],
+      },
+    };
+    initialState.scenes.items["scene-2"].sections.tree = [
+      { id: "scene-2-section-1" },
+      { id: "scene-2-section-2" },
+    ];
+    const projectData = constructProjectData(initialState, {
+      initialSceneId: "scene-1",
+    });
+
+    expect(hasPreviewSceneLines(projectData, "scene-2")).toBe(true);
+    expect(hasPreviewSceneEntryLines(projectData, "scene-2")).toBe(false);
+
+    const result = collectPreviewMissingTargets({
+      projectData,
+      loadedSceneIds: ["scene-1", "scene-2"],
+      sceneIds: ["scene-2"],
+    });
+
+    expect(result).toEqual({
+      missingSceneIds: ["scene-2"],
+      missingSectionIds: [],
+    });
   });
 
   it("treats stripped target sections as missing even when the scene id is already known", () => {
@@ -286,5 +337,70 @@ describe("vnPreview project data helpers", () => {
     expect(result.missingSceneIds).toEqual(["scene-2"]);
     expect(result.projectData.story.scenes["scene-2"]).toBeDefined();
     expect(hasPreviewSceneLines(result.projectData, "scene-2")).toBe(true);
+  });
+
+  it("rehydrates a known scene id when its cached entry section has no lines", async () => {
+    const initialSceneId = "scene-1";
+    const initialState = createRepositoryState({
+      sceneIds: [initialSceneId, "scene-2"],
+    });
+    initialState.scenes.items["scene-2"].sections.items[
+      "scene-2-section-1"
+    ].lines = {
+      items: {},
+      tree: [],
+    };
+    initialState.scenes.items["scene-2"].sections.items[
+      "scene-2-section-2"
+    ] = {
+      id: "scene-2-section-2",
+      name: "Section 2",
+      lines: {
+        items: {
+          "scene-2-line-2": {
+            id: "scene-2-line-2",
+            actions: {},
+          },
+        },
+        tree: [{ id: "scene-2-line-2" }],
+      },
+    };
+    initialState.scenes.items["scene-2"].sections.tree = [
+      { id: "scene-2-section-1" },
+      { id: "scene-2-section-2" },
+    ];
+    const hydratedState = createRepositoryState({
+      sceneIds: [initialSceneId, "scene-2"],
+    });
+    const repository = {
+      getContextState: vi.fn().mockResolvedValue(hydratedState),
+    };
+    const projectData = withPreviewEntryPoint(
+      constructProjectData(initialState, {
+        initialSceneId,
+      }),
+      {
+        sceneId: initialSceneId,
+      },
+    );
+
+    const result = await ensurePreviewProjectDataTargets({
+      repository,
+      projectData,
+      loadedSceneIds: [initialSceneId, "scene-2"],
+      sceneIds: ["scene-2"],
+      sectionIds: [],
+      initialSceneId,
+    });
+
+    expect(repository.getContextState).toHaveBeenCalledWith({
+      sceneIds: [initialSceneId, "scene-2"],
+      sectionIds: [],
+    });
+    expect(result.didLoad).toBe(true);
+    expect(result.missingSceneIds).toEqual(["scene-2"]);
+    expect(hasPreviewSceneEntryLines(result.projectData, "scene-2")).toBe(
+      true,
+    );
   });
 });

--- a/tests/vnPreview/vnPreviewProjectData.test.js
+++ b/tests/vnPreview/vnPreviewProjectData.test.js
@@ -242,4 +242,49 @@ describe("vnPreview project data helpers", () => {
         .initialLineId,
     ).toBe(initialLineId);
   });
+
+  it("rehydrates a known scene id when the cached preview scene has no lines", async () => {
+    const initialSceneId = "scene-1";
+    const initialState = createRepositoryState({
+      sceneIds: [initialSceneId, "scene-2"],
+    });
+    initialState.scenes.items["scene-2"].sections.items[
+      "scene-2-section-1"
+    ].lines = {
+      items: {},
+      tree: [],
+    };
+    const hydratedState = createRepositoryState({
+      sceneIds: [initialSceneId, "scene-2"],
+    });
+    const repository = {
+      getContextState: vi.fn().mockResolvedValue(hydratedState),
+    };
+    const projectData = withPreviewEntryPoint(
+      constructProjectData(initialState, {
+        initialSceneId,
+      }),
+      {
+        sceneId: initialSceneId,
+      },
+    );
+
+    const result = await ensurePreviewProjectDataTargets({
+      repository,
+      projectData,
+      loadedSceneIds: [initialSceneId, "scene-2"],
+      sceneIds: ["scene-2"],
+      sectionIds: [],
+      initialSceneId,
+    });
+
+    expect(repository.getContextState).toHaveBeenCalledWith({
+      sceneIds: [initialSceneId, "scene-2"],
+      sectionIds: [],
+    });
+    expect(result.didLoad).toBe(true);
+    expect(result.missingSceneIds).toEqual(["scene-2"]);
+    expect(result.projectData.story.scenes["scene-2"]).toBeDefined();
+    expect(hasPreviewSceneLines(result.projectData, "scene-2")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- keep scene editor mute applied across engine-driven follow-up renders while leaving full-screen preview audio unaffected
- destroy the full-screen preview runtime on close so audio stops on Escape and close
- fix vn preview lazy hydration by reloading stripped entry sections and prefetching direct target scenes after scene transitions without loading the full project up front
- add regression coverage for audio follow-up renders, preview teardown, cached-scene hydration, and incremental scene prefetching

## Testing
- bunx vitest run tests/vnPreview/vnPreview.handlers.test.js tests/vnPreview/vnPreviewProjectData.test.js tests/graphicsService/graphicsService.test.js