### PR TITLE
fix: prevent lexical backspace line merges

### DIFF
--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -9,7 +9,7 @@ export const PREVIEW_BG_COLOR = "#4a4a4a";
 export const PREVIEW_UPDATE_ELEMENT_ID = "preview-element";
 export const PREVIEW_TRANSITION_ELEMENT_ID = "preview-transition-element";
 export const PREVIEW_TRANSITION_PREV_FILL = "#ffffff";
-export const PREVIEW_TRANSITION_NEXT_FILL = "#8fd3ff";
+export const PREVIEW_TRANSITION_NEXT_FILL = "#000000";
 export const AUTO_TWEEN_DEFAULT_DURATION = 1000;
 export const AUTO_TWEEN_DEFAULT_EASING = "linear";
 

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1448,7 +1448,28 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     if (event.key === "Backspace" && !event.isComposing) {
-      const didMerge = this.mergeCurrentLineBackward();
+      const context = this.getLineSelectionContext();
+      const nativeSelection = this.getNativeCollapsedLineSelectionContext();
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (
+        context &&
+        context.selection.start === 0 &&
+        context.selection.end === 0 &&
+        this.isNativeSelectionAfterLineStart(context, nativeSelection)
+      ) {
+        event.preventDefault();
+        this.deleteCharacterBackward({ nativeSelection });
+        return;
+      }
+
+      const didMerge = this.mergeCurrentLineBackward({
+        context,
+        nativeSelection,
+      });
       if (didMerge) {
         event.preventDefault();
       }
@@ -2265,10 +2286,11 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     if (inputType === "deleteContentBackward") {
+      const nativeSelection = this.getNativeCollapsedLineSelectionContext();
       event.preventDefault();
       event.stopPropagation?.();
       event.stopImmediatePropagation?.();
-      this.deleteCharacterBackward();
+      this.deleteCharacterBackward({ nativeSelection });
       return;
     }
 
@@ -3238,12 +3260,28 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     });
   }
 
-  mergeCurrentLineBackward() {
-    const context = this.getLineSelectionContext();
+  mergeCurrentLineBackward({ context, nativeSelection } = {}) {
+    context = context ?? this.getLineSelectionContext();
     if (
       !context ||
       context.selection.start !== 0 ||
       context.selection.end !== 0
+    ) {
+      return false;
+    }
+
+    if (this.isNativeSelectionAfterLineStart(context, nativeSelection)) {
+      return false;
+    }
+
+    const lineElement = this.editor.getElementByKey(context.lineKey);
+    const lineElementText = String(lineElement?.textContent ?? "").replaceAll(
+      EDITOR_CARET_TEXT,
+      "",
+    );
+    if (
+      getContentLength(context.lineContent) > 0 ||
+      lineElementText.length > 0
     ) {
       return false;
     }
@@ -3468,7 +3506,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     );
   }
 
-  deleteCharacterBackward() {
+  deleteCharacterBackward({
+    nativeSelection = this.getNativeCollapsedLineSelectionContext(),
+  } = {}) {
     this.editor.update(
       () => {
         const selection = $getSelection();
@@ -3477,6 +3517,70 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         }
 
         if (selection.isCollapsed()) {
+          const selectionLineNode = this.getLineNodeFromSelection(selection);
+          const nativeLineKey = nativeSelection?.lineId
+            ? this.lineKeyById?.get(nativeSelection.lineId)
+            : undefined;
+          const nativeLineNode = nativeLineKey
+            ? $getNodeByKey(nativeLineKey)
+            : undefined;
+          const lineNode = nativeLineNode ?? selectionLineNode;
+          const lineMeta = lineNode
+            ? this.lineMetaByKey.get(lineNode.getKey())
+            : undefined;
+          const lineSelection =
+            lineNode && lineNode === selectionLineNode
+              ? getSelectionOffsets(lineNode, selection)
+              : nativeSelection?.lineId === lineMeta?.id
+                ? {
+                    start: nativeSelection.offset,
+                    end: nativeSelection.offset,
+                  }
+                : undefined;
+          const lineContent = lineNode
+            ? this.serializeLineContent(lineNode)
+            : undefined;
+          const lineText =
+            getPlainTextFromContent(lineContent) ||
+            lineNode?.getTextContent() ||
+            "";
+
+          if (
+            lineNode &&
+            lineMeta &&
+            lineSelection?.start === lineSelection?.end &&
+            lineSelection.start <= 1 &&
+            /^\s/.test(lineText)
+          ) {
+            this.deleteLineContentRange(lineNode, lineMeta, 0, 1);
+            return;
+          }
+
+          if (
+            lineNode &&
+            lineMeta &&
+            lineSelection?.start === 0 &&
+            lineSelection.end === 0 &&
+            nativeSelection?.lineId === lineMeta.id &&
+            nativeSelection.offset > 0
+          ) {
+            this.deleteLineContentBackwardAtOffset(
+              lineNode,
+              lineMeta,
+              nativeSelection.offset,
+            );
+            return;
+          }
+
+          if (
+            lineNode &&
+            lineMeta &&
+            lineSelection?.start === 0 &&
+            lineSelection.end === 0
+          ) {
+            return;
+          }
+
           selection.deleteCharacter(true);
           return;
         }
@@ -3485,6 +3589,30 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       },
       { discrete: true },
     );
+  }
+
+  deleteLineContentBackwardAtOffset(lineNode, lineMeta, offset) {
+    const deleteEnd = Math.max(0, Number(offset) || 0);
+    const deleteStart = Math.max(0, deleteEnd - 1);
+    this.deleteLineContentRange(lineNode, lineMeta, deleteStart, deleteEnd);
+  }
+
+  deleteLineContentRange(lineNode, lineMeta, start, end) {
+    const deleteStart = Math.max(0, Number(start) || 0);
+    const deleteEnd = Math.max(deleteStart, Number(end) || 0);
+    const { before, after } = splitContentRange(
+      this.serializeLineContent(lineNode),
+      deleteStart,
+      deleteEnd,
+    );
+
+    lineNode.clear();
+    this.appendParagraphContent(lineNode, appendContentArrays(before, after));
+    applySelectionToLineNode(lineNode, {
+      lineId: lineMeta.id,
+      start: deleteStart,
+      end: deleteStart,
+    });
   }
 
   deleteCharacterForward() {
@@ -4217,6 +4345,35 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     return -1;
+  }
+
+  getNativeCollapsedLineSelectionContext() {
+    const range = getSelectionRange(this.refs.editor);
+    if (!range?.collapsed) {
+      return undefined;
+    }
+
+    const lineElement = this.getLineElementFromRangePoint(
+      range.startContainer,
+      range.startOffset,
+    );
+    const lineId = this.getLineIdFromLineElement(lineElement);
+    const offset = this.getLineOffsetFromRange(lineElement, range);
+
+    if (!lineId || typeof offset !== "number") {
+      return undefined;
+    }
+
+    return {
+      lineId,
+      offset,
+    };
+  }
+
+  isNativeSelectionAfterLineStart(context, nativeSelection) {
+    return (
+      nativeSelection?.lineId === context?.lineId && nativeSelection.offset > 0
+    );
   }
 
   createPointerFallbackSelection(event) {

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -339,4 +339,19 @@ describe("animationEditor.store", () => {
       height: 768,
     });
   });
