### PR TITLE
fix: use ascii license text for macos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Yuusoft
+Copyright (c) 2026 Yuusoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src-tauri/assets/LICENSE.txt
+++ b/src-tauri/assets/LICENSE.txt
@@ -1,7 +1,7 @@
 End User License Agreement
-Last Updated: 2025
+Last Updated: 2026
 
-This software (“Software”) is licensed under the MIT License.
+This software ("Software") is licensed under the MIT License.
 By installing or using the Software, you agree to the terms of the MIT License included below
 
 You can find the full source code of this Software at:
@@ -9,7 +9,7 @@ https://github.com/RouteVN/routevn-creator-client
 
 MIT License
 
-Copyright (c) 2025 Yuusoft
+Copyright (c) 2026 Yuusoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tasks/TASK/000/TASK-006.md
+++ b/tasks/TASK/000/TASK-006.md
@@ -15,7 +15,7 @@ priority: high
 End User License Agreement
 Last Updated: [DATE]
 
-This software (“Software”) is licensed under the MIT License.
+This software ("Software") is licensed under the MIT License.
 By installing or using the Software, you agree to the terms of the MIT License included below
 
 You can find the full source code of this Software at:
@@ -23,7 +23,7 @@ You can find the full source code of this Software at:
 
 MIT License
 
-Copyright (c) 2025 Yuusoft
+Copyright (c) 2026 Yuusoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -42,4 +42,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-


### PR DESCRIPTION
## Summary
- replace UTF-8 smart quotes in packaged Tauri license text with ASCII quotes to avoid macOS installer mojibake
- update license year references from 2025 to 2026 in legal text/template

## Testing
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src
- verified touched legal files have no 2025, smart quotes, or non-ASCII characters