### PR TITLE
chore: update route-graphics to 1.17.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "lexical": "^0.22.0",
         "nanoid": "^5.1.5",
         "route-engine-js": "1.14.5",
-        "route-graphics": "1.17.3",
+        "route-graphics": "1.17.4",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
         "snabbdom-to-html": "^7.1.0",
@@ -372,7 +372,7 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
-    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
+    "@webgpu/types": ["@webgpu/types@0.1.70", "", {}, "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
@@ -712,7 +712,7 @@
 
     "route-engine-js": ["route-engine-js@1.14.5", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-2PCQpKnkSmOtLKP3E5NNGWhK0mlJeQRdHzMZilU23ZJMTD71F+e9jqP7f+fVZiiiMq1IKzh912f7uMFuWkVFZw=="],
 
-    "route-graphics": ["route-graphics@1.17.3", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-WObDaWuldNBDhdtVY33OTHXl/DTRh648UodLkV2Lq+747O8rPik0nqc9NEa7u0TgWH5I/ZBwd4XbBj2+oHKWww=="],
+    "route-graphics": ["route-graphics@1.17.4", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-K5E0XPOFyqxc0jSPm9l1SiuQfkDeNm1EH60zSsvn/wCyhDo6KRIAabff7DT9qdG4x58YX80gQQSy0ik4c+3IBA=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "^0.22.0",
     "nanoid": "^5.1.5",
     "route-engine-js": "1.14.5",
-    "route-graphics": "1.17.3",
+    "route-graphics": "1.17.4",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",
     "snabbdom-to-html": "^7.1.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- update `route-graphics` from `1.17.3` to `1.17.4`
- refresh `bun.lock` for the new package integrity and transitive `@webgpu/types` entry
- bump Tauri app version from `1.3.3` to `1.3.4`

## Testing
- `bun run build:bundle`
- pre-push hook: `oxlint && bun prettier --check src`

## Notes
- verified installed `route-graphics@1.17.4` dist contains the video CORS fix before `video.src` assignment