### PR TITLE
chore: bump app version and route graphics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "lexical": "^0.22.0",
         "nanoid": "^5.1.5",
         "route-engine-js": "1.14.5",
-        "route-graphics": "1.17.4",
+        "route-graphics": "1.17.5",
         "rxjs": "^7.8.2",
         "snabbdom": "^3.6.2",
         "snabbdom-to-html": "^7.1.0",
@@ -712,7 +712,7 @@
 
     "route-engine-js": ["route-engine-js@1.14.5", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-2PCQpKnkSmOtLKP3E5NNGWhK0mlJeQRdHzMZilU23ZJMTD71F+e9jqP7f+fVZiiiMq1IKzh912f7uMFuWkVFZw=="],
 
-    "route-graphics": ["route-graphics@1.17.4", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-K5E0XPOFyqxc0jSPm9l1SiuQfkDeNm1EH60zSsvn/wCyhDo6KRIAabff7DT9qdG4x58YX80gQQSy0ik4c+3IBA=="],
+    "route-graphics": ["route-graphics@1.17.5", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-8YnD6xJNvqLGiRhcsCUMYXLulBIS0BHs5jsAbGt1fUOd253IYkU00AUg2x28rB/balrmQlnwwrHIZtbfODeY+A=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "^0.22.0",
     "nanoid": "^5.1.5",
     "route-engine-js": "1.14.5",
-    "route-graphics": "1.17.4",
+    "route-graphics": "1.17.5",
     "rxjs": "^7.8.2",
     "snabbdom": "^3.6.2",
     "snabbdom-to-html": "^7.1.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump RouteVN Creator Tauri config version to 1.4.0
- bump route-graphics dependency to 1.17.5

## Testing
- bun run lint
- pre-push hook: oxlint and prettier