### PR TITLE
Add AppImage build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tauri:dev:mac": "tauri dev --target aarch64-apple-darwin",
     "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
-    "tauri:build:appimage": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --bundles appimage",
+    "tauri:build:appimage": "./scripts/tauri-build-appimage.sh",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
     "tauri:build:mac": "./scripts/tauri-build-mac.sh"
   },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "tauri:dev:mac": "tauri dev --target aarch64-apple-darwin",
     "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
+    "tauri:build:appimage": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --bundles appimage",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
     "tauri:build:mac": "./scripts/tauri-build-mac.sh"
   },

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+load_env() {
+  if [ -f ".env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+  fi
+}
+
 prepare_gdk_pixbuf_pkg_config() {
   if ! command -v pkg-config >/dev/null 2>&1; then
     return
@@ -38,14 +47,21 @@ prepare_gdk_pixbuf_pkg_config() {
   export PKG_CONFIG_PATH="${override_dir}${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 }
 
+load_env
+
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  echo "Error: TAURI_SIGNING_PRIVATE_KEY is not set. Add it to .env before building the AppImage."
+  exit 1
+fi
+
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" ]; then
+  echo "Error: TAURI_SIGNING_PRIVATE_KEY_PASSWORD is not set. Add it to .env before building the AppImage."
+  exit 1
+fi
+
 bun run build:tauri
 prepare_gdk_pixbuf_pkg_config
 
 export NO_STRIP="${NO_STRIP:-1}"
 
-sign_args=()
-if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
-  sign_args+=(--no-sign)
-fi
-
-tauri build --config src-tauri/tauri.prod.conf.json --bundles appimage "${sign_args[@]}"
+tauri build --config src-tauri/tauri.prod.conf.json --bundles appimage

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -47,6 +47,41 @@ prepare_gdk_pixbuf_pkg_config() {
   export PKG_CONFIG_PATH="${override_dir}${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 }
 
+write_appimage_checksum() {
+  local bundle_dir="src-tauri/target/release/bundle/appimage"
+  local appimage
+  local appimage_path
+  local appimage_file
+  local checksum_file
+  local appimages=()
+
+  while IFS= read -r -d '' appimage; do
+    appimages+=("${appimage}")
+  done < <(find "${bundle_dir}" -maxdepth 1 -type f -name "*.AppImage" -print0)
+
+  if [ "${#appimages[@]}" -eq 0 ]; then
+    echo "Error: no AppImage found in ${bundle_dir}."
+    exit 1
+  fi
+
+  appimage_path="${appimages[0]}"
+  for appimage in "${appimages[@]}"; do
+    if [ "${appimage}" -nt "${appimage_path}" ]; then
+      appimage_path="${appimage}"
+    fi
+  done
+
+  appimage_file=$(basename "${appimage_path}")
+  checksum_file="${appimage_file}.sha256"
+
+  (
+    cd "${bundle_dir}"
+    sha256sum "${appimage_file}" > "${checksum_file}"
+  )
+
+  echo "SHA256 checksum: ${bundle_dir}/${checksum_file}"
+}
+
 load_env
 
 if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
@@ -68,3 +103,4 @@ prepare_gdk_pixbuf_pkg_config
 export NO_STRIP="${NO_STRIP:-1}"
 
 tauri build --config src-tauri/tauri.prod.conf.json --bundles appimage
+write_appimage_checksum

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -11,42 +11,6 @@ load_env() {
   fi
 }
 
-prepare_gdk_pixbuf_pkg_config() {
-  if ! command -v pkg-config >/dev/null 2>&1; then
-    return
-  fi
-
-  local binary_dir
-  binary_dir=$(pkg-config --variable=gdk_pixbuf_binarydir gdk-pixbuf-2.0 2>/dev/null || true)
-
-  if [ -z "${binary_dir}" ] || [ -d "${binary_dir}" ]; then
-    return
-  fi
-
-  local pc_file
-  local pc_dir
-  local override_dir
-  local override_binary_dir
-
-  pc_dir=$(pkg-config --variable=pcfiledir gdk-pixbuf-2.0)
-  pc_file="${pc_dir}/gdk-pixbuf-2.0.pc"
-  override_dir="/tmp/routevn-appimage-pkgconfig"
-  override_binary_dir="/tmp/routevn-appimage-gdk-pixbuf/2.10.0"
-
-  if [ ! -f "${pc_file}" ]; then
-    return
-  fi
-
-  echo "Using temporary gdk-pixbuf pkg-config override for AppImage bundling."
-  mkdir -p "${override_dir}" "${override_binary_dir}/loaders"
-  cp "${pc_file}" "${override_dir}/gdk-pixbuf-2.0.pc"
-  sed -i "s#^gdk_pixbuf_binarydir=.*#gdk_pixbuf_binarydir=${override_binary_dir}#" "${override_dir}/gdk-pixbuf-2.0.pc"
-  sed -i 's#^gdk_pixbuf_moduledir=.*#gdk_pixbuf_moduledir=${gdk_pixbuf_binarydir}/loaders#' "${override_dir}/gdk-pixbuf-2.0.pc"
-  sed -i 's#^gdk_pixbuf_cache_file=.*#gdk_pixbuf_cache_file=${gdk_pixbuf_binarydir}/loaders.cache#' "${override_dir}/gdk-pixbuf-2.0.pc"
-
-  export PKG_CONFIG_PATH="${override_dir}${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
-}
-
 write_appimage_checksum() {
   local bundle_dir="src-tauri/target/release/bundle/appimage"
   local appimage
@@ -86,7 +50,7 @@ load_env
 
 if ! command -v patchelf >/dev/null 2>&1; then
   echo "Error: patchelf is required for AppImage media framework bundling."
-  echo "Install it before building the AppImage. On Arch: sudo pacman -S patchelf"
+  echo "Install it before building the AppImage. On Ubuntu: sudo apt install patchelf"
   exit 1
 fi
 
@@ -104,7 +68,6 @@ fi
 export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}"
 
 bun run build:tauri
-prepare_gdk_pixbuf_pkg_config
 
 export NO_STRIP="${NO_STRIP:-1}"
 

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -55,8 +55,22 @@ if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
 fi
 
 if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" ]; then
-  echo "Error: TAURI_SIGNING_PRIVATE_KEY_PASSWORD is not set. Add it to .env before building the AppImage."
-  exit 1
+  if [ ! -t 0 ]; then
+    echo "Error: TAURI_SIGNING_PRIVATE_KEY_PASSWORD is not set and no interactive terminal is available."
+    echo "Add it to .env or run this script from a terminal to enter it manually."
+    exit 1
+  fi
+
+  printf "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: "
+  IFS= read -r -s TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+  printf "\n"
+
+  if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD}" ]; then
+    echo "Error: TAURI_SIGNING_PRIVATE_KEY_PASSWORD cannot be empty."
+    exit 1
+  fi
+
+  export TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 fi
 
 bun run build:tauri

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+prepare_gdk_pixbuf_pkg_config() {
+  if ! command -v pkg-config >/dev/null 2>&1; then
+    return
+  fi
+
+  local binary_dir
+  binary_dir=$(pkg-config --variable=gdk_pixbuf_binarydir gdk-pixbuf-2.0 2>/dev/null || true)
+
+  if [ -z "${binary_dir}" ] || [ -d "${binary_dir}" ]; then
+    return
+  fi
+
+  local pc_file
+  local pc_dir
+  local override_dir
+  local override_binary_dir
+
+  pc_dir=$(pkg-config --variable=pcfiledir gdk-pixbuf-2.0)
+  pc_file="${pc_dir}/gdk-pixbuf-2.0.pc"
+  override_dir="/tmp/routevn-appimage-pkgconfig"
+  override_binary_dir="/tmp/routevn-appimage-gdk-pixbuf/2.10.0"
+
+  if [ ! -f "${pc_file}" ]; then
+    return
+  fi
+
+  echo "Using temporary gdk-pixbuf pkg-config override for AppImage bundling."
+  mkdir -p "${override_dir}" "${override_binary_dir}/loaders"
+  cp "${pc_file}" "${override_dir}/gdk-pixbuf-2.0.pc"
+  sed -i "s#^gdk_pixbuf_binarydir=.*#gdk_pixbuf_binarydir=${override_binary_dir}#" "${override_dir}/gdk-pixbuf-2.0.pc"
+  sed -i 's#^gdk_pixbuf_moduledir=.*#gdk_pixbuf_moduledir=${gdk_pixbuf_binarydir}/loaders#' "${override_dir}/gdk-pixbuf-2.0.pc"
+  sed -i 's#^gdk_pixbuf_cache_file=.*#gdk_pixbuf_cache_file=${gdk_pixbuf_binarydir}/loaders.cache#' "${override_dir}/gdk-pixbuf-2.0.pc"
+
+  export PKG_CONFIG_PATH="${override_dir}${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+}
+
+bun run build:tauri
+prepare_gdk_pixbuf_pkg_config
+
+export NO_STRIP="${NO_STRIP:-1}"
+
+sign_args=()
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  sign_args+=(--no-sign)
+fi
+
+tauri build --config src-tauri/tauri.prod.conf.json --bundles appimage "${sign_args[@]}"

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -54,24 +54,13 @@ if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
   exit 1
 fi
 
-if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" ]; then
-  if [ ! -t 0 ]; then
-    echo "Error: TAURI_SIGNING_PRIVATE_KEY_PASSWORD is not set and no interactive terminal is available."
-    echo "Add it to .env or run this script from a terminal to enter it manually."
-    exit 1
-  fi
-
-  printf "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: "
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD+x}" ] && [ -t 0 ]; then
+  printf "TAURI_SIGNING_PRIVATE_KEY_PASSWORD (press Enter for none): "
   IFS= read -r -s TAURI_SIGNING_PRIVATE_KEY_PASSWORD
   printf "\n"
-
-  if [ -z "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD}" ]; then
-    echo "Error: TAURI_SIGNING_PRIVATE_KEY_PASSWORD cannot be empty."
-    exit 1
-  fi
-
-  export TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 fi
+
+export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}"
 
 bun run build:tauri
 prepare_gdk_pixbuf_pkg_config

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -84,6 +84,12 @@ write_appimage_checksum() {
 
 load_env
 
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "Error: patchelf is required for AppImage media framework bundling."
+  echo "Install it before building the AppImage. On Arch: sudo pacman -S patchelf"
+  exit 1
+fi
+
 if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
   echo "Error: TAURI_SIGNING_PRIVATE_KEY is not set. Add it to .env before building the AppImage."
   exit 1

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -83,6 +83,11 @@
     ],
     "createUpdaterArtifacts": true,
     "licenseFile": "assets/LICENSE.txt",
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    },
     "macOS": {
       "dmg": {
         "windowSize": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.8",
+  "version": "1.3.7",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- Add a package.json script for building the Linux AppImage bundle.
- Route the AppImage build through a shell script that reuses the existing Tauri frontend build and production config.
- Enable AppImage media framework bundling for audio/video playback.
- Load signing variables from .env, require the updater signing key, and allow the signing password to be empty.
- Disable linuxdeploy stripping by default to avoid .relr.dyn failures on modern Linux libraries.
- Keep the AppImage script environment-based instead of patching distro-specific pkg-config paths.
- Check for patchelf before AppImage media framework bundling so missing dependencies fail clearly.
- Keep CrabNebula DevTools behind an explicit dev-only Cargo feature so production bundles do not start the devtools listener.
- Generate a .sha256 sidecar file next to the built AppImage.

## Validation
- Confirmed .env is present and TAURI_SIGNING_PRIVATE_KEY is set.
- Confirmed the script no longer passes --no-sign.
- Confirmed the signing password prompt accepts an empty value.
- Confirmed the AppImage script now reports the missing patchelf dependency before invoking linuxdeploy.
- Generated RouteVN Creator_1.3.7_amd64.AppImage.sha256 for the current local AppImage artifact.
- Parsed src-tauri/tauri.conf.json and confirmed version remains 1.3.7.
- Parsed src-tauri/tauri.conf.json after enabling bundle.linux.appimage.bundleMediaFramework.
- Verified scripts/tauri-build-appimage.sh parses with bash -n.
- Verified package.json parses with jq.
- Verified production Rust build path with cargo check --manifest-path src-tauri/Cargo.toml --release.
- Verified devtools feature path with cargo check --manifest-path src-tauri/Cargo.toml --features devtools.
- Push hook passed oxlint and bun prettier --check src.
