### PR TITLE
fix: animation editor preview defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.2",
-        "@routevn/creator-model": "1.5.1",
+        "@routevn/creator-model": "1.5.2",
         "@tauri-apps/api": "^2.8.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.2",
@@ -280,7 +280,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.5.1", "", {}, "sha512-XTFKtjz5n3HA5r3EbKiBegNhNgR3/DIXI1lrvfTABMFpwE+xEr/k+sHkunBSxnrj9RXVc8p58aSOFOfmi3tuzA=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.5.2", "", {}, "sha512-DhUw6TJPVpViZTjQmYFGYxcvGMYh31w+SqUyskC7qGyCFtbYAiHyrxPN2nj0E3xaei8GIOncF3pKxMcOKFzaJA=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.2",
-    "@routevn/creator-model": "1.5.1",
+    "@routevn/creator-model": "1.5.2",
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.2",

--- a/src/internal/animationPreview.js
+++ b/src/internal/animationPreview.js
@@ -158,12 +158,19 @@ export const PREVIEW_IMAGE_SLOT_CONFIGS = Object.freeze([
     field: "incoming",
     supportsTransform: true,
   },
+  {
+    label: "Target Image",
+    target: "preview-target",
+    field: "target",
+    supportsTransform: true,
+  },
 ]);
 
 export const createInitialAnimationPreviewImages = () => ({
   background: {},
   outgoing: {},
   incoming: {},
+  target: {},
 });
 
 export const getPreviewSlotConfig = (target) => {
@@ -216,6 +223,10 @@ export const normalizeAnimationPreviewData = (previewData) => {
     incoming: normalizePreviewSlot(source.incoming ?? source.incomingImageId, {
       supportsTransform: true,
     }),
+    target: normalizePreviewSlot(
+      source.target ?? source.targetImageId ?? source.incoming,
+      { supportsTransform: true },
+    ),
   };
 };
 
