### PR TITLE
Add visual animation controls

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -32,7 +32,7 @@ const ANIMATION_MODE_OPTIONS = [
 
 const PLAYBACK_CONTINUITY_OPTIONS = [
   {
-    label: "Render",
+    label: "Current Line",
     value: "render",
   },
   {

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -1,7 +1,8 @@
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
-  const { images, videos, layouts, transforms } = projectService.getState();
+  const { animations, images, videos, layouts, transforms } =
+    projectService.getState();
 
   store.setImages({
     images: images || { tree: [], items: {} },
@@ -14,6 +15,9 @@ export const handleAfterMount = async (deps) => {
   });
   store.setTransforms({
     transforms: transforms || { tree: [], items: {} },
+  });
+  store.setAnimations({
+    animations: animations || { tree: [], items: {} },
   });
 
   // Use presentationState if available, otherwise fall back to visual prop
@@ -64,6 +68,22 @@ export const handleTransformChange = (deps, payload) => {
   const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
   const value = payload._event.detail.value;
   store.updateVisualTransform({ index, transform: value });
+  render();
+};
+
+export const handleAnimationModeChange = (deps, payload) => {
+  const { store, render } = deps;
+  const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
+  const value = payload._event.detail.value;
+  store.updateVisualAnimationMode({ index, animationMode: value });
+  render();
+};
+
+export const handleAnimationChange = (deps, payload) => {
+  const { store, render } = deps;
+  const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
+  const value = payload._event.detail.value;
+  store.updateVisualAnimation({ index, animationId: value });
   render();
 };
 
@@ -118,11 +138,21 @@ export const handleSubmitClick = (deps) => {
 
   const visualData = {
     visual: {
-      items: selectedVisuals.map((visual) => ({
-        id: visual.id,
-        resourceId: visual.resourceId,
-        transformId: visual.transformId,
-      })),
+      items: selectedVisuals.map((visual) => {
+        const item = {
+          id: visual.id,
+          resourceId: visual.resourceId,
+          transformId: visual.transformId,
+        };
+
+        if (visual.animations?.resourceId) {
+          item.animations = {
+            resourceId: visual.animations.resourceId,
+          };
+        }
+
+        return item;
+      }),
     },
   };
 

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -7,6 +7,61 @@ const RESOURCE_TYPES = [
   { type: "layout", label: "Layouts" },
 ];
 
+const ANIMATION_MODE_OPTIONS = [
+  {
+    label: "None",
+    value: "none",
+  },
+  {
+    label: "Update",
+    value: "update",
+  },
+  {
+    label: "Transition",
+    value: "transition",
+  },
+];
+
+const createEmptyCollection = () => ({
+  items: {},
+  tree: [],
+});
+
+const getAnimationType = (item = {}) => {
+  return item?.animation?.type === "transition" ? "transition" : "update";
+};
+
+const getAnimationItemById = (collection = {}, animationId) => {
+  if (!animationId) {
+    return undefined;
+  }
+
+  return toFlatItems(collection).find(
+    (item) => item.id === animationId && item.type === "animation",
+  );
+};
+
+const getAnimationModeById = (collection = {}, animationId) => {
+  const item = getAnimationItemById(collection, animationId);
+  return item ? getAnimationType(item) : undefined;
+};
+
+const normalizeSelectedVisual = (visual = {}, animations = {}) => {
+  const nextVisual = structuredClone(visual ?? {});
+  const selectedAnimationId = nextVisual?.animations?.resourceId;
+  const selectedAnimationMode = getAnimationModeById(
+    animations,
+    selectedAnimationId,
+  );
+
+  nextVisual.animationMode =
+    nextVisual.animationMode ??
+    selectedAnimationMode ??
+    (selectedAnimationId ? "update" : "none");
+
+  return nextVisual;
+};
+
 const getCollectionTree = (collection) => {
   if (Array.isArray(collection?.tree)) {
     return collection.tree;
@@ -88,16 +143,18 @@ const parseResourceExplorerId = (itemId = "") => {
 
 export const createInitialState = () => ({
   mode: "current",
-  images: { items: {}, tree: [] },
-  videos: { items: {}, tree: [] },
-  layouts: { items: {}, tree: [] },
-  transforms: { tree: [], items: {} },
+  images: createEmptyCollection(),
+  videos: createEmptyCollection(),
+  layouts: createEmptyCollection(),
+  transforms: createEmptyCollection(),
+  animations: createEmptyCollection(),
   /**
    * Array of raw visual objects with the following structure:
    * {
    *   id: string,              // Unique visual ID
    *   resourceId: string,      // Image/video/layout resource ID
    *   transformId: string,     // Transform ID
+   *   animations: object,      // Optional animation selection with resourceId
    * }
    */
   selectedVisuals: [],
@@ -134,6 +191,13 @@ export const setTransforms = ({ state }, { transforms } = {}) => {
   state.transforms = transforms;
 };
 
+export const setAnimations = ({ state }, { animations } = {}) => {
+  state.animations = animations;
+  state.selectedVisuals = state.selectedVisuals.map((visual) =>
+    normalizeSelectedVisual(visual, state.animations),
+  );
+};
+
 const generateVisualId = () => {
   return generatePrefixedId("visual-");
 };
@@ -149,6 +213,7 @@ export const addVisual = ({ state }, { resourceId } = {}) => {
     id: generateVisualId(),
     resourceId: resourceId,
     transformId: defaultTransform,
+    animationMode: "none",
   });
 };
 
@@ -159,6 +224,59 @@ export const removeVisual = ({ state }, { index } = {}) => {
 export const updateVisualTransform = ({ state }, { index, transform } = {}) => {
   if (state.selectedVisuals[index]) {
     state.selectedVisuals[index].transformId = transform;
+  }
+};
+
+export const updateVisualAnimation = (
+  { state },
+  { index, animationId } = {},
+) => {
+  if (!state.selectedVisuals[index]) {
+    return;
+  }
+
+  if (!animationId || animationId === "none") {
+    state.selectedVisuals[index].animations = undefined;
+    return;
+  }
+
+  state.selectedVisuals[index].animations = {
+    resourceId: animationId,
+  };
+
+  const selectedAnimationMode = getAnimationModeById(
+    state.animations,
+    animationId,
+  );
+  if (selectedAnimationMode) {
+    state.selectedVisuals[index].animationMode = selectedAnimationMode;
+  }
+};
+
+export const updateVisualAnimationMode = (
+  { state },
+  { index, animationMode } = {},
+) => {
+  if (!state.selectedVisuals[index]) {
+    return;
+  }
+
+  if (animationMode !== "update" && animationMode !== "transition") {
+    state.selectedVisuals[index].animationMode = "none";
+    state.selectedVisuals[index].animations = undefined;
+    return;
+  }
+
+  state.selectedVisuals[index].animationMode = animationMode;
+
+  const selectedAnimationId =
+    state.selectedVisuals[index]?.animations?.resourceId;
+  const selectedAnimationMode = getAnimationModeById(
+    state.animations,
+    selectedAnimationId,
+  );
+  if (selectedAnimationMode && selectedAnimationMode !== animationMode) {
+    state.selectedVisuals[index].animations = undefined;
   }
 };
 
@@ -234,7 +352,9 @@ export const selectResourceExplorerTarget = (_deps, { itemId } = {}) => {
 };
 
 export const setExistingVisuals = ({ state }, { visuals } = {}) => {
-  state.selectedVisuals = visuals;
+  state.selectedVisuals = (Array.isArray(visuals) ? visuals : []).map(
+    (visual) => normalizeSelectedVisual(visual, state.animations),
+  );
 };
 
 export const selectResourceItemById = ({ state }, { resourceId } = {}) => {
@@ -384,12 +504,31 @@ export const selectViewData = ({ state }) => {
     label: transform.name,
     value: transform.id,
   }));
+  const animationItems = toFlatItems(state.animations).filter(
+    (item) => item.type === "animation",
+  );
+  const updateAnimationOptions = animationItems
+    .filter((item) => getAnimationType(item) === "update")
+    .map((item) => ({
+      value: item.id,
+      label: item.name,
+    }));
+  const transitionAnimationOptions = animationItems
+    .filter((item) => getAnimationType(item) === "transition")
+    .map((item) => ({
+      value: item.id,
+      label: item.name,
+    }));
 
   // Get enriched visual data
   const enrichedVisuals = selectVisualsWithRepositoryData({ state });
   const processedSelectedVisuals = enrichedVisuals.map((visual) => ({
     ...visual,
     displayName: visual.displayName || "Unknown Resource",
+    animationMode:
+      visual.animationMode ??
+      getAnimationModeById(state.animations, visual.animations?.resourceId) ??
+      "none",
   }));
 
   let breadcrumb = [
@@ -421,8 +560,12 @@ export const selectViewData = ({ state }) => {
       transformId:
         visual.transformId ||
         (transformOptions.length > 0 ? transformOptions[0].value : undefined),
+      animationId: visual.animations?.resourceId,
     })),
     transformOptions,
+    animationModeOptions: ANIMATION_MODE_OPTIONS,
+    updateAnimationOptions,
+    transitionAnimationOptions,
   };
 
   return {
@@ -431,6 +574,9 @@ export const selectViewData = ({ state }) => {
     resourceGroups,
     selectedVisuals: processedSelectedVisuals,
     transformOptions,
+    animationModeOptions: ANIMATION_MODE_OPTIONS,
+    updateAnimationOptions,
+    transitionAnimationOptions,
     searchQuery: state.searchQuery,
     searchPlaceholder: "Search...",
     fullImagePreviewVisible: state.fullImagePreviewVisible,

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -54,6 +54,18 @@ refs:
     eventListeners:
       value-change:
         handler: handleTransformChange
+  animationMode*:
+    eventListeners:
+      value-change:
+        handler: handleAnimationModeChange
+  updateAnimation*:
+    eventListeners:
+      value-change:
+        handler: handleAnimationChange
+  transitionAnimation*:
+    eventListeners:
+      value-change:
+        handler: handleAnimationChange
 template:
   - rtgl-view w=f h=f p=lg:
       - $if mode == 'current':
@@ -74,6 +86,12 @@ template:
                           - rtgl-view w=1fg g=sm:
                               - rtgl-text s=sm c=mu-fg: Transform
                               - rtgl-select#transform${i} data-index=${i} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear: null
+                              - rtgl-text s=sm c=mu-fg: Animation
+                              - rtgl-segmented-control#animationMode${i} data-index=${i} key=${visual.animationMode} :options=${defaultValues.animationModeOptions} :selectedValue=${visual.animationMode} w=f no-clear: null
+                              - $if visual.animationMode == 'update':
+                                  - rtgl-select#updateAnimation${i} data-index=${i} key=${visual.animationId} :options=${defaultValues.updateAnimationOptions} :selectedValue=${visual.animationId} w=f no-clear: null
+                                $elif visual.animationMode == 'transition':
+                                  - rtgl-select#transitionAnimation${i} data-index=${i} key=${visual.animationId} :options=${defaultValues.transitionAnimationOptions} :selectedValue=${visual.animationId} w=f no-clear: null
                   - rtgl-button#addVisualButton v=ol w=f mt=md: + Add Visual
           - rtgl-view d=h av=c ah=e w=f g=lg:
               - rtgl-button#submitButton: Submit

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -150,7 +150,7 @@ describe("commandLineBackground.store", () => {
       options: [
         {
           value: "render",
-          label: "Render",
+          label: "Current Line",
         },
         {
           value: "persistent",

--- a/tests/commandLineVisual/commandLineVisual.handlers.test.js
+++ b/tests/commandLineVisual/commandLineVisual.handlers.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAnimationChange,
+  handleAnimationModeChange,
+  handleSubmitClick,
+} from "../../src/components/commandLineVisual/commandLineVisual.handlers.js";
+import {
+  createInitialState,
+  selectSelectedVisuals,
+  setAnimations,
+  setExistingVisuals,
+  updateVisualAnimation,
+  updateVisualAnimationMode,
+} from "../../src/components/commandLineVisual/commandLineVisual.store.js";
+
+const createStoreApi = (state) => ({
+  selectSelectedVisuals: () => selectSelectedVisuals({ state }),
+  updateVisualAnimation: (payload) => updateVisualAnimation({ state }, payload),
+  updateVisualAnimationMode: (payload) =>
+    updateVisualAnimationMode({ state }, payload),
+});
+
+const setAnimationCollection = (state) => {
+  setAnimations(
+    { state },
+    {
+      animations: {
+        items: {
+          "visual-fade": {
+            id: "visual-fade",
+            type: "animation",
+            name: "Fade",
+            animation: {
+              type: "update",
+            },
+          },
+        },
+        tree: [{ id: "visual-fade" }],
+      },
+    },
+  );
+};
+
+describe("commandLineVisual.handlers animation controls", () => {
+  it("updates per-visual animation mode and animation selection", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+
+    setAnimationCollection(state);
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            transformId: "visual-center",
+          },
+        ],
+      },
+    );
+
+    handleAnimationModeChange(
+      {
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: "update",
+          },
+        },
+      },
+    );
+    handleAnimationChange(
+      {
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: "visual-fade",
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      animationMode: "update",
+      animations: {
+        resourceId: "visual-fade",
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("submits animations for selected visuals without changing other data keys", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setAnimationCollection(state);
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            transformId: "visual-center",
+            animations: {
+              resourceId: "visual-fade",
+            },
+          },
+        ],
+      },
+    );
+
+    handleSubmitClick({
+      dispatchEvent,
+      store: createStoreApi(state),
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      visual: {
+        items: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            transformId: "visual-center",
+            animations: {
+              resourceId: "visual-fade",
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectSelectedVisuals,
+  selectViewData,
+  setAnimations,
+  setExistingVisuals,
+  setImages,
+  setTransforms,
+  updateVisualAnimation,
+  updateVisualAnimationMode,
+} from "../../src/components/commandLineVisual/commandLineVisual.store.js";
+
+const createEmptyCollection = () => ({
+  items: {},
+  tree: [],
+});
+
+const setRepositoryCollections = (state) => {
+  setImages(
+    { state },
+    {
+      images: {
+        items: {
+          "visual-image": {
+            id: "visual-image",
+            type: "image",
+            name: "Spotlight",
+            fileId: "file-spotlight",
+          },
+        },
+        tree: [{ id: "visual-image" }],
+      },
+    },
+  );
+  setTransforms(
+    { state },
+    {
+      transforms: {
+        items: {
+          "visual-center": {
+            id: "visual-center",
+            type: "transform",
+            name: "Center",
+          },
+        },
+        tree: [{ id: "visual-center" }],
+      },
+    },
+  );
+  setAnimations(
+    { state },
+    {
+      animations: {
+        items: {
+          "visual-fade": {
+            id: "visual-fade",
+            type: "animation",
+            name: "Fade",
+            animation: {
+              type: "update",
+            },
+          },
+          "visual-wipe": {
+            id: "visual-wipe",
+            type: "animation",
+            name: "Wipe",
+            animation: {
+              type: "transition",
+            },
+          },
+        },
+        tree: [{ id: "visual-fade" }, { id: "visual-wipe" }],
+      },
+    },
+  );
+};
+
+describe("commandLineVisual.store animation controls", () => {
+  it("exposes animation controls for each selected visual", () => {
+    const state = createInitialState();
+    setRepositoryCollections(state);
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            transformId: "visual-center",
+            animations: {
+              resourceId: "visual-wipe",
+            },
+          },
+        ],
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.defaultValues.visuals[0]).toMatchObject({
+      id: "visual-1",
+      resourceId: "visual-image",
+      transformId: "visual-center",
+      animationMode: "transition",
+      animationId: "visual-wipe",
+    });
+    expect(viewData.defaultValues.animationModeOptions).toEqual([
+      { label: "None", value: "none" },
+      { label: "Update", value: "update" },
+      { label: "Transition", value: "transition" },
+    ]);
+    expect(viewData.defaultValues.updateAnimationOptions).toEqual([
+      {
+        value: "visual-fade",
+        label: "Fade",
+      },
+    ]);
+    expect(viewData.defaultValues.transitionAnimationOptions).toEqual([
+      {
+        value: "visual-wipe",
+        label: "Wipe",
+      },
+    ]);
+  });
+
+  it("clears mismatched visual animation selections when mode changes", () => {
+    const state = createInitialState();
+    setRepositoryCollections(state);
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            transformId: "visual-center",
+            animations: {
+              resourceId: "visual-wipe",
+            },
+          },
+        ],
+      },
+    );
+
+    updateVisualAnimationMode(
+      { state },
+      {
+        index: 0,
+        animationMode: "update",
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      animationMode: "update",
+    });
+    expect(selectSelectedVisuals({ state })[0].animations).toBeUndefined();
+
+    updateVisualAnimation(
+      { state },
+      {
+        index: 0,
+        animationId: "visual-fade",
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      animationMode: "update",
+      animations: {
+        resourceId: "visual-fade",
+      },
+    });
+
+    updateVisualAnimationMode(
+      { state },
+      {
+        index: 0,
+        animationMode: "none",
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      animationMode: "none",
+    });
+    expect(selectSelectedVisuals({ state })[0].animations).toBeUndefined();
+  });
+
+  it("handles empty animation collections", () => {
+    const state = createInitialState();
+    setAnimations({ state }, { animations: createEmptyCollection() });
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.defaultValues.updateAnimationOptions).toEqual([]);
+    expect(viewData.defaultValues.transitionAnimationOptions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add per-visual animation mode and animation resource controls to commandLineVisual
- submit selected visual animations as visual.items[].animations.resourceId
- rename background playback continuity render label to Current Line
- add focused store and handler coverage for commandLineVisual and update background label test

## Tests
- bunx vitest run tests/commandLineVisual tests/commandLineBackground
- bun run lint

## Notes
- bun run check:contracts currently fails repo-wide with pre-existing diagnostics unrelated to this change.