### PR TITLE
feat: expose particles and spritesheets in layout editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.5",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "file:../routevn-creator-model",
+        "@routevn/creator-model": "1.3.4",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -259,7 +259,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@file:../routevn-creator-model", { "devDependencies": { "js-yaml": "^4.1.0", "puty": "0.1.2", "vitest": "^3.2.1" } }],
+    "@routevn/creator-model": ["@routevn/creator-model@1.3.4", "", {}, "sha512-+advbZmzNmlVzEWAHFVjvsZChfIV50my0DJXEmRTSLmtatL0IHYUlXFKry70lZrvAURqL3HzPll17MXe1xj9xw=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.5",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.3.2",
+        "@routevn/creator-model": "file:../routevn-creator-model",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -259,7 +259,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.3.2", "", {}, "sha512-TwCfV5PpHchfjH2PK/fC8MF9XIDbJaK0lFV66D+LUFez7FQD+QVb7xMa3E15P29IIcPz6g0XHZZuZfdZ2V3FtQ=="],
+    "@routevn/creator-model": ["@routevn/creator-model@file:../routevn-creator-model", { "devDependencies": { "js-yaml": "^4.1.0", "puty": "0.1.2", "vitest": "^3.2.1" } }],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.5",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "1.3.2",
+    "@routevn/creator-model": "file:../routevn-creator-model",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.5",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "file:../routevn-creator-model",
+    "@routevn/creator-model": "1.3.4",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/src/components/baseFileExplorer/baseFileExplorer.store.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.store.js
@@ -296,21 +296,23 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       bgc = "mu";
     }
 
