### PR TITLE
Fix VN preview contain sizing

### DIFF
--- a/src/components/vnPreview/vnPreview.view.yaml
+++ b/src/components/vnPreview/vnPreview.view.yaml
@@ -1,8 +1,8 @@
 refs:
   canvas: {}
 template:
-  - 'rtgl-view pos=fix w=100vw h=100vh style="left: 0; top: 0; background: black; justify-content: center;" z=3500':
-      - 'rtgl-view w=f pos=rel bwb=xs style="aspect-ratio: ${canvasAspectRatio}; max-width: 100%; max-height: 100%"':
+  - 'rtgl-view pos=fix w=100vw h=100vh style="left: 0; top: 0; background: black; justify-content: center; align-items: center;" z=3500':
+      - 'rtgl-view pos=rel bwb=xs style="aspect-ratio: ${canvasAspectRatio}; width: min(100vw, calc(100vh * (${canvasAspectRatio}))); height: min(100vh, calc(100vw / (${canvasAspectRatio}))); max-width: 100%; max-height: 100%"':
           - rtgl-view pos=abs cor=full:
               - 'div#canvas id=canvas style="width: 100%; height: 100%;display: flex; justify-content: center"': null
           - $if isAssetLoading:


### PR DESCRIPTION
## Summary
- center the fullscreen VN preview on both axes
- size the preview frame with explicit contain math so wide, short viewports letterbox correctly
- keep the fix limited to the vnPreview shell without changing preview runtime behavior

## Validation
- git push hook: oxlint
- git push hook: bun prettier --check src
- did not run bun run build:web per request