### PR TITLE
Fix scene editor preview canvas host detaching on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The project uses platform-specific entry points that are automatically configure
 
 Run the project in watch mode:
 ```shell
-bun run watch
+bun run watch:web
 ```
 
 Or build project and serve without watch mode:
@@ -114,7 +114,7 @@ Open: http://localhost:3001/project
 
 **Build Commands:**
 - `bun run build` or `bun run build:web` - Build for web platform
-- `bun run watch` - Watch mode for web development
+- `bun run watch:web` - Watch mode for web development
 
 ### Desktop Application (Tauri)
 
@@ -131,6 +131,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # Ubuntu/Debian:
 sudo apt update
 sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libayatana-appindicator3-dev librsvg2-dev
+
+# Arch Linux:
+sudo pacman -S --needed webkit2gtk-4.1 base-devel curl wget file openssl libayatana-appindicator librsvg
 
 # Fedora/RHEL:
 sudo dnf install webkit2gtk4.1-devel openssl-devel curl wget file libappindicator-gtk3-devel librsvg2-devel

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lint:fix": "oxlint && bun prettier --check --write src",
     "prepare": "husky",
     "tauri": "tauri",
+    "tauri:dev:linux": "tauri dev --target $(rustc --print host-tuple)",
     "tauri:dev:mac": "tauri dev --target aarch64-apple-darwin",
     "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",

--- a/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.methods.js
+++ b/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.methods.js
@@ -1,6 +1,5 @@
 export function getCanvasRoot() {
   return (
-    this.shadowRoot?.querySelector("#canvas") ||
-    this.querySelector("#canvas")
+    this.shadowRoot?.querySelector("#canvas") || this.querySelector("#canvas")
   );
 }

--- a/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.methods.js
+++ b/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.methods.js
@@ -1,0 +1,6 @@
+export function getCanvasRoot() {
+  return (
+    this.shadowRoot?.querySelector("#canvas") ||
+    this.querySelector("#canvas")
+  );
+}

--- a/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.schema.yaml
+++ b/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.schema.yaml
@@ -1,0 +1,13 @@
+componentName: rvn-scene-editor-preview-canvas
+propsSchema:
+  type: object
+  properties:
+    canvasAspectRatio:
+      type: string
+methods:
+  type: object
+  properties:
+    getCanvasRoot:
+      description: Returns the mounted canvas host element used by the scene editor graphics runtime.
+      params: []
+      returns: object

--- a/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.store.js
+++ b/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.store.js
@@ -1,0 +1,7 @@
+export const createInitialState = () => ({});
+
+export const selectViewData = ({ props }) => {
+  return {
+    canvasAspectRatio: props.canvasAspectRatio || "16 / 9",
+  };
+};

--- a/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.view.yaml
+++ b/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.view.yaml
@@ -1,0 +1,4 @@
+template:
+  - 'div style="display: block; position: relative; width: 100%; aspect-ratio: ${canvasAspectRatio}; max-width: 100%; min-height: 1px; background: #000;"':
+      - 'div style="position: absolute; inset: 0; display: flex; background: #000;"':
+          - 'div#canvas style="width: 100%; height: 100%; display: flex; background: #000;"': null

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -34,17 +34,44 @@ const waitForNextFrame = () =>
     globalThis.setTimeout(resolve, 0);
   });
 
