### PR TITLE
fix: keep command line action footers visible

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -54,41 +54,41 @@ template:
       - rtgl-view d=h g=md: null
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
-          - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues}:
-              - $if selectedResource:
-                  - $if selectedResource.resourceType == 'image':
-                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
-                          - rtgl-view p=md g=md br=md:
-                              - rvn-file-image w=200 h=120 fileId=${selectedResource.fileId}: null
-                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
-                    $elif selectedResource.resourceType == 'layout':
-                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
-                          - 'rtgl-view w=225 br=md style="overflow: hidden;"':
-                              - $if selectedResource.item.thumbnailFileId:
-                                  - rvn-file-image fileId=${selectedResource.item.thumbnailFileId} w=225 h=120: null
-                                $else:
-                                  - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
-                                      - rtgl-text s=sm c=mu-fg: No thumbnail
-                              - rtgl-view d=v w=f g=xs ph=md pt=sm pb=md:
-                                  - rtgl-text s=sm ellipsis w=193: ${selectedResource.name}
-                                  - $if selectedResource.typeInfo:
-                                      - rtgl-text s=xs c=mu-fg ellipsis w=193: ${selectedResource.typeInfo}
-                    $elif selectedResource.resourceType == 'video':
-                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
-                          - rtgl-view p=md g=md br=md:
-                              - rtgl-view pos=rel:
-                                  - rvn-file-image w=200 h=120 fileId=${selectedResource.item.thumbnailFileId}: null
-                                  - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
-                                      - rtgl-icon icon=play s=xl c=fg: null
-                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues}:
+                  - $if selectedResource:
+                      - $if selectedResource.resourceType == 'image':
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
+                              - rtgl-view p=md g=md br=md:
+                                  - rvn-file-image w=200 h=120 fileId=${selectedResource.fileId}: null
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
+                        $elif selectedResource.resourceType == 'layout':
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
+                              - 'rtgl-view w=225 br=md style="overflow: hidden;"':
+                                  - $if selectedResource.item.thumbnailFileId:
+                                      - rvn-file-image fileId=${selectedResource.item.thumbnailFileId} w=225 h=120: null
+                                    $else:
+                                      - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
+                                          - rtgl-text s=sm c=mu-fg: No thumbnail
+                                  - rtgl-view d=v w=f g=xs ph=md pt=sm pb=md:
+                                      - rtgl-text s=sm ellipsis w=193: ${selectedResource.name}
+                                      - $if selectedResource.typeInfo:
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=193: ${selectedResource.typeInfo}
+                        $elif selectedResource.resourceType == 'video':
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
+                              - rtgl-view p=md g=md br=md:
+                                  - rtgl-view pos=rel:
+                                      - rvn-file-image w=200 h=120 fileId=${selectedResource.item.thumbnailFileId}: null
+                                      - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
+                                          - rtgl-icon icon=play s=xl c=fg: null
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
+                        $else:
+                          - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
+                              - rtgl-text s=md c=mu-fg: Select Background
                     $else:
                       - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
                           - rtgl-text s=md c=mu-fg: Select Background
-                $else:
-                  - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
-                      - rtgl-text s=md c=mu-fg: Select Background
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':
           - rtgl-view d=h w=f av=c g=md:
@@ -132,7 +132,7 @@ template:
                                           - rtgl-view p=md g=md br=md:
                                               - rvn-file-image w=200 h=120 fileId=${item.thumbnailFileId}: null
                                               - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -47,17 +47,17 @@ template:
       - rtgl-view d=h g=md: null
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
-          - rtgl-form#form key=${audio.id} :form=${form} :defaultValues=${defaultValues}:
-              - $if defaultValues.audioWaveformDataFileId:
-                  - rtgl-view#audioWaveform slot=audio cur=pointer bw=xs bc=${audio.itemBorderColor} h-bc=${audio.itemHoverBorderColor} br=sm:
-                      - rtgl-view p=md g=md br=md:
-                          - rvn-waveform-visualizer waveformDataFileId=${defaultValues.audioWaveformDataFileId} w=200 h=120: null
-                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${audio.name}
-                $else:
-                  - rtgl-view#audioWaveform w=250 h=150 bgc=mu av=c ah=c cur=pointer slot=audio:
-                      - rtgl-text s=md c=mu-fg: Select BGM
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-form#form key=${audio.id} :form=${form} :defaultValues=${defaultValues}:
+                  - $if defaultValues.audioWaveformDataFileId:
+                      - rtgl-view#audioWaveform slot=audio cur=pointer bw=xs bc=${audio.itemBorderColor} h-bc=${audio.itemHoverBorderColor} br=sm:
+                          - rtgl-view p=md g=md br=md:
+                              - rvn-waveform-visualizer waveformDataFileId=${defaultValues.audioWaveformDataFileId} w=200 h=120: null
+                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${audio.name}
+                    $else:
+                      - rtgl-view#audioWaveform w=250 h=150 bgc=mu av=c ah=c cur=pointer slot=audio:
+                          - rtgl-text s=md c=mu-fg: Select BGM
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':
           - rtgl-view d=h w=f av=c g=md:
