### PR TITLE
fix: support screen animation in choice transitions

### DIFF
--- a/src/components/commandLineChoices/commandLineChoices.handlers.js
+++ b/src/components/commandLineChoices/commandLineChoices.handlers.js
@@ -89,9 +89,12 @@ export const handleBeforeMount = (deps) => {
 export const handleAfterMount = async (deps) => {
   const { projectService, store, render } = deps;
   await projectService.ensureRepository();
-  const { scenes } = projectService.getRepositoryState();
+  const { animations, scenes } = projectService.getRepositoryState();
   store.setScenes({
     scenes,
+  });
+  store.setAnimations({
+    animations,
   });
   render();
 };

--- a/src/components/commandLineChoices/commandLineChoices.store.js
+++ b/src/components/commandLineChoices/commandLineChoices.store.js
@@ -1,4 +1,5 @@
 import { toFlatItems } from "../../internal/project/tree.js";
+import { getTransitionAnimationOptions } from "../../internal/animationOptions.js";
 
 const CHOICE_FORM_TEMPLATE = Object.freeze({
   title: "Edit Choice",
@@ -33,6 +34,16 @@ const CHOICE_FORM_TEMPLATE = Object.freeze({
       type: "select",
       label: "Section",
       options: "${sections}",
+    },
+    {
+      $when: `values.actionType == 'sectionTransition'`,
+      name: "transitionAnimationId",
+      type: "select",
+      label: "Screen",
+      required: false,
+      clearable: true,
+      placeholder: "Animation",
+      options: "${transitionAnimationOptions}",
     },
   ],
 });
@@ -86,6 +97,10 @@ export const createInitialState = () => ({
     items: {},
     tree: [],
   },
+  animations: {
+    items: {},
+    tree: [],
+  },
 });
 
 export const setMode = ({ state }, { mode } = {}) => {
@@ -106,8 +121,18 @@ export const setEditingIndex = ({ state }, { index } = {}) => {
         choice.events?.click?.actions?.sectionTransition?.sceneId;
       state.editForm.sectionId =
         choice.events?.click?.actions?.sectionTransition?.sectionId;
+      state.editForm.transitionAnimationId =
+        choice.events?.click?.actions?.sectionTransition?.screen?.animations?.resourceId;
     } else if (choice.events?.click?.actions?.nextLine) {
       state.editForm.actionType = "nextLine";
+      state.editForm.sceneId = "";
+      state.editForm.sectionId = "";
+      state.editForm.transitionAnimationId = "";
+    } else {
+      state.editForm.actionType = "nextLine";
+      state.editForm.sceneId = "";
+      state.editForm.sectionId = "";
+      state.editForm.transitionAnimationId = "";
     }
   } else {
     // New choice or reset
@@ -116,6 +141,7 @@ export const setEditingIndex = ({ state }, { index } = {}) => {
     state.editForm.actionType = "nextLine";
     state.editForm.sceneId = "";
     state.editForm.sectionId = "";
+    state.editForm.transitionAnimationId = "";
   }
 };
 
