### PR TITLE
feat: move and duplicate scene sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ If you need deeper or broader Rettangoli framework reference material, use
   (`const { store, refs, appService, projectService } = deps`) instead of
   repeatedly calling `deps.store`, `deps.refs`, and similar dotted access
   throughout the function body.
+- Do not call `store.getState()` from page/component handlers. Add a named
+  selector to the store and call that selector instead.
 - Do not add dynamic form method wrappers (for example, `callFormMethod`) or retry loops to wait for refs.
 - Call known methods directly (`formRef.reset()`, `formRef.setValues(...)`).
 - Avoid defensive guard noise when data contract is already stable.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.5",
-        "@routevn/creator-model": "1.5.2",
+        "@routevn/creator-model": "1.6.0",
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "2.5.1",
@@ -310,7 +310,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.5.2", "", {}, "sha512-DhUw6TJPVpViZTjQmYFGYxcvGMYh31w+SqUyskC7qGyCFtbYAiHyrxPN2nj0E3xaei8GIOncF3pKxMcOKFzaJA=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.6.0", "", {}, "sha512-KtBCYLWG6lRZm3lJzoCjEs74AezznThZ7/yHOjEZN4aiQJhXuSsxZ8RJ87JMDOf8PYGoem+wzgnSsy3BLdcVJw=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -47,6 +47,8 @@ Local-first collaboration:
   function (`const { store, refs, appService, projectService } = deps`)
   instead of repeatedly using `deps.store`, `deps.refs`, and similar dotted
   access throughout the body.
+- Do not read handler state with `store.getState()`. Create and use named store
+  selectors for every state slice a handler needs.
 
 ## ID Generation
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.5",
-    "@routevn/creator-model": "1.5.2",
+    "@routevn/creator-model": "1.6.0",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "2.5.1",

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -41,6 +41,167 @@ export const createStoryCommandApi = (shared) => {
     return appendMissingIds(orderedFromTree, fallbackIds);
   };
 