@@ -82,7 +82,7 @@ template:
                                               - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
                                                   - rtgl-text s=sm c=mu-fg: No waveform
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - $if showAudioPlayer:
       - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -91,7 +91,7 @@ template:
       - $if mode == 'current':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-view h=1fg sv w=f:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md w=f:
                   - rtgl-form#form :form=${form} :defaultValues=${defaultValues}:
                       - rtgl-view#charactersContainer slot=characters g=md w=f:
@@ -121,7 +121,7 @@ template:
                                                   - 'rtgl-view.characterSpriteGroupBox data-index=${i} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
                                                       - rtgl-text s=xs: ${spriteGroup.name}
                   - rtgl-button#addCharacterButton v=ol w=f mt=md: + Add Character
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'character-select':
           - rtgl-view d=h g=md:
@@ -171,7 +171,7 @@ template:
                                       - rtgl-view p=md g=md br=md:
                                           - rvn-file-image fileId=${item.fileId} w=200 h=120: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
   - $when: fullImagePreviewVisible

--- a/src/components/commandLineChoices/commandLineChoices.view.yaml
+++ b/src/components/commandLineChoices/commandLineChoices.view.yaml
@@ -50,10 +50,10 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - $if mode == "list":
-          - rtgl-view wh=f:
+          - 'rtgl-view wh=f style="min-height: 0;"':
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-              - rtgl-view h=1fg sv w=f:
+              - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
                   - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context}:
                       - rtgl-view#choicesContainer slot=choices g=md w=f:
                           - $for item, index in defaultValues.items:
@@ -61,15 +61,15 @@ template:
                                   - rtgl-view w=1fg:
                                       - rtgl-text: ${item.content}
                           - rtgl-button#addChoiceButton v=ol w=f mt=md: + Add Choice
-              - rtgl-view d=h av=c ah=e w=f g=lg:
+              - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
                   - rtgl-button#submitButton: Submit
         $elif mode == "editChoice":
-          - rtgl-view wh=f:
+          - 'rtgl-view wh=f style="min-height: 0;"':
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-              - rtgl-form#choiceForm :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm}: null
-              - rtgl-view h=1fg: null
-              - rtgl-view d=h av=c ah=e w=f g=lg:
+              - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+                  - rtgl-form#choiceForm :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm}: null
+              - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
                   - rtgl-button#cancelEditButton v=ol: Cancel
                   - rtgl-button#saveChoiceButton: Save Choice
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineConditional/commandLineConditional.view.yaml
+++ b/src/components/commandLineConditional/commandLineConditional.view.yaml
@@ -69,56 +69,56 @@ template:
   - rtgl-view w=f h=f p=lg:
       - $if mode == 'current' && initiated:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - rtgl-view g=md mt=md w=f:
