### PR TITLE
Bump Tauri app version to 1.2.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump Tauri app version from 1.1.1 to 1.2.0

## Testing
- not run; config-only version bump
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src