### PR TITLE
Use OR semantics for resource tag filters

### DIFF
--- a/docs/resource-tags-spec.md
+++ b/docs/resource-tags-spec.md
@@ -279,7 +279,7 @@ Recommended behavior:
 - each supported page gets a `Manage Tags` action
 - the page header uses `rtgl-tag-select` for tag filtering
 - selected filter tags render inside the `rtgl-tag-select` trigger
-- selecting multiple tags uses AND semantics
+- selecting multiple tags uses OR semantics
 - search matches item name, item description, and assigned tag names
 - the detail panel shows assigned tags through a slot in `rvn-detail-view`
 - edit dialogs use `rtgl-form` `field.type: "tag-select"` for tag assignment
@@ -761,9 +761,7 @@ Add shared helpers to:
 Recommended derived field:
 
 ```js
-item.resolvedTags = [
-  { id, name, color },
-]
+item.resolvedTags = [{ id, name, color }];
 ```
 
 Do not persist `resolvedTags`. This is client-only display data.
@@ -789,7 +787,7 @@ Add actions/selectors:
 
 Filtering behavior:
 
-- selected tags use AND semantics
+- selected tags use OR semantics
 - search matches `name`, `description`, and `resolvedTags[].name`
 - filtering happens in the shared store so images, sounds, and videos all use
   one implementation
@@ -809,7 +807,7 @@ Mirror the same local store behavior as the shared media-page store:
 - `activeTagIds`
 - `isTagsDialogOpen`
 - search includes tag names
-- selected tags filter with AND semantics
+- selected tags filter with OR semantics
 
 Character sprites remain the one custom page because their scope key depends on
 the current character id.
@@ -985,7 +983,7 @@ Minimum expected visible coverage:
 - create a tag with color
 - assign multiple tags to one item
 - filter by one tag
-- filter by multiple tags with AND semantics
+- filter by multiple tags with OR semantics
 - clear filters
 - edit tag name/color
 - delete a tag and verify the assignment disappears

--- a/src/internal/resourceTags.js
+++ b/src/internal/resourceTags.js
@@ -98,7 +98,7 @@ export const matchesTagFilter = ({ item, activeTagIds = [] } = {}) => {
   }
 
   const itemTagIds = Array.isArray(item?.tagIds) ? item.tagIds : [];
-  return activeTagIds.every((tagId) => itemTagIds.includes(tagId));
+  return activeTagIds.some((tagId) => itemTagIds.includes(tagId));
 };
 
 export const buildUniqueTagIds = (...tagIdGroups) => {

--- a/tests/characterSprites/characterSprites.store.test.js
+++ b/tests/characterSprites/characterSprites.store.test.js
@@ -49,8 +49,9 @@ describe("characterSprites store", () => {
     );
 
     const viewDataWhilePending = selectViewData({ state });
-    expect(viewDataWhilePending.mediaGroups[0].children.map((child) => child.id))
-      .toEqual(["pending-sprite-1"]);
+    expect(
+      viewDataWhilePending.mediaGroups[0].children.map((child) => child.id),
+    ).toEqual(["pending-sprite-1"]);
 
     removePendingUploads(
       { state },
@@ -60,8 +61,9 @@ describe("characterSprites store", () => {
     );
 
     const viewDataAfterPending = selectViewData({ state });
-    expect(viewDataAfterPending.mediaGroups[0].children.map((child) => child.id))
-      .toEqual(["sprite-1"]);
+    expect(
+      viewDataAfterPending.mediaGroups[0].children.map((child) => child.id),
+    ).toEqual(["sprite-1"]);
   });
 
   it("filters and searches sprites by tags", () => {
@@ -122,12 +124,27 @@ describe("characterSprites store", () => {
     );
 
     const filteredViewData = selectViewData({ state });
-    expect(filteredViewData.mediaGroups[0].children.map((child) => child.id))
-      .toEqual(["sprite-1"]);
+    expect(
+      filteredViewData.mediaGroups[0].children.map((child) => child.id),
+    ).toEqual(["sprite-1"]);
+
+    setActiveTagIds(
+      { state },
+      {
+        tagIds: ["tag-idle", "tag-attack"],
+      },
+    );
+
+    const orFilteredViewData = selectViewData({ state });
+    expect(
+      orFilteredViewData.mediaGroups[0].children.map((child) => child.id),
+    ).toEqual(["sprite-1", "sprite-2"]);
 
     state.searchQuery = "attack";
     const searchViewData = selectViewData({ state });
-    expect(searchViewData.mediaGroups).toEqual([]);
+    expect(
+      searchViewData.mediaGroups[0].children.map((child) => child.id),
+    ).toEqual(["sprite-2"]);
 
     setActiveTagIds(
       { state },
@@ -137,7 +154,8 @@ describe("characterSprites store", () => {
     );
 
     const searchOnlyViewData = selectViewData({ state });
-    expect(searchOnlyViewData.mediaGroups[0].children.map((child) => child.id))
-      .toEqual(["sprite-2"]);
+    expect(
+      searchOnlyViewData.mediaGroups[0].children.map((child) => child.id),
+    ).toEqual(["sprite-2"]);
   });
 });


### PR DESCRIPTION
## Summary
- change shared resource tag filtering from AND to OR semantics
- update the tag spec text to match the actual filtering behavior
- add a store test covering multi-tag OR filtering

## Testing
- bunx vitest run tests/characterSprites/characterSprites.store.test.js