### PR TITLE
Polish help links and character selection flows

### DIFF
--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -5,6 +5,51 @@ const getCharacterIndexFromEvent = (event) => {
   return Number.isInteger(index) ? index : undefined;
 };
 
+const getSelectedSpriteId = (character = {}) => {
+  return character?.sprites?.[0]?.resourceId;
+};
+
+const beginExistingCharacterSpriteSelection = (store, index) => {
+  const selectedCharacters = store.selectSelectedCharacters();
+  const selectedCharacter = selectedCharacters[index];
+
+  store.clearPendingCharacterIndex();
+  store.setSelectedCharacterIndex({ index });
+  store.setTempSelectedSpriteId({
+    spriteId: getSelectedSpriteId(selectedCharacter),
+  });
+  store.setSearchQuery({ value: "" });
+  store.setMode({
+    mode: "sprite-select",
+  });
+};
+
+const beginNewCharacterSpriteSelection = (store, characterId) => {
+  store.addCharacter({ id: characterId });
+
+  const currentCharacters = store.selectSelectedCharacters();
+  const newCharacterIndex = currentCharacters.length - 1;
+
+  store.setPendingCharacterIndex({ index: newCharacterIndex });
+  store.setSelectedCharacterIndex({ index: newCharacterIndex });
+  store.setTempSelectedSpriteId({ spriteId: undefined });
+  store.setSearchQuery({ value: "" });
+  store.setMode({
+    mode: "sprite-select",
+  });
+};
+
+const discardPendingCharacterSelection = (store) => {
+  const pendingCharacterIndex = store.selectPendingCharacterIndex();
+
+  if (!Number.isInteger(pendingCharacterIndex)) {
+    return;
+  }
+
+  store.removeCharacter({ index: pendingCharacterIndex });
+  store.clearPendingCharacterIndex();
+};
+
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
@@ -46,15 +91,7 @@ export const handleCharacterClick = (deps, payload) => {
     return;
   }
 
-  // Set the character index for sprite selection
-  store.setSelectedCharacterIndex({ index });
-  store.setSearchQuery({ value: "" });
-
-  // Go to sprite selection mode
-  store.setMode({
-    mode: "sprite-select",
-  });
-
+  beginExistingCharacterSpriteSelection(store, index);
   render();
 };
 
@@ -118,16 +155,7 @@ export const handleFileExplorerItemClick = (deps, payload) => {
     return;
   }
 
-  store.addCharacter({ id: itemId });
-
-  const currentCharacters = store.selectSelectedCharacters();
-  const newCharacterIndex = currentCharacters.length - 1;
-  store.setSelectedCharacterIndex({ index: newCharacterIndex });
-  store.setSearchQuery({ value: "" });
-  store.setMode({
-    mode: "sprite-select",
-  });
-
+  beginNewCharacterSpriteSelection(store, itemId);
   render();
 };
 
@@ -153,20 +181,7 @@ export const handleCharacterItemClick = (deps, payload) => {
     target?.id?.replace("characterItem", "") ||
     "";
 
-  // Add character to selected characters
-  store.addCharacter({ id: characterId });
-
-  // Set the character index for sprite selection
-  const currentCharacters = store.selectSelectedCharacters();
-  const newCharacterIndex = currentCharacters.length - 1;
-  store.setSelectedCharacterIndex({ index: newCharacterIndex });
-  store.setSearchQuery({ value: "" });
-
-  // Jump directly to sprite selection mode
-  store.setMode({
-    mode: "sprite-select",
-  });
-
+  beginNewCharacterSpriteSelection(store, characterId);
   render();
 };
 
