### PR TITLE
chore: use @rettangoli/ui 1.7.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "dependencies": {
         "@rettangoli/fe": "1.1.3",
-        "@rettangoli/ui": "1.7.5",
+        "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.2",
         "@routevn/creator-model": "1.3.5",
         "@tauri-apps/api": "^2.8.0",
@@ -205,7 +205,7 @@
 
     "@rettangoli/fe": ["@rettangoli/fe@1.1.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-/fia9Ir5x5NU7fjfXtuioCwbc4ELj939pM+/vB9R7bOAPVKosKTspyOuYqMrstysfT84xfLEcPidBrI5OY/l0g=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.7.5", "", { "dependencies": { "@rettangoli/fe": "1.1.3", "jempl": "1.0.1" } }, "sha512-xtrXJ0p6mcFCENLV8w0K80CQzXTRJJ9SXqQdSGwSB7BnsiHyV3HVgxQXk3CPisW7jQSPzfpiFd36My+f551X4w=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.7.6", "", { "dependencies": { "@rettangoli/fe": "1.1.3", "jempl": "1.0.1" } }, "sha512-zx5oEhAqDL3e3dQGCiHrdxwksBjz4OFVkr8PuP+7v5HRwK5ouEIDD+I/w7HpGIn9/ngE68X4LX2VONDPnDOiWw=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.2", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-QHweZ2BJFiQi0mc8KvSLiFjKTm9ovjs++x9cOTtN89AyK/Pn0acuD0mA+kjOu4zgPcaHvjOAINNqMFsqhx9Hgw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "dependencies": {
     "@rettangoli/fe": "1.1.3",
-    "@rettangoli/ui": "1.7.5",
+    "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.2",
     "@routevn/creator-model": "1.3.5",
     "@tauri-apps/api": "^2.8.0",

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.7.5/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.7.6/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">


### PR DESCRIPTION
## Summary
- bump @rettangoli/ui from 1.7.5 to 1.7.6 in package.json and bun.lock
- update static HTML loader URLs to use /public/@rettangoli/ui@1.7.6/...
- rebuild the web output so the npm 1.7.6 dist bundle is copied into the app output

## Testing
- bun install
- bun run build:web
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src
- verified node_modules, static, and _site Rettangoli UI bundle hashes match