### PR TITLE
fix: allow updater restart

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -39,6 +39,7 @@
     "updater:allow-download",
     "updater:allow-install",
     "updater:allow-download-and-install",
+    "process:allow-restart",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- allow the Tauri process `restart` command required after updater installation
- bump the Tauri app version from `1.3.5` to `1.3.6`

## Testing
- parsed `src-tauri/tauri.conf.json` and `src-tauri/capabilities/default.json` with Bun
- pre-push hook: `oxlint && bun prettier --check src`