### PR TITLE
Fix scene editor Lexical preview sync

### DIFF
--- a/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.store.js
+++ b/src/components/sceneEditorPreviewCanvas/sceneEditorPreviewCanvas.store.js
@@ -2,6 +2,6 @@ export const createInitialState = () => ({});
 
 export const selectViewData = ({ props }) => {
   return {
-    canvasAspectRatio: props.canvasAspectRatio || "16 / 9",
+    canvasAspectRatio: props.canvasAspectRatio ?? "16 / 9",
   };
 };

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -115,8 +115,7 @@ const getCurrentCanvasRoot = (refs) => {
   const canvasRoot =
     previewCanvasHost?.getCanvasRoot?.() ||
     previewCanvasHost?.shadowRoot?.querySelector?.("#canvas") ||
-    previewCanvasHost?.querySelector?.("#canvas") ||
-    refs?.canvas;
+    previewCanvasHost?.querySelector?.("#canvas");
 
   if (canvasRoot?.isConnected) {
     return canvasRoot;

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -128,7 +128,6 @@ refs:
       current-line-changed:
         handler: handlePreviewCurrentLineChanged
   previewCanvasHost: {}
-  canvas: {}
 template:
   - $if isScenePageLoading:
       - rtgl-view d=v w=f h=f av=c ah=c g=sm:
@@ -167,9 +166,9 @@ template:
               - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h jc=e g=sm:
                   - rtgl-button#previewButton: Preview
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
-                  - rtgl-view:
-                      - 'rtgl-view w=f pos=rel style="aspect-ratio: ${canvasAspectRatio}; max-width: 100%;"':
-                          - 'div#canvas id=canvas style="width: 100%; height: 100%; display: flex; background: #000;"': null
+                  - 'rtgl-view w=f style="min-width: 0;"':
+                      - 'rtgl-view pos=rel w=f':
+                          - rvn-scene-editor-preview-canvas#previewCanvasHost canvas-aspect-ratio="${canvasAspectRatio}": null
                           - $if isSceneAssetLoading:
                               - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
                                   - rtgl-text s=h3: Loading assets...

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -99,6 +99,7 @@ const BLOCK_ROW_BACKGROUND = "var(--muted)";
 const DELETE_SHORTCUT_TIMEOUT_MS = 1200;
 const TEXT_INPUT_FALLBACK_MAX_AGE_MS = 1000;
 const PROGRAMMATIC_FOCUS_BLUR_SUPPRESS_MS = 750;
+const VERTICAL_NAVIGATION_SELECTION_SYNC_FRAMES = 4;
 
 const normalizeMentionTarget = (target = {}) => {
   const label = String(target.label ?? "")
@@ -824,6 +825,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.pendingPointerFallbackSelection = undefined;
     this.pendingBlockContextMenuSelectedLineId = undefined;
     this.pendingDefaultContextMenuLineId = undefined;
+    this.verticalNavigationSelectionSyncId = 0;
 
     this.editor = createEditor({
       namespace: "routevn-lexical-scene-document-editor",
@@ -2048,25 +2050,39 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
-    requestAnimationFrame(() => {
-      if (!this.isConnected || this.state?.mode !== "text-editor") {
-        return;
-      }
+    const syncNativeSelectionLine = (framesRemaining) => {
+      const syncId = (this.verticalNavigationSelectionSyncId ?? 0) + 1;
+      this.verticalNavigationSelectionSyncId = syncId;
 
-      const nativeSelection = this.getNativeLineSelectionContext();
-      const lineId = nativeSelection?.lineId;
-      if (!lineId || lineId === this.state.selectedLineId) {
-        return;
-      }
+      requestAnimationFrame(() => {
+        if (this.verticalNavigationSelectionSyncId !== syncId) {
+          return;
+        }
 
-      this.state.selectedLineId = lineId;
-      this.scheduleRender();
-      this.dispatchSelectedLineChanged(lineId, {
-        cursorPosition: nativeSelection.start,
-        isCollapsed: nativeSelection.start === nativeSelection.end,
-        mode: "text-editor",
+        if (!this.isConnected || this.state?.mode !== "text-editor") {
+          return;
+        }
+
+        const nativeSelection = this.getNativeLineSelectionContext();
+        const lineId = nativeSelection?.lineId;
+        if (!lineId || lineId === this.state.selectedLineId) {
+          if (framesRemaining > 1) {
+            syncNativeSelectionLine(framesRemaining - 1);
+          }
+          return;
+        }
+
+        this.state.selectedLineId = lineId;
+        this.scheduleRender();
+        this.dispatchSelectedLineChanged(lineId, {
+          cursorPosition: nativeSelection.start,
+          isCollapsed: nativeSelection.start === nativeSelection.end,
+          mode: "text-editor",
+        });
       });
-    });
+    };
+
+    syncNativeSelectionLine(VERTICAL_NAVIGATION_SELECTION_SYNC_FRAMES);
   }
 
   handleWindowKeyDownCapture(event) {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -751,6 +751,81 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("retries text-mode vertical selection sync when the native selection lags", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+      };
+      editorElement.getNativeLineSelectionContext = vi
+        .fn()
+        .mockReturnValueOnce({
+          lineId: "line-2",
+          start: 0,
+          end: 0,
+        })
+        .mockReturnValueOnce({
+          lineId: "line-1",
+          start: 3,
+          end: 3,
+        });
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation({
+        key: "ArrowUp",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+      });
+
+      expect(animationFrameCallbacks).toHaveLength(1);
+      animationFrameCallbacks[0]();
+      expect(editorElement.dispatchSelectedLineChanged).not.toHaveBeenCalled();
+      expect(animationFrameCallbacks).toHaveLength(2);
+
+      animationFrameCallbacks[1]();
+
+      expect(editorElement.state.selectedLineId).toBe("line-1");
+      expect(editorElement.scheduleRender).toHaveBeenCalledTimes(1);
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-1",
+        {
+          cursorPosition: 3,
+          isCollapsed: true,
+          mode: "text-editor",
+        },
+      );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
   it("suppresses native text insertion beforeinput while the editor is focused in block mode", async () => {
     const restoreDomGlobals = installDomGlobals();
 

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -426,8 +426,10 @@ describe("renderSceneEditorState", () => {
         render,
         graphicsService,
         refs: {
-          canvas: {
-            isConnected: true,
+          previewCanvasHost: {
+            getCanvasRoot: () => ({
+              isConnected: true,
+            }),
           },
         },
       },


### PR DESCRIPTION
## Summary
- restore the scene editor Lexical preview to use the dedicated preview canvas host
- remove the runtime fallback to the old raw canvas ref
- retry text-mode vertical selection sync so Linux/WebKitGTK ArrowUp navigation updates the preview line

## Validation
- bunx vitest run tests/sceneEditor/runtime.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/lexicalLineEditing.test.js
- bun run build:web