### PR TITLE
Fix scene editor presentation state and dialogue command line

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "jsdom": "^26.1.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.5",
-        "route-engine-js": "1.3.0",
+        "route-engine-js": "1.4.1",
         "route-graphics": "1.8.1",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
@@ -687,7 +687,7 @@
 
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
 
-    "route-engine-js": ["route-engine-js@1.3.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-GsT359Y2znkIAEwmn5hAlJwX5BxuATV2rHw9fitf4oKsYIyF/uFcIVGaQ8FkZhu1VT09j/5DyR1JOMHPzoqFRw=="],
+    "route-engine-js": ["route-engine-js@1.4.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.0", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-Cer5b2p2tWHPmyjt7qcGkdyAtbx15P/H1rLj1pvE0q/tlMxg+ZsTPhcpV3gvFktSLm/nSLpSfoi6/KjxckUzBQ=="],
 
     "route-graphics": ["route-graphics@1.8.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-L1z2B16E448dvvXDPjO9gss7c8qM/dAUJKs48ZTkFC/+V2Y8w2K7ZhnmhzVa/4BhU93cwCa3qYCrtte2U+N7OQ=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsdom": "^26.1.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.5",
-    "route-engine-js": "1.3.0",
+    "route-engine-js": "1.4.1",
     "route-graphics": "1.8.1",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -41,12 +41,15 @@ const getSelectedCharacterName = ({ characters, characterId } = {}) => {
   }
 
   return (
-    (characters ?? []).find((character) => character.id === characterId)?.name ??
-    ""
+    (characters ?? []).find((character) => character.id === characterId)
+      ?.name ?? ""
   );
 };
 
-const hasDialogueCharacter = ({ selectedCharacterId, customCharacterName } = {}) => {
+const hasDialogueCharacter = ({
+  selectedCharacterId,
+  customCharacterName,
+} = {}) => {
   return !!selectedCharacterId || toBoolean(customCharacterName);
 };
 
@@ -160,7 +163,8 @@ export const handleFormChange = (deps, payload) => {
     selectedCharacterId,
     customCharacterName,
   });
-  const persistCharacterVisibilityChanged = hadDialogueCharacter !== hasCharacter;
+  const persistCharacterVisibilityChanged =
+    hadDialogueCharacter !== hasCharacter;
   let characterName = formValues.characterName ?? currentState.characterName;
 
   if (!customCharacterName) {

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -35,14 +35,37 @@ const resolveSelectedResourceId = ({ layouts, mode, resourceId } = {}) => {
   return availableLayouts[0]?.id ?? "";
 };
 
+const getSelectedCharacterName = ({ characters, characterId } = {}) => {
+  if (!characterId) {
+    return "";
+  }
+
+  return (
+    (characters ?? []).find((character) => character.id === characterId)?.name ??
+    ""
+  );
+};
+
+const hasDialogueCharacter = ({ selectedCharacterId, customCharacterName } = {}) => {
+  return !!selectedCharacterId || toBoolean(customCharacterName);
+};
+
 const syncDialogueStateFromProps = (deps, dialogue = {}) => {
   const { store, props } = deps;
   const selectedMode = resolveDialogueMode({
     layouts: props?.layouts,
     dialogue,
   });
+  const selectedCharacterId = dialogue?.characterId ?? "";
+  const customCharacterName =
+    typeof dialogue?.character?.name === "string" &&
+    dialogue.character.name.length > 0;
+  const hasCharacter = hasDialogueCharacter({
+    selectedCharacterId,
+    customCharacterName,
+  });
   const selectedResourceId =
-    dialogue?.ui?.resourceId || dialogue?.gui?.resourceId || "";
+    dialogue?.ui?.resourceId ?? dialogue?.gui?.resourceId ?? "";
 
   store.setSelectedMode({
     mode: selectedMode,
@@ -55,7 +78,21 @@ const syncDialogueStateFromProps = (deps, dialogue = {}) => {
     }),
   });
   store.setSelectedCharacterId({
-    characterId: dialogue?.characterId || "",
+    characterId: selectedCharacterId,
+  });
+  store.setCustomCharacterName({
+    customCharacterName,
+  });
+  store.setCharacterName({
+    characterName:
+      dialogue?.character?.name ??
+      getSelectedCharacterName({
+        characters: props?.characters,
+        characterId: selectedCharacterId,
+      }),
+  });
+  store.setPersistCharacter({
+    persistCharacter: hasCharacter && dialogue?.persistCharacter === true,
   });
 
   store.setClearPage({
@@ -65,8 +102,15 @@ const syncDialogueStateFromProps = (deps, dialogue = {}) => {
 
 const syncDialogueFormValues = (deps) => {
   const { refs, store } = deps;
-  const { selectedMode, selectedResourceId, selectedCharacterId, clearPage } =
-    store.getState();
+  const {
+    selectedMode,
+    selectedResourceId,
+    selectedCharacterId,
+    customCharacterName,
+    characterName,
+    persistCharacter,
+    clearPage,
+  } = store.getState();
 
   refs.dialogueForm.reset();
   refs.dialogueForm.setValues({
@@ -74,6 +118,9 @@ const syncDialogueFormValues = (deps) => {
       mode: selectedMode,
       resourceId: selectedResourceId,
       characterId: selectedCharacterId,
+      customCharacterName,
+      characterName,
+      persistCharacter,
       clearPage,
     },
   });
@@ -100,31 +147,77 @@ export const handleFormChange = (deps, payload) => {
     return;
   }
 
+  const currentState = store.getState();
   const selectedMode = formValues.mode === "nvl" ? "nvl" : "adv";
-  const modeChanged = selectedMode !== store.getState().selectedMode;
+  const modeChanged = selectedMode !== currentState.selectedMode;
+  const customCharacterName = toBoolean(formValues.customCharacterName);
+  const selectedCharacterId = formValues.characterId ?? "";
+  const hadDialogueCharacter = hasDialogueCharacter({
+    selectedCharacterId: currentState.selectedCharacterId,
+    customCharacterName: currentState.customCharacterName,
+  });
+  const hasCharacter = hasDialogueCharacter({
+    selectedCharacterId,
+    customCharacterName,
+  });
+  const persistCharacterVisibilityChanged = hadDialogueCharacter !== hasCharacter;
+  let characterName = formValues.characterName ?? currentState.characterName;
+
+  if (!customCharacterName) {
+    characterName = getSelectedCharacterName({
+      characters: props?.characters,
+      characterId: selectedCharacterId,
+    });
+  } else if (
+    currentState.customCharacterName !== true &&
+    (characterName ?? "").length === 0
+  ) {
+    characterName = getSelectedCharacterName({
+      characters: props?.characters,
+      characterId: selectedCharacterId,
+    });
+  }
 
   store.setSelectedMode({ mode: selectedMode });
   store.setSelectedResource({
     resourceId: resolveSelectedResourceId({
       layouts: props?.layouts,
       mode: selectedMode,
-      resourceId: formValues.resourceId || "",
+      resourceId: formValues.resourceId ?? "",
     }),
   });
-  store.setSelectedCharacterId({ characterId: formValues.characterId || "" });
+  store.setSelectedCharacterId({ characterId: selectedCharacterId });
+  store.setCustomCharacterName({
+    customCharacterName,
+  });
+  store.setCharacterName({
+    characterName,
+  });
+  const persistCharacter =
+    hasCharacter && hadDialogueCharacter ? formValues.persistCharacter : false;
+  store.setPersistCharacter({
+    persistCharacter,
+  });
   store.setClearPage({ clearPage: formValues.clearPage });
 
   render();
 
-  if (modeChanged) {
+  if (modeChanged || persistCharacterVisibilityChanged) {
     syncDialogueFormValues(deps);
   }
 };
 
 export const handleSubmitClick = (deps) => {
   const { store, dispatchEvent, props } = deps;
-  const { selectedMode, selectedResourceId, selectedCharacterId, clearPage } =
-    store.getState();
+  const {
+    selectedMode,
+    selectedResourceId,
+    selectedCharacterId,
+    customCharacterName,
+    characterName,
+    persistCharacter,
+    clearPage,
+  } = store.getState();
   const effectiveMode = resolveDialogueMode({
     layouts: props?.layouts,
     dialogue: {
@@ -157,6 +250,17 @@ export const handleSubmitClick = (deps) => {
   if (selectedCharacterId) {
     dialogue.characterId = selectedCharacterId;
   }
+  if (toBoolean(customCharacterName)) {
+    dialogue.character = {
+      name: characterName ?? "",
+    };
+  }
+  const persistCharacterEnabled =
+    hasDialogueCharacter({
+      selectedCharacterId,
+      customCharacterName,
+    }) && toBoolean(persistCharacter);
+  dialogue.persistCharacter = persistCharacterEnabled;
   if (effectiveMode === "nvl" && toBoolean(clearPage)) {
     dialogue.clearPage = true;
   }

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.schema.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.schema.yaml
@@ -27,6 +27,8 @@ propsSchema:
           type: string
         clearPage:
           type: boolean
+        persistCharacter:
+          type: boolean
         ui:
           type: object
           properties:
@@ -39,3 +41,8 @@ propsSchema:
               type: string
         characterId:
           type: string
+        character:
+          type: object
+          properties:
+            name:
+              type: string

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -32,13 +32,19 @@ export const createInitialState = () => ({
   selectedResourceId: "",
   characters: [],
   selectedCharacterId: "",
+  customCharacterName: false,
+  characterName: "",
   selectedMode: "adv",
+  persistCharacter: false,
   clearPage: false,
 
   defaultValues: {
     mode: "adv",
     resourceId: "",
     characterId: "",
+    customCharacterName: false,
+    characterName: "",
+    persistCharacter: false,
     clearPage: false,
   },
 
@@ -76,6 +82,40 @@ export const createInitialState = () => ({
         options: [],
       },
       {
+        name: "customCharacterName",
+        type: "segmented-control",
+        label: "Custom Character Name",
+        description: "",
+        required: true,
+        clearable: false,
+        options: [
+          { value: false, label: "No" },
+          { value: true, label: "Yes" },
+        ],
+      },
+      {
+        $when: "values.customCharacterName == true",
+        name: "characterName",
+        type: "input-text",
+        label: "Character Name",
+        description: "",
+        required: true,
+        placeholder: "Enter character name",
+      },
+      {
+        $when: "values.characterId || values.customCharacterName",
+        name: "persistCharacter",
+        type: "segmented-control",
+        label: "Persist Character",
+        description: "",
+        required: true,
+        clearable: false,
+        options: [
+          { value: false, label: "No" },
+          { value: true, label: "Yes" },
+        ],
+      },
+      {
         $when: 'values.mode == "nvl"',
         name: "clearPage",
         type: "segmented-control",
@@ -110,10 +150,31 @@ export const setSelectedCharacterId = ({ state }, { characterId } = {}) => {
   state.defaultValues.characterId = characterId;
 };
 
+export const setCustomCharacterName = (
+  { state },
+  { customCharacterName } = {},
+) => {
+  const customCharacterNameValue = toBoolean(customCharacterName);
+  state.customCharacterName = customCharacterNameValue;
+  state.defaultValues.customCharacterName = customCharacterNameValue;
+};
+
+export const setCharacterName = ({ state }, { characterName } = {}) => {
+  const nextCharacterName = characterName ?? "";
+  state.characterName = nextCharacterName;
+  state.defaultValues.characterName = nextCharacterName;
+};
+
 export const setSelectedMode = ({ state }, { mode } = {}) => {
   const selectedMode = mode === "nvl" ? "nvl" : "adv";
   state.selectedMode = selectedMode;
   state.defaultValues.mode = selectedMode;
+};
+
+export const setPersistCharacter = ({ state }, { persistCharacter } = {}) => {
+  const persistCharacterValue = toBoolean(persistCharacter);
+  state.persistCharacter = persistCharacterValue;
+  state.defaultValues.persistCharacter = persistCharacterValue;
 };
 
 export const setClearPage = ({ state }, { clearPage } = {}) => {
@@ -181,6 +242,24 @@ export const selectViewData = ({ state, props }) => {
           value: state.selectedCharacterId,
         };
       }
+      if (field.name === "customCharacterName") {
+        return {
+          ...field,
+          value: state.customCharacterName,
+        };
+      }
+      if (field.name === "characterName") {
+        return {
+          ...field,
+          value: state.characterName,
+        };
+      }
+      if (field.name === "persistCharacter") {
+        return {
+          ...field,
+          value: state.persistCharacter,
+        };
+      }
       if (field.name === "clearPage") {
         return {
           ...field,
@@ -196,6 +275,9 @@ export const selectViewData = ({ state, props }) => {
     mode: selectedMode,
     resourceId: selectedResourceId,
     characterId: state.selectedCharacterId,
+    customCharacterName: state.customCharacterName,
+    characterName: state.characterName,
+    persistCharacter: state.persistCharacter,
     clearPage: state.clearPage,
   };
 
@@ -208,7 +290,10 @@ export const selectViewData = ({ state, props }) => {
     characters: characterOptions,
     selectedResourceId,
     selectedCharacterId: state.selectedCharacterId,
+    customCharacterName: state.customCharacterName,
+    characterName: state.characterName,
     selectedMode,
+    persistCharacter: state.persistCharacter,
     clearPage: state.clearPage,
     submitDisabled: !selectedResourceId,
     breadcrumb,

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -446,10 +446,29 @@ export const selectActionsData = ({ props, state }) => {
       presentationState.dialogue,
       layoutsItems,
     );
+    const customCharacterNameLabel =
+      presentationState.dialogue.clear === true ||
+      typeof presentationState.dialogue.character?.name !== "string" ||
+      presentationState.dialogue.character.name.length === 0
+        ? undefined
+        : `Name: ${truncatePreviewText(
+            presentationState.dialogue.character.name,
+          )}`;
+    const hasDialogueCharacter =
+      !!presentationState.dialogue.characterId ||
+      customCharacterNameLabel !== undefined;
+    const persistCharacterLabel =
+      presentationState.dialogue.clear === true ||
+      hasDialogueCharacter !== true ||
+      presentationState.dialogue.persistCharacter !== true
+        ? undefined
+        : "Persist Character";
     if (presentationState.dialogue.clear === true) {
       preview.dialogue = {
         name: "Dialogue: Clear",
         modeLabel: dialogueModeLabel,
+        customCharacterNameLabel,
+        persistCharacterLabel,
       };
     } else {
       preview.dialogue = {
@@ -459,6 +478,8 @@ export const selectActionsData = ({ props, state }) => {
               presentationState.dialogue.gui?.resourceId
           ]?.name || "No layout",
         modeLabel: dialogueModeLabel,
+        customCharacterNameLabel,
+        persistCharacterLabel,
       };
     }
   }

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -86,11 +86,17 @@ template:
                       - rtgl-svg svg="settings" wh=24: null
                       - rtgl-text s=sm: ${preview.resetStoryAtSection.label}
               - $if preview.dialogue:
-                  - rtgl-view#actionItemDialogue data-mode=dialogue g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
+                  - rtgl-view#actionItemDialogue data-mode=dialogue g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md w=f cur=pointer pv=md:
                       - rtgl-svg svg=dialogue wh=24: null
-                      - rtgl-view d=h av=c g=xs:
+                      - rtgl-view d=h av=c g=xs wrap:
                           - rtgl-text s=sm: ${preview.dialogue.name}
                           - rtgl-text s=xs c=mu-fg: ${preview.dialogue.modeLabel}
+                          - $if preview.dialogue.customCharacterNameLabel:
+                              - rtgl-view bw=xs bc=bo br=sm ph=md pv=sm:
+                                  - rtgl-text s=sm: ${preview.dialogue.customCharacterNameLabel}
+                          - $if preview.dialogue.persistCharacterLabel:
+                              - rtgl-view bw=xs bc=bo br=sm ph=md pv=sm:
+                                  - rtgl-text s=sm: ${preview.dialogue.persistCharacterLabel}
               - $if preview.choice && preview.choice.items:
                   - rtgl-view#actionItemChoices data-mode=choice g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md w=f cur=pointer pv=md:
                       - rtgl-svg svg=choices wh=24: null

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -1,10 +1,9 @@
 import { toFlatItems } from "../../project/tree.js";
 import { normalizeLineActions } from "../../project/engineActions.js";
 
-const getLineChanges = (sectionLineChanges, lineId) => {
+const getSectionLineEntry = (sectionLineChanges, lineId) => {
   const changesLines = sectionLineChanges?.lines || [];
-  const lineChanges = changesLines.find((change) => change.id === lineId);
-  return lineChanges?.changes || {};
+  return changesLines.find((change) => change.id === lineId);
 };
 
 const buildCharacterLookups = (repositoryState) => {
@@ -162,9 +161,7 @@ const buildChoicesPreview = (line) => {
   };
 };
 
-const buildDialogueSpeakerPreview = (line, characterLookups) => {
-  const lineActions = normalizeLineActions(line.actions || {});
-  const characterId = lineActions?.dialogue?.characterId;
+const buildDialogueSpeakerPreview = (characterId, characterLookups) => {
   if (!characterId) {
     return undefined;
   }
@@ -213,10 +210,12 @@ export const buildSceneEditorLineViewModels = ({
 }) => {
   const characterLookups = buildCharacterLookups(repositoryState);
 
-  return (lines || []).map((line, index) => {
+  const viewModels = (lines || []).map((line, index) => {
     const lineActions = normalizeLineActions(line.actions || {});
-    const changes = getLineChanges(sectionLineChanges, line.id);
+    const sectionLineEntry = getSectionLineEntry(sectionLineChanges, line.id);
+    const changes = sectionLineEntry?.changes || {};
     const choicesPreview = buildChoicesPreview(line);
+    const linePresentationState = sectionLineEntry?.presentationState;
 
     return {
       ...line,
@@ -229,7 +228,10 @@ export const buildSceneEditorLineViewModels = ({
             resourceId: changes.bgm.data?.resourceId,
           }
         : undefined,
-      characterFileId: buildDialogueSpeakerPreview(line, characterLookups),
+      characterFileId: buildDialogueSpeakerPreview(
+        linePresentationState?.dialogue?.characterId,
+        characterLookups,
+      ),
       characterSprites: buildCharacterSpritePreview(
         repositoryState,
         changes,
@@ -250,4 +252,6 @@ export const buildSceneEditorLineViewModels = ({
       controlChangeType: changes.control?.changeType,
     };
   });
+
+  return viewModels;
 };

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -661,7 +661,10 @@ export const updateSceneEditorSectionChanges = async (deps) => {
     return;
   }
 
-  const changes = graphicsService.engineSelectSectionLineChanges({ sectionId });
+  const changes = graphicsService.engineSelectSectionLineChanges({
+    sectionId,
+    includePresentationState: true,
+  });
   store.setSectionLineChanges({ changes });
 };
 

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -1,0 +1,768 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAfterMount,
+  handleBeforeMount,
+  handleFormChange,
+  handleSubmitClick,
+} from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js";
+import {
+  createInitialState,
+  setCharacterName,
+  setClearPage,
+  setCustomCharacterName,
+  setPersistCharacter,
+  setSelectedCharacterId,
+  setSelectedMode,
+  setSelectedResource,
+} from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
+
+const layouts = [
+  {
+    id: "layout-adv",
+    name: "ADV Layout",
+    layoutType: "dialogue-adv",
+  },
+  {
+    id: "layout-nvl",
+    name: "NVL Layout",
+    layoutType: "dialogue-nvl",
+  },
+];
+
+const characters = [
+  {
+    id: "character-1",
+    type: "character",
+    name: "Aki",
+  },
+  {
+    id: "character-2",
+    type: "character",
+    name: "Mina",
+  },
+];
+
+const createStore = (state) => ({
+  getState: () => state,
+  setSelectedMode: (payload) => setSelectedMode({ state }, payload),
+  setSelectedResource: (payload) => setSelectedResource({ state }, payload),
+  setSelectedCharacterId: (payload) => setSelectedCharacterId({ state }, payload),
+  setCustomCharacterName: (payload) => setCustomCharacterName({ state }, payload),
+  setCharacterName: (payload) => setCharacterName({ state }, payload),
+  setPersistCharacter: (payload) => setPersistCharacter({ state }, payload),
+  setClearPage: (payload) => setClearPage({ state }, payload),
+});
+
+const createFormRefs = () => ({
+  dialogueForm: {
+    reset: vi.fn(),
+    setValues: vi.fn(),
+  },
+});
+
+describe("commandLineDialogueBox.handlers", () => {
+  it("hydrates persistCharacter and custom character name from props into the form state", () => {
+    const state = createInitialState();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    const deps = {
+      props: {
+        layouts,
+        characters,
+        dialogue: {
+          mode: "adv",
+          ui: {
+            resourceId: "layout-adv",
+          },
+          characterId: "character-1",
+          character: {
+            name: "Boss",
+          },
+          persistCharacter: true,
+        },
+      },
+      refs: {
+        dialogueForm: {
+          reset,
+          setValues,
+        },
+      },
+      store: createStore(state),
+    };
+
+    handleBeforeMount(deps);
+    handleAfterMount(deps);
+
+    expect(state.persistCharacter).toBe(true);
+    expect(state.customCharacterName).toBe(true);
+    expect(state.characterName).toBe("Boss");
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        customCharacterName: true,
+        characterName: "Boss",
+        persistCharacter: true,
+      }),
+    });
+  });
+
+  it("hydrates persistCharacter when only a custom character name is present", () => {
+    const state = createInitialState();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    const deps = {
+      props: {
+        layouts,
+        characters,
+        dialogue: {
+          mode: "adv",
+          ui: {
+            resourceId: "layout-adv",
+          },
+          character: {
+            name: "Boss",
+          },
+          persistCharacter: true,
+        },
+      },
+      refs: {
+        dialogueForm: {
+          reset,
+          setValues,
+        },
+      },
+      store: createStore(state),
+    };
+
+    handleBeforeMount(deps);
+    handleAfterMount(deps);
+
+    expect(state.selectedCharacterId).toBe("");
+    expect(state.customCharacterName).toBe(true);
+    expect(state.persistCharacter).toBe(true);
+    expect(setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        customCharacterName: true,
+        characterName: "Boss",
+        persistCharacter: true,
+      }),
+    });
+  });
+
+  it("clears persistCharacter from props when no character is selected", () => {
+    const state = createInitialState();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    const deps = {
+      props: {
+        layouts,
+        characters,
+        dialogue: {
+          mode: "adv",
+          ui: {
+            resourceId: "layout-adv",
+          },
+          persistCharacter: true,
+        },
+      },
+      refs: {
+        dialogueForm: {
+          reset,
+          setValues,
+        },
+      },
+      store: createStore(state),
+    };
+
+    handleBeforeMount(deps);
+    handleAfterMount(deps);
+
+    expect(state.selectedCharacterId).toBe("");
+    expect(state.persistCharacter).toBe(false);
+    expect(setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        characterId: "",
+        persistCharacter: false,
+      }),
+    });
+  });
+
+  it("tracks persistCharacter changes from the form payload after the field is visible", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const refs = createFormRefs();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: false,
+              characterName: "Aki",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.persistCharacter).toBe(true);
+    expect(state.characterName).toBe("Aki");
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets persistCharacter to false when selecting a character makes the field appear", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    setPersistCharacter({ state }, { persistCharacter: true });
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs: {
+          dialogueForm: {
+            reset,
+            setValues,
+          },
+        },
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.selectedCharacterId).toBe("character-1");
+    expect(state.persistCharacter).toBe(false);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        characterId: "character-1",
+        persistCharacter: false,
+      }),
+    });
+  });
+
+  it("clears persistCharacter when the selected character is removed", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const refs = createFormRefs();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.selectedCharacterId).toBe("");
+    expect(state.persistCharacter).toBe(false);
+  });
+
+  it("shows persistCharacter for custom names and keeps it enabled", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs: {
+          dialogueForm: {
+            reset,
+            setValues,
+          },
+        },
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: true,
+              characterName: "Boss",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.customCharacterName).toBe(true);
+    expect(state.persistCharacter).toBe(false);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        customCharacterName: true,
+        persistCharacter: false,
+      }),
+    });
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs: {
+          dialogueForm: {
+            reset,
+            setValues,
+          },
+        },
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: true,
+              characterName: "Boss",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.persistCharacter).toBe(true);
+  });
+
+  it("keeps the custom character name when switching characters with custom naming on", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const refs = createFormRefs();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: true,
+              characterName: "Boss",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-2",
+              customCharacterName: true,
+              characterName: "Boss",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.selectedCharacterId).toBe("character-2");
+    expect(state.customCharacterName).toBe(true);
+    expect(state.characterName).toBe("Boss");
+  });
+
+  it("submits persistCharacter when enabled", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setSelectedCharacterId({ state }, { characterId: "character-1" });
+    setPersistCharacter({ state }, { persistCharacter: true });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {},
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        characterId: "character-1",
+        persistCharacter: true,
+      },
+    });
+  });
+
+  it("submits dialogue.character.name when custom naming is enabled", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setSelectedCharacterId({ state }, { characterId: "character-1" });
+    setCustomCharacterName({ state }, { customCharacterName: true });
+    setCharacterName({ state }, { characterName: "Boss" });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {},
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        characterId: "character-1",
+        character: {
+          name: "Boss",
+        },
+        persistCharacter: false,
+      },
+    });
+  });
+
+  it("submits persistCharacter for custom naming without a selected character", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setCustomCharacterName({ state }, { customCharacterName: true });
+    setCharacterName({ state }, { characterName: "Boss" });
+    setPersistCharacter({ state }, { persistCharacter: true });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {},
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        character: {
+          name: "Boss",
+        },
+        persistCharacter: true,
+      },
+    });
+  });
+
+  it("submits persistCharacter false when clearing an existing persisted flag", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setPersistCharacter({ state }, { persistCharacter: false });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {
+          persistCharacter: true,
+        },
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        persistCharacter: false,
+      },
+    });
+  });
+
+  it("submits persistCharacter false by default", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {},
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        persistCharacter: false,
+      },
+    });
+  });
+
+  it("submits persistCharacter false when no character is selected", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setPersistCharacter({ state }, { persistCharacter: true });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {},
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        persistCharacter: false,
+      },
+    });
+  });
+
+  it("omits dialogue.character when custom naming is disabled", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setSelectedCharacterId({ state }, { characterId: "character-1" });
+    setCustomCharacterName({ state }, { customCharacterName: false });
+    setCharacterName({ state }, { characterName: "Boss" });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {
+          character: {
+            name: "Boss",
+          },
+        },
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        characterId: "character-1",
+        persistCharacter: false,
+      },
+    });
+  });
+});

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  setCharacterName,
+  setCustomCharacterName,
+  selectViewData,
+  setPersistCharacter,
+} from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
+
+describe("commandLineDialogueBox.store", () => {
+  it("includes custom character name and persistCharacter in form defaults and field values", () => {
+    const state = createInitialState();
+
+    setCustomCharacterName(
+      { state },
+      {
+        customCharacterName: true,
+      },
+    );
+    setCharacterName(
+      { state },
+      {
+        characterName: "Boss",
+      },
+    );
+    setPersistCharacter(
+      { state },
+      {
+        persistCharacter: true,
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        layouts: [
+          {
+            id: "layout-adv",
+            name: "ADV Layout",
+            layoutType: "dialogue-adv",
+          },
+        ],
+        characters: [],
+      },
+    });
+
+    expect(viewData.defaultValues.customCharacterName).toBe(true);
+    expect(viewData.defaultValues.characterName).toBe("Boss");
+    expect(viewData.defaultValues.persistCharacter).toBe(true);
+    expect(
+      viewData.form.fields.find((field) => field.name === "customCharacterName"),
+    ).toMatchObject({
+      type: "segmented-control",
+      value: true,
+    });
+    expect(
+      viewData.form.fields.find((field) => field.name === "characterName"),
+    ).toMatchObject({
+      type: "input-text",
+      value: "Boss",
+    });
+    expect(
+      viewData.form.fields.find((field) => field.name === "persistCharacter"),
+    ).toMatchObject({
+      $when: "values.characterId || values.customCharacterName",
+      type: "segmented-control",
+      value: true,
+    });
+  });
+});