@@ -128,10 +154,20 @@ const buildChoiceDataFromEditForm = (editForm = {}) => {
   if (editForm.actionType === "nextLine") {
     actions.nextLine = {};
   } else if (editForm.actionType === "sectionTransition") {
-    actions.sectionTransition = {
+    const sectionTransition = {
       sceneId: editForm.sceneId,
       sectionId: editForm.sectionId,
     };
+
+    if (editForm.transitionAnimationId) {
+      sectionTransition.screen = {
+        animations: {
+          resourceId: editForm.transitionAnimationId,
+        },
+      };
+    }
+
+    actions.sectionTransition = sectionTransition;
   }
 
   return {
@@ -166,6 +202,10 @@ export const removeChoice = ({ state }, { index } = {}) => {
 
 export const setScenes = ({ state }, { scenes } = {}) => {
   state.scenes = scenes;
+};
+
+export const setAnimations = ({ state }, { animations } = {}) => {
+  state.animations = animations ?? { items: {}, tree: [] };
 };
 
 export const saveChoice = ({ state }, _payload = {}) => {
@@ -350,6 +390,10 @@ export const selectViewData = ({ state, props }) => {
     values: state.editForm,
     scenes,
     sections,
+    transitionAnimationOptions: getTransitionAnimationOptions(
+      state.animations,
+      state.editForm.transitionAnimationId,
+    ),
   };
 
   // Create defaultValues with items data
@@ -360,6 +404,7 @@ export const selectViewData = ({ state, props }) => {
     actionType: state?.editForm?.actionType,
     sceneId: state?.editForm?.sceneId,
     sectionId: state?.editForm?.sectionId,
+    transitionAnimationId: state?.editForm?.transitionAnimationId,
   };
 
   const viewData = {

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.js
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.js
@@ -28,7 +28,7 @@ const form = {
       description: "",
       required: false,
       clearable: true,
-      placeholder: "Choose a transition animation",
+      placeholder: "Animation",
       options: "${transitionAnimationOptions}",
     },
   ],

--- a/src/components/commandLineScreen/commandLineScreen.store.js
+++ b/src/components/commandLineScreen/commandLineScreen.store.js
@@ -10,11 +10,11 @@ const form = {
     {
       name: "transitionAnimationId",
       type: "select",
-      label: "Transition Animation",
+      label: "Animation",
       description: "",
       required: true,
       clearable: false,
-      placeholder: "Choose a transition animation",
+      placeholder: "Animation",
       options: "${transitionAnimationOptions}",
     },
   ],
@@ -38,9 +38,9 @@ export const setFormValues = ({ state }, { values } = {}) => {
 };
 
 export const selectViewData = ({ state, props }) => {
+  const propsAnimationId = props?.screen?.animations?.resourceId;
   const selectedAnimationId =
-    state.formValues?.transitionAnimationId ??
-    props?.screen?.animations?.resourceId;
+    state.formValues?.transitionAnimationId ?? propsAnimationId;
 
   return {
     breadcrumb: [
@@ -54,7 +54,11 @@ export const selectViewData = ({ state, props }) => {
       },
     ],
     form,
-    defaultValues: state.formValues,
+    formKey: propsAnimationId ?? "new-screen",
+    defaultValues: {
+      ...state.formValues,
+      transitionAnimationId: selectedAnimationId,
+    },
     context: {
       transitionAnimationOptions: getTransitionAnimationOptions(
         state.animations,

--- a/src/components/commandLineScreen/commandLineScreen.view.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.store.js
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.store.js
@@ -28,7 +28,7 @@ const form = {
       description: "",
       required: false,
       clearable: true,
-      placeholder: "Choose a transition animation",
+      placeholder: "Animation",
       options: "${transitionAnimationOptions}",
     },
   ],

--- a/tests/commandLineChoices/commandLineChoices.handlers.test.js
+++ b/tests/commandLineChoices/commandLineChoices.handlers.test.js
@@ -232,6 +232,92 @@ describe("commandLineChoices.handlers", () => {
     });
   });
 
+  it("saves a choice section transition with an optional screen animation", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setItems({ state }, { items: [] });
+    setSelectedResourceId(
+      { state },
+      {
+        resourceId: "choice-layout",
+      },
+    );
+    setMode({ state }, { mode: "editChoice" });
+    setEditingIndex({ state }, { index: -1 });
+    updateEditForm(
+      { state },
+      {
+        field: "content",
+        value: "Leave",
+      },
+    );
+    updateEditForm(
+      { state },
+      {
+        field: "actionType",
+        value: "sectionTransition",
+      },
+    );
+    updateEditForm(
+      { state },
+      {
+        field: "sceneId",
+        value: "scene-1",
+      },
+    );
+    updateEditForm(
+      { state },
+      {
+        field: "sectionId",
+        value: "section-2",
+      },
+    );
+    updateEditForm(
+      { state },
+      {
+        field: "transitionAnimationId",
+        value: "screen-crossfade",
+      },
+    );
+
+    handleSaveChoiceClick({
+      store,
+      render,
+      dispatchEvent,
+      appService: {
+        showAlert: vi.fn(),
+      },
+      props: {
+        layouts,
+      },
+    });
+
+    expect(selectItems({ state })[0]).toEqual({
+      content: "Leave",
+      events: {
+        click: {
+          actions: {
+            sectionTransition: {
+              sceneId: "scene-1",
+              sectionId: "section-2",
+              screen: {
+                animations: {
+                  resourceId: "screen-crossfade",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      dispatchEvent.mock.calls[0][0].detail.presentationState.choice.items[0],
+    ).toEqual(selectItems({ state })[0]);
+  });
+
   it("submits the saved choice state with the selected layout", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();

--- a/tests/commandLineChoices/commandLineChoices.store.test.js
+++ b/tests/commandLineChoices/commandLineChoices.store.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectEditForm,
+  selectViewData,
+  setAnimations,
+  setEditingIndex,
+  setItems,
+  setScenes,
+} from "../../src/components/commandLineChoices/commandLineChoices.store.js";
+
+describe("commandLineChoices.store", () => {
+  it("prefills and offers screen animations for choice section transitions", () => {
+    const state = createInitialState();
+
+    setItems(
+      { state },
+      {
+        items: [
+          {
+            content: "Leave",
+            events: {
+              click: {
+                actions: {
+                  sectionTransition: {
+                    sceneId: "scene-1",
+                    sectionId: "section-2",
+                    screen: {
+                      animations: {
+                        resourceId: "screen-crossfade",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    );
+    setScenes(
+      { state },
+      {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              name: "Opening",
+              sections: {
+                items: {
+                  "section-2": {
+                    id: "section-2",
+                    type: "section",
+                    name: "Exit",
+                  },
+                },
+                tree: [{ id: "section-2" }],
+              },
+            },
+          },
+          tree: [{ id: "scene-1" }],
+        },
+      },
+    );
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            "screen-crossfade": {
+              id: "screen-crossfade",
+              type: "animation",
+              name: "Screen Crossfade",
+              animation: {
+                type: "transition",
+              },
+            },
+            "pulse-update": {
+              id: "pulse-update",
+              type: "animation",
+              name: "Pulse",
+              animation: {
+                type: "update",
+              },
+            },
+          },
+          tree: [{ id: "screen-crossfade" }, { id: "pulse-update" }],
+        },
+      },
+    );
+
+    setEditingIndex({ state }, { index: 0 });
+
+    const viewData = selectViewData({ state, props: { layouts: [] } });
+
+    expect(selectEditForm({ state }).transitionAnimationId).toBe(
+      "screen-crossfade",
+    );
+    expect(viewData.editFormContext.transitionAnimationOptions).toEqual([
+      {
+        value: "screen-crossfade",
+        label: "Screen Crossfade",
+      },
+    ]);
+  });
+});

--- a/tests/commandLineScreen/commandLineScreen.store.test.js
+++ b/tests/commandLineScreen/commandLineScreen.store.test.js
@@ -7,6 +7,32 @@ import {
 } from "../../src/components/commandLineScreen/commandLineScreen.store.js";
 
 describe("commandLineScreen.store", () => {
+  it("uses the current screen animation as the initial form value", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        screen: {
+          animations: {
+            resourceId: "screen-crossfade",
+          },
+        },
+      },
+    });
+
+    expect(viewData.formKey).toBe("screen-crossfade");
+    expect(viewData.defaultValues.transitionAnimationId).toBe(
+      "screen-crossfade",
+    );
+    expect(viewData.form.fields[0]).toEqual(
+      expect.objectContaining({
+        label: "Animation",
+        placeholder: "Animation",
+      }),
+    );
+  });
+
   it("offers transition animations for the screen transition picker", () => {
     const state = createInitialState();
 


### PR DESCRIPTION
## Summary
- prefill the Screen editor animation immediately when opened from the selected action preview
- rename screen animation picker labels/placeholders to `Animation`
- add optional Screen animation selection to choice section transitions and preserve it when reopening choices
- clear hidden choice section/screen fields when editing continue actions

## Testing
- `bunx vitest run tests/commandLineChoices/commandLineChoices.handlers.test.js tests/commandLineChoices/commandLineChoices.store.test.js tests/commandLineScreen/commandLineScreen.store.test.js tests/commandLineSectionTransition/commandLineSectionTransition.store.test.js tests/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.test.js`
- `bun run lint`
- push hook: `oxlint && bun prettier --check src`