### PR TITLE
fix: create empty layouts and clean preview/tag payloads

### DIFF
--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -1,9 +1,6 @@
 import { generateId } from "../../internal/id.js";
 import { createLayoutEditorPayload } from "../../internal/layoutEditorRoute.js";
-import {
-  requireProjectResolution,
-  scaleLayoutElementsForProjectResolution,
-} from "../../internal/projectResolution.js";
+import { scaleLayoutElementsForProjectResolution } from "../../internal/projectResolution.js";
 import { isFragmentLayout } from "../../internal/project/layout.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
 import { appendTagIdToForm } from "../../internal/ui/resourcePages/tags.js";
@@ -282,6 +279,11 @@ export const handleEditFormAddOptionClick = (deps) => {
 const createLayoutElement = (id, data) => ({
   id,
   ...data,
+});
+
+const createEmptyLayoutElements = () => ({
+  items: {},
+  tree: [],
 });
 
 export const createLayoutTemplate = (layoutType, projectResolution) => {
@@ -1049,11 +1051,6 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
   const isFragment = normalizeBooleanField(values?.isFragment);
   const description = values?.description ?? "";
 
-  const projectResolution = requireProjectResolution(
-    projectService.getRepositoryState().project?.resolution,
-    "Project resolution",
-  );
-
   const createAttempt = await runResourcePageMutation({
     appService,
     fallbackMessage: "Failed to create layout.",
@@ -1067,7 +1064,7 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
           tagIds: Array.isArray(values?.tagIds) ? values.tagIds : [],
           isFragment,
         },
-        elements: createLayoutTemplate(layoutType, projectResolution),
+        elements: createEmptyLayoutElements(),
         parentId: store.getState().targetGroupId,
         position: "last",
       }),

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -260,13 +260,14 @@ const buildTextStyleData = ({
   previewText,
   strokeColor,
   strokeWidth,
+  includeEmptyTagIds = true,
   clearOutlineColor = false,
 } = {}) => {
   const hasStrokeColor = Boolean(strokeColor);
+  const normalizedTagIds = Array.isArray(tagIds) ? tagIds : [];
   const textStyleData = {
     name,
     description: description ?? "",
-    tagIds: Array.isArray(tagIds) ? tagIds : [],
     fontSize: Number(fontSize ?? 16),
     lineHeight: Number(lineHeight ?? 1.5),
     colorId: fontColor,
@@ -275,6 +276,10 @@ const buildTextStyleData = ({
     previewText: previewText ?? "",
     strokeWidth: hasStrokeColor ? Number(strokeWidth ?? 0) : 0,
   };
+
+  if (normalizedTagIds.length > 0 || includeEmptyTagIds) {
+    textStyleData.tagIds = normalizedTagIds;
+  }
 
   if (hasStrokeColor) {
     textStyleData.strokeColorId = strokeColor;
@@ -322,6 +327,7 @@ const handleTextStyleCreated = async (deps, payload) => {
             previewText,
             strokeColor,
             strokeWidth,
+            includeEmptyTagIds: false,
           }),
         },
         parentId: groupId,

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -362,8 +362,8 @@ const STYLES = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(220, 38, 38, 0.92);
-    color: #ffffff;
+    background: transparent;
+    color: var(--error);
   }
 
   .preview-thumb rvn-file-image {
@@ -384,8 +384,8 @@ const STYLES = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #dc2626;
-    color: #ffffff;
+    background: transparent;
+    color: var(--error);
   }
 
   .preview-dialogue-item {
@@ -4771,14 +4771,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   createDeleteOverlay() {
     const overlay = document.createElement("div");
     overlay.className = "preview-delete-overlay";
-    overlay.append(this.createSvgIcon("x", 16, "white"));
+    overlay.append(this.createSvgIcon("x", 16, "er"));
     return overlay;
   }
 
   createPreviewGroupDeleteOverlay() {
     const overlay = document.createElement("div");
     overlay.className = "preview-group-delete-overlay";
-    overlay.append(this.createSvgIcon("x", 16, "white"));
+    overlay.append(this.createSvgIcon("x", 16, "er"));
     return overlay;
   }
 

--- a/tests/layouts/layouts.handlers.test.js
+++ b/tests/layouts/layouts.handlers.test.js
@@ -67,7 +67,7 @@ describe("createLayoutTemplate", () => {
     });
   });
 
-  it("creates layouts with description and fragment data", async () => {
+  it("creates layouts with empty elements and metadata", async () => {
     const createLayoutItem = vi.fn(async () => "layout-1");
     const deps = {
       store: {
@@ -101,9 +101,9 @@ describe("createLayoutTemplate", () => {
         detail: {
           actionId: "submit",
           values: {
-            name: "Save",
-            layoutType: "save-load",
-            description: "Reusable save fragment",
+            name: "Choices",
+            layoutType: "choice",
+            description: "Choice menu",
             isFragment: "true",
           },
         },
@@ -112,12 +112,16 @@ describe("createLayoutTemplate", () => {
 
     expect(createLayoutItem).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: "Save",
-        layoutType: "save-load",
+        name: "Choices",
+        layoutType: "choice",
         parentId: "group-1",
         position: "last",
+        elements: {
+          items: {},
+          tree: [],
+        },
         data: expect.objectContaining({
-          description: "Reusable save fragment",
+          description: "Choice menu",
           isFragment: true,
           tagIds: [],
         }),

--- a/tests/textStyles/textStyles.handlers.test.js
+++ b/tests/textStyles/textStyles.handlers.test.js
@@ -1,15 +1,132 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleItemDuplicate } from "../../src/pages/textStyles/textStyles.handlers.js";
+import {
+  handleFormActionClick,
+  handleItemDuplicate,
+} from "../../src/pages/textStyles/textStyles.handlers.js";
 
 describe("textStyles.handlers", () => {
+  const createProjectState = () => ({
+    textStyles: {
+      items: {},
+      tree: [],
+    },
+    colors: {
+      items: {},
+      tree: [],
+    },
+    fonts: {
+      items: {},
+      tree: [],
+    },
+  });
+
+  const createFormDeps = ({
+    createTextStyle = vi.fn(async () => "text-style-new"),
+    updateTextStyle = vi.fn(async () => ({ valid: true })),
+    dialogState = {
+      targetGroupId: undefined,
+      editMode: false,
+      editingItemId: undefined,
+    },
+  } = {}) => ({
+    store: {
+      getState: () => ({
+        currentFormValues: {
+          previewText: "Preview",
+        },
+      }),
+      selectDialogState: vi.fn(() => dialogState),
+      resetFormValues: vi.fn(),
+      clearEditMode: vi.fn(),
+      toggleDialog: vi.fn(),
+      setItems: vi.fn(),
+      setTagsData: vi.fn(),
+      setColorsData: vi.fn(),
+      setFontsData: vi.fn(),
+      openAddColorDialog: vi.fn(),
+      openAddFontDialog: vi.fn(),
+    },
+    projectService: {
+      createTextStyle,
+      updateTextStyle,
+      getState: createProjectState,
+    },
+    appService: {
+      showAlert: vi.fn(),
+    },
+    render: vi.fn(),
+  });
+
+  const createSubmitPayload = (values = {}) => ({
+    _event: {
+      detail: {
+        actionId: "submit",
+        values: {
+          name: "Dialogue",
+          description: "",
+          tagIds: [],
+          fontSize: 24,
+          lineHeight: 1.5,
+          fontColor: "color-1",
+          fontStyle: "font-1",
+          fontWeight: "400",
+          strokeColor: "",
+          strokeWidth: 0,
+          ...values,
+        },
+      },
+    },
+  });
+
+  it("omits empty tag ids when creating a text style", async () => {
+    const createTextStyle = vi.fn(async () => "text-style-new");
+    const deps = createFormDeps({ createTextStyle });
+
+    await handleFormActionClick(deps, createSubmitPayload());
+
+    const createPayload = createTextStyle.mock.calls[0][0];
+    expect(Object.hasOwn(createPayload.data, "tagIds")).toBe(false);
+  });
+
+  it("keeps empty tag ids when updating a text style", async () => {
+    const updateTextStyle = vi.fn(async () => ({ valid: true }));
+    const deps = createFormDeps({
+      updateTextStyle,
+      dialogState: {
+        targetGroupId: undefined,
+        editMode: true,
+        editingItemId: "text-style-1",
+      },
+    });
+
+    await handleFormActionClick(deps, createSubmitPayload());
+
+    expect(updateTextStyle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textStyleId: "text-style-1",
+        data: expect.objectContaining({
+          tagIds: [],
+        }),
+      }),
+    );
+  });
+
   it("duplicates a text style and selects the duplicate", async () => {
     const duplicateTextStyle = vi.fn(async () => "text-style-copy");
+    let textStylesData = {
+      items: {},
+      tree: [],
+    };
     const deps = {
       store: {
-        setItems: vi.fn(),
+        getState: () => ({ textStylesData }),
+        setItems: vi.fn(({ textStylesData: nextTextStylesData } = {}) => {
+          textStylesData = nextTextStylesData;
+        }),
         setTagsData: vi.fn(),
         setColorsData: vi.fn(),
         setFontsData: vi.fn(),
+        setSelectedFolderId: vi.fn(),
         setSelectedItemId: vi.fn(),
       },
       refs: {


### PR DESCRIPTION
## Summary
- create new layouts with an empty elements collection for every layout type
- keep scene editor delete X indicators while removing the red delete overlay background
- omit empty `tagIds` when creating text styles so no-tag creation validates, while preserving `tagIds: []` on update to clear tags
- update layout and text style handler coverage for the affected payloads

## Testing
- bunx vitest run tests/layouts/layouts.handlers.test.js
- bunx vitest run tests/sceneEditor/lineViewModels.test.js
- bunx vitest run tests/textStyles/textStyles.handlers.test.js
- bun prettier --check src/pages/layouts/layouts.handlers.js tests/layouts/layouts.handlers.test.js
- bun prettier --check src/primitives/lexicalSceneDocumentEditor.js
- bun prettier --check src/pages/textStyles/textStyles.handlers.js tests/textStyles/textStyles.handlers.test.js
- pre-push hook: oxlint && bun prettier --check src