### PR TITLE
Fix command line audio volume range

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -1,9 +1,19 @@
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
 
+const normalizeVolume = (volume, fallback = 50) => {
+  const parsedVolume = Number(volume);
+  if (!Number.isFinite(parsedVolume)) {
+    return fallback;
+  }
+
+  const nextVolume = parsedVolume > 100 ? parsedVolume / 10 : parsedVolume;
+  return Math.max(0, Math.min(100, Math.round(nextVolume)));
+};
+
 const normalizeBgm = (bgm = {}) => ({
   resourceId: bgm?.resourceId,
   loop: bgm?.loop ?? true,
-  volume: bgm?.volume ?? 500,
+  volume: normalizeVolume(bgm?.volume),
   delay: bgm?.delay,
 });
 
@@ -28,7 +38,7 @@ const form = {
       description: "Volume",
       type: "slider-with-input",
       min: 0,
-      max: 1000,
+      max: 100,
       step: 1,
     },
   ],
@@ -199,7 +209,7 @@ export const selectViewData = ({ state }) => {
 
   const defaultValues = {
     loop: state.bgm?.loop ?? true,
-    volume: state.bgm?.volume ?? 500,
+    volume: normalizeVolume(state.bgm?.volume),
     delay: state.bgm?.delay,
     audioWaveformDataFileId: selectedResource?.item?.waveformDataFileId || "",
   };

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
@@ -1,10 +1,20 @@
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
 
+const normalizeVolume = (volume, fallback = 50) => {
+  const parsedVolume = Number(volume);
+  if (!Number.isFinite(parsedVolume)) {
+    return fallback;
+  }
+
+  const nextVolume = parsedVolume > 100 ? parsedVolume / 10 : parsedVolume;
+  return Math.max(0, Math.min(100, Math.round(nextVolume)));
+};
+
 const normalizeSfx = (sfx = {}) => ({
   id: sfx?.id,
   resourceId: sfx?.resourceId,
   name: sfx?.name ?? "New Sound Effect",
-  volume: sfx?.volume ?? 500,
+  volume: normalizeVolume(sfx?.volume),
   loop: sfx?.loop ?? false,
 });
 

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -72,7 +72,7 @@ template:
                           - rtgl-text s=sm c=mu-fg: Loop
                           - rtgl-segmented-control#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
                           - rtgl-text s=sm c=mu-fg: Volume
-                          - rtgl-slider-input#volumeInput${i} data-index=${i} key=${sfx.id} min=0 max=1000 step=1 w=f value=${sfx.volume}: null
+                          - rtgl-slider-input#volumeInput${i} data-index=${i} key=${sfx.id} min=0 max=100 step=1 w=f value=${sfx.volume}: null
               - rtgl-button#addNewButton v=ol w=f mt=md: + Add New Sound Effect
           - rtgl-view h=1fg: null
           - rtgl-view d=h av=c ah=e w=f g=lg:

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectBgm,
+  selectViewData,
+  setBgm,
+} from "../../src/components/commandLineBgm/commandLineBgm.store.js";
+
+describe("commandLineBgm.store", () => {
+  it("uses a 0 to 100 volume range with a default of 50", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({ state });
+    const volumeField = viewData.form.fields.find(
+      (field) => field.name === "volume",
+    );
+
+    expect(volumeField).toMatchObject({
+      min: 0,
+      max: 100,
+      step: 1,
+    });
+    expect(viewData.defaultValues.volume).toBe(50);
+  });
+
+  it("normalizes legacy 0 to 1000 BGM volume values into the 0 to 100 UI range", () => {
+    const state = createInitialState();
+
+    setBgm(
+      { state },
+      {
+        bgm: {
+          resourceId: "sound-1",
+          volume: 500,
+        },
+      },
+    );
+
+    expect(selectBgm({ state }).volume).toBe(50);
+    expect(selectViewData({ state }).defaultValues.volume).toBe(50);
+  });
+});

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setExistingSfxs,
+} from "../../src/components/commandLineSoundEffects/commandLineSoundEffects.store.js";
+
+describe("commandLineSoundEffects.store", () => {
+  it("normalizes legacy 0 to 1000 sound effect volume values into the 0 to 100 UI range", () => {
+    const state = createInitialState();
+
+    setExistingSfxs(
+      { state },
+      {
+        sfx: [
+          {
+            id: "sfx-1",
+            resourceId: "sound-1",
+            volume: 500,
+          },
+        ],
+      },
+    );
+
+    expect(selectViewData({ state }).defaultValues.sfx).toEqual([
+      expect.objectContaining({
+        id: "sfx-1",
+        volume: 50,
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- change command-line BGM and sound effect volume controls to use a 0 to 100 range
- normalize legacy 0 to 1000 saved values into the new UI range
- add focused store tests covering the new defaults and legacy compatibility

## Testing
- bunx vitest run tests/commandLineBgm/commandLineBgm.store.test.js tests/commandLineBgm/commandLineBgm.handlers.test.js tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js