### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump the Tauri app version from 1.2.3 to 1.3.0

## Testing
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`