### PR TITLE
chore: update route engine js

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "jszip": "^3.10.1",
         "lexical": "^0.22.0",
         "nanoid": "^5.1.5",
-        "route-engine-js": "1.13.2",
+        "route-engine-js": "1.14.2",
         "route-graphics": "1.15.1",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
@@ -710,7 +710,7 @@
 
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
 
-    "route-engine-js": ["route-engine-js@1.13.2", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-Tp/PaLsWsaZWD4seY/cqpG+sRFyGek8nz3PKRTaft+Of7cAMGGabDiGJBaaPZnNG4j47Lcho5hlydT0OMz8o6g=="],
+    "route-engine-js": ["route-engine-js@1.14.2", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-pd0tdLwzkcxDynOFRpw+SUoLzEuk1AyVmO3ezwDu4upfpOcZeW+P7AcTF0k+oUAQKF37GDi97mt9nevJg4PuVg=="],
 
     "route-graphics": ["route-graphics@1.15.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-9SDdqEWDGmI/uety8oHvLBUKkWsdU/zUYsc3+zBCdLDnRfv0tRmn3OCyW0kmCPBvR5PKg8RkDzKyNMH6J3H7Tg=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jszip": "^3.10.1",
     "lexical": "^0.22.0",
     "nanoid": "^5.1.5",
-    "route-engine-js": "1.13.2",
+    "route-engine-js": "1.14.2",
     "route-graphics": "1.15.1",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -4,7 +4,7 @@ import createRouteGraphics, {
   createAssetBufferManager,
 } from "route-graphics";
 import createRouteEngine, { createEffectsHandler } from "route-engine-js";
-import { Rectangle, Ticker } from "pixi.js";
+import { Ticker } from "pixi.js";
 import {
   prepareRenderStateKeyboardForGraphics,
   toRouteGraphicsKeyboardResource,
@@ -1269,7 +1269,6 @@ export const createGraphicsService = async ({
     }
 
     routeGraphics.render(nextRenderState);
-    applyInteractiveContainerHitAreas(nextRenderState.elements);
     void pruneDecodedAudioCache(retainedAudioKeys);
   };
 
@@ -1302,75 +1301,6 @@ export const createGraphicsService = async ({
 
       return nextElement;
     });
-  };
-
-  const applyInteractiveContainerHitAreas = (elements = []) => {
-    if (
-      !routeGraphics ||
-      typeof routeGraphics.findElementByLabel !== "function" ||
-      !Array.isArray(elements)
-    ) {
-      return;
-    }
-
-    const queue = [...elements];
-    while (queue.length > 0) {
-      const element = queue.shift();
-      if (!element || typeof element !== "object") {
-        continue;
-      }
-
-      if (Array.isArray(element.children) && element.children.length > 0) {
-        queue.push(...element.children);
-      }
-
-      if (element.type !== "container") {
-        continue;
-      }
-
-      const hasPointerInteraction = Boolean(
-        element.hover || element.click || element.rightClick,
-      );
-      if (!hasPointerInteraction) {
-        continue;
-      }
-
-      const container = routeGraphics.findElementByLabel(element.id);
-      if (!container) {
-        continue;
-      }
-
-      const localBounds =
-        typeof container.getLocalBounds === "function"
-          ? container.getLocalBounds()
-          : undefined;
-      const hitAreaX = typeof localBounds?.x === "number" ? localBounds.x : 0;
-      const hitAreaY = typeof localBounds?.y === "number" ? localBounds.y : 0;
-      const hitAreaWidth =
-        typeof element.width === "number" && element.width > 0
-          ? element.width
-          : localBounds?.width;
-      const hitAreaHeight =
-        typeof element.height === "number" && element.height > 0
-          ? element.height
-          : localBounds?.height;
-      if (
-        typeof hitAreaWidth !== "number" ||
-        typeof hitAreaHeight !== "number" ||
-        hitAreaWidth <= 0 ||
-        hitAreaHeight <= 0
-      ) {
-        continue;
-      }
-
-      container.hitArea = new Rectangle(
-        hitAreaX,
-        hitAreaY,
-        hitAreaWidth,
-        hitAreaHeight,
-      );
-      container.eventMode = "static";
-    }
   };
 
   const runWithSuppressedEngineRenderEffects = (callback) => {


### PR DESCRIPTION
## Summary
- bump route-engine-js from 1.13.2 to 1.14.2
- remove the app-side interactive container hit-area workaround now covered by the engine/graphics stack

## Testing
- bun run lint
- pre-push hook: oxlint and Prettier check