+
+  it("uses black as the default incoming transition preview image", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "transition" });
+
+    const renderState = selectAnimationRenderStateWithAnimations({ state });
+    const renderTransitionElement = renderState.elements.find(
+      (element) => element.id === PREVIEW_TRANSITION_ELEMENT_ID,
+    );
+
+    expect(renderTransitionElement).toMatchObject({
+      type: "rect",
+      fill: "#000000",
+    });
+  });
 });

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1,0 +1,367 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+} from "lexical";
+import { JSDOM } from "jsdom";
+import { describe, expect, it, vi } from "vitest";
+
+const installDomGlobals = () => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>");
+  const previousGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    getComputedStyle: globalThis.getComputedStyle,
+    HTMLElement: globalThis.HTMLElement,
+    MutationObserver: globalThis.MutationObserver,
+    Node: globalThis.Node,
+  };
+
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.MutationObserver = dom.window.MutationObserver;
+  globalThis.Node = dom.window.Node;
+
+  return () => {
+    for (const [name, value] of Object.entries(previousGlobals)) {
+      if (value === undefined) {
+        delete globalThis[name];
+      } else {
+        globalThis[name] = value;
+      }
+    }
+
+    dom.window.close();
+  };
+};
+
+describe("lexical scene document editor line editing", () => {
+  it("deletes from the native caret instead of merging when Backspace follows leading whitespace", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const preventDefault = vi.fn();
+      const mergeCurrentLineBackward = vi.fn();
+      const deleteCharacterBackward = vi.fn();
+      const nativeSelection = {
+        lineId: "line-2",
+        offset: 1,
+      };
+
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.getLineSelectionContext = vi.fn(() => ({
+        lineId: "line-2",
+        selection: {
+          start: 0,
+          end: 0,
+        },
+      }));
+      editorElement.getNativeCollapsedLineSelectionContext = vi.fn(
+        () => nativeSelection,
+      );
+      editorElement.mergeCurrentLineBackward = mergeCurrentLineBackward;
+      editorElement.deleteCharacterBackward = deleteCharacterBackward;
+      editorElement.handleNativeKeyDown({
+        key: "Backspace",
+        isComposing: false,
+        preventDefault,
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(deleteCharacterBackward).toHaveBeenCalledWith({
+        nativeSelection,
+      });
+      expect(mergeCurrentLineBackward).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not merge when Backspace was already handled by Lexical", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const preventDefault = vi.fn();
+      const mergeCurrentLineBackward = vi.fn();
+      const deleteCharacterBackward = vi.fn();
+
+      editorElement.state = {
+        selectedLineId: "line-2",
+      };
+      editorElement.editor = {
+        getElementByKey: vi.fn(),
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.getLineSelectionContext = vi.fn(() => ({
+        lineKey: "line-key-2",
+        lineId: "line-2",
+        selection: {
+          start: 0,
+          end: 0,
+        },
+        lineContent: [{ text: "" }],
+      }));
+      editorElement.getNativeCollapsedLineSelectionContext = vi.fn(() => ({
+        lineId: "line-2",
+        offset: 0,
+      }));
+      editorElement.mergeCurrentLineBackward = mergeCurrentLineBackward;
+      editorElement.deleteCharacterBackward = deleteCharacterBackward;
+      editorElement.handleNativeKeyDown({
+        key: "Backspace",
+        isComposing: false,
+        defaultPrevented: true,
+        preventDefault,
+      });
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(deleteCharacterBackward).not.toHaveBeenCalled();
+      expect(mergeCurrentLineBackward).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("removes leading whitespace without merging the current line into the previous line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-line-leading-whitespace-test",
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const previousLine = $createParagraphNode();
+          const currentLine = $createParagraphNode();
+
+          previousLine.append($createTextNode("previous"));
+          currentLine.append($createTextNode(" current"));
+          root.append(previousLine, currentLine);
+          editorElement.lineMetaByKey.set(previousLine.getKey(), {
+            id: "line-1",
+          });
+          editorElement.lineMetaByKey.set(currentLine.getKey(), {
+            id: "line-2",
+          });
+          editorElement.deleteLineContentBackwardAtOffset(
+            currentLine,
+            {
+              id: "line-2",
+            },
+            1,
+          );
+        },
+        { discrete: true },
+      );
+
+      const result = editor.getEditorState().read(() => {
+        const lines = $getRoot().getChildren();
+        return {
+          count: lines.length,
+          text: lines.map((line) => line.getTextContent()),
+        };
+      });
+
+      expect(result).toEqual({
+        count: 2,
+        text: ["previous", "current"],
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not merge a non-empty line when Backspace resolves to line start", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-line-no-non-empty-merge-test",
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let currentLineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const previousLine = $createParagraphNode();
+          const currentLine = $createParagraphNode();
+
+          previousLine.append($createTextNode("previous"));
+          currentLine.append($createTextNode("current"));
+          root.append(previousLine, currentLine);
+          currentLineKey = currentLine.getKey();
+          editorElement.lineMetaByKey.set(previousLine.getKey(), {
+            id: "line-1",
+          });
+          editorElement.lineMetaByKey.set(currentLineKey, {
+            id: "line-2",
+          });
+        },
+        { discrete: true },
+      );
+
+      const didMerge = editorElement.mergeCurrentLineBackward({
+        context: {
+          lineKey: currentLineKey,
+          lineId: "line-2",
+          selection: {
+            start: 0,
+            end: 0,
+          },
+          lineContent: [{ text: "current" }],
+        },
+        nativeSelection: {
+          lineId: "line-2",
+          offset: 0,
+        },
+      });
+      const result = editor.getEditorState().read(() => {
+        const lines = $getRoot().getChildren();
+        return {
+          count: lines.length,
+          text: lines.map((line) => line.getTextContent()),
+        };
+      });
+
+      expect(didMerge).toBe(false);
+      expect(result).toEqual({
+        count: 2,
+        text: ["previous", "current"],
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not merge a single whitespace line when content serialization is empty", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-line-single-space-delete-test",
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let currentLineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const previousLine = $createParagraphNode();
+          const currentLine = $createParagraphNode();
+
+          previousLine.append($createTextNode("previous"));
+          currentLine.append($createTextNode(" "));
+          root.append(previousLine, currentLine);
+          currentLineKey = currentLine.getKey();
+          editorElement.lineMetaByKey.set(previousLine.getKey(), {
+            id: "line-1",
+          });
+          editorElement.lineMetaByKey.set(currentLineKey, {
+            id: "line-2",
+          });
+        },
+        { discrete: true },
+      );
+
+      const didMerge = editorElement.mergeCurrentLineBackward({
+        context: {
+          lineKey: currentLineKey,
+          lineId: "line-2",
+          selection: {
+            start: 0,
+            end: 0,
+          },
+          lineContent: [{ text: "" }],
+        },
+        nativeSelection: {
+          lineId: "line-2",
+          offset: 0,
+        },
+      });
+
+      const result = editor.getEditorState().read(() => {
+        const lines = $getRoot().getChildren();
+        return {
+          count: lines.length,
+          text: lines.map((line) => line.getTextContent()),
+        };
+      });
+
+      expect(didMerge).toBe(false);
+      expect(result).toEqual({
+        count: 2,
+        text: ["previous", " "],
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- make animation editor incoming transition placeholder black instead of blue
- prevent lexical Backspace handling from merging lines after Lexical already handled the key event
- block structural Backspace merges for non-empty/whitespace-only lexical lines and add targeted regression coverage

## Testing
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js tests/sceneEditor/lexicalLinePreview.test.js tests/animationEditor/animationEditor.store.test.js
- bunx prettier --check src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js src/pages/animationEditor/animationEditor.constants.js tests/animationEditor/animationEditor.store.test.js
- bunx oxlint src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js src/pages/animationEditor/animationEditor.constants.js tests/animationEditor/animationEditor.store.test.js
- git diff --check
- pre-push hook: oxlint && bun prettier --check src

Not run: bun run build:web