### PR TITLE
Fix scene editor draft persistence and control inheritance

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -83,6 +83,10 @@ bun run vt:generate
 bun run vt:report
 ```
 
+Do not add unit tests for temporary diagnostic/debug logs. If debug logs are
+needed to inspect a local issue, keep tests focused on the underlying behavior
+instead of asserting log payloads.
+
 Run one Puty scenario directly:
 
 ```bash
@@ -794,6 +798,33 @@ The Lexical document editor must not own:
 - project service orchestration
 - split/merge/create/delete persistence workflows
 - scene-specific badge/preview shaping
+
+Scene editor draft persistence uses latest-wins coalescing for draft flushes:
+if a running flush already has a pending replacement, the newer pending flush
+replaces it. This coalesces scheduled draft tasks, not generated commands.
+
+If a running flush saves a stale snapshot and notices that the draft advanced
+during the write, the newer draft is kept dirty and rescheduled through the
+normal debounce/throttle path instead of being submitted immediately. This
+avoids inserting every intermediate text version into `local_drafts`.
+
+Editor blur uses the normal text debounce path; navigation, preview, and
+explicit persistence workflows remain responsible for immediate flushes when
+leaving the editing context. Scheduled autosaves defer while a previous draft
+flush is still writing, then reschedule through the normal debounce/throttle
+path instead of queueing another storage submit behind the in-flight write.
+
+Direct persistence for navigation, preview, and action workflows must call
+`flushSceneEditorDrafts` with `force: true`. The max-wait cap may shorten
+debounce for a long-running dirty draft, but it must not bypass the minimum
+interval after a flush. `flushSceneEditorDrafts()` also enforces that minimum
+interval for non-forced saves so stale timers or direct autosave calls cannot
+submit rows too soon after the previous scene-editor draft write. Draft flush
+timing is tracked per project service owner, not only in page store state, so
+repository-state reconciliation cannot accidentally clear the active throttle
+window. The same minimum-interval check runs inside the queued draft-flush task
+before `syncSectionLinesSnapshot()` is called, so a task already accepted by the
+latest-task queue still reschedules instead of writing too soon.
 
 ### Scene Asset Loading
 

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -360,7 +360,7 @@ export const createStoryCommandApi = (shared) => {
       });
     },
 