+  const findTreeNodeById = (nodes = [], nodeId) => {
+    for (const node of nodes || []) {
+      if (!node || typeof node !== "object") {
+        continue;
+      }
+
+      if (node.id === nodeId) {
+        return node;
+      }
+
+      const childNode = findTreeNodeById(node.children, nodeId);
+      if (childNode) {
+        return childNode;
+      }
+    }
+
+    return undefined;
+  };
+
+  const collectTreeNodeIds = (node) => {
+    if (!node || typeof node !== "object") {
+      return [];
+    }
+
+    const ids = [];
+    const visit = (entry) => {
+      if (!entry || typeof entry !== "object") {
+        return;
+      }
+
+      if (typeof entry.id === "string" && entry.id.length > 0) {
+        ids.push(entry.id);
+      }
+
+      for (const child of entry.children || []) {
+        visit(child);
+      }
+    };
+
+    visit(node);
+    return ids;
+  };
+
+  const removeTreeNodeById = (nodes = [], nodeId) => {
+    const index = nodes.findIndex((node) => node?.id === nodeId);
+    if (index >= 0) {
+      nodes.splice(index, 1);
+      return true;
+    }
+
+    for (const node of nodes || []) {
+      if (removeTreeNodeById(node?.children, nodeId)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  const findTreeNodeParentId = (nodes = [], nodeId, parentId = null) => {
+    for (const node of nodes || []) {
+      if (!node || typeof node !== "object") {
+        continue;
+      }
+
+      if (node.id === nodeId) {
+        return parentId;
+      }
+
+      const childParentId = findTreeNodeParentId(
+        node.children,
+        nodeId,
+        node.id,
+      );
+      if (childParentId !== undefined) {
+        return childParentId;
+      }
+    }
+
+    return undefined;
+  };
+
+  const buildSectionLineCreateItems = (section) => {
+    const lineItems = section?.lines?.items || {};
+    return getOrderedLineIds(section)
+      .map((lineId) => {
+        const line = lineItems[lineId];
+        if (!line) {
+          return undefined;
+        }
+
+        return {
+          lineId,
+          data: {
+            actions: structuredClone(line.actions || {}),
+          },
+        };
+      })
+      .filter(Boolean);
+  };
+
+  const buildDuplicatedSectionLineCreateItems = (section, createId) => {
+    return buildSectionLineCreateItems(section).map((line) => ({
+      lineId: createId(),
+      data: structuredClone(line.data),
+    }));
+  };
+
+  const getSectionName = (section) => {
+    return typeof section?.name === "string" && section.name.length > 0
+      ? section.name
+      : "Section";
+  };
+
+  const buildMovedSectionLineSets = (sectionLocation) => {
+    const rootNode = findTreeNodeById(
+      sectionLocation?.sectionCollection?.tree,
+      sectionLocation?.section?.id,
+    );
+    const sectionIds =
+      rootNode !== undefined
+        ? collectTreeNodeIds(rootNode)
+        : [sectionLocation?.section?.id].filter(Boolean);
+    const sectionItems = sectionLocation?.sectionCollection?.items || {};
+
+    return sectionIds
+      .map((sectionId) => ({
+        sectionId,
+        lines: buildSectionLineCreateItems(sectionItems[sectionId]),
+      }))
+      .filter((entry) => entry.lines.length > 0);
+  };
+
+  const removeMovedSectionLinesFromContextState = ({
+    context,
+    sectionLineSets = [],
+  } = {}) => {
+    if (!context?.state || sectionLineSets.length === 0) {
+      return;
+    }
+
+    const nextState = structuredClone(context.state);
+    for (const sectionLineSet of sectionLineSets) {
+      const sectionLocation = findSectionLocation(
+        nextState,
+        sectionLineSet.sectionId,
+      );
+      const lines = sectionLocation?.section?.lines;
+      if (!lines) {
+        continue;
+      }
+
+      for (const line of sectionLineSet.lines) {
+        delete lines.items?.[line.lineId];
+        removeTreeNodeById(lines.tree, line.lineId);
+      }
+    }
+
+    context.state = nextState;
+  };
+
   const getUniqueSceneIds = (sceneIds = []) => {
     const uniqueSceneIds = [];
     const seen = new Set();
@@ -857,6 +1018,75 @@ export const createStoryCommandApi = (shared) => {
       });
     },
 
+    async duplicateSectionItem({ sectionId }) {
+      const context = await shared.ensureCommandContext({
+        sectionIds: [sectionId],
+      });
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      if (!sectionLocation) {
+        return {
+          valid: false,
+          error: {
+            message: "Section not found.",
+          },
+        };
+      }
+
+      const duplicateSectionId = shared.createId();
+      const duplicateLines = buildDuplicatedSectionLineCreateItems(
+        sectionLocation.section,
+        shared.createId,
+      );
+      const parentId =
+        findTreeNodeParentId(
+          sectionLocation.sectionCollection?.tree,
+          sectionId,
+        ) ?? null;
+      const commands = [
+        {
+          scope: "story",
+          partition: getMainScenePartition(context, [sectionLocation.sceneId]),
+          type: COMMAND_TYPES.SECTION_CREATE,
+          payload: {
+            sceneId: sectionLocation.sceneId,
+            sectionId: duplicateSectionId,
+            ...shared.buildPlacementPayload({
+              parentId,
+              position: "after",
+              positionTargetId: sectionId,
+            }),
+            data: {
+              name: getSectionName(sectionLocation.section),
+            },
+          },
+        },
+      ];
+
+      if (duplicateLines.length > 0) {
+        commands.push({
+          scope: "story",
+          partition: getSceneOnlyPartition(context, [sectionLocation.sceneId]),
+          type: COMMAND_TYPES.LINE_CREATE,
+          payload: buildLineCreatePayload({
+            sectionId: duplicateSectionId,
+            normalizedLines: duplicateLines,
+            position: "last",
+          }),
+        });
+      }
+
+      const submitResult = await shared.submitCommandsWithContext({
+        context,
+        commands,
+      });
+
+      if (submitResult?.valid === false) {
+        return submitResult;
+      }
+
+      return duplicateSectionId;
+    },
+
     async reorderSectionItem({
       sectionId,
       parentId = null,
@@ -888,6 +1118,119 @@ export const createStoryCommandApi = (shared) => {
             positionTargetId,
           }),
         },
+      });
+    },
+
+    async moveSectionItem({
+      sectionId,
+      sceneId,
+      parentId = null,
+      position = "last",
+      positionTargetId,
+      index,
+    }) {
+      const sectionIds = [sectionId, parentId, positionTargetId].filter(
+        Boolean,
+      );
+      const context = await shared.ensureCommandContext({
+        sceneIds: typeof sceneId === "string" ? [sceneId] : [],
+        sectionIds,
+      });
+      const sectionLocation = findSectionLocation(context.state, sectionId);
+      const targetSceneId = sceneId ?? sectionLocation?.sceneId;
+      const targetScene = context.state?.scenes?.items?.[targetSceneId];
+      const sourceSceneId = sectionLocation?.sceneId;
+      const isCrossSceneMove =
+        typeof sceneId === "string" &&
+        typeof sourceSceneId === "string" &&
+        sceneId !== sourceSceneId;
+      const movedSectionLineSets = isCrossSceneMove
+        ? buildMovedSectionLineSets(sectionLocation)
+        : [];
+      const movedLineIds = movedSectionLineSets.flatMap((entry) =>
+        entry.lines.map((line) => line.lineId),
+      );
+      const resolvedIndex = shared.resolveSectionIndex({
+        scene: targetScene,
+        parentId,
+        position,
+        positionTargetId,
+        index,
+        movingId: sectionId,
+      });
+      const placementPayload = shared.buildPlacementPayload({
+        parentId,
+        index: resolvedIndex,
+        position,
+        positionTargetId,
+      });
+      const payload = {
+        sectionId,
+      };
+
+      if (placementPayload.parentId !== undefined) {
+        payload.parentId = placementPayload.parentId;
+      }
+      if (placementPayload.index !== undefined) {
+        payload.index = placementPayload.index;
+      }
+      if (placementPayload.position !== undefined) {
+        payload.position = placementPayload.position;
+      }
+      if (placementPayload.positionTargetId !== undefined) {
+        payload.positionTargetId = placementPayload.positionTargetId;
+      }
+
+      if (sceneId !== undefined) {
+        payload.sceneId = sceneId;
+      }
+
+      if (isCrossSceneMove && movedLineIds.length > 0) {
+        removeMovedSectionLinesFromContextState({
+          context,
+          sectionLineSets: movedSectionLineSets,
+        });
+
+        const commands = [
+          {
+            scope: "story",
+            partition: getMainScenePartition(context, [
+              sourceSceneId,
+              targetSceneId,
+            ]),
+            type: COMMAND_TYPES.SECTION_MOVE,
+            payload,
+          },
+        ];
+
+        for (const sectionLineSet of movedSectionLineSets) {
+          commands.push({
+            scope: "story",
+            partition: getSceneOnlyPartition(context, [targetSceneId]),
+            type: COMMAND_TYPES.LINE_CREATE,
+            payload: buildLineCreatePayload({
+              sectionId: sectionLineSet.sectionId,
+              normalizedLines: sectionLineSet.lines,
+              position: "last",
+            }),
+          });
+        }
+
+        return shared.submitCommandsWithContext({
+          context,
+          commands,
+        });
+      }
+
+      return shared.submitCommandWithContext({
+        context,
+        scope: "story",
+        partition: getMainScenePartition(context, [
+          sectionLocation?.sceneId,
+          targetSceneId,
+        ]),
+        type: COMMAND_TYPES.SECTION_MOVE,
+        payload,
       });
     },
 

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -84,22 +84,6 @@ export const createStoryCommandApi = (shared) => {
     return ids;
   };
 
