### PR TITLE
chore: bump Tauri app version to 1.3.7

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump the Tauri app version from `1.3.6` to `1.3.7` for updater testing

## Testing
- parsed `src-tauri/tauri.conf.json` with Bun
- pre-push hook: `oxlint && bun prettier --check src`