-const waitForMountedCanvas = async (refs, maxFrames = 10) => {
+const getCurrentCanvasRoot = (refs) => {
+  const previewCanvasHost = refs?.previewCanvasHost;
+  const canvasRoot =
+    previewCanvasHost?.getCanvasRoot?.() ||
+    previewCanvasHost?.shadowRoot?.querySelector?.("#canvas") ||
+    previewCanvasHost?.querySelector?.("#canvas");
+
+  if (canvasRoot?.isConnected) {
+    return canvasRoot;
+  }
+
+  return canvasRoot;
+};
+
+const waitForMountedCanvasRoot = async (refs, maxFrames = 10) => {
   for (let attempt = 0; attempt < maxFrames; attempt += 1) {
-    const canvas = refs?.canvas;
-    if (canvas?.isConnected) {
-      return canvas;
+    const canvasRoot = getCurrentCanvasRoot(refs);
+    if (canvasRoot?.isConnected) {
+      return canvasRoot;
     }
 
     await waitForNextFrame();
   }
 
-  return refs?.canvas;
+  return getCurrentCanvasRoot(refs);
+};
+
+const attachGraphicsCanvasToMountedRoot = async (deps, maxFrames = 10) => {
+  const mountedCanvasRoot = await waitForMountedCanvasRoot(
+    deps?.refs,
+    maxFrames,
+  );
+  if (!mountedCanvasRoot?.isConnected) {
+    return mountedCanvasRoot;
+  }
+
+  await deps?.graphicsService?.attachCanvas?.(mountedCanvasRoot);
+  return mountedCanvasRoot;
 };
 
 export const createSceneEditorRenderQueue = (renderCanvas) => {
@@ -416,7 +443,7 @@ const createBeforeHandleActionsHook = (deps) => {
         actions,
         eventContext,
         graphicsService: deps.graphicsService,
-        canvasRoot: deps.refs?.canvas,
+        canvasRoot: getCurrentCanvasRoot(deps.refs),
         resolveEventBindings,
       });
     const layoutIds = Array.from(
@@ -558,6 +585,17 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     : undefined;
   const renderStateSelectStartedAt = perfEnabled ? getDebugNow() : 0;
   const currentRenderState = graphicsService.engineSelectRenderState();
+  const renderStateSummary = {
+    elementCount: Array.isArray(currentRenderState?.elements)
+      ? currentRenderState.elements.length
+      : 0,
+    animationCount: Array.isArray(currentRenderState?.animations)
+      ? currentRenderState.animations.length
+      : 0,
+    audioCount: Array.isArray(currentRenderState?.audio)
+      ? currentRenderState.audio.length
+      : 0,
+  };
   const renderStateSelectDurationMs = perfEnabled
     ? getDebugDurationMs(renderStateSelectStartedAt)
     : undefined;
@@ -587,6 +625,7 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
 
   let canvasPaintDurationMs = 0;
   if (!skipCanvasPaint) {
+    await attachGraphicsCanvasToMountedRoot(deps, 2);
     const canvasPaintStartedAt = perfEnabled ? getDebugNow() : 0;
     graphicsService.engineRenderCurrentState({
       skipAudio: isMuted,
@@ -641,15 +680,9 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
       canvasPaintDurationMs,
       nextLineConfigDurationMs,
       presentationStateDurationMs,
-      elementCount: Array.isArray(currentRenderState?.elements)
-        ? currentRenderState.elements.length
-        : 0,
-      animationCount: Array.isArray(currentRenderState?.animations)
-        ? currentRenderState.animations.length
-        : 0,
-      audioCount: Array.isArray(currentRenderState?.audio)
-        ? currentRenderState.audio.length
-        : 0,
+      elementCount: renderStateSummary.elementCount,
+      animationCount: renderStateSummary.animationCount,
+      audioCount: renderStateSummary.audioCount,
     });
   }
 };
@@ -718,12 +751,6 @@ export const initializeSceneEditorPage = async (deps) => {
   const previewWidth = projectData?.screen?.width;
   const previewHeight = projectData?.screen?.height;
 
-  await graphicsService.init({
-    beforeHandleActions: createBeforeHandleActionsHook(deps),
-    width: previewWidth,
-    height: previewHeight,
-  });
-
   const initialProjectData = createProjectDataWithSelectedEntryPoint(
     projectData,
     {
@@ -734,23 +761,32 @@ export const initializeSceneEditorPage = async (deps) => {
   );
   const initialSceneIds = extractInitialHybridSceneIds(projectData, sceneId);
 
+  store.setScenePageLoading({ isLoading: false });
+  render();
+  const mountedCanvasRoot = await waitForMountedCanvasRoot(refs);
+  if (!mountedCanvasRoot?.isConnected) {
+    throw new Error("Scene editor canvas failed to mount");
+  }
+
+  await graphicsService.init({
+    canvas: mountedCanvasRoot,
+    beforeHandleActions: createBeforeHandleActionsHook(deps),
+    width: previewWidth,
+    height: previewHeight,
+  });
+
   await loadAssetsForSceneIds(deps, projectData, initialSceneIds, {
     showLoading: false,
   });
 
-  store.setScenePageLoading({ isLoading: false });
-  render();
-  const mountedCanvas = await waitForMountedCanvas(refs);
-  if (!mountedCanvas?.isConnected) {
-    throw new Error("Scene editor canvas failed to mount");
-  }
-
-  await graphicsService.attachCanvas(mountedCanvas);
   void preloadDirectTransitionScenes(deps, initialProjectData, initialSceneIds);
-  subject.dispatch("sceneEditor.renderCanvas", {
+
+  await renderSceneEditorState(deps, {
     skipAnimations: true,
-    skipCanvasPaint: true,
   });
+  await updateSceneEditorSectionChanges(deps);
+  render();
+
   setTimeout(() => {
     subject.dispatch("sceneEditor.renderCanvas", {});
   }, 1000);
@@ -769,8 +805,12 @@ export const restoreSceneEditorFromPreview = async (deps) => {
   const projectData = store.selectProjectData();
   const previewWidth = projectData?.screen?.width;
   const previewHeight = projectData?.screen?.height;
+  const mountedCanvasRoot = await waitForMountedCanvasRoot(refs);
+  if (!mountedCanvasRoot?.isConnected) {
+    throw new Error("Scene editor canvas failed to mount");
+  }
   await graphicsService.init({
-    canvas: refs.canvas,
+    canvas: mountedCanvasRoot,
     beforeHandleActions: createBeforeHandleActionsHook(deps),
     width: previewWidth,
     height: previewHeight,
@@ -803,8 +843,8 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
     return;
   }
 
-  const mountedCanvas = deps.refs?.canvas;
-  if (!mountedCanvas?.isConnected) {
+  const mountedCanvasRoot = getCurrentCanvasRoot(deps.refs);
+  if (!mountedCanvasRoot?.isConnected) {
     return;
   }
 

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -55,6 +55,7 @@ refs:
         handler: handleSectionsOverviewWarningMouseEnter
       mouseleave:
         handler: handleSectionsOverviewWarningMouseLeave
+  previewCanvasHost: {}
   dropdownMenu:
     eventListeners:
       close:
@@ -162,9 +163,9 @@ template:
               - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h jc=e g=sm:
                   - rtgl-button#previewButton: Preview
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
-                  - rtgl-view:
-                      - 'rtgl-view w=f pos=rel style="aspect-ratio: ${canvasAspectRatio}; max-width: 100%;"':
-                          - 'div#canvas id=canvas style="width: 100%; height: 100%; display: flex; background: #000;"': null
+                  - 'rtgl-view w=f style="min-width: 0;"':
+                      - 'rtgl-view pos=rel w=f':
+                          - rvn-scene-editor-preview-canvas#previewCanvasHost canvasAspectRatio=${canvasAspectRatio}: null
                           - $if isSceneAssetLoading:
                               - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
                                   - rtgl-text s=h3: Loading assets...

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -165,7 +165,7 @@ template:
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - 'rtgl-view w=f style="min-width: 0;"':
                       - 'rtgl-view pos=rel w=f':
-                          - rvn-scene-editor-preview-canvas#previewCanvasHost canvasAspectRatio=${canvasAspectRatio}: null
+                          - rvn-scene-editor-preview-canvas#previewCanvasHost canvas-aspect-ratio="${canvasAspectRatio}": null
                           - $if isSceneAssetLoading:
                               - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
                                   - rtgl-text s=h3: Loading assets...


### PR DESCRIPTION
## Summary
- move the scene editor preview surface into a dedicated `rvn-scene-editor-preview-canvas` component so page rerenders do not wipe the graphics host DOM
- update scene editor runtime to resolve the live canvas root from that component before init, interaction handling, and paint
- keep the scene editor startup path explicit by mounting the host first, then initializing graphics against the mounted root

## Testing
- `bun run build:tauri`
- `git push` pre-push hook (`oxlint && bun prettier --check src`)

## Notes
- repo-wide `bun run check:contracts` currently reports many unrelated existing violations, so it was not a useful signal for this PR