### PR TITLE
fix runtime audio volume defaults

### DIFF
--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -288,6 +288,8 @@ const applyPanelValueUpdate = (
     const runtimeDefaultValue = Number(runtimeField?.default);
     const nextMin = Number(currentValues.min);
     const nextMax = Number(currentValues.max);
+    const runtimeMin = Number(runtimeField?.min);
+    const runtimeMax = Number(runtimeField?.max);
     const pendingUpdates = [];
     const nextInitialValue = runtimeId
       ? toRuntimeTemplateValue(runtimeId)
@@ -298,28 +300,32 @@ const applyPanelValueUpdate = (
     if (runtimeId && Number.isFinite(runtimeDefaultValue)) {
       const normalizedMin = Number.isFinite(nextMin) ? nextMin : 0;
       const normalizedMax = Number.isFinite(nextMax) ? nextMax : 100;
-      const widenedMin = Math.min(normalizedMin, runtimeDefaultValue);
-      const widenedMax = Math.max(normalizedMax, runtimeDefaultValue);
+      const targetMin = Number.isFinite(runtimeMin)
+        ? runtimeMin
+        : Math.min(normalizedMin, runtimeDefaultValue);
+      const targetMax = Number.isFinite(runtimeMax)
+        ? runtimeMax
+        : Math.max(normalizedMax, runtimeDefaultValue);
 
-      if (widenedMin !== normalizedMin) {
+      if (targetMin !== normalizedMin) {
         store.updateValueProperty({
           name: "min",
-          value: widenedMin,
+          value: targetMin,
         });
         pendingUpdates.push({
           name: "min",
-          value: widenedMin,
+          value: targetMin,
         });
       }
 
-      if (widenedMax !== normalizedMax) {
+      if (targetMax !== normalizedMax) {
         store.updateValueProperty({
           name: "max",
-          value: widenedMax,
+          value: targetMax,
         });
         pendingUpdates.push({
           name: "max",
-          value: widenedMax,
+          value: targetMax,
         });
       }
     }

--- a/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
+++ b/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
@@ -4,6 +4,7 @@ import {
   buildLayoutElements,
   extractFileIdsFromRenderState,
 } from "../../../internal/project/layout.js";
+import { normalizeRuntimeFieldValue } from "../../../internal/runtimeFields.js";
 import { getLayoutEditorItemResizeEdges } from "../../../internal/layoutEditorElementRegistry.js";
 import { toHierarchyStructure } from "../../../internal/project/tree.js";
 
@@ -165,8 +166,14 @@ const normalizeLayoutEditorPreviewData = (previewData = {}) => {
       skipUnseenText: nextRuntime.skipUnseenText ?? false,
       skipTransitionsAndAnimations:
         nextRuntime.skipTransitionsAndAnimations ?? false,
-      soundVolume: nextRuntime.soundVolume ?? 500,
-      musicVolume: nextRuntime.musicVolume ?? 500,
+      soundVolume: normalizeRuntimeFieldValue(
+        "soundVolume",
+        nextRuntime.soundVolume,
+      ),
+      musicVolume: normalizeRuntimeFieldValue(
+        "musicVolume",
+        nextRuntime.musicVolume,
+      ),
       muteAll: nextRuntime.muteAll ?? false,
     },
     dialogue: {

--- a/src/components/layoutEditorPreview/support/layoutEditorPreviewRuntimeState.js
+++ b/src/components/layoutEditorPreview/support/layoutEditorPreviewRuntimeState.js
@@ -5,30 +5,12 @@ import {
 } from "../../../internal/layoutConditions.js";
 import {
   getRuntimeFieldItems,
+  normalizeRuntimeFieldValue,
   toRuntimeConditionTarget,
 } from "../../../internal/runtimeFields.js";
 
 const toPreviewRuntimeValue = (field = {}, value) => {
-  if (field.type === "number") {
-    const parsedValue = Number(value);
-    return Number.isFinite(parsedValue)
-      ? parsedValue
-      : Number(field.default ?? 0);
-  }
-
-  if (field.type === "boolean") {
-    if (typeof value === "boolean") {
-      return value;
-    }
-
-    if (typeof value === "string") {
-      return value === "true";
-    }
-
-    return Boolean(value ?? field.default);
-  }
-
-  return value ?? field.default ?? "";
+  return normalizeRuntimeFieldValue(field.id, value);
 };
 
 const getPreviewRuntimeOverrideValue = (

--- a/src/internal/runtimeActions.js
+++ b/src/internal/runtimeActions.js
@@ -19,11 +19,14 @@ const createValueActionDefinition = ({
   runtimeId,
   inputType,
   min,
+  max,
   step,
   description,
   placeholder,
 } = {}) => {
   const field = getRuntimeFieldItem(runtimeId);
+  const resolvedMin = min ?? field?.min;
+  const resolvedMax = max ?? field?.max;
 
   return {
     mode,
@@ -35,7 +38,8 @@ const createValueActionDefinition = ({
     defaultValue: field?.default,
     valueLabel: "Value",
     placeholder,
-    min,
+    min: resolvedMin,
+    max: resolvedMax,
     step,
   };
 };
@@ -234,6 +238,7 @@ const createFixedValueField = (definition) => {
     type: definition.inputType === "number" ? "input-number" : "input-text",
     description: definition.description,
     min: definition.min,
+    max: definition.max,
     step: definition.step,
     placeholder: definition.placeholder,
   };

--- a/src/internal/runtimeFields.js
+++ b/src/internal/runtimeFields.js
@@ -1,3 +1,5 @@
+export const DEFAULT_CLIENT_AUDIO_VOLUME = 75;
+
 const RUNTIME_FIELD_GROUPS = Object.freeze([
   {
     id: "routeEngine",
@@ -42,7 +44,9 @@ const RUNTIME_FIELD_GROUPS = Object.freeze([
         name: "Sound Volume",
         type: "number",
         scope: "device",
-        default: 500,
+        default: DEFAULT_CLIENT_AUDIO_VOLUME,
+        min: 0,
+        max: 100,
         description: "Controls the effective sound effects volume.",
       },
       {
@@ -50,7 +54,9 @@ const RUNTIME_FIELD_GROUPS = Object.freeze([
         name: "Music Volume",
         type: "number",
         scope: "device",
-        default: 500,
+        default: DEFAULT_CLIENT_AUDIO_VOLUME,
+        min: 0,
+        max: 100,
         description: "Controls the effective music volume.",
       },
       {
@@ -130,9 +136,11 @@ const createRuntimeFieldItem = ({
   scope,
   type,
   default: defaultValue,
+  min,
+  max,
   description,
 } = {}) => {
-  return {
+  const item = {
     id,
     name,
     scope,
@@ -143,6 +151,16 @@ const createRuntimeFieldItem = ({
     source: "runtime",
     readOnly: true,
   };
+
+  if (Number.isFinite(min)) {
+    item.min = min;
+  }
+
+  if (Number.isFinite(max)) {
+    item.max = max;
+  }
+
+  return item;
 };
 
 const RUNTIME_FIELD_ITEMS = Object.freeze(
@@ -215,6 +233,48 @@ export const getRuntimeFieldItems = () => {
 
 export const getRuntimeFieldItem = (runtimeId) => {
   return RUNTIME_FIELD_ITEMS[runtimeId];
+};
+
+export const normalizeRuntimeFieldValue = (runtimeId, value) => {
+  const field = getRuntimeFieldItem(runtimeId);
+  if (!field) {
+    return value;
+  }
+
+  if (field.type === "number") {
+    const parsedValue = Number(value);
+    let nextValue = Number.isFinite(parsedValue)
+      ? parsedValue
+      : Number(field.default ?? 0);
+
+    if (!Number.isFinite(nextValue)) {
+      nextValue = 0;
+    }
+
+    if (Number.isFinite(field.min)) {
+      nextValue = Math.max(field.min, nextValue);
+    }
+
+    if (Number.isFinite(field.max)) {
+      nextValue = Math.min(field.max, nextValue);
+    }
+
+    return nextValue;
+  }
+
+  if (field.type === "boolean") {
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      return value === "true";
+    }
+
+    return Boolean(value ?? field.default);
+  }
+
+  return value ?? field.default ?? "";
 };
 
 export const getRuntimeNumberFieldOptions = () => {

--- a/tests/commandLineRuntimeAction/commandLineRuntimeAction.store.test.js
+++ b/tests/commandLineRuntimeAction/commandLineRuntimeAction.store.test.js
@@ -71,8 +71,16 @@ describe("commandLineRuntimeAction.store", () => {
 
     expect(eventViewData.defaultValues).toEqual({
       valueSource: "event",
-      value: 500,
+      value: 75,
     });
+    expect(eventViewData.form.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "value",
+          max: 100,
+        }),
+      ]),
+    );
     expect(eventViewData.context).toEqual({
       values: eventViewData.defaultValues,
     });

--- a/tests/layoutEditPanel/layoutEditPanel.sliderValue.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.sliderValue.test.js
@@ -47,7 +47,7 @@ describe("layoutEditPanel slider values", () => {
         type: "slider",
         initialValue: 0,
         min: 0,
-        max: 100,
+        max: 500,
       },
     });
 
@@ -66,14 +66,14 @@ describe("layoutEditPanel slider values", () => {
 
     expect(deps.state.values.sliderRuntimeValueId).toBe("musicVolume");
     expect(deps.state.values.min).toBe(0);
-    expect(deps.state.values.max).toBe(500);
+    expect(deps.state.values.max).toBe(100);
     expect(deps.state.values.initialValue).toBe("${runtime.musicVolume}");
     expect(
       deps.dispatchEvent.mock.calls.map(([event]) => event.detail),
     ).toEqual([
       expect.objectContaining({
         name: "max",
-        value: 500,
+        value: 100,
       }),
       expect.objectContaining({
         name: "initialValue",

--- a/tests/layoutEditor/layoutEditorPreview.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.test.js
@@ -40,6 +40,8 @@ describe("layoutEditorPreview", () => {
       boolVar: true,
     });
     expect(previewData.runtime.dialogueTextSpeed).toBe(50);
+    expect(previewData.runtime.soundVolume).toBe(75);
+    expect(previewData.runtime.musicVolume).toBe(75);
     expect(previewData.dialogue.characterId).toBe("character-1");
     expect(previewData.dialogue.character.name).toBe("Aki");
     expect(previewData.dialogue.content[0].text).toBe("Hello there");

--- a/tests/layoutEditor/layoutEditorPreviewPersistence.test.js
+++ b/tests/layoutEditor/layoutEditorPreviewPersistence.test.js
@@ -27,6 +27,8 @@ describe("layoutEditor preview persistence", () => {
       },
       runtime: {
         dialogueTextSpeed: 25,
+        soundVolume: 500,
+        musicVolume: 500,
         autoMode: true,
         skipMode: false,
         isLineCompleted: true,
@@ -97,6 +99,8 @@ describe("layoutEditor preview persistence", () => {
       backgroundImageId: "image-preview",
       runtime: {
         dialogueTextSpeed: 25,
+        soundVolume: 100,
+        musicVolume: 100,
         autoMode: true,
         skipMode: false,
         isLineCompleted: true,


### PR DESCRIPTION
## Summary
- default client runtime sound/music volume to 75 with a 0-100 range
- normalize layout preview runtime volume values before rendering so legacy over-range values do not reach route-graphics
- update runtime action and layout slider UI/tests to respect the 0-100 client volume range

## Testing
- `bunx vitest run tests/layoutEditor/layoutEditorPreview.test.js tests/layoutEditor/layoutEditorPreviewPersistence.test.js tests/layoutEditPanel/layoutEditPanel.sliderValue.test.js tests/commandLineRuntimeAction/commandLineRuntimeAction.store.test.js`
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`