@@ -230,6 +241,12 @@ const getPreviewSlot = (previewImages, target) => {
 
 export const getPreviewSlotImageId = (previewImages, target) => {
   return getPreviewSlot(previewImages, target).imageId;
+};
+
+const getUpdatePreviewSlot = (previewImages = {}) => {
+  return previewImages.target?.imageId
+    ? previewImages.target
+    : (previewImages.incoming ?? {});
 };
 
 const createPreviewBackgroundElement = ({
@@ -340,7 +357,7 @@ export const createAnimationPreviewResetState = ({
     elements.push(
       createPreviewContentElement({
         id: ANIMATION_PREVIEW_UPDATE_ELEMENT_ID,
-        previewSlot: getPreviewSlot(previewImages, "preview-incoming"),
+        previewSlot: getUpdatePreviewSlot(previewImages),
         imagesData,
         projectResolution,
         fallbackFill: "white",

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -9,6 +9,7 @@ import { resolveResourceFileType } from "../../internal/resourceFileMetadata.js"
 import { createFileExplorerKeyboardScopeHandlers } from "../../internal/ui/fileExplorerKeyboardScope.js";
 import { runResourcePageMutation } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import {
+  addKeyframeDefaultValues,
   AUTO_TWEEN_DEFAULT_DURATION,
   AUTO_TWEEN_DEFAULT_EASING,
 } from "./animationEditor.constants.js";
@@ -223,6 +224,19 @@ const renderPreviewAnimationState = async ({
   return true;
 };
 
+const clearPreviewCanvas = async ({ graphicsService } = {}) => {
+  if (!graphicsService) {
+    return;
+  }
+
+  graphicsService.setAnimationPlaybackMode("manual");
+  graphicsService.setAnimationTime(0);
+  await graphicsService.render({
+    elements: [],
+    animations: [],
+  });
+};
+
 const waitForPreviewPaint = async () => {
   await new Promise((resolve) => {
     if (typeof globalThis.requestAnimationFrame === "function") {
@@ -320,6 +334,7 @@ const ensureManualPreviewAtTime = async ({
 const renderPreviewForThumbnailCapture = async ({
   graphicsService,
   projectService,
+  resetCanvas = false,
   store,
 } = {}) => {
   if (!graphicsService) {
@@ -329,6 +344,12 @@ const renderPreviewForThumbnailCapture = async ({
   const captureTimeMs = store.selectPreviewPlayheadVisible()
     ? (store.selectPreviewPlayheadTimeMs() ?? 0)
     : 0;
+
+  if (resetCanvas) {
+    await clearPreviewCanvas({
+      graphicsService,
+    });
+  }
 
   await ensureManualPreviewAtTime({
     graphicsService,
@@ -772,25 +793,28 @@ export const handleAddPropertySideMenuItemClick = (deps, payload) => {
 
 export const handleAddPropertyFormSubmit = (deps, payload) => {
   const { render, store } = deps;
+  const popover = store.selectPopover();
   const {
     payload: { side },
-  } = store.selectPopover();
-  const {
-    property,
-    initialValue,
-    useInitialValue,
-    tweenMode,
-    duration,
-    easing,
-  } = payload._event.detail.values;
+  } = popover;
+  const trackedValues = popover.formValues ?? {};
+  const mergedValues = mergeSubmittedFormValues({
+    popover,
+    payload,
+  });
+  const { property, useInitialValue, tweenMode, duration, easing } =
+    mergedValues;
   const defaultInitialValue = store.selectDefaultInitialValue({ property });
   const useAutoTween = side === "update" && tweenMode === "auto";
+  const submittedInitialValue = hasOwnFormValue(trackedValues, "initialValue")
+    ? trackedValues.initialValue
+    : defaultInitialValue;
 
   const finalInitialValue = useAutoTween
     ? undefined
     : useInitialValue
-      ? initialValue !== undefined && initialValue !== ""
-        ? initialValue
+      ? submittedInitialValue !== undefined && submittedInitialValue !== ""
+        ? submittedInitialValue
         : defaultInitialValue
       : undefined;
 
@@ -833,13 +857,21 @@ export const handleAddKeyframeInDialog = (deps, payload) => {
 
 export const handleAddKeyframeFormSubmit = (deps, payload) => {
   const { render, store } = deps;
+  const popover = store.selectPopover();
   const {
     payload: { side, property, index },
-  } = store.selectPopover();
+  } = popover;
+  const trackedValues = popover.formValues ?? {};
 
   const formValues = {
-    ...payload._event.detail.values,
+    ...mergeSubmittedFormValues({
+      popover,
+      payload,
+    }),
   };
+  if (!hasOwnFormValue(trackedValues, "value")) {
+    formValues.value = addKeyframeDefaultValues.value;
+  }
 
   if (formValues.duration < 1) {
     formValues.duration = 1;
@@ -1098,6 +1130,18 @@ const updatePopoverFieldValue = ({ store, detail } = {}) => {
   });
 };
 
+const mergeSubmittedFormValues = ({ popover, payload } = {}) => {
+  return Object.assign(
+    {},
+    payload?._event?.detail?.values,
+    popover?.formValues,
+  );
+};
+
+const hasOwnFormValue = (values, name) => {
+  return Object.prototype.hasOwnProperty.call(values ?? {}, name);
+};
+
 const resolveValueChange = (payload) => {
   return (
     payload._event.detail?.value ??
@@ -1148,6 +1192,7 @@ const PREVIEW_IMAGE_SELECTOR_TARGETS = new Set([
   "preview-background",
   "preview-outgoing",
   "preview-incoming",
+  "preview-target",
 ]);
 
 const isPreviewImageSelectorTarget = (target) => {
@@ -1156,12 +1201,29 @@ const isPreviewImageSelectorTarget = (target) => {
 
 export const handleAddPropertyFormChange = (deps, payload) => {
   const { render, store } = deps;
+  const { name, value } = payload._event.detail ?? {};
+  if (name === "property") {
+    const currentFormValues = store.selectPopover().formValues ?? {};
+    const initialValue = store.selectDefaultInitialValue({
+      property: value,
+    });
+    const nextFormValues = {
+      ...currentFormValues,
+      property: value,
+      initialValue,
+    };
+    store.updatePopoverFormValues({
+      formValues: nextFormValues,
+    });
+    render();
+    return;
+  }
+
   updatePopoverFieldValue({
     store,
     detail: payload._event.detail,
   });
 
-  const { name, value } = payload._event.detail ?? {};
   if (name === "tweenMode" && value === "auto") {
     const currentFormValues = store.selectPopover().formValues ?? {};
     store.updatePopoverFormValues({
@@ -1173,6 +1235,15 @@ export const handleAddPropertyFormChange = (deps, payload) => {
     });
   }
 
+  render();
+};
+
+export const handleAddKeyframeFormChange = (deps, payload) => {
+  const { render, store } = deps;
+  updatePopoverFieldValue({
+    store,
+    detail: payload._event.detail,
+  });
   render();
 };
 
@@ -1530,6 +1601,7 @@ export const handleConfirmMaskImageSelection = async (deps) => {
       await renderPreviewForThumbnailCapture({
         graphicsService,
         projectService,
+        resetCanvas: true,
         store,
       });
     } catch {
@@ -1627,11 +1699,15 @@ export const handleReplayAnimation = async (deps) => {
 
 export const handleEditInitialValueFormSubmit = (deps, payload) => {
   const { render, store } = deps;
+  const popover = store.selectPopover();
   const {
     payload: { side, property },
-  } = store.selectPopover();
+  } = popover;
 
-  const { initialValue, valueSource } = payload._event.detail.values;
+  const { initialValue, valueSource } = mergeSubmittedFormValues({
+    popover,
+    payload,
+  });
   const defaultInitialValue = store.selectDefaultInitialValue({ property });
   const finalInitialValue =
     valueSource === "default"

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -172,7 +172,22 @@ const getPreviewImageResource = (imagesData, imageId) => {
   return imageItem;
 };
 
-const PREVIEW_IMAGE_SLOT_CONFIGS = Object.freeze([
+const UPDATE_PREVIEW_IMAGE_SLOT_CONFIGS = Object.freeze([
+  {
+    label: "BG Image",
+    target: "preview-background",
+    field: "background",
+    supportsTransform: false,
+  },
+  {
+    label: "Target Image",
+    target: "preview-target",
+    field: "target",
+    supportsTransform: true,
+  },
+]);
+
+const TRANSITION_PREVIEW_IMAGE_SLOT_CONFIGS = Object.freeze([
   {
     label: "BG Image",
     target: "preview-background",
@@ -197,10 +212,19 @@ const createInitialPreviewImages = () => ({
   background: {},
   outgoing: {},
   incoming: {},
+  target: {},
 });
 
+const getPreviewImageSlotConfigs = (dialogType) =>
+  dialogType === "transition"
+    ? TRANSITION_PREVIEW_IMAGE_SLOT_CONFIGS
+    : UPDATE_PREVIEW_IMAGE_SLOT_CONFIGS;
+
 const getPreviewSlotConfig = (target) => {
-  return PREVIEW_IMAGE_SLOT_CONFIGS.find((slot) => slot.target === target);
+  return [
+    ...TRANSITION_PREVIEW_IMAGE_SLOT_CONFIGS,
+    ...UPDATE_PREVIEW_IMAGE_SLOT_CONFIGS,
+  ].find((slot) => slot.target === target);
 };
 
 const normalizePreviewSlot = (value, { supportsTransform = false } = {}) => {
@@ -249,6 +273,10 @@ const normalizeAnimationPreviewData = (previewData) => {
     incoming: normalizePreviewSlot(source.incoming ?? source.incomingImageId, {
       supportsTransform: true,
     }),
+    target: normalizePreviewSlot(
+      source.target ?? source.targetImageId ?? source.incoming,
+      { supportsTransform: true },
+    ),
   };
 };
 
@@ -263,6 +291,12 @@ const getPreviewSlot = (previewImages, target) => {
 
 const getPreviewSlotImageId = (previewImages, target) => {
   return getPreviewSlot(previewImages, target).imageId;
+};
+
+const getUpdatePreviewSlot = (previewImages = {}) => {
+  return previewImages.target?.imageId
+    ? previewImages.target
+    : (previewImages.incoming ?? {});
 };
 
 const createPreviewBackgroundElement = ({
@@ -373,7 +407,7 @@ const createAnimationResetState = ({
     elements.push(
       createPreviewContentElement({
         id: PREVIEW_UPDATE_ELEMENT_ID,
-        previewSlot: getPreviewSlot(previewImages, "preview-incoming"),
+        previewSlot: getUpdatePreviewSlot(previewImages),
         imagesData,
         projectResolution,
         fallbackFill: "white",
@@ -614,23 +648,24 @@ const createUpdateKeyframeForm = (
 const createAddPropertyForm = (
   availableProperties,
   propertyFieldConfig,
-  { side } = {},
+  { side, property } = {},
 ) => {
   const isUpdateSide = side === "update";
-  const initialValueFields = Object.keys(propertyFieldConfig).map(
-    (property) => {
-      const field = createSliderField({
+  const initialValueField = property
+    ? createSliderField({
         property,
         propertyFieldConfig,
         name: "initialValue",
         label: "Initial value",
-      });
-      field.$when = isUpdateSide
-        ? `tweenMode != "auto" && useInitialValue == true && property == "${property}"`
-        : `useInitialValue == true && property == "${property}"`;
-      return field;
-    },
-  );
+      })
+    : undefined;
+  if (initialValueField) {
+    initialValueField.defaultValue =
+      propertyFieldConfig[property]?.defaultValue ?? 0;
+    initialValueField.$when = isUpdateSide
+      ? 'tweenMode != "auto" && useInitialValue == true'
+      : "useInitialValue == true";
+  }
   const fields = [
     {
       name: "property",
@@ -675,31 +710,34 @@ const createAddPropertyForm = (
       ...field,
       $when: 'tweenMode == "auto"',
     }));
-    fields.push(...initialValueFields, ...autoFields);
+    if (initialValueField) {
+      fields.push(initialValueField);
+    }
+    fields.push(...autoFields);
   } else {
-    fields.push(
-      {
-        name: "useInitialValue",
-        type: "segmented-control",
-        label: "Use initial value",
-        noClear: true,
-        tooltip: {
-          content:
-            "The initial value of the property at the start of the animation. If not set, it will use the element's current value at start of animation",
-        },
-        options: [
-          {
-            label: "No",
-            value: false,
-          },
-          {
-            label: "Yes",
-            value: true,
-          },
-        ],
+    fields.push({
+      name: "useInitialValue",
+      type: "segmented-control",
+      label: "Use initial value",
+      noClear: true,
+      tooltip: {
+        content:
+          "The initial value of the property at the start of the animation. If not set, it will use the element's current value at start of animation",
       },
-      ...initialValueFields,
-    );
+      options: [
+        {
+          label: "No",
+          value: false,
+        },
+        {
+          label: "Yes",
+          value: true,
+        },
+      ],
+    });
+    if (initialValueField) {
+      fields.push(initialValueField);
+    }
   }
 
   return {
@@ -1968,11 +2006,28 @@ export const setPreviewImage = ({ state }, { target, imageId } = {}) => {
 };
 
 export const selectPreviewImageId = ({ state }, { target } = {}) => {
+  if (target === "preview-target") {
+    return getUpdatePreviewSlot(state.previewImages).imageId;
+  }
+
   return getPreviewSlotImageId(state.previewImages, target);
 };
 
 export const selectPreviewData = ({ state }) => {
-  return structuredClone(state.previewImages);
+  const background = structuredClone(state.previewImages.background ?? {});
+
+  if (state.dialogType === "transition") {
+    return {
+      background,
+      outgoing: structuredClone(state.previewImages.outgoing ?? {}),
+      incoming: structuredClone(state.previewImages.incoming ?? {}),
+    };
+  }
+
+  return {
+    background,
+    target: structuredClone(getUpdatePreviewSlot(state.previewImages)),
+  };
 };
 
 export const showFullImagePreview = ({ state }, { imageId } = {}) => {
@@ -2187,8 +2242,11 @@ const buildTransitionMaskPanelData = (state) => {
 
 const buildPreviewPanelData = (state) => {
   return {
-    items: PREVIEW_IMAGE_SLOT_CONFIGS.map((slot) => {
-      const imageId = state.previewImages[slot.field]?.imageId;
+    items: getPreviewImageSlotConfigs(state.dialogType).map((slot) => {
+      const imageId =
+        slot.target === "preview-target"
+          ? getUpdatePreviewSlot(state.previewImages).imageId
+          : state.previewImages[slot.field]?.imageId;
       const image = buildMaskImageItem(state, imageId);
 
       return {
@@ -2288,20 +2346,55 @@ export const selectViewData = ({ state }) => {
   })();
 
   let addPropertyContext = {};
+  let addPropertyFormDefaultValues = {
+    useInitialValue: false,
+    tweenMode: "keyframes",
+    duration: AUTO_TWEEN_DEFAULT_DURATION,
+    easing: AUTO_TWEEN_DEFAULT_EASING,
+  };
   let editKeyframeDefaultValues = {};
   let editAutoDefaultValues = {};
   let editInitialValueDefaultValues = {};
   let editInitialValueContext = {};
+  let addPropertySelectedProperty = addPropertyOptions[0]?.value;
 
   if (state.popover.mode === "addProperty") {
-    addPropertyContext = {
-      useInitialValue: false,
-      tweenMode: "keyframes",
-      duration: AUTO_TWEEN_DEFAULT_DURATION,
-      easing: AUTO_TWEEN_DEFAULT_EASING,
+    addPropertySelectedProperty =
+      state.popover.formValues.property ?? addPropertySelectedProperty;
+  }
+
+  if (addPropertySelectedProperty) {
+    addPropertyFormDefaultValues.property = addPropertySelectedProperty;
+    addPropertyFormDefaultValues.initialValue =
+      defaultInitialValuesByProperty[addPropertySelectedProperty] ?? 0;
+  }
+
+  if (state.popover.mode === "addProperty") {
+    addPropertyFormDefaultValues = {
+      ...addPropertyFormDefaultValues,
       ...state.popover.formValues,
     };
+
+    if (
+      addPropertySelectedProperty &&
+      (addPropertyFormDefaultValues.initialValue === undefined ||
+        addPropertyFormDefaultValues.initialValue === "")
+    ) {
+      addPropertyFormDefaultValues.initialValue =
+        defaultInitialValuesByProperty[addPropertySelectedProperty] ?? 0;
+    }
+
+    addPropertyContext = {
+      ...addPropertyFormDefaultValues,
+    };
   }
+  const addPropertyFormKey = [
+    state.popover.mode === "addProperty" ? "open" : "closed",
+    addPropertySide,
+    addPropertySelectedProperty ?? "",
+    addPropertyFormDefaultValues.tweenMode ?? "",
+    addPropertyFormDefaultValues.useInitialValue ? "initial" : "current",
+  ].join(":");
 
   if (state.popover.mode === "editKeyframe") {
     const { side, property, index } = state.popover.payload;
@@ -2372,8 +2465,10 @@ export const selectViewData = ({ state }) => {
       propertyFieldConfig,
       {
         side: addPropertySide,
+        property: addPropertySelectedProperty,
       },
     ),
+    addPropertyFormKey,
     addPropertyContext,
     addKeyframeForm: createAddKeyframeForm(
       state.popover.payload?.property,
@@ -2423,12 +2518,7 @@ export const selectViewData = ({ state }) => {
       ),
       addPropertySideMenuIsOpen: state.popover.mode === "addPropertySideMenu",
     },
-    addPropertyFormDefaultValues: {
-      useInitialValue: false,
-      tweenMode: "keyframes",
-      duration: AUTO_TWEEN_DEFAULT_DURATION,
-      easing: AUTO_TWEEN_DEFAULT_EASING,
-    },
+    addPropertyFormDefaultValues,
     imageSelectorDialog: state.imageSelectorDialog,
     imageFolderItems,
     fullImagePreviewVisible: state.fullImagePreviewVisible,

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -81,6 +81,8 @@ refs:
     eventListeners:
       form-action:
         handler: handleAddKeyframeFormSubmit
+      form-change:
+        handler: handleAddKeyframeFormChange
   editKeyframeForm:
     eventListeners:
       form-action:
@@ -372,7 +374,7 @@ template:
   - rtgl-popover#addPropertyPopover ?open=${popover.popoverIsOpen} x=${popover.x} y=${popover.y}:
       - $if popover.mode == 'addProperty':
           - rtgl-view slot=content:
-              - rtgl-form#addPropertyForm :form=${addPropertyForm} :context=${addPropertyContext} :defaultValues=${addPropertyFormDefaultValues}: null
+              - rtgl-form#addPropertyForm key=${addPropertyFormKey} :form=${addPropertyForm} :context=${addPropertyContext} :defaultValues=${addPropertyFormDefaultValues}: null
       - $if popover.mode == 'addKeyframe':
           - rtgl-view slot=content:
               - rtgl-form#addKeyframeForm :form=${addKeyframeForm} :defaultValues=${addKeyframeDefaultValues}: null

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -844,7 +844,7 @@
           "mask": {
             "kind": "single",
             "imageId": "ZvJUEaaujuQj",
-            "channel": "alpha",
+            "channel": "red",
             "invert": false,
             "softness": 0.08,
             "progressDuration": 1000,

--- a/tests/animationEditor/animationEditor.handlers.test.js
+++ b/tests/animationEditor/animationEditor.handlers.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleAddMaskClick,
+  handleAddKeyframeFormSubmit,
+  handleAddPropertyFormChange,
+  handleAddPropertyFormSubmit,
   handleConfirmMaskImageSelection,
   handleEditMaskClick,
   handleOpenAddMaskClick,
@@ -12,6 +15,12 @@ import {
 } from "../../src/pages/animationEditor/animationEditor.handlers.js";
 
 describe("animationEditor.handlers", () => {
+  const createIdleAutosaveMocks = () => ({
+    selectAutosaveInFlight: vi.fn(() => false),
+    selectAutosavePersistedVersion: vi.fn(() => 1),
+    selectAutosaveVersion: vi.fn(() => 1),
+  });
+
   it("opens a pending transition mask from the right panel", () => {
     const store = {
       startPendingTransitionMask: vi.fn(),
@@ -115,7 +124,7 @@ describe("animationEditor.handlers", () => {
         _event: {
           currentTarget: {
             dataset: {
-              target: "preview-incoming",
+              target: "preview-target",
             },
           },
         },
@@ -123,14 +132,265 @@ describe("animationEditor.handlers", () => {
     );
 
     expect(store.selectPreviewImageId).toHaveBeenCalledWith({
-      target: "preview-incoming",
+      target: "preview-target",
     });
     expect(store.showImageSelectorDialog).toHaveBeenCalledWith({
-      target: "preview-incoming",
+      target: "preview-target",
       index: undefined,
       selectedImageId: "image-current",
     });
     expect(render).toHaveBeenCalled();
+  });
+
+  it("preserves zero initial values when adding a property", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        payload: {
+          side: "update",
+        },
+        formValues: {
+          property: "alpha",
+          useInitialValue: true,
+          initialValue: 0,
+          tweenMode: "keyframes",
+        },
+      })),
+      selectDefaultInitialValue: vi.fn(() => 1),
+      addProperty: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      stopPreviewPlayback: vi.fn(),
+      bumpPreviewRenderVersion: vi.fn(),
+      closePopover: vi.fn(),
+      queueAutosave: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertyFormSubmit(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              property: "alpha",
+              useInitialValue: true,
+              initialValue: 1,
+              tweenMode: "keyframes",
+            },
+          },
+        },
+      },
+    );
+
+    expect(store.addProperty).toHaveBeenCalledWith({
+      side: "update",
+      property: "alpha",
+      initialValue: 0,
+      tweenMode: "keyframes",
+      autoDuration: undefined,
+      autoEasing: undefined,
+    });
+  });
+
+  it("uses the selected property default when the add-property initial value is not edited", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        payload: {
+          side: "update",
+        },
+        formValues: {
+          property: "alpha",
+          useInitialValue: true,
+          tweenMode: "keyframes",
+        },
+      })),
+      selectDefaultInitialValue: vi.fn(() => 1),
+      addProperty: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      stopPreviewPlayback: vi.fn(),
+      bumpPreviewRenderVersion: vi.fn(),
+      closePopover: vi.fn(),
+      queueAutosave: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertyFormSubmit(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              property: "alpha",
+              useInitialValue: true,
+              tweenMode: "keyframes",
+            },
+          },
+        },
+      },
+    );
+
+    expect(store.addProperty).toHaveBeenCalledWith({
+      side: "update",
+      property: "alpha",
+      initialValue: 1,
+      tweenMode: "keyframes",
+      autoDuration: undefined,
+      autoEasing: undefined,
+    });
+  });
+
+  it("resets stale initial values when the add-property property changes", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        formValues: {
+          property: "alpha",
+          useInitialValue: true,
+          initialValue: 0,
+        },
+      })),
+      selectDefaultInitialValue: vi.fn(() => 1),
+      updatePopoverFormValues: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertyFormChange(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            name: "property",
+            value: "scaleX",
+          },
+        },
+      },
+    );
+
+    expect(store.updatePopoverFormValues).toHaveBeenCalledWith({
+      formValues: {
+        initialValue: 1,
+        property: "scaleX",
+        useInitialValue: true,
+      },
+    });
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("preserves zero values when adding a keyframe", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        payload: {
+          side: "update",
+          property: "alpha",
+          index: 0,
+        },
+        formValues: {
+          duration: 1000,
+          value: 0,
+          easing: "linear",
+          relative: false,
+        },
+      })),
+      addKeyframe: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      stopPreviewPlayback: vi.fn(),
+      bumpPreviewRenderVersion: vi.fn(),
+      closePopover: vi.fn(),
+      queueAutosave: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleAddKeyframeFormSubmit(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              duration: 1000,
+              easing: "linear",
+              relative: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(store.addKeyframe).toHaveBeenCalledWith({
+      side: "update",
+      property: "alpha",
+      index: 0,
+      duration: 1000,
+      value: 0,
+      easing: "linear",
+      relative: false,
+    });
+  });
+
+  it("uses the keyframe value default when the value field is not edited", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        payload: {
+          side: "update",
+          property: "translateX",
+          index: 0,
+        },
+        formValues: {
+          duration: 1000,
+          easing: "linear",
+          relative: false,
+        },
+      })),
+      addKeyframe: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      stopPreviewPlayback: vi.fn(),
+      bumpPreviewRenderVersion: vi.fn(),
+      closePopover: vi.fn(),
+      queueAutosave: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleAddKeyframeFormSubmit(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              duration: 1000,
+              value: 1,
+              easing: "linear",
+              relative: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(store.addKeyframe).toHaveBeenCalledWith({
+      side: "update",
+      property: "translateX",
+      index: 0,
+      duration: 1000,
+      value: 0,
+      easing: "linear",
+      relative: false,
+    });
   });
 
   it("commits preview image selections and updates the preview canvas", async () => {
@@ -189,8 +449,12 @@ describe("animationEditor.handlers", () => {
     expect(graphicsService.setAnimationPlaybackMode).toHaveBeenCalledWith(
       "manual",
     );
-    expect(graphicsService.render).toHaveBeenNthCalledWith(1, resetState);
-    expect(graphicsService.render).toHaveBeenNthCalledWith(2, renderState);
+    expect(graphicsService.render).toHaveBeenNthCalledWith(1, {
+      elements: [],
+      animations: [],
+    });
+    expect(graphicsService.render).toHaveBeenNthCalledWith(2, resetState);
+    expect(graphicsService.render).toHaveBeenNthCalledWith(3, renderState);
     expect(graphicsService.setAnimationTime).toHaveBeenCalledWith(0);
   });
 

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { produce } from "immer";
-import { PREVIEW_TRANSITION_ELEMENT_ID } from "../../src/pages/animationEditor/animationEditor.constants.js";
+import {
+  PREVIEW_TRANSITION_ELEMENT_ID,
+  PREVIEW_UPDATE_ELEMENT_ID,
+} from "../../src/pages/animationEditor/animationEditor.constants.js";
 import {
   commitPendingTransitionMask,
   createInitialState,
@@ -17,6 +20,7 @@ import {
   setTransitionMaskChannel,
   setTransitionMaskImage,
   startPendingTransitionMask,
+  updatePopoverFormValues,
 } from "../../src/pages/animationEditor/animationEditor.store.js";
 
 describe("animationEditor.store", () => {
@@ -154,6 +158,92 @@ describe("animationEditor.store", () => {
     });
   });
 
+  it("creates a single add-property initial value field for the selected property", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    setProjectResolution(
+      { state },
+      {
+        projectResolution: {
+          width: 1920,
+          height: 1080,
+        },
+      },
+    );
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "update",
+        },
+      },
+    );
+    updatePopoverFormValues(
+      { state },
+      {
+        formValues: {
+          property: "x",
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    const addPropertyForm = viewData.addPropertyForm;
+    const initialValueFields = addPropertyForm.fields.filter(
+      (field) => field.name === "initialValue",
+    );
+
+    expect(viewData.addPropertyFormKey).toBe("open:update:x:keyframes:current");
+    expect(viewData.addPropertyFormDefaultValues).toMatchObject({
+      property: "x",
+      initialValue: 960,
+    });
+    expect(initialValueFields).toHaveLength(1);
+    expect(initialValueFields[0]).toMatchObject({
+      defaultValue: 960,
+      $when: 'tweenMode != "auto" && useInitialValue == true',
+    });
+  });
+
+  it("uses zero as the add-property initial value default when the property default is zero", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "update",
+        },
+      },
+    );
+    updatePopoverFormValues(
+      { state },
+      {
+        formValues: {
+          property: "translateX",
+        },
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+    });
+    const initialValueFields = viewData.addPropertyForm.fields.filter(
+      (field) => field.name === "initialValue",
+    );
+
+    expect(viewData.addPropertyFormDefaultValues).toMatchObject({
+      property: "translateX",
+      initialValue: 0,
+    });
+    expect(initialValueFields).toHaveLength(1);
+    expect(initialValueFields[0]).toMatchObject({
+      defaultValue: 0,
+    });
+  });
+
   it("commits a pending mask inside Immer-backed store actions", () => {
     const state = createInitialState();
     openDialog({ state }, { dialogType: "transition" });
@@ -227,10 +317,10 @@ describe("animationEditor.store", () => {
               fileId: "file-bg",
               thumbnailFileId: "thumb-bg",
             },
-            incoming: {
+            target: {
               type: "image",
-              name: "Incoming",
-              fileId: "file-incoming",
+              name: "Target",
+              fileId: "file-target",
               width: 1024,
               height: 768,
             },
@@ -248,8 +338,8 @@ describe("animationEditor.store", () => {
     setPreviewImage(
       { state },
       {
-        target: "preview-incoming",
-        imageId: "incoming",
+        target: "preview-target",
+        imageId: "target",
       },
     );
 
@@ -265,16 +355,11 @@ describe("animationEditor.store", () => {
         }),
       }),
       expect.objectContaining({
-        label: "Outgoing Image",
-        target: "preview-outgoing",
-        imageLabel: "Select image",
-      }),
-      expect.objectContaining({
-        label: "Incoming Image",
-        target: "preview-incoming",
-        imageLabel: "Incoming",
+        label: "Target Image",
+        target: "preview-target",
+        imageLabel: "Target",
         image: expect.objectContaining({
-          previewFileId: "file-incoming",
+          previewFileId: "file-target",
           previewAspectRatio: "1024 / 768",
         }),
       }),
@@ -323,6 +408,100 @@ describe("animationEditor.store", () => {
         imageId: "incoming",
         transformId: "transform-in",
       },
+    });
+  });
+
+  it("stores update preview data in the target slot", () => {
+    const state = createInitialState();
+    openDialog(
+      { state },
+      {
+        editMode: true,
+        itemId: "animation-1",
+        itemData: {
+          name: "Fade",
+          description: "",
+          animation: {
+            type: "update",
+            tween: {},
+          },
+          preview: {
+            background: {
+              imageId: "bg",
+            },
+            incoming: {
+              imageId: "legacy-incoming",
+            },
+          },
+        },
+      },
+    );
+
+    expect(selectPreviewData({ state })).toEqual({
+      background: {
+        imageId: "bg",
+      },
+      target: {
+        imageId: "legacy-incoming",
+      },
+    });
+
+    setPreviewImage(
+      { state },
+      {
+        target: "preview-target",
+        imageId: "target",
+      },
+    );
+
+    expect(selectPreviewData({ state })).toEqual({
+      background: {
+        imageId: "bg",
+      },
+      target: {
+        imageId: "target",
+      },
+    });
+  });
+
+  it("uses the target image in update render states", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    setImages(
+      { state },
+      {
+        images: {
+          tree: [],
+          items: {
+            target: {
+              type: "image",
+              name: "Target",
+              fileId: "file-target",
+              width: 1024,
+              height: 768,
+            },
+          },
+        },
+      },
+    );
+    setPreviewImage(
+      { state },
+      {
+        target: "preview-target",
+        imageId: "target",
+      },
+    );
+
+    const renderState = selectAnimationRenderStateWithAnimations({ state });
+    const updateElement = renderState.elements.find(
+      (element) => element.id === PREVIEW_UPDATE_ELEMENT_ID,
+    );
+
+    expect(updateElement).toMatchObject({
+      type: "sprite",
+      src: "file-target",
+      width: 1024,
+      height: 768,
     });
   });
 


### PR DESCRIPTION
## Summary
- update animation editor update previews to use a target image slot and keep preview data/render state aligned
- preserve explicit zero values while making untouched Add Property initial values use the selected property default
- reset preview canvas before preview image selection rerenders and update Slide Mask 1s to use the red channel
- bump @routevn/creator-model to 1.5.2

## Testing
- bunx vitest run tests/animationEditor/animationEditor.handlers.test.js tests/animationEditor/animationEditor.store.test.js tests/animations/animations.handlers.test.js tests/animations/animations.store.test.js
- bunx oxlint src/internal/animationPreview.js src/pages/animationEditor/animationEditor.handlers.js src/pages/animationEditor/animationEditor.store.js tests/animationEditor/animationEditor.handlers.test.js tests/animationEditor/animationEditor.store.test.js
- bunx prettier --check src/internal/animationPreview.js src/pages/animationEditor/animationEditor.handlers.js src/pages/animationEditor/animationEditor.store.js src/pages/animationEditor/animationEditor.view.yaml tests/animationEditor/animationEditor.handlers.test.js tests/animationEditor/animationEditor.store.test.js
- pre-push hook: oxlint and prettier --check src

Not run: bun run build:web