@@ -216,6 +231,13 @@ export const handleCharacterSelectorClick = (deps) => {
 
 export const handleBreadcumbClick = (deps, payload) => {
   const { dispatchEvent, store, render } = deps;
+  const mode = store.selectMode();
+
+  if (mode === "sprite-select") {
+    discardPendingCharacterSelection(store);
+    store.setSelectedCharacterIndex({ index: undefined });
+    store.setTempSelectedSpriteId({ spriteId: undefined });
+  }
 
   if (payload._event.detail.id === "actions") {
     dispatchEvent(
@@ -231,7 +253,7 @@ export const handleBreadcumbClick = (deps, payload) => {
   } else if (payload._event.detail.id === "character-select") {
     store.setSearchQuery({ value: "" });
     store.setMode({
-      mode: "sprite-select",
+      mode: "character-select",
     });
     render();
   }
@@ -250,6 +272,9 @@ export const handleRemoveCharacterClick = (deps, payload) => {
 export const handleAddCharacterClick = (deps) => {
   const { store, render } = deps;
 
+  store.clearPendingCharacterIndex();
+  store.setSelectedCharacterIndex({ index: undefined });
+  store.setTempSelectedSpriteId({ spriteId: undefined });
   store.setSearchQuery({ value: "" });
   store.setMode({
     mode: "character-select",
@@ -318,6 +343,9 @@ export const handleButtonSelectClick = (deps) => {
       }
     }
 
+    store.clearPendingCharacterIndex();
+    store.setSelectedCharacterIndex({ index: undefined });
+    store.setTempSelectedSpriteId({ spriteId: undefined });
     store.setMode({
       mode: "current",
     });

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -78,6 +78,7 @@ export const createInitialState = () => ({
   tempSelectedCharacterId: undefined,
   tempSelectedSpriteId: undefined,
   selectedCharacterIndex: undefined, // For sprite selection
+  pendingCharacterIndex: undefined,
   searchQuery: "",
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
@@ -136,6 +137,15 @@ export const removeCharacter = ({ state }, { index } = {}) => {
   }
 
   state.selectedCharacters.splice(index, 1);
+
+  if (state.pendingCharacterIndex === index) {
+    state.pendingCharacterIndex = undefined;
+  } else if (
+    Number.isInteger(state.pendingCharacterIndex) &&
+    state.pendingCharacterIndex > index
+  ) {
+    state.pendingCharacterIndex -= 1;
+  }
 
   if (state.selectedCharacterIndex === index) {
     state.selectedCharacterIndex = undefined;
@@ -235,6 +245,9 @@ export const updateCharacterSpriteName = (
 
 export const clearCharacters = ({ state }, _payload = {}) => {
   state.selectedCharacters = [];
+  state.pendingCharacterIndex = undefined;
+  state.selectedCharacterIndex = undefined;
+  state.tempSelectedSpriteId = undefined;
 };
 
 export const setTempSelectedCharacterId = ({ state }, { characterId } = {}) => {
@@ -265,6 +278,14 @@ export const hideFullImagePreview = ({ state }, _payload = {}) => {
 
 export const setSelectedCharacterIndex = ({ state }, { index } = {}) => {
   state.selectedCharacterIndex = index;
+};
+
+export const setPendingCharacterIndex = ({ state }, { index } = {}) => {
+  state.pendingCharacterIndex = index;
+};
+
+export const clearPendingCharacterIndex = ({ state }) => {
+  state.pendingCharacterIndex = undefined;
 };
 
 export const selectTempSelectedCharacterId = ({ state }) => {
@@ -303,6 +324,10 @@ export const selectMode = ({ state }) => {
 
 export const selectSelectedCharacterIndex = ({ state }) => {
   return state.selectedCharacterIndex;
+};
+
+export const selectPendingCharacterIndex = ({ state }) => {
+  return state.pendingCharacterIndex;
 };
 
 export const selectCurrentSpriteItemById = ({ state }, { spriteId } = {}) => {

--- a/src/components/mediaResourcesView/mediaResourcesView.schema.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.schema.yaml
@@ -17,6 +17,9 @@ propsSchema:
     uploadText:
       type: string
       description: Text to display in upload affordances
+    uploadIcon:
+      type: string
+      description: Icon to display in upload affordances
     acceptedFileTypes:
       type: array
       description: Array of accepted file extensions

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -210,6 +210,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     searchQuery: props.searchQuery ?? "",
     searchPlaceholder: props.searchPlaceholder ?? "Search...",
     uploadText: props.uploadText ?? "Upload Files",
+    uploadIcon: props.uploadIcon ?? "upload",
     emptyMessage:
       props.emptyMessage ??
       `No items found matching "${props.searchQuery ?? ""}"`,

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -92,7 +92,7 @@ template:
                               - rtgl-text: ${group.fullLabel}
                           - rtgl-view w=1fg: null
                           - $if canUpload:
-                              - rtgl-button#uploadBtnHeaderRef${gIndex} data-group-id=${group.id} s=sm w=1fg pre=upload: ${uploadText}
+                              - rtgl-button#uploadBtnHeaderRef${gIndex} data-group-id=${group.id} s=sm w=1fg pre=${uploadIcon}: ${uploadText}
                       - rtgl-view w=f pos=rel:
                           - $if !group.isCollapsed:
                               - 'rtgl-view w=f d=h ph=sm pt=md pb=sm mb=lg wrap g=md style="min-width: 0;"':
@@ -159,7 +159,7 @@ template:
                                     $else:
                                       - $if canUpload:
                                           - rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=sm cur=pointer:
-                                              - rtgl-svg svg=upload wh=32: null
+                                              - rtgl-svg svg=${uploadIcon} wh=32: null
                                               - rtgl-text: ${uploadText}
                           - $if draggingGroupId == group.id:
                               - 'rtgl-view d=h av=c pos=abs w=f h=f bw=md bc=pr style="top: 0; bottom: 0; left: 0; right: 0;"':
@@ -173,7 +173,7 @@ template:
               - rtgl-view w=f h=f av=c ah=c g=lg:
                   - $if canUpload:
                       - rtgl-view#uploadBtnRoot w=300 h=200 bw=xs bc=bo br=md ah=c av=c g=sm cur=pointer:
-                          - rtgl-svg svg=upload wh=32: null
+                          - rtgl-svg svg=${uploadIcon} wh=32: null
                           - rtgl-text: ${uploadText}
                     $else:
                       - rtgl-text s=lg c=mu-fg: No data

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -1,5 +1,5 @@
 import { normalizeLineActions } from "../../internal/project/engineActions.js";
-import { ROUTEVN_CREATOR_DOCS_URL } from "../../internal/routevnUrls.js";
+import { getRoutevnCreatorSystemActionDocsUrl } from "../../internal/routevnUrls.js";
 
 const toPlainObject = (value) => {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -111,9 +111,9 @@ export const handleEmbeddedCloseClick = (deps, payload) => {
 export const handleHelpFloatingButtonClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { appService, store } = deps;
+  const mode = store.selectMode();
 
-  console.log("systemActions mode:", store.selectMode());
-  appService.openUrl(ROUTEVN_CREATOR_DOCS_URL);
+  appService.openUrl(getRoutevnCreatorSystemActionDocsUrl(mode));
 };
 
 export const handleActionsDialogClose = (deps) => {

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -164,8 +164,8 @@ template:
                   - rtgl-button#embeddedCloseButton: Confirm
   - rtgl-dialog#actionsDialog key=${mode} ?open=${isActionsDialogOpen}:
       - rtgl-view slot=content w=800 h=80vh pos=rel:
-          - 'rtgl-view#helpFloatingButton pos=abs z=10 w=40 h=40 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="top: 16px; right: 16px; box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);"':
-              - rtgl-text s=sm c=mu-fg: '?'
+          - 'rtgl-view#helpFloatingButton pos=abs z=10 w=28 h=28 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="top: 10px; right: 10px; box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);"':
+              - rtgl-text s=xs c=mu-fg: '?'
           - $if mode == "actions":
               - rvn-command-line-actions#commandLineActions :actionsType=${actionsType} :hiddenModes=${hiddenModes}: null
             $elif mode == "dialogue":

--- a/src/internal/routevnUrls.js
+++ b/src/internal/routevnUrls.js
@@ -1,2 +1,102 @@
-export const ROUTEVN_CREATOR_DOCS_URL =
-  "https://routevn.com/creator/docs/intro/";
+const ROUTEVN_CREATOR_DOCS_BASE_URL = "https://routevn.com/creator/docs";
+
+export const ROUTEVN_CREATOR_DOCS_URL = `${ROUTEVN_CREATOR_DOCS_BASE_URL}/introduction/`;
+export const ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL = `${ROUTEVN_CREATOR_DOCS_BASE_URL}/page-index/`;
+
+const creatorDocsPathByRoutePattern = {
+  "/project": "/projects/",
+  "/projects": "/projects/",
+  "/project/images": "/images/",
+  "/project/characters": "/characters/",
+  "/project/sounds": "/sounds/",
+  "/project/transforms": "/transforms/",
+  "/project/animations": "/animations/",
+  "/project/videos": "/videos/",
+  "/project/colors": "/colors/",
+  "/project/text-styles": "/text-styles/",
+  "/project/controls": "/controls/",
+  "/project/scenes": "/scene-map/",
+  "/project/scene-editor": "/scene-editor/",
+  "/project/fonts": "/fonts/",
+  "/project/layouts": "/layouts/",
+  "/project/releases": "/versions/",
+  "/project/releases/versions": "/versions/",
+};
+
+const creatorDocsPathBySystemActionMode = {
+  actions: "/scene-editor/",
+  hidden: "/page-index/",
+  dialogue: "/line-actions/dialogue/",
+  choice: "/line-actions/choices/",
+  background: "/line-actions/background/",
+  bgm: "/line-actions/bgm/",
+  sfx: "/line-actions/sfx/",
+  character: "/line-actions/characters/",
+  visual: "/line-actions/visual/",
+  sectionTransition: "/line-actions/section-transition/",
+  resetStoryAtSection: "/line-actions/section-transition/",
+  control: "/line-actions/controls/",
+  nextLine: "/line-actions/next-line/",
+  toggleAutoMode: "/line-actions/toggle-auto-mode/",
+  toggleSkipMode: "/line-actions/toggle-skip-mode/",
+  toggleDialogueUI: "/line-actions/dialogue/",
+  setDialogueTextSpeed: "/line-actions/dialogue/",
+  pushOverlay: "/line-actions/visual/",
+  popOverlay: "/line-actions/visual/",
+  rollbackByOffset: "/line-actions/next-line/",
+  showConfirmDialog: "/line-actions/controls/",
+  hideConfirmDialog: "/line-actions/controls/",
+  saveSlot: "/line-actions/controls/",
+  loadSlot: "/line-actions/controls/",
+  setNextLineConfig: "/line-actions/next-line-config/",
+  setSaveLoadPagination: "/line-actions/controls/",
+  incrementSaveLoadPagination: "/line-actions/controls/",
+  decrementSaveLoadPagination: "/line-actions/controls/",
+  setSoundVolume: "/line-actions/sfx/",
+  setMusicVolume: "/line-actions/bgm/",
+  setMuteAll: "/line-actions/bgm/",
+  setMenuPage: "/line-actions/controls/",
+  setMenuEntryPoint: "/line-actions/controls/",
+};
+
+const normalizeRoutePattern = (routePattern) => {
+  if (typeof routePattern !== "string" || routePattern.length === 0) {
+    return undefined;
+  }
+
+  if (routePattern.length > 1) {
+    return routePattern.replace(/\/+$/, "");
+  }
+
+  return routePattern;
+};
+
+const normalizeMode = (mode) => {
+  if (typeof mode !== "string" || mode.length === 0) {
+    return undefined;
+  }
+
+  return mode;
+};
+
+export const getRoutevnCreatorDocsUrl = (routePattern) => {
+  const normalizedRoutePattern = normalizeRoutePattern(routePattern);
+  const docsPath = creatorDocsPathByRoutePattern[normalizedRoutePattern];
+
+  if (!docsPath) {
+    return ROUTEVN_CREATOR_DOCS_URL;
+  }
+
+  return `${ROUTEVN_CREATOR_DOCS_BASE_URL}${docsPath}`;
+};
+
+export const getRoutevnCreatorSystemActionDocsUrl = (mode) => {
+  const normalizedMode = normalizeMode(mode);
+  const docsPath = creatorDocsPathBySystemActionMode[normalizedMode];
+
+  if (!docsPath) {
+    return ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL;
+  }
+
+  return `${ROUTEVN_CREATOR_DOCS_BASE_URL}${docsPath}`;
+};

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -12,7 +12,7 @@ import {
   getProjectOpenErrorMessage,
   isIncompatibleProjectOpenError,
 } from "../../internal/projectOpenErrors.js";
-import { ROUTEVN_CREATOR_DOCS_URL } from "../../internal/routevnUrls.js";
+import { getRoutevnCreatorDocsUrl } from "../../internal/routevnUrls.js";
 
 const GLOBAL_NAV_TIMEOUT_MS = 1500;
 
@@ -328,9 +328,10 @@ export const handleUpdateColor = async (deps, payload) => {
 };
 
 export const handleHelpFloatingButtonClick = (deps) => {
-  const { appService } = deps;
+  const { appService, store } = deps;
+  const currentRoutePattern = store.selectCurrentRoutePattern();
 
-  appService.openUrl(ROUTEVN_CREATOR_DOCS_URL);
+  appService.openUrl(getRoutevnCreatorDocsUrl(currentRoutePattern));
 };
 
 const subscriptions = (deps) => {

--- a/src/pages/spritesheets/spritesheets.store.js
+++ b/src/pages/spritesheets/spritesheets.store.js
@@ -447,6 +447,7 @@ export const selectViewData = ({ state }) => {
     selectedResourceId: "spritesheets",
     title: "Spritesheets",
     uploadText: "Add",
+    uploadIcon: "plus",
     acceptedFileTypes: [".png", ".json"],
     flatItems,
     mediaGroups,

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -78,7 +78,7 @@ template:
                   - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
           - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
-                  - rvn-media-resources-view#groupview w=f h=f :navTitle=${title} show-zoom-controls progressive-render lazy-image-cards :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :acceptedFileTypes=${acceptedFileTypes} :itemContextMenuItems=${centerItemContextMenuItems}: null
+                  - rvn-media-resources-view#groupview w=f h=f :navTitle=${title} show-zoom-controls progressive-render lazy-image-cards :groups=${mediaGroups} :selectedItemId=${selectedItemId} :searchQuery=${searchQuery} :uploadText=${uploadText} :uploadIcon=${uploadIcon} :acceptedFileTypes=${acceptedFileTypes} :itemContextMenuItems=${centerItemContextMenuItems}: null
           - rvn-resizable-panel panel-type=detail-panel w=300 min-w=220 max-w=520 resize-side="left":
               - rtgl-view wh=f slot="content":
                   - 'div#fileExplorerDetailKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -1,17 +1,183 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleBreadcumbClick,
+  handleCharacterClick,
+  handleCharacterItemClick,
   handleCharacterContextMenu,
   handleDropdownMenuClickItem,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.handlers.js";
 import {
+  addCharacter,
+  clearPendingCharacterIndex,
   createInitialState,
   removeCharacter,
   selectDropdownMenuCharacterIndex,
+  selectMode,
+  selectPendingCharacterIndex,
+  selectSelectedCharacterIndex,
+  selectSelectedCharacters,
+  selectTempSelectedSpriteId,
+  setMode,
+  setPendingCharacterIndex,
+  setSearchQuery,
+  setSelectedCharacterIndex,
+  setTempSelectedSpriteId,
   setExistingCharacters,
+  setTransforms,
   showDropdownMenu,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
 
+const createStoreApi = (state) => ({
+  addCharacter: (payload) => addCharacter({ state }, payload),
+  clearPendingCharacterIndex: () => clearPendingCharacterIndex({ state }),
+  hideDropdownMenu: () => {
+    state.dropdownMenu.isOpen = false;
+    state.dropdownMenu.characterIndex = null;
+  },
+  removeCharacter: (payload) => removeCharacter({ state }, payload),
+  selectDropdownMenuCharacterIndex: () =>
+    selectDropdownMenuCharacterIndex({ state }),
+  selectMode: () => selectMode({ state }),
+  selectPendingCharacterIndex: () => selectPendingCharacterIndex({ state }),
+  selectSelectedCharacters: () => selectSelectedCharacters({ state }),
+  setMode: (payload) => setMode({ state }, payload),
+  setPendingCharacterIndex: (payload) =>
+    setPendingCharacterIndex({ state }, payload),
+  setSearchQuery: (payload) => setSearchQuery({ state }, payload),
+  setSelectedCharacterIndex: (payload) =>
+    setSelectedCharacterIndex({ state }, payload),
+  setTempSelectedSpriteId: (payload) =>
+    setTempSelectedSpriteId({ state }, payload),
+  showDropdownMenu: (payload) => showDropdownMenu({ state }, payload),
+});
+
 describe("commandLineCharacters.handlers", () => {
+  it("drops a newly added character when sprite selection is cancelled from the breadcrumb", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    handleCharacterItemClick(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              characterId: "character-2",
+            },
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedCharacters({ state }).map((character) => character.id)).toEqual([
+      "character-2",
+    ]);
+    expect(selectPendingCharacterIndex({ state })).toBe(0);
+    expect(selectMode({ state })).toBe("sprite-select");
+
+    handleBreadcumbClick(
+      {
+        dispatchEvent,
+        render,
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            id: "current",
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedCharacters({ state })).toEqual([]);
+    expect(selectPendingCharacterIndex({ state })).toBeUndefined();
+    expect(selectSelectedCharacterIndex({ state })).toBeUndefined();
+    expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
+    expect(selectMode({ state })).toBe("current");
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps existing characters when returning from sprite selection", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setTransforms(
+      { state },
+      {
+        transforms: {
+          items: {},
+          tree: [],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-1",
+            sprites: [
+              {
+                id: "base",
+                resourceId: "sprite-1",
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    handleCharacterClick(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+        },
+      },
+    );
+
+    expect(selectMode({ state })).toBe("sprite-select");
+    expect(selectPendingCharacterIndex({ state })).toBeUndefined();
+    expect(selectTempSelectedSpriteId({ state })).toBe("sprite-1");
+
+    handleBreadcumbClick(
+      {
+        dispatchEvent,
+        render,
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            id: "current",
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedCharacters({ state }).map((character) => character.id)).toEqual([
+      "character-1",
+    ]);
+    expect(selectMode({ state })).toBe("current");
+    expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
   it("keeps the clicked character index when a context menu opens", () => {
     const state = createInitialState();
     const render = vi.fn();
@@ -19,9 +185,7 @@ describe("commandLineCharacters.handlers", () => {
 
     handleCharacterContextMenu(
       {
-        store: {
-          showDropdownMenu: (payload) => showDropdownMenu({ state }, payload),
-        },
+        store: createStoreApi(state),
         render,
       },
       {
@@ -59,9 +223,7 @@ describe("commandLineCharacters.handlers", () => {
 
     handleCharacterContextMenu(
       {
-        store: {
-          showDropdownMenu: (payload) => showDropdownMenu({ state }, payload),
-        },
+        store: createStoreApi(state),
         render,
       },
       {
@@ -106,15 +268,7 @@ describe("commandLineCharacters.handlers", () => {
 
     handleDropdownMenuClickItem(
       {
-        store: {
-          selectDropdownMenuCharacterIndex: () =>
-            selectDropdownMenuCharacterIndex({ state }),
-          removeCharacter: (payload) => removeCharacter({ state }, payload),
-          hideDropdownMenu: () => {
-            state.dropdownMenu.isOpen = false;
-            state.dropdownMenu.characterIndex = null;
-          },
-        },
+        store: createStoreApi(state),
         render,
       },
       {

--- a/tests/internal/routevnUrls.test.js
+++ b/tests/internal/routevnUrls.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRoutevnCreatorDocsUrl,
+  getRoutevnCreatorSystemActionDocsUrl,
+  ROUTEVN_CREATOR_DOCS_URL,
+  ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL,
+} from "../../src/internal/routevnUrls.js";
+
+describe("routevnUrls", () => {
+  it("returns the verified docs page for a known resource route", () => {
+    expect(getRoutevnCreatorDocsUrl("/project/images")).toBe(
+      "https://routevn.com/creator/docs/images/",
+    );
+    expect(getRoutevnCreatorDocsUrl("/projects")).toBe(
+      "https://routevn.com/creator/docs/projects/",
+    );
+  });
+
+  it("maps non-slug route names to their docs page", () => {
+    expect(getRoutevnCreatorDocsUrl("/project/scenes/")).toBe(
+      "https://routevn.com/creator/docs/scene-map/",
+    );
+    expect(getRoutevnCreatorDocsUrl("/project/releases")).toBe(
+      "https://routevn.com/creator/docs/versions/",
+    );
+  });
+
+  it("falls back to the introduction page when no dedicated docs route exists", () => {
+    expect(getRoutevnCreatorDocsUrl("/project/variables")).toBe(
+      ROUTEVN_CREATOR_DOCS_URL,
+    );
+    expect(getRoutevnCreatorDocsUrl(undefined)).toBe(
+      ROUTEVN_CREATOR_DOCS_URL,
+    );
+  });
+
+  it("returns the dedicated line-action docs page for known system action modes", () => {
+    expect(getRoutevnCreatorSystemActionDocsUrl("background")).toBe(
+      "https://routevn.com/creator/docs/line-actions/background/",
+    );
+    expect(getRoutevnCreatorSystemActionDocsUrl("setNextLineConfig")).toBe(
+      "https://routevn.com/creator/docs/line-actions/next-line-config/",
+    );
+  });
+
+  it("maps related system action modes to the closest documented guide", () => {
+    expect(getRoutevnCreatorSystemActionDocsUrl("toggleDialogueUI")).toBe(
+      "https://routevn.com/creator/docs/line-actions/dialogue/",
+    );
+    expect(getRoutevnCreatorSystemActionDocsUrl("setSoundVolume")).toBe(
+      "https://routevn.com/creator/docs/line-actions/sfx/",
+    );
+  });
+
+  it("falls back to the docs index for generic or undocumented system action modes", () => {
+    expect(getRoutevnCreatorSystemActionDocsUrl("actions")).toBe(
+      "https://routevn.com/creator/docs/scene-editor/",
+    );
+    expect(getRoutevnCreatorSystemActionDocsUrl("updateVariable")).toBe(
+      ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL,
+    );
+    expect(getRoutevnCreatorSystemActionDocsUrl(undefined)).toBe(
+      ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make floating help links route-aware across app pages and system action command lines
- tighten the command-line help FAB sizing and fix the spritesheets add affordance to use the plus icon
- treat newly chosen command-line characters as pending until sprite selection is confirmed, so backing out does not leave an empty-sprite row

## Validation
- bunx vitest run tests/internal/routevnUrls.test.js
- bunx vitest run tests/commandLineCharacters/commandLineCharacters.handlers.test.js
- bun run build:tauri