-              - rtgl-text s=sm c=mu-fg: Branches
-              - $for branch, i in branches:
-                  - rtgl-view#conditionalBranch${i} data-branch-id=${branch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
-                      - rtgl-view d=v w=1fg:
-                          - rtgl-text s=sm: ${branch.summary}
-                          - rtgl-text s=xs c=mu-fg: ${branch.actionsSummary}
-              - rtgl-button#addBranchButton v=ol w=f mt=md: + Add Branch
-              - rtgl-text s=sm c=mu-fg mt=md: Default
-              - $if hasDefaultBranch:
-                  - rtgl-view#defaultBranch data-branch-id=${defaultBranch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
-                      - rtgl-view d=v w=1fg:
-                          - rtgl-text s=sm: ${defaultBranch.summary}
-                          - rtgl-text s=xs c=mu-fg: ${defaultBranch.actionsSummary}
-              - $if !hasDefaultBranch:
-                  - rtgl-button#addDefaultButton v=ol w=f: + Add Default Branch
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-view g=md mt=md w=f:
+                  - rtgl-text s=sm c=mu-fg: Branches
+                  - $for branch, i in branches:
+                      - rtgl-view#conditionalBranch${i} data-branch-id=${branch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
+                          - rtgl-view d=v w=1fg:
+                              - rtgl-text s=sm: ${branch.summary}
+                              - rtgl-text s=xs c=mu-fg: ${branch.actionsSummary}
+                  - rtgl-button#addBranchButton v=ol w=f mt=md: + Add Branch
+                  - rtgl-text s=sm c=mu-fg mt=md: Default
+                  - $if hasDefaultBranch:
+                      - rtgl-view#defaultBranch data-branch-id=${defaultBranch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
+                          - rtgl-view d=v w=1fg:
+                              - rtgl-text s=sm: ${defaultBranch.summary}
+                              - rtgl-text s=xs c=mu-fg: ${defaultBranch.actionsSummary}
+                  - $if !hasDefaultBranch:
+                      - rtgl-button#addDefaultButton v=ol w=f: + Add Default Branch
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${!hasBranches}: Submit
       - $if mode == 'editBranch' && initiated:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - rtgl-view g=md mt=md w=f:
-              - $if !isEditingDefault:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-view g=md mt=md w=f:
+                  - $if !isEditingDefault:
+                      - rtgl-view g=md w=f:
+                          - rtgl-text s=sm c=mu-fg: Condition
+                          - $if isEditingUnsupportedCondition:
+                              - rtgl-text s=sm c=mu-fg mt=md: Unsupported condition
+                          - $if !isEditingUnsupportedCondition:
+                              - rtgl-text s=sm c=mu-fg mt=md: Variable
+                              - rtgl-select#variableSelect w=f :selectedValue=${tempBranch.variableId} :options=${variableOptions} placeholder="Choose a variable...": null
+                              - $if tempBranch.variableId:
+                                  - rtgl-text s=sm c=mu-fg mt=md: Operator
+                                  - rtgl-select#operatorSelect w=f :selectedValue=${tempBranch.op} :options=${operatorOptions}: null
+                              - $if showValueField && valueInputType == 'number':
+                                  - rtgl-text s=sm c=mu-fg mt=md: Value
+                                  - rtgl-input#valueInput type=number w=f placeholder="Enter number..." value=${tempBranch.value}: null
+                              - $if showValueField && valueInputType == 'boolean':
+                                  - rtgl-text s=sm c=mu-fg mt=md: Value
+                                  - rtgl-select#booleanSelect w=f :selectedValue=${tempBranch.booleanValue} :options=${booleanOptions}: null
+                              - $if showValueField && showEnumValueSelect:
+                                  - rtgl-text s=sm c=mu-fg mt=md: Value
+                                  - rtgl-select#enumValueSelect w=f :selectedValue=${tempBranch.value} :options=${enumValueOptions} placeholder="Choose a value...": null
+                              - $if showValueField && valueInputType == 'string' && !showEnumValueSelect:
+                                  - rtgl-text s=sm c=mu-fg mt=md: Value
+                                  - rtgl-input#valueInput w=f placeholder="Enter text..." value=${tempBranch.value}: null
+                      - rtgl-view w=f h=1 bgc=mu mt=lg mb=sm: null
                   - rtgl-view g=md w=f:
