### PR TITLE
Fix scene editor block mode interactions

### DIFF
--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
@@ -19,6 +19,10 @@ refs:
         handler: handleForwardEditorEvent
       delete-line-shortcut:
         handler: handleForwardEditorEvent
+      line-context-menu-request:
+        handler: handleForwardEditorEvent
+      line-context-menu-dismiss:
+        handler: handleForwardEditorEvent
       furigana-dialog-request:
         handler: handleFuriganaDialogRequest
 template:

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1234,6 +1234,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   const dropdownState = store.getState().dropdownMenu;
   const sectionId = dropdownState.sectionId;
   const actionsType = dropdownState.actionsType;
+  const lineId = dropdownState.lineId;
   const sceneId = store.selectSceneId();
 
   store.hideDropdownMenu();
@@ -1284,6 +1285,8 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
     store.showSectionEditDialog({
       sectionId,
     });
+  } else if (action === "delete-line") {
+    await deleteSceneEditorLine(deps, lineId);
   } else if (action === "delete-actions") {
     const selectedLineId = store.selectSelectedLineId();
     const selectedSectionId = store.selectSelectedSectionId();
@@ -1603,23 +1606,17 @@ export const handlePreviewShortcut = (deps, payload) => {
   handlePreviewClick(deps, payload);
 };
 
-export const handleDeleteLineShortcut = async (deps, payload) => {
-  const { store, render } = deps;
-  const { subject } = deps;
+const deleteSceneEditorLine = async (deps, lineId) => {
+  const { store, render, subject } = deps;
   if (isSectionsOverviewOpen(store)) {
-    return;
+    return false;
   }
   cancelSceneEditorDraftFlush(deps);
 
-  const detail = payload?._event?.detail || {};
-  const lineId =
-    typeof detail.lineId === "string" && detail.lineId
-      ? detail.lineId
-      : store.selectSelectedLineId();
   const sectionId = store.selectSelectedSectionId();
 
   if (!lineId || !sectionId) {
-    return;
+    return false;
   }
 
   const scene = store.selectScene();
@@ -1627,20 +1624,20 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
   const lines = Array.isArray(section?.lines) ? section.lines : [];
   const currentIndex = lines.findIndex((line) => line.id === lineId);
   if (currentIndex < 0) {
-    return;
+    return false;
   }
 
   const nextSelectedLineId =
     lines[currentIndex + 1]?.id || lines[currentIndex - 1]?.id;
 
   if (lines.length <= 1) {
-    return;
+    return false;
   }
 
   const draftSection =
     store.selectDraftSection() || reconcileCurrentEditorSession(deps);
   if (!draftSection) {
-    return;
+    return false;
   }
 
   const nextLines = cloneSceneEditorLines(draftSection.lines).filter(
@@ -1673,6 +1670,49 @@ export const handleDeleteLineShortcut = async (deps, payload) => {
   scheduleSceneEditorDraftFlush(deps, {
     reason: "structure",
   });
+  return true;
+};
+
+export const handleDeleteLineShortcut = async (deps, payload) => {
+  const { store } = deps;
+  const detail = payload?._event?.detail || {};
+  const lineId =
+    typeof detail.lineId === "string" && detail.lineId
+      ? detail.lineId
+      : store.selectSelectedLineId();
+
+  await deleteSceneEditorLine(deps, lineId);
+};
+
+export const handleLineContextMenuRequest = (deps, payload) => {
+  const { store, render } = deps;
+  if (isSectionsOverviewOpen(store)) {
+    return;
+  }
+
+  const detail = payload?._event?.detail || {};
+  const lineId = detail.lineId;
+  if (!lineId) {
+    return;
+  }
+
+  store.setSelectedLineId({ selectedLineId: lineId });
+  store.showLineDropdownMenu({
+    position: detail.position || { x: 0, y: 0 },
+    lineId,
+  });
+  render();
+};
+
+export const handleLineContextMenuDismiss = (deps) => {
+  const { store, render } = deps;
+  const dropdownState = store.getState().dropdownMenu;
+  if (!dropdownState.lineId) {
+    return;
+  }
+
+  store.hideDropdownMenu();
+  render();
 };
 
 export const handleLineDeleteActionItem = async (deps, payload) => {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -486,6 +486,7 @@ export const createInitialState = () => ({
     items: [],
     sectionId: null,
     actionsType: null,
+    lineId: undefined,
   },
   popover: {
     isOpen: false,
@@ -969,6 +970,7 @@ export const showSectionDropdownMenu = (
     items,
     sectionId,
     actionsType: null,
+    lineId: undefined,
   };
 };
 
@@ -989,6 +991,7 @@ export const showSectionsOverviewDropdownMenu = (
     items,
     sectionId: null,
     actionsType: null,
+    lineId: undefined,
   };
 };
 
@@ -1002,6 +1005,18 @@ export const showActionsDropdownMenu = (
     items: [{ label: "Delete", type: "item", value: "delete-actions" }],
     sectionId: null,
     actionsType,
+    lineId: undefined,
+  };
+};
+
+export const showLineDropdownMenu = ({ state }, { position, lineId } = {}) => {
+  state.dropdownMenu = {
+    isOpen: true,
+    position,
+    items: [{ label: "Delete", type: "item", value: "delete-line" }],
+    sectionId: null,
+    actionsType: null,
+    lineId,
   };
 };
 
@@ -1012,6 +1027,7 @@ export const hideDropdownMenu = ({ state }, _payload = {}) => {
     items: [],
     sectionId: null,
     actionsType: null,
+    lineId: undefined,
   };
 };
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -19,6 +19,10 @@ refs:
         handler: handleDialogueCharacterShortcut
       delete-line-shortcut:
         handler: handleDeleteLineShortcut
+      line-context-menu-request:
+        handler: handleLineContextMenuRequest
+      line-context-menu-dismiss:
+        handler: handleLineContextMenuDismiss
   sectionTab*:
     eventListeners:
       click:

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -217,6 +217,7 @@ const STYLES = `
   .gutter-left {
     left: 0;
     width: var(--left-gutter-width);
+    pointer-events: auto;
   }
 
   .gutter-right {
@@ -237,6 +238,10 @@ const STYLES = `
     width: 100%;
     gap: 0;
     justify-content: flex-start;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    pointer-events: auto;
   }
 
   .gutter-right .gutter-row {
@@ -280,6 +285,10 @@ const STYLES = `
     overflow: hidden;
     margin-right: 2px;
     background: transparent;
+    cursor: pointer;
+    pointer-events: auto;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   .speaker-slot rvn-file-image {
@@ -613,6 +622,22 @@ const isBlockModeNativeEditorKey = (event) => {
   );
 };
 
+const containsDomNode = (container, node) => {
+  if (!container?.contains || !node) {
+    return false;
+  }
+
+  const nodeConstructor = globalThis.Node;
+  if (
+    typeof nodeConstructor === "function" &&
+    !(node instanceof nodeConstructor)
+  ) {
+    return false;
+  }
+
+  return container.contains(node);
+};
+
 const isEditorOrSurfaceEventTarget = ({
   activeElement,
   event,
@@ -620,11 +645,16 @@ const isEditorOrSurfaceEventTarget = ({
   surfaceElement,
 }) => {
   const eventPath = event?.composedPath?.() ?? [];
+  const target = event?.target;
   return (
     activeElement === editorElement ||
     activeElement === surfaceElement ||
-    event?.target === editorElement ||
-    event?.target === surfaceElement ||
+    containsDomNode(editorElement, activeElement) ||
+    containsDomNode(surfaceElement, activeElement) ||
+    target === editorElement ||
+    target === surfaceElement ||
+    containsDomNode(editorElement, target) ||
+    containsDomNode(surfaceElement, target) ||
     eventPath.includes(editorElement) ||
     eventPath.includes(surfaceElement)
   );
@@ -792,6 +822,8 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.isPointerDownInsideEditor = false;
     this.pointerDownInsideEditorTimerId = undefined;
     this.pendingPointerFallbackSelection = undefined;
+    this.pendingBlockContextMenuSelectedLineId = undefined;
+    this.pendingDefaultContextMenuLineId = undefined;
 
     this.editor = createEditor({
       namespace: "routevn-lexical-scene-document-editor",
@@ -816,6 +848,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.handleNativeDragEvent = this.handleNativeDragEvent.bind(this);
     this.handleNativeMouseDown = this.handleNativeMouseDown.bind(this);
     this.handleNativeMouseUp = this.handleNativeMouseUp.bind(this);
+    this.handleLeftGutterMouseDown = this.handleLeftGutterMouseDown.bind(this);
     this.handleNativeContextMenu = this.handleNativeContextMenu.bind(this);
     this.handleCompositionStart = this.handleCompositionStart.bind(this);
     this.handleCompositionEnd = this.handleCompositionEnd.bind(this);
@@ -945,6 +978,11 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       true,
     );
     this.refs.editor.addEventListener("mouseup", this.handleNativeMouseUp);
+    this.refs.leftGutter.addEventListener(
+      "mousedown",
+      this.handleLeftGutterMouseDown,
+      true,
+    );
     this.refs.editor.addEventListener("dragstart", this.handleNativeDragEvent);
     this.refs.editor.addEventListener("dragenter", this.handleNativeDragEvent);
     this.refs.editor.addEventListener("dragover", this.handleNativeDragEvent);
@@ -1028,6 +1066,11 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       true,
     );
     this.refs.editor?.removeEventListener("mouseup", this.handleNativeMouseUp);
+    this.refs.leftGutter?.removeEventListener(
+      "mousedown",
+      this.handleLeftGutterMouseDown,
+      true,
+    );
     this.refs.editor?.removeEventListener(
       "dragstart",
       this.handleNativeDragEvent,
@@ -1949,7 +1992,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       event.stopPropagation();
       this.enterBlockMode({
         focusSurface: true,
-        lineId: this.getSelectedLineIdSnapshot(),
+        lineId: this.state.selectedLineId || this.getSelectedLineIdSnapshot(),
         emitSelectionChange: true,
       });
       return;
@@ -2027,11 +2070,55 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   handleWindowKeyDownCapture(event) {
+    if (this.handleBlockModeWindowShortcut(event)) {
+      return;
+    }
+
     if (this.handleBlockModeWindowArrowNavigation(event)) {
       return;
     }
 
     this.handleBlockModeWindowEnter(event);
+  }
+
+  handleBlockModeWindowShortcut(event) {
+    if (
+      event.defaultPrevented ||
+      event.isComposing ||
+      this.state.mode !== "block"
+    ) {
+      return false;
+    }
+
+    const activeElement = this.getActiveElement();
+    const target = event.target;
+    const isDocumentKeyTarget =
+      (activeElement === document.body ||
+        activeElement === document.documentElement ||
+        activeElement === this) &&
+      (target === document.body ||
+        target === document.documentElement ||
+        target === document ||
+        target === window ||
+        target === this);
+    const isEditorKeyTarget = isEditorOrSurfaceEventTarget({
+      activeElement,
+      event,
+      editorElement: this.refs.editor,
+      surfaceElement: this.refs.surface,
+    });
+
+    if (!isDocumentKeyTarget && !isEditorKeyTarget) {
+      return false;
+    }
+
+    const didHandle = this.handleSurfaceKeyDown(event);
+    if (!didHandle) {
+      return false;
+    }
+
+    event.stopImmediatePropagation?.();
+    return true;
   }
 
   handleBlockModeWindowArrowNavigation(event) {
@@ -2236,6 +2323,26 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   handleNativeMouseDown(event) {
     if (event.button !== 0) {
+      if (event.button === 2 && this.state.mode === "block") {
+        this.pendingBlockContextMenuSelectedLineId = this.state.selectedLineId;
+        const lineElement = this.getLineElementFromEvent(event);
+        const lineId = this.getLineIdFromLineElement(lineElement);
+        if (lineId && lineId !== this.state.selectedLineId) {
+          this.pendingDefaultContextMenuLineId = lineId;
+          this.hideSelectionPopover();
+          this.closeMentionMenu();
+          this.enterTextMode({
+            lineId,
+            cursorPosition: this.getLineOffsetFromPointerEvent(
+              event,
+              lineElement,
+            ),
+          });
+          return;
+        }
+
+        event.preventDefault?.();
+      }
       return;
     }
 
@@ -2279,6 +2386,55 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
       this.selectReferenceByNodeKey(referenceSnapshot.nodeKey);
     });
+  }
+
+  handleLeftGutterMouseDown(event) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const row = this.getLeftGutterRowFromEvent(event);
+    const lineId = row?.dataset?.lineId;
+    if (!lineId || !this.hasLine(lineId)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    this.clearPointerDownInsideEditor();
+    this.pendingPointerFallbackSelection = undefined;
+    this.awaitingCharacterShortcut = false;
+    this.clearDeleteShortcutState();
+    this.hideSelectionPopover();
+    this.closeMentionMenu();
+    this.enterBlockMode({
+      focusSurface: true,
+      lineId,
+      emitSelectionChange: true,
+    });
+  }
+
+  getLeftGutterRowFromEvent(event) {
+    const path =
+      typeof event.composedPath === "function" ? event.composedPath() : [];
+    const candidates = path.length > 0 ? path : [event.target];
+
+    for (const candidate of candidates) {
+      const element =
+        candidate?.nodeType === Node.TEXT_NODE
+          ? candidate.parentElement
+          : candidate;
+      const row = element?.classList?.contains("gutter-row")
+        ? element
+        : element?.closest?.(".gutter-row");
+
+      if (row && this.refs.leftGutter?.contains(row)) {
+        return row;
+      }
+    }
+
+    return undefined;
   }
 
   enterTextModeFromBlockModePointer(event) {
@@ -2427,6 +2583,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   handleNativeMouseUp(event) {
+    if (typeof event?.button === "number" && event.button !== 0) {
+      return;
+    }
+
     setTimeout(() => {
       this.clearPointerDownInsideEditor();
     }, 0);
@@ -2554,6 +2714,17 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   handleNativeContextMenu(event) {
+    if (this.pendingDefaultContextMenuLineId) {
+      this.pendingDefaultContextMenuLineId = undefined;
+      this.dispatchShortcutEvent("line-context-menu-dismiss", {});
+      return;
+    }
+
+    if (this.state.mode === "block") {
+      this.handleBlockModeContextMenu(event);
+      return;
+    }
+
     const referenceSnapshot = this.getReferenceSnapshotFromContextEvent(event);
     if (referenceSnapshot) {
       event.preventDefault();
@@ -2594,6 +2765,44 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     event.preventDefault();
     event.stopPropagation();
     this.showSelectionPopover(event);
+  }
+
+  handleBlockModeContextMenu(event) {
+    if (this.state.mode !== "block") {
+      return false;
+    }
+
+    const selectedLineId =
+      this.pendingBlockContextMenuSelectedLineId ?? this.state.selectedLineId;
+    this.pendingBlockContextMenuSelectedLineId = undefined;
+
+    const lineElement = this.getLineElementFromEvent(event);
+    const lineId = this.getLineIdFromLineElement(lineElement);
+    if (!lineId || lineId !== selectedLineId) {
+      this.hideSelectionPopover();
+      this.closeMentionMenu();
+      this.dispatchShortcutEvent("line-context-menu-dismiss", {});
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    this.hideSelectionPopover();
+    this.closeMentionMenu();
+    this.enterBlockMode({
+      focusSurface: true,
+      lineId,
+      emitSelectionChange: true,
+    });
+    this.dispatchShortcutEvent("line-context-menu-request", {
+      lineId,
+      position: {
+        x: event.clientX ?? 0,
+        y: event.clientY ?? 0,
+      },
+    });
+    return true;
   }
 
   isContextMenuEventInsideRange(event, range) {
@@ -3166,6 +3375,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           cursorPosition: -1,
         });
         return true;
+      case "i":
       case "Shift+I":
         event.preventDefault();
         event.stopPropagation();
@@ -5332,7 +5542,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     const previousLines = this.state.lines;
     const previousSelectedLineId = this.state.selectedLineId;
     this.state.lines = cloneSceneEditorLines(snapshot.lines);
-    this.state.selectedLineId = snapshot.selectedLineId;
+    this.state.selectedLineId =
+      this.state.mode === "block"
+        ? previousSelectedLineId
+        : snapshot.selectedLineId;
     this.state.activeFormats = snapshot.activeFormats;
     this.state.plainText = snapshot.lines
       .map((line) => getPlainTextFromContent(getLineDialogueContent(line)))

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -233,6 +233,160 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("routes block-mode shortcuts from the window capture path when focus has fallen to the document", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.refs = {
+        editor: document.createElement("div"),
+        surface: document.createElement("div"),
+      };
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        lines: [{ id: "line-1" }],
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.dispatchShortcutEvent = vi.fn();
+      editorElement.getActiveElement = vi.fn(() => document.body);
+
+      const event = {
+        key: "o",
+        code: "KeyO",
+        defaultPrevented: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        target: document,
+        composedPath: vi.fn(() => [document, window]),
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleWindowKeyDownCapture(event);
+
+      expect(editorElement.dispatchShortcutEvent).toHaveBeenCalledWith(
+        "newLine",
+        {
+          lineId: "line-1",
+          position: "after",
+        },
+      );
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("routes block-mode shortcuts from the window capture path when the host owns focus", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.refs = {
+        editor: document.createElement("div"),
+        surface: document.createElement("div"),
+      };
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        lines: [{ id: "line-1" }],
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.enterTextMode = vi.fn();
+      editorElement.getActiveElement = vi.fn(() => editorElement);
+
+      const event = {
+        key: "Enter",
+        code: "Enter",
+        defaultPrevented: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        target: editorElement,
+        composedPath: vi.fn(() => [editorElement]),
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleWindowKeyDownCapture(event);
+
+      expect(editorElement.enterTextMode).toHaveBeenCalledWith({
+        lineId: "line-1",
+        cursorPosition: -1,
+      });
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("routes lowercase i to enter text mode at the start of the selected block line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        lines: [{ id: "line-1" }],
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.enterTextMode = vi.fn();
+
+      const event = {
+        key: "i",
+        code: "KeyI",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+
+      editorElement.handleSurfaceKeyDown(event);
+
+      expect(editorElement.enterTextMode).toHaveBeenCalledWith({
+        lineId: "line-1",
+        cursorPosition: 0,
+      });
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("focuses before restoring selection in focusLine recovery", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -906,6 +1060,473 @@ describe("lexical scene document editor line editing", () => {
       expect(editorElement.state.selectedLineId).toBe("line-1");
       expect(editorElement.applyModeState).toHaveBeenCalledWith("text-editor");
       expect(editorElement.scheduleRender).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("enters block mode for the clicked line from the left gutter", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const leftGutter = document.createElement("div");
+      const row = document.createElement("div");
+      const lineNumber = document.createElement("div");
+
+      row.className = "gutter-row";
+      row.dataset.lineId = "line-2";
+      lineNumber.className = "line-number";
+      lineNumber.textContent = "2";
+      row.append(lineNumber);
+      leftGutter.append(row);
+
+      editorElement.refs = {
+        leftGutter,
+      };
+      editorElement.hasLine = vi.fn(() => true);
+      editorElement.clearPointerDownInsideEditor = vi.fn();
+      editorElement.clearDeleteShortcutState = vi.fn();
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.enterBlockMode = vi.fn();
+
+      const event = {
+        button: 0,
+        target: lineNumber.firstChild,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleLeftGutterMouseDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.hasLine).toHaveBeenCalledWith("line-2");
+      expect(editorElement.enterBlockMode).toHaveBeenCalledWith({
+        focusSurface: true,
+        lineId: "line-2",
+        emitSelectionChange: true,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("enters block mode for the clicked line from an empty speaker slot", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const leftGutter = document.createElement("div");
+      const row = document.createElement("div");
+      const speakerSlot = document.createElement("div");
+
+      row.className = "gutter-row";
+      row.dataset.lineId = "line-3";
+      speakerSlot.className = "speaker-slot";
+      row.append(speakerSlot);
+      leftGutter.append(row);
+
+      editorElement.refs = {
+        leftGutter,
+      };
+      editorElement.hasLine = vi.fn(() => true);
+      editorElement.clearPointerDownInsideEditor = vi.fn();
+      editorElement.clearDeleteShortcutState = vi.fn();
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.enterBlockMode = vi.fn();
+
+      const event = {
+        button: 0,
+        target: speakerSlot,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleLeftGutterMouseDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.hasLine).toHaveBeenCalledWith("line-3");
+      expect(editorElement.enterBlockMode).toHaveBeenCalledWith({
+        focusSurface: true,
+        lineId: "line-3",
+        emitSelectionChange: true,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("enters block mode for the clicked line from avatar content", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const leftGutter = document.createElement("div");
+      const row = document.createElement("div");
+      const speakerSlot = document.createElement("div");
+      const avatar = document.createElement("rvn-file-image");
+      const avatarImage = document.createElement("img");
+
+      row.className = "gutter-row";
+      row.dataset.lineId = "line-4";
+      speakerSlot.className = "speaker-slot";
+      speakerSlot.append(avatar);
+      row.append(speakerSlot);
+      leftGutter.append(row);
+
+      editorElement.refs = {
+        leftGutter,
+      };
+      editorElement.hasLine = vi.fn(() => true);
+      editorElement.clearPointerDownInsideEditor = vi.fn();
+      editorElement.clearDeleteShortcutState = vi.fn();
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.enterBlockMode = vi.fn();
+
+      const event = {
+        button: 0,
+        target: avatar,
+        composedPath: () => [avatarImage, avatar, speakerSlot, row, leftGutter],
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleLeftGutterMouseDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.hasLine).toHaveBeenCalledWith("line-4");
+      expect(editorElement.enterBlockMode).toHaveBeenCalledWith({
+        focusSurface: true,
+        lineId: "line-4",
+        emitSelectionChange: true,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("requests a line context menu when right-clicking a line in block mode", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-5",
+      };
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-5");
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.enterBlockMode = vi.fn();
+      editorElement.dispatchShortcutEvent = vi.fn();
+
+      const event = {
+        clientX: 32,
+        clientY: 48,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeContextMenu(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.enterBlockMode).toHaveBeenCalledWith({
+        focusSurface: true,
+        lineId: "line-5",
+        emitSelectionChange: true,
+      });
+      expect(editorElement.dispatchShortcutEvent).toHaveBeenCalledWith(
+        "line-context-menu-request",
+        {
+          lineId: "line-5",
+          position: {
+            x: 32,
+            y: 48,
+          },
+        },
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps default context menu behavior for an unselected line in block mode", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+      };
+      editorElement.refs = {
+        editor: document.createElement("div"),
+      };
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-2");
+      editorElement.getReferenceSnapshotFromContextEvent = vi.fn();
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.enterBlockMode = vi.fn();
+      editorElement.dispatchShortcutEvent = vi.fn();
+
+      const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeContextMenu(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+      expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+      expect(editorElement.enterBlockMode).not.toHaveBeenCalled();
+      expect(editorElement.dispatchShortcutEvent).toHaveBeenCalledWith(
+        "line-context-menu-dismiss",
+        {},
+      );
+      expect(editorElement.hideSelectionPopover).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not select a line from right-button mouseup before the context menu opens", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+      };
+      editorElement.clearPointerDownInsideEditor = vi.fn();
+      editorElement.getLineIdFromRange = vi.fn(() => "line-2");
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.handleNativeMouseUp({
+        button: 2,
+      });
+
+      expect(editorElement.state.selectedLineId).toBe("line-1");
+      expect(editorElement.clearPointerDownInsideEditor).not.toHaveBeenCalled();
+      expect(editorElement.scheduleRender).not.toHaveBeenCalled();
+      expect(editorElement.dispatchSelectedLineChanged).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("enters text mode and keeps default context menu behavior when right-clicking a different line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+      };
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-2");
+      editorElement.getLineOffsetFromPointerEvent = vi.fn(() => 4);
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.enterTextMode = vi.fn();
+      editorElement.dispatchShortcutEvent = vi.fn();
+
+      const mouseDownEvent = {
+        button: 2,
+        preventDefault: vi.fn(),
+      };
+
+      editorElement.handleNativeMouseDown(mouseDownEvent);
+      editorElement.state.selectedLineId = "line-2";
+
+      const contextMenuEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeContextMenu(contextMenuEvent);
+
+      expect(mouseDownEvent.preventDefault).not.toHaveBeenCalled();
+      expect(editorElement.hideSelectionPopover).toHaveBeenCalledTimes(1);
+      expect(editorElement.closeMentionMenu).toHaveBeenCalledTimes(1);
+      expect(editorElement.enterTextMode).toHaveBeenCalledWith({
+        lineId: "line-2",
+        cursorPosition: 4,
+      });
+      expect(contextMenuEvent.preventDefault).not.toHaveBeenCalled();
+      expect(contextMenuEvent.stopPropagation).not.toHaveBeenCalled();
+      expect(contextMenuEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+      expect(editorElement.dispatchShortcutEvent).toHaveBeenCalledWith(
+        "line-context-menu-dismiss",
+        {},
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("uses the current selected line when Escape returns from text mode to block mode", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation =
+        vi.fn();
+      editorElement.updatePendingTextInputFallback = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.getSelectedLineIdSnapshot = vi.fn(() => "line-1");
+      editorElement.enterBlockMode = vi.fn();
+
+      const event = {
+        key: "Escape",
+        isComposing: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.enterBlockMode).toHaveBeenCalledWith({
+        focusSurface: true,
+        lineId: "line-2",
+        emitSelectionChange: true,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("preserves block selection when editor state sync has stale native selection", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "first" }],
+            },
+          },
+        },
+        {
+          id: "line-2",
+          actions: {
+            dialogue: {
+              content: [{ text: "second" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "block",
+        lines,
+        selectedLineId: "line-2",
+        mentionTargets: [],
+      };
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+      }));
+      editorElement.shouldPreserveMentionMenuAfterSelectionLoss = vi.fn(
+        () => false,
+      );
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.selectedLineId).toBe("line-2");
+      expect(editorElement.dispatchSelectedLineChanged).not.toHaveBeenCalled();
     } finally {
       restoreDomGlobals();
     }


### PR DESCRIPTION
## Summary
- make line number and speaker/avatar gutter clicks enter block mode for that line
- add selected-line block-mode right-click menu with Delete, while preserving native context menus for other lines
- preserve selected line when Escape returns from text mode to block mode
- restore block-mode keyboard shortcuts when focus lands on document/body/editor host, and support lowercase `i`

## Testing
- `bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js`
- `bun prettier --check src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js`
- `bunx oxlint src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js`
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`