### PR TITLE
Fix layout editor text fixed width mode

### DIFF
--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -21,6 +21,7 @@ import { getLayoutEditorElementDefinition } from "../../internal/layoutEditorEle
 import { parseSpritesheetAnimationSelectionValue } from "../../internal/spritesheets.js";
 
 const ACTION_INTERACTION_TYPES = ["click", "rightClick", "change"];
+const DEFAULT_TEXT_FIXED_WIDTH = 300;
 const EMPTY_TREE = { items: {}, tree: [] };
 const INTEGER_ONLY_FIELDS = new Set([
   "x",
@@ -155,12 +156,44 @@ const syncFixedAspectRatioValue = (store, { name, value } = {}) => {
 };
 
 const getMeasuredTextWidth = (metrics = {}) => {
-  const measuredWidth = Number(metrics.measuredWidth ?? metrics.width);
+  const measuredWidth = Number(metrics.measuredWidth);
   if (Number.isFinite(measuredWidth) && measuredWidth > 0) {
     return Math.round(measuredWidth);
   }
 
+  const width = Number(metrics.width);
+  if (Number.isFinite(width) && width > 0) {
+    return Math.round(width);
+  }
+
   return undefined;
+};
+
+const getPositiveRoundedNumber = (value) => {
+  const number = Number(value);
+  if (Number.isFinite(number) && number > 0) {
+    return Math.round(number);
+  }
+
+  return undefined;
+};
+
+const getTextFixedWidthFallback = ({ props, values } = {}) => {
+  const wordWrapWidth = getPositiveRoundedNumber(
+    values?.textStyle?.wordWrapWidth,
+  );
+  if (wordWrapWidth !== undefined) {
+    return wordWrapWidth;
+  }
+
+  const projectWidth = getPositiveRoundedNumber(
+    props?.projectResolution?.width,
+  );
+  if (projectWidth !== undefined) {
+    return Math.min(projectWidth, DEFAULT_TEXT_FIXED_WIDTH);
+  }
+
+  return DEFAULT_TEXT_FIXED_WIDTH;
 };
 
 const getMeasuredDimension = (metrics = {}, name) => {
@@ -208,20 +241,19 @@ const applySizeModeUpdate = (deps, { name, value } = {}) => {
     return;
   }
 
-  const currentSize = Number(store.selectValues()[fieldName]);
+  const values = store.selectValues();
+  const currentSize = Number(values[fieldName]);
   const nextSize = isTextWidthMode
     ? (getMeasuredTextWidth(selectedElementMetrics) ??
       (Number.isFinite(currentSize) && currentSize > 0
         ? currentSize
-        : undefined))
+        : undefined) ??
+      getTextFixedWidthFallback({ props, values }))
     : (getMeasuredDimension(selectedElementMetrics, fieldName) ??
       (Number.isFinite(currentSize) && currentSize > 0
         ? currentSize
         : undefined) ??
       100);
-  if (nextSize === undefined) {
-    return;
-  }
 
   applyPanelValueUpdate(deps, {
     name: fieldName,
@@ -428,7 +460,8 @@ export const handleOnUpdate = (deps, payload) => {
     oldProps?.spritesheetsData === newProps?.spritesheetsData &&
     oldProps?.particlesData === newProps?.particlesData &&
     oldProps?.variablesData === newProps?.variablesData &&
-    oldProps?.textStylesData === newProps?.textStylesData
+    oldProps?.textStylesData === newProps?.textStylesData &&
+    oldProps?.selectedElementMetrics === newProps?.selectedElementMetrics
   ) {
     return;
   }
@@ -457,6 +490,9 @@ export const handleOnUpdate = (deps, payload) => {
   });
   store.setVariablesData({
     variablesData: newProps.variablesData || EMPTY_TREE,
+  });
+  store.setSelectedElementMetrics?.({
+    metrics: newProps.selectedElementMetrics,
   });
 
   const popover = store.selectPopoverForm();

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -1527,6 +1527,10 @@ export const handleLayoutEditorCanvasMetricsChange = (deps, payload) => {
     return;
   }
 
+  store.setSelectedElementMetrics({
+    metrics,
+  });
+
   if (selectedItemId && detailPanelSelectedItemId !== selectedItemId) {
     return;
   }

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -471,6 +471,7 @@ export const selectViewData = ({ state, constants }) => {
     textStylesData: state.textStylesData,
     variablesData: state.variablesData,
     layoutsData: state.layoutsData,
+    selectedElementMetrics: state.selectedElementMetrics,
     selectedItemIsInsideSaveLoadSlot,
     selectedItemIsInsideDirectedContainer,
     isInsideSaveLoadSlot: detailPanelIsInsideSaveLoadSlot,

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -68,7 +68,7 @@ template:
                               - rtgl-text w=1fg ellipsis=true: ${item.name}
                               - rtgl-text s=xs c=mu-fg: ${item.type}
                       - rtgl-view w=f h=1fg sv pv=md:
-                          - rvn-layout-edit-panel#layoutEditPanel layout-type=${layout.layoutType} resource-type=${layout.resourceType} item-type=${item.type} :projectResolution=${projectResolution} :isInsideSaveLoadSlot=${isInsideSaveLoadSlot} :isInsideDirectedContainer=${isInsideDirectedContainer} :values=${item} :imagesData=${imagesData} :soundsData=${soundsData} :spritesheetsData=${spritesheetsData} :particlesData=${particlesData} :charactersData=${charactersData} :textStylesData=${textStylesData} :variablesData=${variablesData} :layoutsData=${layoutsData}: null
+                          - rvn-layout-edit-panel#layoutEditPanel layout-type=${layout.layoutType} resource-type=${layout.resourceType} item-type=${item.type} :projectResolution=${projectResolution} :selectedElementMetrics=${selectedElementMetrics} :isInsideSaveLoadSlot=${isInsideSaveLoadSlot} :isInsideDirectedContainer=${isInsideDirectedContainer} :values=${item} :imagesData=${imagesData} :soundsData=${soundsData} :spritesheetsData=${spritesheetsData} :particlesData=${particlesData} :charactersData=${charactersData} :textStylesData=${textStylesData} :variablesData=${variablesData} :layoutsData=${layoutsData}: null
                 $else:
                   - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                       - rtgl-text s=md c=mu-fg: No selection

--- a/tests/layoutEditPanel/layoutEditPanel.sizeMode.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.sizeMode.test.js
@@ -8,6 +8,7 @@ import { handleOptionSelected } from "../../src/components/layoutEditPanel/layou
 
 const createDeps = ({
   itemType = "container",
+  projectResolution,
   values = {},
   selectedElementMetrics = {},
 } = {}) => {
@@ -17,6 +18,7 @@ const createDeps = ({
   return {
     props: {
       itemType,
+      projectResolution,
       selectedElementMetrics,
     },
     store: {
@@ -112,5 +114,94 @@ describe("layoutEditPanel size modes", () => {
     });
 
     expect(deps.state.values.height).toBe(188);
+  });
+
+  it("sets text width to fixed from measured text width", () => {
+    const deps = createDeps({
+      itemType: "text",
+      values: {
+        type: "text",
+        width: undefined,
+      },
+      selectedElementMetrics: {
+        width: 180,
+        measuredWidth: 142,
+      },
+    });
+
+    handleOptionSelected(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {
+            name: "widthMode",
+          },
+        },
+        detail: {
+          value: "fixed",
+        },
+      },
+    });
+
+    expect(deps.state.values.width).toBe(142);
+  });
+
+  it("sets text width to fixed from word wrap fallback when metrics are missing", () => {
+    const deps = createDeps({
+      itemType: "text",
+      values: {
+        type: "text",
+        textStyle: {
+          wordWrapWidth: 240,
+        },
+      },
+      selectedElementMetrics: undefined,
+    });
+
+    handleOptionSelected(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {
+            name: "widthMode",
+          },
+        },
+        detail: {
+          value: "fixed",
+        },
+      },
+    });
+
+    expect(deps.state.values.width).toBe(240);
+  });
+
+  it("sets text width to fixed from default fallback when text has no measured width", () => {
+    const deps = createDeps({
+      itemType: "text",
+      projectResolution: {
+        width: 200,
+        height: 120,
+      },
+      values: {
+        type: "text",
+      },
+      selectedElementMetrics: {
+        width: 0,
+        measuredWidth: 0,
+      },
+    });
+
+    handleOptionSelected(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {
+            name: "widthMode",
+          },
+        },
+        detail: {
+          value: "fixed",
+        },
+      },
+    });
+
+    expect(deps.state.values.width).toBe(200);
   });
 });

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -289,6 +289,7 @@ describe("layoutEditor.handleLayoutEditorCanvasMetricsChange", () => {
       store: {
         selectSelectedItemId: vi.fn(() => "selected-item"),
         selectDetailPanelSelectedItemId: vi.fn(() => "stale-panel-item"),
+        setSelectedElementMetrics: vi.fn(),
       },
       refs: {
         layoutEditPanel: {
@@ -314,6 +315,13 @@ describe("layoutEditor.handleLayoutEditorCanvasMetricsChange", () => {
       },
     });
 
+    expect(deps.store.setSelectedElementMetrics).toHaveBeenCalledWith({
+      metrics: {
+        id: "selected-item",
+        width: 76,
+        height: 54,
+      },
+    });
     expect(
       deps.refs.layoutEditPanel.setSelectedElementMetrics,
     ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- keep selected canvas metrics in layout editor page state and pass them to the detail edit panel
- make text Fixed width mode deterministic with measured/current/word-wrap/default fallbacks
- add focused size-mode coverage for text width behavior

## Validation
- bunx vitest run tests/layoutEditPanel/layoutEditPanel.sizeMode.test.js
- bun prettier --check src/components/layoutEditPanel/layoutEditPanel.handlers.js src/pages/layoutEditor/layoutEditor.handlers.js src/pages/layoutEditor/layoutEditor.store.js src/pages/layoutEditor/layoutEditor.view.yaml tests/layoutEditPanel/layoutEditPanel.sizeMode.test.js
- bunx oxlint src/components/layoutEditPanel/layoutEditPanel.handlers.js src/pages/layoutEditor/layoutEditor.handlers.js src/pages/layoutEditor/layoutEditor.store.js tests/layoutEditPanel/layoutEditPanel.sizeMode.test.js
- bun run build:web

Note: bun run check:contracts still fails on existing repo-wide baseline diagnostics unrelated to this change.