### PR TITLE
Add appearance theme selection page

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -91,6 +91,7 @@ const getResourceCollectionsFromDomainState = (domainState) => ({
   layouts: normalizeLayoutCollection(domainState?.layouts),
   videos: domainState?.videos || createEmptyCollection(),
   animations: domainState?.animations || createEmptyCollection(),
+  transforms: domainState?.transforms || createEmptyCollection(),
 });
 
 const getDomainStateFromProjectService = (projectService) => {
@@ -116,6 +117,7 @@ export const handleBeforeMount = (deps) => {
 
   const {
     resourceId,
+    transformId,
     animations: backgroundAnimations,
     loop: backgroundLoop,
   } = props.background;
@@ -138,6 +140,20 @@ export const handleBeforeMount = (deps) => {
       animationId: animationResourceId,
     });
   }
+
+  const animationPlaybackContinuity =
+    backgroundAnimations?.playback?.continuity;
+  if (animationPlaybackContinuity) {
+    store.setSelectedAnimationPlaybackContinuity({
+      continuity: animationPlaybackContinuity,
+    });
+  }
+
+  if (transformId) {
+    store.setSelectedTransform({
+      transformId,
+    });
+  }
 };
 
 export const handleAfterMount = async (deps) => {
@@ -145,7 +161,7 @@ export const handleAfterMount = async (deps) => {
 
   await projectService.ensureRepository();
   const domainState = getDomainStateFromProjectService(projectService);
-  const { images, layouts, videos, animations } =
+  const { images, layouts, videos, animations, transforms } =
     getResourceCollectionsFromDomainState(domainState);
 
   store.setRepositoryState({
@@ -153,6 +169,7 @@ export const handleAfterMount = async (deps) => {
     layouts,
     videos,
     animations,
+    transforms,
   });
 
   const pendingResourceId = store.selectPendingResourceId();
@@ -293,6 +310,22 @@ export const handleFormInputChange = (deps, payload) => {
     return;
   }
 
+  if (name === "transformId") {
+    store.setSelectedTransform({
+      transformId: fieldValue,
+    });
+    render();
+    return;
+  }
+
+  if (name === "playbackContinuity") {
+    store.setSelectedAnimationPlaybackContinuity({
+      continuity: fieldValue,
+    });
+    render();
+    return;
+  }
+
   if (name === "loop") {
     store.setBackgroundLoop({
       loop: fieldValue,
@@ -337,8 +370,11 @@ export const handleSubmitClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { dispatchEvent, store } = deps;
   const selectedResource = store.selectSelectedResource();
+  const selectedTransformId = store.selectSelectedTransform();
   const selectedAnimationMode = store.selectSelectedAnimationMode();
   const selectedAnimationId = store.selectSelectedAnimation();
+  const selectedAnimationPlaybackContinuity =
+    store.selectSelectedAnimationPlaybackContinuity();
   const backgroundLoop = store.selectBackgroundLoop();
 
   const backgroundData = {
@@ -349,6 +385,10 @@ export const handleSubmitClick = (deps, payload) => {
     backgroundData.loop = backgroundLoop ?? false;
   }
 
+  if (selectedResource?.resourceId && selectedTransformId) {
+    backgroundData.transformId = selectedTransformId;
+  }
+
   if (
     selectedResource?.resourceId &&
     selectedAnimationMode !== "none" &&
@@ -356,6 +396,9 @@ export const handleSubmitClick = (deps, payload) => {
   ) {
     backgroundData.animations = {
       resourceId: selectedAnimationId,
+      playback: {
+        continuity: selectedAnimationPlaybackContinuity,
+      },
     };
   }
 

--- a/src/components/commandLineBackground/commandLineBackground.schema.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.schema.yaml
@@ -7,10 +7,17 @@ propsSchema:
       properties:
         resourceId:
           type: string
+        transformId:
+          type: string
         animations:
           type: object
           properties:
             resourceId:
               type: string
+            playback:
+              type: object
+              properties:
+                continuity:
+                  type: string
         loop:
           type: boolean

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -30,6 +30,17 @@ const ANIMATION_MODE_OPTIONS = [
   },
 ];
 
+const PLAYBACK_CONTINUITY_OPTIONS = [
+  {
+    label: "Render",
+    value: "render",
+  },
+  {
+    label: "Persistent",
+    value: "persistent",
+  },
+];
+
 // Form structure will be created dynamically in selectViewData
 const createEmptyCollection = () => ({
   items: {},
@@ -73,11 +84,14 @@ export const createInitialState = () => ({
   layoutItems: createEmptyCollection(),
   videoItems: createEmptyCollection(),
   animationItems: createEmptyCollection(),
+  transformItems: createEmptyCollection(),
   selectedResourceId: undefined,
   selectedResourceType: undefined,
   tempSelectedResourceId: undefined,
+  selectedTransformId: undefined,
   selectedAnimationMode: "none",
   selectedAnimationId: undefined,
+  selectedAnimationPlaybackContinuity: "render",
   backgroundLoop: false,
   pendingResourceId: undefined,
   fullImagePreviewVisible: false,
@@ -95,12 +109,13 @@ export const setMode = ({ state }, { mode } = {}) => {
 
 export const setRepositoryState = (
   { state },
-  { images, layouts, videos, animations } = {},
+  { images, layouts, videos, animations, transforms } = {},
 ) => {
   state.imageItems = normalizeResourceCollection(images);
   state.layoutItems = normalizeResourceCollection(layouts);
   state.videoItems = normalizeResourceCollection(videos);
   state.animationItems = normalizeResourceCollection(animations);
+  state.transformItems = normalizeResourceCollection(transforms);
 
   const selectedAnimationMode = getAnimationModeById(
     state.animationItems,
@@ -199,6 +214,29 @@ export const setSelectedAnimation = ({ state }, { animationId } = {}) => {
 
 export const selectSelectedAnimation = ({ state }) => {
   return state.selectedAnimationId;
+};
+
+export const setSelectedTransform = ({ state }, { transformId } = {}) => {
+  state.selectedTransformId =
+    typeof transformId === "string" && transformId.length > 0
+      ? transformId
+      : undefined;
+};
+
+export const selectSelectedTransform = ({ state }) => {
+  return state.selectedTransformId;
+};
+
+export const setSelectedAnimationPlaybackContinuity = (
+  { state },
+  { continuity } = {},
+) => {
+  state.selectedAnimationPlaybackContinuity =
+    continuity === "persistent" ? "persistent" : "render";
+};
+
+export const selectSelectedAnimationPlaybackContinuity = ({ state }) => {
+  return state.selectedAnimationPlaybackContinuity;
 };
 
 export const setBackgroundLoop = ({ state }, { loop } = {}) => {
@@ -365,12 +403,26 @@ export const selectViewData = ({ state }) => {
       value: item.id,
       label: item.name,
     }));
+  const transformOptions = toFlatItems(state.transformItems)
+    .filter((item) => item.type === "transform")
+    .map((item) => ({
+      value: item.id,
+      label: item.name,
+    }));
 
   const formFields = [
     {
       type: "slot",
       slot: "background",
       description: "Background",
+    },
+    {
+      name: "transformId",
+      label: "Transform",
+      type: "select",
+      clearable: true,
+      placeholder: "Select transform",
+      options: transformOptions,
     },
     {
       name: "animationType",
@@ -380,6 +432,16 @@ export const selectViewData = ({ state }) => {
       options: ANIMATION_MODE_OPTIONS,
     },
   ];
+
+  if (selectedAnimationMode !== "none") {
+    formFields.push({
+      name: "playbackContinuity",
+      label: "Playback Continuity",
+      type: "segmented-control",
+      clearable: false,
+      options: PLAYBACK_CONTINUITY_OPTIONS,
+    });
+  }
 
   if (selectedAnimationMode === "update") {
     formFields.push({
@@ -419,6 +481,8 @@ export const selectViewData = ({ state }) => {
 
   const defaultValues = {
     background: selectedResource?.fileId || "",
+    transformId: state.selectedTransformId,
+    playbackContinuity: state.selectedAnimationPlaybackContinuity,
     animationType: selectedAnimationMode,
     updateAnimation:
       selectedAnimationMode === "update"
@@ -448,6 +512,8 @@ export const selectViewData = ({ state }) => {
       key: [
         selectedResource?.resourceType ?? "none",
         selectedResource?.resourceId ?? "none",
+        state.selectedTransformId ?? "none",
+        state.selectedAnimationPlaybackContinuity ?? "render",
         selectedAnimationMode,
         state.selectedAnimationId ?? "none",
         state.backgroundLoop ? "loop" : "no-loop",

--- a/src/deps/services/shared/appServiceCore.js
+++ b/src/deps/services/shared/appServiceCore.js
@@ -3,6 +3,10 @@ import { createFileSelectionService } from "./fileSelectionService.js";
 import { createProjectEntriesService } from "./projectEntriesService.js";
 import { createUserConfigService } from "./userConfigService.js";
 
+const normalizeTheme = (theme) => {
+  return theme === "light" ? "light" : "dark";
+};
+
 export const createAppServiceCore = ({
   db,
   router,
@@ -65,10 +69,29 @@ export const createAppServiceCore = ({
     },
   });
 
+  const getTheme = () => {
+    return normalizeTheme(userConfigService.getUserConfig("appearance.theme"));
+  };
+
   return {
     ...projectEntriesService,
     ...fileSelectionService,
     ...appShellService,
     ...userConfigService,
+
+    async initUserConfig() {
+      const userConfig = await userConfigService.initUserConfig();
+      appShellService.applyTheme(getTheme());
+      return userConfig;
+    },
+
+    getTheme,
+
+    setTheme(theme) {
+      const nextTheme = normalizeTheme(theme);
+      userConfigService.setUserConfig("appearance.theme", nextTheme);
+      appShellService.applyTheme(nextTheme);
+      return nextTheme;
+    },
   };
 };

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -8,6 +8,29 @@ const createNoopUpdater = () => ({
   isUpdateAvailable: () => false,
 });
 
+const normalizeTheme = (theme) => {
+  return theme === "light" ? "light" : "dark";
+};
+
+const applyThemeToDocument = (
+  theme,
+  root = typeof document === "undefined" ? undefined : document,
+) => {
+  const resolvedTheme = normalizeTheme(theme);
+  const body = root?.body;
+  const documentElement = root?.documentElement;
+
+  if (body?.classList) {
+    body.classList.toggle("dark", resolvedTheme === "dark");
+  }
+
+  if (documentElement?.classList) {
+    documentElement.classList.toggle("dark", resolvedTheme === "dark");
+  }
+
+  return resolvedTheme;
+};
+
 const getActiveElement = (root = document) => {
   let active = root.activeElement;
   while (active && active.shadowRoot && active.shadowRoot.activeElement) {
@@ -129,6 +152,10 @@ export const createAppShellService = ({
       if (active?.blur) {
         active.blur();
       }
+    },
+
+    applyTheme(theme) {
+      return applyThemeToDocument(theme);
     },
 
     getAppVersion() {

--- a/src/deps/services/shared/userConfigService.js
+++ b/src/deps/services/shared/userConfigService.js
@@ -1,4 +1,7 @@
 const DEFAULT_USER_CONFIG = {
+  appearance: {
+    theme: "dark",
+  },
   groupImagesView: {
     zoomLevel: 1.0,
   },

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -41,6 +41,7 @@ export const selectCurrentRoutePattern = ({ state }) => {
     "/project/scene-editor",
     "/project/animation-editor",
     "/project/about",
+    "/project/appearance",
     "/project/user",
     "/project/fonts",
     "/project/layouts",

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -53,6 +53,8 @@ template:
                   - rvn-animation-editor: []
                 $elif currentRoutePattern == "/project/about":
                   - rvn-about: []
+                $elif currentRoutePattern == "/project/appearance":
+                  - rvn-appearance: []
                 $elif currentRoutePattern == "/project/user":
                   - rvn-settings-user: []
                 $elif currentRoutePattern == "/project/colors":

--- a/src/pages/appearance/appearance.handlers.js
+++ b/src/pages/appearance/appearance.handlers.js
@@ -1,0 +1,26 @@
+export const handleBeforeMount = (deps) => {
+  const { appService, store } = deps;
+
+  store.setCurrentTheme({
+    theme: appService.getTheme(),
+  });
+};
+
+export const handleDataChanged = () => {
+  // Handle file explorer data changes
+};
+
+export const handleThemeCardClick = (deps, payload) => {
+  const { appService, render, store } = deps;
+  const { _event } = payload;
+  const theme = _event.currentTarget?.dataset?.theme;
+  const currentTheme = store.selectState().currentTheme;
+
+  if (!theme || theme === currentTheme) {
+    return;
+  }
+
+  const nextTheme = appService.setTheme(theme);
+  store.setCurrentTheme({ theme: nextTheme });
+  render();
+};

--- a/src/pages/appearance/appearance.schema.yaml
+++ b/src/pages/appearance/appearance.schema.yaml
@@ -1,0 +1,4 @@
+componentName: rvn-appearance
+propsSchema:
+  type: object
+  properties: {}

--- a/src/pages/appearance/appearance.store.js
+++ b/src/pages/appearance/appearance.store.js
@@ -1,0 +1,54 @@
+const themeOptions = [
+  {
+    id: "dark",
+    name: "Dark",
+    previewPageBackground: "oklch(0.145 0 0)",
+    previewPanelBackground: "oklch(0.18 0 0)",
+    previewCardBackground: "oklch(0.269 0 0)",
+    previewAccent: "oklch(0.371 0 0)",
+    previewBorder: "oklch(1 0 0 / 10%)",
+  },
+  {
+    id: "light",
+    name: "Light",
+    previewPageBackground: "oklch(1 0 0)",
+    previewPanelBackground: "oklch(0.99 0 0)",
+    previewCardBackground: "oklch(0.97 0 0)",
+    previewAccent: "oklch(0.95 0 0)",
+    previewBorder: "oklch(0.922 0 0)",
+  },
+];
+
+export const createInitialState = () => ({
+  resourceCategory: "settings",
+  selectedResourceId: "appearance",
+  repositoryTarget: "settings",
+  flatItems: [],
+  currentTheme: "dark",
+});
+
+export const setCurrentTheme = ({ state }, { theme } = {}) => {
+  state.currentTheme = theme === "light" ? "light" : "dark";
+};
+
+export const selectViewData = ({ state }) => {
+  const themes = themeOptions.map((item) => {
+    const isSelected = state.currentTheme === item.id;
+
+    return {
+      ...item,
+      isSelected,
+      itemBorderColor: isSelected ? "pr" : "bo",
+      itemHoverBorderColor: isSelected ? "pr" : "ac",
+    };
+  });
+
+  return {
+    ...state,
+    themes,
+  };
+};
+
+export const selectState = ({ state }) => {
+  return state;
+};

--- a/src/pages/appearance/appearance.view.yaml
+++ b/src/pages/appearance/appearance.view.yaml
@@ -1,0 +1,30 @@
+refs:
+  leftPanel:
+    eventListeners:
+      data-changed:
+        handler: handleDataChanged
+  themeCard*:
+    eventListeners:
+      click:
+        handler: handleThemeCardClick
+template:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h h=f style="min-width: 0; min-height: 0;"':
+          - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
+              - rtgl-view slot="content" w=f h=f:
+                  - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=f h=f p=lg sv style="min-width: 0;"':
+                  - rtgl-text s=h2: Appearance
+                  - rtgl-view g=sm mt=lg:
+                      - rtgl-text s=h4: Themes
+                  - rtgl-view d=h g=lg wrap mt=lg:
+                      - $for item, i in themes:
+                          - 'rtgl-view#themeCard${i} data-theme=${item.id} d=v g=md w=320 p=md bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} bgc=bg br=md cur=pointer':
+                              - 'rtgl-view d=v g=sm w=f p=md br=md bw=xs style="background-color: ${item.previewPageBackground}; border-color: ${item.previewBorder}; min-height: 152px;"':
+                                  - 'rtgl-view h=88 w=f br=md style="background-color: ${item.previewPanelBackground};"': null
+                                  - rtgl-view d=h g=sm:
+                                      - 'rtgl-view w=1fg h=36 br=md style="background-color: ${item.previewCardBackground};"': null
+                                      - 'rtgl-view w=1fg h=36 br=md style="background-color: ${item.previewAccent}; opacity: 0.3;"': null
+                                      - 'rtgl-view w=1fg h=36 br=md style="background-color: ${item.previewAccent}; opacity: 0.65;"': null
+                              - rtgl-text s=xs c=mu-fg ellipsis=true w=f mt=auto: ${item.name}

--- a/src/pages/resourceTypes/resourceTypes.store.js
+++ b/src/pages/resourceTypes/resourceTypes.store.js
@@ -86,6 +86,11 @@ const settingsItems = [
     name: "About",
     path: "/project/about",
   },
+  {
+    id: "appearance",
+    name: "Appearance",
+    path: "/project/appearance",
+  },
   // {
   //   id: "user",
   //   name: "User",

--- a/src/pages/sidebar/sidebar.store.js
+++ b/src/pages/sidebar/sidebar.store.js
@@ -149,7 +149,11 @@ export const selectViewData = ({ state }) => {
     }
 
     // For settings
-    if (currentPath === "/project/about" || currentPath === "/project/user") {
+    if (
+      currentPath === "/project/about" ||
+      currentPath === "/project/appearance" ||
+      currentPath === "/project/user"
+    ) {
       const settingsItem = state.items.find(
         (item) => item.title === SIDEBAR_TITLE_SETTINGS,
       );

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleBeforeMount,
+  handleFormInputChange,
+  handleSubmitClick,
+} from "../../src/components/commandLineBackground/commandLineBackground.handlers.js";
+import {
+  createInitialState,
+  selectBackgroundLoop,
+  selectPendingResourceId,
+  selectSelectedAnimation,
+  selectSelectedAnimationPlaybackContinuity,
+  selectSelectedAnimationMode,
+  selectSelectedResource,
+  selectSelectedTransform,
+  selectTab,
+  setBackgroundLoop,
+  setRepositoryState,
+  setSearchQuery,
+  setSelectedAnimation,
+  setSelectedAnimationPlaybackContinuity,
+  setSelectedAnimationMode,
+  setSelectedResource,
+  setSelectedTransform,
+  setTab,
+} from "../../src/components/commandLineBackground/commandLineBackground.store.js";
+
+const createEmptyCollection = () => ({
+  items: {},
+  tree: [],
+});
+
+const createStoreApi = (state) => ({
+  selectBackgroundLoop: () => selectBackgroundLoop({ state }),
+  selectPendingResourceId: () => selectPendingResourceId({ state }),
+  selectSelectedAnimation: () => selectSelectedAnimation({ state }),
+  selectSelectedAnimationPlaybackContinuity: () =>
+    selectSelectedAnimationPlaybackContinuity({ state }),
+  selectSelectedAnimationMode: () => selectSelectedAnimationMode({ state }),
+  selectSelectedResource: () => selectSelectedResource({ state }),
+  selectSelectedTransform: () => selectSelectedTransform({ state }),
+  selectTab: () => selectTab({ state }),
+  setBackgroundLoop: (payload) => setBackgroundLoop({ state }, payload),
+  setPendingResourceId: ({ resourceId }) => {
+    state.pendingResourceId = resourceId;
+  },
+  setSearchQuery: (payload) => setSearchQuery({ state }, payload),
+  setSelectedAnimation: (payload) => setSelectedAnimation({ state }, payload),
+  setSelectedAnimationPlaybackContinuity: (payload) =>
+    setSelectedAnimationPlaybackContinuity({ state }, payload),
+  setSelectedAnimationMode: (payload) =>
+    setSelectedAnimationMode({ state }, payload),
+  setSelectedResource: (payload) => setSelectedResource({ state }, payload),
+  setSelectedTransform: (payload) => setSelectedTransform({ state }, payload),
+  setTab: (payload) => setTab({ state }, payload),
+});
+
+const setRepositoryCollections = (state) => {
+  setRepositoryState(
+    { state },
+    {
+      images: {
+        items: {
+          "bg-school": {
+            id: "bg-school",
+            type: "image",
+            name: "School",
+            fileId: "file-school",
+          },
+        },
+        tree: [{ id: "bg-school" }],
+      },
+      layouts: createEmptyCollection(),
+      videos: createEmptyCollection(),
+      animations: createEmptyCollection(),
+      transforms: {
+        items: {
+          "bg-center": {
+            id: "bg-center",
+            type: "transform",
+            name: "Center",
+          },
+        },
+        tree: [{ id: "bg-center" }],
+      },
+    },
+  );
+};
+
+describe("commandLineBackground.handlers", () => {
+  it("hydrates existing transform state before mount", () => {
+    const state = createInitialState();
+
+    handleBeforeMount({
+      store: createStoreApi(state),
+      props: {
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+          animations: {
+            resourceId: "bg-fade",
+            playback: {
+              continuity: "render",
+            },
+          },
+          loop: true,
+        },
+      },
+    });
+
+    expect(selectPendingResourceId({ state })).toBe("bg-school");
+    expect(selectSelectedTransform({ state })).toBe("bg-center");
+    expect(selectSelectedAnimation({ state })).toBe("bg-fade");
+    expect(selectSelectedAnimationPlaybackContinuity({ state })).toBe("render");
+    expect(selectBackgroundLoop({ state })).toBe(true);
+  });
+
+  it("submits transformId when selected and omits it when cleared", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            name: "transformId",
+            value: "bg-center",
+          },
+        },
+      },
+    );
+
+    handleSubmitClick(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+      },
+      {},
+    );
+
+    expect(selectSelectedTransform({ state })).toBe("bg-center");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+        transformId: "bg-center",
+      },
+    });
+
+    dispatchEvent.mockClear();
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            name: "transformId",
+            value: undefined,
+          },
+        },
+      },
+    );
+
+    handleSubmitClick(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+      },
+      {},
+    );
+
+    expect(selectSelectedTransform({ state })).toBeUndefined();
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("submits playback continuity inside background animations", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedAnimationMode(
+      { state },
+      {
+        mode: "update",
+      },
+    );
+    setSelectedAnimation(
+      { state },
+      {
+        animationId: "bg-fade",
+      },
+    );
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            name: "playbackContinuity",
+            value: "render",
+          },
+        },
+      },
+    );
+
+    handleSubmitClick(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+      },
+      {},
+    );
+
+    expect(selectSelectedAnimationPlaybackContinuity({ state })).toBe("render");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+        animations: {
+          resourceId: "bg-fade",
+          playback: {
+            continuity: "render",
+          },
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setRepositoryState,
+  setSelectedAnimationMode,
+  setSelectedResource,
+  setSelectedTransform,
+} from "../../src/components/commandLineBackground/commandLineBackground.store.js";
+
+const createEmptyCollection = () => ({
+  items: {},
+  tree: [],
+});
+
+describe("commandLineBackground.store", () => {
+  it("hides playback continuity when animation mode is none", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        images: {
+          items: {
+            "bg-school": {
+              id: "bg-school",
+              type: "image",
+              name: "School",
+              fileId: "file-school",
+            },
+          },
+          tree: [{ id: "bg-school" }],
+        },
+        layouts: createEmptyCollection(),
+        videos: createEmptyCollection(),
+        animations: createEmptyCollection(),
+        transforms: {
+          items: {
+            "bg-center": {
+              id: "bg-center",
+              type: "transform",
+              name: "Center",
+            },
+          },
+          tree: [{ id: "bg-center" }],
+        },
+      },
+    );
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedTransform(
+      { state },
+      {
+        transformId: "bg-center",
+      },
+    );
+    const viewData = selectViewData({ state });
+    const transformField = viewData.dialogueForm.form.fields.find(
+      (field) => field.name === "transformId",
+    );
+    const continuityField = viewData.dialogueForm.form.fields.find(
+      (field) => field.name === "playbackContinuity",
+    );
+
+    expect(transformField).toMatchObject({
+      label: "Transform",
+      type: "select",
+      clearable: true,
+      placeholder: "Select transform",
+      options: [
+        {
+          value: "bg-center",
+          label: "Center",
+        },
+      ],
+    });
+    expect(continuityField).toBeUndefined();
+    expect(viewData.dialogueForm.defaultValues.transformId).toBe("bg-center");
+    expect(viewData.dialogueForm.defaultValues.playbackContinuity).toBe(
+      "render",
+    );
+  });
+
+  it("shows playback continuity with render first when animation mode is active", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        images: {
+          items: {
+            "bg-school": {
+              id: "bg-school",
+              type: "image",
+              name: "School",
+              fileId: "file-school",
+            },
+          },
+          tree: [{ id: "bg-school" }],
+        },
+        layouts: createEmptyCollection(),
+        videos: createEmptyCollection(),
+        animations: createEmptyCollection(),
+        transforms: {
+          items: {
+            "bg-center": {
+              id: "bg-center",
+              type: "transform",
+              name: "Center",
+            },
+          },
+          tree: [{ id: "bg-center" }],
+        },
+      },
+    );
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedTransform(
+      { state },
+      {
+        transformId: "bg-center",
+      },
+    );
+    setSelectedAnimationMode(
+      { state },
+      {
+        mode: "update",
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    const continuityField = viewData.dialogueForm.form.fields.find(
+      (field) => field.name === "playbackContinuity",
+    );
+
+    expect(continuityField).toMatchObject({
+      label: "Playback Continuity",
+      type: "segmented-control",
+      clearable: false,
+      options: [
+        {
+          value: "render",
+          label: "Render",
+        },
+        {
+          value: "persistent",
+          label: "Persistent",
+        },
+      ],
+    });
+    expect(viewData.dialogueForm.defaultValues.transformId).toBe("bg-center");
+    expect(viewData.dialogueForm.defaultValues.playbackContinuity).toBe(
+      "render",
+    );
+  });
+});

--- a/vt/specs/project/appearance.yaml
+++ b/vt/specs/project/appearance.yaml
@@ -1,0 +1,81 @@
+---
+title: Project Appearance Page
+description: Covers the appearance page route and placeholder layout from the project shell.
+url: /projects
+skipInitialScreenshot: true
+viewport:
+  id: wide
+  width: 1440
+  height: 900
+steps:
+  - action: waitFor
+    selector: "[data-testid='create-project-button']"
+    state: visible
+    timeoutMs: 5000
+  - action: wait
+    ms: 250
+  - action: select
+    testId: create-project-button
+    steps:
+      - action: click
+  - action: waitFor
+    selector: rtgl-global-ui rtgl-form#createProjectForm rtgl-input#field0 input
+    state: attached
+    timeoutMs: 5000
+  - action: select
+    selector: rtgl-global-ui rtgl-form#createProjectForm rtgl-input#field0 input
+    steps:
+      - action: clear
+      - action: write
+        value: VT Project Appearance Page
+  - action: select
+    selector: rtgl-global-ui rtgl-form#createProjectForm rtgl-input#field1 input
+    steps:
+      - action: clear
+      - action: write
+        value: Covers the project appearance placeholder page.
+  - action: wait
+    ms: 250
+  - action: select
+    selector: rtgl-global-ui rtgl-button[data-action-id='submit']
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#projectItem0"
+    state: visible
+    timeoutMs: 10000
+  - action: wait
+    ms: 500
+  - action: select
+    selector: "#projectItem0"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: rvn-project
+    state: attached
+    timeoutMs: 10000
+  - action: wait
+    ms: 500
+  - action: select
+    selector: "#sidebar [data-item-id='/project/about']"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: rvn-about
+    state: attached
+    timeoutMs: 10000
+  - action: select
+    selector: "rvn-resource-types [data-item-id='appearance']"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: rvn-appearance
+    state: attached
+    timeoutMs: 10000
+  - action: assert
+    type: url
+    value: /project/appearance
+  - action: wait
+    ms: 450
+  - action: screenshot
+---


### PR DESCRIPTION
## Summary
- add a new Appearance page under project settings
- add light and dark theme cards that apply immediately and persist in user config
- wire the route, settings navigation, and VT coverage for the new page

## Validation
- bun run build:tauri