### PR TITLE
fix: preserve variable enum values in editor

### DIFF
--- a/src/components/groupVariablesView/groupVariablesView.handlers.js
+++ b/src/components/groupVariablesView/groupVariablesView.handlers.js
@@ -106,26 +106,45 @@ const getDefaultValueByType = (type) => {
   return "";
 };
 
-const addEnumValueForm = {
-  title: "Add Enum Value",
-  fields: [
-    {
-      name: "value",
-      type: "input-text",
-      label: "Value",
-      required: true,
-    },
-  ],
-  actions: {
-    layout: "",
-    buttons: [
-      {
-        id: "submit",
-        variant: "pr",
-        label: "Add Value",
-      },
-    ],
-  },
+const mergeVariableFormValues = ({
+  storedValues = {},
+  formValues = {},
+} = {}) => {
+  const hasFormEnumValues = Object.prototype.hasOwnProperty.call(
+    formValues,
+    "enumValues",
+  );
+  const enumValues = hasFormEnumValues
+    ? formValues.enumValues
+    : (storedValues.enumValues ?? []);
+  const shouldPreserveEnum =
+    !hasFormEnumValues &&
+    storedValues.isEnum === true &&
+    normalizeVariableEnumValues(storedValues.enumValues).length > 0;
+
+  return {
+    ...storedValues,
+    ...formValues,
+    isEnum: shouldPreserveEnum
+      ? true
+      : (formValues.isEnum ?? storedValues.isEnum),
+    enumValues,
+  };
+};
+
+const getVariableFormValues = ({ refs, store } = {}) => {
+  return mergeVariableFormValues({
+    storedValues: store.selectDefaultValues(),
+    formValues: refs?.variableForm?.getValues?.(),
+  });
+};
+
+const setVariableFormValues = ({ refs, render, store }, values = {}) => {
+  refs?.variableForm?.setValues?.({
+    values,
+  });
+  store.updateFormValues(values);
+  render();
 };
 
 const getFormFieldNameFromEvent = (event) => {
@@ -315,60 +334,9 @@ export const handleCloseDialog = (deps) => {
   render();
 };
 
-export const handleFormAddOptionClick = async (deps, payload) => {
-  const { appService, dispatchEvent, refs, render, store } = deps;
+export const handleFormAddOptionClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
   const fieldName = getFormFieldNameFromEvent(payload?._event);
-
-  if (fieldName === "enumValues") {
-    payload?._event?.stopPropagation?.();
-    const dialogResult = await appService.showFormDialog({
-      form: addEnumValueForm,
-      defaultValues: {
-        value: "",
-      },
-    });
-
-    if (!dialogResult || dialogResult.actionId !== "submit") {
-      return;
-    }
-
-    const value = String(dialogResult.values?.value ?? "").trim();
-    if (!value) {
-      appService.showAlert({
-        message: "Enum value is required.",
-        title: "Warning",
-      });
-      return;
-    }
-
-    const currentValues =
-      refs.variableForm?.getValues?.() ?? store.selectDefaultValues();
-    const enumValues = normalizeVariableEnumValues(currentValues.enumValues);
-    if (enumValues.includes(value)) {
-      appService.showAlert({
-        message: "Enum value must be unique.",
-        title: "Warning",
-      });
-      return;
-    }
-
-    const nextEnumValues = [...enumValues, value];
-    const nextValues = {
-      ...currentValues,
-      isEnum: true,
-      enumValues: nextEnumValues,
-      default: nextEnumValues.includes(currentValues.default)
-        ? currentValues.default
-        : value,
-    };
-
-    refs.variableForm?.setValues?.({
-      values: nextValues,
-    });
-    store.updateFormValues(nextValues);
-    render();
-    return;
-  }
 
   dispatchEvent(
     new CustomEvent("form-add-option-click", {
@@ -380,6 +348,115 @@ export const handleFormAddOptionClick = async (deps, payload) => {
       composed: true,
     }),
   );
+};
+
+export const handleEnumAddValueClick = (deps, payload) => {
+  const { store, render } = deps;
+  payload._event.stopPropagation();
+
+  const rect = payload._event.currentTarget.getBoundingClientRect();
+  store.openEnumValuePopover({
+    x: rect.left,
+    y: rect.bottom,
+  });
+  render();
+};
+
+export const handleEnumValuePopoverClose = (deps) => {
+  const { store, render } = deps;
+  store.closeEnumValuePopover();
+  render();
+};
+
+export const handleEnumValueFormAction = (deps, payload) => {
+  const { appService, store } = deps;
+  const actionId = payload._event.detail.actionId;
+  if (actionId !== "submit") {
+    return;
+  }
+
+  const currentValues = getVariableFormValues(deps);
+  const value = String(payload._event.detail.values?.value ?? "").trim();
+
+  if (!value) {
+    appService.showAlert({
+      message: "Enum value is required.",
+      title: "Warning",
+    });
+    return;
+  }
+
+  const enumValues = normalizeVariableEnumValues(currentValues.enumValues);
+  if (enumValues.includes(value)) {
+    appService.showAlert({
+      message: "Enum value must be unique.",
+      title: "Warning",
+    });
+    return;
+  }
+
+  const nextEnumValues = [...enumValues, value];
+  const nextValues = {
+    ...currentValues,
+    isEnum: true,
+    enumValues: nextEnumValues,
+    default: nextEnumValues.includes(currentValues.default)
+      ? currentValues.default
+      : value,
+  };
+
+  store.closeEnumValuePopover();
+  setVariableFormValues(deps, nextValues);
+};
+
+export const handleEnumValueContextMenu = (deps, payload) => {
+  const { store, render } = deps;
+  payload._event.preventDefault();
+  payload._event.stopPropagation();
+
+  const index = Number(payload._event.currentTarget.dataset.index);
+  if (Number.isNaN(index)) {
+    return;
+  }
+
+  store.showEnumValueMenu({
+    index,
+    x: payload._event.clientX,
+    y: payload._event.clientY,
+  });
+  render();
+};
+
+export const handleEnumValueMenuClose = (deps) => {
+  const { store, render } = deps;
+  store.hideEnumValueMenu();
+  render();
+};
+
+export const handleEnumValueMenuClick = (deps, payload) => {
+  const { render, store } = deps;
+  const item = payload._event.detail.item || payload._event.detail;
+  if (item?.value !== "remove") {
+    store.hideEnumValueMenu();
+    render();
+    return;
+  }
+
+  const targetIndex = store.selectEnumValueMenuTargetIndex();
+  const currentValues = getVariableFormValues(deps);
+  const enumValues = normalizeVariableEnumValues(currentValues.enumValues);
+  const nextEnumValues = enumValues.filter((_, index) => index !== targetIndex);
+  const nextDefault = nextEnumValues.includes(currentValues.default)
+    ? currentValues.default
+    : (nextEnumValues[0] ?? "");
+  const nextValues = {
+    ...currentValues,
+    enumValues: nextEnumValues,
+    default: nextDefault,
+  };
+
+  store.hideEnumValueMenu();
+  setVariableFormValues(deps, nextValues);
 };
 
 export const handleRowClick = (deps, payload) => {
@@ -477,8 +554,7 @@ export const handleAppendTagIdToForm = (deps, payload = {}) => {
     return;
   }
 
-  const currentValues =
-    refs.variableForm?.getValues?.() ?? store.selectDefaultValues();
+  const currentValues = getVariableFormValues(deps);
   const nextValues = {
     ...currentValues,
     tagIds: buildUniqueTagIds(currentValues?.tagIds ?? [], [tagId]),
@@ -497,13 +573,18 @@ export const handleFormActionClick = (deps, payload) => {
   }
 
   const { store, render, dispatchEvent, props, appService } = deps;
+  const storeState = store.getState
+    ? store.getState()
+    : store._state || store.state;
 
   // Check which button was clicked
   const actionId = payload._event.detail.actionId;
 
   if (actionId === "submit") {
-    // Get form values from the event detail - it's in formValues
-    const formData = payload._event.detail.values;
+    const formData = mergeVariableFormValues({
+      storedValues: storeState.defaultValues,
+      formValues: payload._event.detail.values,
+    });
     const name = formData.name?.trim();
 
     // Don't submit if name is not set
@@ -515,10 +596,6 @@ export const handleFormActionClick = (deps, payload) => {
       return;
     }
 
-    // Get current dialog state
-    const storeState = store.getState
-      ? store.getState()
-      : store._state || store.state;
     const targetGroupId = storeState.targetGroupId;
     const isEditMode = storeState.dialogMode === "edit";
     const editingItemId = storeState.editingItemId;
@@ -592,6 +669,7 @@ export const handleFormActionClick = (deps, payload) => {
             description: formData.description ?? "",
             tagIds: Array.isArray(formData.tagIds) ? formData.tagIds : [],
             scope,
+            type,
             isEnum,
             enumValues,
             default: defaultValue,

--- a/src/components/groupVariablesView/groupVariablesView.store.js
+++ b/src/components/groupVariablesView/groupVariablesView.store.js
@@ -29,6 +29,32 @@ const DEFAULT_FORM_VALUES = {
   tagIds: [],
 };
 
+const DEFAULT_ENUM_VALUE_FORM_VALUES = {
+  value: "",
+};
+
+const createEnumValueForm = () => ({
+  title: "Add Value",
+  fields: [
+    {
+      name: "value",
+      type: "input-text",
+      label: "Value",
+      required: true,
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Add Value",
+      },
+    ],
+  },
+});
+
 export const createInitialState = () => ({
   collapsedIds: [],
   ...createTagFilterPopoverState(),
@@ -48,6 +74,21 @@ export const createInitialState = () => ({
       { label: "Delete", type: "item", value: "delete-item" },
     ],
   },
+
+  enumValuePopover: {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    key: 0,
+  },
+  enumValueMenu: {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    targetIndex: undefined,
+    items: [{ label: "Remove", type: "item", value: "remove" }],
+  },
+  enumValueDefaultValues: structuredClone(DEFAULT_ENUM_VALUE_FORM_VALUES),
 
   defaultValues: structuredClone(DEFAULT_FORM_VALUES),
 
@@ -112,15 +153,9 @@ export const createInitialState = () => ({
       },
       {
         $when: "values.type == 'string' && values.isEnum == true",
-        name: "enumValues",
-        type: "tag-select",
+        type: "slot",
+        slot: "enum-values",
         label: "Values",
-        placeholder: "Add value",
-        addOption: {
-          label: "Add value",
-        },
-        options: "${enumValueOptions}",
-        required: false,
       },
       {
         $when: "values.type == 'boolean'",
@@ -200,6 +235,9 @@ export const openAddDialog = ({ state }, { groupId } = {}) => {
   state.dialogMode = "add";
   state.editingItemId = null;
   state.defaultValues = structuredClone(DEFAULT_FORM_VALUES);
+  state.enumValuePopover.isOpen = false;
+  state.enumValueMenu.isOpen = false;
+  state.enumValueMenu.targetIndex = undefined;
 };
 
 export const openEditDialog = (
@@ -214,6 +252,9 @@ export const openEditDialog = (
     ...structuredClone(DEFAULT_FORM_VALUES),
     ...defaultValues,
   };
+  state.enumValuePopover.isOpen = false;
+  state.enumValueMenu.isOpen = false;
+  state.enumValueMenu.targetIndex = undefined;
 };
 
 export const closeDialog = ({ state }, _payload = {}) => {
@@ -222,6 +263,9 @@ export const closeDialog = ({ state }, _payload = {}) => {
   state.dialogMode = "add";
   state.editingItemId = null;
   state.defaultValues = structuredClone(DEFAULT_FORM_VALUES);
+  state.enumValuePopover.isOpen = false;
+  state.enumValueMenu.isOpen = false;
+  state.enumValueMenu.targetIndex = undefined;
 };
 
 export const setSearchQuery = ({ state }, { query } = {}) => {
@@ -246,6 +290,39 @@ export const hideContextMenu = ({ state }, _payload = {}) => {
 
 export const selectTargetItemId = ({ state }) => {
   return state.dropdownMenu.targetItemId;
+};
+
+export const openEnumValuePopover = ({ state }, { x, y } = {}) => {
+  state.enumValuePopover.isOpen = true;
+  state.enumValuePopover.x = x ?? 0;
+  state.enumValuePopover.y = y ?? 0;
+  state.enumValuePopover.key += 1;
+  state.enumValueDefaultValues = structuredClone(
+    DEFAULT_ENUM_VALUE_FORM_VALUES,
+  );
+};
+
+export const closeEnumValuePopover = ({ state }) => {
+  state.enumValuePopover.isOpen = false;
+  state.enumValueDefaultValues = structuredClone(
+    DEFAULT_ENUM_VALUE_FORM_VALUES,
+  );
+};
+
+export const showEnumValueMenu = ({ state }, { index, x, y } = {}) => {
+  state.enumValueMenu.isOpen = true;
+  state.enumValueMenu.x = x ?? 0;
+  state.enumValueMenu.y = y ?? 0;
+  state.enumValueMenu.targetIndex = index;
+};
+
+export const hideEnumValueMenu = ({ state }) => {
+  state.enumValueMenu.isOpen = false;
+  state.enumValueMenu.targetIndex = undefined;
+};
+
+export const selectEnumValueMenuTargetIndex = ({ state }) => {
+  return state.enumValueMenu.targetIndex;
 };
 
 export {
@@ -397,6 +474,13 @@ export const selectViewData = ({ state, props }) => {
   }
 
   const enumValueOptions = buildVariableEnumOptions(defaultValues.enumValues);
+  const enumValues = normalizeVariableEnumValues(defaultValues.enumValues).map(
+    (value, index) => ({
+      value,
+      label: value,
+      index,
+    }),
+  );
   const dialogKey = [
     state.dialogMode,
     state.editingItemId || "new",
@@ -437,6 +521,11 @@ export const selectViewData = ({ state, props }) => {
     dialogKey,
     dialogMode: state.dialogMode,
     editingItemId: state.editingItemId,
+    enumValues,
+    enumValuePopover: state.enumValuePopover,
+    enumValueForm: createEnumValueForm(),
+    enumValueDefaultValues: state.enumValueDefaultValues,
+    enumValueMenu: state.enumValueMenu,
     context: {
       values: defaultValues,
       enumValueOptions,

--- a/src/components/groupVariablesView/groupVariablesView.view.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.view.yaml
@@ -55,6 +55,28 @@ refs:
         handler: handleDialogFormChange
       add-option-click:
         handler: handleFormAddOptionClick
+  enumAddValueButton:
+    eventListeners:
+      click:
+        handler: handleEnumAddValueClick
+  enumValuePopover:
+    eventListeners:
+      close:
+        handler: handleEnumValuePopoverClose
+  enumValueForm:
+    eventListeners:
+      form-action:
+        handler: handleEnumValueFormAction
+  enumValueItem*:
+    eventListeners:
+      contextmenu:
+        handler: handleEnumValueContextMenu
+  enumValueMenu:
+    eventListeners:
+      close:
+        handler: handleEnumValueMenuClose
+      item-click:
+        handler: handleEnumValueMenuClick
   row*:
     eventListeners:
       click:
@@ -86,16 +108,16 @@ template:
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; min-height: 0;"':
           - $if flatGroups.length > 0:
               - $for group, i in flatGroups:
-                  - rtgl-view w=f ph=md:
-                      - 'rtgl-view#groupRef${i} data-group-id=${group.id} d=h w=f av=c bgc=${group.headerBackgroundColor} cur=pointer style="position: sticky; top: 0px;"':
-                          - rtgl-view w=f d=h av=c:
+                  - rtgl-view w=f ph=md pos=rel:
+                      - 'rtgl-view d=h w=f av=c bgc=${group.headerBackgroundColor} z=100 pv=sm style="position: sticky; top: 0px;"':
+                          - rtgl-view#groupRef${i} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:
                                   - rtgl-svg wh=16 svg=folderArrowRight: null
                                 $else:
                                   - rtgl-svg wh=16 svg=folderArrowDown: null
-                              - rtgl-view d=h av=c g=md:
-                                  - rtgl-svg wh=16 svg=folder: null
-                                  - rtgl-text: ${group.fullLabel}
+                              - rtgl-svg wh=16 svg=folder: null
+                              - rtgl-text: ${group.fullLabel}
+                          - rtgl-view w=1fg: null
                           - $if !readonly:
                               - rtgl-button#addVariableButtonRef${i} data-group-id=${group.id} s=sm w=1fg pre=plus: Add
                       - $if !group.isCollapsed:
@@ -156,8 +178,21 @@ template:
   - $if !readonly:
       - rtgl-dialog#addVariableDialog s=md ?open=${isDialogOpen}:
           - rtgl-view slot=content g=md:
-              - rtgl-form#variableForm key=${dialogKey} :defaultValues=${defaultValues} :form=${form} w=f :context=${context}: null
+              - rtgl-form#variableForm key=${dialogKey} :defaultValues=${defaultValues} :form=${form} w=f :context=${context}:
+                  - 'rtgl-view slot="enum-values" d=v w=f g=sm':
+                      - $if enumValues.length > 0:
+                          - rtgl-view d=h wrap g=sm w=f:
+                              - $for option, i in enumValues:
+                                  - rtgl-view#enumValueItemRef${i} data-index=${option.index} d=h av=c g=xs ph=md pv=xs bw=xs bc=bo br=md bgc=bg h-bgc=mu cur=context-menu:
+                                      - rtgl-text s=sm: ${option.label}
+                        $else:
+                          - rtgl-text s=sm c=mu-fg: No values yet
+                      - rtgl-view d=h w=f:
+                          - rtgl-button#enumAddValueButton s=sm v=se pre=plus: Add Value
       - rtgl-dropdown-menu#contextMenu :items=${dropdownMenu.items} ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null
+      - rtgl-popover#enumValuePopover ?open=${enumValuePopover.isOpen} x=${enumValuePopover.x} y=${enumValuePopover.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
+          - rtgl-form#enumValueForm key=${enumValuePopover.key} :defaultValues=${enumValueDefaultValues} :form=${enumValueForm} w=f: null
+      - rtgl-dropdown-menu#enumValueMenu :items=${enumValueMenu.items} ?open=${enumValueMenu.isOpen} x=${enumValueMenu.x} y=${enumValueMenu.y}: null
   - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=bs content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
       - $if showFilterPopoverSearch:
           - rtgl-text s=md: Filter

--- a/src/pages/variables/variables.handlers.js
+++ b/src/pages/variables/variables.handlers.js
@@ -426,6 +426,7 @@ export const handleVariableUpdated = async (deps, payload) => {
     description,
     tagIds,
     scope,
+    type,
     isEnum,
     enumValues,
     default: defaultValue,
@@ -442,9 +443,10 @@ export const handleVariableUpdated = async (deps, payload) => {
     value: defaultValue,
   };
   const selectedItem = store.selectSelectedItem();
+  const variableType = type ?? selectedItem?.type;
   const normalizedTagIds = normalizeOptionalTagIds(tagIds);
 
-  if (selectedItem?.type === "string") {
+  if (variableType === "string") {
     data.isEnum = isEnum === true;
     data.enumValues =
       isEnum === true ? normalizeVariableEnumValues(enumValues) : [];


### PR DESCRIPTION
## Summary
- replace the variable enum tag-select with a custom slot, add-value popover, and right-click remove menu
- preserve slot-backed enum values across repeated adds and edit submits
- include variable type on updates so string enum metadata persists after saving
- align the variables folder header/container with the standard resource page pattern

## Testing
- push hook: oxlint
- push hook: bun prettier --check src
- bun prettier --check src/components/groupVariablesView/groupVariablesView.store.js src/components/groupVariablesView/groupVariablesView.handlers.js src/components/groupVariablesView/groupVariablesView.view.yaml src/pages/variables/variables.handlers.js
- bunx oxlint src/components/groupVariablesView/groupVariablesView.store.js src/components/groupVariablesView/groupVariablesView.handlers.js src/pages/variables/variables.handlers.js
- bunx vitest run tests/project/variableEnumMetadata.test.js
- git diff --check

Did not run bun run build:web.