### PR TITLE
feat: add background color action previews

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -92,6 +92,7 @@ const getResourceCollectionsFromDomainState = (domainState) => ({
   videos: domainState?.videos || createEmptyCollection(),
   animations: domainState?.animations || createEmptyCollection(),
   transforms: domainState?.transforms || createEmptyCollection(),
+  colors: domainState?.colors || createEmptyCollection(),
 });
 
 const getDomainStateFromProjectService = (projectService) => {
@@ -117,26 +118,33 @@ const buildBackgroundDataFromState = (
       ? (store.selectTempSelectedResource?.() ?? store.selectSelectedResource())
       : store.selectSelectedResource();
   const selectedTransformId = store.selectSelectedTransform();
+  const selectedColorId = store.selectSelectedColor();
   const selectedAnimationMode = store.selectSelectedAnimationMode();
   const selectedAnimationId = store.selectSelectedAnimation();
   const selectedAnimationPlaybackContinuity =
     store.selectSelectedAnimationPlaybackContinuity();
   const backgroundLoop = store.selectBackgroundLoop();
+  const hasBackgroundTarget =
+    !!selectedResource?.resourceId || !!selectedColorId;
 
   const backgroundData = {
     resourceId: selectedResource?.resourceId,
   };
 
+  if (selectedColorId) {
+    backgroundData.colorId = selectedColorId;
+  }
+
   if (selectedResource?.resourceType === "video") {
     backgroundData.loop = backgroundLoop ?? false;
   }
 
-  if (selectedResource?.resourceId && selectedTransformId) {
+  if (hasBackgroundTarget && selectedTransformId) {
     backgroundData.transformId = selectedTransformId;
   }
 
   if (
-    selectedResource?.resourceId &&
+    hasBackgroundTarget &&
     selectedAnimationMode !== "none" &&
     selectedAnimationId
   ) {
@@ -180,16 +188,21 @@ export const handleBeforeMount = (deps) => {
 
   const {
     resourceId,
+    colorId,
     transformId,
     animations: backgroundAnimations,
     loop: backgroundLoop,
   } = props.background;
 
-  if (!resourceId) {
-    return;
+  if (colorId) {
+    store.setSelectedColor({
+      colorId,
+    });
   }
 
-  store.setPendingResourceId({ resourceId: resourceId });
+  if (resourceId) {
+    store.setPendingResourceId({ resourceId: resourceId });
+  }
 
   if (backgroundLoop !== undefined) {
     store.setBackgroundLoop({
@@ -224,7 +237,7 @@ export const handleAfterMount = async (deps) => {
 
   await projectService.ensureRepository();
   const domainState = getDomainStateFromProjectService(projectService);
-  const { images, layouts, videos, animations, transforms } =
+  const { images, layouts, videos, animations, transforms, colors } =
     getResourceCollectionsFromDomainState(domainState);
 
   store.setRepositoryState({
@@ -233,6 +246,7 @@ export const handleAfterMount = async (deps) => {
     videos,
     animations,
     transforms,
+    colors,
   });
 
   const pendingResourceId = store.selectPendingResourceId();
@@ -285,29 +299,36 @@ export const handleAfterMount = async (deps) => {
 };
 
 export const handleBackgroundImageRightClick = async (deps, payload) => {
-  const { store, render, globalUI } = deps;
+  const { store, render, appService } = deps;
   const { _event: event } = payload;
   event.preventDefault();
+  event.stopPropagation();
 
-  const result = await globalUI.showDropdownMenu({
+  const result = await appService.showDropdownMenu({
     items: [{ type: "item", label: "Remove", key: "remove" }],
     x: event.clientX,
     y: event.clientY,
     place: "bs",
   });
 
-  if (result.item.key === "remove") {
-    store.setSelectedResource({
-      resourceId: undefined,
-      resourceType: undefined,
-    });
-    store.setBackgroundLoop({
-      loop: false,
-    });
-
-    render();
-    dispatchTemporaryPresentationStateChange(deps);
+  if (result?.item?.key !== "remove") {
+    return;
   }
+
+  store.setSelectedResource({
+    resourceId: undefined,
+    resourceType: undefined,
+  });
+  store.setTempSelectedResource({
+    resourceId: undefined,
+    resourceType: undefined,
+  });
+  store.setBackgroundLoop({
+    loop: false,
+  });
+
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleImageSelected = async (deps, payload) => {
@@ -372,6 +393,15 @@ export const handleFormInputChange = (deps, payload) => {
   if (name === "transformId") {
     store.setSelectedTransform({
       transformId: fieldValue,
+    });
+    render();
+    dispatchTemporaryPresentationStateChange(deps);
+    return;
+  }
+
+  if (name === "colorId") {
+    store.setSelectedColor({
+      colorId: fieldValue,
     });
     render();
     dispatchTemporaryPresentationStateChange(deps);

--- a/src/components/commandLineBackground/commandLineBackground.schema.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.schema.yaml
@@ -7,6 +7,8 @@ propsSchema:
       properties:
         resourceId:
           type: string
+        colorId:
+          type: string
         transformId:
           type: string
         animations:

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -70,11 +70,13 @@ export const createInitialState = () => ({
   videoItems: createEmptyCollection(),
   animationItems: createEmptyCollection(),
   transformItems: createEmptyCollection(),
+  colorItems: createEmptyCollection(),
   selectedResourceId: undefined,
   selectedResourceType: undefined,
   tempSelectedResourceId: undefined,
   tempSelectedResourceType: undefined,
   selectedTransformId: undefined,
+  selectedColorId: undefined,
   selectedAnimationMode: "none",
   selectedAnimationId: undefined,
   selectedAnimationPlaybackContinuity: "render",
@@ -110,13 +112,14 @@ export const selectMode = ({ state }) => {
 
 export const setRepositoryState = (
   { state },
-  { images, layouts, videos, animations, transforms } = {},
+  { images, layouts, videos, animations, transforms, colors } = {},
 ) => {
   state.imageItems = normalizeResourceCollection(images);
   state.layoutItems = normalizeResourceCollection(layouts);
   state.videoItems = normalizeResourceCollection(videos);
   state.animationItems = normalizeResourceCollection(animations);
   state.transformItems = normalizeResourceCollection(transforms);
+  state.colorItems = normalizeResourceCollection(colors);
 
   const selectedAnimationMode = getAnimationModeById(
     state.animationItems,
@@ -232,6 +235,15 @@ export const setSelectedTransform = ({ state }, { transformId } = {}) => {
 
 export const selectSelectedTransform = ({ state }) => {
   return state.selectedTransformId;
+};
+
+export const setSelectedColor = ({ state }, { colorId } = {}) => {
+  state.selectedColorId =
+    typeof colorId === "string" && colorId.length > 0 ? colorId : undefined;
+};
+
+export const selectSelectedColor = ({ state }) => {
+  return state.selectedColorId;
 };
 
 export const setSelectedAnimationPlaybackContinuity = (
@@ -424,12 +436,26 @@ export const selectViewData = ({ state }) => {
       value: item.id,
       label: item.name,
     }));
+  const colorOptions = toFlatItems(state.colorItems)
+    .filter((item) => item.type === "color")
+    .map((item) => ({
+      value: item.id,
+      label: item.name ?? item.id,
+    }));
 
   const formFields = [
     {
       type: "slot",
       slot: "background",
       description: "Background",
+    },
+    {
+      name: "colorId",
+      label: "Background Color",
+      type: "select",
+      clearable: true,
+      placeholder: "Select color",
+      options: colorOptions,
     },
     {
       name: "transformId",
@@ -477,6 +503,7 @@ export const selectViewData = ({ state }) => {
 
   const defaultValues = {
     background: selectedResource?.fileId || "",
+    colorId: state.selectedColorId,
     transformId: state.selectedTransformId,
     playbackContinuity: state.selectedAnimationPlaybackContinuity,
     animationId: state.selectedAnimationId,
@@ -500,6 +527,7 @@ export const selectViewData = ({ state }) => {
       key: [
         selectedResource?.resourceType ?? "none",
         selectedResource?.resourceId ?? "none",
+        state.selectedColorId ?? "none",
         state.selectedTransformId ?? "none",
         state.selectedAnimationPlaybackContinuity ?? "render",
         selectedAnimationMode,

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -88,6 +88,50 @@ const shouldShowEmbeddedClose = (attrs = {}) => {
   );
 };
 
+const buildColorPreview = (colors, colorId) => {
+  if (!colorId) {
+    return undefined;
+  }
+
+  const color = colors[colorId];
+  if (!color) {
+    return {
+      colorId,
+      colorName: colorId,
+      colorHex: undefined,
+    };
+  }
+
+  return {
+    colorId,
+    colorName: color.name ?? colorId,
+    colorHex: color.hex,
+  };
+};
+
+const resolveBackgroundPreviewAction = ({ actions, presentationState }) => {
+  const actionBackground = isPlainObject(actions.background)
+    ? actions.background
+    : undefined;
+  const effectiveBackground = isPlainObject(presentationState.background)
+    ? presentationState.background
+    : undefined;
+
+  if (!actionBackground) {
+    return effectiveBackground;
+  }
+
+  const previewBackground = { ...actionBackground };
+  if (!previewBackground.resourceId && actionBackground.colorId) {
+    previewBackground.resourceId = effectiveBackground?.resourceId;
+  }
+  if (!previewBackground.colorId && actionBackground.resourceId) {
+    previewBackground.colorId = effectiveBackground?.colorId;
+  }
+
+  return previewBackground;
+};
+
 export const selectViewData = ({ state, props, props: attrs }) => {
   const displayActions = selectDisplayActions({ state });
   const actionProps = { ...props };
@@ -359,6 +403,7 @@ export const selectActionsData = ({ props, state }) => {
   const videos = repositoryStateData.videos?.items || {};
   const sounds = repositoryStateData.sounds?.items || {};
   const animations = repositoryStateData.animations?.items || {};
+  const colors = repositoryStateData.colors?.items || {};
   const scenes = repositoryStateData.scenes || {};
   // Layouts: need full tree structure for toFlatItems() to search through nested folders
   const layoutsHierarchy = repositoryStateData.layouts || {};
@@ -369,22 +414,41 @@ export const selectActionsData = ({ props, state }) => {
   const actionsObject = {};
   const preview = {};
 
-  const backgroundAction =
-    actions.background && typeof actions.background === "object"
-      ? actions.background
-      : presentationState.background;
+  const backgroundAction = resolveBackgroundPreviewAction({
+    actions,
+    presentationState,
+  });
 
-  if (backgroundAction?.resourceId) {
+  if (backgroundAction?.resourceId || backgroundAction?.colorId) {
     const backgroundImage = images[backgroundAction.resourceId];
     const backgroundVideo = videos[backgroundAction.resourceId];
     const backgroundLayout = layoutsItems[backgroundAction.resourceId];
+    const colorPreview = buildColorPreview(colors, backgroundAction.colorId);
     actionsObject.background = backgroundAction;
     if (backgroundImage) {
-      preview.background = { ...backgroundImage, type: "image" };
+      preview.background = {
+        ...backgroundImage,
+        ...colorPreview,
+        type: "image",
+      };
     } else if (backgroundVideo) {
-      preview.background = { ...backgroundVideo, type: "video" };
+      preview.background = {
+        ...backgroundVideo,
+        ...colorPreview,
+        type: "video",
+      };
     } else if (backgroundLayout) {
-      preview.background = { ...backgroundLayout, type: "layout" };
+      preview.background = {
+        ...backgroundLayout,
+        ...colorPreview,
+        type: "layout",
+      };
+    } else if (colorPreview) {
+      preview.background = {
+        ...colorPreview,
+        name: colorPreview.colorName,
+        type: "color",
+      };
     }
   }
 

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -49,14 +49,24 @@ template:
                   - rtgl-view#actionItemBackground data-mode=background g=md d=h av=c ph=md bgc=mu br=md h-bgc=ac h=36 w=f cur=pointer:
                       - $if preview.background.type == 'image':
                           - rtgl-svg svg=image wh=24: null
+                          - $if preview.background.colorHex:
+                              - 'rtgl-view w=36 h=24 bw=xs bc=bo style="background-color: ${preview.background.colorHex}; flex-shrink: 0;"': null
                           - rvn-file-image fileId=${preview.background.fileId} w=50 h=35: null
                           - rtgl-text s=sm: ${preview.background.name}
                         $elif preview.background.type == 'video':
                           - rtgl-svg svg=video wh=24: null
+                          - $if preview.background.colorHex:
+                              - 'rtgl-view w=36 h=24 bw=xs bc=bo style="background-color: ${preview.background.colorHex}; flex-shrink: 0;"': null
                           - rvn-file-image fileId=${preview.background.thumbnailFileId} w=50 h=35: null
                           - rtgl-text s=sm: ${preview.background.name}
                         $elif preview.background.type == 'layout':
                           - rtgl-svg svg=layout wh=24: null
+                          - $if preview.background.colorHex:
+                              - 'rtgl-view w=36 h=24 bw=xs bc=bo style="background-color: ${preview.background.colorHex}; flex-shrink: 0;"': null
+                          - rtgl-text s=sm: ${preview.background.name}
+                        $elif preview.background.type == 'color':
+                          - rtgl-svg svg=image wh=24: null
+                          - 'rtgl-view w=36 h=24 bw=xs bc=bo style="background-color: ${preview.background.colorHex}; flex-shrink: 0;"': null
                           - rtgl-text s=sm: ${preview.background.name}
               - $if preview.screen:
                   - rtgl-view#actionItemScreen data-mode=screen g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -20,17 +20,86 @@ const buildCharacterLookups = (repositoryState) => {
   };
 };
 
-const buildBackgroundPreview = (repositoryState, changes) => {
-  if (!changes.background) {
+const isPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+};
+
+const resolveBackgroundChangeParts = (backgroundChange) => {
+  if (!isPlainObject(backgroundChange)) {
+    return {};
+  }
+
+  if (
+    isPlainObject(backgroundChange.resource) ||
+    isPlainObject(backgroundChange.color)
+  ) {
+    return {
+      resourceChange: backgroundChange.resource,
+      colorChange: backgroundChange.color,
+      isSplitChange: true,
+    };
+  }
+
+  return {
+    resourceChange:
+      backgroundChange.data?.resourceId !== undefined
+        ? backgroundChange
+        : undefined,
+    colorChange:
+      backgroundChange.data?.colorId !== undefined
+        ? backgroundChange
+        : undefined,
+    isSplitChange: false,
+  };
+};
+
+const buildBackgroundPreview = (
+  repositoryState,
+  changes,
+  { previousPresentationState } = {},
+) => {
+  const backgroundChange = changes.background;
+  if (!backgroundChange) {
     return undefined;
   }
 
-  const backgroundData = changes.background.data || {};
-  return {
-    changeType: changes.background.changeType,
-    resourceId: backgroundData.resourceId,
-    fileId: repositoryState?.images?.items?.[backgroundData.resourceId]?.fileId,
+  const { resourceChange, colorChange, isSplitChange } =
+    resolveBackgroundChangeParts(backgroundChange);
+
+  if (!resourceChange && !colorChange) {
+    return undefined;
+  }
+
+  const resourceData = resourceChange?.data || {};
+  const colorData = colorChange?.data || {};
+  const previousColorId = isSplitChange
+    ? undefined
+    : previousPresentationState?.background?.colorId;
+  const hasColorChange =
+    !!colorData.colorId &&
+    (isSplitChange ||
+      colorChange?.changeType === "delete" ||
+      colorData.colorId !== previousColorId);
+  const colorId = hasColorChange ? colorData.colorId : undefined;
+  const color = colorId ? repositoryState?.colors?.items?.[colorId] : undefined;
+  const preview = {
+    changeType: resourceChange?.changeType ?? colorChange?.changeType,
+    resourceChangeType: resourceChange?.changeType,
+    colorChangeType: colorChange?.changeType,
+    resourceId: resourceData.resourceId,
+    fileId: resolvePreviewResourceFileId({
+      repositoryState,
+      resourceId: resourceData.resourceId,
+    }),
   };
+
+  if (colorId) {
+    preview.colorId = colorId;
+    preview.colorHex = color?.hex;
+    preview.colorName = color?.name ?? colorId;
+  }
+
+  return preview;
 };
 
 const resolvePreviewResourceFileId = ({ repositoryState, resourceId }) => {
@@ -216,6 +285,10 @@ const buildSceneDocumentLineViewModels = ({
   const viewModels = (lines || []).map((line, index) => {
     const lineActions = normalizeLineActions(line.actions || {});
     const sectionLineEntry = getSectionLineEntry(sectionLineChanges, line.id);
+    const previousLine = index > 0 ? lines[index - 1] : undefined;
+    const previousSectionLineEntry = previousLine
+      ? getSectionLineEntry(sectionLineChanges, previousLine.id)
+      : undefined;
     const changes = sectionLineEntry?.changes || {};
     const choicesPreview = buildChoicesPreview(line);
     const linePresentationState = sectionLineEntry?.presentationState;
@@ -224,7 +297,9 @@ const buildSceneDocumentLineViewModels = ({
       ...line,
       domRefSuffix: toStableDomRefSuffix(line.id),
       lineNumber: index + 1,
-      background: buildBackgroundPreview(repositoryState, changes),
+      background: buildBackgroundPreview(repositoryState, changes, {
+        previousPresentationState: previousSectionLineEntry?.presentationState,
+      }),
       bgm: changes.bgm
         ? {
             changeType: changes.bgm.changeType,

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -359,6 +359,18 @@ const STYLES = `
     height: 24px;
   }
 
+  .preview-color-swatch {
+    position: relative;
+    display: inline-flex;
+    width: 28px;
+    height: 18px;
+    align-self: center;
+    flex-shrink: 0;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: transparent;
+  }
+
   .preview-image-stack {
     display: flex;
     flex-wrap: wrap;
@@ -6410,15 +6422,40 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     container.className = "preview-items";
 
     if (lineDecoration.background) {
-      container.append(
-        this.createMediaPreview({
-          type: "background",
-          fileId: lineDecoration.background.fileId,
-          placeholderIcon: "image",
-          size: "bg",
-          isDelete: lineDecoration.background.changeType === "delete",
-        }),
-      );
+      const item = document.createElement("div");
+      item.className = "preview-item";
+      const resourceIsDelete =
+        (lineDecoration.background.resourceChangeType ??
+          lineDecoration.background.changeType) === "delete";
+      const colorIsDelete =
+        (lineDecoration.background.colorChangeType ??
+          lineDecoration.background.changeType) === "delete";
+
+      if (lineDecoration.background.colorHex) {
+        item.append(
+          this.createColorSwatch({
+            colorHex: lineDecoration.background.colorHex,
+            colorName: lineDecoration.background.colorName,
+            isDelete: colorIsDelete,
+          }),
+        );
+      }
+
+      if (
+        lineDecoration.background.fileId ||
+        !lineDecoration.background.colorHex
+      ) {
+        item.append(
+          this.createMediaThumb({
+            fileId: lineDecoration.background.fileId,
+            placeholderIcon: "image",
+            size: "bg",
+            isDelete: resourceIsDelete,
+          }),
+        );
+      }
+
+      container.append(item);
     }
 
     if (lineDecoration.characterSprites) {
@@ -6642,6 +6679,19 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     return thumb;
+  }
+
+  createColorSwatch({ colorHex, colorName, isDelete = false } = {}) {
+    const swatch = document.createElement("div");
+    swatch.className = "preview-color-swatch";
+    swatch.style.backgroundColor = colorHex;
+    if (colorName) {
+      swatch.title = colorName;
+    }
+    if (isDelete) {
+      swatch.append(this.createDeleteOverlay());
+    }
+    return swatch;
   }
 
   createIconPreview({


### PR DESCRIPTION
## Summary
- add a clearable background color selector to command line background actions and submit `background.colorId`
- show background color swatches before existing background previews in system actions and the lines editor
- update lines editor preview handling for split `background.resource` / `background.color` diffs with legacy fallback
- make background resource removal use `appService.showDropdownMenu`

## Testing
- `bun prettier --check src/components/commandLineBackground/commandLineBackground.handlers.js src/components/commandLineBackground/commandLineBackground.schema.yaml src/components/commandLineBackground/commandLineBackground.store.js src/components/systemActions/systemActions.store.js src/components/systemActions/systemActions.view.yaml src/internal/ui/sceneEditor/lineViewModels.js src/primitives/lexicalSceneDocumentEditor.js`
- `./node_modules/.bin/oxlint src/components/commandLineBackground/commandLineBackground.handlers.js src/components/commandLineBackground/commandLineBackground.store.js src/components/systemActions/systemActions.store.js src/internal/ui/sceneEditor/lineViewModels.js src/primitives/lexicalSceneDocumentEditor.js`
- `git diff --cached --check`
- pre-push hook: `oxlint && bun prettier --check src`

Not run: `bun run build:web` per request.