### PR TITLE
Update dialogue speaker labels

### DIFF
--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -53,7 +53,7 @@ export const createInitialState = () => ({
       {
         name: "mode",
         type: "segmented-control",
-        label: "Dialogue Mode",
+        label: "Mode",
         description: "",
         required: true,
         clearable: false,
@@ -65,7 +65,7 @@ export const createInitialState = () => ({
       {
         name: "resourceId",
         type: "select",
-        label: "Dialogue Layout",
+        label: "Layout",
         description: "",
         required: true,
         clearable: false,
@@ -75,16 +75,16 @@ export const createInitialState = () => ({
       {
         name: "characterId",
         type: "select",
-        label: "Dialogue Character",
+        label: "Speaker",
         description: "",
         required: false,
-        placeholder: "Choose a character...",
+        placeholder: "Choose a speaker...",
         options: [],
       },
       {
         name: "customCharacterName",
         type: "segmented-control",
-        label: "Custom Character Name",
+        label: "Custom Speaker Name",
         description: "",
         required: true,
         clearable: false,
@@ -97,16 +97,16 @@ export const createInitialState = () => ({
         $when: "values.customCharacterName == true",
         name: "characterName",
         type: "input-text",
-        label: "Character Name",
+        label: "Speaker Name",
         description: "",
         required: true,
-        placeholder: "Enter character name",
+        placeholder: "Enter speaker name",
       },
       {
         $when: "values.characterId || values.customCharacterName",
         name: "persistCharacter",
         type: "segmented-control",
-        label: "Persist Character",
+        label: "Persist Speaker",
         description: "",
         required: true,
         clearable: false,
@@ -229,10 +229,7 @@ export const selectViewData = ({ state, props }) => {
           ...field,
           options: layoutOptions,
           value: selectedResourceId,
-          label:
-            selectedMode === "nvl"
-              ? "Dialogue NVL Layout"
-              : "Dialogue ADV Layout",
+          label: "Layout",
         };
       }
       if (field.name === "characterId") {

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -471,7 +471,7 @@ export const selectActionsData = ({ props, state }) => {
       hasDialogueCharacter !== true ||
       presentationState.dialogue.persistCharacter !== true
         ? undefined
-        : "Persist Character";
+        : "Persist Speaker";
     if (presentationState.dialogue.clear === true) {
       preview.dialogue = {
         name: "Dialogue: Clear",

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -46,8 +46,10 @@ const createStore = (state) => ({
   getState: () => state,
   setSelectedMode: (payload) => setSelectedMode({ state }, payload),
   setSelectedResource: (payload) => setSelectedResource({ state }, payload),
-  setSelectedCharacterId: (payload) => setSelectedCharacterId({ state }, payload),
-  setCustomCharacterName: (payload) => setCustomCharacterName({ state }, payload),
+  setSelectedCharacterId: (payload) =>
+    setSelectedCharacterId({ state }, payload),
+  setCustomCharacterName: (payload) =>
+    setCustomCharacterName({ state }, payload),
   setCharacterName: (payload) => setCharacterName({ state }, payload),
   setPersistCharacter: (payload) => setPersistCharacter({ state }, payload),
   setClearPage: (payload) => setClearPage({ state }, payload),
@@ -451,6 +453,106 @@ describe("commandLineDialogueBox.handlers", () => {
     expect(state.persistCharacter).toBe(true);
   });
 
+  it("resets persistCharacter when custom naming makes the field appear without a name", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs: {
+          dialogueForm: {
+            reset,
+            setValues,
+          },
+        },
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: true,
+              characterName: "",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.customCharacterName).toBe(true);
+    expect(state.characterName).toBe("");
+    expect(state.persistCharacter).toBe(false);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        customCharacterName: true,
+        characterName: "",
+        persistCharacter: false,
+      }),
+    });
+  });
+
+  it("keeps persistCharacter when a custom character name is removed but custom naming stays enabled", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const reset = vi.fn();
+    const setValues = vi.fn();
+
+    setCustomCharacterName({ state }, { customCharacterName: true });
+    setCharacterName({ state }, { characterName: "Boss" });
+    setPersistCharacter({ state }, { persistCharacter: true });
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs: {
+          dialogueForm: {
+            reset,
+            setValues,
+          },
+        },
+        render,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: true,
+              characterName: "",
+              persistCharacter: true,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.customCharacterName).toBe(true);
+    expect(state.characterName).toBe("");
+    expect(state.persistCharacter).toBe(true);
+    expect(reset).not.toHaveBeenCalled();
+    expect(setValues).not.toHaveBeenCalled();
+  });
+
   it("keeps the custom character name when switching characters with custom naming on", () => {
     const state = createInitialState();
     const render = vi.fn();
@@ -636,6 +738,40 @@ describe("commandLineDialogueBox.handlers", () => {
         },
         character: {
           name: "Boss",
+        },
+        persistCharacter: true,
+      },
+    });
+  });
+
+  it("submits persistCharacter when custom naming has no character name", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setCustomCharacterName({ state }, { customCharacterName: true });
+    setCharacterName({ state }, { characterName: "" });
+    setPersistCharacter({ state }, { persistCharacter: true });
+
+    handleSubmitClick({
+      props: {
+        layouts,
+        dialogue: {},
+      },
+      store: createStore(state),
+      dispatchEvent,
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "layout-adv",
+        },
+        character: {
+          name: "",
         },
         persistCharacter: true,
       },

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseAndRender } from "jempl";
 import {
   createInitialState,
   setCharacterName,
@@ -7,8 +8,29 @@ import {
   setPersistCharacter,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
 
+const isFieldVisible = ({ field, values }) => {
+  const rendered = parseAndRender(
+    {
+      fields: [
+        {
+          [`$if ${field.$when}`]: {
+            name: field.name,
+          },
+        },
+      ],
+    },
+    {
+      values,
+    },
+  );
+
+  return rendered.fields.some(
+    (renderedField) => renderedField.name === field.name,
+  );
+};
+
 describe("commandLineDialogueBox.store", () => {
-  it("includes custom character name and persistCharacter in form defaults and field values", () => {
+  it("includes custom speaker name and persistCharacter in form defaults and field values", () => {
     const state = createInitialState();
 
     setCustomCharacterName(
@@ -48,14 +70,35 @@ describe("commandLineDialogueBox.store", () => {
     expect(viewData.defaultValues.characterName).toBe("Boss");
     expect(viewData.defaultValues.persistCharacter).toBe(true);
     expect(
-      viewData.form.fields.find((field) => field.name === "customCharacterName"),
+      viewData.form.fields.find((field) => field.name === "mode"),
     ).toMatchObject({
+      label: "Mode",
+    });
+    expect(
+      viewData.form.fields.find((field) => field.name === "resourceId"),
+    ).toMatchObject({
+      label: "Layout",
+    });
+    expect(
+      viewData.form.fields.find((field) => field.name === "characterId"),
+    ).toMatchObject({
+      label: "Speaker",
+      placeholder: "Choose a speaker...",
+    });
+    expect(
+      viewData.form.fields.find(
+        (field) => field.name === "customCharacterName",
+      ),
+    ).toMatchObject({
+      label: "Custom Speaker Name",
       type: "segmented-control",
       value: true,
     });
     expect(
       viewData.form.fields.find((field) => field.name === "characterName"),
     ).toMatchObject({
+      label: "Speaker Name",
+      placeholder: "Enter speaker name",
       type: "input-text",
       value: "Boss",
     });
@@ -63,8 +106,125 @@ describe("commandLineDialogueBox.store", () => {
       viewData.form.fields.find((field) => field.name === "persistCharacter"),
     ).toMatchObject({
       $when: "values.characterId || values.customCharacterName",
+      label: "Persist Speaker",
       type: "segmented-control",
       value: true,
     });
+  });
+
+  it("uses one layout label for every dialogue mode", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        layouts: [
+          {
+            id: "layout-nvl",
+            name: "NVL Layout",
+            layoutType: "dialogue-nvl",
+          },
+        ],
+        characters: [],
+      },
+    });
+
+    expect(
+      viewData.form.fields.find((field) => field.name === "resourceId"),
+    ).toMatchObject({
+      label: "Layout",
+    });
+
+    state.selectedMode = "nvl";
+    const nvlViewData = selectViewData({
+      state,
+      props: {
+        layouts: [
+          {
+            id: "layout-nvl",
+            name: "NVL Layout",
+            layoutType: "dialogue-nvl",
+          },
+        ],
+        characters: [],
+      },
+    });
+
+    expect(
+      nvlViewData.form.fields.find((field) => field.name === "resourceId"),
+    ).toMatchObject({
+      label: "Layout",
+    });
+  });
+
+  it("shows persistCharacter only for selected characters or enabled custom naming", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({
+      state,
+      props: {
+        layouts: [
+          {
+            id: "layout-adv",
+            name: "ADV Layout",
+            layoutType: "dialogue-adv",
+          },
+        ],
+        characters: [],
+      },
+    });
+    const persistCharacterField = viewData.form.fields.find(
+      (field) => field.name === "persistCharacter",
+    );
+
+    expect(
+      isFieldVisible({
+        field: persistCharacterField,
+        values: {
+          characterId: "",
+          customCharacterName: false,
+          characterName: "",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isFieldVisible({
+        field: persistCharacterField,
+        values: {
+          characterId: "character-1",
+          customCharacterName: false,
+          characterName: "",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isFieldVisible({
+        field: persistCharacterField,
+        values: {
+          characterId: "",
+          customCharacterName: true,
+          characterName: "Boss",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isFieldVisible({
+        field: persistCharacterField,
+        values: {
+          characterId: "",
+          customCharacterName: true,
+          characterName: "",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isFieldVisible({
+        field: persistCharacterField,
+        values: {
+          characterId: "",
+          customCharacterName: true,
+          characterName: "   ",
+        },
+      }),
+    ).toBe(true);
   });
 });

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -114,7 +114,7 @@ describe("systemActions.store", () => {
       name: "Main Dialogue",
       modeLabel: "ADV",
       customCharacterNameLabel: "Name: Boss",
-      persistCharacterLabel: "Persist Character",
+      persistCharacterLabel: "Persist Speaker",
     });
   });
 
@@ -163,7 +163,7 @@ describe("systemActions.store", () => {
       name: "Main Dialogue",
       modeLabel: "ADV",
       customCharacterNameLabel: "Name: Boss",
-      persistCharacterLabel: "Persist Character",
+      persistCharacterLabel: "Persist Speaker",
     });
   });
 


### PR DESCRIPTION
## Summary
- remove redundant "Dialogue" wording from dialogue box field labels
- change visible character terminology to speaker while keeping underlying data keys unchanged
- add regression coverage for Persist Speaker visibility and preview labels

## Tests
- bunx vitest run tests/commandLineDialogueBox tests/systemActions/systemActions.store.test.js
- bun run lint