### PR TITLE
chore: update route-graphics to 1.17.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "lexical": "^0.22.0",
         "nanoid": "^5.1.5",
         "route-engine-js": "1.14.5",
-        "route-graphics": "1.17.1",
+        "route-graphics": "1.17.3",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
         "snabbdom-to-html": "^7.1.0",
@@ -712,7 +712,7 @@
 
     "route-engine-js": ["route-engine-js@1.14.5", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-2PCQpKnkSmOtLKP3E5NNGWhK0mlJeQRdHzMZilU23ZJMTD71F+e9jqP7f+fVZiiiMq1IKzh912f7uMFuWkVFZw=="],
 
-    "route-graphics": ["route-graphics@1.17.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-o7Dz1sqT1kGTWZEaEW90Ul89UfYJzeWiq6CpoGizvyqLCHWOqyA1KMgwn5odfGYglbcYFS8ZbbY+fcfaZNd8mQ=="],
+    "route-graphics": ["route-graphics@1.17.3", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-WObDaWuldNBDhdtVY33OTHXl/DTRh648UodLkV2Lq+747O8rPik0nqc9NEa7u0TgWH5I/ZBwd4XbBj2+oHKWww=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "^0.22.0",
     "nanoid": "^5.1.5",
     "route-engine-js": "1.14.5",
-    "route-graphics": "1.17.1",
+    "route-graphics": "1.17.3",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",
     "snabbdom-to-html": "^7.1.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- update `route-graphics` from `1.17.1` to `1.17.3`
- refresh `bun.lock` for the new package integrity
- bump Tauri app version from `1.3.2` to `1.3.3`

## Testing
- `bunx vitest run tests/graphicsService/graphicsService.test.js tests/project/layout.soundVariants.test.js`
- pre-push hook: `oxlint && bun prettier --check src`

## Note
- `bun run test:smoke` currently fails on an unrelated store mock issue: `store.loadMaterializedViewCheckpoints is not a function`