### PR TITLE
feat: add screen action animations

### DIFF
--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -158,6 +158,12 @@ const PRESENTATION_ACTION_SECTIONS = [
   ]),
   createSection("Visual", [
     {
+      id: "28",
+      label: "Screen",
+      icon: "screen",
+      mode: "screen",
+    },
+    {
       id: "4",
       label: "Background",
       icon: "image",

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.js
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.js
@@ -40,7 +40,7 @@ const resolveInitialSceneId = (scenes = {}, currentSceneId, sectionId) => {
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
-  const { scenes } = projectService.getRepositoryState();
+  const { animations, scenes } = projectService.getRepositoryState();
   const sectionId = props?.resetStoryAtSection?.sectionId;
   const sceneId = resolveInitialSceneId(
     scenes,
@@ -51,10 +51,15 @@ export const handleAfterMount = async (deps) => {
   store.setScenes({
     scenes,
   });
+  store.setAnimations({
+    animations,
+  });
   store.setFormValues({
     values: {
       sceneId,
       sectionId,
+      transitionAnimationId:
+        props?.resetStoryAtSection?.screen?.animations?.resourceId,
     },
   });
   render();
@@ -104,12 +109,22 @@ export const handleSubmitClick = (deps) => {
     return;
   }
 
+  const resetStoryAtSection = {
+    sectionId,
+  };
+
+  if (formValues.transitionAnimationId) {
+    resetStoryAtSection.screen = {
+      animations: {
+        resourceId: formValues.transitionAnimationId,
+      },
+    };
+  }
+
   dispatchEvent(
     new CustomEvent("submit", {
       detail: {
-        resetStoryAtSection: {
-          sectionId,
-        },
+        resetStoryAtSection,
       },
     }),
   );

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.schema.yaml
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.schema.yaml
@@ -4,5 +4,16 @@ propsSchema:
   properties:
     resetStoryAtSection:
       type: object
+      properties:
+        sectionId:
+          type: string
+        screen:
+          type: object
+          properties:
+            animations:
+              type: object
+              properties:
+                resourceId:
+                  type: string
     currentSceneId:
       type: string

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.js
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.js
@@ -1,4 +1,5 @@
 import { toFlatItems } from "../../internal/project/tree.js";
+import { getTransitionAnimationOptions } from "../../internal/animationOptions.js";
 
 const form = {
   fields: [
@@ -20,6 +21,16 @@ const form = {
       placeholder: "Choose a section",
       options: "${sectionOptions}",
     },
+    {
+      name: "transitionAnimationId",
+      type: "select",
+      label: "Screen",
+      description: "",
+      required: false,
+      clearable: true,
+      placeholder: "Choose a transition animation",
+      options: "${transitionAnimationOptions}",
+    },
   ],
   actions: {
     layout: "",
@@ -29,11 +40,16 @@ const form = {
 
 export const createInitialState = () => ({
   scenes: { items: {}, tree: [] },
+  animations: { items: {}, tree: [] },
   formValues: {},
 });
 
 export const setScenes = ({ state }, { scenes } = {}) => {
   state.scenes = scenes ?? { items: {}, tree: [] };
+};
+
+export const setAnimations = ({ state }, { animations } = {}) => {
+  state.animations = animations ?? { items: {}, tree: [] };
 };
 
 export const setFormValues = ({ state }, { values } = {}) => {
@@ -46,6 +62,9 @@ export const selectViewData = ({ state, props }) => {
   const selectedSceneId = state.formValues?.sceneId || props?.currentSceneId;
   const selectedScene = allScenes.find((scene) => scene.id === selectedSceneId);
   const selectedSectionId = state.formValues?.sectionId;
+  const selectedAnimationId =
+    state.formValues?.transitionAnimationId ??
+    props?.resetStoryAtSection?.screen?.animations?.resourceId;
 
   const sceneOptions = allScenes.map((scene) => ({
     value: scene.id,
@@ -88,6 +107,10 @@ export const selectViewData = ({ state, props }) => {
     context: {
       sceneOptions,
       sectionOptions,
+      transitionAnimationOptions: getTransitionAnimationOptions(
+        state.animations,
+        selectedAnimationId,
+      ),
     },
   };
 };

--- a/src/components/commandLineScreen/commandLineScreen.handlers.js
+++ b/src/components/commandLineScreen/commandLineScreen.handlers.js
@@ -1,0 +1,66 @@
+export const handleAfterMount = async (deps) => {
+  const { projectService, store, props, render } = deps;
+  await projectService.ensureRepository();
+  const { animations } = projectService.getRepositoryState();
+
+  store.setAnimations({
+    animations,
+  });
+  store.setFormValues({
+    values: {
+      transitionAnimationId: props?.screen?.animations?.resourceId,
+    },
+  });
+  render();
+};
+
+export const handleFormChange = (deps, payload) => {
+  const { render, store } = deps;
+  const values = payload?._event?.detail?.values;
+  if (!values) {
+    return;
+  }
+
+  store.setFormValues({ values });
+  render();
+};
+
+export const handleSubmitClick = (deps) => {
+  const { appService, dispatchEvent, store } = deps;
+  const { formValues } = store.getState();
+  const transitionAnimationId = formValues?.transitionAnimationId;
+
+  if (!transitionAnimationId) {
+    appService.showAlert({
+      message: "Please select a transition animation",
+      title: "Warning",
+    });
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("submit", {
+      detail: {
+        screen: {
+          animations: {
+            resourceId: transitionAnimationId,
+          },
+        },
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleBreadcrumbClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+
+  if (payload?._event?.detail?.id === "actions") {
+    dispatchEvent(
+      new CustomEvent("back-to-actions", {
+        detail: {},
+      }),
+    );
+  }
+};

--- a/src/components/commandLineScreen/commandLineScreen.schema.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.schema.yaml
@@ -1,0 +1,12 @@
+componentName: rvn-command-line-screen
+propsSchema:
+  type: object
+  properties:
+    screen:
+      type: object
+      properties:
+        animations:
+          type: object
+          properties:
+            resourceId:
+              type: string

--- a/src/components/commandLineScreen/commandLineScreen.store.js
+++ b/src/components/commandLineScreen/commandLineScreen.store.js
@@ -1,0 +1,65 @@
+import { getTransitionAnimationOptions } from "../../internal/animationOptions.js";
+
+const createEmptyCollection = () => ({
+  items: {},
+  tree: [],
+});
+
+const form = {
+  fields: [
+    {
+      name: "transitionAnimationId",
+      type: "select",
+      label: "Transition Animation",
+      description: "",
+      required: true,
+      clearable: false,
+      placeholder: "Choose a transition animation",
+      options: "${transitionAnimationOptions}",
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [],
+  },
+};
+
+export const createInitialState = () => ({
+  animations: createEmptyCollection(),
+  formValues: {},
+});
+
+export const setAnimations = ({ state }, { animations } = {}) => {
+  state.animations = animations ?? createEmptyCollection();
+};
+
+export const setFormValues = ({ state }, { values } = {}) => {
+  state.formValues = values ?? {};
+};
+
+export const selectViewData = ({ state, props }) => {
+  const selectedAnimationId =
+    state.formValues?.transitionAnimationId ??
+    props?.screen?.animations?.resourceId;
+
+  return {
+    breadcrumb: [
+      {
+        id: "actions",
+        label: "Actions",
+        click: true,
+      },
+      {
+        label: "Screen",
+      },
+    ],
+    form,
+    defaultValues: state.formValues,
+    context: {
+      transitionAnimationOptions: getTransitionAnimationOptions(
+        state.animations,
+        selectedAnimationId,
+      ),
+    },
+  };
+};

--- a/src/components/commandLineScreen/commandLineScreen.view.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.view.yaml
@@ -1,0 +1,20 @@
+refs:
+  breadcrumb:
+    eventListeners:
+      item-click:
+        handler: handleBreadcrumbClick
+  form:
+    eventListeners:
+      form-change:
+        handler: handleFormChange
+  submitButton:
+    eventListeners:
+      click:
+        handler: handleSubmitClick
+template:
+  - rtgl-view w=f h=f p=lg:
+      - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
+      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
+          - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js
@@ -1,13 +1,16 @@
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
-  const { scenes } = projectService.getRepositoryState();
+  const { animations, scenes } = projectService.getRepositoryState();
 
   // Safe access to nested properties
   const sectionTransition = props?.sectionTransition;
 
   store.setScenes({
     scenes,
+  });
+  store.setAnimations({
+    animations,
   });
 
   if (!sectionTransition) {
@@ -23,7 +26,7 @@ export const handleAfterMount = async (deps) => {
   // Initialize form values from existing line data
   const transition = sectionTransition;
   const formValues = {
-    animation: transition.animation,
+    transitionAnimationId: transition.screen?.animations?.resourceId,
   };
 
   if (transition.sceneId) {
@@ -76,14 +79,23 @@ export const handleSubmitClick = (deps) => {
     return;
   }
 
+  const sectionTransition = {
+    sceneId: formValues.sceneId,
+    sectionId: formValues.sectionId,
+  };
+
+  if (formValues.transitionAnimationId) {
+    sectionTransition.screen = {
+      animations: {
+        resourceId: formValues.transitionAnimationId,
+      },
+    };
+  }
+
   dispatchEvent(
     new CustomEvent("submit", {
       detail: {
-        sectionTransition: {
-          sceneId: formValues.sceneId,
-          sectionId: formValues.sectionId,
-          animation: formValues.animation || "fade",
-        },
+        sectionTransition,
       },
       bubbles: true,
       composed: true,

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.schema.yaml
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.schema.yaml
@@ -9,7 +9,13 @@ propsSchema:
           type: string
         sectionId:
           type: string
-        animation:
-          type: string
+        screen:
+          type: object
+          properties:
+            animations:
+              type: object
+              properties:
+                resourceId:
+                  type: string
     currentSceneId:
       type: string

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.store.js
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.store.js
@@ -1,4 +1,5 @@
 import { toFlatItems } from "../../internal/project/tree.js";
+import { getTransitionAnimationOptions } from "../../internal/animationOptions.js";
 
 const form = {
   fields: [
@@ -20,21 +21,16 @@ const form = {
       placeholder: "Choose a section",
       options: "${sectionOptions}",
     },
-    // {
-    //   name: "animation",
-    //   type: "select",
-    //   label: "Transition Animation",
-    //   description: "",
-    //   required: false,
-    //   placeholder: "Choose animation...",
-    //   options: [
-    //     { value: "fade", label: "Fade" },
-    //     { value: "slide", label: "Slide" },
-    //     { value: "dissolve", label: "Dissolve" },
-    //     { value: "wipe", label: "Wipe" },
-    //     { value: "none", label: "None" },
-    //   ],
-    // },
+    {
+      name: "transitionAnimationId",
+      type: "select",
+      label: "Screen",
+      description: "",
+      required: false,
+      clearable: true,
+      placeholder: "Choose a transition animation",
+      options: "${transitionAnimationOptions}",
+    },
   ],
   actions: {
     layout: "",
@@ -46,6 +42,7 @@ export const createInitialState = () => ({
   mode: "current",
   initiated: false,
   scenes: { items: {}, tree: [] },
+  animations: { items: {}, tree: [] },
   formValues: {},
 });
 
@@ -61,6 +58,10 @@ export const setScenes = ({ state }, { scenes } = {}) => {
   state.scenes = scenes;
 };
 
+export const setAnimations = ({ state }, { animations } = {}) => {
+  state.animations = animations ?? { items: {}, tree: [] };
+};
+
 export const setFormValues = ({ state }, values = {}) => {
   state.formValues = values;
 };
@@ -69,6 +70,9 @@ export const selectViewData = ({ state, props }) => {
   const scenes = toFlatItems(state.scenes);
   const allScenes = scenes.filter((item) => item.type === "scene");
   const selectedSceneId = state.formValues?.sceneId || props?.currentSceneId;
+  const selectedAnimationId =
+    state.formValues?.transitionAnimationId ??
+    props?.sectionTransition?.screen?.animations?.resourceId;
 
   const currentScene = allScenes.find((item) => item.id === selectedSceneId);
   const currentSceneSections = currentScene?.sections
@@ -116,6 +120,10 @@ export const selectViewData = ({ state, props }) => {
   const context = {
     sceneOptions,
     sectionOptions,
+    transitionAnimationOptions: getTransitionAnimationOptions(
+      state.animations,
+      selectedAnimationId,
+    ),
   };
 
   return {

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -358,6 +358,7 @@ export const selectActionsData = ({ props, state }) => {
   const images = repositoryStateData.images?.items || {};
   const videos = repositoryStateData.videos?.items || {};
   const sounds = repositoryStateData.sounds?.items || {};
+  const animations = repositoryStateData.animations?.items || {};
   const scenes = repositoryStateData.scenes || {};
   // Layouts: need full tree structure for toFlatItems() to search through nested folders
   const layoutsHierarchy = repositoryStateData.layouts || {};
@@ -385,6 +386,15 @@ export const selectActionsData = ({ props, state }) => {
     } else if (backgroundLayout) {
       preview.background = { ...backgroundLayout, type: "layout" };
     }
+  }
+
+  if (actions.screen?.animations?.resourceId) {
+    const animation = animations[actions.screen.animations.resourceId];
+    actionsObject.screen = actions.screen;
+    preview.screen = {
+      animation,
+      label: animation?.name || actions.screen.animations.resourceId,
+    };
   }
 
   if (presentationState.layout) {

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -40,7 +40,7 @@ refs:
 template:
   - $if showSelected:
       - rtgl-view g=md w=f:
-          - $if preview.background || preview.bgm || preview.sfx || preview.character || preview.visual || preview.sectionTransition || preview.resetStoryAtSection || preview.dialogue || preview.choice || preview.control || preview.nextLine || preview.toggleAutoMode || preview.toggleSkipMode || preview.startSkipMode || preview.stopSkipMode || preview.toggleDialogueUI || preview.runtimeActions || preview.setNextLineConfig || preview.updateVariable || preview.conditional || preview.pushOverlay || preview.popOverlay || preview.rollbackByOffset || preview.showConfirmDialog || preview.hideConfirmDialog || preview.saveSlot || preview.loadSlot:
+          - $if preview.screen || preview.background || preview.bgm || preview.sfx || preview.character || preview.visual || preview.sectionTransition || preview.resetStoryAtSection || preview.dialogue || preview.choice || preview.control || preview.nextLine || preview.toggleAutoMode || preview.toggleSkipMode || preview.startSkipMode || preview.stopSkipMode || preview.toggleDialogueUI || preview.runtimeActions || preview.setNextLineConfig || preview.updateVariable || preview.conditional || preview.pushOverlay || preview.popOverlay || preview.rollbackByOffset || preview.showConfirmDialog || preview.hideConfirmDialog || preview.saveSlot || preview.loadSlot:
               - $if preview.control:
                   - rtgl-view#actionItemControl data-mode=control g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=control wh=24: null
@@ -58,6 +58,10 @@ template:
                         $elif preview.background.type == 'layout':
                           - rtgl-svg svg=layout wh=24: null
                           - rtgl-text s=sm: ${preview.background.name}
+              - $if preview.screen:
+                  - rtgl-view#actionItemScreen data-mode=screen g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
+                      - rtgl-svg svg=screen wh=24: null
+                      - rtgl-text s=sm: ${preview.screen.label}
               - $if preview.bgm:
                   - rtgl-view#actionItemBgm data-mode=bgm g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=music wh=24: null
@@ -204,6 +208,8 @@ template:
                   - rvn-command-line-choices#commandLineChoices :layouts=${choiceLayouts} :choice=${actions.choice}: null
                 $elif mode == "background":
                   - rvn-command-line-background#commandLineBackground data-mode="background" :background=${actions.background}: null
+                $elif mode == "screen":
+                  - rvn-command-line-screen#commandLineScreen :screen=${actions.screen}: null
                 $elif mode == "bgm":
                   - rvn-command-line-bgm#commandLineBgm :bgm=${actions.bgm}: null
                 $elif mode == "sfx":

--- a/src/internal/animationOptions.js
+++ b/src/internal/animationOptions.js
@@ -1,0 +1,33 @@
+import { toFlatItems } from "./project/tree.js";
+
+export const getAnimationResourceType = (item = {}) => {
+  return item?.animation?.type === "transition" ? "transition" : "update";
+};
+
+export const getTransitionAnimationOptions = (
+  animations = {},
+  selectedAnimationId,
+) => {
+  const options = toFlatItems(animations)
+    .filter(
+      (item) =>
+        item.type === "animation" &&
+        getAnimationResourceType(item) === "transition",
+    )
+    .map((item) => ({
+      value: item.id,
+      label: item.name,
+    }));
+
+  if (
+    selectedAnimationId &&
+    !options.some((option) => option.value === selectedAnimationId)
+  ) {
+    options.unshift({
+      value: selectedAnimationId,
+      label: `Missing animation (${selectedAnimationId})`,
+    });
+  }
+
+  return options;
+};

--- a/src/internal/routevnUrls.js
+++ b/src/internal/routevnUrls.js
@@ -29,6 +29,7 @@ const creatorDocsPathByRoutePattern = {
   "/project/releases/versions": "/versions/",
   "/project/releases/web-server": "/web-server/",
   "/project/about": "/page-index/#settings",
+  "/project/appearance": "/page-index/#settings",
   "/project/user": "/page-index/#settings",
 };
 
@@ -37,6 +38,7 @@ const creatorDocsPathBySystemActionMode = {
   hidden: "/page-index/",
   dialogue: "/line-actions/dialogue/",
   choice: "/line-actions/choices/",
+  screen: "/line-actions/visual/",
   background: "/line-actions/background/",
   bgm: "/line-actions/bgm/",
   sfx: "/line-actions/sfx/",

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -138,6 +138,10 @@ const buildSectionTransitionPreview = (line) => {
   return !!transitionData.sectionId || !!transitionData.sceneId;
 };
 
+const buildScreenTransitionPreview = (lineActions) => {
+  return !!lineActions?.screen?.animations?.resourceId;
+};
+
 const buildChoicesPreview = (line) => {
   const lineActions = normalizeLineActions(line.actions || {});
   const choicesData = lineActions?.choice;
@@ -236,6 +240,7 @@ const buildSceneDocumentLineViewModels = ({
         characterLookups.characterItems,
       ),
       visual: buildVisualPreview(repositoryState, changes),
+      screenTransition: buildScreenTransitionPreview(lineActions),
       sectionTransition: buildSectionTransitionPreview(line),
       hasChoices: choicesPreview.hasChoices,
       hasConditional: buildConditionalPreview(lineActions),

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -5597,6 +5597,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       background: lineDecoration.background,
       characterSprites: lineDecoration.characterSprites,
       visual: lineDecoration.visual,
+      screenTransition: Boolean(lineDecoration.screenTransition),
       sectionTransition: Boolean(lineDecoration.sectionTransition),
       hasDialogueLayout: Boolean(lineDecoration.hasDialogueLayout),
       dialogueModeLabel: lineDecoration.dialogueModeLabel || "",
@@ -6204,6 +6205,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         item.append(this.createPreviewGroupDeleteOverlay());
       }
       container.append(item);
+    }
+
+    if (lineDecoration.screenTransition) {
+      container.append(
+        this.createIconPreview({
+          icon: "screen",
+        }),
+      );
     }
 
     if (lineDecoration.sectionTransition) {

--- a/svg/screen.svg
+++ b/svg/screen.svg
@@ -1,4 +1,3 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="3" y="4" width="18" height="12" rx="1" stroke="currentColor" stroke-width="2"/>
-  <rect x="5" y="6" width="14" height="8" rx="0.5" stroke="currentColor" stroke-width="1.5" fill="none"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="7.5" width="16" height="9" rx="1.25" fill="currentColor"/>
 </svg>

--- a/tests/commandLineActions/commandLineActions.store.test.js
+++ b/tests/commandLineActions/commandLineActions.store.test.js
@@ -272,6 +272,9 @@ describe("commandLineActions.store", () => {
     });
 
     expect(getSectionModes(items, "Dialogue")).toEqual(["dialogue"]);
+    expect(getSectionModes(items, "Visual")).toEqual(
+      expect.arrayContaining(["screen", "background", "character", "visual"]),
+    );
     expect(getSectionModes(items, "Audio")).toEqual(["bgm", "sfx"]);
     expect(getSectionModes(items, "Navigation")).toEqual(
       expect.arrayContaining([

--- a/tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.test.js
+++ b/tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.handlers.test.js
@@ -57,4 +57,61 @@ describe("commandLineResetStoryAtSection.handlers", () => {
       },
     });
   });
+
+  it("submits resetStoryAtSection with an optional screen transition", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setScenes(
+      { state },
+      {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              sections: {
+                items: {
+                  "section-2": {
+                    id: "section-2",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+    setFormValues(
+      { state },
+      {
+        values: {
+          sceneId: "scene-1",
+          sectionId: "section-2",
+          transitionAnimationId: "screen-mask-reveal",
+        },
+      },
+    );
+
+    handleSubmitClick({
+      appService: {
+        showAlert: vi.fn(),
+      },
+      dispatchEvent,
+      store: {
+        getState: () => state,
+      },
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      resetStoryAtSection: {
+        sectionId: "section-2",
+        screen: {
+          animations: {
+            resourceId: "screen-mask-reveal",
+          },
+        },
+      },
+    });
+  });
 });

--- a/tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.test.js
+++ b/tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   selectViewData,
+  setAnimations,
   setFormValues,
   setScenes,
 } from "../../src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.js";
@@ -67,6 +68,54 @@ describe("commandLineResetStoryAtSection.store", () => {
     ]);
     expect(viewData.context.sectionOptions).toEqual([
       { value: "section-2", label: "Credits" },
+    ]);
+  });
+
+  it("shows transition animation options", () => {
+    const state = createInitialState();
+
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            "screen-mask-reveal": {
+              id: "screen-mask-reveal",
+              type: "animation",
+              name: "Screen Mask Reveal",
+              animation: {
+                type: "transition",
+              },
+            },
+            "pulse-update": {
+              id: "pulse-update",
+              type: "animation",
+              name: "Pulse",
+              animation: {
+                type: "update",
+              },
+            },
+          },
+          tree: [{ id: "screen-mask-reveal" }, { id: "pulse-update" }],
+        },
+      },
+    );
+    setFormValues(
+      { state },
+      {
+        values: {
+          transitionAnimationId: "screen-mask-reveal",
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state, props: {} });
+
+    expect(viewData.context.transitionAnimationOptions).toEqual([
+      {
+        value: "screen-mask-reveal",
+        label: "Screen Mask Reveal",
+      },
     ]);
   });
 });

--- a/tests/commandLineScreen/commandLineScreen.handlers.test.js
+++ b/tests/commandLineScreen/commandLineScreen.handlers.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createInitialState,
+  setFormValues,
+} from "../../src/components/commandLineScreen/commandLineScreen.store.js";
+import { handleSubmitClick } from "../../src/components/commandLineScreen/commandLineScreen.handlers.js";
+
+describe("commandLineScreen.handlers", () => {
+  it("submits a screen animation payload", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setFormValues(
+      { state },
+      {
+        values: {
+          transitionAnimationId: "screen-crossfade",
+        },
+      },
+    );
+
+    handleSubmitClick({
+      appService: {
+        showAlert: vi.fn(),
+      },
+      dispatchEvent,
+      store: {
+        getState: () => state,
+      },
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      screen: {
+        animations: {
+          resourceId: "screen-crossfade",
+        },
+      },
+    });
+  });
+
+  it("shows an alert when no transition animation is selected", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+    const showAlert = vi.fn();
+
+    handleSubmitClick({
+      appService: {
+        showAlert,
+      },
+      dispatchEvent,
+      store: {
+        getState: () => state,
+      },
+    });
+
+    expect(dispatchEvent).not.toHaveBeenCalled();
+    expect(showAlert).toHaveBeenCalledWith({
+      message: "Please select a transition animation",
+      title: "Warning",
+    });
+  });
+});

--- a/tests/commandLineScreen/commandLineScreen.store.test.js
+++ b/tests/commandLineScreen/commandLineScreen.store.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setAnimations,
+  setFormValues,
+} from "../../src/components/commandLineScreen/commandLineScreen.store.js";
+
+describe("commandLineScreen.store", () => {
+  it("offers transition animations for the screen transition picker", () => {
+    const state = createInitialState();
+
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            "fade-in": {
+              id: "fade-in",
+              type: "animation",
+              name: "Fade In",
+              animation: {
+                type: "transition",
+              },
+            },
+            "pulse-update": {
+              id: "pulse-update",
+              type: "animation",
+              name: "Pulse",
+              animation: {
+                type: "update",
+              },
+            },
+          },
+          tree: [{ id: "fade-in" }, { id: "pulse-update" }],
+        },
+      },
+    );
+    setFormValues(
+      { state },
+      {
+        values: {
+          transitionAnimationId: "fade-in",
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state, props: {} });
+
+    expect(viewData.context.transitionAnimationOptions).toEqual([
+      {
+        value: "fade-in",
+        label: "Fade In",
+      },
+    ]);
+    expect(viewData.defaultValues.transitionAnimationId).toBe("fade-in");
+  });
+});

--- a/tests/commandLineSectionTransition/commandLineSectionTransition.handlers.test.js
+++ b/tests/commandLineSectionTransition/commandLineSectionTransition.handlers.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createInitialState,
+  setFormValues,
+  setScenes,
+} from "../../src/components/commandLineSectionTransition/commandLineSectionTransition.store.js";
+import { handleSubmitClick } from "../../src/components/commandLineSectionTransition/commandLineSectionTransition.handlers.js";
+
+describe("commandLineSectionTransition.handlers", () => {
+  it("submits sectionTransition with an optional screen transition", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setScenes(
+      { state },
+      {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              sections: {
+                items: {
+                  "section-2": {
+                    id: "section-2",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+    setFormValues(
+      { state },
+      {
+        sceneId: "scene-1",
+        sectionId: "section-2",
+        transitionAnimationId: "screen-crossfade",
+      },
+    );
+
+    handleSubmitClick({
+      appService: {
+        showAlert: vi.fn(),
+      },
+      dispatchEvent,
+      store: {
+        getState: () => state,
+      },
+    });
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      sectionTransition: {
+        sceneId: "scene-1",
+        sectionId: "section-2",
+        screen: {
+          animations: {
+            resourceId: "screen-crossfade",
+          },
+        },
+      },
+    });
+  });
+});

--- a/tests/commandLineSectionTransition/commandLineSectionTransition.store.test.js
+++ b/tests/commandLineSectionTransition/commandLineSectionTransition.store.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setAnimations,
+  setFormValues,
+  setScenes,
+} from "../../src/components/commandLineSectionTransition/commandLineSectionTransition.store.js";
+
+describe("commandLineSectionTransition.store", () => {
+  it("builds transition animation options from animation resources", () => {
+    const state = createInitialState();
+
+    setScenes(
+      { state },
+      {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              name: "Opening",
+              sections: {
+                items: {
+                  "section-1": {
+                    id: "section-1",
+                    type: "section",
+                    name: "Intro",
+                  },
+                },
+                tree: [{ id: "section-1" }],
+              },
+            },
+          },
+          tree: [{ id: "scene-1" }],
+        },
+      },
+    );
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            "screen-crossfade": {
+              id: "screen-crossfade",
+              type: "animation",
+              name: "Screen Crossfade",
+              animation: {
+                type: "transition",
+              },
+            },
+            "shake-update": {
+              id: "shake-update",
+              type: "animation",
+              name: "Shake",
+              animation: {
+                type: "update",
+              },
+            },
+          },
+          tree: [{ id: "screen-crossfade" }, { id: "shake-update" }],
+        },
+      },
+    );
+    setFormValues(
+      { state },
+      {
+        sceneId: "scene-1",
+        sectionId: "section-1",
+        transitionAnimationId: "screen-crossfade",
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        currentSceneId: "scene-1",
+      },
+    });
+
+    expect(viewData.context.transitionAnimationOptions).toEqual([
+      {
+        value: "screen-crossfade",
+        label: "Screen Crossfade",
+      },
+    ]);
+  });
+});

--- a/tests/internal/routevnUrls.test.js
+++ b/tests/internal/routevnUrls.test.js
@@ -72,6 +72,9 @@ describe("routevnUrls", () => {
     expect(getRoutevnCreatorSystemActionDocsUrl("background")).toBe(
       "https://routevn.com/creator/docs/line-actions/background/",
     );
+    expect(getRoutevnCreatorSystemActionDocsUrl("screen")).toBe(
+      "https://routevn.com/creator/docs/line-actions/visual/",
+    );
     expect(getRoutevnCreatorSystemActionDocsUrl("setNextLineConfig")).toBe(
       "https://routevn.com/creator/docs/line-actions/next-line-config/",
     );

--- a/tests/project/projection.test.js
+++ b/tests/project/projection.test.js
@@ -322,6 +322,93 @@ describe("constructProjectData", () => {
     ]);
   });
 
+  it("projects line screen transitions for route-engine rendering", () => {
+    const projectData = constructProjectData(
+      createExportRepositoryState({
+        animations: createTreeCollection(
+          {
+            "screen-crossfade": {
+              id: "screen-crossfade",
+              type: "animation",
+              name: "Screen Crossfade",
+              animation: {
+                type: "transition",
+                next: {
+                  tween: {
+                    alpha: {
+                      initialValue: 0,
+                      keyframes: [
+                        {
+                          duration: 300,
+                          value: 1,
+                          easing: "linear",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          [{ id: "screen-crossfade" }],
+        ),
+        scenes: createTreeCollection(
+          {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              name: "Scene 1",
+              sections: createTreeCollection(
+                {
+                  "section-1": {
+                    id: "section-1",
+                    name: "Section 1",
+                    lines: createTreeCollection(
+                      {
+                        "line-1": {
+                          id: "line-1",
+                          actions: {
+                            screen: {
+                              animations: {
+                                resourceId: "screen-crossfade",
+                              },
+                            },
+                          },
+                        },
+                      },
+                      [{ id: "line-1" }],
+                    ),
+                  },
+                },
+                [{ id: "section-1" }],
+              ),
+            },
+          },
+          [{ id: "scene-1" }],
+        ),
+      }),
+    );
+
+    expect(
+      projectData.story.scenes["scene-1"].sections["section-1"].lines[0].actions
+        .screen,
+    ).toEqual({
+      animations: {
+        resourceId: "screen-crossfade",
+      },
+    });
+
+    const renderState = selectRouteEngineRenderState(projectData);
+
+    expect(renderState.animations).toEqual([
+      expect.objectContaining({
+        id: "screen-animation-in",
+        targetId: "story",
+        type: "transition",
+      }),
+    ]);
+  });
+
   it("projects dialogue character sprites with the route-engine 1.9.0 render contract", () => {
     const projectData = constructProjectData(
       createExportRepositoryState({

--- a/tests/sceneEditor/lineViewModels.test.js
+++ b/tests/sceneEditor/lineViewModels.test.js
@@ -290,4 +290,50 @@ describe("sceneEditor.lineDecorations", () => {
     expect(viewModels[0].hasUpdateVariable).toBe(true);
     expect(viewModels[1].hasUpdateVariable).toBe(false);
   });
+
+  it("marks screen actions for inline action previews without duplicating section transitions", () => {
+    const lines = [
+      {
+        id: "line-1",
+        actions: {
+          screen: {
+            animations: {
+              resourceId: "screen-crossfade",
+            },
+          },
+        },
+      },
+      {
+        id: "line-2",
+        actions: {
+          sectionTransition: {
+            sceneId: "scene-1",
+            sectionId: "section-2",
+            screen: {
+              animations: {
+                resourceId: "screen-mask-reveal",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "line-3",
+        actions: {},
+      },
+    ];
+
+    const viewModels = buildSceneDocumentLineDecorations({
+      lines,
+      repositoryState: createRepositoryState(),
+      sectionLineChanges: {
+        lines: [],
+      },
+    });
+
+    expect(viewModels[0].screenTransition).toBe(true);
+    expect(viewModels[1].screenTransition).toBe(false);
+    expect(viewModels[1].sectionTransition).toBe(true);
+    expect(viewModels[2].screenTransition).toBe(false);
+  });
 });

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -169,6 +169,50 @@ describe("systemActions.store", () => {
     });
   });
 
+  it("preserves and previews screen transition actions", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          animations: {
+            items: {
+              "screen-crossfade": {
+                id: "screen-crossfade",
+                type: "animation",
+                name: "Screen Crossfade",
+              },
+            },
+            tree: [{ id: "screen-crossfade" }],
+          },
+        },
+      },
+    );
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actions: {
+          screen: {
+            animations: {
+              resourceId: "screen-crossfade",
+            },
+          },
+        },
+      },
+    });
+
+    expect(actions.screen).toEqual({
+      animations: {
+        resourceId: "screen-crossfade",
+      },
+    });
+    expect(preview.screen).toMatchObject({
+      label: "Screen Crossfade",
+    });
+  });
+
   it("includes custom character name and persist character labels in dialogue preview when a character is selected", () => {
     const state = createInitialState();
 

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -24,6 +24,10 @@ describe("systemActions view", () => {
     expect(systemActionsView).toContain(
       "rvn-command-line-actions#commandLineActions :actionsType=${actionsType} :hiddenModes=${hiddenModes} :allowedModes=${allowedModes}",
     );
+    expect(systemActionsView).toContain(
+      "rvn-command-line-screen#commandLineScreen :screen=${actions.screen}",
+    );
+    expect(systemActionsView).toContain("rtgl-svg svg=screen wh=24");
     expect(conditionalView).toContain(
       "rvn-system-actions#branchActionsEditor :showSelected=${true} :actions=${branchActions} actionType=system :hiddenModes=${hiddenModes} :allowedModes=${branchActionAllowedModes}",
     );


### PR DESCRIPTION
## Summary
- add the Screen command-line action for line-level `screen.animations` payloads
- add optional Screen animation selectors to section transition and reset-story-at-section commands
- preview direct Screen actions with a filled 16:9 screen icon and avoid duplicate icons for section transitions with screen animations
- add projection, store, handler, view, and scene-editor coverage for the new action shape

## Testing
- focused Vitest screen/transition/system/scene/projection suite: 13 files, 108 tests passed
- `bunx vitest run tests/sceneEditor/lineViewModels.test.js tests/systemActions/systemActions.view.test.js tests/commandLineActions/commandLineActions.store.test.js`
- `bun run build:web`
- push hook: `oxlint && bun prettier --check src`