### PR TITLE
Preview scene action edits before submit

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -108,6 +108,69 @@ const getDomainStateFromRepository = (repository) => {
   return repository.getState();
 };
 
+const buildBackgroundDataFromState = (
+  store,
+  { includeTemporaryResource = false } = {},
+) => {
+  const selectedResource =
+    includeTemporaryResource && store.selectMode?.() === "gallery"
+      ? (store.selectTempSelectedResource?.() ?? store.selectSelectedResource())
+      : store.selectSelectedResource();
+  const selectedTransformId = store.selectSelectedTransform();
+  const selectedAnimationMode = store.selectSelectedAnimationMode();
+  const selectedAnimationId = store.selectSelectedAnimation();
+  const selectedAnimationPlaybackContinuity =
+    store.selectSelectedAnimationPlaybackContinuity();
+  const backgroundLoop = store.selectBackgroundLoop();
+
+  const backgroundData = {
+    resourceId: selectedResource?.resourceId,
+  };
+
+  if (selectedResource?.resourceType === "video") {
+    backgroundData.loop = backgroundLoop ?? false;
+  }
+
+  if (selectedResource?.resourceId && selectedTransformId) {
+    backgroundData.transformId = selectedTransformId;
+  }
+
+  if (
+    selectedResource?.resourceId &&
+    selectedAnimationMode !== "none" &&
+    selectedAnimationId
+  ) {
+    backgroundData.animations = {
+      resourceId: selectedAnimationId,
+      playback: {
+        continuity: selectedAnimationPlaybackContinuity,
+      },
+    };
+  }
+
+  return backgroundData;
+};
+
+const dispatchTemporaryPresentationStateChange = (deps) => {
+  const { dispatchEvent, store } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState: {
+          background: buildBackgroundDataFromState(store, {
+            includeTemporaryResource: true,
+          }),
+        },
+      },
+    }),
+  );
+};
+
 export const handleBeforeMount = (deps) => {
   const { store, props } = deps;
 
@@ -243,6 +306,7 @@ export const handleBackgroundImageRightClick = async (deps, payload) => {
     });
 
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -260,6 +324,7 @@ export const handleImageSelected = async (deps, payload) => {
   });
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 
   const flatImageItems = toFlatItems(images);
   const existingImage = flatImageItems.find((item) => item.id === imageId);
