### PR TITLE
Refactor command-line action controls

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -360,16 +360,7 @@ export const handleFormInputChange = (deps, payload) => {
   const { store, render } = deps;
   const { name, value: fieldValue } = payload._event.detail;
 
-  if (name === "animationType") {
-    store.setSelectedAnimationMode({
-      mode: fieldValue,
-    });
-    render();
-    dispatchTemporaryPresentationStateChange(deps);
-    return;
-  }
-
-  if (name === "updateAnimation" || name === "transitionAnimation") {
+  if (name === "animationId") {
     store.setSelectedAnimation({
       animationId: fieldValue,
     });

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -15,24 +15,9 @@ const tabs = [
   },
 ];
 
-const ANIMATION_MODE_OPTIONS = [
-  {
-    label: "None",
-    value: "none",
-  },
-  {
-    label: "Update",
-    value: "update",
-  },
-  {
-    label: "Transition",
-    value: "transition",
-  },
-];
-
 const ANIMATION_PLAYBACK_CONTINUITY_OPTIONS = [
   {
-    label: "Render",
+    label: "Single Line",
     value: "render",
   },
   {
@@ -229,6 +214,8 @@ export const setSelectedAnimation = ({ state }, { animationId } = {}) => {
   );
   if (selectedAnimationMode) {
     state.selectedAnimationMode = selectedAnimationMode;
+  } else if (!state.selectedAnimationId) {
+    state.selectedAnimationMode = "none";
   }
 };
 
@@ -425,18 +412,12 @@ export const selectViewData = ({ state }) => {
   const allAnimationItems = toFlatItems(state.animationItems).filter(
     (item) => item.type === "animation",
   );
-  const updateAnimationOptions = allAnimationItems
-    .filter((item) => getAnimationType(item) === "update")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
-    }));
-  const transitionAnimationOptions = allAnimationItems
-    .filter((item) => getAnimationType(item) === "transition")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
-    }));
+  const animationOptions = allAnimationItems.map((item) => ({
+    value: item.id,
+    label: item.name,
+    suffixText:
+      getAnimationType(item) === "transition" ? "Transition" : "Update",
+  }));
   const transformOptions = toFlatItems(state.transformItems)
     .filter((item) => item.type === "transform")
     .map((item) => ({
@@ -459,33 +440,14 @@ export const selectViewData = ({ state }) => {
       options: transformOptions,
     },
     {
-      name: "animationType",
+      name: "animationId",
       label: "Animation",
-      type: "segmented-control",
-      clearable: false,
-      options: ANIMATION_MODE_OPTIONS,
+      type: "select",
+      clearable: true,
+      placeholder: "Select animation",
+      options: animationOptions,
     },
   ];
-
-  if (selectedAnimationMode === "update") {
-    formFields.push({
-      name: "updateAnimation",
-      label: "Update Animation",
-      type: "select",
-      clearable: false,
-      placeholder: "Select update animation",
-      options: updateAnimationOptions,
-    });
-  } else if (selectedAnimationMode === "transition") {
-    formFields.push({
-      name: "transitionAnimation",
-      label: "Transition Animation",
-      type: "select",
-      clearable: false,
-      placeholder: "Select transition animation",
-      options: transitionAnimationOptions,
-    });
-  }
 
   if (selectedAnimationMode !== "none") {
     formFields.push({
@@ -517,15 +479,7 @@ export const selectViewData = ({ state }) => {
     background: selectedResource?.fileId || "",
     transformId: state.selectedTransformId,
     playbackContinuity: state.selectedAnimationPlaybackContinuity,
-    animationType: selectedAnimationMode,
-    updateAnimation:
-      selectedAnimationMode === "update"
-        ? state.selectedAnimationId
-        : undefined,
-    transitionAnimation:
-      selectedAnimationMode === "transition"
-        ? state.selectedAnimationId
-        : undefined,
+    animationId: state.selectedAnimationId,
     loop: state.backgroundLoop ?? false,
   };
 

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -286,15 +286,6 @@ export const handleTransformChange = (deps, payload) => {
   dispatchTemporaryPresentationStateChange(deps);
 };
 
-export const handleAnimationModeChange = (deps, payload) => {
-  const { store, render } = deps;
-  const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
-  const value = payload._event.detail.value;
-  store.updateCharacterAnimationMode({ index, animationMode: value });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
 export const handleAnimationChange = (deps, payload) => {
   const { store, render } = deps;
   const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -6,21 +6,6 @@ const createEmptyCollection = () => ({
   tree: [],
 });
 
-const ANIMATION_MODE_OPTIONS = [
-  {
-    label: "None",
-    value: "none",
-  },
-  {
-    label: "Update",
-    value: "update",
-  },
-  {
-    label: "Transition",
-    value: "transition",
-  },
-];
-
 const UNGROUPED_CHARACTER_GROUP_ID = "__ungrouped_characters__";
 const UNGROUPED_SPRITE_GROUP_ID = "__ungrouped_sprites__";
 const UNGROUPED_GROUP_LABEL = "Ungrouped";
@@ -335,6 +320,7 @@ export const updateCharacterAnimation = (
 
   if (!animationId || animationId === "none") {
     state.selectedCharacters[index].animations = undefined;
+    state.selectedCharacters[index].animationMode = "none";
     return;
   }
 
@@ -348,33 +334,6 @@ export const updateCharacterAnimation = (
   );
   if (selectedAnimationMode) {
     state.selectedCharacters[index].animationMode = selectedAnimationMode;
-  }
-};
-
-export const updateCharacterAnimationMode = (
-  { state },
-  { index, animationMode } = {},
-) => {
-  if (!state.selectedCharacters[index]) {
-    return;
-  }
-
-  if (animationMode !== "update" && animationMode !== "transition") {
-    state.selectedCharacters[index].animationMode = "none";
-    state.selectedCharacters[index].animations = undefined;
-    return;
-  }
-
-  state.selectedCharacters[index].animationMode = animationMode;
-
-  const selectedAnimationId =
-    state.selectedCharacters[index]?.animations?.resourceId;
-  const selectedAnimationMode = getAnimationModeById(
-    state.animations,
-    selectedAnimationId,
-  );
-  if (selectedAnimationMode && selectedAnimationMode !== animationMode) {
-    state.selectedCharacters[index].animations = undefined;
   }
 };
 
@@ -791,18 +750,12 @@ export const selectViewData = ({ state }) => {
   const animationItems = toFlatItems(state.animations).filter(
     (item) => item.type === "animation",
   );
-  const updateAnimationOptions = animationItems
-    .filter((item) => getAnimationType(item) === "update")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
-    }));
-  const transitionAnimationOptions = animationItems
-    .filter((item) => getAnimationType(item) === "transition")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
-    }));
+  const animationOptions = animationItems.map((item) => ({
+    value: item.id,
+    label: item.name,
+    suffixText:
+      getAnimationType(item) === "transition" ? "Transition" : "Update",
+  }));
 
   // Get enriched character data
   const enrichedCharacters = selectCharactersWithRepositoryData({ state });
@@ -921,9 +874,7 @@ export const selectViewData = ({ state }) => {
       animationId: char.animations?.resourceId,
     })),
     transformOptions,
