### PR TITLE
Fix sidebar project icon refresh

### DIFF
--- a/src/pages/sidebar/sidebar.handlers.js
+++ b/src/pages/sidebar/sidebar.handlers.js
@@ -10,17 +10,20 @@ export const handleBeforeMount = (deps) => {
   return mountSubscriptions(deps);
 };
 
-const syncSidebarProjectIcon = (deps) => {
+const syncSidebarProjectIcon = (deps, currentProjectEntry) => {
   const { appService, store, render } = deps;
-  const currentProjectEntry = appService.getCurrentProjectEntry();
-  if (currentProjectEntry?.iconUrl) {
-    store.setProjectImageUrl({ imageUrl: currentProjectEntry.iconUrl });
+  const projectEntry =
+    currentProjectEntry ?? appService.getCurrentProjectEntry();
+  if (projectEntry?.iconUrl) {
+    store.setProjectImageUrl({ imageUrl: projectEntry.iconUrl });
     render();
   }
 };
 
 export const handleAfterMount = async (deps) => {
-  syncSidebarProjectIcon(deps);
+  const { appService } = deps;
+  const currentProjectEntry = await appService.refreshCurrentProjectEntry();
+  syncSidebarProjectIcon(deps, currentProjectEntry);
 };
 
 export const handleItemClick = async (deps, payload) => {
@@ -43,8 +46,8 @@ export const handleHeaderClick = (deps) => {
 
 export const handleProjectImageUpdate = async (deps) => {
   const { appService } = deps;
-  await appService.refreshCurrentProjectEntry();
-  syncSidebarProjectIcon(deps);
+  const currentProjectEntry = await appService.refreshCurrentProjectEntry();
+  syncSidebarProjectIcon(deps, currentProjectEntry);
 };
 
 const subscriptions = (deps) => {

--- a/tests/sidebar/sidebar.handlers.test.js
+++ b/tests/sidebar/sidebar.handlers.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAfterMount,
+  handleProjectImageUpdate,
+} from "../../src/pages/sidebar/sidebar.handlers.js";
+
+const createDeps = () => ({
+  appService: {
+    refreshCurrentProjectEntry: vi.fn(),
+    getCurrentProjectEntry: vi.fn(),
+  },
+  store: {
+    setProjectImageUrl: vi.fn(),
+  },
+  render: vi.fn(),
+});
+
+describe("sidebar.handlers", () => {
+  it("refreshes the current project entry before syncing the sidebar icon on mount", async () => {
+    const deps = createDeps();
+    deps.appService.refreshCurrentProjectEntry.mockResolvedValue({
+      iconUrl: "blob:project-icon",
+    });
+
+    await handleAfterMount(deps);
+
+    expect(deps.appService.refreshCurrentProjectEntry).toHaveBeenCalledTimes(1);
+    expect(deps.store.setProjectImageUrl).toHaveBeenCalledWith({
+      imageUrl: "blob:project-icon",
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.appService.getCurrentProjectEntry).not.toHaveBeenCalled();
+  });
+
+  it("refreshes and syncs the sidebar icon after project image updates", async () => {
+    const deps = createDeps();
+    deps.appService.refreshCurrentProjectEntry.mockResolvedValue({
+      iconUrl: "blob:updated-project-icon",
+    });
+
+    await handleProjectImageUpdate(deps);
+
+    expect(deps.appService.refreshCurrentProjectEntry).toHaveBeenCalledTimes(1);
+    expect(deps.store.setProjectImageUrl).toHaveBeenCalledWith({
+      imageUrl: "blob:updated-project-icon",
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the current project entry before syncing the sidebar icon on mount so the header uses the resolved project `iconUrl`
- use the refreshed entry directly for project-image updates instead of re-reading stale cached state
- add focused sidebar handler coverage for mount and project-image update icon sync

## Testing
- bunx vitest run tests/sidebar/sidebar.handlers.test.js