### PR TITLE
fix: harden scene editor preview rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "lexical": "^0.22.0",
         "nanoid": "^5.1.5",
         "route-engine-js": "1.13.2",
-        "route-graphics": "1.12.3",
+        "route-graphics": "1.15.1",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
         "snabbdom-to-html": "^7.1.0",
@@ -374,7 +374,7 @@
 
     "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -514,13 +514,13 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "hotkeys-js": ["hotkeys-js@4.0.0", "", {}, "sha512-gIoeqMWYqPIItc4HaseVbtTRpEpBbeufZMUcoWtN62JZdDq3KadS1ijN6wpaDjTzRK7PjT3QOPUcx+yNT0rrZQ=="],
+    "hotkeys-js": ["hotkeys-js@4.0.4", "", {}, "sha512-hseNiqaskxSnujuGp8aRMLJfcjaFiTSS0I2GQhqru82N/sx6CGyUf6pvU5X1iycvw2EqmvILkFIb5OzYFXY+9A=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
@@ -668,7 +668,7 @@
 
     "pixelmatch": ["pixelmatch@7.1.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng=="],
 
-    "pixi.js": ["pixi.js@8.15.0", "", { "dependencies": { "@pixi/colord": "^2.9.6", "@types/css-font-loading-module": "^0.0.12", "@types/earcut": "^3.0.0", "@webgpu/types": "^0.1.40", "@xmldom/xmldom": "^0.8.10", "earcut": "^3.0.2", "eventemitter3": "^5.0.1", "gifuct-js": "^2.1.2", "ismobilejs": "^1.1.1", "parse-svg-path": "^0.1.2", "tiny-lru": "^11.4.5" } }, "sha512-J/Ghze/K9fjHRlfwC2EMZ7vnMIhGo4ByKCsKMcS0AB12iT79nf9zzWKUTzMJ8QAQFqQfDOl5ULwmHMUdeih2zQ=="],
+    "pixi.js": ["pixi.js@8.18.1", "", { "dependencies": { "@pixi/colord": "^2.9.6", "@types/earcut": "^3.0.0", "@webgpu/types": "^0.1.69", "@xmldom/xmldom": "^0.8.12", "earcut": "^3.0.2", "eventemitter3": "^5.0.1", "gifuct-js": "^2.1.2", "ismobilejs": "^1.1.1", "parse-svg-path": "^0.1.2", "tiny-lru": "^11.4.7" } }, "sha512-6LUPWYgulZhp/w4kam2XHXB0QedISZIqrJbRdHLLQ3csn5a38uzKxAp6B5j6s89QFYaIJbg95kvgTRcbgpO1ow=="],
 
     "playwright": ["playwright@1.57.0", "", { "dependencies": { "playwright-core": "1.57.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw=="],
 
@@ -692,7 +692,7 @@
 
     "puty": ["puty@0.1.2", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-VNEwqORf0u/LiVdjyHPsIOKWC5z4uNuHhMgYu9WGea6u3YCP4OimQHQfWkw0DB/tE3KuWgPO0dhkM8uH4Yweig=="],
 
-    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -712,7 +712,7 @@
 
     "route-engine-js": ["route-engine-js@1.13.2", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-Tp/PaLsWsaZWD4seY/cqpG+sRFyGek8nz3PKRTaft+Of7cAMGGabDiGJBaaPZnNG4j47Lcho5hlydT0OMz8o6g=="],
 
-    "route-graphics": ["route-graphics@1.12.3", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "pixi.js": "^8.7.1" } }, "sha512-fOWucJxa2BWRo0XxD/37o+W0vV6koqpy9im4htE6Hj2bO20+YgEcxL4AZdu9O2PntVIHmEseIlMYCM8zQKY0MA=="],
+    "route-graphics": ["route-graphics@1.15.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-9SDdqEWDGmI/uety8oHvLBUKkWsdU/zUYsc3+zBCdLDnRfv0tRmn3OCyW0kmCPBvR5PKg8RkDzKyNMH6J3H7Tg=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
@@ -734,7 +734,7 @@
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "^0.22.0",
     "nanoid": "^5.1.5",
     "route-engine-js": "1.13.2",
-    "route-graphics": "1.12.3",
+    "route-graphics": "1.15.1",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",
     "snabbdom-to-html": "^7.1.0",

--- a/src/components/commandLineChoices/commandLineChoices.handlers.js
+++ b/src/components/commandLineChoices/commandLineChoices.handlers.js
@@ -61,6 +61,20 @@ const dispatchTemporaryPresentationStateChange = (deps) => {
   );
 };
 
+const readChoiceIndex = (payload = {}) => {
+  const currentTarget = payload._event.currentTarget;
+  const indexValue =
+    currentTarget.dataset?.index ?? currentTarget.getAttribute("data-index");
+
+  if (indexValue === undefined || indexValue === null || indexValue === "") {
+    return undefined;
+  }
+
+  const index = Number(indexValue);
+
+  return Number.isInteger(index) && index >= 0 ? index : undefined;
+};
+
 export const handleBeforeMount = (deps) => {
   const { store, props } = deps;
   store.setItems({ items: props.choice?.items || [] });
@@ -92,24 +106,26 @@ export const handleAddChoiceClick = (deps) => {
 
 export const handleChoiceClick = (deps, payload) => {
   const { store, render } = deps;
+  const index = readChoiceIndex(payload);
 
-  const index = parseInt(
-    payload._event.currentTarget.getAttribute("data-index"),
-  );
+  if (index === undefined) {
+    return;
+  }
 
   store.setMode({ mode: "editChoice" });
-  store.setEditingIndex({ index: index });
+  store.setEditingIndex({ index });
 
   render();
 };
 
 export const handleChoiceContextMenu = (deps, payload) => {
-  payload._event.preventDefault();
   const { store, render } = deps;
+  payload._event.preventDefault();
+  const index = readChoiceIndex(payload);
 
-  const index = parseInt(
-    payload._event.currentTarget.getAttribute("data-index"),
-  );
+  if (index === undefined) {
+    return;
+  }
 
   store.showDropdownMenu({
     position: { x: payload._event.clientX, y: payload._event.clientY },
@@ -236,11 +252,12 @@ export const handleSubmitClick = (deps) => {
 
 export const handleRemoveChoiceClick = (deps, payload) => {
   const { store, render } = deps;
-  const index = parseInt(
+  const index = Number.parseInt(
     payload._event.currentTarget.id.replace("removeChoice", ""),
+    10,
   );
 
-  store.removeChoice({ index: index });
+  store.removeChoice({ index });
   render();
   dispatchTemporaryPresentationStateChange(deps);
 };
@@ -280,7 +297,7 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
   const { item } = payload._event.detail;
   const choiceIndex = store.selectDropdownMenuChoiceIndex();
 
-  if (item.value === "delete" && choiceIndex !== null) {
+  if (item.value === "delete" && Number.isInteger(choiceIndex)) {
     store.removeChoice({ index: choiceIndex });
   }
 

--- a/src/components/commandLineChoices/commandLineChoices.store.js
+++ b/src/components/commandLineChoices/commandLineChoices.store.js
@@ -152,9 +152,16 @@ export const addChoice = ({ state }, _payload = {}) => {
 };
 
 export const removeChoice = ({ state }, { index } = {}) => {
-  if (state.items.length > 1) {
-    state.items.splice(index, 1);
+  if (
+    state.items.length <= 1 ||
+    !Number.isInteger(index) ||
+    index < 0 ||
+    index >= state.items.length
+  ) {
+    return;
   }
+
+  state.items.splice(index, 1);
 };
 
 export const setScenes = ({ state }, { scenes } = {}) => {

--- a/src/components/commandLineChoices/commandLineChoices.view.yaml
+++ b/src/components/commandLineChoices/commandLineChoices.view.yaml
@@ -3,7 +3,7 @@ refs:
     eventListeners:
       click:
         handler: handleAddChoiceClick
-  choice*:
+  choiceItem*:
     eventListeners:
       click:
         handler: handleChoiceClick
@@ -57,7 +57,7 @@ template:
                   - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context}:
                       - rtgl-view#choicesContainer slot=choices g=md w=f:
                           - $for item, index in defaultValues.items:
-                              - rtgl-view#choice${index} data-index=${index} d=h av=c w=f g=md p=sm bgc=mu br=sm cur=pointer:
+                              - rtgl-view#choiceItem${index} data-index=${index} d=h av=c w=f g=md p=sm bgc=mu br=sm cur=pointer:
                                   - rtgl-view w=1fg:
                                       - rtgl-text: ${item.content}
                           - rtgl-button#addChoiceButton v=ol w=f mt=md: + Add Choice

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -482,6 +482,7 @@ export const createGraphicsService = async ({
 } = {}) => {
   let routeGraphics;
   let routeGraphicsInitPromise;
+  let destroyRuntimePromise;
   let engine;
   let assetBufferManager;
   let loadedAssetTypes = new Map();
@@ -1021,6 +1022,16 @@ export const createGraphicsService = async ({
     ticker = undefined;
   };
 
+  const runDestroyRuntime = () => {
+    if (!destroyRuntimePromise) {
+      destroyRuntimePromise = destroyRuntime().finally(() => {
+        destroyRuntimePromise = undefined;
+      });
+    }
+
+    return destroyRuntimePromise;
+  };
+
   const loadBuffersWithRetry = async (
     bufferManager,
     assets,
@@ -1453,8 +1464,12 @@ export const createGraphicsService = async ({
         await routeGraphicsInitPromise;
       }
 
+      if (destroyRuntimePromise) {
+        await destroyRuntimePromise;
+      }
+
       if (routeGraphics) {
-        await destroyRuntime();
+        await runDestroyRuntime();
       }
 
       routeGraphicsInitPromise = (async () => {
@@ -1717,6 +1732,12 @@ export const createGraphicsService = async ({
       return routeGraphics?.render(payload);
     },
     parse: (payload) => routeGraphics?.parse(payload),
-    destroy: destroyRuntime,
+    destroy: async () => {
+      if (routeGraphicsInitPromise) {
+        await routeGraphicsInitPromise.catch(() => {});
+      }
+
+      await runDestroyRuntime();
+    },
   };
 };

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -938,12 +938,14 @@ export const createGraphicsService = async ({
 
     await Promise.all(
       pixiAssetKeys.map(async (key) => {
-        await Assets.unload(key).catch((error) => {
-          console.error(
-            `[graphicsService] Failed to unload asset ${key}`,
-            error,
-          );
-        });
+        if (!Assets.cache?.has || Assets.cache.has(key)) {
+          await Assets.unload(key).catch((error) => {
+            console.error(
+              `[graphicsService] Failed to unload asset ${key}`,
+              error,
+            );
+          });
+        }
         destroyCachedPixiAsset(key);
       }),
     );
@@ -988,33 +990,34 @@ export const createGraphicsService = async ({
 
   const destroyRuntime = async () => {
     assetLoadRuntimeVersion += 1;
+    ticker?.stop();
+    invalidateDeferredAudioRender();
+    clearAllPendingClickInteractions();
+
+    const activeRouteGraphics = routeGraphics;
+    routeGraphics = undefined;
+    engine = undefined;
+    routeEngineProjectData = undefined;
+    enableGlobalKeyboardBindings = true;
+    beforeHandleActions = undefined;
+    actionQueue = Promise.resolve();
+    assetLoadQueue = Promise.resolve();
+
     const trackedVideoEntries = getTrackedVideoEntries();
 
     releaseTrackedVideoResources(trackedVideoEntries);
-    await unloadTrackedPixiAssets();
-
-    if (routeGraphics) {
-      routeGraphics.destroy();
-      routeGraphics = undefined;
+    if (activeRouteGraphics) {
+      activeRouteGraphics.setAnimationPlaybackMode?.("manual");
+      activeRouteGraphics.destroy();
     }
 
+    await unloadTrackedPixiAssets();
     await unloadTrackedAudioAssets();
     clearLoadedFonts();
     loadedAssetTypes = new Map();
     assetBufferManager?.clear();
     assetBufferManager = undefined;
 
-    if (engine) {
-      engine = undefined;
-    }
-    routeEngineProjectData = undefined;
-    enableGlobalKeyboardBindings = true;
-    beforeHandleActions = undefined;
-    actionQueue = Promise.resolve();
-    assetLoadQueue = Promise.resolve();
-    invalidateDeferredAudioRender();
-    clearAllPendingClickInteractions();
-    ticker?.stop();
     ticker = undefined;
   };
 
@@ -1120,10 +1123,18 @@ export const createGraphicsService = async ({
     const renderAssetBufferMap = Object.fromEntries(renderAssetEntries);
 
     if (Object.keys(renderAssetBufferMap).length > 0) {
-      if (!routeGraphics) {
+      const activeRouteGraphics = routeGraphics;
+      if (!activeRouteGraphics) {
         return;
       }
-      await routeGraphics.loadAssets(renderAssetBufferMap);
+      await activeRouteGraphics.loadAssets(renderAssetBufferMap);
+
+      if (
+        runtimeVersion !== assetLoadRuntimeVersion ||
+        routeGraphics !== activeRouteGraphics
+      ) {
+        return;
+      }
     }
 
     newAssetEntries.forEach(([key, asset]) => {
@@ -1242,6 +1253,10 @@ export const createGraphicsService = async ({
       ...nextRenderState,
       animations: nextRenderState?.animations || [],
     };
+    if (!routeGraphics) {
+      return;
+    }
+
     routeGraphics.render(nextRenderState);
     applyInteractiveContainerHitAreas(nextRenderState.elements);
     void pruneDecodedAudioCache(retainedAudioKeys);
@@ -1659,6 +1674,9 @@ export const createGraphicsService = async ({
         return;
       }
       const { skipAudio = false, skipAnimations = false } = options;
+      routeGraphics.setAnimationPlaybackMode?.(
+        skipAnimations ? "manual" : "auto",
+      );
       const effectiveSkipAudio = skipAudio || isEngineAudioMuted;
       let renderState = engine.selectRenderState();
       if (skipAnimations) {
@@ -1696,9 +1714,9 @@ export const createGraphicsService = async ({
     waitUntilReady,
     attachCanvas,
     render: (payload) => {
-      return routeGraphics.render(payload);
+      return routeGraphics?.render(payload);
     },
-    parse: (payload) => routeGraphics.parse(payload),
+    parse: (payload) => routeGraphics?.parse(payload),
     destroy: destroyRuntime,
   };
 };

--- a/src/internal/animationMasks.js
+++ b/src/internal/animationMasks.js
@@ -1,5 +1,5 @@
 const DEFAULT_TRANSITION_MASK_KIND = "single";
-const DEFAULT_TRANSITION_MASK_CHANNEL = "alpha";
+const DEFAULT_TRANSITION_MASK_CHANNEL = "red";
 const DEFAULT_TRANSITION_MASK_COMBINE = "max";
 const DEFAULT_TRANSITION_MASK_SAMPLE = "step";
 const DEFAULT_TRANSITION_MASK_SOFTNESS = 0.08;
@@ -8,6 +8,13 @@ const DEFAULT_TRANSITION_MASK_PROGRESS_EASING = "linear";
 
 const TRANSITION_MASK_KINDS = new Set(["single", "sequence", "composite"]);
 const EDITABLE_TRANSITION_MASK_KINDS = new Set(["single"]);
+const TRANSITION_MASK_CHANNELS = new Set(["red", "alpha"]);
+
+const normalizeTransitionMaskChannel = (channel) => {
+  return TRANSITION_MASK_CHANNELS.has(channel)
+    ? channel
+    : DEFAULT_TRANSITION_MASK_CHANNEL;
+};
 
 const hasMaskImageReference = (value) => {
   return typeof value === "string" && value.length > 0;
@@ -16,7 +23,7 @@ const hasMaskImageReference = (value) => {
 const cloneCompositeItem = (item = {}) => {
   return {
     imageId: item.imageId,
-    channel: item.channel ?? DEFAULT_TRANSITION_MASK_CHANNEL,
+    channel: normalizeTransitionMaskChannel(item.channel),
     invert: item.invert ?? false,
   };
 };
@@ -126,7 +133,7 @@ export const normalizeTransitionMaskForEditor = (mask, imageItems = {}) => {
   nextMask.progressDuration = progress.duration;
   nextMask.progressEasing = progress.easing;
   nextMask.imageId = resolveEditorSingleMaskImageId(mask, imageItems);
-  nextMask.channel = mask.channel ?? nextMask.channel;
+  nextMask.channel = normalizeTransitionMaskChannel(mask.channel);
   nextMask.invert = mask.invert ?? nextMask.invert;
 
   return nextMask;
@@ -185,7 +192,7 @@ export const serializeTransitionMask = (mask) => {
   };
 
   if (mask.kind === "single") {
-    serializedMask.channel = mask.channel ?? DEFAULT_TRANSITION_MASK_CHANNEL;
+    serializedMask.channel = normalizeTransitionMaskChannel(mask.channel);
     serializedMask.invert = mask.invert ?? false;
     if (mask.imageId) {
       serializedMask.imageId = mask.imageId;
@@ -194,7 +201,7 @@ export const serializeTransitionMask = (mask) => {
   }
 
   if (mask.kind === "sequence") {
-    serializedMask.channel = mask.channel ?? DEFAULT_TRANSITION_MASK_CHANNEL;
+    serializedMask.channel = normalizeTransitionMaskChannel(mask.channel);
     serializedMask.invert = mask.invert ?? false;
     serializedMask.sample = mask.sample ?? DEFAULT_TRANSITION_MASK_SAMPLE;
     serializedMask.imageIds = (mask.imageIds ?? []).filter(Boolean);
@@ -248,7 +255,7 @@ export const compileTransitionMaskForRuntime = (mask, imageItems = {}) => {
     }
 
     runtimeMask.texture = texture;
-    runtimeMask.channel = mask.channel ?? DEFAULT_TRANSITION_MASK_CHANNEL;
+    runtimeMask.channel = normalizeTransitionMaskChannel(mask.channel);
     runtimeMask.invert = mask.invert ?? false;
     return runtimeMask;
   }
@@ -267,7 +274,7 @@ export const compileTransitionMaskForRuntime = (mask, imageItems = {}) => {
     }
 
     runtimeMask.textures = Array.from(new Set(textures));
-    runtimeMask.channel = mask.channel ?? DEFAULT_TRANSITION_MASK_CHANNEL;
+    runtimeMask.channel = normalizeTransitionMaskChannel(mask.channel);
     runtimeMask.invert = mask.invert ?? false;
     runtimeMask.sample = mask.sample ?? DEFAULT_TRANSITION_MASK_SAMPLE;
     return runtimeMask;
@@ -285,7 +292,7 @@ export const compileTransitionMaskForRuntime = (mask, imageItems = {}) => {
 
       return {
         texture,
-        channel: item.channel ?? DEFAULT_TRANSITION_MASK_CHANNEL,
+        channel: normalizeTransitionMaskChannel(item.channel),
         invert: item.invert ?? false,
       };
     })

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -717,7 +717,7 @@ const prepareTemporaryPresentationProjectData = async (
 
 export const renderSceneEditorState = async (deps, payload = {}) => {
   const { store, graphicsService } = deps;
-  const { skipAnimations = false, skipCanvasPaint = false } = payload;
+  const { skipAnimations = true, skipCanvasPaint = false } = payload;
   const perfEnabled = isDebugEnabled(SCENE_EDITOR_PERF_SCOPE);
   const renderStartedAt = perfEnabled ? getDebugNow() : 0;
   const sceneId = store.selectSceneId();
@@ -1103,7 +1103,7 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
       sectionId,
       lineId,
       skipRender: payload?.skipRender === true,
-      skipAnimations: payload?.skipAnimations === true,
+      skipAnimations: payload?.skipAnimations ?? true,
       skipCanvasPaint: payload?.skipCanvasPaint === true,
       sceneAssetLoadDurationMs,
       renderSceneStateDurationMs,

--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -143,10 +143,8 @@ export const MASK_KIND_OPTIONS = Object.freeze([
 ]);
 
 export const MASK_CHANNEL_OPTIONS = Object.freeze([
+  { label: "Greyscale", value: "red" },
   { label: "Alpha", value: "alpha" },
-  { label: "Red", value: "red" },
-  { label: "Green", value: "green" },
-  { label: "Blue", value: "blue" },
 ]);
 
 export const MASK_SAMPLE_OPTIONS = Object.freeze([

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -759,14 +759,22 @@ const createEmptyImagesData = () => ({
   tree: [],
 });
 
+const DEFAULT_MASK_CHANNEL_OPTION = MASK_CHANNEL_OPTIONS[0];
+
+const normalizeEditorMaskChannel = (channel) => {
+  return MASK_CHANNEL_OPTIONS.some((option) => option.value === channel)
+    ? channel
+    : DEFAULT_MASK_CHANNEL_OPTION.value;
+};
+
 const createEmptyMaskPanelData = () => ({
   enabled: false,
   unsupported: false,
   unsupportedKind: undefined,
   kind: "single",
   kindLabel: "Single",
-  channelValue: "alpha",
-  channelLabel: "Alpha",
+  channelValue: DEFAULT_MASK_CHANNEL_OPTION.value,
+  channelLabel: DEFAULT_MASK_CHANNEL_OPTION.label,
   sampleValue: "step",
   combineValue: "max",
   invertValue: "off",
@@ -1609,10 +1617,10 @@ export const setTransitionMaskKind = ({ state }, { kind } = {}) => {
     currentMask.imageId ??
     currentMask.imageIds?.find(Boolean) ??
     currentMask.items?.find((item) => item?.imageId)?.imageId;
-  nextMask.channel =
+  nextMask.channel = normalizeEditorMaskChannel(
     currentMask.channel ??
-    currentMask.items?.find((item) => item?.channel)?.channel ??
-    nextMask.channel;
+      currentMask.items?.find((item) => item?.channel)?.channel,
+  );
   nextMask.invert =
     currentMask.invert ??
     currentMask.items?.find((item) => item?.invert !== undefined)?.invert ??
@@ -1636,7 +1644,7 @@ export const setTransitionMaskChannel = ({ state }, { channel } = {}) => {
     return;
   }
 
-  transitionMask.channel = channel;
+  transitionMask.channel = normalizeEditorMaskChannel(channel);
 };
 
 export const setTransitionMaskSample = ({ state }, { sample } = {}) => {
@@ -2103,7 +2111,7 @@ const buildTransitionMaskPanelDataForMask = (
   }
 
   const kind = transitionMask.kind;
-  const channelValue = transitionMask.channel ?? "alpha";
+  const channelValue = normalizeEditorMaskChannel(transitionMask.channel);
   const invertValue = transitionMask.invert ? "on" : "off";
   const progressDuration = transitionMask.progressDuration ?? 900;
   const progressEasing = transitionMask.progressEasing ?? "linear";
@@ -2119,7 +2127,7 @@ const buildTransitionMaskPanelDataForMask = (
   const compositeItems = (transitionMask.items ?? []).map((item, index) => ({
     ...buildMaskImageItem(state, item.imageId),
     index,
-    channelValue: item.channel ?? "alpha",
+    channelValue: normalizeEditorMaskChannel(item.channel),
     invertValue: item.invert ? "on" : "off",
     canMoveUp: index > 0,
     canMoveDown: index < transitionMask.items.length - 1,

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -63,16 +63,18 @@ const createPropertyFieldConfig = (
       label: "Position X",
       defaultValue: width / 2,
       slider: {
-        min: 0,
+        min: -width,
         max: width,
+        step: 0.01,
       },
     },
     y: {
       label: "Position Y",
       defaultValue: height / 2,
       slider: {
-        min: 0,
+        min: -height,
         max: height,
+        step: 0.01,
       },
     },
     scaleX: {

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -1,9 +1,6 @@
 import { generateId } from "../../internal/id.js";
 import { createLayoutEditorPayload } from "../../internal/layoutEditorRoute.js";
-import {
-  requireProjectResolution,
-  scaleLayoutElementsForProjectResolution,
-} from "../../internal/projectResolution.js";
+import { scaleLayoutElementsForProjectResolution } from "../../internal/projectResolution.js";
 import { isFragmentLayout } from "../../internal/project/layout.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
 import { appendTagIdToForm } from "../../internal/ui/resourcePages/tags.js";
@@ -282,6 +279,11 @@ export const handleEditFormAddOptionClick = (deps) => {
 const createLayoutElement = (id, data) => ({
   id,
   ...data,
+});
+
+const createEmptyLayoutElements = () => ({
+  items: {},
+  tree: [],
 });
 
 export const createLayoutTemplate = (layoutType, projectResolution) => {
@@ -1049,11 +1051,6 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
   const isFragment = normalizeBooleanField(values?.isFragment);
   const description = values?.description ?? "";
 
-  const projectResolution = requireProjectResolution(
-    projectService.getRepositoryState().project?.resolution,
-    "Project resolution",
-  );
-
   const createAttempt = await runResourcePageMutation({
     appService,
     fallbackMessage: "Failed to create layout.",
@@ -1067,7 +1064,7 @@ export const handleLayoutFormActionClick = async (deps, payload) => {
           tagIds: Array.isArray(values?.tagIds) ? values.tagIds : [],
           isFragment,
         },
-        elements: createLayoutTemplate(layoutType, projectResolution),
+        elements: createEmptyLayoutElements(),
         parentId: store.getState().targetGroupId,
         position: "last",
       }),

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -260,13 +260,14 @@ const buildTextStyleData = ({
   previewText,
   strokeColor,
   strokeWidth,
+  includeEmptyTagIds = true,
   clearOutlineColor = false,
 } = {}) => {
   const hasStrokeColor = Boolean(strokeColor);
+  const normalizedTagIds = Array.isArray(tagIds) ? tagIds : [];
   const textStyleData = {
     name,
     description: description ?? "",
-    tagIds: Array.isArray(tagIds) ? tagIds : [],
     fontSize: Number(fontSize ?? 16),
     lineHeight: Number(lineHeight ?? 1.5),
     colorId: fontColor,
@@ -275,6 +276,10 @@ const buildTextStyleData = ({
     previewText: previewText ?? "",
     strokeWidth: hasStrokeColor ? Number(strokeWidth ?? 0) : 0,
   };
+
+  if (normalizedTagIds.length > 0 || includeEmptyTagIds) {
+    textStyleData.tagIds = normalizedTagIds;
+  }
 
   if (hasStrokeColor) {
     textStyleData.strokeColorId = strokeColor;
@@ -322,6 +327,7 @@ const handleTextStyleCreated = async (deps, payload) => {
             previewText,
             strokeColor,
             strokeWidth,
+            includeEmptyTagIds: false,
           }),
         },
         parentId: groupId,

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -362,8 +362,8 @@ const STYLES = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(220, 38, 38, 0.92);
-    color: #ffffff;
+    background: transparent;
+    color: var(--error);
   }
 
   .preview-thumb rvn-file-image {
@@ -384,8 +384,8 @@ const STYLES = `
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #dc2626;
-    color: #ffffff;
+    background: transparent;
+    color: var(--error);
   }
 
   .preview-dialogue-item {
@@ -4771,14 +4771,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   createDeleteOverlay() {
     const overlay = document.createElement("div");
     overlay.className = "preview-delete-overlay";
-    overlay.append(this.createSvgIcon("x", 16, "white"));
+    overlay.append(this.createSvgIcon("x", 16, "er"));
     return overlay;
   }
 
   createPreviewGroupDeleteOverlay() {
     const overlay = document.createElement("div");
     overlay.className = "preview-group-delete-overlay";
-    overlay.append(this.createSvgIcon("x", 16, "white"));
+    overlay.append(this.createSvgIcon("x", 16, "er"));
     return overlay;
   }
 

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -14,6 +14,7 @@ import {
   setPopover,
   setPreviewImage,
   setProjectResolution,
+  setTransitionMaskChannel,
   setTransitionMaskImage,
   startPendingTransitionMask,
 } from "../../src/pages/animationEditor/animationEditor.store.js";
@@ -70,9 +71,37 @@ describe("animationEditor.store", () => {
 
     expect(viewData.transitionMaskPanel.enabled).toBe(false);
     expect(viewData.maskEditorPanel.enabled).toBe(true);
+    expect(viewData.maskEditorPanel.channelValue).toBe("red");
+    expect(viewData.maskEditorPanel.channelLabel).toBe("Greyscale");
     expect(viewData.popover.popoverIsOpen).toBe(false);
     expect(viewData.popover.maskDialogIsOpen).toBe(true);
     expect(viewData.popover.mode).toBe("addMask");
+    expect(viewData.maskChannelOptions).toEqual([
+      { label: "Greyscale", value: "red" },
+      { label: "Alpha", value: "alpha" },
+    ]);
+  });
+
+  it("uses greyscale red as the default mask channel", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "transition" });
+    enableTransitionMask({ state });
+
+    const viewData = selectViewData({ state });
+
+    expect(state.transitionMask.channel).toBe("red");
+    expect(viewData.transitionMaskPanel.channelValue).toBe("red");
+    expect(viewData.transitionMaskPanel.channelLabel).toBe("Greyscale");
+  });
+
+  it("normalizes removed mask channels to greyscale red", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "transition" });
+    enableTransitionMask({ state });
+
+    setTransitionMaskChannel({ state }, { channel: "green" });
+
+    expect(state.transitionMask.channel).toBe("red");
   });
 
   it("commits a pending mask inside Immer-backed store actions", () => {

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -104,6 +104,56 @@ describe("animationEditor.store", () => {
     expect(state.transitionMask.channel).toBe("red");
   });
 
+  it("allows negative two-decimal position keyframe values", () => {
+    const state = createInitialState();
+    setProjectResolution(
+      { state },
+      {
+        projectResolution: {
+          width: 1920,
+          height: 1080,
+        },
+      },
+    );
+
+    setPopover(
+      { state },
+      {
+        mode: "addKeyframe",
+        payload: {
+          property: "x",
+        },
+      },
+    );
+    const xField = selectViewData({ state }).addKeyframeForm.fields.find(
+      (field) => field.name === "value",
+    );
+
+    setPopover(
+      { state },
+      {
+        mode: "addKeyframe",
+        payload: {
+          property: "y",
+        },
+      },
+    );
+    const yField = selectViewData({ state }).addKeyframeForm.fields.find(
+      (field) => field.name === "value",
+    );
+
+    expect(xField).toMatchObject({
+      min: -1920,
+      max: 1920,
+      step: 0.01,
+    });
+    expect(yField).toMatchObject({
+      min: -1080,
+      max: 1080,
+      step: 0.01,
+    });
+  });
+
   it("commits a pending mask inside Immer-backed store actions", () => {
     const state = createInitialState();
     openDialog({ state }, { dialogType: "transition" });

--- a/tests/commandLineChoices/commandLineChoices.handlers.test.js
+++ b/tests/commandLineChoices/commandLineChoices.handlers.test.js
@@ -1,13 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleCancelEditClick,
+  handleChoiceContextMenu,
   handleChoiceFormChange,
+  handleDropdownMenuClickItem,
   handleSaveChoiceClick,
   handleSubmitClick,
 } from "../../src/components/commandLineChoices/commandLineChoices.handlers.js";
 import {
   createInitialState,
+  hideDropdownMenu,
+  removeChoice,
   saveChoice,
+  selectDropdownMenuChoiceIndex,
   selectEditForm,
   selectItems,
   selectItemsWithEditingDraft,
@@ -17,6 +22,7 @@ import {
   setItems,
   setMode,
   setSelectedResourceId,
+  showDropdownMenu,
   updateEditForm,
 } from "../../src/components/commandLineChoices/commandLineChoices.store.js";
 
@@ -29,7 +35,10 @@ const layouts = [
 ];
 
 const createStoreApi = (state) => ({
+  hideDropdownMenu: () => hideDropdownMenu({ state }),
+  removeChoice: (payload) => removeChoice({ state }, payload),
   saveChoice: () => saveChoice({ state }),
+  selectDropdownMenuChoiceIndex: () => selectDropdownMenuChoiceIndex({ state }),
   selectEditForm: () => selectEditForm({ state }),
   selectItems: () => selectItems({ state }),
   selectItemsWithEditingDraft: () => selectItemsWithEditingDraft({ state }),
@@ -38,6 +47,7 @@ const createStoreApi = (state) => ({
   setEditingIndex: (payload) => setEditingIndex({ state }, payload),
   setMode: (payload) => setMode({ state }, payload),
   setSelectedResourceId: (payload) => setSelectedResourceId({ state }, payload),
+  showDropdownMenu: (payload) => showDropdownMenu({ state }, payload),
   updateEditForm: (payload) => updateEditForm({ state }, payload),
 });
 
@@ -255,6 +265,89 @@ describe("commandLineChoices.handlers", () => {
             },
           },
         ],
+      },
+    });
+  });
+
+  it("deletes the right-clicked choice after a bubbled container context menu event", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setItems(
+      { state },
+      {
+        items: [
+          { content: "Stay" },
+          { content: "Leave" },
+          { content: "Return" },
+        ],
+      },
+    );
+    setSelectedResourceId(
+      { state },
+      {
+        resourceId: "choice-layout",
+      },
+    );
+
+    const deps = {
+      store,
+      render,
+      dispatchEvent,
+      props: {
+        layouts,
+      },
+    };
+
+    handleChoiceContextMenu(deps, {
+      _event: {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          dataset: {
+            index: "2",
+          },
+          getAttribute: vi.fn(),
+        },
+        clientX: 40,
+        clientY: 80,
+      },
+    });
+    handleChoiceContextMenu(deps, {
+      _event: {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          dataset: {},
+          getAttribute: vi.fn(() => null),
+        },
+        clientX: 40,
+        clientY: 80,
+      },
+    });
+
+    expect(selectDropdownMenuChoiceIndex({ state })).toBe(2);
+
+    handleDropdownMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "delete",
+          },
+        },
+      },
+    });
+
+    expect(selectItems({ state }).map((item) => item.content)).toEqual([
+      "Stay",
+      "Leave",
+    ]);
+    expect(dispatchEvent.mock.calls.at(-1)[0].detail).toEqual({
+      presentationState: {
+        choice: {
+          resourceId: "choice-layout",
+          items: [{ content: "Stay" }, { content: "Leave" }],
+        },
       },
     });
   });

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -229,6 +229,79 @@ describe("graphicsService", () => {
     expect(service.hasLoadedAsset("image-1")).toBe(false);
   });
 
+  it("waits for in-flight destroy before reinitializing the runtime", async () => {
+    let resolveUnload;
+    const bufferManager = {
+      has: vi.fn(() => false),
+      load: vi.fn(async () => {}),
+      getBufferMap: vi.fn(() => ({
+        "image-1": {
+          buffer: new ArrayBuffer(8),
+          type: "image/png",
+        },
+      })),
+      clear: vi.fn(),
+    };
+    createAssetBufferManagerMock.mockReturnValue(bufferManager);
+    assetsApi.unload.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUnload = resolve;
+        }),
+    );
+    assetsCache.set("image-1", {
+      source: {},
+    });
+
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    const initOptions = {
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    };
+
+    await service.init(initOptions);
+    await service.loadAssets({
+      "image-1": {
+        url: "blob:http://localhost/image-1",
+        type: "image/png",
+      },
+    });
+
+    const destroyPromise = service.destroy();
+    await vi.waitFor(() => {
+      expect(assetsApi.unload).toHaveBeenCalledWith("image-1");
+    });
+
+    const initPromise = service.init(initOptions);
+    await Promise.resolve();
+
+    expect(routeGraphicsInstance.init).toHaveBeenCalledTimes(1);
+
+    resolveUnload();
+    await destroyPromise;
+    await initPromise;
+
+    expect(routeGraphicsInstance.init).toHaveBeenCalledTimes(2);
+    expect(() => {
+      service.initRouteEngine({
+        screen: { width: 1920, height: 1080 },
+      });
+    }).not.toThrow();
+  });
+
   it("routes tauri Pixi media through the provided localhost origin", async () => {
     const filePath = "/Users/test/project/files/image-1";
     const localhostOrigin = "http://127.0.0.1:45123";

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -13,6 +13,7 @@ const routeGraphicsInstance = {
   destroy: vi.fn(),
   loadAssets: vi.fn(async () => {}),
   render: vi.fn(),
+  setAnimationPlaybackMode: vi.fn(),
   canvas: {
     style: {},
   },
@@ -80,6 +81,7 @@ describe("graphicsService", () => {
     routeGraphicsInstance.destroy.mockClear();
     routeGraphicsInstance.loadAssets.mockClear();
     routeGraphicsInstance.render.mockClear();
+    routeGraphicsInstance.setAnimationPlaybackMode.mockClear();
     createAssetBufferManagerMock.mockReset();
     createRouteGraphicsMock.mockReset();
     createRouteEngineMock.mockReset();
@@ -165,6 +167,66 @@ describe("graphicsService", () => {
 
     await expect(pendingLoad).resolves.toBeUndefined();
     expect(routeGraphicsInstance.loadAssets).not.toHaveBeenCalled();
+  });
+
+  it("ignores asset loads that finish after route graphics has been destroyed", async () => {
+    let resolveRenderAssetLoad;
+    const bufferManager = {
+      has: vi.fn(() => false),
+      load: vi.fn(async () => {}),
+      getBufferMap: vi.fn(() => ({
+        "image-1": {
+          buffer: new ArrayBuffer(8),
+          type: "image/png",
+        },
+      })),
+      clear: vi.fn(),
+    };
+    createAssetBufferManagerMock.mockReturnValue(bufferManager);
+    routeGraphicsInstance.loadAssets.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRenderAssetLoad = resolve;
+        }),
+    );
+    assetsCache.set("image-1", {
+      source: {},
+    });
+
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+
+    const pendingLoad = service.loadAssets({
+      "image-1": {
+        url: "blob:http://localhost/image-1",
+        type: "image/png",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(resolveRenderAssetLoad).toEqual(expect.any(Function));
+    });
+    await service.destroy();
+    resolveRenderAssetLoad();
+
+    await expect(pendingLoad).resolves.toBeUndefined();
+    expect(service.hasLoadedAsset("image-1")).toBe(false);
   });
 
   it("routes tauri Pixi media through the provided localhost origin", async () => {
@@ -667,6 +729,79 @@ describe("graphicsService", () => {
     expect(routeGraphicsInstance.render).toHaveBeenCalledWith(
       expect.objectContaining({
         audio: [],
+      }),
+    );
+  });
+
+  it("switches scene editor preview renders to manual playback when animations are skipped", async () => {
+    createRouteEngineMock.mockReturnValue({
+      init: vi.fn(),
+      selectRenderState: vi.fn(() => ({
+        id: "render-1",
+        elements: [
+          {
+            id: "dialogue",
+            type: "text-revealing",
+            revealEffect: "typing",
+          },
+        ],
+        audio: [],
+        animations: [
+          {
+            id: "animation-1",
+            targetId: "dialogue",
+            type: "update",
+          },
+        ],
+      })),
+      selectPresentationState: vi.fn(() => undefined),
+      selectPresentationChanges: vi.fn(() => undefined),
+      selectSectionLineChanges: vi.fn(() => []),
+      handleActions: vi.fn(),
+    });
+
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+
+    service.initRouteEngine({
+      screen: { width: 1920, height: 1080 },
+      story: { scenes: {} },
+      resources: {},
+    });
+    routeGraphicsInstance.render.mockClear();
+
+    service.engineRenderCurrentState({
+      skipAnimations: true,
+    });
+
+    expect(routeGraphicsInstance.setAnimationPlaybackMode).toHaveBeenCalledWith(
+      "manual",
+    );
+    expect(routeGraphicsInstance.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        animations: [],
+        elements: [
+          expect.objectContaining({
+            id: "dialogue",
+            revealEffect: "none",
+          }),
+        ],
       }),
     );
   });

--- a/tests/layouts/layouts.handlers.test.js
+++ b/tests/layouts/layouts.handlers.test.js
@@ -67,7 +67,7 @@ describe("createLayoutTemplate", () => {
     });
   });
 
-  it("creates layouts with description and fragment data", async () => {
+  it("creates layouts with empty elements and metadata", async () => {
     const createLayoutItem = vi.fn(async () => "layout-1");
     const deps = {
       store: {
@@ -101,9 +101,9 @@ describe("createLayoutTemplate", () => {
         detail: {
           actionId: "submit",
           values: {
-            name: "Save",
-            layoutType: "save-load",
-            description: "Reusable save fragment",
+            name: "Choices",
+            layoutType: "choice",
+            description: "Choice menu",
             isFragment: "true",
           },
         },
@@ -112,12 +112,16 @@ describe("createLayoutTemplate", () => {
 
     expect(createLayoutItem).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: "Save",
-        layoutType: "save-load",
+        name: "Choices",
+        layoutType: "choice",
         parentId: "group-1",
         position: "last",
+        elements: {
+          items: {},
+          tree: [],
+        },
         data: expect.objectContaining({
-          description: "Reusable save fragment",
+          description: "Choice menu",
           isFragment: true,
           tagIds: [],
         }),

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -341,6 +341,51 @@ describe("renderSceneEditorState", () => {
     expect(engineRenderCurrentState).toHaveBeenCalledTimes(1);
   });
 
+  it("skips preview animations by default unless explicitly enabled", async () => {
+    const projectData = createProjectData();
+    const graphicsService = createGraphicsService();
+    const engineRenderCurrentState = vi.fn();
+    graphicsService.engineRenderCurrentState = engineRenderCurrentState;
+    const store = {
+      selectSceneId: () => "scene-1",
+      selectSelectedSectionId: () => "section-1",
+      selectSelectedLineId: () => "line-2",
+      selectProjectData: () => projectData,
+      selectPreviewRuntimeGlobal: () => ({
+        dialogueTextSpeed: 100,
+      }),
+      selectIsMuted: () => false,
+      setPresentationState: ({ presentationState }) => {
+        store.presentationState = presentationState;
+      },
+      presentationState: undefined,
+    };
+
+    await renderSceneEditorState({
+      store,
+      graphicsService,
+    });
+
+    await renderSceneEditorState(
+      {
+        store,
+        graphicsService,
+      },
+      {
+        skipAnimations: false,
+      },
+    );
+
+    expect(engineRenderCurrentState).toHaveBeenNthCalledWith(1, {
+      skipAudio: false,
+      skipAnimations: true,
+    });
+    expect(engineRenderCurrentState).toHaveBeenNthCalledWith(2, {
+      skipAudio: false,
+      skipAnimations: false,
+    });
+  });
+
   it("renders the UI after a skipped canvas render when presentation state changes", async () => {
     const projectData = createProjectData();
     const graphicsService = createGraphicsService();

--- a/tests/textStyles/textStyles.handlers.test.js
+++ b/tests/textStyles/textStyles.handlers.test.js
@@ -1,15 +1,132 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleItemDuplicate } from "../../src/pages/textStyles/textStyles.handlers.js";
+import {
+  handleFormActionClick,
+  handleItemDuplicate,
+} from "../../src/pages/textStyles/textStyles.handlers.js";
 
 describe("textStyles.handlers", () => {
+  const createProjectState = () => ({
+    textStyles: {
+      items: {},
+      tree: [],
+    },
+    colors: {
+      items: {},
+      tree: [],
+    },
+    fonts: {
+      items: {},
+      tree: [],
+    },
+  });
+
+  const createFormDeps = ({
+    createTextStyle = vi.fn(async () => "text-style-new"),
+    updateTextStyle = vi.fn(async () => ({ valid: true })),
+    dialogState = {
+      targetGroupId: undefined,
+      editMode: false,
+      editingItemId: undefined,
+    },
+  } = {}) => ({
+    store: {
+      getState: () => ({
+        currentFormValues: {
+          previewText: "Preview",
+        },
+      }),
+      selectDialogState: vi.fn(() => dialogState),
+      resetFormValues: vi.fn(),
+      clearEditMode: vi.fn(),
+      toggleDialog: vi.fn(),
+      setItems: vi.fn(),
+      setTagsData: vi.fn(),
+      setColorsData: vi.fn(),
+      setFontsData: vi.fn(),
+      openAddColorDialog: vi.fn(),
+      openAddFontDialog: vi.fn(),
+    },
+    projectService: {
+      createTextStyle,
+      updateTextStyle,
+      getState: createProjectState,
+    },
+    appService: {
+      showAlert: vi.fn(),
+    },
+    render: vi.fn(),
+  });
+
+  const createSubmitPayload = (values = {}) => ({
+    _event: {
+      detail: {
+        actionId: "submit",
+        values: {
+          name: "Dialogue",
+          description: "",
+          tagIds: [],
+          fontSize: 24,
+          lineHeight: 1.5,
+          fontColor: "color-1",
+          fontStyle: "font-1",
+          fontWeight: "400",
+          strokeColor: "",
+          strokeWidth: 0,
+          ...values,
+        },
+      },
+    },
+  });
+
+  it("omits empty tag ids when creating a text style", async () => {
+    const createTextStyle = vi.fn(async () => "text-style-new");
+    const deps = createFormDeps({ createTextStyle });
+
+    await handleFormActionClick(deps, createSubmitPayload());
+
+    const createPayload = createTextStyle.mock.calls[0][0];
+    expect(Object.hasOwn(createPayload.data, "tagIds")).toBe(false);
+  });
+
+  it("keeps empty tag ids when updating a text style", async () => {
+    const updateTextStyle = vi.fn(async () => ({ valid: true }));
+    const deps = createFormDeps({
+      updateTextStyle,
+      dialogState: {
+        targetGroupId: undefined,
+        editMode: true,
+        editingItemId: "text-style-1",
+      },
+    });
+
+    await handleFormActionClick(deps, createSubmitPayload());
+
+    expect(updateTextStyle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textStyleId: "text-style-1",
+        data: expect.objectContaining({
+          tagIds: [],
+        }),
+      }),
+    );
+  });
+
   it("duplicates a text style and selects the duplicate", async () => {
     const duplicateTextStyle = vi.fn(async () => "text-style-copy");
+    let textStylesData = {
+      items: {},
+      tree: [],
+    };
     const deps = {
       store: {
-        setItems: vi.fn(),
+        getState: () => ({ textStylesData }),
+        setItems: vi.fn(({ textStylesData: nextTextStylesData } = {}) => {
+          textStylesData = nextTextStylesData;
+        }),
         setTagsData: vi.fn(),
         setColorsData: vi.fn(),
         setFontsData: vi.fn(),
+        setSelectedFolderId: vi.fn(),
         setSelectedItemId: vi.fn(),
       },
       refs: {


### PR DESCRIPTION
## Summary
- create new layouts without default text elements across layout types
- keep removed visual/character delete markers as an X without the red preview background
- allow text styles to be created with empty tags by omitting empty `tagIds` payloads
- harden scene editor graphics teardown, asset unloads, and init/destroy ordering so preview teardown cannot clear a restored inline canvas ticker
- simplify animation mask channels to Greyscale (`red`) and Alpha, with Greyscale/red as the default
- allow animation editor X/Y position keyframe values to go negative and use 0.01 increments
- move the root particle runtime cleanup fix to RouteVN/route-graphics#273

## Testing
- bunx vitest run tests/animationEditor/animationEditor.store.test.js tests/animationEditor/animationEditor.handlers.test.js
- bunx vitest run tests/graphicsService/graphicsService.test.js
- bunx vitest run tests/sceneEditor/runtime.test.js
- bunx vitest run tests/layouts/layouts.handlers.test.js tests/textStyles/textStyles.handlers.test.js
- bun run build:web
- bun run lint
- pre-push hook: oxlint && bun prettier --check src
- route-graphics local dependency check against RouteVN/route-graphics#273: bunx vitest run src/plugins/elements/particles/particleRuntime.test.js src/plugins/elements/particles/emitter/emitter.test.js
- route-graphics local dependency check against RouteVN/route-graphics#273: bun run test
- route-graphics local dependency check against RouteVN/route-graphics#273: bun run build