-    animationModeOptions: ANIMATION_MODE_OPTIONS,
-    updateAnimationOptions,
-    transitionAnimationOptions,
+    animationOptions,
   };
 
   return {
@@ -932,9 +883,7 @@ export const selectViewData = ({ state }) => {
     groups: characterTreeData.groups,
     selectedCharacters: processedSelectedCharacters,
     transformOptions,
-    animationModeOptions: ANIMATION_MODE_OPTIONS,
-    updateAnimationOptions,
-    transitionAnimationOptions,
+    animationOptions,
     spriteItems,
     spriteGroups,
     showSpriteGroupTabs: spriteSelectionTabs.length > 1,

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -66,15 +66,7 @@ refs:
     eventListeners:
       value-change:
         handler: handleTransformChange
-  animationMode*:
-    eventListeners:
-      value-change:
-        handler: handleAnimationModeChange
-  updateAnimation*:
-    eventListeners:
-      value-change:
-        handler: handleAnimationChange
-  transitionAnimation*:
+  animation*:
     eventListeners:
       value-change:
         handler: handleAnimationChange
@@ -109,11 +101,7 @@ template:
                                       - rtgl-text s=sm c=mu-fg: Transform
                                       - rtgl-select#transform${i} data-index=${i} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
                                       - rtgl-text s=sm c=mu-fg: Animation
-                                      - rtgl-segmented-control#animationMode${i} data-index=${i} key=${character.animationMode} :options=${defaultValues.animationModeOptions} :selectedValue=${character.animationMode} w=f no-clear: null
-                                      - $if character.animationMode == 'update':
-                                          - rtgl-select#updateAnimation${i} data-index=${i} key=${character.animationId} :options=${defaultValues.updateAnimationOptions} :selectedValue=${character.animationId} w=f no-clear: null
-                                        $elif character.animationMode == 'transition':
-                                          - rtgl-select#transitionAnimation${i} data-index=${i} key=${character.animationId} :options=${defaultValues.transitionAnimationOptions} :selectedValue=${character.animationId} w=f no-clear: null
+                                      - rtgl-select#animation${i} data-index=${i} key=${character.animationId} :options=${defaultValues.animationOptions} :selectedValue=${character.animationId} w=f placeholder="Select animation": null
                                       - $if character.showSpriteGroupBoxes:
                                           - rtgl-text s=sm c=mu-fg: Sprite Groups
                                           - rtgl-view d=h wrap g=xs w=f:

--- a/src/components/commandLineChoices/commandLineChoices.store.js
+++ b/src/components/commandLineChoices/commandLineChoices.store.js
@@ -72,12 +72,20 @@ const resolveSelectedResourceId = ({ layouts, resourceId } = {}) => {
   return resourceOptions[0]?.value ?? "";
 };
 
+const createNextLineChoice = (content) => ({
+  content,
+  events: {
+    click: {
+      actions: {
+        nextLine: {},
+      },
+    },
+  },
+});
+
 export const createInitialState = () => ({
   mode: "list", // "list" or "editChoice"
-  items: [
-    { content: "Choice 1", action: { type: "continue" } },
-    { content: "Choice 2", action: { type: "continue" } },
-  ],
+  items: [createNextLineChoice("Choice 1"), createNextLineChoice("Choice 2")],
   selectedResourceId: "",
   editingIndex: -1,
   editForm: {
@@ -181,10 +189,7 @@ const buildChoiceDataFromEditForm = (editForm = {}) => {
 };
 
 export const addChoice = ({ state }, _payload = {}) => {
-  state.items.push({
-    content: `Choice ${state.items.length + 1}`,
-    action: { type: "continue" },
-  });
+  state.items.push(createNextLineChoice(`Choice ${state.items.length + 1}`));
 };
 
 export const removeChoice = ({ state }, { index } = {}) => {
@@ -248,7 +253,7 @@ export const hideDropdownMenu = ({ state }, _payload = {}) => {
 };
 
 export const setItems = ({ state }, { items } = {}) => {
-  state.items = items;
+  state.items = Array.isArray(items) ? items : [];
 };
 
 export const selectDropdownMenuChoiceIndex = ({ state }) => {
@@ -262,7 +267,7 @@ export const selectEditForm = ({ state }) =>
   state?.editForm || {
     content: "",
     variables: "",
-    actionType: "continue",
+    actionType: "nextLine",
     sceneId: "",
     sectionId: "",
   };
@@ -338,21 +343,9 @@ export const selectViewData = ({ state, props }) => {
     resourceId: state.selectedResourceId,
   });
 
-  const actionTypeOptions = [
-    { value: "continue", label: "Continue (Do Nothing)" },
-    { value: "moveToScene", label: "Move to Scene" },
-    { value: "moveToSection", label: "Move to Section" },
-  ];
-
   // Pre-compute complex expressions for template
   const processedItems = (state?.items || []).map((item) => ({
     ...item,
-    actionLabel:
-      item.action?.type === "continue"
-        ? "Continue"
-        : item.action?.type === "moveToScene"
-          ? "Move to Scene"
-          : "Move to Section",
   }));
 
   const editModeTitle =
@@ -416,7 +409,6 @@ export const selectViewData = ({ state, props }) => {
     editForm: state?.editForm,
     editFormContext,
     defaultValues,
-    actionTypeOptions,
     editModeTitle,
     breadcrumb,
     choiceFormTemplate: CHOICE_FORM_TEMPLATE,

--- a/src/components/commandLineScreen/commandLineScreen.store.js
+++ b/src/components/commandLineScreen/commandLineScreen.store.js
@@ -13,7 +13,7 @@ const form = {
       label: "Animation",
       description: "",
       required: true,
-      clearable: false,
+      clearable: true,
       placeholder: "Animation",
       options: "${transitionAnimationOptions}",
     },
@@ -39,8 +39,13 @@ export const setFormValues = ({ state }, { values } = {}) => {
 
 export const selectViewData = ({ state, props }) => {
   const propsAnimationId = props?.screen?.animations?.resourceId;
-  const selectedAnimationId =
-    state.formValues?.transitionAnimationId ?? propsAnimationId;
+  const hasFormAnimationId = Object.prototype.hasOwnProperty.call(
+    state.formValues ?? {},
+    "transitionAnimationId",
+  );
+  const selectedAnimationId = hasFormAnimationId
+    ? state.formValues.transitionAnimationId
+    : propsAnimationId;
 
   return {
     breadcrumb: [
@@ -63,7 +68,10 @@ export const selectViewData = ({ state, props }) => {
       transitionAnimationOptions: getTransitionAnimationOptions(
         state.animations,
         selectedAnimationId,
-      ),
+      ).map((option) => ({
+        ...option,
+        suffixText: "Transition",
+      })),
     },
   };
 };

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -157,15 +157,6 @@ export const handleTransformChange = (deps, payload) => {
   dispatchTemporaryPresentationStateChange(deps);
 };
 
-export const handleAnimationModeChange = (deps, payload) => {
-  const { store, render } = deps;
-  const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);
-  const value = payload._event.detail.value;
-  store.updateVisualAnimationMode({ index, animationMode: value });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
 export const handleAnimationChange = (deps, payload) => {
   const { store, render } = deps;
   const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -7,21 +7,6 @@ const RESOURCE_TYPES = [
   { type: "layout", label: "Layouts" },
 ];
 
-const ANIMATION_MODE_OPTIONS = [
-  {
-    label: "None",
-    value: "none",
-  },
-  {
-    label: "Update",
-    value: "update",
-  },
-  {
-    label: "Transition",
-    value: "transition",
-  },
-];
-
 const createEmptyCollection = () => ({
   items: {},
   tree: [],
@@ -241,6 +226,7 @@ export const updateVisualAnimation = (
 
   if (!animationId || animationId === "none") {
     state.selectedVisuals[index].animations = undefined;
+    state.selectedVisuals[index].animationMode = "none";
     return;
   }
 
@@ -254,33 +240,6 @@ export const updateVisualAnimation = (
   );
   if (selectedAnimationMode) {
     state.selectedVisuals[index].animationMode = selectedAnimationMode;
-  }
-};
-
-export const updateVisualAnimationMode = (
-  { state },
-  { index, animationMode } = {},
-) => {
-  if (!state.selectedVisuals[index]) {
-    return;
-  }
-
-  if (animationMode !== "update" && animationMode !== "transition") {
-    state.selectedVisuals[index].animationMode = "none";
-    state.selectedVisuals[index].animations = undefined;
-    return;
-  }
-
-  state.selectedVisuals[index].animationMode = animationMode;
-
-  const selectedAnimationId =
-    state.selectedVisuals[index]?.animations?.resourceId;
-  const selectedAnimationMode = getAnimationModeById(
-    state.animations,
-    selectedAnimationId,
-  );
-  if (selectedAnimationMode && selectedAnimationMode !== animationMode) {
-    state.selectedVisuals[index].animations = undefined;
   }
 };
 
@@ -515,18 +474,12 @@ export const selectViewData = ({ state }) => {
   const animationItems = toFlatItems(state.animations).filter(
     (item) => item.type === "animation",
   );
-  const updateAnimationOptions = animationItems
-    .filter((item) => getAnimationType(item) === "update")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
-    }));
-  const transitionAnimationOptions = animationItems
-    .filter((item) => getAnimationType(item) === "transition")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
-    }));
+  const animationOptions = animationItems.map((item) => ({
+    value: item.id,
+    label: item.name,
+    suffixText:
+      getAnimationType(item) === "transition" ? "Transition" : "Update",
+  }));
 
   // Get enriched visual data
   const enrichedVisuals = selectVisualsWithRepositoryData({ state });
@@ -571,9 +524,7 @@ export const selectViewData = ({ state }) => {
       animationId: visual.animations?.resourceId,
     })),
     transformOptions,
-    animationModeOptions: ANIMATION_MODE_OPTIONS,
-    updateAnimationOptions,
-    transitionAnimationOptions,
+    animationOptions,
   };
 
   return {
@@ -582,9 +533,7 @@ export const selectViewData = ({ state }) => {
     resourceGroups,
     selectedVisuals: processedSelectedVisuals,
     transformOptions,
-    animationModeOptions: ANIMATION_MODE_OPTIONS,
-    updateAnimationOptions,
-    transitionAnimationOptions,
+    animationOptions,
     searchQuery: state.searchQuery,
     searchPlaceholder: "Search...",
     fullImagePreviewVisible: state.fullImagePreviewVisible,

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -54,15 +54,7 @@ refs:
     eventListeners:
       value-change:
         handler: handleTransformChange
-  animationMode*:
-    eventListeners:
-      value-change:
-        handler: handleAnimationModeChange
-  updateAnimation*:
-    eventListeners:
-      value-change:
-        handler: handleAnimationChange
-  transitionAnimation*:
+  animation*:
     eventListeners:
       value-change:
         handler: handleAnimationChange
@@ -87,11 +79,7 @@ template:
                               - rtgl-text s=sm c=mu-fg: Transform
                               - rtgl-select#transform${i} data-index=${i} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear: null
                               - rtgl-text s=sm c=mu-fg: Animation
-                              - rtgl-segmented-control#animationMode${i} data-index=${i} key=${visual.animationMode} :options=${defaultValues.animationModeOptions} :selectedValue=${visual.animationMode} w=f no-clear: null
-                              - $if visual.animationMode == 'update':
-                                  - rtgl-select#updateAnimation${i} data-index=${i} key=${visual.animationId} :options=${defaultValues.updateAnimationOptions} :selectedValue=${visual.animationId} w=f no-clear: null
-                                $elif visual.animationMode == 'transition':
-                                  - rtgl-select#transitionAnimation${i} data-index=${i} key=${visual.animationId} :options=${defaultValues.transitionAnimationOptions} :selectedValue=${visual.animationId} w=f no-clear: null
+                              - rtgl-select#animation${i} data-index=${i} key=${visual.animationId} :options=${defaultValues.animationOptions} :selectedValue=${visual.animationId} w=f placeholder="Select animation": null
                   - rtgl-button#addVisualButton v=ol w=f mt=md: + Add Visual
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -82,7 +82,19 @@ const setRepositoryCollections = (state) => {
       },
       layouts: createEmptyCollection(),
       videos: createEmptyCollection(),
-      animations: createEmptyCollection(),
+      animations: {
+        items: {
+          "bg-fade": {
+            id: "bg-fade",
+            type: "animation",
+            name: "Fade",
+            animation: {
+              type: "transition",
+            },
+          },
+        },
+        tree: [{ id: "bg-fade" }],
+      },
       transforms: {
         items: {
           "bg-center": {
@@ -248,6 +260,136 @@ describe("commandLineBackground.handlers", () => {
         },
       },
     });
+  });
+
+  it("selects animation from the single animation field", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            name: "animationId",
+            value: "bg-fade",
+          },
+        },
+      },
+    );
+
+    handleSubmitClick(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+      },
+      {},
+    );
+
+    expect(selectSelectedAnimation({ state })).toBe("bg-fade");
+    expect(selectSelectedAnimationMode({ state })).toBe("transition");
+    expect(dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+          animations: {
+            resourceId: "bg-fade",
+            playback: {
+              continuity: "render",
+            },
+          },
+        },
+      },
+    });
+    expect(dispatchEvent.mock.calls[1][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+        animations: {
+          resourceId: "bg-fade",
+          playback: {
+            continuity: "render",
+          },
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears animation from the clearable animation field", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedAnimation(
+      { state },
+      {
+        animationId: "bg-fade",
+      },
+    );
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            name: "animationId",
+            value: undefined,
+          },
+        },
+      },
+    );
+
+    handleSubmitClick(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+      },
+      {},
+    );
+
+    expect(selectSelectedAnimation({ state })).toBeUndefined();
+    expect(selectSelectedAnimationMode({ state })).toBe("none");
+    expect(dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+        },
+      },
+    });
+    expect(dispatchEvent.mock.calls[1][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it("emits temporary presentation state from gallery resource selection", () => {

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -3,7 +3,7 @@ import {
   createInitialState,
   selectViewData,
   setRepositoryState,
-  setSelectedAnimationMode,
+  setSelectedAnimation,
   setSelectedResource,
   setSelectedTransform,
 } from "../../src/components/commandLineBackground/commandLineBackground.store.js";
@@ -14,7 +14,7 @@ const createEmptyCollection = () => ({
 });
 
 describe("commandLineBackground.store", () => {
-  it("hides playback continuity when animation mode is none", () => {
+  it("uses a clearable animation select with type suffix text", () => {
     const state = createInitialState();
 
     setRepositoryState(
@@ -33,7 +33,27 @@ describe("commandLineBackground.store", () => {
         },
         layouts: createEmptyCollection(),
         videos: createEmptyCollection(),
-        animations: createEmptyCollection(),
+        animations: {
+          items: {
+            "bg-pan": {
+              id: "bg-pan",
+              type: "animation",
+              name: "Pan",
+              animation: {
+                type: "update",
+              },
+            },
+            "bg-fade": {
+              id: "bg-fade",
+              type: "animation",
+              name: "Fade",
+              animation: {
+                type: "transition",
+              },
+            },
+          },
+          tree: [{ id: "bg-pan" }, { id: "bg-fade" }],
+        },
         transforms: {
           items: {
             "bg-center": {
@@ -63,6 +83,9 @@ describe("commandLineBackground.store", () => {
     const transformField = viewData.dialogueForm.form.fields.find(
       (field) => field.name === "transformId",
     );
+    const animationField = viewData.dialogueForm.form.fields.find(
+      (field) => field.name === "animationId",
+    );
     const continuityField = viewData.dialogueForm.form.fields.find(
       (field) => field.name === "playbackContinuity",
     );
@@ -79,14 +102,33 @@ describe("commandLineBackground.store", () => {
         },
       ],
     });
+    expect(animationField).toMatchObject({
+      label: "Animation",
+      type: "select",
+      clearable: true,
+      placeholder: "Select animation",
+      options: [
+        {
+          value: "bg-pan",
+          label: "Pan",
+          suffixText: "Update",
+        },
+        {
+          value: "bg-fade",
+          label: "Fade",
+          suffixText: "Transition",
+        },
+      ],
+    });
     expect(continuityField).toBeUndefined();
     expect(viewData.dialogueForm.defaultValues.transformId).toBe("bg-center");
+    expect(viewData.dialogueForm.defaultValues.animationId).toBeUndefined();
     expect(viewData.dialogueForm.defaultValues.playbackContinuity).toBe(
       "render",
     );
   });
 
-  it("hides playback continuity when animation mode is active", () => {
+  it("shows playback continuity when an animation is selected", () => {
     const state = createInitialState();
 
     setRepositoryState(
@@ -105,7 +147,19 @@ describe("commandLineBackground.store", () => {
         },
         layouts: createEmptyCollection(),
         videos: createEmptyCollection(),
-        animations: createEmptyCollection(),
+        animations: {
+          items: {
+            "bg-pan": {
+              id: "bg-pan",
+              type: "animation",
+              name: "Pan",
+              animation: {
+                type: "update",
+              },
+            },
+          },
+          tree: [{ id: "bg-pan" }],
+        },
         transforms: {
           items: {
             "bg-center": {
@@ -131,20 +185,49 @@ describe("commandLineBackground.store", () => {
         transformId: "bg-center",
       },
     );
-    setSelectedAnimationMode(
+    setSelectedAnimation(
       { state },
       {
-        mode: "update",
+        animationId: "bg-pan",
       },
     );
 
     const viewData = selectViewData({ state });
+    const animationField = viewData.dialogueForm.form.fields.find(
+      (field) => field.name === "animationId",
+    );
     const continuityField = viewData.dialogueForm.form.fields.find(
       (field) => field.name === "playbackContinuity",
     );
 
-    expect(continuityField).toBeUndefined();
+    expect(animationField).toMatchObject({
+      type: "select",
+      clearable: true,
+      options: [
+        {
+          value: "bg-pan",
+          label: "Pan",
+          suffixText: "Update",
+        },
+      ],
+    });
+    expect(continuityField).toMatchObject({
+      name: "playbackContinuity",
+      label: "Playback",
+      type: "segmented-control",
+      options: [
+        {
+          label: "Single Line",
+          value: "render",
+        },
+        {
+          label: "Persistent",
+          value: "persistent",
+        },
+      ],
+    });
     expect(viewData.dialogueForm.defaultValues.transformId).toBe("bg-center");
+    expect(viewData.dialogueForm.defaultValues.animationId).toBe("bg-pan");
     expect(viewData.dialogueForm.defaultValues.playbackContinuity).toBe(
       "render",
     );

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleButtonSelectClick,
   handleBreadcumbClick,
+  handleAnimationChange,
   handleCharacterClick,
   handleCharacterItemClick,
   handleCharacterContextMenu,
@@ -27,6 +28,7 @@ import {
   selectTempSelectedSpriteIds,
   selectTempSelectedSpriteId,
   setMode,
+  setAnimations,
   setPendingCharacterIndex,
   setSearchQuery,
   setSelectedCharacterIndex,
@@ -36,6 +38,7 @@ import {
   setExistingCharacters,
   setItems,
   setTransforms,
+  updateCharacterAnimation,
   showDropdownMenu,
   updateCharacterSprites,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
@@ -74,11 +77,120 @@ const createStoreApi = (state) => ({
   setTempSelectedSpriteId: (payload) =>
     setTempSelectedSpriteId({ state }, payload),
   showDropdownMenu: (payload) => showDropdownMenu({ state }, payload),
+  updateCharacterAnimation: (payload) =>
+    updateCharacterAnimation({ state }, payload),
   updateCharacterSprites: (payload) =>
     updateCharacterSprites({ state }, payload),
 });
 
 describe("commandLineCharacters.handlers", () => {
+  it("updates and clears per-character animation selection", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            "character-enter": {
+              id: "character-enter",
+              type: "animation",
+              name: "Enter",
+              animation: {
+                type: "transition",
+              },
+            },
+          },
+          tree: [{ id: "character-enter" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+            sprites: [],
+          },
+        ],
+      },
+    );
+
+    handleAnimationChange(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: "character-enter",
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedCharacters({ state })[0]).toMatchObject({
+      animationMode: "transition",
+      animations: {
+        resourceId: "character-enter",
+      },
+    });
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        character: {
+          items: [
+            {
+              id: "character-hero",
+              transformId: undefined,
+              sprites: [],
+              spriteName: "",
+              animations: {
+                resourceId: "character-enter",
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    handleAnimationChange(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: undefined,
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedCharacters({ state })[0]).toMatchObject({
+      animationMode: "none",
+    });
+    expect(selectSelectedCharacters({ state })[0].animations).toBeUndefined();
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
   it("drops a newly added character when sprite selection is cancelled from the breadcrumb", () => {
     const state = createInitialState();
     const render = vi.fn();

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   selectViewData,
+  setAnimations,
   setExistingCharacters,
   setItems,
   setMode,
   setSelectedCharacterIndex,
   setSelectedSpriteGroupId,
+  setTransforms,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
 
 const createSpriteSelectState = () => {
@@ -93,6 +95,100 @@ const createSpriteSelectState = () => {
 };
 
 describe("commandLineCharacters.store sprite group filtering", () => {
+  it("exposes a single clearable animation option list with type suffix text", () => {
+    const state = createInitialState();
+
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            "character-hero": {
+              id: "character-hero",
+              type: "character",
+              name: "Hero",
+            },
+          },
+          tree: [{ id: "character-hero" }],
+        },
+      },
+    );
+    setTransforms(
+      { state },
+      {
+        transforms: {
+          items: {
+            "character-center": {
+              id: "character-center",
+              type: "transform",
+              name: "Center",
+            },
+          },
+          tree: [{ id: "character-center" }],
+        },
+      },
+    );
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            "character-idle": {
+              id: "character-idle",
+              type: "animation",
+              name: "Idle",
+              animation: {
+                type: "update",
+              },
+            },
+            "character-enter": {
+              id: "character-enter",
+              type: "animation",
+              name: "Enter",
+              animation: {
+                type: "transition",
+              },
+            },
+          },
+          tree: [{ id: "character-idle" }, { id: "character-enter" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+            animations: {
+              resourceId: "character-enter",
+            },
+          },
+        ],
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.defaultValues.characters[0]).toMatchObject({
+      id: "character-hero",
+      animationMode: "transition",
+      animationId: "character-enter",
+    });
+    expect(viewData.defaultValues.animationOptions).toEqual([
+      {
+        value: "character-idle",
+        label: "Idle",
+        suffixText: "Update",
+      },
+      {
+        value: "character-enter",
+        label: "Enter",
+        suffixText: "Transition",
+      },
+    ]);
+  });
+
   it("exposes current-mode sprite group boxes for multipart characters", () => {
     const state = createSpriteSelectState();
 

--- a/tests/commandLineChoices/commandLineChoices.store.test.js
+++ b/tests/commandLineChoices/commandLineChoices.store.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  addChoice,
   createInitialState,
   selectEditForm,
+  selectItems,
   selectViewData,
   setAnimations,
   setEditingIndex,
@@ -10,6 +12,46 @@ import {
 } from "../../src/components/commandLineChoices/commandLineChoices.store.js";
 
 describe("commandLineChoices.store", () => {
+  it("uses nextLine events for default and added choices", () => {
+    const state = createInitialState();
+
+    expect(selectItems({ state })).toEqual([
+      {
+        content: "Choice 1",
+        events: {
+          click: {
+            actions: {
+              nextLine: {},
+            },
+          },
+        },
+      },
+      {
+        content: "Choice 2",
+        events: {
+          click: {
+            actions: {
+              nextLine: {},
+            },
+          },
+        },
+      },
+    ]);
+
+    addChoice({ state });
+
+    expect(selectItems({ state })[2]).toEqual({
+      content: "Choice 3",
+      events: {
+        click: {
+          actions: {
+            nextLine: {},
+          },
+        },
+      },
+    });
+  });
+
   it("prefills and offers screen animations for choice section transitions", () => {
     const state = createInitialState();
 

--- a/tests/commandLineScreen/commandLineScreen.store.test.js
+++ b/tests/commandLineScreen/commandLineScreen.store.test.js
@@ -27,6 +27,7 @@ describe("commandLineScreen.store", () => {
     );
     expect(viewData.form.fields[0]).toEqual(
       expect.objectContaining({
+        clearable: true,
         label: "Animation",
         placeholder: "Animation",
       }),
@@ -77,8 +78,35 @@ describe("commandLineScreen.store", () => {
       {
         value: "fade-in",
         label: "Fade In",
+        suffixText: "Transition",
       },
     ]);
     expect(viewData.defaultValues.transitionAnimationId).toBe("fade-in");
+  });
+
+  it("keeps a cleared screen animation empty instead of falling back to props", () => {
+    const state = createInitialState();
+
+    setFormValues(
+      { state },
+      {
+        values: {
+          transitionAnimationId: undefined,
+        },
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        screen: {
+          animations: {
+            resourceId: "screen-crossfade",
+          },
+        },
+      },
+    });
+
+    expect(viewData.defaultValues.transitionAnimationId).toBeUndefined();
   });
 });

--- a/tests/commandLineVisual/commandLineVisual.handlers.test.js
+++ b/tests/commandLineVisual/commandLineVisual.handlers.test.js
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleAddVisualClick,
   handleAnimationChange,
-  handleAnimationModeChange,
   handleResourceItemClick,
   handleSubmitClick,
 } from "../../src/components/commandLineVisual/commandLineVisual.handlers.js";
@@ -22,7 +21,6 @@ import {
   setTransforms,
   updateVisualResource,
   updateVisualAnimation,
-  updateVisualAnimationMode,
 } from "../../src/components/commandLineVisual/commandLineVisual.store.js";
 
 const createStoreApi = (state) => ({
@@ -38,8 +36,6 @@ const createStoreApi = (state) => ({
   setTempSelectedResourceId: (payload) =>
     setTempSelectedResourceId({ state }, payload),
   updateVisualAnimation: (payload) => updateVisualAnimation({ state }, payload),
-  updateVisualAnimationMode: (payload) =>
-    updateVisualAnimationMode({ state }, payload),
   updateVisualResource: (payload) => updateVisualResource({ state }, payload),
 });
 
@@ -65,7 +61,7 @@ const setAnimationCollection = (state) => {
 };
 
 describe("commandLineVisual.handlers animation controls", () => {
-  it("updates per-visual animation mode and animation selection", () => {
+  it("updates and clears per-visual animation selection", () => {
     const state = createInitialState();
     const render = vi.fn();
 
@@ -83,24 +79,6 @@ describe("commandLineVisual.handlers animation controls", () => {
       },
     );
 
-    handleAnimationModeChange(
-      {
-        store: createStoreApi(state),
-        render,
-      },
-      {
-        _event: {
-          currentTarget: {
-            dataset: {
-              index: "0",
-            },
-          },
-          detail: {
-            value: "update",
-          },
-        },
-      },
-    );
     handleAnimationChange(
       {
         store: createStoreApi(state),
@@ -126,6 +104,30 @@ describe("commandLineVisual.handlers animation controls", () => {
         resourceId: "visual-fade",
       },
     });
+
+    handleAnimationChange(
+      {
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: undefined,
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      animationMode: "none",
+    });
+    expect(selectSelectedVisuals({ state })[0].animations).toBeUndefined();
     expect(render).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -8,7 +8,6 @@ import {
   setImages,
   setTransforms,
   updateVisualAnimation,
-  updateVisualAnimationMode,
 } from "../../src/components/commandLineVisual/commandLineVisual.store.js";
 
 const createEmptyCollection = () => ({
@@ -105,26 +104,21 @@ describe("commandLineVisual.store animation controls", () => {
       animationMode: "transition",
       animationId: "visual-wipe",
     });
-    expect(viewData.defaultValues.animationModeOptions).toEqual([
-      { label: "None", value: "none" },
-      { label: "Update", value: "update" },
-      { label: "Transition", value: "transition" },
-    ]);
-    expect(viewData.defaultValues.updateAnimationOptions).toEqual([
+    expect(viewData.defaultValues.animationOptions).toEqual([
       {
         value: "visual-fade",
         label: "Fade",
+        suffixText: "Update",
       },
-    ]);
-    expect(viewData.defaultValues.transitionAnimationOptions).toEqual([
       {
         value: "visual-wipe",
         label: "Wipe",
+        suffixText: "Transition",
       },
     ]);
   });
 
-  it("clears mismatched visual animation selections when mode changes", () => {
+  it("updates and clears visual animation selections", () => {
     const state = createInitialState();
     setRepositoryCollections(state);
     setExistingVisuals(
@@ -143,39 +137,26 @@ describe("commandLineVisual.store animation controls", () => {
       },
     );
 
-    updateVisualAnimationMode(
+    updateVisualAnimation(
       { state },
       {
         index: 0,
-        animationMode: "update",
+        animationId: "visual-wipe",
       },
     );
 
     expect(selectSelectedVisuals({ state })[0]).toMatchObject({
-      animationMode: "update",
+      animationMode: "transition",
+      animations: {
+        resourceId: "visual-wipe",
+      },
     });
-    expect(selectSelectedVisuals({ state })[0].animations).toBeUndefined();
 
     updateVisualAnimation(
       { state },
       {
         index: 0,
-        animationId: "visual-fade",
-      },
-    );
-
-    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
-      animationMode: "update",
-      animations: {
-        resourceId: "visual-fade",
-      },
-    });
-
-    updateVisualAnimationMode(
-      { state },
-      {
-        index: 0,
-        animationMode: "none",
+        animationId: undefined,
       },
     );
 
@@ -191,7 +172,6 @@ describe("commandLineVisual.store animation controls", () => {
 
     const viewData = selectViewData({ state });
 
-    expect(viewData.defaultValues.updateAnimationOptions).toEqual([]);
-    expect(viewData.defaultValues.transitionAnimationOptions).toEqual([]);
+    expect(viewData.defaultValues.animationOptions).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- replace split animation mode/update/transition controls in command-line background, characters, and visuals with one clearable animation select with type suffixes
- make screen transition animation clearable and preserve explicitly cleared values
- default command-line choices to nextLine event actions

## Testing
- bunx vitest run tests/commandLineBackground/commandLineBackground.handlers.test.js tests/commandLineBackground/commandLineBackground.store.test.js tests/commandLineCharacters/commandLineCharacters.handlers.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js tests/commandLineChoices/commandLineChoices.store.test.js tests/commandLineScreen/commandLineScreen.store.test.js tests/commandLineVisual/commandLineVisual.handlers.test.js tests/commandLineVisual/commandLineVisual.store.test.js
- bun run lint