### PR TITLE
fix: materialize normalized creator model state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.4.0",
+        "@routevn/creator-model": "1.4.1",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -280,7 +280,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.4.0", "", {}, "sha512-BQ8GE25Iz7VgE0cbpMXaDfyfU4W/R3zgTBW40xv7qYuOzZByeCPgFjU5ez4tGTQCajy/mc9bETyOaZ4V6RD/+Q=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.4.1", "", {}, "sha512-NiJVhEKff0pqwJxB8NkpunRpxlNGszZkGVvV8GB+ugjF4DJZKDIfs1kU7d10RT92nfuc5g91J2n8NB/jRAMuLg=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "1.4.0",
+    "@routevn/creator-model": "1.4.1",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/deps/services/shared/projectRepository.js
+++ b/src/deps/services/shared/projectRepository.js
@@ -8,6 +8,7 @@ import {
 import {
   applyCommandToRepositoryStateWithCreatorModel,
   applyCommandsToRepositoryStateWithCreatorModel,
+  normalizeRepositoryStateWithCreatorModel,
   toCreatorModelState,
   validateClientModelStateExtensions,
 } from "../../../internal/creatorModelAdapter.js";
@@ -673,6 +674,7 @@ export const createProjectRepository = async ({
 
       return applyResult.repositoryState;
     },
+    normalizeState: normalizeRepositoryStateWithCreatorModel,
     assertState: assertSupportedProjectState,
     onHydrationProgress,
   });

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -472,6 +472,7 @@ export const createProjectRepositoryRuntime = async ({
   createInitialState,
   reduceEventToState,
   reduceEventsToState,
+  normalizeState = (state) => state,
   assertState = () => {},
   onHydrationProgress = () => {},
 }) => {
@@ -614,6 +615,18 @@ export const createProjectRepositoryRuntime = async ({
     activeHydrationProgress = undefined;
   };
 
+  const loadCurrentMainState = async () => {
+    const loadedState = cloneState(
+      await materializedViewRuntime.loadMaterializedView({
+        viewName: MAIN_VIEW_NAME,
+        partition: MAIN_PARTITION,
+      }),
+      createMainProjectionState(createInitialState()),
+    );
+
+    return createMainProjectionState(normalizeState(loadedState));
+  };
+
   const materializedViewRuntime = createMaterializedViewRuntime({
     materializedViews: [
       createMainStateViewDefinition({
@@ -678,15 +691,7 @@ export const createProjectRepositoryRuntime = async ({
   let currentMainState;
 
   try {
-    currentMainState = createMainProjectionState(
-      cloneState(
-        await materializedViewRuntime.loadMaterializedView({
-          viewName: MAIN_VIEW_NAME,
-          partition: MAIN_PARTITION,
-        }),
-        createMainProjectionState(createInitialState()),
-      ),
-    );
+    currentMainState = await loadCurrentMainState();
   } finally {
     endInitialMainHydrationProgress({
       progress: initialMainHydrationProgress,
@@ -697,15 +702,7 @@ export const createProjectRepositoryRuntime = async ({
   assertState(currentMainState);
 
   const refreshMainState = async () => {
-    currentMainState = createMainProjectionState(
-      cloneState(
-        await materializedViewRuntime.loadMaterializedView({
-          viewName: MAIN_VIEW_NAME,
-          partition: MAIN_PARTITION,
-        }),
-        createMainProjectionState(createInitialState()),
-      ),
-    );
+    currentMainState = await loadCurrentMainState();
     assertState(currentMainState);
   };
 

--- a/src/internal/creatorModelAdapter.js
+++ b/src/internal/creatorModelAdapter.js
@@ -1,4 +1,5 @@
 import {
+  normalizeState as normalizeCreatorModelState,
   processCommand as processCreatorModelCommand,
   replayCommands as replayCreatorModelCommands,
 } from "@routevn/creator-model";
@@ -51,7 +52,13 @@ const cloneStateWithoutTransformThumbnails = (state) => {
 };
 
 export const toCreatorModelState = (state) => {
-  return cloneStateWithoutTransformThumbnails(state);
+  return cloneStateWithoutTransformThumbnails(
+    normalizeRepositoryStateWithCreatorModel(state),
+  );
+};
+
+export const normalizeRepositoryStateWithCreatorModel = (state) => {
+  return normalizeCreatorModelState({ state });
 };
 
 const toCreatorModelCommand = (command) => {

--- a/tests/projectRepositoryService/projectRepositoryService.mainCheckpoint.test.js
+++ b/tests/projectRepositoryService/projectRepositoryService.mainCheckpoint.test.js
@@ -13,6 +13,58 @@ const noopCollabAdapter = {
   afterCreateRepository: async () => undefined,
 };
 
+const createProjectStateWithDirtyVariables = () => {
+  const state = structuredClone(initialProjectData);
+  state.variables = {
+    items: {
+      "system-variables-folder": {
+        id: "system-variables-folder",
+        type: "folder",
+        name: "System",
+      },
+      _textSpeed: {
+        id: "_textSpeed",
+        type: "number",
+        name: "_textSpeed",
+        scope: "device",
+        default: 50,
+        value: 50,
+      },
+      _muteAll: {
+        id: "_muteAll",
+        type: "boolean",
+        name: "_muteAll",
+        scope: "device",
+        default: false,
+        value: false,
+      },
+      defaultFolder: {
+        id: "defaultFolder",
+        type: "folder",
+        name: "Default",
+      },
+    },
+    tree: [
+      {
+        id: "defaultFolder",
+        children: [],
+      },
+      {
+        id: "system-variables-folder",
+        children: [
+          {
+            id: "_textSpeed",
+          },
+          {
+            id: "_muteAll",
+          },
+        ],
+      },
+    ],
+  };
+  return state;
+};
+
 describe("projectRepositoryService main checkpoint reuse", () => {
   it("skips full event loading when the persisted main checkpoint is current", async () => {
     const repositoryEvents = [
@@ -125,6 +177,131 @@ describe("projectRepositoryService main checkpoint reuse", () => {
 
     expect(listDraftsOrdered).toHaveBeenCalledTimes(1);
     expect(events).toHaveLength(1);
+  });
+
+  it("materializes creator-model normalized state from a reused main checkpoint", async () => {
+    const dirtyState = createProjectStateWithDirtyVariables();
+    const repositoryEvents = [
+      {
+        id: "project-create:project-1",
+        partition: "m",
+        projectId: "project-1",
+        type: "project.create",
+        schemaVersion: 1,
+        payload: {
+          state: dirtyState,
+        },
+        clientTs: 1,
+        meta: {
+          clientTs: 1,
+        },
+      },
+    ];
+    const listDraftsOrdered = vi.fn(async () =>
+      createDraftRowsFromRepositoryEvents(repositoryEvents),
+    );
+    const store = {
+      listCommittedAfter: vi.fn(async () => []),
+      listDraftsOrdered,
+      getCursor: vi.fn(async () => 0),
+      getRepositoryHistoryStats: async () => ({
+        committedCount: 0,
+        latestCommittedId: 0,
+        draftCount: 1,
+        latestDraftClock: 1,
+      }),
+      isRepositoryHistoryStatsEqual: (left, right) =>
+        JSON.stringify(left) === JSON.stringify(right),
+      loadMaterializedViewCheckpoint: async () => ({
+        viewName: "project_repository_main_state",
+        viewVersion: "1",
+        partition: "m",
+        lastCommittedId: 1,
+        value: dirtyState,
+        meta: {
+          historyStats: {
+            committedCount: 0,
+            latestCommittedId: 0,
+            draftCount: 1,
+            latestDraftClock: 1,
+          },
+        },
+        updatedAt: 1,
+      }),
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      deleteMaterializedViewCheckpoint: async () => {},
+      app: {
+        get: async (key) => {
+          if (key === "creatorVersion") {
+            return 1;
+          }
+
+          if (key === "projectInfo") {
+            return {
+              id: "project-1",
+              namespace: "namespace-1",
+              name: "Project 1",
+              description: "",
+              iconFileId: null,
+            };
+          }
+
+          return undefined;
+        },
+        set: vi.fn(async () => {}),
+      },
+    };
+    const storageAdapter = {
+      readCreatorVersionByReference: vi.fn(async () => 1),
+      resolveProjectReferenceByProjectId: vi.fn(async ({ projectId }) => ({
+        projectPath: `/tmp/${projectId}`,
+        cacheKey: `/tmp/${projectId}`,
+        repositoryProjectId: projectId,
+      })),
+      createStore: vi.fn(async () => store),
+    };
+    const service = createProjectRepositoryService({
+      router: {
+        getPayload: () => ({
+          p: "project-1",
+        }),
+      },
+      db: {},
+      creatorVersion: 1,
+      storageAdapter,
+      collabAdapter: noopCollabAdapter,
+    });
+
+    const repository = await service.ensureRepository();
+    const variables = repository.getState().variables;
+
+    expect(listDraftsOrdered).not.toHaveBeenCalled();
+    expect(variables.items._textSpeed).toBeUndefined();
+    expect(variables.items._muteAll).toBeUndefined();
+    expect(variables).toEqual({
+      items: {
+        defaultFolder: {
+          id: "defaultFolder",
+          type: "folder",
+          name: "Default",
+        },
+        "system-variables-folder": {
+          id: "system-variables-folder",
+          type: "folder",
+          name: "System",
+        },
+      },
+      tree: [
+        {
+          id: "defaultFolder",
+          children: [],
+        },
+        {
+          id: "system-variables-folder",
+          children: [],
+        },
+      ],
+    });
   });
 
   it("backfills legacy checkpoint metadata and still skips full event loading", async () => {


### PR DESCRIPTION
## Summary
- update `@routevn/creator-model` to `1.4.1`
- materialize creator-model normalized repository state when loading reused main checkpoints, so dirty legacy variable items do not reach page state
- bump Tauri app version to `1.2.1`
- add checkpoint reuse coverage for dropping unsupported legacy variable item types

## Testing
- `bunx vitest run tests/projectRepositoryService/projectRepositoryService.mainCheckpoint.test.js tests/project/variableEnumMetadata.test.js`
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`
