### PR TITLE
fix: generate macOS updater artifacts

### DIFF
--- a/scripts/tauri-build-mac.sh
+++ b/scripts/tauri-build-mac.sh
@@ -33,7 +33,7 @@ else
 fi
 
 bun run build:tauri
-tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles dmg
+tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles app,dmg
 
 DMG_DIR="src-tauri/target/universal-apple-darwin/release/bundle/dmg"
 DMG_PATH=$(find "${DMG_DIR}" -maxdepth 1 -type f -name "*.dmg" -print | sort | tail -n 1)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- build macOS releases with both `app` and `dmg` bundles so Tauri can emit `.app.tar.gz` updater artifacts while preserving the DMG
- bump the Tauri app version from `1.3.4` to `1.3.5`

## Testing
- `bash -n scripts/tauri-build-mac.sh`
- `bun -e "JSON.parse(await Bun.file('src-tauri/tauri.conf.json').text())"`
- pre-push hook: `oxlint && bun prettier --check src`