--- a/tests/sceneEditor/lineViewModels.test.js
+++ b/tests/sceneEditor/lineViewModels.test.js
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { buildSceneEditorLineViewModels } from "../../src/internal/ui/sceneEditor/lineViewModels.js";
+
+const createRepositoryState = () => ({
+  characters: {
+    items: {
+      "character-1": {
+        id: "character-1",
+        type: "character",
+        name: "Aki",
+        fileId: "file-character-1",
+      },
+    },
+    tree: [{ id: "character-1" }],
+  },
+});
+
+describe("sceneEditor.lineViewModels", () => {
+  it("uses per-line presentationState from section changes for dialogue avatars", () => {
+    const lines = [
+      {
+        id: "line-1",
+        actions: {
+          dialogue: {
+            characterId: "character-1",
+            persistCharacter: true,
+            content: [{ text: "First" }],
+          },
+        },
+      },
+      {
+        id: "line-2",
+      },
+      {
+        id: "line-3",
+      },
+    ];
+
+    const viewModels = buildSceneEditorLineViewModels({
+      lines,
+      repositoryState: createRepositoryState(),
+      sectionLineChanges: {
+        lines: [
+          {
+            id: "line-1",
+            changes: {},
+            presentationState: {
+              dialogue: {
+                characterId: "character-1",
+              },
+            },
+          },
+          {
+            id: "line-2",
+            changes: {},
+            presentationState: {
+              dialogue: {
+                characterId: "character-1",
+              },
+            },
+          },
+          {
+            id: "line-3",
+            changes: {},
+            presentationState: {},
+          },
+        ],
+      },
+    });
+
+    expect(viewModels[0].characterFileId).toBe("file-character-1");
+    expect(viewModels[1].characterFileId).toBe("file-character-1");
+    expect(viewModels[2].characterFileId).toBeUndefined();
+  });
+
+  it("does not derive a dialogue avatar from raw line actions when section presentationState has no character", () => {
+    const lines = [
+      {
+        id: "line-1",
+        actions: {
+          dialogue: {
+            characterId: "character-1",
+            content: [{ text: "First" }],
+          },
+        },
+      },
+    ];
+
+    const viewModels = buildSceneEditorLineViewModels({
+      lines,
+      repositoryState: createRepositoryState(),
+      sectionLineChanges: {
+        lines: [
+          {
+            id: "line-1",
+            changes: {},
+            presentationState: {
+              dialogue: {
+                content: [{ text: "First" }],
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(viewModels[0].characterFileId).toBeUndefined();
+  });
+
+  it("does not flash a stale selected presentationState onto a line when section presentationState has no character", () => {
+    const lines = [
+      {
+        id: "line-1",
+      },
+    ];
+
+    const viewModels = buildSceneEditorLineViewModels({
+      lines,
+      repositoryState: createRepositoryState(),
+      sectionLineChanges: {
+        lines: [
+          {
+            id: "line-1",
+            changes: {},
+            presentationState: {},
+          },
+        ],
+      },
+    });
+
+    expect(viewModels[0].characterFileId).toBeUndefined();
+  });
+});

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -3,6 +3,7 @@ import createRouteEngine from "route-engine-js";
 import {
   createSceneEditorRenderQueue,
   renderSceneEditorState,
+  updateSceneEditorSectionChanges,
 } from "../../src/internal/ui/sceneEditor/runtime.js";
 
 const createProjectData = () => {
@@ -128,6 +129,30 @@ const createGraphicsService = () => {
 };
 
 describe("renderSceneEditorState", () => {
+  it("requests per-line presentationState from section line changes", async () => {
+    const changes = { lines: [] };
+    const engineSelectSectionLineChanges = vi.fn(() => changes);
+    const setSectionLineChanges = vi.fn();
+
+    await updateSceneEditorSectionChanges({
+      store: {
+        selectSelectedSectionId: () => "section-1",
+        setSectionLineChanges,
+      },
+      graphicsService: {
+        engineSelectSectionLineChanges,
+      },
+    });
+
+    expect(engineSelectSectionLineChanges).toHaveBeenCalledWith({
+      sectionId: "section-1",
+      includePresentationState: true,
+    });
+    expect(setSectionLineChanges).toHaveBeenCalledWith({
+      changes,
+    });
+  });
+
   it("coalesces overlapping canvas renders to the latest pending payload", async () => {
     const resolvers = [];
     const renderCanvas = vi.fn(

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -56,4 +56,114 @@ describe("systemActions.store", () => {
       label: "Reset story at Opening - Arrival",
     });
   });
+
+  it("includes custom character name and persist character labels in dialogue preview when a character is selected", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          layouts: {
+            items: {
+              "dialogue-layout": {
+                id: "dialogue-layout",
+                type: "layout",
+                name: "Main Dialogue",
+                layoutType: "dialogue-adv",
+              },
+            },
+            tree: [{ id: "dialogue-layout" }],
+          },
+        },
+      },
+    );
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actions: {},
+        presentationState: {
+          dialogue: {
+            ui: {
+              resourceId: "dialogue-layout",
+            },
+            mode: "adv",
+            characterId: "character-1",
+            character: {
+              name: "Boss",
+            },
+            persistCharacter: true,
+          },
+        },
+      },
+    });
+
+    expect(actions.dialogue).toEqual({
+      ui: {
+        resourceId: "dialogue-layout",
+      },
+      mode: "adv",
+      characterId: "character-1",
+      character: {
+        name: "Boss",
+      },
+      persistCharacter: true,
+    });
+    expect(preview.dialogue).toMatchObject({
+      name: "Main Dialogue",
+      modeLabel: "ADV",
+      customCharacterNameLabel: "Name: Boss",
+      persistCharacterLabel: "Persist Character",
+    });
+  });
+
+  it("includes the persist character label for custom character names without a selected character", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          layouts: {
+            items: {
+              "dialogue-layout": {
+                id: "dialogue-layout",
+                type: "layout",
+                name: "Main Dialogue",
+                layoutType: "dialogue-adv",
+              },
+            },
+            tree: [{ id: "dialogue-layout" }],
+          },
+        },
+      },
+    );
+
+    const { preview } = selectActionsData({
+      state,
+      props: {
+        actions: {},
+        presentationState: {
+          dialogue: {
+            ui: {
+              resourceId: "dialogue-layout",
+            },
+            mode: "adv",
+            character: {
+              name: "Boss",
+            },
+            persistCharacter: true,
+          },
+        },
+      },
+    });
+
+    expect(preview.dialogue).toMatchObject({
+      name: "Main Dialogue",
+      modeLabel: "ADV",
+      customCharacterNameLabel: "Name: Boss",
+      persistCharacterLabel: "Persist Character",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- bump `route-engine-js` to `1.4.1`
- drive scene editor dialogue avatars from engine-provided per-line `presentationState`
- add custom dialogue character naming and `persistCharacter` handling to the command line dialogue box
- show custom character name and persist state in the bottom-right state panel

## Testing
- `bunx vitest run tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js tests/systemActions/systemActions.store.test.js tests/systemActions/systemActions.handlers.test.js tests/sceneEditor/lineViewModels.test.js tests/sceneEditor/runtime.test.js tests/sceneEditor/sessionRuntime.test.js`
- `bunx vitest run tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js`