@@ -279,6 +344,7 @@ export const handleImageDoubleClick = (deps, payload) => {
   });
   store.showFullImagePreview({ imageId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleFormExtra = (deps) => {
@@ -299,6 +365,7 @@ export const handleFormInputChange = (deps, payload) => {
       mode: fieldValue,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 
@@ -307,6 +374,7 @@ export const handleFormInputChange = (deps, payload) => {
       animationId: fieldValue,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 
@@ -315,6 +383,7 @@ export const handleFormInputChange = (deps, payload) => {
       transformId: fieldValue,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 
@@ -323,6 +392,7 @@ export const handleFormInputChange = (deps, payload) => {
       continuity: fieldValue,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 
@@ -331,6 +401,7 @@ export const handleFormInputChange = (deps, payload) => {
       loop: fieldValue,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -348,6 +419,7 @@ export const handleResourceItemClick = (deps, payload) => {
     resourceType,
   });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleTabClick = (deps, payload) => {
@@ -369,38 +441,7 @@ export const handleSearchInput = (deps, payload) => {
 export const handleSubmitClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { dispatchEvent, store } = deps;
-  const selectedResource = store.selectSelectedResource();
-  const selectedTransformId = store.selectSelectedTransform();
-  const selectedAnimationMode = store.selectSelectedAnimationMode();
-  const selectedAnimationId = store.selectSelectedAnimation();
-  const selectedAnimationPlaybackContinuity =
-    store.selectSelectedAnimationPlaybackContinuity();
-  const backgroundLoop = store.selectBackgroundLoop();
-
-  const backgroundData = {
-    resourceId: selectedResource?.resourceId,
-  };
-
-  if (selectedResource?.resourceType === "video") {
-    backgroundData.loop = backgroundLoop ?? false;
-  }
-
-  if (selectedResource?.resourceId && selectedTransformId) {
-    backgroundData.transformId = selectedTransformId;
-  }
-
-  if (
-    selectedResource?.resourceId &&
-    selectedAnimationMode !== "none" &&
-    selectedAnimationId
-  ) {
-    backgroundData.animations = {
-      resourceId: selectedAnimationId,
-      playback: {
-        continuity: selectedAnimationPlaybackContinuity,
-      },
-    };
-  }
+  const backgroundData = buildBackgroundDataFromState(store);
 
   dispatchEvent(
     new CustomEvent("submit", {
@@ -460,6 +501,7 @@ export const handleBreadcumbActionsClick = (deps, payload) => {
       mode: payload._event.detail.id,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -504,4 +546,5 @@ export const handleButtonSelectClick = async (deps) => {
     mode: "current",
   });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -88,6 +88,7 @@ export const createInitialState = () => ({
   selectedResourceId: undefined,
   selectedResourceType: undefined,
   tempSelectedResourceId: undefined,
+  tempSelectedResourceType: undefined,
   selectedTransformId: undefined,
   selectedAnimationMode: "none",
   selectedAnimationId: undefined,
@@ -103,8 +104,23 @@ export const selectTempSelectedResourceId = ({ state }) => {
   return state.tempSelectedResourceId;
 };
 
+export const selectTempSelectedResource = ({ state }) => {
+  const resourceId = state.tempSelectedResourceId;
+  const resourceType = state.tempSelectedResourceType ?? state.tab;
+
+  if (!resourceId || !resourceType) {
+    return null;
+  }
+
+  return selectResourceById({ state }, { resourceId, resourceType });
+};
+
 export const setMode = ({ state }, { mode } = {}) => {
   state.mode = mode;
+};
+
+export const selectMode = ({ state }) => {
+  return state.mode;
 };
 
 export const setRepositoryState = (
@@ -143,8 +159,12 @@ export const setSelectedResource = (
   }
 };
 
-export const setTempSelectedResource = ({ state }, { resourceId } = {}) => {
+export const setTempSelectedResource = (
+  { state },
+  { resourceId, resourceType } = {},
+) => {
   state.tempSelectedResourceId = resourceId;
+  state.tempSelectedResourceType = resourceType ?? state.tab;
 };
 
 export const setPendingResourceId = ({ state }, { resourceId } = {}) => {
@@ -283,15 +303,29 @@ export const selectSelectedResource = ({ state }) => {
     return null;
   }
 
+  return selectResourceById(
+    { state },
+    {
+      resourceId: state.selectedResourceId,
+      resourceType: state.selectedResourceType,
+    },
+  );
+};
+
+const selectResourceById = ({ state }, { resourceId, resourceType } = {}) => {
+  if (!resourceId || !resourceType) {
+    return null;
+  }
+
   const itemsMap = {
     image: state.imageItems,
     layout: state.layoutItems,
     video: state.videoItems,
   };
 
-  const itemsList = itemsMap[state.selectedResourceType] || [];
+  const itemsList = itemsMap[resourceType] || [];
   const flatItems = toFlatItems(itemsList);
-  const item = flatItems.find((item) => item.id === state.selectedResourceId);
+  const item = flatItems.find((item) => item.id === resourceId);
 
   if (!item) {
     return null;
@@ -310,8 +344,8 @@ export const selectSelectedResource = ({ state }) => {
   const typeInfo = layoutTypeLabels[item.layoutType] ?? item.layoutType;
 
   return {
-    resourceId: state.selectedResourceId,
-    resourceType: state.selectedResourceType,
+    resourceId,
+    resourceType,
     fileId: item.thumbnailFileId || item.fileId,
     name: item.name,
     itemBorderColor: "bo",
@@ -322,7 +356,7 @@ export const selectSelectedResource = ({ state }) => {
       ? layoutTypeLabels[item.layoutType] || item.layoutType
       : "Layout",
     item: item,
-    tab: state.selectedResourceType,
+    tab: resourceType,
   };
 };
 

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -121,6 +121,87 @@ const discardPendingCharacterSelection = (store) => {
   store.clearPendingCharacterIndex();
 };
 
+const buildCharacterItemsFromState = (
+  store,
+  { includeTemporarySprites = false } = {},
+) => {
+  const selectedCharacters = store.selectSelectedCharacters();
+  const mode = store.selectMode?.();
+  const selectedCharacterIndex = store.selectSelectedCharacterIndex?.();
+  const shouldUseTemporarySprites =
+    includeTemporarySprites &&
+    mode === "sprite-select" &&
+    Number.isInteger(selectedCharacterIndex);
+  const spriteSelectionGroups = shouldUseTemporarySprites
+    ? store.selectCurrentSpriteSelectionGroups()
+    : [];
+  const tempSelectedSpriteIds = shouldUseTemporarySprites
+    ? store.selectTempSelectedSpriteIds()
+    : {};
+
+  return selectedCharacters.map((char, index) => {
+    const item = {
+      id: char.id,
+      transformId: char.transformId,
+      sprites: char.sprites || [],
+      spriteName: char.spriteName || "",
+    };
+
+    if (shouldUseTemporarySprites && index === selectedCharacterIndex) {
+      item.sprites = spriteSelectionGroups
+        .map((spriteSelectionGroup) => {
+          const resourceId = tempSelectedSpriteIds[spriteSelectionGroup.id];
+          if (!resourceId) {
+            return undefined;
+          }
+
+          return {
+            id: spriteSelectionGroup.id,
+            resourceId,
+          };
+        })
+        .filter(Boolean);
+    }
+
+    if (char.animations?.resourceId) {
+      item.animations = {
+        resourceId: char.animations.resourceId,
+      };
+    }
+
+    return item;
+  });
+};
+
+const buildCharacterDataFromState = (
+  store,
+  { includeTemporarySprites = false } = {},
+) => ({
+  character: {
+    items: buildCharacterItemsFromState(store, {
+      includeTemporarySprites,
+    }),
+  },
+});
+
+const dispatchTemporaryPresentationStateChange = (deps) => {
+  const { dispatchEvent, store } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState: buildCharacterDataFromState(store, {
+          includeTemporarySprites: true,
+        }),
+      },
+    }),
+  );
+};
+
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
@@ -202,6 +283,7 @@ export const handleTransformChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.updateCharacterTransform({ index, transform: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAnimationModeChange = (deps, payload) => {
@@ -210,6 +292,7 @@ export const handleAnimationModeChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.updateCharacterAnimationMode({ index, animationMode: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAnimationChange = (deps, payload) => {
@@ -218,6 +301,7 @@ export const handleAnimationChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.updateCharacterAnimation({ index, animationId: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleFileExplorerItemClick = (deps, payload) => {
@@ -239,11 +323,13 @@ export const handleFileExplorerItemClick = (deps, payload) => {
       spriteId: itemId,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 
   beginNewCharacterSpriteSelection(store, itemId);
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSearchInput = (deps, payload) => {
@@ -270,6 +356,7 @@ export const handleCharacterItemClick = (deps, payload) => {
 
   beginNewCharacterSpriteSelection(store, characterId);
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSpriteGroupTabClick = (deps, payload) => {
@@ -286,28 +373,7 @@ export const handleSpriteGroupTabClick = (deps, payload) => {
 
 export const handleSubmitClick = (deps) => {
   const { dispatchEvent, store } = deps;
-  const selectedCharacters = store.selectSelectedCharacters();
-
-  const characterData = {
-    character: {
-      items: selectedCharacters.map((char) => {
-        const item = {
-          id: char.id,
-          transformId: char.transformId,
-          sprites: char.sprites || [],
-          spriteName: char.spriteName || "",
-        };
-
-        if (char.animations?.resourceId) {
-          item.animations = {
-            resourceId: char.animations.resourceId,
-          };
-        }
-
-        return item;
-      }),
-    },
-  };
+  const characterData = buildCharacterDataFromState(store);
   dispatchEvent(
     new CustomEvent("submit", {
       detail: characterData,
@@ -352,12 +418,14 @@ export const handleBreadcumbClick = (deps, payload) => {
       mode: "current",
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   } else if (payload._event.detail.id === "character-select") {
     store.setSearchQuery({ value: "" });
     store.setMode({
       mode: "character-select",
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -369,6 +437,7 @@ export const handleRemoveCharacterClick = (deps, payload) => {
 
   store.removeCharacter({ index: index });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAddCharacterClick = (deps) => {
@@ -398,6 +467,7 @@ export const handleSpriteItemClick = (deps, payload) => {
   });
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSpriteItemDoubleClick = (deps, payload) => {
@@ -415,6 +485,7 @@ export const handleSpriteItemDoubleClick = (deps, payload) => {
   });
   store.showFullImagePreview({ fileId: sprite.fileId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleButtonSelectClick = (deps) => {
@@ -453,6 +524,7 @@ export const handleButtonSelectClick = (deps) => {
   }
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleDropdownMenuClose = (deps) => {
@@ -472,4 +544,5 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
 
   store.hideDropdownMenu();
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };

--- a/src/components/commandLineChoices/commandLineChoices.handlers.js
+++ b/src/components/commandLineChoices/commandLineChoices.handlers.js
@@ -13,6 +13,54 @@ const resolveSelectedResourceId = ({ layouts, resourceId } = {}) => {
   return availableLayouts[0]?.id ?? "";
 };
 
+const buildChoicesDataFromState = (
+  deps,
+  { includeEditingDraft = false } = {},
+) => {
+  const { store, props } = deps;
+  const selectedResourceId = resolveSelectedResourceId({
+    layouts: props?.layouts,
+    resourceId: store.selectSelectedResourceId(),
+  });
+
+  if (!selectedResourceId) {
+    return undefined;
+  }
+
+  const items = includeEditingDraft
+    ? store.selectItemsWithEditingDraft()
+    : store.selectItems();
+  const choicesData = {
+    items,
+  };
+
+  if (selectedResourceId !== "") {
+    choicesData.resourceId = selectedResourceId;
+  }
+
+  return choicesData;
+};
+
+const dispatchTemporaryPresentationStateChange = (deps) => {
+  const { dispatchEvent } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  const choice = buildChoicesDataFromState(deps, {
+    includeEditingDraft: true,
+  });
+
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState: choice ? { choice } : {},
+      },
+    }),
+  );
+};
+
 export const handleBeforeMount = (deps) => {
   const { store, props } = deps;
   store.setItems({ items: props.choice?.items || [] });
@@ -81,6 +129,7 @@ export const handleCancelEditClick = (deps) => {
   const mode = store.selectMode();
   if (mode === "list") {
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -124,6 +173,7 @@ export const handleSaveChoiceClick = (deps) => {
 
   store.saveChoice();
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleChoiceFormInput = (deps, payload) => {
@@ -145,6 +195,7 @@ export const handleChoiceFormInput = (deps, payload) => {
 
   store.updateEditForm({ field, value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleChoiceFormChange = (deps, payload) => {
@@ -153,6 +204,7 @@ export const handleChoiceFormChange = (deps, payload) => {
 
   store.updateEditForm({ field: name, value: fieldValue });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleChoiceItemClick = (deps) => {
@@ -162,26 +214,15 @@ export const handleChoiceItemClick = (deps) => {
 };
 
 export const handleSubmitClick = (deps) => {
-  const { dispatchEvent, store, appService, props } = deps;
-  const items = store.selectItems();
-  const selectedResourceId = resolveSelectedResourceId({
-    layouts: props.layouts,
-    resourceId: store.selectSelectedResourceId(),
-  });
+  const { dispatchEvent, appService } = deps;
+  const choicesData = buildChoicesDataFromState(deps);
 
-  if (!selectedResourceId) {
+  if (!choicesData) {
     appService.showAlert({
       message: "Please select a choice layout",
       title: "Warning",
     });
     return;
-  }
-  // Create choices object with new structure
-  const choicesData = {
-    items,
-  };
-  if (selectedResourceId && selectedResourceId !== "") {
-    choicesData.resourceId = selectedResourceId;
   }
 
   dispatchEvent(
@@ -201,6 +242,7 @@ export const handleRemoveChoiceClick = (deps, payload) => {
 
   store.removeChoice({ index: index });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleLayoutSelectChange = (deps, payload) => {
@@ -209,6 +251,7 @@ export const handleLayoutSelectChange = (deps, payload) => {
 
   store.setSelectedResourceId({ resourceId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleFormExtra = (_deps) => {
@@ -222,6 +265,7 @@ export const handleFormChange = (deps, payload) => {
   if (name === "resourceId") {
     store.setSelectedResourceId({ resourceId: fieldValue });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -242,6 +286,7 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
 
   store.hideDropdownMenu();
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleBreadcumbClick = (deps, payload) => {
@@ -261,6 +306,7 @@ export const handleBreadcumbClick = (deps, payload) => {
     const mode = store.selectMode();
     if (mode === "list") {
       render();
+      dispatchTemporaryPresentationStateChange(deps);
     }
   }
 };

--- a/src/components/commandLineChoices/commandLineChoices.store.js
+++ b/src/components/commandLineChoices/commandLineChoices.store.js
@@ -123,6 +123,27 @@ export const updateEditForm = ({ state }, { field, value } = {}) => {
   state.editForm[field] = value;
 };
 
+const buildChoiceDataFromEditForm = (editForm = {}) => {
+  const actions = {};
+  if (editForm.actionType === "nextLine") {
+    actions.nextLine = {};
+  } else if (editForm.actionType === "sectionTransition") {
+    actions.sectionTransition = {
+      sceneId: editForm.sceneId,
+      sectionId: editForm.sectionId,
+    };
+  }
+
+  return {
+    content: editForm.content,
+    events: {
+      click: {
+        actions,
+      },
+    },
+  };
+};
+
 export const addChoice = ({ state }, _payload = {}) => {
   state.items.push({
     content: `Choice ${state.items.length + 1}`,
@@ -142,25 +163,7 @@ export const setScenes = ({ state }, { scenes } = {}) => {
 
 export const saveChoice = ({ state }, _payload = {}) => {
   const { editingIndex, editForm } = state;
-
-  const actions = {};
-  if (editForm.actionType === "nextLine") {
-    actions.nextLine = {};
-  } else if (editForm.actionType === "sectionTransition") {
-    actions.sectionTransition = {
-      sceneId: editForm.sceneId,
-      sectionId: editForm.sectionId,
-    };
-  }
-
-  const choiceData = {
-    content: editForm.content,
-    events: {
-      click: {
-        actions: actions,
-      },
-    },
-  };
+  const choiceData = buildChoiceDataFromEditForm(editForm);
 
   if (editingIndex >= 0) {
     // Update existing choice
@@ -217,6 +220,24 @@ export const selectEditForm = ({ state }) =>
     sectionId: "",
   };
 export const selectItems = ({ state }) => state?.items || [];
+export const selectItemsWithEditingDraft = ({ state }) => {
+  const items = [...(state?.items || [])];
+
+  if (state?.mode !== "editChoice") {
+    return items;
+  }
+
+  const choiceData = buildChoiceDataFromEditForm(state.editForm);
+  const editingIndex = state?.editingIndex ?? -1;
+
+  if (editingIndex >= 0 && items[editingIndex]) {
+    items[editingIndex] = choiceData;
+  } else {
+    items.push(choiceData);
+  }
+
+  return items;
+};
 export const selectSelectedResourceId = ({ state }) =>
   state?.selectedResourceId || "";
 

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -353,11 +353,163 @@ const buildDialogueCharacterSprite = ({
   return sprite;
 };
 
+const resolveEffectiveSelectedSpriteIds = ({
+  state,
+  props,
+  includeTemporarySpriteSelection = false,
+} = {}) => {
+  if (!includeTemporarySpriteSelection || state.mode !== "sprite-select") {
+    return state.selectedSpriteIds;
+  }
+
+  const spriteSelectionGroups = getSpriteSelectionGroupsForCharacterId({
+    characters: props?.characters,
+    characterId: state.spriteCharacterId,
+  });
+  const selectedSpriteIds = {};
+
+  for (const spriteSelectionGroup of spriteSelectionGroups) {
+    const resourceId =
+      state.tempSelectedSpriteIds?.[spriteSelectionGroup.id] ??
+      state.selectedSpriteIds?.[spriteSelectionGroup.id];
+
+    if (resourceId) {
+      selectedSpriteIds[spriteSelectionGroup.id] = resourceId;
+    }
+  }
+
+  return selectedSpriteIds;
+};
+
 const hasDialogueCharacter = ({
   selectedCharacterId,
   customCharacterName,
 } = {}) => {
   return !!selectedCharacterId || toBoolean(customCharacterName);
+};
+
+const buildDialogueFromState = (
+  deps,
+  { includeTemporarySpriteSelection = false, includeContent = false } = {},
+) => {
+  const { store, props } = deps;
+  const {
+    selectedMode,
+    selectedResourceId,
+    selectedCharacterId,
+    customCharacterName,
+    characterName,
+    characterSpriteEnabled,
+    spriteCharacterId,
+    spriteTransformId,
+    spriteAnimationMode,
+    spriteAnimationId,
+    appendDialogue,
+    persistCharacter,
+    clearPage,
+  } = store.getState();
+  const selectedSpriteIds = resolveEffectiveSelectedSpriteIds({
+    state: store.getState(),
+    props,
+    includeTemporarySpriteSelection,
+  });
+  const effectiveMode = resolveDialogueMode({
+    layouts: props?.layouts,
+    dialogue: {
+      mode: selectedMode,
+      ui: {
+        resourceId: selectedResourceId,
+      },
+    },
+  });
+  const effectiveResourceId = resolveSelectedResourceId({
+    layouts: props?.layouts,
+    mode: effectiveMode,
+    resourceId: selectedResourceId,
+  });
+
+  if (!effectiveResourceId) {
+    return undefined;
+  }
+
+  const dialogue = {
+    mode: effectiveMode,
+  };
+
+  dialogue.ui = {
+    resourceId: effectiveResourceId,
+  };
+  if (selectedCharacterId) {
+    dialogue.characterId = selectedCharacterId;
+  }
+  const character = {};
+  if (toBoolean(customCharacterName)) {
+    character.name = characterName ?? "";
+  }
+  const characterSprite = buildDialogueCharacterSprite({
+    characters: props?.characters,
+    transforms: props?.transforms,
+    spriteCharacterId,
+    characterSpriteEnabled:
+      characterSpriteEnabled || Object.keys(selectedSpriteIds).length > 0,
+    spriteTransformId,
+    selectedSpriteIds,
+    spriteAnimationMode,
+    spriteAnimationId,
+  });
+  if (characterSprite) {
+    character.sprite = characterSprite;
+  }
+  if (Object.keys(character).length > 0) {
+    dialogue.character = character;
+  }
+  const persistCharacterEnabled =
+    hasDialogueCharacter({
+      selectedCharacterId,
+      customCharacterName,
+    }) && toBoolean(persistCharacter);
+  const appendDialogueEnabled = toBoolean(appendDialogue);
+  const appendDialoguePreviouslyEnabled = props?.dialogue?.append === true;
+  if (
+    effectiveMode === "adv" &&
+    (appendDialogueEnabled || appendDialoguePreviouslyEnabled)
+  ) {
+    dialogue.append = appendDialogueEnabled;
+  }
+  dialogue.persistCharacter = persistCharacterEnabled;
+  if (effectiveMode === "nvl" && toBoolean(clearPage)) {
+    dialogue.clearPage = true;
+  }
+  if (
+    includeContent &&
+    !Object.hasOwn(dialogue, "content") &&
+    props?.dialogue?.content !== undefined
+  ) {
+    dialogue.content = structuredClone(props.dialogue.content);
+  }
+
+  return dialogue;
+};
+
+const dispatchTemporaryPresentationStateChange = (deps) => {
+  const { dispatchEvent } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  const dialogue = buildDialogueFromState(deps, {
+    includeTemporarySpriteSelection: true,
+    includeContent: true,
+  });
+
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState: dialogue ? { dialogue } : {},
+      },
+    }),
+  );
 };
 
 const syncDialogueStateFromProps = (deps, dialogue = {}) => {
@@ -561,6 +713,8 @@ export const handleFormChange = (deps, payload) => {
   if (modeChanged || persistCharacterVisibilityChanged) {
     syncDialogueFormValues(deps);
   }
+
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleCharacterSpriteBoxClick = (deps) => {
@@ -598,6 +752,7 @@ export const handleClearCharacterSpriteClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   store.clearCharacterSprite();
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleFileExplorerItemClick = (deps, payload) => {
@@ -619,6 +774,7 @@ export const handleFileExplorerItemClick = (deps, payload) => {
       spriteId: itemId,
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 
@@ -626,6 +782,7 @@ export const handleFileExplorerItemClick = (deps, payload) => {
     characterId: itemId,
   });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSearchInput = (deps, payload) => {
@@ -642,6 +799,7 @@ export const handleCharacterItemClick = (deps, payload) => {
     characterId,
   });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSpriteItemClick = (deps, payload) => {
@@ -654,6 +812,7 @@ export const handleSpriteItemClick = (deps, payload) => {
   });
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSpriteItemDoubleClick = (deps, payload) => {
@@ -677,6 +836,7 @@ export const handleSpriteItemDoubleClick = (deps, payload) => {
   });
   store.showFullImagePreview({ fileId: sprite.fileId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSpriteGroupTabClick = (deps, payload) => {
@@ -699,6 +859,7 @@ export const handleTransformChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.setSpriteTransformId({ transformId: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAnimationModeChange = (deps, payload) => {
@@ -706,6 +867,7 @@ export const handleAnimationModeChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.setSpriteAnimationMode({ mode: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAnimationChange = (deps, payload) => {
@@ -713,6 +875,7 @@ export const handleAnimationChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.setSpriteAnimationId({ animationId: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleButtonSelectClick = (deps) => {
@@ -747,93 +910,15 @@ export const handleButtonSelectClick = (deps) => {
   }
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSubmitClick = (deps) => {
-  const { store, dispatchEvent, props } = deps;
-  const {
-    selectedMode,
-    selectedResourceId,
-    selectedCharacterId,
-    customCharacterName,
-    characterName,
-    characterSpriteEnabled,
-    spriteCharacterId,
-    spriteTransformId,
-    spriteAnimationMode,
-    spriteAnimationId,
-    selectedSpriteIds,
-    appendDialogue,
-    persistCharacter,
-    clearPage,
-  } = store.getState();
-  const effectiveMode = resolveDialogueMode({
-    layouts: props?.layouts,
-    dialogue: {
-      mode: selectedMode,
-      ui: {
-        resourceId: selectedResourceId,
-      },
-    },
-  });
-  const effectiveResourceId = resolveSelectedResourceId({
-    layouts: props?.layouts,
-    mode: effectiveMode,
-    resourceId: selectedResourceId,
-  });
+  const { dispatchEvent } = deps;
+  const dialogue = buildDialogueFromState(deps);
 
-  if (!effectiveResourceId) {
+  if (!dialogue) {
     return;
-  }
-
-  const dialogue = {
-    mode: effectiveMode,
-  };
-
-  if (effectiveResourceId) {
-    dialogue.ui = {
-      resourceId: effectiveResourceId,
-    };
-  }
-  if (selectedCharacterId) {
-    dialogue.characterId = selectedCharacterId;
-  }
-  const character = {};
-  if (toBoolean(customCharacterName)) {
-    character.name = characterName ?? "";
-  }
-  const characterSprite = buildDialogueCharacterSprite({
-    characters: props?.characters,
-    transforms: props?.transforms,
-    spriteCharacterId,
-    characterSpriteEnabled,
-    spriteTransformId,
-    selectedSpriteIds,
-    spriteAnimationMode,
-    spriteAnimationId,
-  });
-  if (characterSprite) {
-    character.sprite = characterSprite;
-  }
-  if (Object.keys(character).length > 0) {
-    dialogue.character = character;
-  }
-  const persistCharacterEnabled =
-    hasDialogueCharacter({
-      selectedCharacterId,
-      customCharacterName,
-    }) && toBoolean(persistCharacter);
-  const appendDialogueEnabled = toBoolean(appendDialogue);
-  const appendDialoguePreviouslyEnabled = props?.dialogue?.append === true;
-  if (
-    effectiveMode === "adv" &&
-    (appendDialogueEnabled || appendDialoguePreviouslyEnabled)
-  ) {
-    dialogue.append = appendDialogueEnabled;
-  }
-  dialogue.persistCharacter = persistCharacterEnabled;
-  if (effectiveMode === "nvl" && toBoolean(clearPage)) {
-    dialogue.clearPage = true;
   }
 
   dispatchEvent(
@@ -866,6 +951,7 @@ export const handleBreadcumbClick = (deps, payload) => {
       mode: "current",
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
     return;
   }
 

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -1,3 +1,88 @@
+const TEMPORARY_VISUAL_PREVIEW_ID = "temporary-visual-preview";
+
+const buildVisualItem = (visual = {}) => {
+  const item = {
+    id: visual.id,
+    resourceId: visual.resourceId,
+    transformId: visual.transformId,
+  };
+
+  if (visual.animations?.resourceId) {
+    item.animations = {
+      resourceId: visual.animations.resourceId,
+    };
+  }
+
+  return item;
+};
+
+const buildVisualItemsFromState = (
+  store,
+  { includeTemporaryResource = false } = {},
+) => {
+  const visualItems = store.selectSelectedVisuals().map(buildVisualItem);
+
+  if (!includeTemporaryResource || store.selectMode?.() !== "resource-select") {
+    return visualItems;
+  }
+
+  const tempSelectedResourceId = store.selectTempSelectedResourceId?.();
+  if (!tempSelectedResourceId) {
+    return visualItems;
+  }
+
+  const selectedVisualIndex = store.selectSelectedVisualIndex?.();
+  if (selectedVisualIndex === -1) {
+    visualItems.push({
+      id: TEMPORARY_VISUAL_PREVIEW_ID,
+      resourceId: tempSelectedResourceId,
+      transformId: store.selectDefaultTransformId?.(),
+    });
+    return visualItems;
+  }
+
+  if (
+    Number.isInteger(selectedVisualIndex) &&
+    visualItems[selectedVisualIndex]
+  ) {
+    visualItems[selectedVisualIndex] = {
+      ...visualItems[selectedVisualIndex],
+      resourceId: tempSelectedResourceId,
+    };
+  }
+
+  return visualItems;
+};
+
+const buildVisualDataFromState = (
+  store,
+  { includeTemporaryResource = false } = {},
+) => ({
+  visual: {
+    items: buildVisualItemsFromState(store, {
+      includeTemporaryResource,
+    }),
+  },
+});
+
+const dispatchTemporaryPresentationStateChange = (deps) => {
+  const { dispatchEvent, store } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState: buildVisualDataFromState(store, {
+          includeTemporaryResource: true,
+        }),
+      },
+    }),
+  );
+};
+
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
@@ -69,6 +154,7 @@ export const handleTransformChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.updateVisualTransform({ index, transform: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAnimationModeChange = (deps, payload) => {
@@ -77,6 +163,7 @@ export const handleAnimationModeChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.updateVisualAnimationMode({ index, animationMode: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleAnimationChange = (deps, payload) => {
@@ -85,6 +172,7 @@ export const handleAnimationChange = (deps, payload) => {
   const value = payload._event.detail.value;
   store.updateVisualAnimation({ index, animationId: value });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleFileExplorerItemClick = (deps, payload) => {
@@ -102,6 +190,7 @@ export const handleFileExplorerItemClick = (deps, payload) => {
 
   store.setTempSelectedResourceId({ resourceId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSearchInput = (deps, payload) => {
@@ -116,6 +205,7 @@ export const handleResourceItemClick = (deps, payload) => {
 
   store.setTempSelectedResourceId({ resourceId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleResourceItemDoubleClick = (deps, payload) => {
@@ -130,31 +220,12 @@ export const handleResourceItemDoubleClick = (deps, payload) => {
   store.setTempSelectedResourceId({ resourceId });
   store.showFullImagePreview({ fileId: item.previewFileId });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSubmitClick = (deps) => {
   const { dispatchEvent, store } = deps;
-  const selectedVisuals = store.selectSelectedVisuals();
-
-  const visualData = {
-    visual: {
-      items: selectedVisuals.map((visual) => {
-        const item = {
-          id: visual.id,
-          resourceId: visual.resourceId,
-          transformId: visual.transformId,
-        };
-
-        if (visual.animations?.resourceId) {
-          item.animations = {
-            resourceId: visual.animations.resourceId,
-          };
-        }
-
-        return item;
-      }),
-    },
-  };
+  const visualData = buildVisualDataFromState(store);
 
   dispatchEvent(
     new CustomEvent("submit", {
@@ -190,6 +261,7 @@ export const handleBreadcumbClick = (deps, payload) => {
       mode: "current",
     });
     render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };
 
@@ -201,6 +273,7 @@ export const handleRemoveVisualClick = (deps, payload) => {
 
   store.removeVisual({ index: index });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleButtonSelectClick = (deps) => {
@@ -236,6 +309,7 @@ export const handleButtonSelectClick = (deps) => {
   }
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleDropdownMenuClose = (deps) => {
@@ -255,4 +329,5 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
 
   store.hideDropdownMenu();
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -202,12 +202,16 @@ const generateVisualId = () => {
   return generatePrefixedId("visual-");
 };
 
-export const addVisual = ({ state }, { resourceId } = {}) => {
+const getDefaultTransformId = (state) => {
   const transformItems = toFlatItems(state.transforms).filter(
     (item) => item.type === "transform",
   );
-  const defaultTransform =
-    transformItems.length > 0 ? transformItems[0].id : undefined;
+
+  return transformItems.length > 0 ? transformItems[0].id : undefined;
+};
+
+export const addVisual = ({ state }, { resourceId } = {}) => {
+  const defaultTransform = getDefaultTransformId(state);
 
   state.selectedVisuals.push({
     id: generateVisualId(),
@@ -345,6 +349,10 @@ export const selectMode = ({ state }) => {
 
 export const selectSelectedVisualIndex = ({ state }) => {
   return state.selectedVisualIndex;
+};
+
+export const selectDefaultTransformId = ({ state }) => {
+  return getDefaultTransformId(state);
 };
 
 export const selectResourceExplorerTarget = (_deps, { itemId } = {}) => {

--- a/src/components/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/components/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -57,6 +57,11 @@ const requestTemporaryPresentationCanvasRender = (subject) => {
   });
 };
 
+const clearTemporaryPresentationPreview = ({ store, subject }) => {
+  store.clearTemporaryPresentationState?.();
+  requestTemporaryPresentationCanvasRender(subject);
+};
+
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
 };
@@ -730,46 +735,51 @@ export const handleCommandLineSubmit = async (deps, payload) => {
       ? ["dialogue.content"]
       : undefined;
 
-  await runSceneEditorPersistence(
-    deps,
-    async () => {
-      if (dialogue) {
-        assertSceneEditorCommandResult(
-          await projectService.updateLineDialogueAction({
-            lineId,
-            dialogue,
-            preserve: preserveDialogueContent,
-          }),
-          {
-            appService,
-            fallbackMessage: "Failed to save dialogue action",
-          },
-        );
-      }
+  try {
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        if (dialogue) {
+          assertSceneEditorCommandResult(
+            await projectService.updateLineDialogueAction({
+              lineId,
+              dialogue,
+              preserve: preserveDialogueContent,
+            }),
+            {
+              appService,
+              fallbackMessage: "Failed to save dialogue action",
+            },
+          );
+        }
 
-      if (Object.keys(otherActions).length > 0) {
-        assertSceneEditorCommandResult(
-          await projectService.updateLineActions({
-            lineId,
-            data: otherActions,
-            replace: false,
-          }),
-          {
-            appService,
-            fallbackMessage: "Failed to save line actions",
-          },
-        );
-      }
-    },
-    {
-      label: "command-line-submit",
-      meta: {
-        lineId,
-        hasDialogue: Boolean(dialogue),
-        otherActionCount: Object.keys(otherActions).length,
+        if (Object.keys(otherActions).length > 0) {
+          assertSceneEditorCommandResult(
+            await projectService.updateLineActions({
+              lineId,
+              data: otherActions,
+              replace: false,
+            }),
+            {
+              appService,
+              fallbackMessage: "Failed to save line actions",
+            },
+          );
+        }
       },
-    },
-  );
+      {
+        label: "command-line-submit",
+        meta: {
+          lineId,
+          hasDialogue: Boolean(dialogue),
+          otherActionCount: Object.keys(otherActions).length,
+        },
+      },
+    );
+  } catch (error) {
+    clearTemporaryPresentationPreview(deps);
+    throw error;
+  }
 
   store.clearTemporaryPresentationState?.();
   await refreshSceneEditorStateFromProject(deps);
@@ -1329,9 +1339,8 @@ export const handleActionsDialogClose = (deps) => {
     store.setSelectedLineId({ selectedLineId: lineId });
   }
   store.clearActionTargetLineId?.();
-  store.clearTemporaryPresentationState?.();
+  clearTemporaryPresentationPreview({ store, subject });
   render();
-  requestTemporaryPresentationCanvasRender(subject);
 };
 
 export const handleTemporaryPresentationStateChange = (deps, payload) => {

--- a/src/components/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/components/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -40,6 +40,23 @@ const MISSING_PROJECT_RESOLUTION_MESSAGE =
 const SHOW_LINE_NUMBERS_CONFIG_KEY = "sceneEditor.showLineNumbers";
 const IS_MUTED_CONFIG_KEY = "sceneEditor.isMuted";
 
+const toPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+};
+
+const normalizeTemporaryPresentationState = (detail = {}) => {
+  return toPlainObject(detail.presentationState);
+};
+
+const requestTemporaryPresentationCanvasRender = (subject) => {
+  subject?.dispatch?.("sceneEditor.renderCanvas", {
+    skipRender: true,
+    skipAnimations: true,
+  });
+};
+
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
 };
@@ -754,6 +771,7 @@ export const handleCommandLineSubmit = async (deps, payload) => {
     },
   );
 
+  store.clearTemporaryPresentationState?.();
   await refreshSceneEditorStateFromProject(deps);
   finalizeActionTargetLine(store, lineId);
   render();
@@ -1305,13 +1323,26 @@ export const handleSectionTabRightClick = (deps, payload) => {
 };
 
 export const handleActionsDialogClose = (deps) => {
-  const { render, store } = deps;
+  const { render, store, subject } = deps;
   const lineId = store.selectActionTargetLineId?.();
   if (lineId) {
     store.setSelectedLineId({ selectedLineId: lineId });
   }
   store.clearActionTargetLineId?.();
+  store.clearTemporaryPresentationState?.();
   render();
+  requestTemporaryPresentationCanvasRender(subject);
+};
+
+export const handleTemporaryPresentationStateChange = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { store, subject } = deps;
+  store.setTemporaryPresentationState?.({
+    presentationState: normalizeTemporaryPresentationState(
+      payload?._event?.detail,
+    ),
+  });
+  requestTemporaryPresentationCanvasRender(subject);
 };
 
 export const handleDropdownMenuClickOverlay = (deps) => {

--- a/src/components/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/components/sceneEditorLexical/sceneEditorLexical.store.js
@@ -58,6 +58,16 @@ const toPlainObject = (value) => {
     : {};
 };
 
+const mergePresentationStates = (
+  presentationState,
+  temporaryPresentationState,
+) => {
+  return {
+    ...toPlainObject(presentationState),
+    ...toPlainObject(temporaryPresentationState),
+  };
+};
+
 const toFlatTree = (ids = []) => {
   return ids.map((id) => ({ id }));
 };
@@ -472,6 +482,7 @@ export const createInitialState = () => ({
   previewLineId: undefined,
   skipNextEditorBlurDraftFlush: false,
   presentationState: {},
+  temporaryPresentationState: {},
   sectionLineChanges: {},
   isMuted: false,
   isScenePageLoading: true,
@@ -552,6 +563,28 @@ export const selectSkipNextEditorBlurDraftFlush = ({ state }) => {
 
 export const setPresentationState = ({ state }, { presentationState } = {}) => {
   state.presentationState = presentationState;
+};
+
+export const setTemporaryPresentationState = (
+  { state },
+  { presentationState } = {},
+) => {
+  state.temporaryPresentationState = toPlainObject(presentationState);
+};
+
+export const clearTemporaryPresentationState = ({ state }, _payload = {}) => {
+  state.temporaryPresentationState = {};
+};
+
+export const selectTemporaryPresentationState = ({ state }) => {
+  return toPlainObject(state.temporaryPresentationState);
+};
+
+export const selectEffectivePresentationState = ({ state }) => {
+  return mergePresentationStates(
+    state.presentationState,
+    state.temporaryPresentationState,
+  );
 };
 
 export const setSectionLineChanges = ({ state }, { changes } = {}) => {
@@ -1018,7 +1051,7 @@ export const selectViewData = ({ state }) => {
       mentionTargets: [],
       currentLine: null,
       actionsData: [],
-      presentationState: null,
+      presentationState: selectEffectivePresentationState({ state }),
       dropdownMenu: state.dropdownMenu,
       popover: state.popover,
       selectedLineId: state.selectedLineId,
@@ -1245,7 +1278,7 @@ export const selectViewData = ({ state }) => {
     previewSectionId: state.previewSectionId,
     previewLineId: state.previewLineId,
     canvasAspectRatio: selectCanvasAspectRatio({ state }),
-    presentationState: state.presentationState,
+    presentationState: selectEffectivePresentationState({ state }),
     sectionLineChanges: state.sectionLineChanges,
     sectionCreateDialog: state.sectionCreateDialog,
     sectionCreateForm,

--- a/src/components/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/components/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -91,6 +91,10 @@ refs:
         handler: handleSystemActionsActionDelete
       actions-change:
         handler: handleCommandLineSubmit
+      temporary-presentation-state-change:
+        handler: handleTemporaryPresentationStateChange
+      close:
+        handler: handleActionsDialogClose
   backButton:
     eventListeners:
       click:
@@ -168,7 +172,7 @@ template:
                       - rtgl-view d=h av=c:
                           - rtgl-text s=sm c=mu-fg: State
                       - rtgl-view g=md w=f pv=md:
-                          - rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState}: null
+                          - 'rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} dialog-variant=scene-editor-left dialog-panel-width="calc((100vw - 64px) / 2)"': null
       - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
       - rtgl-popover#popover ?open=${popover.isOpen} x=${popover.position.x} y=${popover.position.y}:
           - rtgl-form#form slot=content :form=${form}: null

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -18,6 +18,19 @@ const mergeActions = (currentActions, nextPartialActions) => {
   };
 };
 
+const dispatchTemporaryPresentationStateChange = (
+  { dispatchEvent },
+  presentationState = {},
+) => {
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState,
+      },
+    }),
+  );
+};
+
 const syncRepositoryState = async (deps) => {
   const { store, projectService } = deps;
   store.setRepositoryState({
@@ -65,6 +78,7 @@ export const handleOnUpdate = (deps, changes) => {
 export const handleBackToActions = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { store, render } = deps;
+  dispatchTemporaryPresentationStateChange(deps, {});
   store.setMode({ mode: "actions" });
   render();
 };
@@ -78,6 +92,14 @@ export const handleActionClicked = (deps, payload) => {
   });
 
   render();
+};
+
+export const handleTemporaryPresentationStateChange = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const presentationState = toPlainObject(
+    payload?._event?.detail?.presentationState,
+  );
+  dispatchTemporaryPresentationStateChange(deps, presentationState);
 };
 
 export const handleCommandLineSubmit = (deps, payload) => {
@@ -107,6 +129,7 @@ export const handleAddActionButtonClicked = (deps) => {
 
 export const handleEmbeddedCloseClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
+  dispatchTemporaryPresentationStateChange(deps, {});
   deps.dispatchEvent(new CustomEvent("close"));
 };
 
@@ -120,6 +143,7 @@ export const handleHelpFloatingButtonClick = (deps, payload) => {
 
 export const handleActionsDialogClose = (deps) => {
   const { store, render, dispatchEvent } = deps;
+  dispatchTemporaryPresentationStateChange(deps, {});
   store.hideActionsDialog();
   render();
   dispatchEvent(new CustomEvent("close"));

--- a/src/components/systemActions/systemActions.schema.yaml
+++ b/src/components/systemActions/systemActions.schema.yaml
@@ -17,6 +17,13 @@ propsSchema:
       enum:
         - presentation
         - system
+    dialogVariant:
+      type: string
+      enum:
+        - default
+        - scene-editor-left
+    dialogPanelWidth:
+      type: string
     hiddenModes:
       type: array
       items:

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -39,6 +39,9 @@ const getHiddenModes = (attrs = {}) => {
     : [];
 };
 
+const getDialogVariant = (attrs = {}) =>
+  attrs.dialogVariant === "scene-editor-left" ? "scene-editor-left" : "default";
+
 export const selectViewData = ({ state, props, props: attrs }) => {
   const displayActions = selectDisplayActions({ state });
   const actionProps = { ...props };
@@ -117,8 +120,12 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     selectedLine: props.selectedLine,
     actionsType: attrs.actionType,
     showSelected: !!attrs.showSelected,
+    dialogVariant: getDialogVariant(attrs),
     actionsDialogWidth: state.isTouchMode ? "100vw" : "800",
     actionsDialogHeight: state.isTouchMode ? "100vh" : "80vh",
+    actionsDialogPanelWidth: state.isTouchMode
+      ? "100vw"
+      : (attrs.dialogPanelWidth ?? "50vw"),
     hiddenModes,
     isRuntimeActionMode: isRuntimeActionMode(state.mode),
   };

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -5,6 +5,8 @@ refs:
         handler: handleBackToActions
       actionClicked:
         handler: handleActionClicked
+      temporary-presentation-state-change:
+        handler: handleTemporaryPresentationStateChange
       submit:
         handler: handleCommandLineSubmit
   addActionButton:
@@ -189,9 +191,9 @@ template:
           - $if actionsType == 'system':
               - rtgl-view d=h av=c ah=e w=f g=lg:
                   - rtgl-button#embeddedCloseButton: Confirm
-  - rtgl-dialog#actionsDialog key=${mode} ?open=${isActionsDialogOpen}:
+  - rvn-system-actions-dialog-surface#actionsDialog key=${mode} :open=${isActionsDialogOpen} variant=${dialogVariant} :dialogWidth=${actionsDialogWidth} :dialogHeight=${actionsDialogHeight} :panelWidth=${actionsDialogPanelWidth}:
       - $if isActionsDialogOpen:
-          - rtgl-view slot=content w=${actionsDialogWidth} h=${actionsDialogHeight} pos=rel:
+          - 'rtgl-view slot=content w=f h=f pos=rel style="min-width: 0; min-height: 0;"':
               - 'rtgl-view#helpFloatingButton pos=abs z=10 w=28 h=28 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="top: 10px; right: 10px; box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);"':
                   - rtgl-text s=xs c=mu-fg: '?'
               - $if mode == "actions":

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js
@@ -1,0 +1,22 @@
+const dispatchClose = ({ dispatchEvent }) => {
+  dispatchEvent(new CustomEvent("close", { detail: {}, bubbles: true }));
+};
+
+export const handleSurfaceClose = (deps, payload = {}) => {
+  payload._event?.stopPropagation?.();
+  payload._event?.preventDefault?.();
+  dispatchClose(deps);
+};
+
+export const handleDocumentKeyDown = (deps, payload = {}) => {
+  const { props } = deps;
+  const event = payload._event;
+
+  if (props.open !== true || event?.key !== "Escape") {
+    return;
+  }
+
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  dispatchClose(deps);
+};

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.schema.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.schema.yaml
@@ -1,0 +1,20 @@
+componentName: rvn-system-actions-dialog-surface
+propsSchema:
+  type: object
+  properties:
+    open:
+      type: boolean
+    variant:
+      type: string
+      enum:
+        - default
+        - scene-editor-left
+    dialogWidth:
+      type: string
+    dialogHeight:
+      type: string
+    panelWidth:
+      type: string
+events:
+  close:
+    type: object

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
@@ -1,0 +1,20 @@
+export const createInitialState = () => ({});
+
+const normalizeVariant = (variant) =>
+  variant === "scene-editor-left" ? "scene-editor-left" : "default";
+
+export const selectViewData = ({ props }) => {
+  const variant = normalizeVariant(props.variant);
+
+  return {
+    open: props.open === true,
+    variant,
+    isSceneEditorLeft: variant === "scene-editor-left",
+    dialogWidth: props.dialogWidth ?? "800",
+    dialogHeight: props.dialogHeight ?? "80vh",
+    panelWidth: props.panelWidth ?? "50vw",
+    panelHorizontalInset: "96px",
+    panelWidthReduction: "64px",
+    panelVerticalInset: "32px",
+  };
+};

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
@@ -1,0 +1,25 @@
+refs:
+  overlay:
+    eventListeners:
+      click:
+        handler: handleSurfaceClose
+      contextmenu:
+        handler: handleSurfaceClose
+  dialog:
+    eventListeners:
+      close:
+        handler: handleSurfaceClose
+  document:
+    eventListeners:
+      keydown:
+        handler: handleDocumentKeyDown
+template:
+  - $if isSceneEditorLeft:
+      - $if open:
+          - 'rtgl-view#overlay pos=fix edge=f style="z-index: 2000; background: transparent;"': null
+          - 'rtgl-view pos=fix bgc=bg bw=xs bc=bo br=md style="left: ${panelHorizontalInset}; top: ${panelVerticalInset}; bottom: ${panelVerticalInset}; width: calc(${panelWidth} - ${panelWidthReduction}); max-width: calc(100vw - ${panelHorizontalInset}); min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden; z-index: 2001; box-shadow: 8px 0 24px rgba(15, 23, 42, 0.10);"':
+              - slot name=content: null
+    $else:
+      - rtgl-dialog#dialog ?open=${open}:
+          - rtgl-view slot=content w=${dialogWidth} h=${dialogHeight} pos=rel:
+              - slot name=content: null

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -1754,6 +1754,22 @@ const collectResourceSelectionFromValue = (projectData, value) => {
   };
 
   scanValue(value);
+  traverseScene(value, (key, entry) => {
+    if (
+      key !== "character" ||
+      !entry ||
+      typeof entry !== "object" ||
+      !Array.isArray(entry.items)
+    ) {
+      return;
+    }
+
+    entry.items.forEach((item) => {
+      if (typeof item?.id === "string" && resources.characters?.[item.id]) {
+        selection.characters.add(item.id);
+      }
+    });
+  });
 
   while (pendingLayoutIds.length > 0) {
     const layoutId = pendingLayoutIds.shift();

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -1993,6 +1993,31 @@ export const extractFileIdsForScene = (projectData, sceneId) => {
   return dedupeFileReferences(extractFileIdsFromRenderState(scopedResources));
 };
 
+export const extractFileIdsForValue = (projectData, value) => {
+  const resources = projectData?.resources;
+  if (!resources || !value || typeof value !== "object") {
+    return [];
+  }
+
+  const selection = collectResourceSelectionFromValue(projectData, value);
+  const scopedResources = {
+    images: pickByIds(resources.images, selection.images),
+    spritesheets: pickByIds(resources.spritesheets, selection.spritesheets),
+    videos: pickByIds(resources.videos, selection.videos),
+    sounds: pickByIds(resources.sounds, selection.sounds),
+    particles: pickByIds(resources.particles, selection.particles),
+    fonts: pickByIds(resources.fonts, selection.fonts),
+    colors: pickByIds(resources.colors, selection.colors),
+    textStyles: pickByIds(resources.textStyles, selection.textStyles),
+    layouts: pickByIds(resources.layouts, selection.layouts),
+    characters: pickByIds(resources.characters, selection.characters),
+    transforms: pickByIds(resources.transforms, selection.transforms),
+    animations: pickByIds(resources.animations, selection.animations),
+  };
+
+  return dedupeFileReferences(extractFileIdsFromRenderState(scopedResources));
+};
+
 export const extractFileIdsForLayouts = (projectData, layoutIds = []) => {
   const resources = projectData?.resources;
   if (!resources || !Array.isArray(layoutIds) || layoutIds.length === 0) {

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -2,6 +2,7 @@ import { debounceTime, filter, tap } from "rxjs";
 import {
   extractFileIdsForLayouts,
   extractFileIdsForScenes,
+  extractFileIdsForValue,
   extractInitialHybridSceneIds,
   extractLayoutIdsFromValue,
   extractSceneIdsFromValue,
@@ -354,6 +355,92 @@ async function loadAssetsForSceneIds(
   }
 }
 
+async function preloadFileReferences(
+  deps,
+  fileReferences,
+  { resources = {}, showLoading = false } = {},
+) {
+  if (!Array.isArray(fileReferences) || fileReferences.length === 0) {
+    return;
+  }
+
+  const { graphicsService, projectService, appService } = deps;
+  const missingFileReferences = fileReferences.filter((fileReference) => {
+    const fileId = fileReference?.url;
+    return (
+      fileId &&
+      !hasCachedSceneAsset(deps, fileId) &&
+      !assetLoadCache.pendingFileLoads.has(fileId)
+    );
+  });
+  const pendingFileIds = fileReferences
+    .map((fileReference) => fileReference?.url)
+    .filter((fileId) => assetLoadCache.pendingFileLoads.has(fileId));
+
+  if (missingFileReferences.length === 0 && pendingFileIds.length === 0) {
+    return;
+  }
+
+  const shouldShowLoading = showLoading && missingFileReferences.length > 0;
+  const pendingLoadPromises = pendingFileIds
+    .map((fileId) => assetLoadCache.pendingFileLoads.get(fileId))
+    .filter(Boolean);
+  const newFileIds = missingFileReferences
+    .map((fileReference) => fileReference?.url)
+    .filter(Boolean);
+
+  try {
+    if (shouldShowLoading) {
+      setSceneAssetLoading(deps, true);
+    }
+
+    if (missingFileReferences.length > 0) {
+      const nextLoadPromise = (async () => {
+        const assets = await createAssetsFromFileIds(
+          missingFileReferences,
+          projectService,
+          resources,
+        );
+        if (Object.keys(assets).length > 0) {
+          await graphicsService.loadAssets?.(assets);
+        }
+        return Object.keys(assets);
+      })();
+
+      newFileIds.forEach((fileId) => {
+        assetLoadCache.pendingFileLoads.set(fileId, nextLoadPromise);
+      });
+
+      const loadedAssetIds = await nextLoadPromise.finally(() => {
+        newFileIds.forEach((fileId) => {
+          assetLoadCache.pendingFileLoads.delete(fileId);
+        });
+      });
+
+      loadedAssetIds.forEach((fileId) => {
+        assetLoadCache.fileIds.add(fileId);
+      });
+    }
+
+    if (pendingLoadPromises.length > 0) {
+      await Promise.all(pendingLoadPromises);
+    }
+  } catch (error) {
+    appService?.showAlert({
+      message: "Failed to load some scene assets",
+      title: "Warning",
+    });
+    console.error(
+      "[sceneEditor] Failed to load temporary scene assets:",
+      error,
+    );
+  } finally {
+    if (shouldShowLoading) {
+      setSceneAssetLoading(deps, false);
+    }
+  }
+}
+
 async function preloadDirectTransitionScenes(deps, projectData, sceneIds) {
   const directTargets = Array.from(
     new Set(
@@ -552,6 +639,74 @@ const initRouteEngineWithDiagnostics = (
   }
 };
 
+const toPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+};
+
+const selectTemporaryPresentationState = (store) => {
+  return toPlainObject(store.selectTemporaryPresentationState?.());
+};
+
+const hasTemporaryPresentationState = (presentationState) => {
+  return Object.keys(toPlainObject(presentationState)).length > 0;
+};
+
+const createProjectDataWithTemporaryPresentationState = (
+  projectData,
+  { sceneId, sectionId, lineId },
+  temporaryPresentationState,
+) => {
+  if (!hasTemporaryPresentationState(temporaryPresentationState)) {
+    return projectData;
+  }
+
+  const nextProjectData = structuredClone(projectData);
+  const selectedSection =
+    nextProjectData?.story?.scenes?.[sceneId]?.sections?.[sectionId];
+  const selectedLine = selectedSection?.lines?.find(
+    (line) => line?.id === lineId,
+  );
+
+  if (!selectedLine) {
+    return projectData;
+  }
+
+  selectedLine.actions = {
+    ...toPlainObject(selectedLine.actions),
+    ...temporaryPresentationState,
+  };
+
+  return nextProjectData;
+};
+
+const prepareTemporaryPresentationProjectData = async (
+  deps,
+  projectData,
+  selection,
+  temporaryPresentationState,
+) => {
+  if (!hasTemporaryPresentationState(temporaryPresentationState)) {
+    return projectData;
+  }
+
+  await preloadFileReferences(
+    deps,
+    extractFileIdsForValue(projectData, temporaryPresentationState),
+    {
+      resources: projectData?.resources,
+      showLoading: false,
+    },
+  );
+
+  return createProjectDataWithTemporaryPresentationState(
+    projectData,
+    selection,
+    temporaryPresentationState,
+  );
+};
+
 export const renderSceneEditorState = async (deps, payload = {}) => {
   const { store, graphicsService } = deps;
   const { skipAnimations = false, skipCanvasPaint = false } = payload;
@@ -566,13 +721,14 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     ? getDebugDurationMs(projectDataProjectionStartedAt)
     : undefined;
   const projectDataSelectionStartedAt = perfEnabled ? getDebugNow() : 0;
+  const selection = {
+    sceneId,
+    sectionId,
+    lineId,
+  };
   const projectData = createProjectDataWithSelectedEntryPoint(
     projectedProjectData,
-    {
-      sceneId,
-      sectionId,
-      lineId,
-    },
+    selection,
   );
   const projectDataSelectionDurationMs = perfEnabled
     ? getDebugDurationMs(projectDataSelectionStartedAt)
@@ -587,6 +743,31 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
   });
   const engineInitDurationMs = perfEnabled
     ? getDebugDurationMs(engineInitStartedAt)
+    : undefined;
+  const presentationStateStartedAt = perfEnabled ? getDebugNow() : 0;
+  const presentationState = graphicsService.engineSelectPresentationState();
+  store.setPresentationState({
+    presentationState,
+  });
+  const presentationStateDurationMs = perfEnabled
+    ? getDebugDurationMs(presentationStateStartedAt)
+    : undefined;
+  const temporaryPresentationState = selectTemporaryPresentationState(store);
+  const temporaryPresentationStateStartedAt = perfEnabled ? getDebugNow() : 0;
+  const renderProjectData = await prepareTemporaryPresentationProjectData(
+    deps,
+    projectData,
+    selection,
+    temporaryPresentationState,
+  );
+  if (renderProjectData !== projectData) {
+    initRouteEngineWithDiagnostics(graphicsService, renderProjectData, {
+      enableGlobalKeyboardBindings: false,
+      suppressRenderEffects: true,
+    });
+  }
+  const temporaryPresentationStateDurationMs = perfEnabled
+    ? getDebugDurationMs(temporaryPresentationStateStartedAt)
     : undefined;
   const renderStateSelectStartedAt = perfEnabled ? getDebugNow() : 0;
   const currentRenderState = graphicsService.engineSelectRenderState();
@@ -659,15 +840,6 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     ? getDebugDurationMs(nextLineConfigStartedAt)
     : undefined;
 
-  const presentationStateStartedAt = perfEnabled ? getDebugNow() : 0;
-  const presentationState = graphicsService.engineSelectPresentationState();
-  store.setPresentationState({
-    presentationState,
-  });
-  const presentationStateDurationMs = perfEnabled
-    ? getDebugDurationMs(presentationStateStartedAt)
-    : undefined;
-
   if (perfEnabled) {
     debugLog(SCENE_EDITOR_PERF_SCOPE, "render-state.complete", {
       durationMs: getDebugDurationMs(renderStartedAt),
@@ -685,6 +857,7 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
       canvasPaintDurationMs,
       nextLineConfigDurationMs,
       presentationStateDurationMs,
+      temporaryPresentationStateDurationMs,
       elementCount: renderStateSummary.elementCount,
       animationCount: renderStateSummary.animationCount,
       audioCount: renderStateSummary.audioCount,

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -77,6 +77,11 @@ const requestTemporaryPresentationCanvasRender = (subject) => {
   });
 };
 
+const clearTemporaryPresentationPreview = ({ store, subject }) => {
+  store.clearTemporaryPresentationState?.();
+  requestTemporaryPresentationCanvasRender(subject);
+};
+
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
 };
@@ -724,46 +729,51 @@ export const handleCommandLineSubmit = async (deps, payload) => {
       ? ["dialogue.content"]
       : undefined;
 
-  await runSceneEditorPersistence(
-    deps,
-    async () => {
-      if (dialogue) {
-        assertSceneEditorCommandResult(
-          await projectService.updateLineDialogueAction({
-            lineId,
-            dialogue,
-            preserve: preserveDialogueContent,
-          }),
-          {
-            appService,
-            fallbackMessage: "Failed to save dialogue action",
-          },
-        );
-      }
+  try {
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        if (dialogue) {
+          assertSceneEditorCommandResult(
+            await projectService.updateLineDialogueAction({
+              lineId,
+              dialogue,
+              preserve: preserveDialogueContent,
+            }),
+            {
+              appService,
+              fallbackMessage: "Failed to save dialogue action",
+            },
+          );
+        }
 
-      if (Object.keys(otherActions).length > 0) {
-        assertSceneEditorCommandResult(
-          await projectService.updateLineActions({
-            lineId,
-            data: otherActions,
-            replace: false,
-          }),
-          {
-            appService,
-            fallbackMessage: "Failed to save line actions",
-          },
-        );
-      }
-    },
-    {
-      label: "command-line-submit",
-      meta: {
-        lineId,
-        hasDialogue: Boolean(dialogue),
-        otherActionCount: Object.keys(otherActions).length,
+        if (Object.keys(otherActions).length > 0) {
+          assertSceneEditorCommandResult(
+            await projectService.updateLineActions({
+              lineId,
+              data: otherActions,
+              replace: false,
+            }),
+            {
+              appService,
+              fallbackMessage: "Failed to save line actions",
+            },
+          );
+        }
       },
-    },
-  );
+      {
+        label: "command-line-submit",
+        meta: {
+          lineId,
+          hasDialogue: Boolean(dialogue),
+          otherActionCount: Object.keys(otherActions).length,
+        },
+      },
+    );
+  } catch (error) {
+    clearTemporaryPresentationPreview(deps);
+    throw error;
+  }
 
   store.clearTemporaryPresentationState?.();
   syncStoreProjectState(store, projectService);
@@ -1170,9 +1180,8 @@ export const handleSectionTabRightClick = (deps, payload) => {
 
 export const handleActionsDialogClose = (deps) => {
   const { render, store, subject } = deps;
-  store.clearTemporaryPresentationState?.();
+  clearTemporaryPresentationPreview({ store, subject });
   render();
-  requestTemporaryPresentationCanvasRender(subject);
 };
 
 export const handleTemporaryPresentationStateChange = (deps, payload) => {

--- a/src/pages/sceneEditor/sceneEditor.handlers.js
+++ b/src/pages/sceneEditor/sceneEditor.handlers.js
@@ -60,6 +60,23 @@ const nowMs = () => {
   return Date.now();
 };
 
+const toPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+};
+
+const normalizeTemporaryPresentationState = (detail = {}) => {
+  return toPlainObject(detail.presentationState);
+};
+
+const requestTemporaryPresentationCanvasRender = (subject) => {
+  subject?.dispatch?.("sceneEditor.renderCanvas", {
+    skipRender: true,
+    skipAnimations: true,
+  });
+};
+
 const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
 };
@@ -748,6 +765,7 @@ export const handleCommandLineSubmit = async (deps, payload) => {
     },
   );
 
+  store.clearTemporaryPresentationState?.();
   syncStoreProjectState(store, projectService);
   reconcileCurrentEditorSession(deps);
   render();
@@ -1151,8 +1169,21 @@ export const handleSectionTabRightClick = (deps, payload) => {
 };
 
 export const handleActionsDialogClose = (deps) => {
-  const { render } = deps;
+  const { render, store, subject } = deps;
+  store.clearTemporaryPresentationState?.();
   render();
+  requestTemporaryPresentationCanvasRender(subject);
+};
+
+export const handleTemporaryPresentationStateChange = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { store, subject } = deps;
+  store.setTemporaryPresentationState?.({
+    presentationState: normalizeTemporaryPresentationState(
+      payload?._event?.detail,
+    ),
+  });
+  requestTemporaryPresentationCanvasRender(subject);
 };
 
 export const handleDropdownMenuClickOverlay = (deps) => {

--- a/src/pages/sceneEditor/sceneEditor.store.js
+++ b/src/pages/sceneEditor/sceneEditor.store.js
@@ -52,6 +52,16 @@ const toPlainObject = (value) => {
     : {};
 };
 
+const mergePresentationStates = (
+  presentationState,
+  temporaryPresentationState,
+) => {
+  return {
+    ...toPlainObject(presentationState),
+    ...toPlainObject(temporaryPresentationState),
+  };
+};
+
 const collectActionTargetSectionIds = (actions) => {
   const sectionIds = new Set();
 
@@ -320,6 +330,7 @@ export const createInitialState = () => ({
   previewSectionId: undefined,
   previewLineId: undefined,
   presentationState: {},
+  temporaryPresentationState: {},
   sectionLineChanges: {},
   isMuted: false,
   isScenePageLoading: true,
@@ -404,6 +415,28 @@ export const hidePreviewScene = ({ state }, _payload = {}) => {
 
 export const setPresentationState = ({ state }, { presentationState } = {}) => {
   state.presentationState = presentationState;
+};
+
+export const setTemporaryPresentationState = (
+  { state },
+  { presentationState } = {},
+) => {
+  state.temporaryPresentationState = toPlainObject(presentationState);
+};
+
+export const clearTemporaryPresentationState = ({ state }, _payload = {}) => {
+  state.temporaryPresentationState = {};
+};
+
+export const selectTemporaryPresentationState = ({ state }) => {
+  return toPlainObject(state.temporaryPresentationState);
+};
+
+export const selectEffectivePresentationState = ({ state }) => {
+  return mergePresentationStates(
+    state.presentationState,
+    state.temporaryPresentationState,
+  );
 };
 
 export const setSectionLineChanges = ({ state }, { changes } = {}) => {
@@ -859,7 +892,7 @@ export const selectViewData = ({ state }) => {
       currentLines: [],
       currentLine: null,
       actionsData: [],
-      presentationState: null,
+      presentationState: selectEffectivePresentationState({ state }),
       dropdownMenu: state.dropdownMenu,
       popover: state.popover,
       selectedLineId: state.selectedLineId,
@@ -1097,7 +1130,7 @@ export const selectViewData = ({ state }) => {
     previewSectionId: state.previewSectionId,
     previewLineId: state.previewLineId,
     canvasAspectRatio: selectCanvasAspectRatio({ state }),
-    presentationState: state.presentationState,
+    presentationState: selectEffectivePresentationState({ state }),
     sectionLineChanges: state.sectionLineChanges,
     sectionCreateDialog: state.sectionCreateDialog,
     sectionCreateForm,

--- a/src/pages/sceneEditor/sceneEditor.view.yaml
+++ b/src/pages/sceneEditor/sceneEditor.view.yaml
@@ -106,6 +106,10 @@ refs:
         handler: handleSystemActionsActionDelete
       actions-change:
         handler: handleCommandLineSubmit
+      temporary-presentation-state-change:
+        handler: handleTemporaryPresentationStateChange
+      close:
+        handler: handleActionsDialogClose
   backButton:
     eventListeners:
       click:
@@ -158,7 +162,7 @@ template:
                   - rtgl-view w=f ph=sm pv=md:
                       - rvn-lines-editor#linesEditor key=${linesEditorKey} :lines=${currentLines} :selectedLineId=${selectedLineId} :keyboardHandlingDisabled=${previewVisible} :showLineNumbers=${sceneSettings.showLineNumbers}: null
                       - rtgl-view h=30vh: null
-              - rvn-system-actions#systemActions :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState}: null
+              - 'rvn-system-actions#systemActions :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} dialog-variant=scene-editor-left dialog-panel-width="calc((100vw - 64px) / 2)"': null
               - rvn-mobile-keyboard-toolbar#mobileKeyboardToolbar: null
         $else:
           - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
@@ -205,7 +209,7 @@ template:
                           - rtgl-view d=h av=c:
                               - rtgl-text s=sm c=mu-fg: State
                           - rtgl-view g=md w=f pv=md:
-                              - rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState}: null
+                              - 'rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} dialog-variant=scene-editor-left dialog-panel-width="calc((100vw - 64px) / 2)"': null
       - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
       - rtgl-popover#popover ?open=${popover.isOpen} x=${popover.position.x} y=${popover.position.y}:
           - rtgl-form#form slot=content :form=${form}: null

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleBeforeMount,
   handleFormInputChange,
+  handleResourceItemClick,
   handleSubmitClick,
 } from "../../src/components/commandLineBackground/commandLineBackground.handlers.js";
 import {
   createInitialState,
   selectBackgroundLoop,
+  selectMode,
   selectPendingResourceId,
   selectSelectedAnimation,
   selectSelectedAnimationPlaybackContinuity,
@@ -14,7 +16,9 @@ import {
   selectSelectedResource,
   selectSelectedTransform,
   selectTab,
+  selectTempSelectedResource,
   setBackgroundLoop,
+  setMode,
   setRepositoryState,
   setSearchQuery,
   setSelectedAnimation,
@@ -23,6 +27,7 @@ import {
   setSelectedResource,
   setSelectedTransform,
   setTab,
+  setTempSelectedResource,
 } from "../../src/components/commandLineBackground/commandLineBackground.store.js";
 
 const createEmptyCollection = () => ({
@@ -32,6 +37,7 @@ const createEmptyCollection = () => ({
 
 const createStoreApi = (state) => ({
   selectBackgroundLoop: () => selectBackgroundLoop({ state }),
+  selectMode: () => selectMode({ state }),
   selectPendingResourceId: () => selectPendingResourceId({ state }),
   selectSelectedAnimation: () => selectSelectedAnimation({ state }),
   selectSelectedAnimationPlaybackContinuity: () =>
@@ -40,7 +46,9 @@ const createStoreApi = (state) => ({
   selectSelectedResource: () => selectSelectedResource({ state }),
   selectSelectedTransform: () => selectSelectedTransform({ state }),
   selectTab: () => selectTab({ state }),
+  selectTempSelectedResource: () => selectTempSelectedResource({ state }),
   setBackgroundLoop: (payload) => setBackgroundLoop({ state }, payload),
+  setMode: (payload) => setMode({ state }, payload),
   setPendingResourceId: ({ resourceId }) => {
     state.pendingResourceId = resourceId;
   },
@@ -53,6 +61,8 @@ const createStoreApi = (state) => ({
   setSelectedResource: (payload) => setSelectedResource({ state }, payload),
   setSelectedTransform: (payload) => setSelectedTransform({ state }, payload),
   setTab: (payload) => setTab({ state }, payload),
+  setTempSelectedResource: (payload) =>
+    setTempSelectedResource({ state }, payload),
 });
 
 const setRepositoryCollections = (state) => {
@@ -194,6 +204,85 @@ describe("commandLineBackground.handlers", () => {
       },
     });
     expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits temporary presentation state when background form fields change", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            name: "transformId",
+            value: "bg-center",
+          },
+        },
+      },
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+        },
+      },
+    });
+  });
+
+  it("emits temporary presentation state from gallery resource selection", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setMode({ state }, { mode: "gallery" });
+
+    handleResourceItemClick(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              resourceId: "bg-school",
+            },
+          },
+        },
+      },
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+        },
+      },
+    });
   });
 
   it("submits playback continuity inside background animations", () => {

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -7,6 +7,7 @@ import {
   handleCharacterContextMenu,
   handleCharacterSpriteGroupBoxClick,
   handleDropdownMenuClickItem,
+  handleSpriteItemClick,
   handleSpriteGroupTabClick,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.handlers.js";
 import {
@@ -126,7 +127,17 @@ describe("commandLineCharacters.handlers", () => {
     expect(selectSelectedCharacterIndex({ state })).toBeUndefined();
     expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
     expect(selectMode({ state })).toBe("current");
-    expect(dispatchEvent).not.toHaveBeenCalled();
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        character: {
+          items: [],
+        },
+      },
+    });
   });
 
   it("keeps existing characters when returning from sprite selection", () => {
@@ -202,7 +213,29 @@ describe("commandLineCharacters.handlers", () => {
     expect(selectMode({ state })).toBe("current");
     expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
     expect(selectSelectedSpriteGroupId({ state })).toBeUndefined();
-    expect(dispatchEvent).not.toHaveBeenCalled();
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        character: {
+          items: [
+            {
+              id: "character-1",
+              transformId: undefined,
+              sprites: [
+                {
+                  id: "base",
+                  resourceId: "sprite-1",
+                },
+              ],
+              spriteName: "",
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("selects sprite parts per sprite group and keeps tab state", () => {
@@ -309,6 +342,114 @@ describe("commandLineCharacters.handlers", () => {
 
     expect(selectSelectedSpriteGroupId({ state })).toBe("face");
     expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
+  });
+
+  it("emits temporary presentation state while picking character sprites", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            "character-hero": {
+              id: "character-hero",
+              type: "character",
+              name: "Hero",
+              spriteGroups: [
+                {
+                  id: "body",
+                  name: "Body",
+                  tags: [],
+                },
+              ],
+              sprites: {
+                items: {
+                  "sprite-body": {
+                    id: "sprite-body",
+                    type: "image",
+                    name: "Body A",
+                    fileId: "file-body",
+                  },
+                },
+                tree: [{ id: "sprite-body" }],
+              },
+            },
+          },
+          tree: [{ id: "character-hero" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+            sprites: [],
+          },
+        ],
+      },
+    );
+
+    handleCharacterClick(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+        },
+      },
+    );
+    handleSpriteItemClick(
+      {
+        store,
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              spriteId: "sprite-body",
+            },
+          },
+        },
+      },
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        character: {
+          items: [
+            {
+              id: "character-hero",
+              transformId: undefined,
+              sprites: [
+                {
+                  id: "body",
+                  resourceId: "sprite-body",
+                },
+              ],
+              spriteName: "",
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("opens sprite selection at the clicked sprite group box", () => {

--- a/tests/commandLineChoices/commandLineChoices.handlers.test.js
+++ b/tests/commandLineChoices/commandLineChoices.handlers.test.js
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleCancelEditClick,
+  handleChoiceFormChange,
+  handleSaveChoiceClick,
+  handleSubmitClick,
+} from "../../src/components/commandLineChoices/commandLineChoices.handlers.js";
+import {
+  createInitialState,
+  saveChoice,
+  selectEditForm,
+  selectItems,
+  selectItemsWithEditingDraft,
+  selectMode,
+  selectSelectedResourceId,
+  setEditingIndex,
+  setItems,
+  setMode,
+  setSelectedResourceId,
+  updateEditForm,
+} from "../../src/components/commandLineChoices/commandLineChoices.store.js";
+
+const layouts = [
+  {
+    id: "choice-layout",
+    name: "Choice Layout",
+    layoutType: "choice",
+  },
+];
+
+const createStoreApi = (state) => ({
+  saveChoice: () => saveChoice({ state }),
+  selectEditForm: () => selectEditForm({ state }),
+  selectItems: () => selectItems({ state }),
+  selectItemsWithEditingDraft: () => selectItemsWithEditingDraft({ state }),
+  selectMode: () => selectMode({ state }),
+  selectSelectedResourceId: () => selectSelectedResourceId({ state }),
+  setEditingIndex: (payload) => setEditingIndex({ state }, payload),
+  setMode: (payload) => setMode({ state }, payload),
+  setSelectedResourceId: (payload) => setSelectedResourceId({ state }, payload),
+  updateEditForm: (payload) => updateEditForm({ state }, payload),
+});
+
+const setExistingChoice = (state) => {
+  setItems(
+    { state },
+    {
+      items: [
+        {
+          content: "Stay",
+          events: {
+            click: {
+              actions: {
+                nextLine: {},
+              },
+            },
+          },
+        },
+      ],
+    },
+  );
+  setSelectedResourceId(
+    { state },
+    {
+      resourceId: "choice-layout",
+    },
+  );
+};
+
+describe("commandLineChoices.handlers", () => {
+  it("emits temporary presentation state while editing a choice", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setExistingChoice(state);
+    setMode({ state }, { mode: "editChoice" });
+    setEditingIndex({ state }, { index: 0 });
+
+    handleChoiceFormChange(
+      {
+        store,
+        render,
+        dispatchEvent,
+        props: {
+          layouts,
+        },
+      },
+      {
+        _event: {
+          detail: {
+            name: "content",
+            value: "Leave",
+          },
+        },
+      },
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        choice: {
+          resourceId: "choice-layout",
+          items: [
+            {
+              content: "Leave",
+              events: {
+                click: {
+                  actions: {
+                    nextLine: {},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits saved choice state after cancelling an edit draft", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setExistingChoice(state);
+    setMode({ state }, { mode: "editChoice" });
+    setEditingIndex({ state }, { index: 0 });
+    updateEditForm(
+      { state },
+      {
+        field: "content",
+        value: "Draft",
+      },
+    );
+
+    handleCancelEditClick({
+      store,
+      render,
+      dispatchEvent,
+      props: {
+        layouts,
+      },
+    });
+
+    expect(selectMode({ state })).toBe("list");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        choice: {
+          resourceId: "choice-layout",
+          items: [
+            {
+              content: "Stay",
+              events: {
+                click: {
+                  actions: {
+                    nextLine: {},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("emits temporary presentation state after saving a choice", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setExistingChoice(state);
+    setMode({ state }, { mode: "editChoice" });
+    setEditingIndex({ state }, { index: 0 });
+    updateEditForm(
+      { state },
+      {
+        field: "content",
+        value: "Leave",
+      },
+    );
+
+    handleSaveChoiceClick({
+      store,
+      render,
+      dispatchEvent,
+      appService: {
+        showAlert: vi.fn(),
+      },
+      props: {
+        layouts,
+      },
+    });
+
+    expect(selectItems({ state })[0].content).toBe("Leave");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(
+      dispatchEvent.mock.calls[0][0].detail.presentationState.choice,
+    ).toEqual({
+      resourceId: "choice-layout",
+      items: [
+        {
+          content: "Leave",
+          events: {
+            click: {
+              actions: {
+                nextLine: {},
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("submits the saved choice state with the selected layout", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setExistingChoice(state);
+
+    handleSubmitClick({
+      dispatchEvent,
+      store: createStoreApi(state),
+      appService: {
+        showAlert: vi.fn(),
+      },
+      props: {
+        layouts,
+      },
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      choice: {
+        resourceId: "choice-layout",
+        items: [
+          {
+            content: "Stay",
+            events: {
+              click: {
+                actions: {
+                  nextLine: {},
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -404,6 +404,62 @@ describe("commandLineDialogueBox.handlers", () => {
     expect(render).toHaveBeenCalledTimes(2);
   });
 
+  it("emits temporary presentation state changes from form edits", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const refs = createFormRefs();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+          dialogue: {
+            content: [{ text: "Line text" }],
+          },
+        },
+        refs,
+        render,
+        store: createStore(state),
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              mode: "adv",
+              resourceId: "layout-adv",
+              characterId: "character-1",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        dialogue: {
+          mode: "adv",
+          ui: {
+            resourceId: "layout-adv",
+          },
+          characterId: "character-1",
+          persistCharacter: false,
+          content: [{ text: "Line text" }],
+        },
+      },
+    });
+  });
+
   it("resets persistCharacter to false when selecting a character makes the field appear", () => {
     const state = createInitialState();
     const render = vi.fn();
@@ -1089,6 +1145,59 @@ describe("commandLineDialogueBox.handlers", () => {
         resourceId: "portrait-in",
       },
     });
+  });
+
+  it("emits temporary sprite selections before the picker is submitted", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const deps = {
+      props: {
+        layouts,
+        characters,
+        transforms,
+        dialogue: {
+          content: [{ text: "Sprite line" }],
+        },
+      },
+      render,
+      dispatchEvent,
+      store: createStore(state),
+    };
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setSelectedCharacterId({ state }, { characterId: "character-1" });
+
+    handleCharacterItemClick(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {
+            characterId: "character-1",
+          },
+        },
+      },
+    });
+    handleSpriteItemClick(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {
+            spriteId: "sprite-body",
+          },
+        },
+      },
+    });
+
+    const event =
+      dispatchEvent.mock.calls[dispatchEvent.mock.calls.length - 1][0];
+    expect(event.type).toBe("temporary-presentation-state-change");
+    expect(event.detail.presentationState.dialogue.character.sprite).toEqual({
+      transformId: "portrait-left",
+      items: [{ id: "body", resourceId: "sprite-body" }],
+    });
+    expect(event.detail.presentationState.dialogue.content).toEqual([
+      { text: "Sprite line" },
+    ]);
   });
 
   it("submits a character sprite without a selected speaker", () => {

--- a/tests/commandLineVisual/commandLineVisual.handlers.test.js
+++ b/tests/commandLineVisual/commandLineVisual.handlers.test.js
@@ -1,23 +1,46 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleAddVisualClick,
   handleAnimationChange,
   handleAnimationModeChange,
+  handleResourceItemClick,
   handleSubmitClick,
 } from "../../src/components/commandLineVisual/commandLineVisual.handlers.js";
 import {
+  addVisual,
   createInitialState,
+  selectDefaultTransformId,
+  selectMode,
   selectSelectedVisuals,
+  selectSelectedVisualIndex,
+  selectTempSelectedResourceId,
   setAnimations,
   setExistingVisuals,
+  setMode,
+  setSelectedVisualIndex,
+  setTempSelectedResourceId,
+  setTransforms,
+  updateVisualResource,
   updateVisualAnimation,
   updateVisualAnimationMode,
 } from "../../src/components/commandLineVisual/commandLineVisual.store.js";
 
 const createStoreApi = (state) => ({
+  addVisual: (payload) => addVisual({ state }, payload),
+  selectDefaultTransformId: () => selectDefaultTransformId({ state }),
+  selectMode: () => selectMode({ state }),
+  selectSelectedVisualIndex: () => selectSelectedVisualIndex({ state }),
   selectSelectedVisuals: () => selectSelectedVisuals({ state }),
+  selectTempSelectedResourceId: () => selectTempSelectedResourceId({ state }),
+  setMode: (payload) => setMode({ state }, payload),
+  setSelectedVisualIndex: (payload) =>
+    setSelectedVisualIndex({ state }, payload),
+  setTempSelectedResourceId: (payload) =>
+    setTempSelectedResourceId({ state }, payload),
   updateVisualAnimation: (payload) => updateVisualAnimation({ state }, payload),
   updateVisualAnimationMode: (payload) =>
     updateVisualAnimationMode({ state }, payload),
+  updateVisualResource: (payload) => updateVisualResource({ state }, payload),
 });
 
 const setAnimationCollection = (state) => {
@@ -104,6 +127,68 @@ describe("commandLineVisual.handlers animation controls", () => {
       },
     });
     expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits temporary presentation state while picking a new visual resource", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setTransforms(
+      { state },
+      {
+        transforms: {
+          items: {
+            "visual-center": {
+              id: "visual-center",
+              type: "transform",
+              name: "Center",
+            },
+          },
+          tree: [{ id: "visual-center" }],
+        },
+      },
+    );
+
+    handleAddVisualClick({
+      store,
+      render,
+    });
+    handleResourceItemClick(
+      {
+        store,
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              resourceId: "visual-image",
+            },
+          },
+        },
+      },
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        visual: {
+          items: [
+            {
+              id: "temporary-visual-preview",
+              resourceId: "visual-image",
+              transformId: "visual-center",
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("submits animations for selected visuals without changing other data keys", () => {

--- a/tests/project/layout.fileIds.test.js
+++ b/tests/project/layout.fileIds.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { extractFileIdsForValue } from "../../src/internal/project/layout.js";
+
+const createProjectData = () => ({
+  resources: {
+    images: {},
+    spritesheets: {},
+    videos: {},
+    sounds: {},
+    particles: {},
+    fonts: {},
+    colors: {},
+    textStyles: {},
+    layouts: {},
+    transforms: {},
+    animations: {},
+    characters: {
+      "character-hero": {
+        id: "character-hero",
+        type: "character",
+        name: "Hero",
+        sprites: {
+          items: {
+            "sprite-body": {
+              id: "sprite-body",
+              type: "image",
+              name: "Body",
+              fileId: "file-body",
+              fileType: "image/webp",
+            },
+          },
+          tree: [{ id: "sprite-body" }],
+        },
+      },
+    },
+  },
+});
+
+describe("layout file id extraction", () => {
+  it("includes character action item ids when extracting temporary presentation assets", () => {
+    const fileReferences = extractFileIdsForValue(createProjectData(), {
+      character: {
+        items: [
+          {
+            id: "character-hero",
+            sprites: [
+              {
+                id: "body",
+                resourceId: "sprite-body",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(fileReferences).toEqual([
+      {
+        url: "file-body",
+        type: "image/webp",
+      },
+    ]);
+  });
+});

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -253,6 +253,45 @@ describe("renderSceneEditorState", () => {
     );
   });
 
+  it("applies temporary presentation state to the engine without replacing base store state", async () => {
+    const projectData = createProjectData();
+    const graphicsService = createGraphicsService();
+    const temporaryPresentationState = {
+      dialogue: {
+        mode: "adv",
+        ui: {
+          resourceId: "adv",
+        },
+        content: [{ text: "temporary" }],
+      },
+    };
+    const store = {
+      selectSceneId: () => "scene-1",
+      selectSelectedSectionId: () => "section-1",
+      selectSelectedLineId: () => "line-2",
+      selectProjectData: () => projectData,
+      selectTemporaryPresentationState: () => temporaryPresentationState,
+      selectIsMuted: () => false,
+      setPresentationState: ({ presentationState }) => {
+        store.presentationState = presentationState;
+      },
+      presentationState: undefined,
+    };
+
+    await renderSceneEditorState({
+      store,
+      graphicsService,
+    });
+
+    expect(store.presentationState?.dialogue?.content?.[0]?.text).toBe(
+      "second",
+    );
+    expect(
+      graphicsService.engineSelectPresentationState()?.dialogue?.content?.[0]
+        ?.text,
+    ).toBe("temporary");
+  });
+
   it("can warm route-engine state without drawing the canvas", async () => {
     const projectData = createProjectData();
     const graphicsService = createGraphicsService();

--- a/tests/sceneEditor/sceneEditor.handlers.test.js
+++ b/tests/sceneEditor/sceneEditor.handlers.test.js
@@ -118,6 +118,50 @@ describe("sceneEditor.handlers dialogue persistence", () => {
     );
   });
 
+  it("clears temporary presentation state and refreshes the canvas when action save fails", async () => {
+    const saveError = new Error("save failed");
+    const store = {
+      selectSelectedLineId: vi.fn(() => "line-1"),
+      clearTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+      projectService: {
+        updateLineActions: vi.fn(async () => {
+          throw saveError;
+        }),
+      },
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    await expect(
+      handleCommandLineSubmit(deps, {
+        _event: {
+          detail: {
+            background: {
+              resourceId: "bg-school",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("save failed");
+
+    expect(store.clearTemporaryPresentationState).toHaveBeenCalledTimes(1);
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      {
+        skipRender: true,
+        skipAnimations: true,
+      },
+    );
+  });
+
   it("preserves dialogue content when submitting dialogue metadata changes", async () => {
     const updateLineDialogueAction = vi.fn(async () => ({ valid: true }));
     const store = {

--- a/tests/sceneEditor/sceneEditor.handlers.test.js
+++ b/tests/sceneEditor/sceneEditor.handlers.test.js
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  handleActionsDialogClose,
   handleCommandLineSubmit,
   handleDialogueCharacterShortcut,
   handleEditorDataChanged,
@@ -92,6 +93,31 @@ describe("sceneEditor.handlers line navigation", () => {
 });
 
 describe("sceneEditor.handlers dialogue persistence", () => {
+  it("clears temporary presentation state and refreshes the canvas when the actions dialog closes", () => {
+    const store = {
+      clearTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    handleActionsDialogClose(deps);
+
+    expect(store.clearTemporaryPresentationState).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      {
+        skipRender: true,
+        skipAnimations: true,
+      },
+    );
+  });
+
   it("preserves dialogue content when submitting dialogue metadata changes", async () => {
     const updateLineDialogueAction = vi.fn(async () => ({ valid: true }));
     const store = {

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  clearTemporaryPresentationState,
+  selectEffectivePresentationState,
   selectViewData,
   selectSectionTransitionsDAG,
   setRepositoryState,
   setSceneId,
+  setPresentationState,
+  setTemporaryPresentationState,
 } from "../../src/pages/sceneEditor/sceneEditor.store.js";
 
 describe("sceneEditor.store", () => {
@@ -114,5 +118,51 @@ describe("sceneEditor.store", () => {
     const viewData = selectViewData({ state });
     expect(viewData.sections[0].isDeadEnd).toBe(false);
     expect(viewData.sectionsOverviewItems[0].isDeadEnd).toBe(false);
+  });
+
+  it("overlays temporary presentation state over committed presentation state", () => {
+    const state = createInitialState();
+
+    setPresentationState(
+      { state },
+      {
+        presentationState: {
+          dialogue: {
+            mode: "adv",
+          },
+          background: {
+            resourceId: "background-1",
+          },
+        },
+      },
+    );
+    setTemporaryPresentationState(
+      { state },
+      {
+        presentationState: {
+          dialogue: {
+            mode: "nvl",
+          },
+        },
+      },
+    );
+
+    expect(selectEffectivePresentationState({ state })).toEqual({
+      dialogue: {
+        mode: "nvl",
+      },
+      background: {
+        resourceId: "background-1",
+      },
+    });
+    expect(selectViewData({ state }).presentationState.dialogue).toEqual({
+      mode: "nvl",
+    });
+
+    clearTemporaryPresentationState({ state });
+
+    expect(selectEffectivePresentationState({ state }).dialogue).toEqual({
+      mode: "adv",
+    });
   });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleActionsDialogClose } from "../../src/components/sceneEditorLexical/sceneEditorLexical.handlers.js";
+import {
+  handleActionsDialogClose,
+  handleCommandLineSubmit,
+} from "../../src/components/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
 describe("sceneEditorLexical.handlers actions dialog", () => {
   it("clears temporary presentation state and refreshes the canvas when the actions dialog closes", () => {
@@ -25,6 +28,56 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     expect(store.clearActionTargetLineId).toHaveBeenCalledTimes(1);
     expect(store.clearTemporaryPresentationState).toHaveBeenCalledTimes(1);
     expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      {
+        skipRender: true,
+        skipAnimations: true,
+      },
+    );
+  });
+
+  it("clears temporary presentation state and refreshes the canvas when action save fails", async () => {
+    const saveError = new Error("save failed");
+    const store = {
+      selectActionTargetLineId: vi.fn(() => "line-2"),
+      selectSelectedLineId: vi.fn(() => "line-1"),
+      selectDraftSection: vi.fn(() => undefined),
+      setSelectedLineId: vi.fn(),
+      clearTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+      projectService: {
+        updateLineActions: vi.fn(async () => {
+          throw saveError;
+        }),
+      },
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    await expect(
+      handleCommandLineSubmit(deps, {
+        _event: {
+          detail: {
+            background: {
+              resourceId: "bg-school",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("save failed");
+
+    expect(store.setSelectedLineId).toHaveBeenCalledWith({
+      selectedLineId: "line-2",
+    });
+    expect(store.clearTemporaryPresentationState).toHaveBeenCalledTimes(1);
     expect(deps.subject.dispatch).toHaveBeenCalledWith(
       "sceneEditor.renderCanvas",
       {

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleActionsDialogClose } from "../../src/components/sceneEditorLexical/sceneEditorLexical.handlers.js";
+
+describe("sceneEditorLexical.handlers actions dialog", () => {
+  it("clears temporary presentation state and refreshes the canvas when the actions dialog closes", () => {
+    const store = {
+      selectActionTargetLineId: vi.fn(() => "line-2"),
+      setSelectedLineId: vi.fn(),
+      clearActionTargetLineId: vi.fn(),
+      clearTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    handleActionsDialogClose(deps);
+
+    expect(store.setSelectedLineId).toHaveBeenCalledWith({
+      selectedLineId: "line-2",
+    });
+    expect(store.clearActionTargetLineId).toHaveBeenCalledTimes(1);
+    expect(store.clearTemporaryPresentationState).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      {
+        skipRender: true,
+        skipAnimations: true,
+      },
+    );
+  });
+});

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -5,8 +5,10 @@ import {
   updateActions,
 } from "../../src/components/systemActions/systemActions.store.js";
 import {
+  handleActionsDialogClose,
   handleEmbeddedCloseClick,
   handleCommandLineSubmit,
+  handleTemporaryPresentationStateChange,
   open,
 } from "../../src/components/systemActions/systemActions.handlers.js";
 
@@ -199,6 +201,46 @@ describe("systemActions.handlers", () => {
     });
   });
 
+  it("forwards temporary presentation state changes from action editors", () => {
+    const dispatchedEvents = [];
+    let stopPropagationCalled = false;
+
+    handleTemporaryPresentationStateChange(
+      {
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        _event: {
+          stopPropagation: () => {
+            stopPropagationCalled = true;
+          },
+          detail: {
+            presentationState: {
+              dialogue: {
+                mode: "adv",
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(stopPropagationCalled).toBe(true);
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchedEvents[0].detail).toEqual({
+      presentationState: {
+        dialogue: {
+          mode: "adv",
+        },
+      },
+    });
+  });
+
   it("emits close from embedded system action editors", () => {
     const dispatchedEvents = [];
     let stopPropagationCalled = false;
@@ -219,8 +261,49 @@ describe("systemActions.handlers", () => {
     );
 
     expect(stopPropagationCalled).toBe(true);
-    expect(dispatchedEvents).toHaveLength(1);
-    expect(dispatchedEvents[0].type).toBe("close");
+    expect(dispatchedEvents).toHaveLength(2);
+    expect(dispatchedEvents[0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchedEvents[0].detail).toEqual({
+      presentationState: {},
+    });
+    expect(dispatchedEvents[1].type).toBe("close");
+  });
+
+  it("clears temporary presentation state when the actions dialog closes", () => {
+    const dispatchedEvents = [];
+    const state = createInitialState();
+
+    const deps = {
+      store: {
+        hideActionsDialog: () => {
+          state.isActionsDialogOpen = false;
+        },
+        setMode: ({ mode }) => {
+          state.mode = mode;
+        },
+      },
+      render: () => {},
+      dispatchEvent: (event) => {
+        dispatchedEvents.push(event);
+      },
+    };
+
+    state.isActionsDialogOpen = true;
+    state.mode = "dialogue";
+
+    handleActionsDialogClose(deps);
+
+    expect(state.isActionsDialogOpen).toBe(false);
+    expect(dispatchedEvents).toHaveLength(2);
+    expect(dispatchedEvents[0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchedEvents[0].detail).toEqual({
+      presentationState: {},
+    });
+    expect(dispatchedEvents[1].type).toBe("close");
   });
 
   it("resyncs local actions from props when opened", () => {

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -531,4 +531,25 @@ describe("systemActions.store", () => {
       },
     ]);
   });
+
+  it("exposes default and scene-editor dialog surface options", () => {
+    const defaultViewData = selectViewData({
+      state: createInitialState(),
+      props: {},
+    });
+    const sceneViewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        dialogVariant: "scene-editor-left",
+        dialogPanelWidth: "calc((100vw - 64px) / 2)",
+      },
+    });
+
+    expect(defaultViewData.dialogVariant).toBe("default");
+    expect(defaultViewData.actionsDialogPanelWidth).toBe("50vw");
+    expect(sceneViewData.dialogVariant).toBe("scene-editor-left");
+    expect(sceneViewData.actionsDialogPanelWidth).toBe(
+      "calc((100vw - 64px) / 2)",
+    );
+  });
 });

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -25,4 +25,42 @@ describe("systemActions view", () => {
       "rvn-system-actions#branchActionsEditor :showSelected=${true} :actions=${branchActions} actionType=system :hiddenModes=${hiddenModes}",
     );
   });
+
+  it("uses a shared dialog surface with a scene-only left-docked variant", () => {
+    const systemActionsView = readFileSync(
+      new URL(
+        "../../src/components/systemActions/systemActions.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const sceneEditorView = readFileSync(
+      new URL(
+        "../../src/pages/sceneEditor/sceneEditor.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const sceneEditorLexicalView = readFileSync(
+      new URL(
+        "../../src/components/sceneEditorLexical/sceneEditorLexical.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(systemActionsView).toContain(
+      "rvn-system-actions-dialog-surface#actionsDialog",
+    );
+    expect(sceneEditorView).toContain("dialog-variant=scene-editor-left");
+    expect(sceneEditorLexicalView).toContain(
+      "dialog-variant=scene-editor-left",
+    );
+    expect(sceneEditorView).toContain(
+      'dialog-panel-width="calc((100vw - 64px) / 2)"',
+    );
+    expect(sceneEditorLexicalView).toContain(
+      'dialog-panel-width="calc((100vw - 64px) / 2)"',
+    );
+  });
 });

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleDocumentKeyDown,
+  handleSurfaceClose,
+} from "../../src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js";
+
+describe("systemActionsDialogSurface.handlers", () => {
+  it("emits close from overlay interactions", () => {
+    const dispatchedEvents = [];
+    let stopPropagationCalled = false;
+    let preventDefaultCalled = false;
+
+    handleSurfaceClose(
+      {
+        dispatchEvent: (event) => dispatchedEvents.push(event),
+      },
+      {
+        _event: {
+          stopPropagation: () => {
+            stopPropagationCalled = true;
+          },
+          preventDefault: () => {
+            preventDefaultCalled = true;
+          },
+        },
+      },
+    );
+
+    expect(stopPropagationCalled).toBe(true);
+    expect(preventDefaultCalled).toBe(true);
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("close");
+  });
+
+  it("closes on Escape only while open", () => {
+    const dispatchedEvents = [];
+    let preventDefaultCalled = false;
+    let stopPropagationCalled = false;
+
+    handleDocumentKeyDown(
+      {
+        props: {
+          open: true,
+        },
+        dispatchEvent: (event) => dispatchedEvents.push(event),
+      },
+      {
+        _event: {
+          key: "Escape",
+          preventDefault: () => {
+            preventDefaultCalled = true;
+          },
+          stopPropagation: () => {
+            stopPropagationCalled = true;
+          },
+        },
+      },
+    );
+
+    expect(preventDefaultCalled).toBe(true);
+    expect(stopPropagationCalled).toBe(true);
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("close");
+
+    handleDocumentKeyDown(
+      {
+        props: {
+          open: false,
+        },
+        dispatchEvent: (event) => dispatchedEvents.push(event),
+      },
+      {
+        _event: {
+          key: "Escape",
+        },
+      },
+    );
+
+    expect(dispatchedEvents).toHaveLength(1);
+  });
+});

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js";
+
+describe("systemActionsDialogSurface.store", () => {
+  it("normalizes default dialog surface view data", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {},
+    });
+
+    expect(viewData).toEqual({
+      open: false,
+      variant: "default",
+      isSceneEditorLeft: false,
+      dialogWidth: "800",
+      dialogHeight: "80vh",
+      panelWidth: "50vw",
+      panelHorizontalInset: "96px",
+      panelWidthReduction: "64px",
+      panelVerticalInset: "32px",
+    });
+  });
+
+  it("normalizes the scene editor left panel variant", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        open: true,
+        variant: "scene-editor-left",
+        dialogWidth: "100vw",
+        dialogHeight: "100vh",
+        panelWidth: "calc((100vw - 64px) / 2)",
+      },
+    });
+
+    expect(viewData).toMatchObject({
+      open: true,
+      variant: "scene-editor-left",
+      isSceneEditorLeft: true,
+      panelWidth: "calc((100vw - 64px) / 2)",
+      panelHorizontalInset: "96px",
+      panelWidthReduction: "64px",
+      panelVerticalInset: "32px",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add scene-editor-only action dialog surface positioning with transparent overlay support
- add temporary presentation-state events for dialogue box, background, characters, visual, and choices action editors
- merge temporary scene action state into the selected-line preview canvas and clear it on cancel/close/submit
- add focused coverage for action temp previews, dialog surface behavior, and scene editor runtime/store handlers

## Testing
- bunx vitest run tests/commandLineChoices/commandLineChoices.handlers.test.js tests/systemActions/systemActions.handlers.test.js tests/sceneEditor/sceneEditor.handlers.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/runtime.test.js
- bunx vitest run tests/commandLineCharacters/commandLineCharacters.handlers.test.js tests/commandLineVisual/commandLineVisual.handlers.test.js tests/systemActions/systemActions.handlers.test.js tests/sceneEditor/sceneEditor.handlers.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/runtime.test.js
- bunx vitest run tests/commandLineVisual/commandLineVisual.store.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js
- bun prettier --check src/components/commandLineChoices/commandLineChoices.handlers.js src/components/commandLineChoices/commandLineChoices.store.js tests/commandLineChoices/commandLineChoices.handlers.test.js
- bunx oxlint src/components/commandLineChoices/commandLineChoices.handlers.js src/components/commandLineChoices/commandLineChoices.store.js tests/commandLineChoices/commandLineChoices.handlers.test.js
- git diff --check
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src

Not run: bun run build:web