-  const removeTreeNodeById = (nodes = [], nodeId) => {
-    const index = nodes.findIndex((node) => node?.id === nodeId);
-    if (index >= 0) {
-      nodes.splice(index, 1);
-      return true;
-    }
-
-    for (const node of nodes || []) {
-      if (removeTreeNodeById(node?.children, nodeId)) {
-        return true;
-      }
-    }
-
-    return false;
-  };
-
   const findTreeNodeParentId = (nodes = [], nodeId, parentId = null) => {
     for (const node of nodes || []) {
       if (!node || typeof node !== "object") {
@@ -172,34 +156,6 @@ export const createStoryCommandApi = (shared) => {
         lines: buildSectionLineCreateItems(sectionItems[sectionId]),
       }))
       .filter((entry) => entry.lines.length > 0);
-  };
-
-  const removeMovedSectionLinesFromContextState = ({
-    context,
-    sectionLineSets = [],
-  } = {}) => {
-    if (!context?.state || sectionLineSets.length === 0) {
-      return;
-    }
-
-    const nextState = structuredClone(context.state);
-    for (const sectionLineSet of sectionLineSets) {
-      const sectionLocation = findSectionLocation(
-        nextState,
-        sectionLineSet.sectionId,
-      );
-      const lines = sectionLocation?.section?.lines;
-      if (!lines) {
-        continue;
-      }
-
-      for (const line of sectionLineSet.lines) {
-        delete lines.items?.[line.lineId];
-        removeTreeNodeById(lines.tree, line.lineId);
-      }
-    }
-
-    context.state = nextState;
   };
 
   const getUniqueSceneIds = (sceneIds = []) => {
@@ -1186,12 +1142,15 @@ export const createStoryCommandApi = (shared) => {
       }
 
       if (isCrossSceneMove && movedLineIds.length > 0) {
-        removeMovedSectionLinesFromContextState({
-          context,
-          sectionLineSets: movedSectionLineSets,
-        });
-
         const commands = [
+          {
+            scope: "story",
+            partition: getSceneOnlyPartition(context, [sourceSceneId]),
+            type: COMMAND_TYPES.LINE_DELETE,
+            payload: {
+              lineIds: movedLineIds,
+            },
+          },
           {
             scope: "story",
             partition: getMainScenePartition(context, [

--- a/src/deps/services/shared/projectRepositoryViews/sceneStateView.js
+++ b/src/deps/services/shared/projectRepositoryViews/sceneStateView.js
@@ -265,10 +265,13 @@ const isMissingSectionReplayError = (error) =>
     "payload.sectionId must reference an existing section",
   );
 
-const isMissingLineReplayError = (error) =>
-  String(error?.message || "").includes(
-    "payload.lineId must reference an existing line",
+const isMissingLineReplayError = (error) => {
+  const message = String(error?.message || "");
+  return (
+    message.includes("payload.lineId must reference an existing line") ||
+    message.includes("payload.lineIds must reference existing lines")
   );
+};
 
 const isDuplicateSectionReplayError = (error) =>
   String(error?.message || "").includes(
@@ -815,24 +818,54 @@ export const applySceneEventsToLoadedProjection = ({
     if (nextState !== undefined) {
       workingState = nextState;
     }
-  } catch (error) {
-    const failedRelevantIndex = Number(error?.details?.commandIndex);
-    const failedEvent =
-      Number.isInteger(failedRelevantIndex) &&
-      failedRelevantIndex >= 0 &&
-      failedRelevantIndex < relevantEvents.length
-        ? relevantEvents[failedRelevantIndex]
-        : relevantEvents[0];
+  } catch {
+    let recoveredState = workingState;
 
-    logSceneProjectionReplayFailure({
-      sceneId,
-      event: failedEvent,
-      index: Math.max(0, committedEvents.indexOf(failedEvent)),
-      events: committedEvents,
-      repositoryState: workingState,
-      error,
-    });
-    throw error;
+    for (const relevantEvent of relevantEvents) {
+      try {
+        const nextState = reduceEventsToState({
+          repositoryState: recoveredState,
+          events: [relevantEvent],
+        });
+        if (nextState !== undefined) {
+          recoveredState = nextState;
+        }
+      } catch (sequentialError) {
+        if (
+          shouldSkipObsoleteSceneReplayEvent({
+            event: relevantEvent,
+            repositoryState: recoveredState,
+            error: sequentialError,
+          })
+        ) {
+          console.warn("[sceneProjection] skipped obsolete replay event", {
+            sceneId,
+            eventId: relevantEvent?.id,
+            partition: relevantEvent?.partition,
+            error: sequentialError?.message || "unknown",
+          });
+          continue;
+        }
+
+        const failedSequentialIndex = Math.max(
+          0,
+          committedEvents.indexOf(relevantEvent),
+        );
+        logSceneProjectionReplayFailure({
+          sceneId,
+          event: relevantEvent,
+          index: failedSequentialIndex,
+          events: committedEvents,
+          mainState,
+          initialWorkingState: workingState,
+          repositoryState: recoveredState,
+          error: sequentialError,
+        });
+        throw sequentialError;
+      }
+    }
+
+    workingState = recoveredState;
   }
 
   return createSceneProjectionState(workingState, scenePartition);

--- a/src/internal/ui/sceneEditor/sectionOperations.js
+++ b/src/internal/ui/sceneEditor/sectionOperations.js
@@ -217,7 +217,9 @@ export const createSceneEditorSectionWithName = async (
   }
 
   const inheritedActions = inheritPresentationFromSelectedLine
-    ? createInheritedPresentationActions(store.getState()?.presentationState)
+    ? createInheritedPresentationActions(
+        store.selectEffectivePresentationState(),
+      )
     : {};
   const actions =
     Object.keys(inheritedActions).length > 0

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1228,7 +1228,7 @@ export const handleDropdownMenuClickOverlay = (deps) => {
 };
 
 export const handleDropdownMenuClickItem = async (deps, payload) => {
-  const { store, render, projectService, subject } = deps;
+  const { store, render, projectService, subject, appService } = deps;
   const item = payload._event.detail.item || payload._event.detail;
   const action = item?.value;
   const dropdownState = store.getState().dropdownMenu;
@@ -1281,6 +1281,42 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
       });
     }
     reconcileCurrentEditorSession(deps);
+  } else if (action === "duplicate-section") {
+    await flushSceneEditorDrafts(deps, { force: true });
+    let duplicateSectionId;
+    await runSceneEditorPersistence(
+      deps,
+      async () => {
+        duplicateSectionId = assertSceneEditorCommandResult(
+          await projectService.duplicateSectionItem({
+            sectionId,
+          }),
+          {
+            appService,
+            fallbackMessage: "Failed to duplicate section",
+          },
+        );
+      },
+      {
+        label: "duplicate-section",
+        meta: {
+          sceneId,
+          sectionId,
+        },
+      },
+    );
+
+    await refreshSceneEditorStateFromProject(deps);
+
+    if (typeof duplicateSectionId === "string") {
+      await selectSceneEditorSection(deps, duplicateSectionId);
+    } else {
+      subject.dispatch("sceneEditor.renderCanvas", {});
+    }
+  } else if (action === "move-section-scene") {
+    store.showSectionMoveSceneDialog({
+      sectionId,
+    });
   } else if (action === "edit-section") {
     store.showSectionEditDialog({
       sectionId,
@@ -1360,6 +1396,12 @@ export const handleSectionCreateDialogClose = (deps) => {
   render();
 };
 
+export const handleSectionMoveSceneDialogClose = (deps) => {
+  const { store, render } = deps;
+  store.hideSectionMoveSceneDialog();
+  render();
+};
+
 export const handleSceneSettingsClick = (deps) => {
   const { store, render } = deps;
   store.showSceneSettingsDialog();
@@ -1406,6 +1448,84 @@ export const handleSceneSettingsFormAction = (deps, payload) => {
   if (previousIsMuted !== isMuted) {
     subject.dispatch("sceneEditor.renderCanvas", {});
   }
+};
+
+export const handleSectionMoveSceneFormActionClick = async (deps, payload) => {
+  const { store, render, projectService, appService, subject } = deps;
+  const detail = payload._event.detail || {};
+  const action = detail.actionId;
+  const values = detail.values || {};
+
+  if (action === "cancel") {
+    store.hideSectionMoveSceneDialog();
+    render();
+    return;
+  }
+
+  if (action !== "submit") {
+    return;
+  }
+
+  const dialog = store.getState().sectionMoveSceneDialog || {};
+  const sectionId = dialog.sectionId;
+  const sceneId = store.selectSceneId();
+  const targetSceneId = values.sceneId;
+
+  if (!sectionId || !sceneId || !targetSceneId) {
+    appService?.showAlert({
+      message: "Select a scene to move this section.",
+      title: "Error",
+    });
+    return;
+  }
+
+  if (targetSceneId === sceneId) {
+    appService?.showAlert({
+      message: "Select a different scene.",
+      title: "Error",
+    });
+    return;
+  }
+
+  const sourceScene = store.selectCommittedScene();
+  if ((sourceScene?.sections?.length ?? 0) <= 1) {
+    appService?.showAlert({
+      message: "This scene must keep at least one section.",
+      title: "Error",
+    });
+    return;
+  }
+
+  store.hideSectionMoveSceneDialog();
+
+  await runSceneEditorPersistence(
+    deps,
+    async () => {
+      assertSceneEditorCommandResult(
+        await projectService.moveSectionItem({
+          sectionId,
+          sceneId: targetSceneId,
+          position: "last",
+        }),
+        {
+          appService,
+          fallbackMessage: "Failed to move section",
+        },
+      );
+    },
+    {
+      label: "move-section-scene",
+      meta: {
+        sceneId,
+        targetSceneId,
+        sectionId,
+      },
+    },
+  );
+
+  await refreshSceneEditorStateFromProject(deps);
+  subject.dispatch("sceneEditor.renderCanvas", {});
+  render();
 };
 
 export const handleSectionCreateFormActionClick = async (deps, payload) => {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1231,7 +1231,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   const { store, render, projectService, subject, appService } = deps;
   const item = payload._event.detail.item || payload._event.detail;
   const action = item?.value;
-  const dropdownState = store.getState().dropdownMenu;
+  const dropdownState = store.selectDropdownMenu();
   const sectionId = dropdownState.sectionId;
   const actionsType = dropdownState.actionsType;
   const lineId = dropdownState.lineId;
@@ -1466,7 +1466,7 @@ export const handleSectionMoveSceneFormActionClick = async (deps, payload) => {
     return;
   }
 
-  const dialog = store.getState().sectionMoveSceneDialog || {};
+  const dialog = store.selectSectionMoveSceneDialog();
   const sectionId = dialog.sectionId;
   const sceneId = store.selectSceneId();
   const targetSceneId = values.sceneId;
@@ -1542,7 +1542,7 @@ export const handleSectionCreateFormActionClick = async (deps, payload) => {
   }
 
   if (action === "submit") {
-    const sectionCreateDialog = store.getState().sectionCreateDialog || {};
+    const sectionCreateDialog = store.selectSectionCreateDialog();
     const isEditMode = sectionCreateDialog.mode === "edit";
     const sectionId = sectionCreateDialog.sectionId;
     const sceneId = store.selectSceneId();
@@ -1609,7 +1609,7 @@ export const handleFormActionClick = async (deps, payload) => {
   }
 
   if (action === "submit") {
-    const popoverState = store.getState().popover || {};
+    const popoverState = store.selectPopover();
     const sectionId = popoverState.sectionId;
     const popoverMode = popoverState.mode;
     const sceneId = store.selectSceneId();
@@ -1826,7 +1826,7 @@ export const handleLineContextMenuRequest = (deps, payload) => {
 
 export const handleLineContextMenuDismiss = (deps) => {
   const { store, render } = deps;
-  const dropdownState = store.getState().dropdownMenu;
+  const dropdownState = store.selectDropdownMenu();
   if (!dropdownState.lineId) {
     return;
   }

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -970,6 +970,22 @@ export const selectLockingLineId = ({ state }) => {
   return state.lockingLineId;
 };
 
+export const selectDropdownMenu = ({ state }) => {
+  return state.dropdownMenu;
+};
+
+export const selectPopover = ({ state }) => {
+  return state.popover;
+};
+
+export const selectSectionCreateDialog = ({ state }) => {
+  return state.sectionCreateDialog;
+};
+
+export const selectSectionMoveSceneDialog = ({ state }) => {
+  return state.sectionMoveSceneDialog;
+};
+
 export const showSectionDropdownMenu = (
   { state },
   { position, sectionId } = {},

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -166,6 +166,16 @@ const buildMentionTargetOptions = (repositoryState = {}) => {
     }));
 };
 
+const buildMoveSectionSceneOptions = (repositoryState = {}, currentSceneId) => {
+  const scenesData = repositoryState.scenes || { items: {}, tree: [] };
+  return toFlatItems(scenesData)
+    .filter((item) => item?.type === "scene" && item.id !== currentSceneId)
+    .map((item) => ({
+      value: item.id,
+      label: item.name ?? item.id,
+    }));
+};
+
 const isPlainObject = (value) => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
@@ -503,6 +513,14 @@ export const createInitialState = () => ({
     defaultValues: {
       name: "",
       inheritPresentationFromSelectedLine: true,
+    },
+  },
+  sectionMoveSceneDialog: {
+    isOpen: false,
+    formKey: 0,
+    sectionId: undefined,
+    defaultValues: {
+      sceneId: undefined,
     },
   },
   sceneSettings: {
@@ -957,7 +975,27 @@ export const showSectionDropdownMenu = (
   { position, sectionId } = {},
 ) => {
   const scene = selectCommittedScene({ state });
-  const items = [{ label: "Edit", type: "item", value: "edit-section" }];
+  const sceneOptions = buildMoveSectionSceneOptions(
+    state.repositoryState,
+    state.sceneId,
+  );
+  const items = [
+    { label: "Edit", type: "item", value: "edit-section" },
+    { label: "Duplicate", type: "item", value: "duplicate-section" },
+  ];
+
+  if (
+    sceneOptions.length > 0 &&
+    scene &&
+    scene.sections &&
+    scene.sections.length > 1
+  ) {
+    items.push({
+      label: "Move Scene",
+      type: "item",
+      value: "move-section-scene",
+    });
+  }
 
   // Only show delete option if there's more than 1 section
   if (scene && scene.sections && scene.sections.length > 1) {
@@ -1090,6 +1128,22 @@ export const hideSectionCreateDialog = ({ state }, _payload = {}) => {
   };
 };
 
+export const showSectionMoveSceneDialog = ({ state }, { sectionId } = {}) => {
+  state.sectionMoveSceneDialog = {
+    isOpen: true,
+    formKey: (state.sectionMoveSceneDialog?.formKey || 0) + 1,
+    sectionId,
+    defaultValues: {
+      sceneId: undefined,
+    },
+  };
+};
+
+export const hideSectionMoveSceneDialog = ({ state }, _payload = {}) => {
+  state.sectionMoveSceneDialog.isOpen = false;
+  state.sectionMoveSceneDialog.sectionId = undefined;
+};
+
 export const showSceneSettingsDialog = ({ state }, _payload = {}) => {
   state.sceneSettingsDialog.isOpen = true;
   state.sceneSettingsDialog.formKey += 1;
@@ -1150,7 +1204,7 @@ export const selectViewData = ({ state }) => {
       sectionsGraphView: state.sectionsGraphView,
       layouts: [],
       allCharacters: [],
-      form: null,
+      form: { fields: [], actions: { buttons: [] } },
       selectedLine: null,
       selectedLineActions: {},
       sectionsGraph: JSON.stringify(
@@ -1166,6 +1220,8 @@ export const selectViewData = ({ state }) => {
       sectionLineChanges: state.sectionLineChanges,
       sectionCreateDialog: state.sectionCreateDialog,
       sectionCreateForm: { fields: [], actions: { buttons: [] } },
+      sectionMoveSceneDialog: state.sectionMoveSceneDialog,
+      sectionMoveSceneForm: { fields: [], actions: { buttons: [] } },
       sceneSettings: state.sceneSettings,
       linesEditorKey: `document-${state.sceneSettings.showLineNumbers ? "line-numbers-show" : "line-numbers-hide"}`,
       sceneSettingsDialog: state.sceneSettingsDialog,
@@ -1250,7 +1306,7 @@ export const selectViewData = ({ state }) => {
             ],
           },
         }
-      : null;
+      : { fields: [], actions: { buttons: [] } };
 
   // Get current section for lines/actions panel
   const currentSection = scene.sections.find(
@@ -1270,6 +1326,10 @@ export const selectViewData = ({ state }) => {
   });
 
   const isEditingSection = state.sectionCreateDialog.mode === "edit";
+  const moveSectionSceneOptions = buildMoveSectionSceneOptions(
+    repositoryState,
+    state.sceneId,
+  );
   const sectionCreateFields = [
     {
       name: "name",
@@ -1303,6 +1363,30 @@ export const selectViewData = ({ state }) => {
           id: "submit",
           variant: "pr",
           label: isEditingSection ? "Save" : "Create",
+        },
+      ],
+    },
+  };
+
+  const sectionMoveSceneForm = {
+    title: "Move Section",
+    fields: [
+      {
+        name: "sceneId",
+        type: "select",
+        label: "Scene",
+        required: true,
+        options: moveSectionSceneOptions,
+      },
+    ],
+    actions: {
+      buttons: [
+        {
+          id: "submit",
+          variant: "pr",
+          label: "Move",
+          type: "submit",
+          validate: true,
         },
       ],
     },
@@ -1388,6 +1472,8 @@ export const selectViewData = ({ state }) => {
     sectionLineChanges: state.sectionLineChanges,
     sectionCreateDialog: state.sectionCreateDialog,
     sectionCreateForm,
+    sectionMoveSceneDialog: state.sectionMoveSceneDialog,
+    sectionMoveSceneForm,
     sceneSettings: state.sceneSettings,
     linesEditorKey: `document-${state.sceneSettings.showLineNumbers ? "line-numbers-show" : "line-numbers-hide"}`,
     sceneSettingsDialog: state.sceneSettingsDialog,

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -69,6 +69,10 @@ refs:
     eventListeners:
       close:
         handler: handleSectionCreateDialogClose
+  sectionMoveSceneDialog:
+    eventListeners:
+      close:
+        handler: handleSectionMoveSceneDialogClose
   sectionsOverviewDialog:
     eventListeners:
       close:
@@ -77,6 +81,10 @@ refs:
     eventListeners:
       form-action:
         handler: handleSectionCreateFormActionClick
+  sectionMoveSceneForm:
+    eventListeners:
+      form-action:
+        handler: handleSectionMoveSceneFormActionClick
   addActionsButton:
     eventListeners:
       click:
@@ -181,6 +189,9 @@ template:
       - rtgl-dialog#sectionCreateDialog ?open=${sectionCreateDialog.isOpen} s=md:
           - rtgl-view slot=content g=md:
               - rtgl-form#sectionCreateForm key=${sectionCreateDialog.formKey} :form=${sectionCreateForm} :defaultValues=${sectionCreateDialog.defaultValues} w=f: null
+      - rtgl-dialog#sectionMoveSceneDialog ?open=${sectionMoveSceneDialog.isOpen} s=md:
+          - rtgl-view slot=content g=md:
+              - rtgl-form#sectionMoveSceneForm key=${sectionMoveSceneDialog.formKey} :form=${sectionMoveSceneForm} :defaultValues=${sectionMoveSceneDialog.defaultValues} w=f: null
       - rtgl-dialog#sceneSettingsDialog ?open=${sceneSettingsDialog.isOpen} s=md:
           - rtgl-view slot=content g=md:
               - rtgl-form#sceneSettingsForm key=${sceneSettingsDialog.formKey} :form=${sceneSettingsForm} :defaultValues=${sceneSettingsDialog.defaultValues} w=f: null

--- a/tests/commandApi/storyCommandApi.test.js
+++ b/tests/commandApi/storyCommandApi.test.js
@@ -377,4 +377,243 @@ describe("story command api", () => {
       ],
     });
   });
+
+  it("moves a section to another scene with its line snapshot", async () => {
+    const context = {
+      projectId: "project-1",
+      state: {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              sections: {
+                items: {
+                  "section-1": {
+                    id: "section-1",
+                    lines: {
+                      items: {
+                        "line-1": {
+                          id: "line-1",
+                          actions: {
+                            dialogue: {
+                              content: [{ text: "Keep me" }],
+                            },
+                          },
+                        },
+                      },
+                      tree: [{ id: "line-1" }],
+                    },
+                  },
+                },
+                tree: [{ id: "section-1" }],
+              },
+            },
+            "scene-2": {
+              id: "scene-2",
+              type: "scene",
+              sections: {
+                items: {},
+                tree: [],
+              },
+            },
+          },
+          tree: [{ id: "scene-1" }, { id: "scene-2" }],
+        },
+      },
+    };
+    const shared = {
+      ensureCommandContext: vi.fn(async () => context),
+      resolveSectionIndex: vi.fn(() => 0),
+      buildPlacementPayload: vi.fn(
+        ({ parentId = null, index, position, positionTargetId } = {}) => {
+          const payload = {
+            parentId,
+          };
+          if (index !== undefined) {
+            payload.index = index;
+            return payload;
+          }
+          payload.position = position;
+          if (positionTargetId !== undefined) {
+            payload.positionTargetId = positionTargetId;
+          }
+          return payload;
+        },
+      ),
+      submitCommandsWithContext: vi.fn(async () => ({ valid: true })),
+      scenePartitionFor: vi.fn((_projectId, sceneId) => `s:${sceneId}`),
+      storyBasePartitionFor: vi.fn(() => "m"),
+    };
+    const api = createStoryCommandApi(shared);
+
+    await api.moveSectionItem({
+      sectionId: "section-1",
+      sceneId: "scene-2",
+      position: "last",
+    });
+
+    expect(shared.ensureCommandContext).toHaveBeenCalledWith({
+      sceneIds: ["scene-2"],
+      sectionIds: ["section-1"],
+    });
+    expect(
+      shared.submitCommandsWithContext.mock.calls[0][0].context.state.scenes
+        .items["scene-1"].sections.items["section-1"].lines.items["line-1"],
+    ).toBeUndefined();
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+      context,
+      commands: [
+        {
+          scope: "story",
+          partition: "m",
+          type: COMMAND_TYPES.SECTION_MOVE,
+          payload: {
+            sectionId: "section-1",
+            parentId: null,
+            index: 0,
+            sceneId: "scene-2",
+          },
+        },
+        {
+          scope: "story",
+          partition: "s:scene-2",
+          type: COMMAND_TYPES.LINE_CREATE,
+          payload: {
+            sectionId: "section-1",
+            lines: [
+              {
+                lineId: "line-1",
+                data: {
+                  actions: {
+                    dialogue: {
+                      content: [{ text: "Keep me" }],
+                    },
+                  },
+                },
+              },
+            ],
+            position: "last",
+          },
+        },
+      ],
+    });
+  });
+
+  it("duplicates a section after the source section with cloned lines", async () => {
+    const context = {
+      projectId: "project-1",
+      state: {
+        scenes: {
+          items: {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              sections: {
+                items: {
+                  "section-1": {
+                    id: "section-1",
+                    name: "Intro",
+                    lines: {
+                      items: {
+                        "line-1": {
+                          id: "line-1",
+                          actions: {
+                            dialogue: {
+                              content: [{ text: "Hello" }],
+                            },
+                          },
+                        },
+                      },
+                      tree: [{ id: "line-1" }],
+                    },
+                  },
+                },
+                tree: [{ id: "section-1" }],
+              },
+            },
+          },
+          tree: [{ id: "scene-1" }],
+        },
+      },
+    };
+    const createId = vi
+      .fn()
+      .mockReturnValueOnce("section-copy")
+      .mockReturnValueOnce("line-copy");
+    const shared = {
+      ensureCommandContext: vi.fn(async () => context),
+      createId,
+      buildPlacementPayload: vi.fn(
+        ({ parentId = null, index, position, positionTargetId } = {}) => {
+          const payload = {
+            parentId,
+          };
+          if (index !== undefined) {
+            payload.index = index;
+            return payload;
+          }
+          payload.position = position;
+          if (positionTargetId !== undefined) {
+            payload.positionTargetId = positionTargetId;
+          }
+          return payload;
+        },
+      ),
+      submitCommandsWithContext: vi.fn(async () => ({ valid: true })),
+      storyScenePartitionFor: vi.fn((_projectId, sceneId) => `m:s:${sceneId}`),
+      scenePartitionFor: vi.fn((_projectId, sceneId) => `s:${sceneId}`),
+    };
+    const api = createStoryCommandApi(shared);
+
+    const result = await api.duplicateSectionItem({
+      sectionId: "section-1",
+    });
+
+    expect(result).toBe("section-copy");
+    expect(shared.ensureCommandContext).toHaveBeenCalledWith({
+      sectionIds: ["section-1"],
+    });
+    expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
+      context,
+      commands: [
+        {
+          scope: "story",
+          partition: "m:s:scene-1",
+          type: COMMAND_TYPES.SECTION_CREATE,
+          payload: {
+            sceneId: "scene-1",
+            sectionId: "section-copy",
+            parentId: null,
+            position: "after",
+            positionTargetId: "section-1",
+            data: {
+              name: "Intro",
+            },
+          },
+        },
+        {
+          scope: "story",
+          partition: "s:scene-1",
+          type: COMMAND_TYPES.LINE_CREATE,
+          payload: {
+            sectionId: "section-copy",
+            lines: [
+              {
+                lineId: "line-copy",
+                data: {
+                  actions: {
+                    dialogue: {
+                      content: [{ text: "Hello" }],
+                    },
+                  },
+                },
+              },
+            ],
+            position: "last",
+          },
+        },
+      ],
+    });
+  });
 });

--- a/tests/commandApi/storyCommandApi.test.js
+++ b/tests/commandApi/storyCommandApi.test.js
@@ -457,13 +457,17 @@ describe("story command api", () => {
       sceneIds: ["scene-2"],
       sectionIds: ["section-1"],
     });
-    expect(
-      shared.submitCommandsWithContext.mock.calls[0][0].context.state.scenes
-        .items["scene-1"].sections.items["section-1"].lines.items["line-1"],
-    ).toBeUndefined();
     expect(shared.submitCommandsWithContext).toHaveBeenCalledWith({
       context,
       commands: [
+        {
+          scope: "story",
+          partition: "s:scene-1",
+          type: COMMAND_TYPES.LINE_DELETE,
+          payload: {
+            lineIds: ["line-1"],
+          },
+        },
         {
           scope: "story",
           partition: "m",

--- a/tests/project/sceneProjectionCompatibility.test.js
+++ b/tests/project/sceneProjectionCompatibility.test.js
@@ -7,7 +7,10 @@ import {
   repositoryEventToCommand,
   createRepositoryCommandEvent,
 } from "../../src/deps/services/shared/projectRepository.js";
-import { loadSceneProjectionState } from "../../src/deps/services/shared/projectRepositoryViews/sceneStateView.js";
+import {
+  applySceneEventsToLoadedProjection,
+  loadSceneProjectionState,
+} from "../../src/deps/services/shared/projectRepositoryViews/sceneStateView.js";
 import {
   SCENE_VIEW_VERSION,
   createMainProjectionState,
@@ -222,6 +225,15 @@ describe("scene projection compatibility", () => {
         clientTs: 1,
       }),
       createCommandEvent({
+        id: "line-delete-source",
+        partition: scenePartitionFor(sceneId),
+        type: COMMAND_TYPES.LINE_DELETE,
+        payload: {
+          lineIds: [lineId],
+        },
+        clientTs: 2,
+      }),
+      createCommandEvent({
         id: "section-move-target",
         partition: mainPartitionFor(),
         type: COMMAND_TYPES.SECTION_MOVE,
@@ -230,7 +242,7 @@ describe("scene projection compatibility", () => {
           sceneId: targetSceneId,
           position: "last",
         },
-        clientTs: 2,
+        clientTs: 3,
       }),
       createCommandEvent({
         id: "line-create-target",
@@ -250,9 +262,22 @@ describe("scene projection compatibility", () => {
           ],
           position: "last",
         },
-        clientTs: 3,
+        clientTs: 4,
       }),
     ];
+
+    const fullReplayResult = applyRepositoryEventsToRepositoryState({
+      repositoryState: structuredClone(initialProjectData),
+      events,
+      projectId,
+    });
+    expect(fullReplayResult.valid).toBe(true);
+    expect(
+      fullReplayResult.repositoryState.scenes.items[targetSceneId].sections
+        .items[sectionId].lines.items[lineId].actions,
+    ).toEqual({
+      say: "kept",
+    });
 
     const mainEvents = events.filter(
       (event) =>
@@ -296,6 +321,87 @@ describe("scene projection compatibility", () => {
     expect(
       sourceProjection.scenes.items[sceneId].sections.items[sectionId],
     ).toBeUndefined();
+  });
+
+  it("skips obsolete source line deletes during active scene projection refresh", () => {
+    const targetSceneId = "scene-2";
+    const initialState = createRepositoryState();
+    initialState.scenes.items[sceneId].sections.items[sectionId].lines.items[
+      lineId
+    ] = {
+      id: lineId,
+      actions: {
+        say: "kept",
+      },
+    };
+    initialState.scenes.items[sceneId].sections.items[sectionId].lines.tree = [
+      { id: lineId },
+    ];
+    initialState.scenes.items[targetSceneId] = {
+      id: targetSceneId,
+      type: "scene",
+      name: "Scene 2",
+      sections: {
+        items: {},
+        tree: [],
+      },
+    };
+    initialState.scenes.tree.push({ id: targetSceneId });
+
+    const lineDeleteEvent = createCommandEvent({
+      id: "line-delete-source",
+      partition: scenePartitionFor(sceneId),
+      type: COMMAND_TYPES.LINE_DELETE,
+      payload: {
+        lineIds: [lineId],
+      },
+      clientTs: 1,
+    });
+    const sectionMoveEvent = createCommandEvent({
+      id: "section-move-target",
+      partition: mainPartitionFor(),
+      type: COMMAND_TYPES.SECTION_MOVE,
+      payload: {
+        sectionId,
+        sceneId: targetSceneId,
+        position: "last",
+      },
+      clientTs: 2,
+    });
+    const mainReplayResult = applyRepositoryEventsToRepositoryState({
+      repositoryState: structuredClone(initialState),
+      events: [sectionMoveEvent],
+      projectId,
+    });
+    expect(mainReplayResult.valid).toBe(true);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const projection = applySceneEventsToLoadedProjection({
+        mainState: createMainProjectionState(mainReplayResult.repositoryState),
+        sceneState: createSceneProjectionState(
+          initialState,
+          scenePartitionFor(sceneId),
+        ),
+        sceneId,
+        sourceEvents: [lineDeleteEvent],
+        reduceEventsToState,
+      });
+
+      expect(
+        projection.scenes.items[sceneId].sections.items[sectionId],
+      ).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[sceneProjection] skipped obsolete replay event",
+        expect.objectContaining({
+          sceneId,
+          eventId: "line-delete-source",
+          partition: scenePartitionFor(sceneId),
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("falls back to a stale scene checkpoint when project.create seed is missing", async () => {

--- a/tests/project/sceneProjectionCompatibility.test.js
+++ b/tests/project/sceneProjectionCompatibility.test.js
@@ -14,6 +14,7 @@ import {
   createSceneProjectionState,
 } from "../../src/deps/services/shared/projectRepositoryViews/shared.js";
 import {
+  mainPartitionFor,
   mainScenePartitionFor,
   scenePartitionFor,
 } from "../../src/deps/services/shared/collab/partitions.js";
@@ -179,6 +180,122 @@ describe("scene projection compatibility", () => {
         sectionId: targetSectionId,
       },
     });
+  });
+
+  it("preserves moved section lines through target scene partition replay", async () => {
+    const targetSceneId = "scene-2";
+    const initialState = createRepositoryState();
+    initialState.scenes.items[targetSceneId] = {
+      id: targetSceneId,
+      type: "scene",
+      name: "Scene 2",
+      sections: {
+        items: {},
+        tree: [],
+      },
+    };
+    initialState.scenes.tree.push({ id: targetSceneId });
+
+    const events = [
+      createProjectCreateRepositoryEvent({
+        projectId,
+        state: initialState,
+      }),
+      createCommandEvent({
+        id: "line-create-source",
+        partition: scenePartitionFor(sceneId),
+        type: COMMAND_TYPES.LINE_CREATE,
+        payload: {
+          sectionId,
+          lines: [
+            {
+              lineId,
+              data: {
+                actions: {
+                  say: "kept",
+                },
+              },
+            },
+          ],
+          index: 0,
+        },
+        clientTs: 1,
+      }),
+      createCommandEvent({
+        id: "section-move-target",
+        partition: mainPartitionFor(),
+        type: COMMAND_TYPES.SECTION_MOVE,
+        payload: {
+          sectionId,
+          sceneId: targetSceneId,
+          position: "last",
+        },
+        clientTs: 2,
+      }),
+      createCommandEvent({
+        id: "line-create-target",
+        partition: scenePartitionFor(targetSceneId),
+        type: COMMAND_TYPES.LINE_CREATE,
+        payload: {
+          sectionId,
+          lines: [
+            {
+              lineId,
+              data: {
+                actions: {
+                  say: "kept",
+                },
+              },
+            },
+          ],
+          position: "last",
+        },
+        clientTs: 3,
+      }),
+    ];
+
+    const mainEvents = events.filter(
+      (event) =>
+        event.partition === mainPartitionFor() ||
+        event.partition === mainScenePartitionFor(sceneId) ||
+        event.partition === mainScenePartitionFor(targetSceneId),
+    );
+    const appliedResult = applyRepositoryEventsToRepositoryState({
+      repositoryState: structuredClone(initialProjectData),
+      events: mainEvents,
+      projectId,
+    });
+    expect(appliedResult.valid).toBe(true);
+
+    const mainState = createMainProjectionState(appliedResult.repositoryState);
+    const targetProjection = await loadSceneProjectionState({
+      store: createCheckpointStore(),
+      mainState,
+      events,
+      createInitialState: () => structuredClone(initialProjectData),
+      reduceEventToState,
+      reduceEventsToState,
+      sceneId: targetSceneId,
+    });
+    const sourceProjection = await loadSceneProjectionState({
+      store: createCheckpointStore(),
+      mainState,
+      events,
+      createInitialState: () => structuredClone(initialProjectData),
+      reduceEventToState,
+      reduceEventsToState,
+      sceneId,
+    });
+
+    expect(
+      targetProjection.scenes.items[targetSceneId].sections.items[sectionId]
+        .lines.items[lineId].actions,
+    ).toEqual({
+      say: "kept",
+    });
+    expect(
+      sourceProjection.scenes.items[sceneId].sections.items[sectionId],
+    ).toBeUndefined();
   });
 
   it("falls back to a stale scene checkpoint when project.create seed is missing", async () => {

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -9,6 +9,7 @@ import {
   setSceneId,
   setPresentationState,
   setTemporaryPresentationState,
+  showSectionDropdownMenu,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.store.js";
 
 describe("sceneEditorLexical.store", () => {
@@ -164,5 +165,63 @@ describe("sceneEditorLexical.store", () => {
     expect(selectEffectivePresentationState({ state }).dialogue).toEqual({
       mode: "adv",
     });
+  });
+
+  it("hides move scene for the last section in the current scene", () => {
+    const state = createInitialState();
+
+    setSceneId({ state }, { sceneId: "scene-1" });
+    setRepositoryState(
+      { state },
+      {
+        repository: {
+          scenes: {
+            items: {
+              "scene-1": {
+                id: "scene-1",
+                type: "scene",
+                name: "Scene 1",
+                sections: {
+                  items: {
+                    "section-1": {
+                      id: "section-1",
+                      type: "section",
+                      name: "Section 1",
+                      lines: {
+                        items: {},
+                        tree: [],
+                      },
+                    },
+                  },
+                  tree: [{ id: "section-1" }],
+                },
+              },
+              "scene-2": {
+                id: "scene-2",
+                type: "scene",
+                name: "Scene 2",
+                sections: {
+                  items: {},
+                  tree: [],
+                },
+              },
+            },
+            tree: [{ id: "scene-1" }, { id: "scene-2" }],
+          },
+        },
+      },
+    );
+
+    showSectionDropdownMenu(
+      { state },
+      {
+        sectionId: "section-1",
+        position: { x: 0, y: 0 },
+      },
+    );
+
+    const itemValues = state.dropdownMenu.items.map((item) => item.value);
+    expect(itemValues).toContain("duplicate-section");
+    expect(itemValues).not.toContain("move-section-scene");
   });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -4,6 +4,7 @@ import {
   handleCommandLineSubmit,
   handleEditorBlur,
   handleNewLine,
+  handleSectionMoveSceneFormActionClick,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
 describe("sceneEditorLexical.handlers actions dialog", () => {
@@ -380,5 +381,53 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
         globalThis.requestAnimationFrame = previousRequestAnimationFrame;
       }
     }
+  });
+
+  it("does not move the last section out of a scene", async () => {
+    const store = {
+      getState: vi.fn(() => ({
+        sectionMoveSceneDialog: {
+          sectionId: "section-1",
+        },
+      })),
+      selectSceneId: vi.fn(() => "scene-1"),
+      selectCommittedScene: vi.fn(() => ({
+        id: "scene-1",
+        sections: [{ id: "section-1" }],
+      })),
+      hideSectionMoveSceneDialog: vi.fn(),
+    };
+    const moveSectionItem = vi.fn();
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+      projectService: {
+        moveSectionItem,
+      },
+      appService: {
+        showAlert: vi.fn(),
+      },
+    };
+
+    await handleSectionMoveSceneFormActionClick(deps, {
+      _event: {
+        detail: {
+          actionId: "submit",
+          values: {
+            sceneId: "scene-2",
+          },
+        },
+      },
+    });
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message: "This scene must keep at least one section.",
+      title: "Error",
+    });
+    expect(moveSectionItem).not.toHaveBeenCalled();
+    expect(store.hideSectionMoveSceneDialog).not.toHaveBeenCalled();
   });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -385,10 +385,8 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
 
   it("does not move the last section out of a scene", async () => {
     const store = {
-      getState: vi.fn(() => ({
-        sectionMoveSceneDialog: {
-          sectionId: "section-1",
-        },
+      selectSectionMoveSceneDialog: vi.fn(() => ({
+        sectionId: "section-1",
       })),
       selectSceneId: vi.fn(() => "scene-1"),
       selectCommittedScene: vi.fn(() => ({


### PR DESCRIPTION
## Summary
- add scene editor section Move Scene dialog/action backed by creator-model 1.6.0 section.move sceneId support
- preserve moved section line content across scene partitions and prevent moving the last section out of a scene
- add section Duplicate from the right-click menu, creating a copy immediately after the source section with cloned lines and fresh line ids
- bump @routevn/creator-model to 1.6.0

## Testing
- bunx vitest run tests/commandApi/storyCommandApi.test.js tests/project/sceneProjectionCompatibility.test.js tests/sceneEditor/sceneEditor.store.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js
- bunx vitest run tests/commandApi/storyCommandApi.test.js tests/sceneEditor/sceneEditor.store.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/project/sceneProjectionCompatibility.test.js tests/collab/compatibility.test.js
- bun install --lockfile-only
- git diff --check
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src

Note: did not run bun run build:web.