-    let svg = item.type;
-    if (item.type === "fragment-ref") {
-      svg = "fragment";
-    } else if (item.type === "layout" && item.isFragment) {
-      svg = "fragment";
-    } else if (item.type === "particle") {
-      svg = "particles";
-    } else if (item.type === "spritesheet") {
-      svg = "spritesheets";
-    } else if (item.type === "sound") {
-      svg = "audio";
-    } else if (item.type.startsWith("text")) {
-      svg = "text";
-    } else if (item.type.startsWith("container")) {
-      svg = "container";
+    let svg = item.svg ?? item.type;
+    if (item.svg === undefined) {
+      if (item.type === "fragment-ref") {
+        svg = "fragment";
+      } else if (item.type === "layout" && item.isFragment) {
+        svg = "fragment";
+      } else if (item.type === "particle") {
+        svg = "particles";
+      } else if (item.type === "spritesheet") {
+        svg = "spritesheets";
+      } else if (item.type === "sound") {
+        svg = "audio";
+      } else if (item.type.startsWith("text")) {
+        svg = "text";
+      } else if (item.type.startsWith("container")) {
+        svg = "container";
+      }
     }
 
     return {

--- a/src/components/baseFileExplorer/baseFileExplorer.store.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.store.js
@@ -301,6 +301,10 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       svg = "fragment";
     } else if (item.type === "layout" && item.isFragment) {
       svg = "fragment";
+    } else if (item.type === "particle") {
+      svg = "particles";
+    } else if (item.type === "spritesheet") {
+      svg = "spritesheets";
     } else if (item.type === "sound") {
       svg = "audio";
     } else if (item.type.startsWith("text")) {

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -30,17 +30,6 @@ const ANIMATION_MODE_OPTIONS = [
   },
 ];
 
-const PLAYBACK_CONTINUITY_OPTIONS = [
-  {
-    label: "Current Line",
-    value: "render",
-  },
-  {
-    label: "Persistent",
-    value: "persistent",
-  },
-];
-
 // Form structure will be created dynamically in selectViewData
 const createEmptyCollection = () => ({
   items: {},
@@ -450,16 +439,6 @@ export const selectViewData = ({ state }) => {
       clearable: false,
       placeholder: "Select transition animation",
       options: transitionAnimationOptions,
-    });
-  }
-
-  if (selectedAnimationMode !== "none") {
-    formFields.push({
-      name: "playbackContinuity",
-      label: "Playback Continuity",
-      type: "segmented-control",
-      clearable: false,
-      options: PLAYBACK_CONTINUITY_OPTIONS,
     });
   }
 

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -999,7 +999,7 @@ export const selectViewData = ({ state, props, constants }) => {
         selectedSpritesheetAnimation: selectedSpritesheetPreview.animation,
         selectedSpritesheetPreviewKey:
           spritesheetSelectionValue ??
-          `${selectedSpritesheetPreview.fileId ?? ""}:${selectedSpritesheetPreview.animation?.frames?.join(",") ?? ""}`,
+          `${selectedSpritesheetPreview.fileId ?? ""}:${selectedSpritesheetPreview.animation?.frames?.join(",") ?? ""}:${selectedSpritesheetPreview.animation?.fps ?? ""}`,
         fragmentLayoutOptions,
         values,
         showLayoutSizeSection,

--- a/src/components/mobileSidebar/mobileSidebar.store.js
+++ b/src/components/mobileSidebar/mobileSidebar.store.js
@@ -38,13 +38,13 @@ const animatedAssetItems = [
     id: "particles",
     label: "Particles",
     path: "/project/particles",
-    icon: "component",
+    icon: "particles",
   },
   {
     id: "spritesheets",
     label: "Spritesheets",
     path: "/project/spritesheets",
-    icon: "sprite",
+    icon: "spritesheets",
   },
 ];
 

--- a/src/components/spritesheetPreview/spritesheetPreview.handlers.js
+++ b/src/components/spritesheetPreview/spritesheetPreview.handlers.js
@@ -1,7 +1,9 @@
 import { isVisualTestMode } from "../../internal/visualTestMode.js";
+import { resolveSpritesheetAnimationFps } from "../../internal/spritesheets.js";
 
 const PREVIEW_PADDING_PX = 16;
-const DEFAULT_FPS = 30;
+
+const isPaused = (value) => value === true || value === "true";
 
 const clearCanvas = (canvas) => {
   if (
@@ -29,22 +31,8 @@ const clearCanvas = (canvas) => {
   }
 
   context.clearRect(0, 0, width, height);
-  context.fillStyle = "#151515";
+  context.fillStyle = "#000000";
   context.fillRect(0, 0, width, height);
-
-  context.strokeStyle = "rgba(255,255,255,0.08)";
-  for (let x = 0; x < width; x += 24) {
-    context.beginPath();
-    context.moveTo(x, 0);
-    context.lineTo(x, height);
-    context.stroke();
-  }
-  for (let y = 0; y < height; y += 24) {
-    context.beginPath();
-    context.moveTo(0, y);
-    context.lineTo(width, y);
-    context.stroke();
-  }
 };
 
 const revokeOwnedImageSrc = (store) => {
@@ -175,10 +163,7 @@ const startAnimation = (deps) => {
     return;
   }
 
-  const fps = Math.max(
-    1,
-    Number(props.animation?.animationSpeed ?? DEFAULT_FPS / 60) * 60,
-  );
+  const fps = Math.max(1, resolveSpritesheetAnimationFps(props.animation));
   const loop = props.animation?.loop ?? true;
 
   let lastRenderedFrame = -1;
@@ -314,7 +299,7 @@ export const handleOnUpdate = async (deps, payload = {}) => {
       ...deps,
       props: newProps,
     });
-    if (newProps.paused !== true) {
+    if (!isPaused(newProps.paused)) {
       startAnimation({
         ...deps,
         props: newProps,
@@ -328,7 +313,7 @@ export const handleSourceImageLoad = (deps) => {
   const { props, render, store } = deps;
   store.setStatus({ status: "ready" });
   drawFrame(deps);
-  if (props.paused !== true) {
+  if (!isPaused(props.paused)) {
     startAnimation(deps);
   }
   render();

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -5,6 +5,7 @@ import {
   createRenderableParticleData,
   isBuiltinParticleTextureName,
 } from "../particles.js";
+import { resolveSpritesheetAnimationFps } from "../spritesheets.js";
 import { filterTreeCollection, toHierarchyStructure } from "./tree.js";
 import { normalizeEngineActions } from "./engineActions.js";
 import {
@@ -1029,18 +1030,15 @@ const applySpritesheetAnimationNode = ({ element, node, context }) => {
     typeof animationName === "string"
       ? spritesheet.animations?.[animationName]
       : undefined;
+  const fps = resolveSpritesheetAnimationFps(selectedAnimation);
   const playback = {
     autoplay: true,
+    fps,
     loop: selectedAnimation?.loop ?? true,
   };
-  const fps = Number(selectedAnimation?.animationSpeed) * 60;
 
   if (typeof animationName === "string" && animationName.length > 0) {
     playback.clip = animationName;
-  }
-
-  if (Number.isFinite(fps) && fps > 0) {
-    playback.fps = fps;
   }
 
   return {

--- a/src/internal/spritesheets.js
+++ b/src/internal/spritesheets.js
@@ -1,6 +1,66 @@
 import { toFlatItems } from "./project/tree.js";
 
 const SPRITESHEET_SELECTION_SEPARATOR = "::";
+export const INITIAL_SPRITESHEET_CLIP_FPS = 24;
+
+export const normalizeSpritesheetFps = (value) => {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  const fps = Number(value);
+  if (!Number.isFinite(fps) || fps <= 0) {
+    return undefined;
+  }
+
+  return fps;
+};
+
+export const formatSpritesheetFps = (value) => {
+  const fps = normalizeSpritesheetFps(value);
+  if (fps === undefined) {
+    return "";
+  }
+
+  return Number.isInteger(fps)
+    ? String(fps)
+    : fps.toFixed(2).replace(/\.?0+$/, "");
+};
+
+export const resolveSpritesheetAnimationFps = (
+  animation = {},
+  missingClipFps = INITIAL_SPRITESHEET_CLIP_FPS,
+) => {
+  const explicitFps = normalizeSpritesheetFps(animation?.fps);
+  if (explicitFps !== undefined) {
+    return explicitFps;
+  }
+
+  const animationSpeed = Number(animation?.animationSpeed);
+  if (Number.isFinite(animationSpeed) && animationSpeed > 0) {
+    return animationSpeed * 60;
+  }
+
+  return (
+    normalizeSpritesheetFps(missingClipFps) ?? INITIAL_SPRITESHEET_CLIP_FPS
+  );
+};
+
+export const normalizeSpritesheetAnimationsFps = (
+  animations = {},
+  missingClipFps = INITIAL_SPRITESHEET_CLIP_FPS,
+) => {
+  return Object.fromEntries(
+    Object.entries(animations ?? {}).map(([name, animation]) => {
+      const normalizedAnimation = {
+        ...animation,
+        fps: resolveSpritesheetAnimationFps(animation, missingClipFps),
+      };
+      delete normalizedAnimation.animationSpeed;
+      return [name, normalizedAnimation];
+    }),
+  );
+};
 
 const getSpritesheetAnimationNames = (item = {}) => {
   return Object.keys(item.animations ?? {});

--- a/src/pages/layoutEditor/layoutEditor.constants.yaml
+++ b/src/pages/layoutEditor/layoutEditor.constants.yaml
@@ -7,16 +7,12 @@ contextMenuItems:
   - label: Sprite
     type: item
     createType: sprite
-  # Hidden for now. Restore when layout editor should allow creating
-  # spritesheet animations again.
-  # - label: Spritesheet Animation
-  #   type: item
-  #   createType: spritesheet-animation
-  # Hidden for now. Restore when layout editor should allow creating
-  # particles again.
-  # - label: Particle
-  #   type: item
-  #   createType: particle
+  - label: Spritesheet Animation
+    type: item
+    createType: spritesheet-animation
+  - label: Particle
+    type: item
+    createType: particle
   - label: Text
     type: item
     createType: text
@@ -105,16 +101,12 @@ emptyContextMenuItems:
   - label: Sprite
     type: item
     createType: sprite
-  # Hidden for now. Restore when layout editor should allow creating
-  # spritesheet animations again.
-  # - label: Spritesheet Animation
-  #   type: item
-  #   createType: spritesheet-animation
-  # Hidden for now. Restore when layout editor should allow creating
-  # particles again.
-  # - label: Particle
-  #   type: item
-  #   createType: particle
+  - label: Spritesheet Animation
+    type: item
+    createType: spritesheet-animation
+  - label: Particle
+    type: item
+    createType: particle
   - label: Text
     type: item
     createType: text

--- a/src/pages/layoutEditor/support/layoutEditorViewData.js
+++ b/src/pages/layoutEditor/support/layoutEditorViewData.js
@@ -106,9 +106,12 @@ export const toLayoutEditorExplorerItems = (
     const definition = getLayoutEditorElementDefinition(item.type);
     const hasPreviewDependencies =
       Object.keys(definition.previewDependencies).length > 0;
+    const svg =
+      item.type === "spritesheet-animation" ? "spritesheets" : item.svg;
 
     return {
       ...item,
+      svg,
       contextMenuItems:
         definition.isContainer === true
           ? contextMenuItems

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -581,7 +581,7 @@ export const handleParticleDialogClose = async (deps) => {
 
 export const handleParticleFormActionClick = async (deps, payload) => {
   const { appService, projectService, refs, store, render } = deps;
-  const { actionId, values: nextValues } = payload._event.detail;
+  const { actionId, valid, values: nextValues } = payload._event.detail;
   const dialogStep = store.selectDialogStep();
   const mergedValues = mergeDialogFormValues(store, nextValues);
   const values =
@@ -609,6 +609,10 @@ export const handleParticleFormActionClick = async (deps, payload) => {
   }
 
   if (actionId !== "submit") {
+    return;
+  }
+
+  if (valid === false) {
     return;
   }
 

--- a/src/pages/particles/particles.store.js
+++ b/src/pages/particles/particles.store.js
@@ -17,6 +17,7 @@ import {
   buildParticleFormValues,
   createParticleCreateSetupForm,
   createParticleForm,
+  resolveParticleTextureImageItem,
 } from "./support/particleForm.js";
 import { DEFAULT_PARTICLE_PRESET_ID } from "./support/particlePresets.js";
 import { formatParticleAspectRatio } from "./support/particlePreview.js";
@@ -128,6 +129,10 @@ const {
   hiddenMobileDetailSlots: ["particle-preview"],
   extendViewData: ({ state, selectedItem, baseViewData }) => {
     const activeTagIds = state.activeTagIds ?? [];
+    const selectedTextureImageItem = resolveParticleTextureImageItem(
+      selectedItem?.modules?.appearance?.texture,
+      state.imagesData?.items,
+    );
     const filteredCatalogGroups = (baseViewData.catalogGroups ?? [])
       .map((group) => ({
         ...group,
@@ -170,6 +175,8 @@ const {
       dialogFormValues: state.dialogFormValues,
       dialogPreviewAspectRatio: state.dialogPreviewAspectRatio,
       selectedPreviewAspectRatio: formatParticleAspectRatio(selectedItem),
+      selectedTextureImageFileId: selectedTextureImageItem?.fileId,
+      selectedTextureImageName: selectedTextureImageItem?.name ?? "",
       isCreateTagDialogOpen: state.isCreateTagDialogOpen,
       createTagDefaultValues: state.createTagDefaultValues,
       createTagForm,

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -117,6 +117,10 @@ template:
                                               - 'rtgl-view w=f pos=rel br=md bw=xs bc=bo style="aspect-ratio: ${selectedPreviewAspectRatio}; overflow: hidden; background: #000;"':
                                                   - rtgl-view pos=abs cor=full:
                                                       - 'div#detailCanvas style="width: 100%; height: 100%; display: flex; overflow: hidden;"': null
+                                      - $if selectedTextureImageFileId:
+                                          - rtgl-view slot="particle-texture-image" w=f d=v g=xs:
+                                              - rvn-file-image fileId=${selectedTextureImageFileId} w=f h=120 bw=xs bc=bo br=md key=${selectedTextureImageFileId}: null
+                                              - rtgl-text w=f s=sm ellipsis=true: ${selectedTextureImageName}
                                       - rtgl-tag-select#detailTagSelect slot="particle-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
                             $else:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
@@ -137,6 +141,10 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
+                      - $if selectedTextureImageFileId:
+                          - rtgl-view slot="particle-texture-image" w=f d=v g=xs:
+                              - rvn-file-image fileId=${selectedTextureImageFileId} w=f h=120 bw=xs bc=bo br=md key=${selectedTextureImageFileId}: null
+                              - rtgl-text w=f s=sm ellipsis=true: ${selectedTextureImageName}
                       - rtgl-tag-select#detailTagSelect slot="particle-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
   - rtgl-dialog#particleDialog ?open=${isDialogOpen} s=lg:
       - 'rtgl-view slot="content" d=h lg-d=v ah=c g=lg w=f h=70vh style="min-height: 0;"':

--- a/src/pages/particles/support/particleForm.js
+++ b/src/pages/particles/support/particleForm.js
@@ -27,14 +27,9 @@ const VELOCITY_KIND_OPTIONS = [
   { id: "radial", label: "Radial", value: "radial" },
 ];
 
-const BOUNDS_MODE_OPTIONS = [
-  { id: "recycle", label: "Recycle", value: "recycle" },
-  { id: "none", label: "None", value: "none" },
-];
-
-const BOUNDS_SOURCE_OPTIONS = [
-  { id: "area", label: "Area", value: "area" },
-  { id: "custom", label: "Custom", value: "custom" },
+const FACE_VELOCITY_OPTIONS = [
+  { id: "off", label: "Off", value: false },
+  { id: "on", label: "On", value: true },
 ];
 
 const PARTICLE_TAG_FIELD = {
@@ -192,24 +187,6 @@ const resolveTextureFields = (texture) => {
   };
 };
 
-const resolvePaddingValue = (padding) => {
-  if (typeof padding === "number" && Number.isFinite(padding)) {
-    return padding;
-  }
-
-  if (padding && typeof padding === "object") {
-    const values = ["top", "right", "bottom", "left"]
-      .map((key) => Number(padding[key]))
-      .filter((value) => Number.isFinite(value));
-
-    if (values.length > 0) {
-      return Math.max(...values);
-    }
-  }
-
-  return 24;
-};
-
 const resolveSourceDefaults = (particle) => ({
   x: Math.round((particle?.width ?? 1280) / 2),
   y: Math.round((particle?.height ?? 720) / 2),
@@ -315,19 +292,34 @@ const summarizeTexture = (texture, imageItems = {}) => {
   return "Legacy shape";
 };
 
+export const resolveParticleTextureImageItem = (texture, imageItems = {}) => {
+  if (typeof texture === "string") {
+    if (isBuiltinParticleTextureName(texture)) {
+      return;
+    }
+
+    const imageItem = imageItems?.[texture];
+    return imageItem?.type === "image" ? imageItem : undefined;
+  }
+
+  if (!texture || typeof texture !== "object" || Array.isArray(texture)) {
+    return;
+  }
+
+  const firstItem = Array.isArray(texture.items)
+    ? texture.items.find((item) => item?.src)
+    : undefined;
+
+  if (!firstItem?.src) {
+    return;
+  }
+
+  return resolveParticleTextureImageItem(firstItem.src, imageItems);
+};
+
 const summarizeSource = (source) => {
   const kind = source?.kind ?? "rect";
   return capitalize(kind);
-};
-
-const summarizeLifetime = (lifetime) => {
-  const range = resolveRange(lifetime, 1, 1);
-
-  if (range.min === range.max) {
-    return `${range.min}s`;
-  }
-
-  return `${range.min}s to ${range.max}s`;
 };
 
 const withFieldTooltips = (fields = []) =>
@@ -399,7 +391,6 @@ export const PARTICLE_FORM_TABS = [
   { id: "emission", label: "Emission" },
   { id: "source", label: "Source" },
   { id: "movement", label: "Movement" },
-  { id: "bounds", label: "Bounds" },
 ];
 
 const PARTICLE_FORM_TAB_IDS = new Set(
@@ -484,15 +475,17 @@ const createParticleFieldsByTab = ({
         min: 0,
         step: 1,
         required: false,
+        $when: "emissionMode == 'continuous'",
       },
       {
         name: "burstCount",
         type: "input-number",
         label: "Burst Count",
         description: "How many particles spawn each time a burst is emitted.",
-        min: 0,
+        min: 1,
         step: 1,
-        required: false,
+        required: true,
+        $when: "emissionMode == 'burst'",
       },
       {
         name: "maxActive",
@@ -502,6 +495,7 @@ const createParticleFieldsByTab = ({
         min: 1,
         step: 1,
         required: false,
+        $when: "emissionMode == 'continuous'",
       },
       {
         name: "durationMode",
@@ -510,6 +504,7 @@ const createParticleFieldsByTab = ({
         description: "Keep emitting forever or stop after a timed window.",
         options: DURATION_MODE_OPTIONS,
         required: true,
+        $when: "emissionMode == 'continuous'",
       },
       {
         name: "durationSeconds",
@@ -519,7 +514,7 @@ const createParticleFieldsByTab = ({
         min: 0,
         step: 0.1,
         required: false,
-        $when: "values.durationMode == 'timed'",
+        $when: "emissionMode == 'continuous' && durationMode == 'timed'",
       },
       {
         name: "lifetimeMin",
@@ -575,6 +570,7 @@ const createParticleFieldsByTab = ({
         min: 0,
         step: 1,
         required: false,
+        $when: "sourceKind == 'rect'",
       },
       {
         name: "sourceHeight",
@@ -584,6 +580,7 @@ const createParticleFieldsByTab = ({
         min: 0,
         step: 1,
         required: false,
+        $when: "sourceKind == 'rect'",
       },
       {
         name: "sourceRadius",
@@ -593,6 +590,7 @@ const createParticleFieldsByTab = ({
         min: 0,
         step: 1,
         required: false,
+        $when: "sourceKind == 'circle'",
       },
       {
         name: "sourceInnerRadius",
@@ -602,6 +600,7 @@ const createParticleFieldsByTab = ({
         min: 0,
         step: 1,
         required: false,
+        $when: "sourceKind == 'circle'",
       },
       {
         name: "sourceX2",
@@ -610,6 +609,7 @@ const createParticleFieldsByTab = ({
         description: "Horizontal end position for line emitters.",
         step: 1,
         required: false,
+        $when: "sourceKind == 'line'",
       },
       {
         name: "sourceY2",
@@ -618,6 +618,7 @@ const createParticleFieldsByTab = ({
         description: "Vertical end position for line emitters.",
         step: 1,
         required: false,
+        $when: "sourceKind == 'line'",
       },
     ],
     movement: [
@@ -695,11 +696,13 @@ const createParticleFieldsByTab = ({
       },
       {
         name: "faceVelocity",
-        type: "checkbox",
-        content: "Rotate particles toward movement",
+        type: "segmented-control",
+        label: "Rotate Toward Movement",
         description:
           "Turn each particle so it points in the direction it is moving.",
-        required: false,
+        options: FACE_VELOCITY_OPTIONS,
+        required: true,
+        clearable: false,
       },
     ],
     appearance: [
@@ -729,68 +732,6 @@ const createParticleFieldsByTab = ({
           "Maximum particle scale at spawn or across the preset range.",
         min: 0,
         step: 0.05,
-        required: false,
-      },
-    ],
-    bounds: [
-      {
-        name: "boundsMode",
-        type: "select",
-        label: "Bounds Mode",
-        description:
-          "Choose what happens when particles leave the effect area.",
-        options: BOUNDS_MODE_OPTIONS,
-        required: true,
-      },
-      {
-        name: "boundsSource",
-        type: "select",
-        label: "Bounds Source",
-        description: "Recycle against the canvas area or a custom rectangle.",
-        options: BOUNDS_SOURCE_OPTIONS,
-        required: false,
-      },
-      {
-        name: "boundsPadding",
-        type: "input-number",
-        label: "Bounds Padding",
-        description: "Extra padding around the canvas before recycle starts.",
-        min: 0,
-        step: 1,
-        required: false,
-      },
-      {
-        name: "customX",
-        type: "input-number",
-        label: "Custom Bounds X",
-        description: "Horizontal start position of the custom recycle area.",
-        step: 1,
-        required: false,
-      },
-      {
-        name: "customY",
-        type: "input-number",
-        label: "Custom Bounds Y",
-        description: "Vertical start position of the custom recycle area.",
-        step: 1,
-        required: false,
-      },
-      {
-        name: "customWidth",
-        type: "input-number",
-        label: "Custom Bounds Width",
-        description: "Width of the custom recycle area.",
-        min: 0,
-        step: 1,
-        required: false,
-      },
-      {
-        name: "customHeight",
-        type: "input-number",
-        label: "Custom Bounds Height",
-        description: "Height of the custom recycle area.",
-        min: 0,
-        step: 1,
         required: false,
       },
     ],
@@ -828,6 +769,7 @@ export const createParticleForm = ({
         id: "submit",
         variant: "pr",
         label: editMode ? "Update Particle" : "Add Particle",
+        validate: true,
       },
     ],
   },
@@ -869,7 +811,6 @@ export const buildParticleFormValues = ({
   const emission = modules.emission ?? {};
   const movement = modules.movement ?? {};
   const appearance = modules.appearance ?? {};
-  const bounds = modules.bounds ?? {};
   const lifetime = resolveRange(emission.particleLifetime, 1, 2);
   const scale = resolveScaleRange(appearance.scale);
   const textureFields = resolveTextureFields(appearance.texture);
@@ -903,17 +844,6 @@ export const buildParticleFormValues = ({
     ...textureFields,
     scaleMin: toTextValue(scale.min),
     scaleMax: toTextValue(scale.max),
-    boundsMode: bounds.mode ?? "recycle",
-    boundsSource: bounds.source ?? "area",
-    boundsPadding: toTextValue(resolvePaddingValue(bounds.padding)),
-    customX: toTextValue(bounds.custom?.x ?? 0),
-    customY: toTextValue(bounds.custom?.y ?? 0),
-    customWidth: toTextValue(
-      bounds.custom?.width ?? resolvedParticle.width ?? 1280,
-    ),
-    customHeight: toTextValue(
-      bounds.custom?.height ?? resolvedParticle.height ?? 720,
-    ),
   };
 };
 
@@ -1046,34 +976,6 @@ const buildMovementDefinition = (values = {}) => {
   };
 };
 
-const buildBoundsDefinition = ({ values, width, height }) => {
-  const boundsMode = values.boundsMode ?? "recycle";
-  if (boundsMode === "none") {
-    return {
-      mode: "none",
-    };
-  }
-
-  const boundsSource = values.boundsSource ?? "area";
-  const bounds = {
-    mode: "recycle",
-    source: boundsSource,
-  };
-
-  if (boundsSource === "custom") {
-    bounds.custom = {
-      x: toOptionalNumber(values.customX) ?? 0,
-      y: toOptionalNumber(values.customY) ?? 0,
-      width: toPositiveNumber(values.customWidth, width),
-      height: toPositiveNumber(values.customHeight, height),
-    };
-    return bounds;
-  }
-
-  bounds.padding = toNonNegativeNumber(values.boundsPadding, 24);
-  return bounds;
-};
-
 export const buildParticlePayload = ({
   values,
   baseParticle,
@@ -1099,6 +1001,7 @@ export const buildParticlePayload = ({
     Math.round(toPositiveNumber(values?.height, resolvedBaseParticle.height)),
   );
   const modules = structuredClone(resolvedBaseParticle.modules ?? {});
+  const emissionMode = values?.emissionMode ?? "continuous";
   const emissionRate = Number(values?.emissionRate);
   const durationMode = values?.durationMode ?? "infinite";
   const resolvedBaseDuration = resolvedBaseParticle.modules?.emission?.duration;
@@ -1110,15 +1013,7 @@ export const buildParticlePayload = ({
 
   modules.emission = {
     ...modules.emission,
-    mode: values?.emissionMode ?? "continuous",
-    maxActive: Math.max(1, Math.round(toPositiveNumber(values?.maxActive, 60))),
-    duration:
-      durationMode === "timed"
-        ? Math.max(
-            0,
-            toNonNegativeNumber(values?.durationSeconds, fallbackTimedDuration),
-          )
-        : "infinite",
+    mode: emissionMode,
     particleLifetime: {
       min: Math.max(0, toNonNegativeNumber(values?.lifetimeMin, 1)),
       max: Math.max(
@@ -1142,7 +1037,20 @@ export const buildParticlePayload = ({
       Math.round(toPositiveNumber(values?.burstCount, 1)),
     );
     delete modules.emission.rate;
+    delete modules.emission.maxActive;
+    delete modules.emission.duration;
   } else {
+    modules.emission.maxActive = Math.max(
+      1,
+      Math.round(toPositiveNumber(values?.maxActive, 60)),
+    );
+    modules.emission.duration =
+      durationMode === "timed"
+        ? Math.max(
+            0,
+            toNonNegativeNumber(values?.durationSeconds, fallbackTimedDuration),
+          )
+        : "infinite";
     modules.emission.rate = Number.isFinite(emissionRate)
       ? Math.max(1, emissionRate)
       : 20;
@@ -1150,11 +1058,6 @@ export const buildParticlePayload = ({
   }
 
   modules.movement = buildMovementDefinition(values);
-  modules.bounds = buildBoundsDefinition({
-    values,
-    width,
-    height,
-  });
   modules.appearance = {
     ...modules.appearance,
   };
@@ -1204,6 +1107,23 @@ export const buildParticleDetailFields = (input) => {
     return [];
   }
 
+  const texture = item.modules?.appearance?.texture;
+  const textureImageItem = resolveParticleTextureImageItem(
+    texture,
+    imagesData?.items,
+  );
+  const textureImageField = textureImageItem?.fileId
+    ? {
+        type: "slot",
+        slot: "particle-texture-image",
+        label: "Texture Image",
+      }
+    : {
+        type: "text",
+        label: "Texture Image",
+        value: summarizeTexture(texture, imagesData?.items),
+      };
+
   return [
     {
       type: "slot",
@@ -1234,24 +1154,7 @@ export const buildParticleDetailFields = (input) => {
       label: "Source",
       value: summarizeSource(item.modules?.emission?.source),
     },
-    {
-      type: "text",
-      label: "Texture Image",
-      value: summarizeTexture(
-        item.modules?.appearance?.texture,
-        imagesData?.items,
-      ),
-    },
-    {
-      type: "text",
-      label: "Lifetime",
-      value: summarizeLifetime(item.modules?.emission?.particleLifetime),
-    },
-    {
-      type: "text",
-      label: "Max Active",
-      value: toTextValue(item.modules?.emission?.maxActive ?? ""),
-    },
+    textureImageField,
     {
       type: "text",
       label: "Seed",

--- a/src/pages/spritesheets/spritesheets.handlers.js
+++ b/src/pages/spritesheets/spritesheets.handlers.js
@@ -24,6 +24,11 @@ import {
   resolveCollectionWithTags,
 } from "../../internal/resourceTags.js";
 import {
+  INITIAL_SPRITESHEET_CLIP_FPS,
+  normalizeSpritesheetAnimationsFps,
+  normalizeSpritesheetFps,
+} from "../../internal/spritesheets.js";
+import {
   getSpritesheetDisplayName,
   normalizeSizeInput,
   parseSpritesheetAtlasFile,
@@ -38,9 +43,9 @@ const SPRITESHEET_ATLAS_FILE_ACCEPT = ".json";
 const PNG_FILE_PATTERN = /\.png$/i;
 const JSON_FILE_PATTERN = /\.json$/i;
 const INVALID_IMPORT_FORMAT_MESSAGE =
-  "Only PNG spritesheets and JSON atlas files are supported.";
+  "Only PNG spritesheets and spritesheet JSON files are supported.";
 const INVALID_IMPORT_PAIR_MESSAGE =
-  "Spritesheet import requires exactly one PNG image and one JSON atlas.";
+  "Spritesheet import requires exactly one PNG image and one spritesheet JSON file.";
 
 const showInvalidImportFormatToast = (appService) => {
   appService.showAlert({
@@ -156,7 +161,7 @@ const parseImportSelection = async ({ appService, files } = {}) => {
     showResourcePageError({
       appService,
       errorOrResult: error,
-      fallbackMessage: "Failed to import spritesheet atlas.",
+      fallbackMessage: "Failed to import spritesheet JSON.",
     });
     return undefined;
   }
@@ -244,6 +249,7 @@ const openEditDialogForItem = ({ deps, itemId, syncExplorer = false } = {}) => {
   store.openEditDialog({
     itemId,
     values,
+    animations: item.animations,
   });
   render();
   syncDialogFormValues({ refs, values });
@@ -349,6 +355,7 @@ const applyDialogSourceFiles = async ({
 };
 
 const buildSpritesheetPayload = ({
+  dialogAnimations,
   existingItem,
   importData,
   uploadResult,
@@ -356,6 +363,14 @@ const buildSpritesheetPayload = ({
 } = {}) => {
   const width = normalizeSizeInput(values?.width);
   const height = normalizeSizeInput(values?.height);
+  const sourceAnimations =
+    Object.keys(dialogAnimations ?? {}).length > 0
+      ? dialogAnimations
+      : (importData?.animations ?? existingItem?.animations ?? {});
+  const animations = normalizeSpritesheetAnimationsFps(
+    sourceAnimations,
+    INITIAL_SPRITESHEET_CLIP_FPS,
+  );
   const payload = {
     name: values?.name?.trim() ?? "",
     description: values?.description ?? "",
@@ -364,7 +379,7 @@ const buildSpritesheetPayload = ({
     width,
     height,
     jsonData: importData?.jsonData ?? existingItem?.jsonData ?? {},
-    animations: importData?.animations ?? existingItem?.animations ?? {},
+    animations,
   };
 
   const thumbnailFileId =
@@ -701,6 +716,7 @@ export const handleDialogFormAction = async (deps, payload) => {
   const dialogItemId = store.selectDialogItemId();
   const dialogParentId = store.selectDialogParentId();
   const importData = store.selectDialogImportData();
+  const dialogAnimations = store.selectDialogDraftAnimations();
   const dialogSourceFiles = store.selectDialogSourceFiles();
   const existingItem = dialogItemId
     ? store.selectItemById({ itemId: dialogItemId })
@@ -716,7 +732,7 @@ export const handleDialogFormAction = async (deps, payload) => {
 
   if (dialogMode === "create" && !dialogSourceFiles?.atlasFile) {
     appService.showAlert({
-      message: "Atlas JSON is required.",
+      message: "Spritesheet JSON is required.",
       title: "Warning",
     });
     return;
@@ -740,6 +756,7 @@ export const handleDialogFormAction = async (deps, payload) => {
   }
 
   const spritesheetData = buildSpritesheetPayload({
+    dialogAnimations,
     existingItem,
     importData,
     uploadResult,
@@ -824,6 +841,51 @@ export const handleDialogClipClick = (deps, payload) => {
 
   const { render, store } = deps;
   store.setDialogSelectedClipName({ clipName });
+  render();
+};
+
+export const handleDialogClipDoubleClick = (deps, payload) => {
+  const clipName = payload._event.currentTarget.dataset.clipName;
+  if (!clipName) {
+    return;
+  }
+
+  const { render, store } = deps;
+  if (store.selectDialogMode() === "preview") {
+    return;
+  }
+
+  store.openClipFpsDialog({ clipName });
+  render();
+};
+
+export const handleClipFpsDialogClose = (deps) => {
+  const { render, store } = deps;
+  store.closeClipFpsDialog();
+  render();
+};
+
+export const handleClipFpsFormAction = (deps, payload) => {
+  const { actionId, values } = payload._event.detail;
+  if (actionId !== "submit") {
+    return;
+  }
+
+  const { appService, render, store } = deps;
+  const fps = normalizeSpritesheetFps(values?.fps);
+  if (fps === undefined) {
+    appService.showAlert({
+      message: "Clip FPS must be greater than 0.",
+      title: "Warning",
+    });
+    return;
+  }
+
+  store.setDialogClipFps({
+    clipName: store.selectClipFpsDialogClipName(),
+    fps,
+  });
+  store.closeClipFpsDialog();
   render();
 };
 

--- a/src/pages/spritesheets/spritesheets.store.js
+++ b/src/pages/spritesheets/spritesheets.store.js
@@ -2,6 +2,13 @@ import { formatFileSize } from "../../internal/files.js";
 import { applyFolderRequiredRootDragOptions } from "../../internal/fileExplorerDragOptions.js";
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
 import {
+  INITIAL_SPRITESHEET_CLIP_FPS,
+  formatSpritesheetFps,
+  normalizeSpritesheetAnimationsFps,
+  normalizeSpritesheetFps,
+  resolveSpritesheetAnimationFps,
+} from "../../internal/spritesheets.js";
+import {
   buildTagFilterOptions,
   createEmptyTagCollection,
   matchesTagAwareSearch,
@@ -92,7 +99,7 @@ const dialogForm = {
     {
       type: "slot",
       slot: "spritesheet-atlas-source",
-      label: "Atlas JSON",
+      label: "Spritesheet JSON",
     },
     {
       name: "tagIds",
@@ -140,6 +147,38 @@ const buildDialogForm = (submitLabel) => ({
   },
 });
 
+const clipFpsForm = {
+  title: "Clip FPS",
+  fields: [
+    {
+      name: "fps",
+      type: "input-number",
+      label: "FPS",
+      min: 0.1,
+      step: 1,
+      required: true,
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Update FPS",
+      },
+    ],
+  },
+};
+
+const buildClipFpsForm = (clipName) => ({
+  ...clipFpsForm,
+  title:
+    typeof clipName === "string" && clipName.length > 0
+      ? `Clip FPS: ${clipName}`
+      : clipFpsForm.title,
+});
+
 const matchesSearch = matchesTagAwareSearch;
 
 const buildMediaItem = (item) => ({
@@ -159,15 +198,29 @@ const resolveSheetHeight = (item) =>
 const resolveFrameCount = (item) =>
   item?.frameCount ?? Object.keys(item?.jsonData?.frames ?? {}).length ?? 0;
 
-const buildClipOptions = (animations = {}, selectedClipName) => {
+const cloneDialogAnimations = (
+  animations = {},
+  missingClipFps = INITIAL_SPRITESHEET_CLIP_FPS,
+) => normalizeSpritesheetAnimationsFps(animations, missingClipFps);
+
+const buildClipOptions = (
+  animations = {},
+  selectedClipName,
+  missingClipFps = INITIAL_SPRITESHEET_CLIP_FPS,
+) => {
   const clipOptions = Object.entries(animations ?? {}).map(
-    ([name, animation]) => ({
-      name,
-      frameCount: animation?.frames?.length ?? 0,
-      fps: Math.round(Number(animation?.animationSpeed ?? 0.5) * 60),
-      loop: animation?.loop ?? true,
-      isSelected: name === selectedClipName,
-    }),
+    ([name, animation]) => {
+      const fps = resolveSpritesheetAnimationFps(animation, missingClipFps);
+
+      return {
+        name,
+        frameCount: animation?.frames?.length ?? 0,
+        fps,
+        fpsLabel: formatSpritesheetFps(fps),
+        loop: animation?.loop ?? true,
+        isSelected: name === selectedClipName,
+      };
+    },
   );
 
   const fallbackSelectedClipName =
@@ -287,6 +340,10 @@ const createDialogSourceFiles = () => ({
   atlasFile: undefined,
 });
 
+const createClipFpsDialogValues = (fps = INITIAL_SPRITESHEET_CLIP_FPS) => ({
+  fps,
+});
+
 export const createInitialState = () => ({
   data: EMPTY_TREE,
   tagsData: createEmptyTagCollection(),
@@ -314,10 +371,22 @@ export const createInitialState = () => ({
   dialogValues: buildDialogValues(),
   dialogPreviewUrl: undefined,
   dialogImportData: undefined,
+  dialogDraftAnimations: {},
   dialogSourceFiles: createDialogSourceFiles(),
   dialogSelectedClipName: undefined,
   dialogRevision: 0,
+  isClipFpsDialogOpen: false,
+  clipFpsDialogClipName: undefined,
+  clipFpsDialogValues: createClipFpsDialogValues(),
+  clipFpsDialogRevision: 0,
 });
+
+const closeClipFpsDialogState = (state) => {
+  state.isClipFpsDialogOpen = false;
+  state.clipFpsDialogClipName = undefined;
+  state.clipFpsDialogValues = createClipFpsDialogValues();
+  state.clipFpsDialogRevision += 1;
+};
 
 const syncDetailTagIds = (state, { preserveDirty = false } = {}) => {
   if (preserveDirty && state.detailTagIdsDirty) {
@@ -420,18 +489,23 @@ export const openCreateDialog = (
     ...values,
   };
   state.dialogImportData = importData;
+  state.dialogDraftAnimations = cloneDialogAnimations(
+    importData?.animations,
+    INITIAL_SPRITESHEET_CLIP_FPS,
+  );
   state.dialogPreviewUrl = previewUrl;
   state.dialogSourceFiles = {
     ...createDialogSourceFiles(),
     ...sourceFiles,
   };
   state.dialogSelectedClipName = undefined;
+  closeClipFpsDialogState(state);
   state.dialogRevision += 1;
 };
 
 export const openEditDialog = (
   { state },
-  { itemId, values, previewUrl, sourceFiles } = {},
+  { itemId, values, previewUrl, sourceFiles, animations } = {},
 ) => {
   state.isDialogOpen = true;
   state.dialogMode = "edit";
@@ -442,12 +516,17 @@ export const openEditDialog = (
     ...values,
   };
   state.dialogImportData = undefined;
+  state.dialogDraftAnimations = cloneDialogAnimations(
+    animations,
+    INITIAL_SPRITESHEET_CLIP_FPS,
+  );
   state.dialogPreviewUrl = previewUrl;
   state.dialogSourceFiles = {
     ...createDialogSourceFiles(),
     ...sourceFiles,
   };
   state.dialogSelectedClipName = undefined;
+  closeClipFpsDialogState(state);
   state.dialogRevision += 1;
 };
 
@@ -464,9 +543,11 @@ export const openPreviewDialog = (
     ...values,
   };
   state.dialogImportData = undefined;
+  state.dialogDraftAnimations = {};
   state.dialogPreviewUrl = previewUrl;
   state.dialogSourceFiles = createDialogSourceFiles();
   state.dialogSelectedClipName = undefined;
+  closeClipFpsDialogState(state);
   state.dialogRevision += 1;
 };
 
@@ -478,8 +559,10 @@ export const closeDialog = ({ state }) => {
   state.dialogValues = buildDialogValues();
   state.dialogPreviewUrl = undefined;
   state.dialogImportData = undefined;
+  state.dialogDraftAnimations = {};
   state.dialogSourceFiles = createDialogSourceFiles();
   state.dialogSelectedClipName = undefined;
+  closeClipFpsDialogState(state);
   state.dialogRevision += 1;
 };
 
@@ -522,6 +605,10 @@ export const setDialogImport = (
   { importData, previewUrl, values, sourceFiles } = {},
 ) => {
   state.dialogImportData = importData;
+  state.dialogDraftAnimations = cloneDialogAnimations(
+    importData?.animations,
+    INITIAL_SPRITESHEET_CLIP_FPS,
+  );
   state.dialogPreviewUrl = previewUrl;
   state.dialogSourceFiles = {
     ...createDialogSourceFiles(),
@@ -532,11 +619,56 @@ export const setDialogImport = (
     ...values,
   };
   state.dialogSelectedClipName = undefined;
+  closeClipFpsDialogState(state);
   state.dialogRevision += 1;
+};
+
+export const setDialogClipFps = ({ state }, { clipName, fps } = {}) => {
+  if (typeof clipName !== "string" || clipName.length === 0) {
+    return;
+  }
+
+  const animation = state.dialogDraftAnimations?.[clipName];
+  if (!animation) {
+    return;
+  }
+
+  const normalizedFps = normalizeSpritesheetFps(fps);
+  if (normalizedFps === undefined) {
+    delete animation.fps;
+    return;
+  }
+
+  animation.fps = normalizedFps;
+  delete animation.animationSpeed;
 };
 
 export const setDialogSelectedClipName = ({ state }, { clipName } = {}) => {
   state.dialogSelectedClipName = clipName;
+};
+
+export const openClipFpsDialog = ({ state }, { clipName } = {}) => {
+  if (typeof clipName !== "string" || clipName.length === 0) {
+    return;
+  }
+
+  const dialogBaseItem = selectDataItem(state, state.dialogItemId);
+  const animation =
+    state.dialogDraftAnimations?.[clipName] ??
+    state.dialogImportData?.animations?.[clipName] ??
+    dialogBaseItem?.animations?.[clipName];
+
+  state.dialogSelectedClipName = clipName;
+  state.isClipFpsDialogOpen = true;
+  state.clipFpsDialogClipName = clipName;
+  state.clipFpsDialogValues = createClipFpsDialogValues(
+    resolveSpritesheetAnimationFps(animation, INITIAL_SPRITESHEET_CLIP_FPS),
+  );
+  state.clipFpsDialogRevision += 1;
+};
+
+export const closeClipFpsDialog = ({ state }) => {
+  closeClipFpsDialogState(state);
 };
 
 export const selectSelectedItem = ({ state }) =>
@@ -555,11 +687,17 @@ export const selectDialogParentId = ({ state }) => state.dialogParentId;
 
 export const selectDialogImportData = ({ state }) => state.dialogImportData;
 
+export const selectDialogDraftAnimations = ({ state }) =>
+  state.dialogDraftAnimations;
+
 export const selectDialogSourceFiles = ({ state }) => state.dialogSourceFiles;
 
 export const selectDialogValues = ({ state }) => state.dialogValues;
 
 export const selectDialogPreviewUrl = ({ state }) => state.dialogPreviewUrl;
+
+export const selectClipFpsDialogClipName = ({ state }) =>
+  state.clipFpsDialogClipName;
 
 export const selectViewData = ({ state }) => {
   const flatItems = applyFolderRequiredRootDragOptions(toFlatItems(state.data));
@@ -579,17 +717,24 @@ export const selectViewData = ({ state }) => {
   const detailSelection = buildClipOptions(
     selectedItem?.animations,
     state.detailSelectedClipName,
+    INITIAL_SPRITESHEET_CLIP_FPS,
   );
   const detailSelectedClipName = detailSelection.selectedClipName;
   const detailPreviewAnimation =
     selectedItem?.animations?.[detailSelectedClipName];
 
   const dialogBaseItem = selectDataItem(state, state.dialogItemId);
+  const dialogDraftAnimations = state.dialogDraftAnimations ?? {};
   const dialogAnimations =
-    state.dialogImportData?.animations ?? dialogBaseItem?.animations ?? {};
+    Object.keys(dialogDraftAnimations).length > 0
+      ? dialogDraftAnimations
+      : (state.dialogImportData?.animations ??
+        dialogBaseItem?.animations ??
+        {});
   const dialogSelection = buildClipOptions(
     dialogAnimations,
     state.dialogSelectedClipName,
+    INITIAL_SPRITESHEET_CLIP_FPS,
   );
   const dialogSelectedClipName = dialogSelection.selectedClipName;
 
@@ -604,10 +749,10 @@ export const selectViewData = ({ state }) => {
   const dialogPreviewFileId = state.dialogPreviewUrl
     ? undefined
     : dialogBaseItem?.fileId;
-  const detailPreviewKey = `${state.selectedItemId ?? "empty"}-${detailSelectedClipName ?? "default"}`;
+  const detailPreviewKey = `${state.selectedItemId ?? "empty"}-${detailSelectedClipName ?? "default"}-${detailPreviewAnimation?.fps ?? detailPreviewAnimation?.animationSpeed ?? ""}`;
   const dialogPreviewSourceKey =
     state.dialogPreviewUrl ?? dialogPreviewFileId ?? "empty";
-  const dialogPreviewKey = `${state.dialogRevision}-${dialogSelectedClipName ?? "default"}-${dialogPreviewSourceKey}`;
+  const dialogPreviewKey = `${state.dialogRevision}-${dialogSelectedClipName ?? "default"}-${dialogPreviewSourceKey}-${dialogPreviewAnimation?.fps ?? dialogPreviewAnimation?.animationSpeed ?? ""}`;
   const dialogHasAtlasSource = Boolean(
     state.dialogSourceFiles?.atlasFile || dialogBaseItem?.jsonData,
   );
@@ -663,7 +808,7 @@ export const selectViewData = ({ state }) => {
     detailPreviewAtlas: selectedItem?.jsonData,
     detailPreviewFileId: selectedItem?.fileId,
     detailPreviewKey,
-    detailPreviewPaused: state.isDialogOpen && isDialogPreviewMode,
+    detailPreviewPaused: state.isDialogOpen,
     isDialogOpen: state.isDialogOpen,
     isDialogPreviewMode,
     dialogMode: state.dialogMode,
@@ -672,7 +817,7 @@ export const selectViewData = ({ state }) => {
         ? "Add Spritesheet"
         : state.dialogMode === "edit"
           ? "Edit Spritesheet"
-          : "Preview Spritesheet",
+          : "",
     dialogSubmitLabel:
       state.dialogMode === "create" ? "Add Spritesheet" : "Update Spritesheet",
     dialogForm: buildDialogForm(
@@ -683,6 +828,10 @@ export const selectViewData = ({ state }) => {
     isCreateTagDialogOpen: state.isCreateTagDialogOpen,
     createTagDefaultValues: state.createTagDefaultValues,
     createTagForm,
+    isClipFpsDialogOpen: state.isClipFpsDialogOpen,
+    clipFpsDialogValues: state.clipFpsDialogValues,
+    clipFpsDialogKey: `${state.clipFpsDialogClipName ?? "none"}-${state.clipFpsDialogRevision}`,
+    clipFpsForm: buildClipFpsForm(state.clipFpsDialogClipName),
     dialogPreviewUrl: state.dialogPreviewUrl,
     dialogPreviewFileId,
     dialogPreviewKey,
@@ -692,12 +841,10 @@ export const selectViewData = ({ state }) => {
     dialogImageSourceFileId,
     dialogClipOptions: dialogSelection.clipOptions,
     dialogSelectedClipName,
-    dialogAtlasSourceLabel: dialogHasAtlasSource
-      ? "Replace JSON"
-      : "Upload JSON",
+    dialogAtlasSourceLabel: "Upload",
     dialogAtlasFieldValue,
     dialogAtlasFieldPlaceholder: dialogHasAtlasSource
-      ? "Current atlas"
+      ? "Current spritesheet JSON"
       : "No JSON selected",
   };
 };

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -85,6 +85,16 @@ refs:
     eventListeners:
       click:
         handler: handleDialogClipClick
+      dblclick:
+        handler: handleDialogClipDoubleClick
+  clipFpsDialog:
+    eventListeners:
+      close:
+        handler: handleClipFpsDialogClose
+  clipFpsForm:
+    eventListeners:
+      form-action:
+        handler: handleClipFpsFormAction
   detailTagSelect:
     eventListeners:
       value-change:
@@ -127,7 +137,7 @@ template:
                                       - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                                       - rtgl-svg svg=edit wh=16: null
                                   - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
-                                      - 'rvn-spritesheet-preview slot="spritesheet-preview" key=${detailPreviewKey} fileId=${detailPreviewFileId} :atlas=${detailPreviewAtlas} :animation=${detailPreviewAnimation} paused=${detailPreviewPaused} h=220 emptyLabel="No preview available"': null
+                                      - 'rvn-spritesheet-preview slot="spritesheet-preview" key=${detailPreviewKey} fileId=${detailPreviewFileId} :atlas=${detailPreviewAtlas} :animation=${detailPreviewAnimation} :paused=${detailPreviewPaused} h=220 emptyLabel="No preview available"': null
                                       - rtgl-tag-select#detailTagSelect slot="spritesheet-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
                                       - 'rtgl-view slot="spritesheet-animations" d=v w=f g=sm':
                                           - rtgl-text s=sm c=mu-fg: Animations
@@ -137,7 +147,7 @@ template:
                                                       - rtgl-view d=h w=f av=c g=sm:
                                                           - rtgl-text w=1fg s=sm: ${clip.name}
                                                           - rtgl-text s=xs c=mu-fg: ${clip.loopLabel}
-                                                      - rtgl-text s=xs c=mu-fg: ${clip.frameCount} frames • ${clip.fps} fps
+                                                      - rtgl-text s=xs c=mu-fg: ${clip.frameCount} frames • ${clip.fpsLabel} fps
                                             $else:
                                               - rtgl-view w=f p=sm bgc=mu br=md:
                                                   - rtgl-text s=xs c=mu-fg: No animations found
@@ -164,9 +174,6 @@ template:
   - rtgl-dialog#spritesheetDialog ?open=${isDialogOpen} s=lg:
       - $if isDialogPreviewMode:
           - 'rtgl-view slot="content" d=v w=f g=lg style="min-width: min(960px, 100vw - 64px);"':
-              - rtgl-view d=v g=xs:
-                  - rtgl-text s=sm: ${dialogTitle}
-                  - rtgl-text s=xs c=mu-fg: Preview clips for this spritesheet.
               - 'rvn-spritesheet-preview key=${dialogPreviewKey} src=${dialogPreviewUrl} fileId=${dialogPreviewFileId} :atlas=${dialogPreviewAtlas} :animation=${dialogPreviewAnimation} h=320 emptyLabel="No preview available"': null
               - rtgl-view d=v w=f g=sm:
                   - rtgl-text s=sm c=mu-fg: Clips
@@ -176,7 +183,7 @@ template:
                               - rtgl-view d=h w=f av=c g=sm:
                                   - rtgl-text w=1fg s=sm: ${clip.name}
                                   - rtgl-text s=xs c=mu-fg: ${clip.loopLabel}
-                              - rtgl-text s=xs c=mu-fg: ${clip.frameCount} frames • ${clip.fps} fps
+                              - rtgl-text s=xs c=mu-fg: ${clip.frameCount} frames • ${clip.fpsLabel} fps
                     $else:
                       - rtgl-view w=f p=sm bgc=mu br=md:
                           - rtgl-text s=xs c=mu-fg: No animations found
@@ -185,7 +192,7 @@ template:
               - rtgl-view w=5fg lg-w=f d=v g=md:
                   - rtgl-view d=v g=xs:
                       - rtgl-text s=sm: ${dialogTitle}
-                      - rtgl-text s=xs c=mu-fg: Set the name and description, then select the PNG image and JSON atlas here.
+                      - rtgl-text s=xs c=mu-fg: Set the name and description, then select the PNG image and spritesheet JSON here.
                   - rtgl-form#dialogForm key=${dialogFormKey} :defaultValues=${dialogValues} :form=${dialogForm} w=f:
                       - rtgl-view slot=spritesheet-image-source d=v g=xs:
                           - rtgl-view w=120 h=120 av=c ah=c:
@@ -200,7 +207,6 @@ template:
                           - rtgl-view d=h g=sm av=c:
                               - rtgl-input w=f :value=${dialogAtlasFieldValue} disabled=true placeholder=${dialogAtlasFieldPlaceholder}: null
                               - rtgl-button#dialogAtlasSourceButton variant=se size=sm pre=upload: ${dialogAtlasSourceLabel}
-                          - rtgl-text s=xs c=mu-fg: Select the atlas JSON file that defines the frames and clips.
               - rtgl-view w=6fg lg-w=f d=v g=md:
                   - 'rvn-spritesheet-preview key=${dialogPreviewKey} src=${dialogPreviewUrl} fileId=${dialogPreviewFileId} :atlas=${dialogPreviewAtlas} :animation=${dialogPreviewAnimation} h=260 emptyLabel=""': null
                   - rtgl-view d=v w=f g=sm:
@@ -211,9 +217,11 @@ template:
                                   - rtgl-view d=h w=f av=c g=sm:
                                       - rtgl-text w=1fg s=sm: ${clip.name}
                                       - rtgl-text s=xs c=mu-fg: ${clip.loopLabel}
-                                  - rtgl-text s=xs c=mu-fg: ${clip.frameCount} frames • ${clip.fps} fps
+                                  - rtgl-text s=xs c=mu-fg: ${clip.frameCount} frames • ${clip.fpsLabel} fps
                         $else:
                           - rtgl-view w=f p=sm bgc=mu br=md:
-                              - rtgl-text s=xs c=mu-fg: Select a valid atlas to detect clips
+                              - rtgl-text s=xs c=mu-fg: Select valid spritesheet JSON to detect clips
+  - rtgl-dialog#clipFpsDialog ?open=${isClipFpsDialogOpen} s=sm:
+      - rtgl-form#clipFpsForm key=${clipFpsDialogKey} slot=content :defaultValues=${clipFpsDialogValues} :form=${clipFpsForm} w=f: null
   - rtgl-dialog#createTagDialog ?open=${isCreateTagDialogOpen} s=sm:
       - rtgl-form#createTagForm key=${isCreateTagDialogOpen} slot=content :defaultValues=${createTagDefaultValues} :form=${createTagForm} w=f: null

--- a/src/pages/spritesheets/support/spritesheetAtlas.js
+++ b/src/pages/spritesheets/support/spritesheetAtlas.js
@@ -1,7 +1,8 @@
 import { getImageDimensions } from "../../../deps/clients/web/fileProcessors.js";
-
-const DEFAULT_PLAYBACK_FPS = 30;
-const DEFAULT_ANIMATION_SPEED = DEFAULT_PLAYBACK_FPS / 60;
+import {
+  INITIAL_SPRITESHEET_CLIP_FPS,
+  resolveSpritesheetAnimationFps,
+} from "../../../internal/spritesheets.js";
 
 const normalizeAtlasFrame = (frame = {}) => {
   if (frame.frame) {
@@ -245,7 +246,7 @@ const buildResourceAnimations = (atlas = {}, clipFrameNames = {}) => {
           clipName,
           {
             frames,
-            animationSpeed: DEFAULT_ANIMATION_SPEED,
+            fps: INITIAL_SPRITESHEET_CLIP_FPS,
             loop: true,
           },
         ];
@@ -277,7 +278,7 @@ const createClipSummaries = (resourceAnimations = {}) => {
   return Object.entries(resourceAnimations).map(([name, animation]) => ({
     name,
     frameCount: animation.frames?.length ?? 0,
-    fps: Math.round((animation.animationSpeed ?? DEFAULT_ANIMATION_SPEED) * 60),
+    fps: resolveSpritesheetAnimationFps(animation),
     loop: animation.loop ?? true,
   }));
 };
@@ -303,7 +304,7 @@ export const normalizeSizeInput = (value) => {
 
 export const parseSpritesheetAtlasFile = async ({ atlasFile } = {}) => {
   if (!atlasFile) {
-    throw new Error("An atlas JSON file is required.");
+    throw new Error("A spritesheet JSON file is required.");
   }
 
   const atlasText = await atlasFile.text();
@@ -312,21 +313,21 @@ export const parseSpritesheetAtlasFile = async ({ atlasFile } = {}) => {
   try {
     atlasInput = JSON.parse(atlasText);
   } catch {
-    throw new Error("Atlas JSON is invalid.");
+    throw new Error("Spritesheet JSON is invalid.");
   }
 
   const jsonData = normalizeSpritesheetAtlas(atlasInput);
   const frameNames = Object.keys(jsonData.frames ?? {});
 
   if (frameNames.length === 0) {
-    throw new Error("Atlas JSON does not contain any frames.");
+    throw new Error("Spritesheet JSON does not contain any frames.");
   }
 
   const clipFrameNames = buildClipFrameNames(jsonData);
   const animations = buildResourceAnimations(jsonData, clipFrameNames);
 
   if (Object.keys(animations).length === 0) {
-    throw new Error("Atlas JSON did not produce any usable animations.");
+    throw new Error("Spritesheet JSON did not produce any usable animations.");
   }
 
   const defaultFrameSize = getDefaultFrameSize(jsonData, clipFrameNames);

--- a/src/pages/webServer/webServer.view.yaml
+++ b/src/pages/webServer/webServer.view.yaml
@@ -39,9 +39,9 @@ template:
                   - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
           - 'rtgl-view w=1fg h=f pl=sm style="min-width: 0; min-height: 0;"':
               - 'rtgl-view w=f h=f g=sm style="min-width: 0; min-height: 0;"':
-                  - 'rtgl-view h=64 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
+                  - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
                       - rtgl-view w=f d=h av=c g=md wrap:
-                          - rtgl-view d=h av=b g=md w=1fg wrap:
+                          - rtgl-view d=h av=c g=md w=1fg wrap:
                               - rtgl-text: Web Server
                               - rtgl-text s=sm c=mu-fg: Serve a local static site folder over localhost.
                           - $if canAdd:

--- a/svg/particles.svg
+++ b/svg/particles.svg
@@ -1,8 +1,11 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 12L6 6M12 12L18 7M12 12L17 18M12 12L7 17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="12" cy="12" r="2.5" stroke="currentColor" stroke-width="2"/>
-<circle cx="5.5" cy="5.5" r="1.5" fill="currentColor"/>
-<circle cx="18.5" cy="6.5" r="1.5" fill="currentColor"/>
-<circle cx="17.5" cy="18.5" r="1.5" fill="currentColor"/>
-<circle cx="6.5" cy="17.5" r="1.5" fill="currentColor"/>
+  <circle cx="6.5" cy="7" r="1.6" fill="currentColor" />
+  <circle cx="11.5" cy="4.5" r="1.2" fill="currentColor" />
+  <circle cx="17.5" cy="6.5" r="1.8" fill="currentColor" />
+  <circle cx="8.5" cy="12" r="2" fill="currentColor" />
+  <circle cx="14" cy="11" r="1.4" fill="currentColor" />
+  <circle cx="19" cy="12.5" r="1.2" fill="currentColor" />
+  <circle cx="5.5" cy="17" r="1.2" fill="currentColor" />
+  <circle cx="12" cy="18" r="1.7" fill="currentColor" />
+  <circle cx="17.5" cy="17.5" r="1.4" fill="currentColor" />
 </svg>

--- a/svg/particles.svg
+++ b/svg/particles.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 12L6 6M12 12L18 7M12 12L17 18M12 12L7 17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="12" cy="12" r="2.5" stroke="currentColor" stroke-width="2"/>
+<circle cx="5.5" cy="5.5" r="1.5" fill="currentColor"/>
+<circle cx="18.5" cy="6.5" r="1.5" fill="currentColor"/>
+<circle cx="17.5" cy="18.5" r="1.5" fill="currentColor"/>
+<circle cx="6.5" cy="17.5" r="1.5" fill="currentColor"/>
+</svg>

--- a/svg/spritesheets.svg
+++ b/svg/spritesheets.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="5" width="18" height="14" rx="2" stroke="currentColor" stroke-width="2"/>
+<path d="M9 5V19M15 5V19M3 12H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 8.5H6.01M12 8.5H12.01M18 8.5H18.01M6 15.5H6.01M12 15.5H12.01M18 15.5H18.01" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tests/baseFileExplorer/baseFileExplorer.store.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.store.test.js
@@ -71,4 +71,27 @@ describe("baseFileExplorer.store", () => {
     expect(viewData.items).toHaveLength(1);
     expect(viewData.items[0].svg).toBe("audio");
   });
+
+  it("preserves an explicit item icon", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({
+      state,
+      props: {
+        items: [
+          {
+            id: "custom-item-1",
+            type: "custom-item",
+            name: "Custom",
+            svg: "component",
+            _level: 0,
+            hasChildren: false,
+            parentId: null,
+          },
+        ],
+      },
+    });
+
+    expect(viewData.items).toHaveLength(1);
+    expect(viewData.items[0].svg).toBe("component");
+  });
 });

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -86,7 +86,7 @@ describe("commandLineBackground.store", () => {
     );
   });
 
-  it("shows playback continuity with render first when animation mode is active", () => {
+  it("hides playback continuity when animation mode is active", () => {
     const state = createInitialState();
 
     setRepositoryState(
@@ -143,21 +143,7 @@ describe("commandLineBackground.store", () => {
       (field) => field.name === "playbackContinuity",
     );
 
-    expect(continuityField).toMatchObject({
-      label: "Playback Continuity",
-      type: "segmented-control",
-      clearable: false,
-      options: [
-        {
-          value: "render",
-          label: "Current Line",
-        },
-        {
-          value: "persistent",
-          label: "Persistent",
-        },
-      ],
-    });
+    expect(continuityField).toBeUndefined();
     expect(viewData.dialogueForm.defaultValues.transformId).toBe("bg-center");
     expect(viewData.dialogueForm.defaultValues.playbackContinuity).toBe(
       "render",

--- a/tests/layoutEditor/layoutEditorViewData.test.js
+++ b/tests/layoutEditor/layoutEditorViewData.test.js
@@ -86,4 +86,16 @@ describe("layoutEditorViewData", () => {
       },
     ]);
   });
+
+  it("uses the spritesheets icon for spritesheet animation elements", () => {
+    const [item] = toLayoutEditorExplorerItems([
+      {
+        id: "spritesheet-animation-1",
+        type: "spritesheet-animation",
+        name: "Idle",
+      },
+    ]);
+
+    expect(item.svg).toBe("spritesheets");
+  });
 });

--- a/tests/project/layout.spritesheetFps.test.js
+++ b/tests/project/layout.spritesheetFps.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { buildLayoutElements } from "../../src/internal/project/layout.js";
+
+const createSpritesheet = (overrides = {}) => ({
+  type: "spritesheet",
+  fileId: "file-spritesheet",
+  jsonData: {
+    frames: {
+      "idle-0.png": {
+        frame: {
+          x: 0,
+          y: 0,
+          w: 32,
+          h: 32,
+        },
+      },
+      "idle-1.png": {
+        frame: {
+          x: 32,
+          y: 0,
+          w: 32,
+          h: 32,
+        },
+      },
+    },
+  },
+  animations: {
+    idle: {
+      frames: [0, 1],
+      loop: true,
+    },
+  },
+  ...overrides,
+});
+
+const buildSpritesheetElement = (spritesheet, nodeOverrides = {}) => {
+  const { elements } = buildLayoutElements(
+    [
+      {
+        id: "spritesheet-node",
+        type: "spritesheet-animation",
+        resourceId: "spritesheet-1",
+        animationName: "idle",
+        ...nodeOverrides,
+      },
+    ],
+    {},
+    { items: {}, tree: [] },
+    { items: {}, tree: [] },
+    { items: {}, tree: [] },
+    {
+      spritesheetsData: {
+        items: {
+          "spritesheet-1": spritesheet,
+        },
+        tree: [{ id: "spritesheet-1" }],
+      },
+    },
+  );
+
+  return elements[0];
+};
+
+describe("buildLayoutElements spritesheet fps", () => {
+  it("uses clip fps for spritesheet animation playback", () => {
+    const element = buildSpritesheetElement(
+      createSpritesheet({
+        animations: {
+          idle: {
+            frames: [0, 1],
+            fps: 12,
+            loop: false,
+          },
+        },
+      }),
+    );
+
+    expect(element.playback).toMatchObject({
+      clip: "idle",
+      fps: 12,
+      loop: false,
+    });
+  });
+
+  it("uses 24 fps when the clip does not define fps", () => {
+    const element = buildSpritesheetElement(createSpritesheet());
+
+    expect(element.playback.fps).toBe(24);
+  });
+});

--- a/tests/spritesheetPreview/spritesheetPreview.handlers.test.js
+++ b/tests/spritesheetPreview/spritesheetPreview.handlers.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleOnUpdate } from "../../src/components/spritesheetPreview/spritesheetPreview.handlers.js";
+import {
+  handleOnUpdate,
+  handleSourceImageLoad,
+} from "../../src/components/spritesheetPreview/spritesheetPreview.handlers.js";
 import {
   createInitialState,
   selectImageSrc,
@@ -128,6 +131,35 @@ describe("spritesheetPreview.handlers", () => {
 
     expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(42);
     expect(state.animationFrameId).toBeUndefined();
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats string true as paused", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const requestAnimationFrameSpy = vi.fn();
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+    globalThis.requestAnimationFrame = requestAnimationFrameSpy;
+
+    try {
+      handleSourceImageLoad({
+        props: {
+          paused: "true",
+          animation: {
+            frames: [0, 1],
+          },
+        },
+        refs: {},
+        render,
+        store: createStoreApi(state),
+      });
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+
+    expect(selectStatus({ state })).toBe("ready");
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
     expect(render).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/spritesheets/spritesheets.store.test.js
+++ b/tests/spritesheets/spritesheets.store.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  openPreviewDialog,
+  selectViewData,
+} from "../../src/pages/spritesheets/spritesheets.store.js";
+
+describe("spritesheets store", () => {
+  it("pauses the detail preview while the preview dialog is open", () => {
+    const state = createInitialState();
+
+    expect(selectViewData({ state }).detailPreviewPaused).toBe(false);
+
+    openPreviewDialog({ state });
+
+    expect(selectViewData({ state }).detailPreviewPaused).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose particle and spritesheet animation creation in the layout editor explorer
- tighten particle form conditional fields, validation, detail fields, and internal bounds handling
- improve spritesheet animation selection and preview support, including resource icons
- hide command line background playback continuity for now

## Testing
- bunx vitest run tests/commandLineBackground/commandLineBackground.store.test.js tests/commandLineBackground/commandLineBackground.handlers.test.js tests/spritesheetPreview/spritesheetPreview.handlers.test.js tests/spritesheets/spritesheets.store.test.js tests/project/layout.spritesheetFps.test.js
- ./node_modules/.bin/oxlint src/components/baseFileExplorer/baseFileExplorer.store.js src/components/commandLineBackground/commandLineBackground.store.js src/components/layoutEditPanel/layoutEditPanel.store.js src/components/mobileSidebar/mobileSidebar.store.js src/components/spritesheetPreview/spritesheetPreview.handlers.js src/internal/project/layout.js src/internal/spritesheets.js src/pages/particles/particles.handlers.js src/pages/particles/particles.store.js src/pages/particles/support/particleForm.js src/pages/spritesheets/spritesheets.handlers.js src/pages/spritesheets/spritesheets.store.js src/pages/spritesheets/support/spritesheetAtlas.js tests/commandLineBackground/commandLineBackground.store.test.js tests/spritesheetPreview/spritesheetPreview.handlers.test.js tests/project/layout.spritesheetFps.test.js tests/spritesheets/spritesheets.store.test.js
- bun prettier --check package.json src/components/baseFileExplorer/baseFileExplorer.store.js src/components/commandLineBackground/commandLineBackground.store.js src/components/layoutEditPanel/layoutEditPanel.store.js src/components/mobileSidebar/mobileSidebar.store.js src/components/spritesheetPreview/spritesheetPreview.handlers.js src/internal/project/layout.js src/internal/spritesheets.js src/pages/layoutEditor/layoutEditor.constants.yaml src/pages/particles/particles.handlers.js src/pages/particles/particles.store.js src/pages/particles/particles.view.yaml src/pages/particles/support/particleForm.js src/pages/spritesheets/spritesheets.handlers.js src/pages/spritesheets/spritesheets.store.js src/pages/spritesheets/spritesheets.view.yaml src/pages/spritesheets/support/spritesheetAtlas.js src/pages/webServer/webServer.view.yaml tests/commandLineBackground/commandLineBackground.store.test.js tests/spritesheetPreview/spritesheetPreview.handlers.test.js tests/project/layout.spritesheetFps.test.js tests/spritesheets/spritesheets.store.test.js
- pre-push hook: oxlint && bun prettier --check src