### PR TITLE
fix: show update variable in scene actions

### DIFF
--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -9,6 +9,13 @@ const getRuntimeActionItem = (mode) => {
   return RUNTIME_ACTION_ITEMS.find((item) => item.mode === mode);
 };
 
+const UPDATE_VARIABLE_ACTION = {
+  id: "17",
+  label: "Update Variable",
+  icon: "variable",
+  mode: "updateVariable",
+};
+
 const SYSTEM_ACTION_SECTIONS = [
   createSection("Story", [
     {
@@ -83,14 +90,7 @@ const SYSTEM_ACTION_SECTIONS = [
       mode: "popOverlay",
     },
   ]),
-  createSection("Variables", [
-    {
-      id: "17",
-      label: "Update Variable",
-      icon: "variable",
-      mode: "updateVariable",
-    },
-  ]),
+  createSection("Variables", [UPDATE_VARIABLE_ACTION]),
   createSection("Logic", [
     {
       id: "27",
@@ -220,6 +220,7 @@ const PRESENTATION_ACTION_SECTIONS = [
       mode: "control",
     },
   ]),
+  createSection("Variables", [UPDATE_VARIABLE_ACTION]),
   createSection("Logic", [
     {
       id: "27",

--- a/tests/commandLineActions/commandLineActions.store.test.js
+++ b/tests/commandLineActions/commandLineActions.store.test.js
@@ -90,18 +90,16 @@ describe("commandLineActions.store", () => {
   });
 
   it("shows the variables section and update variable action", () => {
-    const items = selectItems({
-      props: {
-        actionsType: "system",
-      },
-    });
+    for (const actionsType of ["system", "presentation"]) {
+      const items = selectItems({
+        props: {
+          actionsType,
+        },
+      });
 
-    expect(
-      items.some(
-        (item) => item.type === "section" && item.label === "Variables",
-      ),
-    ).toBe(true);
-    expect(items.some((item) => item.mode === "updateVariable")).toBe(true);
+      expect(getSectionModes(items, "Variables")).toEqual(["updateVariable"]);
+      expect(items.some((item) => item.mode === "updateVariable")).toBe(true);
+    }
   });
 
   it("shows conditional actions in the logic section", () => {


### PR DESCRIPTION
## Summary
- add Update Variable to the scene editor presentation action picker under Variables
- share the action picker metadata between system and presentation lists
- update command-line action tests to cover both lists

## Testing
- bunx vitest run tests/commandLineActions/commandLineActions.store.test.js
- bun prettier --check src/components/commandLineActions/commandLineActions.store.js tests/commandLineActions/commandLineActions.store.test.js
- bunx oxlint src/components/commandLineActions/commandLineActions.store.js tests/commandLineActions/commandLineActions.store.test.js
- pre-push hook: oxlint && bun prettier --check src