### PR TITLE
Align resource add card icon spacing

### DIFF
--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -238,8 +238,8 @@ template:
                                                       - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
                                     $else:
                                       - $if canUpload:
-                                          - 'rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=sm cur=pointer style="grid-column: 1 / -1;"':
-                                              - rtgl-svg svg=${uploadIcon} wh=32: null
+                                          - 'rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=md cur=pointer style="grid-column: 1 / -1;"':
+                                              - rtgl-svg svg=${uploadIcon} wh=24: null
                                               - rtgl-text: ${uploadText}
                           - $if draggingGroupId == group.id:
                               - 'rtgl-view d=h av=c pos=abs w=f h=f bw=md bc=pr style="top: 0; bottom: 0; left: 0; right: 0;"':
@@ -252,8 +252,8 @@ template:
             $else:
               - rtgl-view w=f h=f av=c ah=c g=lg:
                   - $if canUpload:
-                      - rtgl-view#uploadBtnRoot w=300 h=200 bw=xs bc=bo br=md ah=c av=c g=sm cur=pointer:
-                          - rtgl-svg svg=${uploadIcon} wh=32: null
+                      - rtgl-view#uploadBtnRoot w=300 h=200 bw=xs bc=bo br=md ah=c av=c g=md cur=pointer:
+                          - rtgl-svg svg=${uploadIcon} wh=24: null
                           - rtgl-text: ${uploadText}
                     $else:
                       - rtgl-text s=lg c=mu-fg: No data


### PR DESCRIPTION
## Summary
- make media resource empty add/upload cards use the same 24px icon size as catalog add cards
- align the media add/upload card icon-to-label gap with catalog add cards

## Testing
- bun prettier --check src/components/mediaResourcesView/mediaResourcesView.view.yaml
- git diff --check -- src/components/mediaResourcesView/mediaResourcesView.view.yaml
- pre-push hook: oxlint && bun prettier --check src