### PR TITLE
Fix scene editor preview sync for text arrow navigation

### DIFF
--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1929,6 +1929,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
+    this.scheduleNativeSelectionLineSyncAfterVerticalNavigation(event);
     this.updatePendingTextInputFallback(event);
 
     if (this.handleReferenceArrowNavigation(event)) {
@@ -1989,6 +1990,40 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   handleNativeInput() {
     this.clearPendingTextInputFallback();
+  }
+
+  scheduleNativeSelectionLineSyncAfterVerticalNavigation(event) {
+    if (
+      this.state?.mode !== "text-editor" ||
+      event.isComposing ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.altKey ||
+      (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+      typeof requestAnimationFrame !== "function"
+    ) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      if (!this.isConnected || this.state?.mode !== "text-editor") {
+        return;
+      }
+
+      const nativeSelection = this.getNativeLineSelectionContext();
+      const lineId = nativeSelection?.lineId;
+      if (!lineId || lineId === this.state.selectedLineId) {
+        return;
+      }
+
+      this.state.selectedLineId = lineId;
+      this.scheduleRender();
+      this.dispatchSelectedLineChanged(lineId, {
+        cursorPosition: nativeSelection.start,
+        isCollapsed: nativeSelection.start === nativeSelection.end,
+        mode: "text-editor",
+      });
+    });
   }
 
   handleWindowKeyDownCapture(event) {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -521,6 +521,82 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("syncs selected line from native selection after text-mode vertical arrow navigation", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-1",
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.updatePendingTextInputFallback = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-2",
+        start: 4,
+        end: 4,
+      }));
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      const event = {
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+        preventDefault: vi.fn(),
+      };
+
+      editorElement.handleNativeKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(animationFrameCallbacks).toHaveLength(1);
+
+      animationFrameCallbacks[0]();
+
+      expect(editorElement.state.selectedLineId).toBe("line-2");
+      expect(editorElement.scheduleRender).toHaveBeenCalledTimes(1);
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-2",
+        {
+          cursorPosition: 4,
+          isCollapsed: true,
+          mode: "text-editor",
+        },
+      );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
   it("suppresses native text insertion beforeinput while the editor is focused in block mode", async () => {
     const restoreDomGlobals = installDomGlobals();
 


### PR DESCRIPTION
## Summary
- sync selected line from the native caret after text-mode ArrowUp/ArrowDown navigation
- ensure right-side scene preview updates when WebKit moves the caret without a Lexical selection update
- add regression coverage for vertical arrow navigation in text mode

## Tests
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js
- bun run lint
- bun prettier --check tests/sceneEditor/lexicalLineEditing.test.js