-                      - rtgl-text s=sm c=mu-fg: Condition
-                      - $if isEditingUnsupportedCondition:
-                          - rtgl-text s=sm c=mu-fg mt=md: Unsupported condition
-                      - $if !isEditingUnsupportedCondition:
-                          - rtgl-text s=sm c=mu-fg mt=md: Variable
-                          - rtgl-select#variableSelect w=f :selectedValue=${tempBranch.variableId} :options=${variableOptions} placeholder="Choose a variable...": null
-                          - $if tempBranch.variableId:
-                              - rtgl-text s=sm c=mu-fg mt=md: Operator
-                              - rtgl-select#operatorSelect w=f :selectedValue=${tempBranch.op} :options=${operatorOptions}: null
-                          - $if showValueField && valueInputType == 'number':
-                              - rtgl-text s=sm c=mu-fg mt=md: Value
-                              - rtgl-input#valueInput type=number w=f placeholder="Enter number..." value=${tempBranch.value}: null
-                          - $if showValueField && valueInputType == 'boolean':
-                              - rtgl-text s=sm c=mu-fg mt=md: Value
-                              - rtgl-select#booleanSelect w=f :selectedValue=${tempBranch.booleanValue} :options=${booleanOptions}: null
-                          - $if showValueField && showEnumValueSelect:
-                              - rtgl-text s=sm c=mu-fg mt=md: Value
-                              - rtgl-select#enumValueSelect w=f :selectedValue=${tempBranch.value} :options=${enumValueOptions} placeholder="Choose a value...": null
-                          - $if showValueField && valueInputType == 'string' && !showEnumValueSelect:
-                              - rtgl-text s=sm c=mu-fg mt=md: Value
-                              - rtgl-input#valueInput w=f placeholder="Enter text..." value=${tempBranch.value}: null
-                  - rtgl-view w=f h=1 bgc=mu mt=lg mb=sm: null
-              - rtgl-view g=md w=f:
-                  - rtgl-text s=sm c=mu-fg: Actions
-                  - rvn-system-actions#branchActionsEditor :showSelected=${true} :actions=${branchActions} actionType=system :hiddenModes=${hiddenModes} :allowedModes=${branchActionAllowedModes} :showEmbeddedClose=${false}: null
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+                      - rtgl-text s=sm c=mu-fg: Actions
+                      - rvn-system-actions#branchActionsEditor :showSelected=${true} :actions=${branchActions} actionType=system :hiddenModes=${hiddenModes} :allowedModes=${branchActionAllowedModes} :showEmbeddedClose=${false}: null
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#saveBranchButton ?disabled=${!canSaveBranch}: Save ${editBranchTitle}
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineControl/commandLineControl.view.yaml
+++ b/src/components/commandLineControl/commandLineControl.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -74,36 +74,36 @@ template:
   - rtgl-view w=f h=f p=lg:
       - $if mode == 'current':
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f:
-              - rtgl-view slot=characterSprite g=md w=f:
-                  - rtgl-view d=h g=md av=t pv=md br=md w=f:
-                      - rtgl-view#characterSpriteBox cur=pointer bw=xs bc=bo h-bc=ac br=sm:
-                          - rtgl-view p=md g=md br=md:
-                              - $if selectedSpriteCharacter.hasSpritePreview:
-                                  - rvn-stacked-file-images :fileIds=${selectedSpriteCharacter.spritePreviewFileIds} w=200 h=120 br=sm lazy: null
-                                $else:
-                                  - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg: null
-                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedSpriteCharacter.displayName}
-                      - $if hasSpriteCharacter:
-                          - rtgl-view w=1fg g=sm:
-                              - rtgl-view d=h w=f av=c g=sm:
-                                  - rtgl-text s=sm c=mu-fg w=1fg: Transform
-                                  - rtgl-button#clearCharacterSpriteButton v=ol s=sm: Clear
-                              - rtgl-select#transform key=${spriteTransformId} :options=${transformOptions} :selectedValue=${spriteTransformId} w=f no-clear: null
-                              - rtgl-text s=sm c=mu-fg: Animation
-                              - rtgl-segmented-control#animationMode key=${spriteAnimationMode} :options=${animationModeOptions} :selectedValue=${spriteAnimationMode} w=f no-clear: null
-                              - $if spriteAnimationMode == 'update':
-                                  - rtgl-select#updateAnimation key=${spriteAnimationId} :options=${updateAnimationOptions} :selectedValue=${spriteAnimationId} w=f no-clear: null
-                                $elif spriteAnimationMode == 'transition':
-                                  - rtgl-select#transitionAnimation key=${spriteAnimationId} :options=${transitionAnimationOptions} :selectedValue=${spriteAnimationId} w=f no-clear: null
-                              - $if selectedSpriteCharacter.showSpriteGroupBoxes:
-                                  - rtgl-text s=sm c=mu-fg: Sprite Groups
-                                  - rtgl-view d=h wrap g=xs w=f:
-                                      - $for spriteGroup, i in selectedSpriteCharacter.spriteGroupBoxes:
-                                          - 'rtgl-view.characterSpriteGroupBox data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
-                                              - rtgl-text s=xs: ${spriteGroup.name}
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f:
+                  - rtgl-view slot=characterSprite g=md w=f:
+                      - rtgl-view d=h g=md av=t pv=md br=md w=f:
+                          - rtgl-view#characterSpriteBox cur=pointer bw=xs bc=bo h-bc=ac br=sm:
+                              - rtgl-view p=md g=md br=md:
+                                  - $if selectedSpriteCharacter.hasSpritePreview:
+                                      - rvn-stacked-file-images :fileIds=${selectedSpriteCharacter.spritePreviewFileIds} w=200 h=120 br=sm lazy: null
+                                    $else:
+                                      - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg: null
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedSpriteCharacter.displayName}
+                          - $if hasSpriteCharacter:
+                              - rtgl-view w=1fg g=sm:
+                                  - rtgl-view d=h w=f av=c g=sm:
+                                      - rtgl-text s=sm c=mu-fg w=1fg: Transform
+                                      - rtgl-button#clearCharacterSpriteButton v=ol s=sm: Clear
+                                  - rtgl-select#transform key=${spriteTransformId} :options=${transformOptions} :selectedValue=${spriteTransformId} w=f no-clear: null
+                                  - rtgl-text s=sm c=mu-fg: Animation
+                                  - rtgl-segmented-control#animationMode key=${spriteAnimationMode} :options=${animationModeOptions} :selectedValue=${spriteAnimationMode} w=f no-clear: null
+                                  - $if spriteAnimationMode == 'update':
+                                      - rtgl-select#updateAnimation key=${spriteAnimationId} :options=${updateAnimationOptions} :selectedValue=${spriteAnimationId} w=f no-clear: null
+                                    $elif spriteAnimationMode == 'transition':
+                                      - rtgl-select#transitionAnimation key=${spriteAnimationId} :options=${transitionAnimationOptions} :selectedValue=${spriteAnimationId} w=f no-clear: null
+                                  - $if selectedSpriteCharacter.showSpriteGroupBoxes:
+                                      - rtgl-text s=sm c=mu-fg: Sprite Groups
+                                      - rtgl-view d=h wrap g=xs w=f:
+                                          - $for spriteGroup, i in selectedSpriteCharacter.spriteGroupBoxes:
+                                              - 'rtgl-view.characterSpriteGroupBox data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
+                                                  - rtgl-text s=xs: ${spriteGroup.name}
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit
       - $if mode == 'character-select':
           - rtgl-view d=h g=md:
@@ -153,7 +153,7 @@ template:
                                       - rtgl-view p=md g=md br=md:
                                           - rvn-file-image fileId=${item.fileId} w=200 h=120: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:

--- a/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
+++ b/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
@@ -10,7 +10,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-      - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
+++ b/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-      - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineNextLine/commandLineNextLine.view.yaml
+++ b/src/components/commandLineNextLine/commandLineNextLine.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLinePopOverlay/commandLinePopOverlay.view.yaml
+++ b/src/components/commandLinePopOverlay/commandLinePopOverlay.view.yaml
@@ -9,8 +9,9 @@ refs:
         handler: handleBreadcrumbClick
 template:
   - $if mode == 'current' && initiated:
-      - rtgl-view g=md w=f:
+      - rtgl-view g=md w=f h=f:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - rtgl-text s=sm: Pop the current overlay and return to the previous view.
-          - rtgl-view d=h g=md w=f ah=e mt=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-text s=sm: Pop the current overlay and return to the previous view.
+          - 'rtgl-view d=h g=md w=f ah=e mt=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton variant=pr: Submit

--- a/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
+++ b/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
@@ -16,7 +16,7 @@ template:
       - $if mode == 'current' && initiated:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f: null
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f: null
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton variant=pr: Submit

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-      - rtgl-form#form :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
+++ b/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-      - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.handlers.js
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.handlers.js
@@ -1,4 +1,7 @@
-import { createRuntimeActionSubmitDetail } from "../../internal/runtimeActions.js";
+import {
+  createRuntimeActionDefaultValues,
+  createRuntimeActionSubmitDetail,
+} from "../../internal/runtimeActions.js";
 
 export const handleBeforeMount = (deps) => {
   const { props, store } = deps;
@@ -35,8 +38,13 @@ export const handleSubmitClick = (deps, payload) => {
     return;
   }
 
-  const values = detail.values ?? store.getState().formValues ?? {};
-  const mode = store.getState().mode;
+  const state = store.getState();
+  const mode = state.mode;
+  const values =
+    detail.values ??
+    (Object.keys(state.formValues ?? {}).length > 0
+      ? state.formValues
+      : createRuntimeActionDefaultValues(mode, state.action));
   const submitDetail = createRuntimeActionSubmitDetail(mode, values);
 
   if (!submitDetail) {

--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.store.js
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.store.js
@@ -40,14 +40,23 @@ export const selectViewData = ({ state }) => {
       ? state.formValues
       : createRuntimeActionDefaultValues(state.mode, state.action);
   const valueSource = defaultValues.valueSource ?? "fixed";
+  const form = createRuntimeActionForm(state.mode);
+  const submitButton = form?.actions?.buttons?.find(
+    (button) => button.id === "submit",
+  );
+
+  if (form) {
+    form.actions = undefined;
+  }
 
   return {
     breadcrumb,
-    form: createRuntimeActionForm(state.mode),
+    form,
     defaultValues,
     context: {
       values: defaultValues,
     },
     formKey: `${state.mode}-${valueSource}`,
+    submitLabel: submitButton?.label ?? "Submit",
   };
 };

--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
@@ -9,7 +9,14 @@ refs:
         handler: handleFormChange
       form-action:
         handler: handleSubmitClick
+  submitButton:
+    eventListeners:
+      click:
+        handler: handleSubmitClick
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-      - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
+          - rtgl-button#submitButton variant=pr: ${submitLabel}

--- a/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
+++ b/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-      - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
@@ -16,7 +16,7 @@ template:
       - $if mode == 'current' && initiated:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-form#transitionForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-form#transitionForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
+++ b/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
@@ -15,7 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-view d=h g=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
+++ b/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
@@ -39,18 +39,18 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - $if mode == 'current':
-          - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f: null
-          - rtgl-view g=md mt=md:
-              - rtgl-view#confirmActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
-                  - rtgl-view d=v:
-                      - rtgl-text s=sm: Confirm Actions
-                      - rtgl-text s=xs c=mu-fg: ${confirmActionsSummary}
-              - rtgl-view#cancelActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
-                  - rtgl-view d=v:
-                      - rtgl-text s=sm: Cancel Actions
-                      - rtgl-text s=xs c=mu-fg: ${cancelActionsSummary}
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f: null
+              - rtgl-view g=md mt=md:
+                  - rtgl-view#confirmActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
+                      - rtgl-view d=v:
+                          - rtgl-text s=sm: Confirm Actions
+                          - rtgl-text s=xs c=mu-fg: ${confirmActionsSummary}
+                  - rtgl-view#cancelActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
+                      - rtgl-view d=v:
+                          - rtgl-text s=sm: Cancel Actions
+                          - rtgl-text s=xs c=mu-fg: ${cancelActionsSummary}
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit
         $elif mode == 'confirmActions':
           - rvn-system-actions#confirmActionsEditor w=f h=f :showSelected=${true} :actions=${confirmActions} actionType=system :hiddenModes=${nestedHiddenModes}: null

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -57,25 +57,25 @@ template:
       - rtgl-view d=h g=md: null
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
-          - rtgl-view#soundEffectsContainer w=f g=md:
-              - $for sfx, i in defaultValues.sfx:
-                  - rtgl-view d=h w=f g=md av=t:
-                      - rtgl-view#soundEffectCard${i} data-sfx-id=${sfx.id} cur=pointer bw=xs bc=${sfx.itemBorderColor} h-bc=${sfx.itemHoverBorderColor} br=sm:
-                          - rtgl-view p=md g=md br=md:
-                              - $if sfx.waveformDataFileId:
-                                  - rvn-waveform-visualizer waveformDataFileId=${sfx.waveformDataFileId} w=200 h=120: null
-                                $else:
-                                  - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
-                                      - rtgl-text s=sm c=mu-fg: No waveform
-                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${sfx.name}
-                      - rtgl-view w=1fg g=sm:
-                          - rtgl-text s=sm c=mu-fg: Loop
-                          - rtgl-segmented-control#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
-                          - rtgl-text s=sm c=mu-fg: Volume
-                          - rtgl-slider-input#volumeInput${i} data-index=${i} key=${sfx.id} min=0 max=100 step=1 w=f value=${sfx.volume}: null
-              - rtgl-button#addNewButton v=ol w=f mt=md: + Add New Sound Effect
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-view#soundEffectsContainer w=f g=md:
+                  - $for sfx, i in defaultValues.sfx:
+                      - rtgl-view d=h w=f g=md av=t:
+                          - rtgl-view#soundEffectCard${i} data-sfx-id=${sfx.id} cur=pointer bw=xs bc=${sfx.itemBorderColor} h-bc=${sfx.itemHoverBorderColor} br=sm:
+                              - rtgl-view p=md g=md br=md:
+                                  - $if sfx.waveformDataFileId:
+                                      - rvn-waveform-visualizer waveformDataFileId=${sfx.waveformDataFileId} w=200 h=120: null
+                                    $else:
+                                      - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                          - rtgl-text s=sm c=mu-fg: No waveform
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${sfx.name}
+                          - rtgl-view w=1fg g=sm:
+                              - rtgl-text s=sm c=mu-fg: Loop
+                              - rtgl-segmented-control#loopSelect${i} data-index=${i} w=f no-clear :selectedValue=${sfx.loop} :options=${loopOptions}: null
+                              - rtgl-text s=sm c=mu-fg: Volume
+                              - rtgl-slider-input#volumeInput${i} data-index=${i} key=${sfx.id} min=0 max=100 step=1 w=f value=${sfx.volume}: null
+                  - rtgl-button#addNewButton v=ol w=f mt=md: + Add New Sound Effect
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':
           - rtgl-view d=h w=f av=c g=md:
@@ -100,7 +100,7 @@ template:
                                               - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
                                                   - rtgl-text s=sm c=mu-fg: No waveform
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
   - $if showAudioPlayer:

--- a/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
+++ b/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
+++ b/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSystemActions/commandLineSystemActions.view.yaml
+++ b/src/components/commandLineSystemActions/commandLineSystemActions.view.yaml
@@ -4,10 +4,11 @@ refs:
       click:
         handler: handleActionClick
 template:
-  - rtgl-view w=f h=f p=lg br=md:
+  - 'rtgl-view w=f h=f p=lg br=md d=v style="min-height: 0;"':
       - rtgl-text s=sm c=mu-fg: Actions
-      - rtgl-view h=f w=f g=sm mt=lg:
-          - $for item, i in items:
-              - rtgl-view#action${i} data-action-id=${item.id} g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
-                  - rtgl-svg svg=${item.icon} wh=24: null
-                  - rtgl-text s=sm: ${item.label}
+      - 'rtgl-view h=1fg w=f mt=lg sv style="min-height: 0;"':
+          - rtgl-view w=f d=v g=sm:
+              - $for item, i in items:
+                  - rtgl-view#action${i} data-action-id=${item.id} g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
+                      - rtgl-svg svg=${item.icon} wh=24: null
+                      - rtgl-text s=sm: ${item.label}

--- a/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
+++ b/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
+++ b/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
@@ -14,7 +14,7 @@ refs:
 template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
-      - rtgl-view h=1fg: null
-      - rtgl-view d=h av=c ah=e w=f g=lg:
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineUpdateVariable/commandLineUpdateVariable.view.yaml
+++ b/src/components/commandLineUpdateVariable/commandLineUpdateVariable.view.yaml
@@ -56,42 +56,42 @@ template:
       - $if mode == 'current' && initiated:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - rtgl-view g=md mt=md w=f:
-              - $for operation, i in operations:
-                  - rtgl-view#operation${i} data-operation-id=${operation.id} cur=pointer d=h av=c ah=c g=md p=md bgc=mu h-bgc=ac br=md w=f:
-                      - rtgl-text s=sm: '${operation.variableName}:'
-                      - rtgl-text s=sm c=pr: ${operation.opLabel}
-                      - $if operation.op != 'toggle':
-                          - rtgl-text s=sm: ${operation.displayValue}
-              - rtgl-button#addOperationButton v=ol w=f mt=md: + Add Operation
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-view g=md mt=md w=f:
+                  - $for operation, i in operations:
+                      - rtgl-view#operation${i} data-operation-id=${operation.id} cur=pointer d=h av=c ah=c g=md p=md bgc=mu h-bgc=ac br=md w=f:
+                          - rtgl-text s=sm: '${operation.variableName}:'
+                          - rtgl-text s=sm c=pr: ${operation.opLabel}
+                          - $if operation.op != 'toggle':
+                              - rtgl-text s=sm: ${operation.displayValue}
+                  - rtgl-button#addOperationButton v=ol w=f mt=md: + Add Operation
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${!hasOperations}: Submit
       - $if mode == 'edit' && initiated:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - rtgl-view g=md mt=md w=f:
-              - rtgl-text s=sm c=mu-fg mb=sm: Variable
-              - rtgl-select#variableSelect w=f :selectedValue=${tempOperation.variableId} :options=${variableOptions} placeholder="Choose a variable...": null
-              - $if tempOperation.variableId:
-                  - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Operation
-                  - rtgl-select#operationSelect w=f :selectedValue=${tempOperation.op} :options=${operationOptions} placeholder="Choose an operation...": null
-              - $if showValueField && valueInputType == 'number':
-                  - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
-                  - rtgl-input#valueInput type=number w=f placeholder="Enter number..." value=${tempOperation.value}: null
-              - $if showRoundToField:
-                  - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Decimal Places
-                  - rtgl-input#roundToInput type=number min=0 max=12 step=1 w=f value=${tempOperation.roundToValue}: null
-              - $if showValueField && valueInputType == 'boolean':
-                  - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
-                  - rtgl-select#booleanSelect w=f :selectedValue=${tempOperation.booleanValue} :options=${booleanOptions}: null
-              - $if showValueField && showEnumValueSelect:
-                  - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
-                  - rtgl-select#enumValueSelect w=f :selectedValue=${tempOperation.value} :options=${enumValueOptions} placeholder="Choose a value...": null
-              - $if showValueField && valueInputType == 'string' && !showEnumValueSelect:
-                  - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
-                  - rtgl-input#valueInput w=f placeholder="Enter text..." value=${tempOperation.value}: null
-          - rtgl-view h=1fg: null
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+              - rtgl-view g=md mt=md w=f:
+                  - rtgl-text s=sm c=mu-fg mb=sm: Variable
+                  - rtgl-select#variableSelect w=f :selectedValue=${tempOperation.variableId} :options=${variableOptions} placeholder="Choose a variable...": null
+                  - $if tempOperation.variableId:
+                      - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Operation
+                      - rtgl-select#operationSelect w=f :selectedValue=${tempOperation.op} :options=${operationOptions} placeholder="Choose an operation...": null
+                  - $if showValueField && valueInputType == 'number':
+                      - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
+                      - rtgl-input#valueInput type=number w=f placeholder="Enter number..." value=${tempOperation.value}: null
+                  - $if showRoundToField:
+                      - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Decimal Places
+                      - rtgl-input#roundToInput type=number min=0 max=12 step=1 w=f value=${tempOperation.roundToValue}: null
+                  - $if showValueField && valueInputType == 'boolean':
+                      - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
+                      - rtgl-select#booleanSelect w=f :selectedValue=${tempOperation.booleanValue} :options=${booleanOptions}: null
+                  - $if showValueField && showEnumValueSelect:
+                      - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
+                      - rtgl-select#enumValueSelect w=f :selectedValue=${tempOperation.value} :options=${enumValueOptions} placeholder="Choose a value...": null
+                  - $if showValueField && valueInputType == 'string' && !showEnumValueSelect:
+                      - rtgl-text s=sm c=mu-fg mt=lg mb=sm: Value
+                      - rtgl-input#valueInput w=f placeholder="Enter text..." value=${tempOperation.value}: null
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#saveOperationButton ?disabled=${!canSaveOperation}: Save Operation
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -71,7 +71,7 @@ template:
       - $if mode == 'current':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-view h=1fg sv w=f:
+          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md w=f:
                   - $for visual, i in defaultValues.visuals:
                       - rtgl-view#visual${i} data-index=${i} data-visual-id=${visual.id} d=h g=md av=t p=md br=md w=f:
@@ -93,7 +93,7 @@ template:
                                 $elif visual.animationMode == 'transition':
                                   - rtgl-select#transitionAnimation${i} data-index=${i} key=${visual.animationId} :options=${defaultValues.transitionAnimationOptions} :selectedValue=${visual.animationId} w=f no-clear: null
                   - rtgl-button#addVisualButton v=ol w=f mt=md: + Add Visual
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'resource-select':
           - rtgl-view d=h g=md:
@@ -120,7 +120,7 @@ template:
                                               - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
                                                   - rtgl-text s=sm c=mu-fg: ${item.resourceType}
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - rtgl-view d=h av=c ah=e w=f g=lg:
+          - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
   - $when: fullImagePreviewVisible


### PR DESCRIPTION
## Summary
- keep command-line action submit/select/save footers outside scrollable content on short panels
- make command-line action content and list regions scroll with min-height constraints
- move runtime action submit into the fixed footer while preserving default-value submission
- bump Tauri app version to 1.2.3

## Testing
- bun prettier --check src/components/commandLine* src-tauri/tauri.conf.json
- git diff --check
- ./node_modules/.bin/oxlint src/components/commandLineRuntimeAction/commandLineRuntimeAction.handlers.js src/components/commandLineRuntimeAction/commandLineRuntimeAction.store.js
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src