### PR TITLE
fix: preflight media files and hide conditional action

### DIFF
--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -1,5 +1,7 @@
 import { RUNTIME_ACTION_ITEMS } from "../../internal/runtimeActions.js";
 
+const DEFAULT_HIDDEN_MODES = ["conditional"];
+
 const createSection = (label, items) => ({
   label,
   items,
@@ -232,11 +234,18 @@ const PRESENTATION_ACTION_SECTIONS = [
 ];
 
 const getHiddenModes = (attrs = {}) => {
-  return Array.isArray(attrs.hiddenModes)
-    ? attrs.hiddenModes.filter(
-        (mode) => typeof mode === "string" && mode.length > 0,
-      )
-    : [];
+  const hiddenModes = new Set(DEFAULT_HIDDEN_MODES);
+  if (!Array.isArray(attrs.hiddenModes)) {
+    return [...hiddenModes];
+  }
+
+  for (const mode of attrs.hiddenModes) {
+    if (typeof mode === "string" && mode.length > 0) {
+      hiddenModes.add(mode);
+    }
+  }
+
+  return [...hiddenModes];
 };
 
 const getAllowedModes = (attrs = {}) => {

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -6,6 +6,8 @@ import {
 import { buildCharacterSpritePreviewFileIds } from "../../internal/characterSpritePreview.js";
 import { normalizeLineActions } from "../../internal/project/engineActions.js";
 
+const DEFAULT_HIDDEN_MODES = ["conditional"];
+
 export const createInitialState = () => ({
   mode: "actions",
   actions: {},
@@ -32,11 +34,18 @@ export const setUiConfig = ({ state }, { uiConfig } = {}) => {
 };
 
 const getHiddenModes = (attrs = {}) => {
-  return Array.isArray(attrs.hiddenModes)
-    ? attrs.hiddenModes.filter(
-        (mode) => typeof mode === "string" && mode.length > 0,
-      )
-    : [];
+  const hiddenModes = new Set(DEFAULT_HIDDEN_MODES);
+  if (!Array.isArray(attrs.hiddenModes)) {
+    return [...hiddenModes];
+  }
+
+  for (const mode of attrs.hiddenModes) {
+    if (typeof mode === "string" && mode.length > 0) {
+      hiddenModes.add(mode);
+    }
+  }
+
+  return [...hiddenModes];
 };
 
 const getAllowedModes = (attrs = {}) => {

--- a/src/deps/services/shared/commandApi/characterSprites.js
+++ b/src/deps/services/shared/commandApi/characterSprites.js
@@ -25,32 +25,30 @@ export const createCharacterSpriteCommandApi = (shared) => ({
       context.projectId,
       "characters",
     );
-    const fileCommands = shared.buildMissingFileCommands({
+    const ensureFilesResult = await shared.ensureFilesExist({
       context,
       fileRecords,
     });
+    if (ensureFilesResult?.valid === false) {
+      return ensureFilesResult;
+    }
 
-    const submitResult = await shared.submitCommandsWithContext({
+    const submitResult = await shared.submitCommandWithContext({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: resourcePartition,
-          type: COMMAND_TYPES.CHARACTER_SPRITE_CREATE,
-          payload: {
-            characterId,
-            spriteId: nextSpriteId,
-            data: structuredClone(data || {}),
-            ...shared.buildPlacementPayload({
-              parentId,
-              index: resolvedIndex,
-              position,
-              positionTargetId,
-            }),
-          },
-        },
-      ],
+      scope: "resources",
+      basePartition: resourcePartition,
+      type: COMMAND_TYPES.CHARACTER_SPRITE_CREATE,
+      payload: {
+        characterId,
+        spriteId: nextSpriteId,
+        data: structuredClone(data || {}),
+        ...shared.buildPlacementPayload({
+          parentId,
+          index: resolvedIndex,
+          position,
+          positionTargetId,
+        }),
+      },
     });
 
     if (submitResult?.valid === false) {
@@ -71,26 +69,24 @@ export const createCharacterSpriteCommandApi = (shared) => ({
       context.projectId,
       "characters",
     );
-    const fileCommands = shared.buildMissingFileCommands({
+    const ensureFilesResult = await shared.ensureFilesExist({
       context,
       fileRecords,
     });
+    if (ensureFilesResult?.valid === false) {
+      return ensureFilesResult;
+    }
 
-    return shared.submitCommandsWithContext({
+    return shared.submitCommandWithContext({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: resourcePartition,
-          type: COMMAND_TYPES.CHARACTER_SPRITE_UPDATE,
-          payload: {
-            characterId,
-            spriteId,
-            data: structuredClone(data || {}),
-          },
-        },
-      ],
+      scope: "resources",
+      basePartition: resourcePartition,
+      type: COMMAND_TYPES.CHARACTER_SPRITE_UPDATE,
+      payload: {
+        characterId,
+        spriteId,
+        data: structuredClone(data || {}),
+      },
     });
   },
 

--- a/src/deps/services/shared/commandApi/controls.js
+++ b/src/deps/services/shared/commandApi/controls.js
@@ -81,25 +81,23 @@ export const createControlCommandApi = (shared) => ({
       context.projectId,
       "controls",
     );
-    const fileCommands = shared.buildMissingFileCommands({
+    const ensureFilesResult = await shared.ensureFilesExist({
       context,
       fileRecords,
     });
+    if (ensureFilesResult?.valid === false) {
+      return ensureFilesResult;
+    }
 
-    return shared.submitCommandsWithContext({
+    return shared.submitCommandWithContext({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: resourcePartition,
-          type: COMMAND_TYPES.CONTROL_UPDATE,
-          payload: {
-            controlId,
-            data: structuredClone(data || {}),
-          },
-        },
-      ],
+      scope: "resources",
+      basePartition: resourcePartition,
+      type: COMMAND_TYPES.CONTROL_UPDATE,
+      payload: {
+        controlId,
+        data: structuredClone(data || {}),
+      },
     });
   },
 

--- a/src/deps/services/shared/commandApi/layouts.js
+++ b/src/deps/services/shared/commandApi/layouts.js
@@ -152,25 +152,23 @@ export const createLayoutCommandApi = (shared) => ({
   async updateLayoutItem({ layoutId, data, fileRecords = [] }) {
     const context = await shared.ensureCommandContext();
     const resourcePartition = getLayoutsResourcePartition({ shared, context });
-    const fileCommands = shared.buildMissingFileCommands({
+    const ensureFilesResult = await shared.ensureFilesExist({
       context,
       fileRecords,
     });
+    if (ensureFilesResult?.valid === false) {
+      return ensureFilesResult;
+    }
 
-    return shared.submitCommandsWithContext({
+    return shared.submitCommandWithContext({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: resourcePartition,
-          type: COMMAND_TYPES.LAYOUT_UPDATE,
-          payload: {
-            layoutId,
-            data: structuredClone(data || {}),
-          },
-        },
-      ],
+      scope: "resources",
+      basePartition: resourcePartition,
+      type: COMMAND_TYPES.LAYOUT_UPDATE,
+      payload: {
+        layoutId,
+        data: structuredClone(data || {}),
+      },
     });
   },
 

--- a/src/deps/services/shared/commandApi/resources/shared.js
+++ b/src/deps/services/shared/commandApi/resources/shared.js
@@ -16,10 +16,6 @@ export const submitCreateResourceCommand = async ({
   fileRecords = [],
 }) => {
   const context = await shared.ensureCommandContext();
-  const fileCommands = shared.buildMissingFileCommands({
-    context,
-    fileRecords,
-  });
   const nextResourceId = idValue ?? shared.createId();
   const resolvedIndex = shared.resolveResourceIndex({
     state: context.state,
@@ -29,31 +25,33 @@ export const submitCreateResourceCommand = async ({
     positionTargetId,
     index,
   });
-
-  const submitResult = await shared.submitCommandsWithContext({
+  const ensureFilesResult = await shared.ensureFilesExist({
     context,
-    commands: [
-      ...fileCommands,
-      {
-        scope: "resources",
-        basePartition: createResourcePartition({
-          shared,
-          context,
-          resourceType,
-        }),
-        type,
-        payload: {
-          [idField]: nextResourceId,
-          data: structuredClone(data),
-          ...shared.buildPlacementPayload({
-            parentId,
-            index: resolvedIndex,
-            position,
-            positionTargetId,
-          }),
-        },
-      },
-    ],
+    fileRecords,
+  });
+  if (ensureFilesResult?.valid === false) {
+    return ensureFilesResult;
+  }
+
+  const submitResult = await shared.submitCommandWithContext({
+    context,
+    scope: "resources",
+    basePartition: createResourcePartition({
+      shared,
+      context,
+      resourceType,
+    }),
+    type,
+    payload: {
+      [idField]: nextResourceId,
+      data: structuredClone(data),
+      ...shared.buildPlacementPayload({
+        parentId,
+        index: resolvedIndex,
+        position,
+        positionTargetId,
+      }),
+    },
   });
 
   if (submitResult?.valid === false) {
@@ -73,29 +71,27 @@ export const submitUpdateResourceCommand = async ({
   fileRecords = [],
 }) => {
   const context = await shared.ensureCommandContext();
-  const fileCommands = shared.buildMissingFileCommands({
+  const ensureFilesResult = await shared.ensureFilesExist({
     context,
     fileRecords,
   });
+  if (ensureFilesResult?.valid === false) {
+    return ensureFilesResult;
+  }
 
-  return shared.submitCommandsWithContext({
+  return shared.submitCommandWithContext({
     context,
-    commands: [
-      ...fileCommands,
-      {
-        scope: "resources",
-        basePartition: createResourcePartition({
-          shared,
-          context,
-          resourceType,
-        }),
-        type,
-        payload: {
-          [idField]: idValue,
-          data: structuredClone(data),
-        },
-      },
-    ],
+    scope: "resources",
+    basePartition: createResourcePartition({
+      shared,
+      context,
+      resourceType,
+    }),
+    type,
+    payload: {
+      [idField]: idValue,
+      data: structuredClone(data),
+    },
   });
 };
 

--- a/tests/commandApi/resourceFileBatching.test.js
+++ b/tests/commandApi/resourceFileBatching.test.js
@@ -6,12 +6,12 @@ import {
 import { createCatalogResourceCommandApi } from "../../src/deps/services/shared/commandApi/resources/catalog.js";
 import { createLayoutCommandApi } from "../../src/deps/services/shared/commandApi/layouts.js";
 import { createControlCommandApi } from "../../src/deps/services/shared/commandApi/controls.js";
+import { createCharacterSpriteCommandApi } from "../../src/deps/services/shared/commandApi/characterSprites.js";
 import { COMMAND_TYPES } from "../../src/internal/project/commands.js";
 
 const createShared = ({
   ensureFilesResult = { valid: true, createdCount: 0 },
   submitResult = { valid: true, commandIds: [] },
-  fileCommands = [],
 } = {}) => {
   const context = {
     projectId: "project-1",
@@ -25,9 +25,10 @@ const createShared = ({
   const shared = {
     ensureCommandContext: vi.fn().mockResolvedValue(context),
     ensureFilesExist: vi.fn().mockResolvedValue(ensureFilesResult),
-    buildMissingFileCommands: vi.fn().mockReturnValue(fileCommands),
+    buildMissingFileCommands: vi.fn(),
     createId: vi.fn().mockReturnValue("generated-resource-id"),
     resolveResourceIndex: vi.fn().mockReturnValue(4),
+    resolveCharacterSpriteIndex: vi.fn().mockReturnValue(2),
     buildPlacementPayload: vi
       .fn()
       .mockReturnValue({ parentId: "folder-1", index: 4 }),
@@ -39,14 +40,10 @@ const createShared = ({
   return { context, shared };
 };
 
-describe("resource command file batching", () => {
-  it("batches missing file records with image creation", async () => {
+describe("resource command file preflight", () => {
+  it("ensures file records before image creation", async () => {
     const fileRecords = [{ id: "file-1" }, { id: "file-2" }];
-    const fileCommands = [
-      { type: COMMAND_TYPES.FILE_CREATE, payload: { fileId: "file-1" } },
-      { type: COMMAND_TYPES.FILE_CREATE, payload: { fileId: "file-2" } },
-    ];
-    const { context, shared } = createShared({ fileCommands });
+    const { context, shared } = createShared();
 
     const result = await submitCreateResourceCommand({
       shared,
@@ -63,49 +60,40 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe("generated-resource-id");
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledTimes(1);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledTimes(1);
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
       fileRecords,
     });
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledTimes(1);
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.submitCommandWithContext).toHaveBeenCalledTimes(1);
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.IMAGE_CREATE,
-          payload: {
-            imageId: "generated-resource-id",
-            data: {
-              fileId: "file-1",
-              thumbnailFileId: "file-2",
-            },
-            parentId: "folder-1",
-            index: 4,
-          },
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.IMAGE_CREATE,
+      payload: {
+        imageId: "generated-resource-id",
+        data: {
+          fileId: "file-1",
+          thumbnailFileId: "file-2",
         },
-      ],
+        parentId: "folder-1",
+        index: 4,
+      },
     });
-    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
-    expect(shared.ensureFilesExist).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
   });
 
-  it("batches missing file records with image updates", async () => {
+  it("ensures file records before image updates", async () => {
     const submitResult = { valid: true, commandIds: ["cmd-1"] };
     const fileRecords = [
       {
         id: "file-3",
       },
     ];
-    const fileCommands = [
-      { type: COMMAND_TYPES.FILE_CREATE, payload: { fileId: "file-3" } },
-    ];
     const { context, shared } = createShared({
       submitResult,
-      fileCommands,
     });
 
     const result = await submitUpdateResourceCommand({
@@ -121,40 +109,64 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe(submitResult);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledTimes(1);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledTimes(1);
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
       fileRecords,
     });
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledTimes(1);
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.submitCommandWithContext).toHaveBeenCalledTimes(1);
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.IMAGE_UPDATE,
-          payload: {
-            imageId: "image-1",
-            data: {
-              fileId: "file-3",
-            },
-          },
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.IMAGE_UPDATE,
+      payload: {
+        imageId: "image-1",
+        data: {
+          fileId: "file-3",
         },
-      ],
+      },
     });
-    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
-    expect(shared.ensureFilesExist).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
   });
 
-  it("batches missing file records with layout updates", async () => {
+  it("does not submit the resource command when file preflight fails", async () => {
+    const ensureFilesResult = {
+      valid: false,
+      error: {
+        message: "file metadata missing",
+      },
+    };
+    const fileRecords = [{ id: "file-4" }];
+    const { context, shared } = createShared({ ensureFilesResult });
+
+    const result = await submitCreateResourceCommand({
+      shared,
+      resourceType: "images",
+      type: COMMAND_TYPES.IMAGE_CREATE,
+      idField: "imageId",
+      data: {
+        fileId: "file-4",
+      },
+      fileRecords,
+      parentId: "folder-1",
+      position: "last",
+    });
+
+    expect(result).toBe(ensureFilesResult);
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
+      context,
+      fileRecords,
+    });
+    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+  });
+
+  it("ensures file records before layout updates", async () => {
     const submitResult = { valid: true, commandIds: ["cmd-1"] };
     const fileRecords = [{ id: "thumb-1" }];
-    const fileCommands = [
-      { type: COMMAND_TYPES.FILE_CREATE, payload: { fileId: "thumb-1" } },
-    ];
-    const { context, shared } = createShared({ submitResult, fileCommands });
+    const { context, shared } = createShared({ submitResult });
     const api = createLayoutCommandApi(shared);
 
     const result = await api.updateLayoutItem({
@@ -167,39 +179,31 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe(submitResult);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
       fileRecords,
     });
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.LAYOUT_UPDATE,
-          payload: {
-            layoutId: "layout-1",
-            data: {
-              thumbnailFileId: "thumb-1",
-              preview: {},
-            },
-          },
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.LAYOUT_UPDATE,
+      payload: {
+        layoutId: "layout-1",
+        data: {
+          thumbnailFileId: "thumb-1",
+          preview: {},
         },
-      ],
+      },
     });
-    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
-    expect(shared.ensureFilesExist).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
   });
 
-  it("batches missing file records with control updates", async () => {
+  it("ensures file records before control updates", async () => {
     const submitResult = { valid: true, commandIds: ["cmd-1"] };
     const fileRecords = [{ id: "thumb-2" }];
-    const fileCommands = [
-      { type: COMMAND_TYPES.FILE_CREATE, payload: { fileId: "thumb-2" } },
-    ];
-    const { context, shared } = createShared({ submitResult, fileCommands });
+    const { context, shared } = createShared({ submitResult });
     const api = createControlCommandApi(shared);
 
     const result = await api.updateControlItem({
@@ -212,42 +216,107 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe(submitResult);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
       fileRecords,
     });
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.CONTROL_UPDATE,
-          payload: {
-            controlId: "control-1",
-            data: {
-              thumbnailFileId: "thumb-2",
-              preview: {},
-            },
-          },
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.CONTROL_UPDATE,
+      payload: {
+        controlId: "control-1",
+        data: {
+          thumbnailFileId: "thumb-2",
+          preview: {},
         },
-      ],
+      },
     });
-    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
-    expect(shared.ensureFilesExist).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
   });
 
-  it("batches missing file records with animation preview updates", async () => {
+  it("ensures file records before character sprite creation", async () => {
+    const fileRecords = [{ id: "sprite-file" }];
+    const { context, shared } = createShared();
+    const api = createCharacterSpriteCommandApi(shared);
+
+    const result = await api.createCharacterSpriteItem({
+      characterId: "character-1",
+      data: {
+        fileId: "sprite-file",
+      },
+      fileRecords,
+      parentId: "folder-1",
+      position: "last",
+    });
+
+    expect(result).toBe("generated-resource-id");
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
+      context,
+      fileRecords,
+    });
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
+      context,
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.CHARACTER_SPRITE_CREATE,
+      payload: {
+        characterId: "character-1",
+        spriteId: "generated-resource-id",
+        data: {
+          fileId: "sprite-file",
+        },
+        parentId: "folder-1",
+        index: 4,
+      },
+    });
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
+  });
+
+  it("ensures file records before character sprite updates", async () => {
+    const submitResult = { valid: true, commandIds: ["cmd-1"] };
+    const fileRecords = [{ id: "sprite-file-2" }];
+    const { context, shared } = createShared({ submitResult });
+    const api = createCharacterSpriteCommandApi(shared);
+
+    const result = await api.updateCharacterSpriteItem({
+      characterId: "character-1",
+      spriteId: "sprite-1",
+      data: {
+        fileId: "sprite-file-2",
+      },
+      fileRecords,
+    });
+
+    expect(result).toBe(submitResult);
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
+      context,
+      fileRecords,
+    });
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
+      context,
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.CHARACTER_SPRITE_UPDATE,
+      payload: {
+        characterId: "character-1",
+        spriteId: "sprite-1",
+        data: {
+          fileId: "sprite-file-2",
+        },
+      },
+    });
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
+  });
+
+  it("ensures file records before animation preview updates", async () => {
     const submitResult = { valid: true, commandIds: ["cmd-1"] };
     const fileRecords = [{ id: "thumb-animation" }];
-    const fileCommands = [
-      {
-        type: COMMAND_TYPES.FILE_CREATE,
-        payload: { fileId: "thumb-animation" },
-      },
-    ];
-    const { context, shared } = createShared({ submitResult, fileCommands });
+    const { context, shared } = createShared({ submitResult });
     const api = createCatalogResourceCommandApi(shared);
 
     const result = await api.updateAnimation({
@@ -264,53 +333,38 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe(submitResult);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
       fileRecords,
     });
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.ANIMATION_UPDATE,
-          payload: {
-            animationId: "animation-1",
-            data: {
-              thumbnailFileId: "thumb-animation",
-              preview: {
-                background: {
-                  imageId: "image-bg",
-                },
-              },
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.ANIMATION_UPDATE,
+      payload: {
+        animationId: "animation-1",
+        data: {
+          thumbnailFileId: "thumb-animation",
+          preview: {
+            background: {
+              imageId: "image-bg",
             },
           },
         },
-      ],
+      },
     });
-    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
-    expect(shared.ensureFilesExist).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
   });
 
-  it("batches missing file records with transform thumbnail updates", async () => {
+  it("ensures file records before transform thumbnail updates", async () => {
     const submitResult = { valid: true, commandIds: ["cmd-1"] };
     const fileRecords = [
       { id: "preview-transform" },
       { id: "thumb-transform" },
     ];
-    const fileCommands = [
-      {
-        type: COMMAND_TYPES.FILE_CREATE,
-        payload: { fileId: "preview-transform" },
-      },
-      {
-        type: COMMAND_TYPES.FILE_CREATE,
-        payload: { fileId: "thumb-transform" },
-      },
-    ];
-    const { context, shared } = createShared({ submitResult, fileCommands });
+    const { context, shared } = createShared({ submitResult });
     const api = createCatalogResourceCommandApi(shared);
 
     const result = await api.updateTransform({
@@ -338,48 +392,43 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe(submitResult);
-    expect(shared.buildMissingFileCommands).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
       fileRecords,
     });
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
       context,
-      commands: [
-        ...fileCommands,
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.TRANSFORM_UPDATE,
-          payload: {
-            transformId: "transform-1",
-            data: {
-              x: 0,
-              y: 0,
-              scaleX: 1,
-              scaleY: 1,
-              anchorX: 0,
-              anchorY: 0,
-              rotation: 0,
-              thumbnailFileId: "thumb-transform",
-              previewFileId: "preview-transform",
-              preview: {
-                background: {
-                  imageId: "image-bg",
-                },
-                target: {
-                  imageId: "image-target",
-                },
-              },
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.TRANSFORM_UPDATE,
+      payload: {
+        transformId: "transform-1",
+        data: {
+          x: 0,
+          y: 0,
+          scaleX: 1,
+          scaleY: 1,
+          anchorX: 0,
+          anchorY: 0,
+          rotation: 0,
+          thumbnailFileId: "thumb-transform",
+          previewFileId: "preview-transform",
+          preview: {
+            background: {
+              imageId: "image-bg",
+            },
+            target: {
+              imageId: "image-target",
             },
           },
         },
-      ],
+      },
     });
-    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
-    expect(shared.ensureFilesExist).not.toHaveBeenCalled();
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
+    expect(shared.buildMissingFileCommands).not.toHaveBeenCalled();
   });
 
-  it("submits resource create without file commands when there are no missing files", async () => {
+  it("submits resource create after empty file preflight", async () => {
     const { context, shared } = createShared();
 
     const result = await submitCreateResourceCommand({
@@ -396,27 +445,28 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe("generated-resource-id");
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
-      commands: [
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.IMAGE_CREATE,
-          payload: {
-            imageId: "generated-resource-id",
-            data: {
-              fileId: "file-1",
-            },
-            parentId: "folder-1",
-            index: 4,
-          },
-        },
-      ],
+      fileRecords: [],
     });
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
+      context,
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.IMAGE_CREATE,
+      payload: {
+        imageId: "generated-resource-id",
+        data: {
+          fileId: "file-1",
+        },
+        parentId: "folder-1",
+        index: 4,
+      },
+    });
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
   });
 
-  it("submits resource update without file commands when there are no missing files", async () => {
+  it("submits resource update after empty file preflight", async () => {
     const submitResult = { valid: true, commandIds: ["cmd-1"] };
     const { context, shared } = createShared({ submitResult });
 
@@ -433,21 +483,22 @@ describe("resource command file batching", () => {
     });
 
     expect(result).toBe(submitResult);
-    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+    expect(shared.ensureFilesExist).toHaveBeenCalledWith({
       context,
-      commands: [
-        {
-          scope: "resources",
-          basePartition: "main",
-          type: COMMAND_TYPES.IMAGE_UPDATE,
-          payload: {
-            imageId: "image-1",
-            data: {
-              fileId: "file-3",
-            },
-          },
-        },
-      ],
+      fileRecords: [],
     });
+    expect(shared.submitCommandWithContext).toHaveBeenCalledWith({
+      context,
+      scope: "resources",
+      basePartition: "main",
+      type: COMMAND_TYPES.IMAGE_UPDATE,
+      payload: {
+        imageId: "image-1",
+        data: {
+          fileId: "file-3",
+        },
+      },
+    });
+    expect(shared.submitCommandsWithContext).not.toHaveBeenCalled();
   });
 });

--- a/tests/commandApi/submitCommandsSnapshot.test.js
+++ b/tests/commandApi/submitCommandsSnapshot.test.js
@@ -23,7 +23,9 @@ describe("commandApi submitCommandsWithContext", () => {
     });
 
     const session = {
-      submitCommands: vi.fn(async (commands) => commands.map((command) => command.id)),
+      submitCommands: vi.fn(async (commands) =>
+        commands.map((command) => command.id),
+      ),
     };
 
     const shared = createCommandApiShared({
@@ -180,8 +182,6 @@ describe("commandApi submitCommandsWithContext", () => {
               name: "Image One",
               fileId: "file-1",
               thumbnailFileId: "thumb-1",
-              fileType: "image/png",
-              fileSize: 123,
               width: 640,
               height: 360,
             },

--- a/tests/commandLineActions/commandLineActions.store.test.js
+++ b/tests/commandLineActions/commandLineActions.store.test.js
@@ -53,7 +53,7 @@ describe("commandLineActions.store", () => {
     expect(iconByMode.decrementSaveLoadPagination).toBe("settings");
     expect(iconByMode.setMenuPage).toBe("settings");
     expect(iconByMode.setMenuEntryPoint).toBe("settings");
-    expect(iconByMode.conditional).toBe("settings");
+    expect(iconByMode.conditional).toBeUndefined();
   });
 
   it("offers resetStoryAtSection in system actions and drops resetStorySession", () => {
@@ -103,7 +103,7 @@ describe("commandLineActions.store", () => {
     }
   });
 
-  it("shows conditional actions in the logic section", () => {
+  it("hides conditional actions from the logic section", () => {
     const systemItems = selectItems({
       props: {
         actionsType: "system",
@@ -115,14 +115,26 @@ describe("commandLineActions.store", () => {
       },
     });
 
-    expect(getSectionModes(systemItems, "Logic")).toEqual([
-      "updateVariable",
-      "conditional",
-    ]);
+    expect(getSectionModes(systemItems, "Logic")).toEqual(["updateVariable"]);
     expect(getSectionModes(presentationItems, "Logic")).toEqual([
       "updateVariable",
-      "conditional",
     ]);
+    expect(systemItems.some((item) => item.mode === "conditional")).toBe(false);
+    expect(presentationItems.some((item) => item.mode === "conditional")).toBe(
+      false,
+    );
+  });
+
+  it("keeps conditional hidden even when allowed modes include it", () => {
+    const items = selectItems({
+      props: {
+        actionsType: "system",
+        allowedModes: ["conditional", "updateVariable"],
+      },
+    });
+
+    expect(getSectionModes(items, "Logic")).toEqual(["updateVariable"]);
+    expect(items.some((item) => item.mode === "conditional")).toBe(false);
   });
 
   it("moves dialogue text speed into the dialogue section", () => {

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -8,6 +8,19 @@ import {
 } from "../../src/components/systemActions/systemActions.store.js";
 
 describe("systemActions.store", () => {
+  it("hides conditional mode by default for nested action pickers", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        hiddenModes: ["rollbackByOffset"],
+      },
+    });
+
+    expect(viewData.hiddenModes).toEqual(["conditional", "rollbackByOffset"]);
+  });
+
   it("preserves and previews update variable actions", () => {
     const state = createInitialState();
 


### PR DESCRIPTION
## Summary
- ensure uploaded file records are submitted before resource commands that reference them
- hide the Conditional action from command line and system action choosers by default
- update regression coverage for command file preflight and action filtering

## Testing
- bunx vitest run tests/sounds/sounds.handlers.test.js tests/commandApi
- bunx vitest run tests/commandLineActions/commandLineActions.store.test.js tests/systemActions/systemActions.store.test.js tests/systemActions/systemActions.view.test.js
- bun prettier --check src/components/commandLineActions/commandLineActions.store.js src/components/systemActions/systemActions.store.js tests/commandLineActions/commandLineActions.store.test.js tests/systemActions/systemActions.store.test.js
- bunx oxlint src/components/commandLineActions/commandLineActions.store.js src/components/systemActions/systemActions.store.js tests/commandLineActions/commandLineActions.store.test.js tests/systemActions/systemActions.store.test.js
- pre-push hook: oxlint && bun prettier --check src