-    async syncSectionLinesSnapshot({ sectionId, lines = [] }) {
+    async syncSectionLinesSnapshot({ sectionId, lines = [] } = {}) {
       const context = await shared.ensureCommandContext({
         sectionIds: [sectionId],
       });

--- a/src/internal/ui/sceneEditorLexical/draftPersistence.js
+++ b/src/internal/ui/sceneEditorLexical/draftPersistence.js
@@ -13,7 +13,7 @@ import {
 export const DEFAULT_SCENE_EDITOR_DRAFT_SAVE_TIMING = {
   text: {
     debounceMs: 2000,
-    minIntervalMs: 4000,
+    minIntervalMs: 5000,
     maxIntervalMs: 10000,
   },
   structure: {
@@ -34,6 +34,45 @@ const defaultNowMs = () => {
   return Date.now();
 };
 
+const draftFlushTimingByOwner = new WeakMap();
+
+const getDraftFlushTiming = (owner) => {
+  if (!owner || typeof owner !== "object") {
+    return {
+      lastFlushStartedAt: 0,
+    };
+  }
+
+  let timing = draftFlushTimingByOwner.get(owner);
+  if (!timing) {
+    timing = {
+      lastFlushStartedAt: 0,
+    };
+    draftFlushTimingByOwner.set(owner, timing);
+  }
+
+  return timing;
+};
+
+const getSceneEditorDraftReasonTiming = (reason, timing) => {
+  return (
+    (timing || DEFAULT_SCENE_EDITOR_DRAFT_SAVE_TIMING)[reason] ||
+    DEFAULT_SCENE_EDITOR_DRAFT_SAVE_TIMING.text
+  );
+};
+
+const getSceneEditorDraftReason = (draftSection, fallbackReason = "text") => {
+  if (draftSection?.lastSource === "structure") {
+    return "structure";
+  }
+
+  if (draftSection?.lastSource === "text") {
+    return "text";
+  }
+
+  return fallbackReason;
+};
+
 export const clearScheduledDraftFlush = (store) => {
   const timerId = store.selectDraftSaveTimerId();
   if (timerId !== undefined) {
@@ -46,9 +85,7 @@ export const getSceneEditorDraftSaveDelayMs = (
   store,
   { reason = "text", nowMs = defaultNowMs, timing } = {},
 ) => {
-  const reasonTiming =
-    (timing || DEFAULT_SCENE_EDITOR_DRAFT_SAVE_TIMING)[reason] ||
-    DEFAULT_SCENE_EDITOR_DRAFT_SAVE_TIMING.text;
+  const reasonTiming = getSceneEditorDraftReasonTiming(reason, timing);
   const lastFlushStartedAt = store.selectLastDraftFlushStartedAt();
   const pendingSinceAt = store.selectDraftSavePendingSinceAt();
   const now = nowMs();
@@ -61,9 +98,28 @@ export const getSceneEditorDraftSaveDelayMs = (
       ? Math.max(0, reasonTiming.maxIntervalMs - (now - pendingSinceAt))
       : Number.POSITIVE_INFINITY;
 
-  return Math.min(
-    Math.max(reasonTiming.debounceMs, remainingThrottleMs),
-    remainingMaxWaitMs,
+  const debounceDelayMs = Math.min(reasonTiming.debounceMs, remainingMaxWaitMs);
+
+  return Math.max(remainingThrottleMs, debounceDelayMs);
+};
+
+const getSceneEditorDraftFlushThrottleDelayMs = (
+  store,
+  { owner, reason = "text", nowMs = defaultNowMs, timing } = {},
+) => {
+  const reasonTiming = getSceneEditorDraftReasonTiming(reason, timing);
+  const ownerTiming = getDraftFlushTiming(owner);
+  const lastFlushStartedAt = Math.max(
+    store.selectLastDraftFlushStartedAt(),
+    ownerTiming.lastFlushStartedAt,
+  );
+  if (lastFlushStartedAt <= 0) {
+    return 0;
+  }
+
+  return Math.max(
+    0,
+    reasonTiming.minIntervalMs - (nowMs() - lastFlushStartedAt),
   );
 };
 
@@ -77,7 +133,14 @@ export const createSceneEditorDraftPersistence = ({
 } = {}) => {
   const flushSceneEditorDrafts = async (
     deps,
-    { liveLines, showErrorAlert = true } = {},
+    {
+      liveLines,
+      showErrorAlert = true,
+      rescheduleReason = "text",
+      force = false,
+      deferIfInFlight = !force,
+      enforceMinInterval = !force,
+    } = {},
   ) => {
     const { store } = deps;
     clearScheduledDraftFlush(store);
@@ -92,84 +155,144 @@ export const createSceneEditorDraftPersistence = ({
       return;
     }
 
-    return enqueueLatestSceneEditorPersistence({
-      owner: deps.projectService,
-      key: "draft-flush",
-      task: async () => {
-        const draftSection =
-          Array.isArray(liveLines) && liveLines.length > 0
-            ? syncDraftSectionFromLines(deps, liveLines) ||
-              store.selectDraftSection()
-            : syncDraftSectionFromLiveEditor(deps) ||
-              store.selectDraftSection();
-        const snapshotLines =
-          Array.isArray(liveLines) && liveLines.length > 0
-            ? cloneSceneEditorLines(liveLines)
-            : cloneSceneEditorLines(draftSection?.lines);
-        if (snapshotLines.length === 0) {
-          return;
-        }
+    const draftReason = getSceneEditorDraftReason(
+      store.selectDraftSection(),
+      rescheduleReason,
+    );
 
-        const flushStartedAt = nowMs();
-        store.setLastDraftFlushStartedAt({
-          timestamp: flushStartedAt,
-        });
-        store.setDraftSavePendingSinceAt({ timestamp: 0 });
+    if (
+      enforceMinInterval &&
+      getSceneEditorDraftFlushThrottleDelayMs(store, {
+        reason: draftReason,
+        nowMs,
+        owner: deps.projectService,
+        timing,
+      }) > 0
+    ) {
+      scheduleSceneEditorDraftFlush(deps, {
+        reason: draftReason,
+      });
+      return;
+    }
 
-        try {
-          await deps.projectService.syncSectionLinesSnapshot({
-            sectionId: draftSection?.sectionId,
-            lines: snapshotLines,
-          });
-          syncStoreProjectState(store, deps.projectService);
-          const currentDraftSection = store.selectDraftSection();
-          const revision = store.selectRepositoryRevision();
-          const isSameDraftTarget =
-            currentDraftSection?.sceneId === draftSection?.sceneId &&
-            currentDraftSection?.sectionId === draftSection?.sectionId;
-          const didDraftAdvance =
-            isSameDraftTarget &&
-            !areSceneEditorLinesEqual(
-              currentDraftSection?.lines,
-              snapshotLines,
-            );
+    if (deferIfInFlight && store.selectDraftFlushInFlight?.()) {
+      scheduleSceneEditorDraftFlush(deps, {
+        reason: draftReason,
+      });
+      return;
+    }
 
-          if (didDraftAdvance) {
-            store.setDraftSection({
-              draftSection: rebaseSceneEditorDraftSection(currentDraftSection, {
-                revision,
-              }),
+    store.setDraftFlushInFlight?.({ value: true });
+    try {
+      return await enqueueLatestSceneEditorPersistence({
+        owner: deps.projectService,
+        key: "draft-flush",
+        task: async () => {
+          const draftSection =
+            Array.isArray(liveLines) && liveLines.length > 0
+              ? syncDraftSectionFromLines(deps, liveLines) ||
+                store.selectDraftSection()
+              : syncDraftSectionFromLiveEditor(deps) ||
+                store.selectDraftSection();
+          const taskDraftReason = getSceneEditorDraftReason(
+            draftSection,
+            draftReason,
+          );
+          if (
+            enforceMinInterval &&
+            getSceneEditorDraftFlushThrottleDelayMs(store, {
+              reason: taskDraftReason,
+              nowMs,
+              owner: deps.projectService,
+              timing,
+            }) > 0
+          ) {
+            scheduleSceneEditorDraftFlush(deps, {
+              reason: taskDraftReason,
             });
-            setTimeout(() => {
-              void flushSceneEditorDrafts(deps).catch(() => {});
-            }, 0);
             return;
           }
 
-          if (isSameDraftTarget) {
-            store.setDraftSection({
-              draftSection: markSceneEditorDraftSectionClean(
-                currentDraftSection,
-                {
-                  revision,
-                },
-              ),
-            });
-            reconcileCurrentEditorSession(deps);
+          const snapshotLines =
+            Array.isArray(liveLines) && liveLines.length > 0
+              ? cloneSceneEditorLines(liveLines)
+              : cloneSceneEditorLines(draftSection?.lines);
+          if (snapshotLines.length === 0) {
+            return;
           }
 
-          deps.render();
-        } catch (error) {
-          if (showErrorAlert) {
-            deps.appService?.showAlert({
-              message: "Failed to save scene changes",
-              title: "Error",
+          const flushStartedAt = nowMs();
+          const ownerTiming = getDraftFlushTiming(deps.projectService);
+          ownerTiming.lastFlushStartedAt = flushStartedAt;
+          store.setLastDraftFlushStartedAt({
+            timestamp: flushStartedAt,
+          });
+          store.setDraftSavePendingSinceAt({ timestamp: 0 });
+
+          try {
+            await deps.projectService.syncSectionLinesSnapshot({
+              sectionId: draftSection?.sectionId,
+              lines: snapshotLines,
             });
+            syncStoreProjectState(store, deps.projectService);
+            const currentDraftSection = store.selectDraftSection();
+            const revision = store.selectRepositoryRevision();
+            const isSameDraftTarget =
+              currentDraftSection?.sceneId === draftSection?.sceneId &&
+              currentDraftSection?.sectionId === draftSection?.sectionId;
+            const didDraftAdvance =
+              isSameDraftTarget &&
+              !areSceneEditorLinesEqual(
+                currentDraftSection?.lines,
+                snapshotLines,
+              );
+
+            if (didDraftAdvance) {
+              const nextDraftReason = getSceneEditorDraftReason(
+                currentDraftSection,
+                rescheduleReason,
+              );
+              store.setDraftSection({
+                draftSection: rebaseSceneEditorDraftSection(
+                  currentDraftSection,
+                  {
+                    revision,
+                  },
+                ),
+              });
+              scheduleSceneEditorDraftFlush(deps, {
+                reason: nextDraftReason,
+              });
+              return;
+            }
+
+            if (isSameDraftTarget) {
+              store.setDraftSection({
+                draftSection: markSceneEditorDraftSectionClean(
+                  currentDraftSection,
+                  {
+                    revision,
+                  },
+                ),
+              });
+              reconcileCurrentEditorSession(deps);
+            }
+
+            deps.render();
+          } catch (error) {
+            if (showErrorAlert) {
+              deps.appService?.showAlert({
+                message: "Failed to save scene changes",
+                title: "Error",
+              });
+            }
+            throw error;
           }
-          throw error;
-        }
-      },
-    });
+        },
+      });
+    } finally {
+      store.setDraftFlushInFlight?.({ value: false });
+    }
   };
 
   const cancelSceneEditorDraftFlush = (deps) => {
@@ -196,7 +319,10 @@ export const createSceneEditorDraftPersistence = ({
     }
 
     if (immediate) {
-      return flushSceneEditorDrafts(deps);
+      return flushSceneEditorDrafts(deps, {
+        rescheduleReason: reason,
+        force: true,
+      });
     }
 
     const delayMs = getSceneEditorDraftSaveDelayMs(store, {
@@ -205,14 +331,20 @@ export const createSceneEditorDraftPersistence = ({
       timing,
     });
     const timerId = setTimeout(() => {
-      void flushSceneEditorDrafts(deps).catch(() => {});
+      void flushSceneEditorDrafts(deps, {
+        rescheduleReason: reason,
+      }).catch(() => {});
     }, delayMs);
     store.setDraftSaveTimerId({ timerId });
   };
 
   const runSceneEditorPersistence = async (deps, task, options = {}) => {
     if (hasPendingSceneEditorDraftChanges(deps.store.selectDraftSection())) {
-      await flushSceneEditorDrafts(deps).catch(() => {});
+      await flushSceneEditorDrafts(deps, {
+        deferIfInFlight: true,
+        enforceMinInterval: true,
+        force: true,
+      }).catch(() => {});
     }
 
     return enqueueSceneEditorPersistence({

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -62,57 +62,12 @@ const getLinesEditorRef = (refs) => {
   return refs?.linesEditor;
 };
 
-const cloneControlAction = (action) => {
-  if (!action || typeof action !== "object") {
-    return undefined;
-  }
-
-  return structuredClone(action);
-};
-
-const findFirstControlAction = (repositoryState) => {
-  const controls = repositoryState?.controls?.items || {};
-
-  for (const [controlId, control] of Object.entries(controls)) {
-    if (control?.type === "control") {
-      return {
-        resourceId: controlId,
-        resourceType: "control",
-      };
-    }
-  }
-
-  return undefined;
-};
-
-const resolveDocumentLineControlAction = ({
-  repositoryState,
-  line,
-  fallbackLine,
-} = {}) => {
-  const primaryAction = cloneControlAction(line?.actions?.control);
-  if (primaryAction) {
-    return primaryAction;
-  }
-
-  const fallbackAction = cloneControlAction(fallbackLine?.actions?.control);
-  if (fallbackAction) {
-    return fallbackAction;
-  }
-
-  return findFirstControlAction(repositoryState);
-};
-
-const createDocumentDraftLine = ({ lineId, sectionId, controlAction } = {}) => {
+const createDocumentDraftLine = ({ lineId, sectionId } = {}) => {
   const actions = {
     dialogue: {
       content: createEmptyContent(),
     },
   };
-
-  if (controlAction) {
-    actions.control = controlAction;
-  }
 
   return {
     id: lineId || generateId(),
@@ -404,7 +359,7 @@ export const handleBeforeMount = (deps) => {
   return async () => {
     projectSubscription.unsubscribe();
     cleanupRuntimeSubscriptions();
-    await flushSceneEditorDrafts(deps);
+    await flushSceneEditorDrafts(deps, { force: true });
     await projectService.clearActiveSceneId().catch(() => {});
     await resetSceneEditorRuntime(deps);
   };
@@ -451,7 +406,7 @@ export const handleSectionTabClick = async (deps, payload) => {
     payload._event.currentTarget?.dataset?.sectionId ||
     payload._event.currentTarget?.id?.replace("sectionTab", "") ||
     "";
-  await flushSceneEditorDrafts(deps);
+  await flushSceneEditorDrafts(deps, { force: true });
   await selectSceneEditorSection(deps, sectionId);
   reconcileCurrentEditorSession(deps);
   deps.render();
@@ -809,9 +764,7 @@ export const handleEditorBlur = async (deps) => {
       return;
     }
 
-    Promise.resolve(
-      scheduleSceneEditorDraftFlush(deps, { immediate: true }),
-    ).catch(() => {});
+    scheduleSceneEditorDraftFlush(deps, { reason: "text" });
   }, 0);
 };
 
@@ -992,7 +945,7 @@ export const handleSectionsOverviewRowClick = async (deps, payload) => {
   }
 
   store.closeSectionsOverviewPanel();
-  await flushSceneEditorDrafts(deps);
+  await flushSceneEditorDrafts(deps, { force: true });
   await selectSceneEditorSection(deps, sectionId);
   reconcileCurrentEditorSession(deps);
   deps.render();
@@ -1004,7 +957,7 @@ export const handleNewLine = async (deps, payload) => {
   }
   cancelSceneEditorDraftFlush(deps);
 
-  const { store, render, subject, refs, projectService } = deps;
+  const { store, render, subject, refs } = deps;
   const detail = payload?._event?.detail || {};
   const draftSection =
     store.selectDraftSection() || reconcileCurrentEditorSession(deps);
@@ -1025,17 +978,8 @@ export const handleNewLine = async (deps, payload) => {
   const baseLine = baseLineId
     ? lines.find((line) => line.id === baseLineId)
     : undefined;
-  const fallbackLine = selectedLineId
-    ? lines.find((line) => line.id === selectedLineId)
-    : undefined;
-  const controlAction = resolveDocumentLineControlAction({
-    repositoryState: projectService.getRepositoryState(),
-    line: baseLine,
-    fallbackLine,
-  });
   const newLine = createDocumentDraftLine({
     sectionId: draftSection.sectionId || baseLine?.sectionId,
-    controlAction,
   });
   const baseIndex = baseLineId
     ? lines.findIndex((line) => line.id === baseLineId)
@@ -1290,7 +1234,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   if (typeof action === "string" && action.startsWith("go-to-section:")) {
     const nextSectionId = action.replace("go-to-section:", "");
     if (nextSectionId) {
-      await flushSceneEditorDrafts(deps);
+      await flushSceneEditorDrafts(deps, { force: true });
       await selectSceneEditorSection(deps, nextSectionId);
       reconcileCurrentEditorSession(deps);
       render();
@@ -1299,7 +1243,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   }
 
   if (action === "delete-section") {
-    await flushSceneEditorDrafts(deps);
+    await flushSceneEditorDrafts(deps, { force: true });
     await runSceneEditorPersistence(
       deps,
       async () => {
@@ -1608,6 +1552,7 @@ export const handlePreviewClick = (deps, payload) => {
       await flushSceneEditorDrafts(deps, {
         liveLines,
         showErrorAlert: false,
+        force: true,
       });
       syncStoreProjectState(store, projectService);
       didPersistDraft = true;
@@ -1772,7 +1717,7 @@ export const handleHidePreviewScene = async (deps) => {
 
 export const handleBackClick = async (deps) => {
   const { appService } = deps;
-  await flushSceneEditorDrafts(deps);
+  await flushSceneEditorDrafts(deps, { force: true });
   const { p } = appService.getPayload();
   appService.navigate("/project/scenes", { p });
 };

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -522,6 +522,7 @@ export const createInitialState = () => ({
   draftSaveTimerId: undefined,
   lastDraftFlushStartedAt: 0,
   draftSavePendingSinceAt: 0,
+  draftFlushInFlight: false,
   previewVisible: false,
   previewSceneId: undefined,
   previewSectionId: undefined,
@@ -581,6 +582,10 @@ export const setLastDraftFlushStartedAt = ({ state }, { timestamp } = {}) => {
 
 export const setDraftSavePendingSinceAt = ({ state }, { timestamp } = {}) => {
   state.draftSavePendingSinceAt = Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+export const setDraftFlushInFlight = ({ state }, { value } = {}) => {
+  state.draftFlushInFlight = value === true;
 };
 
 export const showPreviewSceneId = (
@@ -698,6 +703,10 @@ export const selectLastDraftFlushStartedAt = ({ state }) => {
 
 export const selectDraftSavePendingSinceAt = ({ state }) => {
   return state.draftSavePendingSinceAt;
+};
+
+export const selectDraftFlushInFlight = ({ state }) => {
+  return state.draftFlushInFlight === true;
 };
 
 export const selectCharacters = ({ state }) => {

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -522,27 +522,12 @@ const isPlainShortcutKey = (event, key) => {
   );
 };
 
-const cloneControlAction = (action) => {
-  if (!action || typeof action !== "object") {
-    return undefined;
-  }
-
-  return structuredClone(action);
-};
-
-const createNewLineActions = (templateActions = {}) => {
-  const nextActions = {
+const createNewLineActions = () => {
+  return {
     dialogue: {
       content: createEmptyContent(),
     },
   };
-  const controlAction = cloneControlAction(templateActions?.control);
-
-  if (controlAction) {
-    nextActions.control = controlAction;
-  }
-
-  return nextActions;
 };
 
 const toFiniteTimestamp = (value, fallback = 0) => {
@@ -589,7 +574,7 @@ const createNewLineMeta = (templateMeta = {}) => {
       templateMeta?.updatedAt,
       toFiniteTimestamp(templateMeta?.createdAt, 0),
     ),
-    actions: createNewLineActions(templateMeta?.actions),
+    actions: createNewLineActions(),
   };
 };
 

--- a/tests/commandApi/storyCommandApi.test.js
+++ b/tests/commandApi/storyCommandApi.test.js
@@ -266,4 +266,115 @@ describe("story command api", () => {
       },
     });
   });
+
+  it("logs the section line snapshot diff before submitting commands", async () => {
+    const context = {
+      projectId: "project-1",
+      state: {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              sections: {
+                items: {
+                  "section-1": {
+                    id: "section-1",
+                    lines: {
+                      items: {
+                        "line-1": {
+                          id: "line-1",
+                          actions: {
+                            dialogue: {
+                              content: [{ text: "Old" }],
+                            },
+                          },
+                        },
+                        "line-2": {
+                          id: "line-2",
+                          actions: {},
+                        },
+                      },
+                      tree: [{ id: "line-1" }, { id: "line-2" }],
+                    },
+                  },
+                },
+                tree: [{ id: "section-1" }],
+              },
+            },
+          },
+          tree: [{ id: "scene-1" }],
+        },
+      },
+    };
+    const shared = {
+      ensureCommandContext: vi.fn(async () => context),
+      submitCommandsWithContext: vi.fn(async () => ({ valid: true })),
+      scenePartitionFor: vi.fn(() => "s:scene-1"),
+      storyBasePartitionFor: vi.fn(() => "m"),
+    };
+    const api = createStoryCommandApi(shared);
+
+    await api.syncSectionLinesSnapshot({
+      sectionId: "section-1",
+      lines: [
+        {
+          id: "line-3",
+          actions: {},
+        },
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "New" }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+      context,
+      commands: [
+        {
+          scope: "story",
+          type: COMMAND_TYPES.LINE_DELETE,
+          payload: {
+            lineIds: ["line-2"],
+          },
+          partition: "s:scene-1",
+        },
+        {
+          scope: "story",
+          type: COMMAND_TYPES.LINE_CREATE,
+          payload: {
+            sectionId: "section-1",
+            lines: [
+              {
+                lineId: "line-3",
+                data: {
+                  actions: {},
+                },
+              },
+            ],
+            index: 0,
+          },
+          partition: "s:scene-1",
+        },
+        {
+          scope: "story",
+          type: COMMAND_TYPES.LINE_UPDATE_ACTIONS,
+          payload: {
+            lineId: "line-1",
+            data: {
+              dialogue: {
+                content: [{ text: "New" }],
+              },
+            },
+          },
+          partition: "s:scene-1",
+        },
+      ],
+    });
+  });
 });

--- a/tests/sceneEditor/lexicalDraftPersistence.test.js
+++ b/tests/sceneEditor/lexicalDraftPersistence.test.js
@@ -29,6 +29,7 @@ const createStore = ({
   lastDraftFlushStartedAt = 0,
   draftSavePendingSinceAt = 0,
   draftSaveTimerId,
+  draftFlushInFlight = false,
 } = {}) => {
   const state = {
     draftSection,
@@ -36,6 +37,7 @@ const createStore = ({
     lastDraftFlushStartedAt,
     draftSavePendingSinceAt,
     draftSaveTimerId,
+    draftFlushInFlight,
   };
 
   return {
@@ -52,6 +54,10 @@ const createStore = ({
     selectDraftSavePendingSinceAt: () => state.draftSavePendingSinceAt,
     setDraftSavePendingSinceAt: ({ timestamp }) => {
       state.draftSavePendingSinceAt = timestamp;
+    },
+    selectDraftFlushInFlight: () => state.draftFlushInFlight,
+    setDraftFlushInFlight: ({ value }) => {
+      state.draftFlushInFlight = value === true;
     },
     selectDraftSaveTimerId: () => state.draftSaveTimerId,
     setDraftSaveTimerId: ({ timerId }) => {
@@ -79,13 +85,238 @@ describe("scene editor lexical draft persistence", () => {
         reason: "text",
         nowMs: () => 2500,
       }),
-    ).toBe(2500);
+    ).toBe(3500);
     expect(
       getSceneEditorDraftSaveDelayMs(maxWaitStore, {
         reason: "text",
         nowMs: () => 9500,
       }),
     ).toBe(1500);
+  });
+
+  it("does not let max wait bypass the text throttle after a flush", () => {
+    const store = createStore({
+      lastDraftFlushStartedAt: 9000,
+      draftSavePendingSinceAt: 1000,
+    });
+
+    expect(
+      getSceneEditorDraftSaveDelayMs(store, {
+        reason: "text",
+        nowMs: () => 9500,
+      }),
+    ).toBe(4500);
+  });
+
+  it("guards direct non-forced flushes with the text throttle", async () => {
+    vi.useFakeTimers();
+    let now = 1200;
+    const store = createStore({
+      lastDraftFlushStartedAt: 1000,
+      draftSavePendingSinceAt: 1100,
+    });
+    const syncSectionLinesSnapshot = vi.fn(async () => {});
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession: vi.fn(),
+      nowMs: () => now,
+    });
+
+    try {
+      await controller.flushSceneEditorDrafts(
+        {
+          store,
+          projectService: {
+            syncSectionLinesSnapshot,
+          },
+          render: vi.fn(),
+          appService: {
+            showAlert: vi.fn(),
+          },
+        },
+        { rescheduleReason: "text" },
+      );
+
+      expect(syncSectionLinesSnapshot).not.toHaveBeenCalled();
+      expect(store.state.draftSaveTimerId).toBeDefined();
+
+      now = 6000;
+      await vi.advanceTimersByTimeAsync(4800);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps throttling non-forced flushes if store timing is reset", async () => {
+    vi.useFakeTimers();
+    let now = 1000;
+    const store = createStore();
+    const syncSectionLinesSnapshot = vi.fn(async () => {});
+    const projectService = {
+      syncSectionLinesSnapshot,
+    };
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession: vi.fn(),
+      nowMs: () => now,
+    });
+    const deps = {
+      store,
+      projectService,
+      render: vi.fn(),
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    try {
+      await controller.flushSceneEditorDrafts(deps);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+
+      store.setLastDraftFlushStartedAt({ timestamp: 0 });
+      store.setDraftSection({
+        draftSection: createDirtyDraftSection([createLine("line-1", "After")]),
+      });
+      now = 1200;
+      await controller.flushSceneEditorDrafts(deps);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+      expect(store.state.draftSaveTimerId).toBeDefined();
+
+      now = 6000;
+      await vi.advanceTimersByTimeAsync(4800);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not force a draft write from action persistence inside the throttle window", async () => {
+    vi.useFakeTimers();
+    let now = 1000;
+    const store = createStore();
+    const syncSectionLinesSnapshot = vi.fn(async () => {});
+    const actionTask = vi.fn(async () => {});
+    const projectService = {
+      syncSectionLinesSnapshot,
+    };
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession: vi.fn(),
+      nowMs: () => now,
+    });
+    const deps = {
+      store,
+      projectService,
+      render: vi.fn(),
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    try {
+      await controller.flushSceneEditorDrafts(deps);
+
+      store.setDraftSection({
+        draftSection: createDirtyDraftSection([createLine("line-1", "After")]),
+      });
+      now = 1200;
+
+      await controller.runSceneEditorPersistence(deps, actionTask);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+      expect(actionTask).toHaveBeenCalledOnce();
+      expect(store.state.draftSaveTimerId).toBeDefined();
+
+      now = 6000;
+      await vi.advanceTimersByTimeAsync(4800);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("guards a queued draft task before it writes inside the throttle window", async () => {
+    vi.useFakeTimers();
+    let now = 1000;
+    let releaseFirstFlush;
+    const initialLine = createLine("line-1", "Before");
+    const advancedLine = createLine("line-1", "After");
+    const store = createStore({
+      draftSection: createDirtyDraftSection([initialLine]),
+    });
+    const syncSectionLinesSnapshot = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          releaseFirstFlush = resolve;
+        }),
+    );
+    const projectService = {
+      syncSectionLinesSnapshot,
+    };
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession: vi.fn(),
+      nowMs: () => now,
+    });
+    const deps = {
+      store,
+      projectService,
+      render: vi.fn(),
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    try {
+      const firstFlush = controller.flushSceneEditorDrafts(deps, {
+        force: true,
+        enforceMinInterval: true,
+      });
+      while (syncSectionLinesSnapshot.mock.calls.length === 0) {
+        await Promise.resolve();
+      }
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+
+      store.setDraftSection({
+        draftSection: createDirtyDraftSection([advancedLine]),
+      });
+      void controller.flushSceneEditorDrafts(deps, {
+        deferIfInFlight: false,
+        enforceMinInterval: true,
+        force: true,
+      });
+
+      releaseFirstFlush();
+      await firstFlush;
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+      expect(store.state.draftSaveTimerId).toBeDefined();
+
+      syncSectionLinesSnapshot.mockImplementation(async () => {});
+      now = 6000;
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(2);
+      expect(syncSectionLinesSnapshot).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sectionId: "section-1",
+          lines: [advancedLine],
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("flushes a dirty draft section through syncSectionLinesSnapshot and marks it clean", async () => {
@@ -111,10 +342,12 @@ describe("scene editor lexical draft persistence", () => {
       },
     });
 
-    expect(syncSectionLinesSnapshot).toHaveBeenCalledWith({
-      sectionId: "section-1",
-      lines: [createLine("line-1", "Hello")],
-    });
+    expect(syncSectionLinesSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionId: "section-1",
+        lines: [createLine("line-1", "Hello")],
+      }),
+    );
     expect(store.state.lastDraftFlushStartedAt).toBe(1234);
     expect(store.state.draftSavePendingSinceAt).toBe(0);
     expect(store.state.draftSection).toMatchObject({
@@ -124,5 +357,206 @@ describe("scene editor lexical draft persistence", () => {
     });
     expect(reconcileCurrentEditorSession).toHaveBeenCalledOnce();
     expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("reschedules an advanced draft through debounce instead of immediately flushing another row", async () => {
+    vi.useFakeTimers();
+    let now = 5000;
+    const initialLine = createLine("line-1", "Before");
+    const advancedLine = createLine("line-1", "After");
+    const store = createStore({
+      draftSection: createDirtyDraftSection([initialLine]),
+      revision: 2,
+    });
+    const render = vi.fn();
+    const reconcileCurrentEditorSession = vi.fn();
+    const syncSectionLinesSnapshot = vi.fn(async () => {
+      store.setDraftSection({
+        draftSection: createDirtyDraftSection([advancedLine]),
+      });
+    });
+    const projectService = {
+      syncSectionLinesSnapshot,
+    };
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession,
+      nowMs: () => now,
+    });
+
+    try {
+      await controller.flushSceneEditorDrafts({
+        store,
+        projectService,
+        render,
+        appService: {
+          showAlert: vi.fn(),
+        },
+      });
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(1);
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sectionId: "section-1",
+          lines: [initialLine],
+        }),
+      );
+      expect(store.state.draftSection).toMatchObject({
+        dirty: true,
+        baseRevision: 2,
+        lines: [advancedLine],
+      });
+      expect(store.state.draftSaveTimerId).toBeDefined();
+      expect(render).not.toHaveBeenCalled();
+      expect(reconcileCurrentEditorSession).not.toHaveBeenCalled();
+
+      now = 10000;
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(2);
+      expect(syncSectionLinesSnapshot).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sectionId: "section-1",
+          lines: [advancedLine],
+        }),
+      );
+      expect(store.state.draftSection).toMatchObject({
+        dirty: false,
+        baseRevision: 2,
+        lastSource: "repository",
+      });
+      expect(render).toHaveBeenCalledOnce();
+      expect(reconcileCurrentEditorSession).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defers scheduled autosaves while a draft flush is already in flight", async () => {
+    vi.useFakeTimers();
+    let now = 1000;
+    const store = createStore({
+      draftFlushInFlight: true,
+    });
+    const syncSectionLinesSnapshot = vi.fn(async () => {});
+    const render = vi.fn();
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession: vi.fn(),
+      nowMs: () => now,
+    });
+
+    try {
+      controller.scheduleSceneEditorDraftFlush(
+        {
+          store,
+          projectService: {
+            syncSectionLinesSnapshot,
+          },
+          render,
+          appService: {
+            showAlert: vi.fn(),
+          },
+        },
+        { reason: "text" },
+      );
+
+      now = 3000;
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect(syncSectionLinesSnapshot).not.toHaveBeenCalled();
+      expect(store.state.draftFlushInFlight).toBe(true);
+      expect(store.state.draftSaveTimerId).toBeDefined();
+
+      store.setDraftFlushInFlight({ value: false });
+      now = 5000;
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sectionId: "section-1",
+          lines: [createLine("line-1", "Hello")],
+        }),
+      );
+      expect(store.state.draftFlushInFlight).toBe(false);
+      expect(store.state.draftSection).toMatchObject({
+        dirty: false,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not queue an immediate follow-up autosave behind an active flush", async () => {
+    vi.useFakeTimers();
+    let now = 1000;
+    let releaseFirstFlush;
+    const initialLine = createLine("line-1", "Before");
+    const advancedLine = createLine("line-1", "After");
+    const store = createStore({
+      draftSection: createDirtyDraftSection([initialLine]),
+    });
+    const syncSectionLinesSnapshot = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          releaseFirstFlush = resolve;
+        }),
+    );
+    const render = vi.fn();
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: (deps) => deps.store.selectDraftSection(),
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession: vi.fn(),
+      nowMs: () => now,
+    });
+    const deps = {
+      store,
+      projectService: {
+        syncSectionLinesSnapshot,
+      },
+      render,
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    try {
+      const firstFlush = controller.flushSceneEditorDrafts(deps);
+      while (syncSectionLinesSnapshot.mock.calls.length === 0) {
+        await Promise.resolve();
+      }
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+      expect(store.state.draftFlushInFlight).toBe(true);
+
+      store.setDraftSection({
+        draftSection: createDirtyDraftSection([advancedLine]),
+      });
+      controller.flushSceneEditorDrafts(deps);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+      expect(store.state.draftSaveTimerId).toBeDefined();
+
+      releaseFirstFlush();
+      await firstFlush;
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledOnce();
+
+      now = 6000;
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(2);
+      expect(syncSectionLinesSnapshot).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sectionId: "section-1",
+          lines: [advancedLine],
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -364,4 +364,95 @@ describe("lexical scene document editor line editing", () => {
       restoreDomGlobals();
     }
   });
+
+  it("does not copy control actions when splitting a line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-line-split-control-copy-test",
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.scrollLineIntoView = vi.fn();
+      editorElement.focusLine = vi.fn();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+
+          line.append($createTextNode("Hello world"));
+          root.append(line);
+          lineKey = line.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            sectionId: "section-1",
+            actions: {
+              dialogue: {
+                content: [{ text: "Hello world" }],
+              },
+              control: {
+                resourceId: "control-1",
+                resourceType: "control",
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+        },
+        { discrete: true },
+      );
+
+      editorElement.getLineSelectionContext = vi.fn(() => ({
+        lineKey,
+        lineId: "line-1",
+        selection: {
+          start: 5,
+          end: 5,
+        },
+        lineContent: [{ text: "Hello world" }],
+      }));
+
+      editorElement.splitCurrentLine();
+
+      const lines = editorElement.getLinesSnapshot();
+
+      expect(lines).toHaveLength(2);
+      expect(lines[0].actions.control).toEqual({
+        resourceId: "control-1",
+        resourceType: "control",
+      });
+      expect(lines[1].actions.control).toBeUndefined();
+      expect(lines[1].actions.dialogue.content).toEqual([{ text: " world" }]);
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleActionsDialogClose,
   handleCommandLineSubmit,
+  handleEditorBlur,
+  handleNewLine,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
 describe("sceneEditorLexical.handlers actions dialog", () => {
@@ -132,5 +134,157 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       },
       preserve: ["dialogue.content"],
     });
+  });
+
+  it("debounces draft persistence on editor blur instead of flushing immediately", async () => {
+    vi.useFakeTimers();
+    const state = {
+      draftSavePendingSinceAt: 0,
+      draftSaveTimerId: undefined,
+    };
+    const store = {
+      selectSkipNextEditorBlurDraftFlush: vi.fn(() => false),
+      selectDraftSection: vi.fn(() => ({
+        dirty: true,
+        sceneId: "scene-1",
+        sectionId: "section-1",
+        lines: [
+          {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [{ text: "Hello" }],
+              },
+            },
+          },
+        ],
+      })),
+      selectDraftSaveTimerId: vi.fn(() => state.draftSaveTimerId),
+      clearDraftSaveTimer: vi.fn(() => {
+        state.draftSaveTimerId = undefined;
+      }),
+      selectDraftSavePendingSinceAt: vi.fn(() => state.draftSavePendingSinceAt),
+      setDraftSavePendingSinceAt: vi.fn(({ timestamp }) => {
+        state.draftSavePendingSinceAt = timestamp;
+      }),
+      selectLastDraftFlushStartedAt: vi.fn(() => 0),
+      setDraftSaveTimerId: vi.fn(({ timerId }) => {
+        state.draftSaveTimerId = timerId;
+      }),
+    };
+    const syncSectionLinesSnapshot = vi.fn(async () => {});
+
+    try {
+      handleEditorBlur({
+        store,
+        render: vi.fn(),
+        projectService: {
+          syncSectionLinesSnapshot,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(store.setDraftSaveTimerId).toHaveBeenCalledTimes(1);
+      expect(syncSectionLinesSnapshot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not copy control actions onto newly inserted draft lines", async () => {
+    vi.useFakeTimers();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const state = {
+      draftSavePendingSinceAt: 0,
+      draftSaveTimerId: undefined,
+      selectedLineId: "line-1",
+      draftSection: {
+        sceneId: "scene-1",
+        sectionId: "section-1",
+        dirty: false,
+        lines: [
+          {
+            id: "line-1",
+            sectionId: "section-1",
+            actions: {
+              dialogue: {
+                content: [{ text: "Hello" }],
+              },
+              control: {
+                resourceId: "control-1",
+                resourceType: "control",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const store = {
+      selectIsSectionsOverviewOpen: vi.fn(() => false),
+      selectDraftSaveTimerId: vi.fn(() => state.draftSaveTimerId),
+      clearDraftSaveTimer: vi.fn(() => {
+        state.draftSaveTimerId = undefined;
+      }),
+      selectDraftSection: vi.fn(() => state.draftSection),
+      setDraftSection: vi.fn(({ draftSection }) => {
+        state.draftSection = draftSection;
+      }),
+      selectSelectedLineId: vi.fn(() => state.selectedLineId),
+      setSelectedLineId: vi.fn(({ selectedLineId }) => {
+        state.selectedLineId = selectedLineId;
+      }),
+      selectDraftSavePendingSinceAt: vi.fn(
+        () => state.draftSavePendingSinceAt,
+      ),
+      setDraftSavePendingSinceAt: vi.fn(({ timestamp }) => {
+        state.draftSavePendingSinceAt = timestamp;
+      }),
+      selectLastDraftFlushStartedAt: vi.fn(() => 0),
+      setDraftSaveTimerId: vi.fn(({ timerId }) => {
+        state.draftSaveTimerId = timerId;
+      }),
+    };
+
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+
+    try {
+      await handleNewLine(
+        {
+          store,
+          render: vi.fn(),
+          subject: {
+            dispatch: vi.fn(),
+          },
+          refs: {},
+        },
+        {
+          _event: {
+            detail: {
+              lineId: "line-1",
+              position: "after",
+            },
+          },
+        },
+      );
+
+      expect(state.draftSection.lines).toHaveLength(2);
+      expect(state.draftSection.lines[0].actions.control).toEqual({
+        resourceId: "control-1",
+        resourceType: "control",
+      });
+      expect(state.draftSection.lines[1].actions).toEqual({
+        dialogue: {
+          content: [{ text: "" }],
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- throttle and coalesce scene editor draft flushes so text autosaves do not persist every intermediate snapshot
- keep explicit leave-context flows as forced saves while normal blur/autosave stays debounced
- stop newly inserted, split, and pasted Lexical lines from inheriting actions.control
- document the scene editor draft persistence contract

## Testing
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/lexicalDraftPersistence.test.js tests/commandApi/submitCommandsSnapshot.test.js tests/commandApi/storyCommandApi.test.js
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src