### PR TITLE
feat(images): add hover-zone preview navigation

### DIFF
--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -319,6 +319,41 @@ const openImagePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
   focusPreviewOverlay(deps);
 };
 
+const closeImagePreview = (deps) => {
+  const { store, render } = deps;
+
+  store.hideFullImagePreview();
+  render();
+  focusGroupView(deps);
+};
+
+const navigateImagePreview = (deps, { direction, distance, clamp } = {}) => {
+  const { store } = deps;
+  const selectedItemId = store.selectSelectedItemId();
+  if (!selectedItemId || !direction) {
+    return false;
+  }
+
+  const adjacentPayload = {
+    itemId: selectedItemId,
+    direction,
+  };
+  if (distance !== undefined) {
+    adjacentPayload.distance = distance;
+  }
+  if (clamp !== undefined) {
+    adjacentPayload.clamp = clamp;
+  }
+
+  const nextItemId = store.selectAdjacentImageItemId(adjacentPayload);
+  if (!nextItemId) {
+    return false;
+  }
+
+  openImagePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
+  return true;
+};
+
 const resolvePreviewNavigationDirection = (event) => {
   if (event.key === "ArrowDown" || event.key === "ArrowRight") {
     return { direction: "next" };
@@ -573,10 +608,23 @@ export const handleImageItemPreview = (deps, payload) => {
 };
 
 export const handlePreviewOverlayClick = (deps) => {
-  const { store, render } = deps;
-  store.hideFullImagePreview();
-  render();
-  focusGroupView(deps);
+  closeImagePreview(deps);
+};
+
+export const handlePreviewImageFrameClick = (_deps, payload) => {
+  payload?._event?.stopPropagation?.();
+};
+
+export const handlePreviewPreviousClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  navigateImagePreview(deps, { direction: "previous" });
+};
+
+export const handlePreviewNextClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  navigateImagePreview(deps, { direction: "next" });
 };
 
 export const handlePreviewOverlayKeyDown = (deps, payload) => {
@@ -594,14 +642,7 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
   if (event.key === "Escape" || event.key === "Enter") {
     event.preventDefault();
     event.stopPropagation();
-    store.hideFullImagePreview();
-    deps.render();
-    focusGroupView(deps);
-    return;
-  }
-
-  const selectedItemId = store.selectSelectedItemId();
-  if (!selectedItemId) {
+    closeImagePreview(deps);
     return;
   }
 
@@ -613,23 +654,7 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
   event.preventDefault();
   event.stopPropagation();
 
-  const adjacentPayload = {
-    itemId: selectedItemId,
-    direction: navigation.direction,
-  };
-  if (navigation.distance !== undefined) {
-    adjacentPayload.distance = navigation.distance;
-  }
-  if (navigation.clamp !== undefined) {
-    adjacentPayload.clamp = navigation.clamp;
-  }
-
-  const nextItemId = store.selectAdjacentImageItemId(adjacentPayload);
-  if (!nextItemId) {
-    return;
-  }
-
-  openImagePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
+  navigateImagePreview(deps, navigation);
 };
 
 export const handleFileExplorerKeyboardScopeKeyDown = (deps, payload) => {

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -25,6 +25,18 @@ const resolveImageAspectRatio = (item) => {
   return `${Math.max(1, Math.round(width))} / ${Math.max(1, Math.round(height))}`;
 };
 
+const buildPreviewFrameStyle = (item) => {
+  const aspectRatio = resolveImageAspectRatio(item);
+
+  return [
+    `aspect-ratio: ${aspectRatio}`,
+    `width: min(92vw, calc(92vh * (${aspectRatio})))`,
+    `height: min(92vh, calc(92vw / (${aspectRatio})))`,
+    "max-width: 92vw",
+    "max-height: 92vh",
+  ].join("; ");
+};
+
 const buildDetailFields = (item) => {
   if (!item) {
     return [];
@@ -80,6 +92,51 @@ const buildPendingMediaItem = (item) => ({
   isInteractive: false,
   canPreview: false,
 });
+
+const selectVisibleImageIds = ({ mediaGroups, items } = {}) => {
+  return (mediaGroups ?? []).flatMap((group) =>
+    (group.children ?? [])
+      .map((child) => child.id)
+      .filter((childItemId) => items?.[childItemId]?.type === "image"),
+  );
+};
+
+const resolveAdjacentImageItemId = ({
+  visibleImageIds,
+  itemId,
+  direction,
+  distance = 1,
+  clamp = false,
+} = {}) => {
+  const step =
+    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
+  if (!step) {
+    return undefined;
+  }
+
+  const numericDistance = Number(distance);
+  const itemDistance =
+    Number.isFinite(numericDistance) && numericDistance > 0
+      ? Math.floor(numericDistance)
+      : 1;
+  const imageIds = visibleImageIds ?? [];
+
+  if (imageIds.length === 0) {
+    return undefined;
+  }
+
+  const currentIndex = imageIds.indexOf(itemId);
+  if (currentIndex === -1) {
+    return step > 0 ? imageIds[0] : imageIds[imageIds.length - 1];
+  }
+
+  let nextIndex = currentIndex + step * itemDistance;
+  if (clamp) {
+    nextIndex = Math.max(0, Math.min(nextIndex, imageIds.length - 1));
+  }
+
+  return imageIds[nextIndex];
+};
 
 const createEditForm = () => ({
   title: "Edit Image",
@@ -165,12 +222,35 @@ const {
     tagFilterPlaceholder: "Filter tags",
   },
   hiddenMobileDetailSlots: ["image-file-id"],
-  extendViewData: ({ state, baseViewData }) => {
-    return {
-      ...baseViewData,
-      fullImagePreviewVisible: state.fullImagePreviewVisible,
-      fullImagePreviewFileId: state.fullImagePreviewFileId,
-    };
+  extendViewData: ({ state, baseViewData, selectedItem }) => {
+    const selectedItemId = state.selectedItemId;
+    const visibleImageIds = selectVisibleImageIds({
+      mediaGroups: baseViewData.mediaGroups,
+      items: state.data?.items,
+    });
+    const previousItemId = selectedItemId
+      ? resolveAdjacentImageItemId({
+          visibleImageIds,
+          itemId: selectedItemId,
+          direction: "previous",
+        })
+      : undefined;
+    const nextItemId = selectedItemId
+      ? resolveAdjacentImageItemId({
+          visibleImageIds,
+          itemId: selectedItemId,
+          direction: "next",
+        })
+      : undefined;
+    const viewData = { ...baseViewData };
+
+    viewData.fullImagePreviewVisible = state.fullImagePreviewVisible;
+    viewData.fullImagePreviewFileId = state.fullImagePreviewFileId;
+    viewData.fullImagePreviewFrameStyle = buildPreviewFrameStyle(selectedItem);
+    viewData.fullImagePreviewPreviousVisible = Boolean(previousItemId);
+    viewData.fullImagePreviewNextVisible = Boolean(nextItemId);
+
+    return viewData;
   },
 });
 
@@ -215,42 +295,17 @@ export const selectAdjacentImageItemId = (
   context,
   { itemId, direction, distance = 1, clamp = false } = {},
 ) => {
-  const step =
-    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
-  if (!step) {
-    return undefined;
-  }
-  const numericDistance = Number(distance);
-  const itemDistance =
-    Number.isFinite(numericDistance) && numericDistance > 0
-      ? Math.floor(numericDistance)
-      : 1;
-
   const viewData = selectMediaViewData(context);
-  const items = context.state.data?.items ?? {};
-  const visibleImageIds = (viewData.mediaGroups ?? []).flatMap((group) =>
-    (group.children ?? [])
-      .map((child) => child.id)
-      .filter((childItemId) => items[childItemId]?.type === "image"),
-  );
-
-  if (visibleImageIds.length === 0) {
-    return undefined;
-  }
-
-  const currentIndex = visibleImageIds.indexOf(itemId);
-  if (currentIndex === -1) {
-    return step > 0
-      ? visibleImageIds[0]
-      : visibleImageIds[visibleImageIds.length - 1];
-  }
-
-  let nextIndex = currentIndex + step * itemDistance;
-  if (clamp) {
-    nextIndex = Math.max(0, Math.min(nextIndex, visibleImageIds.length - 1));
-  }
-
-  return visibleImageIds[nextIndex];
+  return resolveAdjacentImageItemId({
+    visibleImageIds: selectVisibleImageIds({
+      mediaGroups: viewData.mediaGroups,
+      items: context.state.data?.items,
+    }),
+    itemId,
+    direction,
+    distance,
+    clamp,
+  });
 };
 
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -65,6 +65,23 @@ refs:
         handler: handlePreviewOverlayClick
       keydown:
         handler: handlePreviewOverlayKeyDown
+  previewImageFrame:
+    eventListeners:
+      click:
+        handler: handlePreviewImageFrameClick
+        stopPropagation: true
+  previewPrevious:
+    eventListeners:
+      click:
+        handler: handlePreviewPreviousClick
+        preventDefault: true
+        stopPropagation: true
+  previewNext:
+    eventListeners:
+      click:
+        handler: handlePreviewNextClick
+        preventDefault: true
+        stopPropagation: true
   editDialog:
     eventListeners:
       close:
@@ -117,6 +134,29 @@ refs:
     eventListeners:
       form-action:
         handler: handleCreateTagFormAction
+styles:
+  ".imagePreviewEdge":
+    position: absolute
+    top: "0"
+    bottom: "0"
+    width: 28%
+    min-width: 72px
+    z-index: "1"
+    opacity: "0"
+    transition: opacity 140ms ease
+    cursor: pointer
+  ".imagePreviewEdge:hover":
+    opacity: "1"
+  ".imagePreviewEdgePrevious":
+    left: "0"
+    background: linear-gradient(to right, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
+  ".imagePreviewEdgeNext":
+    right: "0"
+    background: linear-gradient(to left, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
+  ".imagePreviewFrame":
+    position: relative
+    overflow: hidden
+    cursor: default
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -182,7 +222,12 @@ template:
       - rtgl-form#createTagForm key=${isCreateTagDialogOpen} slot=content :defaultValues=${createTagDefaultValues} :form=${createTagForm} w=f: null
   - $when: fullImagePreviewVisible
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: pointer; outline: none;"':
-      - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
+      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: rgba(0, 0, 0, 0.9);"': null
       - $if fullImagePreviewFileId:
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
-              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null
+              - 'div#previewImageFrame.imagePreviewFrame style="${fullImagePreviewFrameStyle}"':
+                  - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
+                  - $if fullImagePreviewPreviousVisible:
+                      - div#previewPrevious.imagePreviewEdge.imagePreviewEdgePrevious role=button aria-label="Previous image": null
+                  - $if fullImagePreviewNextVisible:
+                      - div#previewNext.imagePreviewEdge.imagePreviewEdgeNext role=button aria-label="Next image": null


### PR DESCRIPTION
## Summary
- constrain image preview navigation gradients to the displayed image frame
- keep outside-click close behavior while removing visible close and arrow controls
- reuse the visible image list for mouse and keyboard preview navigation

## Testing
- pre-push hook: `oxlint && bun prettier --check src`
- targeted: `bun prettier --check src/pages/images/images.view.yaml src/pages/images/images.store.js src/pages/images/images.handlers.js`
- targeted: `./node_modules/.bin/oxlint src/pages/images/images.store.js src/pages/images/images.handlers.js`
- `bun run build:web`