### PR TITLE
Improve command line visual controls

### DIFF
--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -621,6 +621,7 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
   const { item } = payload._event.detail;
   const dropdownMenuType = store.selectDropdownMenuType?.();
   const characterIndex = store.selectDropdownMenuCharacterIndex();
+  const hasCharacterIndex = Number.isInteger(characterIndex);
   let shouldDispatchTemporaryPresentationStateChange = false;
 
   if (dropdownMenuType === "add-character-transform") {
@@ -628,8 +629,14 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
       transformId: item.transformId ?? item.value,
     });
     beginAddCharacterSelection(store);
-  } else if (item.value === "delete" && characterIndex !== null) {
+  } else if (item.value === "delete" && hasCharacterIndex) {
     store.removeCharacter({ index: characterIndex });
+    shouldDispatchTemporaryPresentationStateChange = true;
+  } else if (item.value === "move-up" && hasCharacterIndex) {
+    store.moveCharacter({ index: characterIndex, offset: 1 });
+    shouldDispatchTemporaryPresentationStateChange = true;
+  } else if (item.value === "move-down" && hasCharacterIndex) {
+    store.moveCharacter({ index: characterIndex, offset: -1 });
     shouldDispatchTemporaryPresentationStateChange = true;
   }
 

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -23,9 +23,23 @@ const UNGROUPED_SPRITE_GROUP_ID = "__ungrouped_sprites__";
 const UNGROUPED_GROUP_LABEL = "Ungrouped";
 const DEFAULT_SPRITE_GROUP_ID = "base";
 const DEFAULT_SPRITE_GROUP_NAME = "Sprite";
-const createCharacterContextDropdownItems = () => [
-  { label: "Delete", type: "item", value: "delete" },
-];
+const createCharacterContextDropdownItems = (
+  characterIndex,
+  characters = [],
+) => {
+  const items = [];
+
+  if (characterIndex < characters.length - 1) {
+    items.push({ label: "Move Up", type: "item", value: "move-up" });
+  }
+
+  if (characterIndex > 0) {
+    items.push({ label: "Move Down", type: "item", value: "move-down" });
+  }
+
+  items.push({ label: "Delete", type: "item", value: "delete" });
+  return items;
+};
 
 const createAddCharacterTransformDropdownItems = (transforms = {}) =>
   toFlatItems(transforms)
@@ -331,6 +345,45 @@ export const removeCharacter = ({ state }, { index } = {}) => {
   }
 };
 
+const retargetAdjacentMoveIndex = (currentIndex, sourceIndex, targetIndex) => {
+  if (currentIndex === sourceIndex) {
+    return targetIndex;
+  }
+
+  if (currentIndex === targetIndex) {
+    return sourceIndex;
+  }
+
+  return currentIndex;
+};
+
+export const moveCharacter = ({ state }, { index, offset } = {}) => {
+  const targetIndex = index + Math.sign(offset);
+  if (
+    !Number.isInteger(index) ||
+    !Number.isInteger(targetIndex) ||
+    index < 0 ||
+    index >= state.selectedCharacters.length ||
+    targetIndex < 0 ||
+    targetIndex >= state.selectedCharacters.length
+  ) {
+    return;
+  }
+
+  const [character] = state.selectedCharacters.splice(index, 1);
+  state.selectedCharacters.splice(targetIndex, 0, character);
+  state.selectedCharacterIndex = retargetAdjacentMoveIndex(
+    state.selectedCharacterIndex,
+    index,
+    targetIndex,
+  );
+  state.pendingCharacterIndex = retargetAdjacentMoveIndex(
+    state.pendingCharacterIndex,
+    index,
+    targetIndex,
+  );
+};
+
 export const updateCharacterTransform = (
   { state },
   { index, transform } = {},
@@ -566,7 +619,10 @@ export const showDropdownMenu = (
   state.dropdownMenu.position = position;
   state.dropdownMenu.type = "character-context";
   state.dropdownMenu.characterIndex = characterIndex;
-  state.dropdownMenu.items = createCharacterContextDropdownItems();
+  state.dropdownMenu.items = createCharacterContextDropdownItems(
+    characterIndex,
+    state.selectedCharacters,
+  );
 };
 
 export const showAddCharacterTransformDropdownMenu = (
@@ -986,10 +1042,10 @@ export const selectViewData = ({ state }) => {
     });
   }
 
-  // Create default values with character data and options
-  const defaultValues = {
-    characters: processedSelectedCharacters.map((char) => ({
+  const characterControls = processedSelectedCharacters.map(
+    (char, characterIndex) => ({
       ...char,
+      characterIndex,
       // Ensure transformId is set, use first transform as fallback if needed
       transformId:
         char.transformId ||
@@ -1000,7 +1056,12 @@ export const selectViewData = ({ state }) => {
       blur: normalizeCommandLineItemBlur(
         char.blur ?? DEFAULT_COMMAND_LINE_ITEM_BLUR,
       ),
-    })),
+    }),
+  );
+
+  // Create default values with character data and options
+  const defaultValues = {
+    characters: characterControls.slice().reverse(),
     transformOptions,
     animationOptions,
     blurToggleOptions: COMMAND_LINE_ITEM_BLUR_TOGGLE_OPTIONS,

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -116,8 +116,8 @@ template:
                   - rtgl-form#form :form=${form} :defaultValues=${defaultValues}:
                       - rtgl-view#charactersContainer slot=characters g=md w=f:
                           - $for character, i in defaultValues.characters:
-                              - rtgl-view#character${i}.characterRow data-index=${i} data-character-id=${character.id} d=h g=md av=t pv=md br=md w=f:
-                                  - rtgl-view#characterSpriteBox${i} data-index=${i} cur=pointer bw=xs bc=bo h-bc=ac br=sm:
+                              - rtgl-view#character${i}.characterRow data-index=${character.characterIndex} data-character-id=${character.id} d=h g=md av=t pv=md br=md w=f:
+                                  - 'rtgl-view#characterSpriteBox${i} data-index=${character.characterIndex} cur=pointer bw=xs bc=bo h-bc=ac br=sm style="align-self: flex-start; flex: 0 0 auto;"':
                                       - rtgl-view p=md g=md br=md:
                                           - $if character.hasSpritePreview:
                                               - rvn-stacked-file-images :fileIds=${character.spritePreviewFileIds} w=200 h=120 br=sm lazy: null
@@ -127,35 +127,35 @@ template:
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${character.displayName}
                                   - rtgl-view w=1fg g=sm:
                                       - rtgl-text s=sm c=mu-fg: Transform
-                                      - rtgl-select#transform${i} data-index=${i} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
+                                      - rtgl-select#transform${i} data-index=${character.characterIndex} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
                                       - rtgl-text s=sm c=mu-fg: Opacity
-                                      - rtgl-slider-input#opacity${i} data-index=${i} key=${character.id} min=0 max=1 step=0.01 w=f value=${character.opacity}: null
+                                      - rtgl-slider-input#opacity${i} data-index=${character.characterIndex} key=${character.id} min=0 max=1 step=0.01 w=f value=${character.opacity}: null
                                       - rtgl-text s=sm c=mu-fg: Blur
-                                      - rtgl-segmented-control#blurToggle${i} data-index=${i} w=f no-clear :selectedValue=${character.blurEnabled} :options=${defaultValues.blurToggleOptions}: null
+                                      - rtgl-segmented-control#blurToggle${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.blurEnabled} :options=${defaultValues.blurToggleOptions}: null
                                       - $if character.blurEnabled:
                                           - rtgl-view d=h wrap g=sm w=f:
                                               - rtgl-view w=90 g=xs:
                                                   - rtgl-text s=xs c=mu-fg: X
-                                                  - rtgl-input#blurX${i} data-index=${i} data-blur-field=x type=number w=f value=${character.blur.x}: null
+                                                  - rtgl-input#blurX${i} data-index=${character.characterIndex} data-blur-field=x type=number w=f value=${character.blur.x}: null
                                               - rtgl-view w=90 g=xs:
                                                   - rtgl-text s=xs c=mu-fg: Y
-                                                  - rtgl-input#blurY${i} data-index=${i} data-blur-field=y type=number w=f value=${character.blur.y}: null
+                                                  - rtgl-input#blurY${i} data-index=${character.characterIndex} data-blur-field=y type=number w=f value=${character.blur.y}: null
                                               - rtgl-view w=90 g=xs:
                                                   - rtgl-text s=xs c=mu-fg: Quality
-                                                  - rtgl-input#blurQuality${i} data-index=${i} data-blur-field=quality type=number min=1 step=1 w=f value=${character.blur.quality}: null
+                                                  - rtgl-input#blurQuality${i} data-index=${character.characterIndex} data-blur-field=quality type=number min=1 step=1 w=f value=${character.blur.quality}: null
                                               - rtgl-view w=120 g=xs:
                                                   - rtgl-text s=xs c=mu-fg: Kernel
-                                                  - rtgl-select#blurKernelSize${i} data-index=${i} data-blur-field=kernelSize w=f no-clear :selectedValue=${character.blur.kernelSize} :options=${defaultValues.blurKernelSizeOptions}: null
+                                                  - rtgl-select#blurKernelSize${i} data-index=${character.characterIndex} data-blur-field=kernelSize w=f no-clear :selectedValue=${character.blur.kernelSize} :options=${defaultValues.blurKernelSizeOptions}: null
                                               - rtgl-view w=160 g=xs:
                                                   - rtgl-text s=xs c=mu-fg: Repeat Edge
-                                                  - rtgl-segmented-control#blurRepeatEdgePixels${i} data-index=${i} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${character.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}: null
+                                                  - rtgl-segmented-control#blurRepeatEdgePixels${i} data-index=${character.characterIndex} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${character.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}: null
                                       - rtgl-text s=sm c=mu-fg: Animation
-                                      - rtgl-select#animation${i} data-index=${i} key=${character.animationId} :options=${defaultValues.animationOptions} :selectedValue=${character.animationId} w=f placeholder="Select animation": null
+                                      - rtgl-select#animation${i} data-index=${character.characterIndex} key=${character.animationId} :options=${defaultValues.animationOptions} :selectedValue=${character.animationId} w=f placeholder="Select animation": null
                                       - $if character.showSpriteGroupBoxes:
                                           - rtgl-text s=sm c=mu-fg: Sprite Groups
                                           - rtgl-view d=h wrap g=xs w=f:
                                               - $for spriteGroup, j in character.spriteGroupBoxes:
-                                                  - 'rtgl-view.characterSpriteGroupBox data-index=${i} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
+                                                  - 'rtgl-view.characterSpriteGroupBox data-index=${character.characterIndex} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
                                                       - rtgl-text s=xs: ${spriteGroup.name}
                   - rtgl-button#addCharacterButton v=ol w=f mt=md: + Add Character
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -97,7 +97,9 @@ const buildVisualItemsFromState = (
       }),
       resourceId: tempSelectedResourceId,
       resourceType: tempSelectedResourceType,
-      transformId: store.selectDefaultTransformId?.(),
+      transformId:
+        store.selectPendingVisualTransformId?.() ??
+        store.selectDefaultTransformId?.(),
       layer: store.selectPendingVisualLayer?.(),
     });
     return orderVisualItemsForSave(visualItems);
@@ -202,7 +204,8 @@ export const handleVisualClick = (deps, payload) => {
   const index = parseInt(payload._event.currentTarget.dataset.index);
   const visual = store.selectSelectedVisuals()?.[index];
 
-  store.clearPendingVisualLayer?.();
+  store.clearPendingVisualConfig?.();
+  store.hideAddVisualPopover?.();
   store.setSelectedVisualIndex({ index });
   if (visual?.resourceType) {
     store.setTab({ tab: visual.resourceType });
@@ -387,11 +390,43 @@ export const handleSubmitClick = (deps) => {
 export const handleAddVisualClick = (deps, payload = {}) => {
   const { store, render } = deps;
 
-  store.clearPendingVisualLayer?.();
-  store.showAddVisualLayerDropdownMenu({
+  store.clearPendingVisualConfig?.();
+  store.hideDropdownMenu?.();
+  store.openAddVisualPopover({
     position: getDropdownPositionFromEvent(payload._event),
   });
 
+  render();
+};
+
+export const handleAddVisualPopoverClose = (deps) => {
+  const { store, render } = deps;
+  store.hideAddVisualPopover();
+  store.clearPendingVisualConfig?.();
+  render();
+};
+
+export const handleAddVisualFormAction = (deps, payload) => {
+  const { store, render } = deps;
+  const detail = payload._event.detail;
+  if (detail.actionId !== "submit") {
+    return;
+  }
+
+  const values = detail.values ?? {};
+  store.setPendingVisualTransformId({
+    transformId: values.transformId,
+  });
+  store.setPendingVisualLayer({
+    layer: values.layer,
+  });
+  store.hideAddVisualPopover();
+  store.setSelectedVisualIndex({ index: -1 });
+  store.setTempSelectedResourceId({
+    resourceId: undefined,
+    resourceType: undefined,
+  });
+  store.setMode({ mode: "resource-select" });
   render();
 };
 
@@ -399,7 +434,8 @@ export const handleBreadcumbClick = (deps, payload) => {
   const { dispatchEvent, store, render } = deps;
 
   if (payload._event.detail.id === "actions") {
-    store.clearPendingVisualLayer?.();
+    store.hideAddVisualPopover?.();
+    store.clearPendingVisualConfig?.();
     dispatchEvent(
       new CustomEvent("back-to-actions", {
         detail: {},
@@ -409,7 +445,8 @@ export const handleBreadcumbClick = (deps, payload) => {
     store.setMode({
       mode: "current",
     });
-    store.clearPendingVisualLayer?.();
+    store.hideAddVisualPopover?.();
+    store.clearPendingVisualConfig?.();
     render();
     dispatchTemporaryPresentationStateChange(deps);
   }
@@ -447,9 +484,12 @@ export const handleButtonSelectClick = (deps) => {
       store.addVisual({
         resourceId: tempSelectedResourceId,
         resourceType: tempSelectedResourceType,
+        transformId:
+          store.selectPendingVisualTransformId?.() ??
+          store.selectDefaultTransformId?.(),
         layer: store.selectPendingVisualLayer?.(),
       });
-      store.clearPendingVisualLayer?.();
+      store.clearPendingVisualConfig?.();
     } else {
       // Updating existing visual
       store.updateVisualResource({
@@ -481,14 +521,9 @@ export const handleDropdownMenuClose = (deps) => {
 export const handleDropdownMenuClickItem = (deps, payload) => {
   const { store, render } = deps;
   const { item } = payload._event.detail;
-  const dropdownMenuType = store.selectDropdownMenuType?.();
   const visualIndex = store.selectDropdownMenuVisualIndex();
 
-  if (dropdownMenuType === "add-visual-layer") {
-    store.setPendingVisualLayer({ layer: item.layer });
-    store.setSelectedVisualIndex({ index: -1 }); // -1 indicates new visual
-    store.setMode({ mode: "resource-select" });
-  } else if (item.value === "delete" && visualIndex !== null) {
+  if (item.value === "delete" && visualIndex !== null) {
     store.removeVisual({ index: visualIndex });
   } else if (item.value === "move-up" && visualIndex !== null) {
     store.moveVisual({ index: visualIndex, offset: 1 });

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -110,13 +110,41 @@ const createVisualDropdownItems = (visualIndex, visuals = []) => {
   return items;
 };
 
-const createAddVisualLayerDropdownItems = () =>
-  VISUAL_LAYER_OPTIONS.map((option) => ({
-    label: option.label,
-    layer: option.value,
-    type: "item",
-    value: `add-layer:${option.value}`,
-  }));
+const createAddVisualPopover = () => ({
+  isOpen: false,
+  position: { x: 0, y: 0 },
+});
+
+const createAddVisualForm = ({ transformOptions, layerOptions } = {}) => ({
+  title: "Add Visual",
+  fields: [
+    {
+      name: "transformId",
+      type: "select",
+      label: "Transform",
+      options: transformOptions,
+      clearable: false,
+      placeholder: "Select transform",
+    },
+    {
+      name: "layer",
+      type: "select",
+      label: "Layer",
+      options: layerOptions,
+      clearable: false,
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "submit",
+        variant: "pr",
+        label: "Select Resource",
+      },
+    ],
+  },
+});
 
 const isHierarchyCollection = (value) =>
   !!value &&
@@ -422,6 +450,7 @@ export const createInitialState = () => ({
   selectedVisuals: [],
   tempSelectedResourceId: undefined,
   tempSelectedResourceType: undefined,
+  pendingVisualTransformId: undefined,
   pendingVisualLayer: undefined,
   selectedVisualIndex: undefined,
   searchQuery: "",
@@ -434,6 +463,7 @@ export const createInitialState = () => ({
     visualIndex: null,
     items: [{ label: "Delete", type: "item", value: "delete" }],
   },
+  addVisualPopover: createAddVisualPopover(),
 });
 
 export const setMode = ({ state }, { mode } = {}) => {
@@ -483,13 +513,13 @@ const getDefaultTransformId = (state) => {
 
 export const addVisual = (
   { state },
-  { resourceId, resourceType, layer } = {},
+  { resourceId, resourceType, transformId, layer } = {},
 ) => {
   const defaultTransform = getDefaultTransformId(state);
   const visual = {
     id: generateVisualId(),
     resourceId: resourceId,
-    transformId: defaultTransform,
+    transformId: transformId ?? defaultTransform,
     layer: normalizeVisualLayer(layer),
     animationMode: "none",
   };
@@ -673,6 +703,22 @@ export const clearPendingVisualLayer = ({ state }, _payload = {}) => {
   state.pendingVisualLayer = undefined;
 };
 
+export const setPendingVisualTransformId = (
+  { state },
+  { transformId } = {},
+) => {
+  state.pendingVisualTransformId = transformId;
+};
+
+export const clearPendingVisualTransformId = ({ state }, _payload = {}) => {
+  state.pendingVisualTransformId = undefined;
+};
+
+export const clearPendingVisualConfig = ({ state }, _payload = {}) => {
+  state.pendingVisualLayer = undefined;
+  state.pendingVisualTransformId = undefined;
+};
+
 export const setSearchQuery = ({ state }, { value } = {}) => {
   state.searchQuery = value ?? "";
 };
@@ -707,6 +753,10 @@ export const selectPendingVisualLayer = ({ state }) => {
   return state.pendingVisualLayer ?? DEFAULT_VISUAL_LAYER;
 };
 
+export const selectPendingVisualTransformId = ({ state }) => {
+  return state.pendingVisualTransformId ?? getDefaultTransformId(state);
+};
+
 export const showDropdownMenu = ({ state }, { position, visualIndex } = {}) => {
   state.dropdownMenu.isOpen = true;
   state.dropdownMenu.position = position ?? { x: 0, y: 0 };
@@ -718,15 +768,16 @@ export const showDropdownMenu = ({ state }, { position, visualIndex } = {}) => {
   );
 };
 
-export const showAddVisualLayerDropdownMenu = (
-  { state },
-  { position } = {},
-) => {
-  state.dropdownMenu.isOpen = true;
-  state.dropdownMenu.position = position ?? { x: 0, y: 0 };
-  state.dropdownMenu.type = "add-visual-layer";
-  state.dropdownMenu.visualIndex = null;
-  state.dropdownMenu.items = createAddVisualLayerDropdownItems();
+export const openAddVisualPopover = ({ state }, { position } = {}) => {
+  state.addVisualPopover.isOpen = true;
+  state.addVisualPopover.position = position ?? { x: 0, y: 0 };
+  state.pendingVisualTransformId =
+    state.pendingVisualTransformId ?? getDefaultTransformId(state);
+  state.pendingVisualLayer = state.pendingVisualLayer ?? DEFAULT_VISUAL_LAYER;
+};
+
+export const hideAddVisualPopover = ({ state }, _payload = {}) => {
+  state.addVisualPopover = createAddVisualPopover();
 };
 
 export const hideDropdownMenu = ({ state }, _payload = {}) => {
@@ -998,6 +1049,10 @@ export const selectViewData = ({ state }) => {
     blurKernelSizeOptions: COMMAND_LINE_ITEM_BLUR_KERNEL_SIZE_SELECT_OPTIONS,
     blurRepeatEdgeOptions: COMMAND_LINE_ITEM_BLUR_REPEAT_EDGE_OPTIONS,
   };
+  const addVisualDefaultValues = {
+    transformId: state.pendingVisualTransformId ?? getDefaultTransformId(state),
+    layer: state.pendingVisualLayer ?? DEFAULT_VISUAL_LAYER,
+  };
 
   return {
     mode: state.mode,
@@ -1016,5 +1071,16 @@ export const selectViewData = ({ state }) => {
     breadcrumb,
     defaultValues,
     dropdownMenu: state.dropdownMenu,
+    addVisualPopover: {
+      ...state.addVisualPopover,
+      key: state.addVisualPopover.isOpen
+        ? `${addVisualDefaultValues.transformId ?? ""}-${addVisualDefaultValues.layer}`
+        : "closed",
+    },
+    addVisualForm: createAddVisualForm({
+      transformOptions,
+      layerOptions: VISUAL_LAYER_OPTIONS,
+    }),
+    addVisualDefaultValues,
   };
 };

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -3,6 +3,14 @@ refs:
     eventListeners:
       click:
         handler: handleAddVisualClick
+  addVisualPopover:
+    eventListeners:
+      close:
+        handler: handleAddVisualPopoverClose
+  addVisualForm:
+    eventListeners:
+      form-action:
+        handler: handleAddVisualFormAction
   removeVisual*:
     eventListeners:
       click:
@@ -204,6 +212,8 @@ template:
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
+  - rtgl-popover#addVisualPopover ?open=${addVisualPopover.isOpen} x=${addVisualPopover.position.x} y=${addVisualPopover.position.y} place=bs:
+      - rtgl-form#addVisualForm key=${addVisualPopover.key} slot=content :defaultValues=${addVisualDefaultValues} :form=${addVisualForm} w=320: null
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -680,10 +680,53 @@ export const handleTransformPreviewImageClick = (deps, payload) => {
   const { render, store } = deps;
   const target = payload._event.currentTarget?.dataset?.target;
 
+  store.closePreviewImageMenu();
   store.openPreviewImageSelectorDialog({
     target,
   });
   render();
+};
+
+export const handleTransformPreviewImageContextMenu = (deps, payload) => {
+  const { render, store } = deps;
+  const event = payload._event;
+  const target = event.currentTarget?.dataset?.target;
+
+  event.preventDefault();
+  event.stopPropagation();
+  store.openPreviewImageMenu({
+    target,
+    x: event.clientX,
+    y: event.clientY,
+  });
+  render();
+};
+
+export const handleTransformPreviewImageMenuClose = (deps) => {
+  const { render, store } = deps;
+  store.closePreviewImageMenu();
+  render();
+};
+
+export const handleTransformPreviewImageMenuItemClick = async (
+  deps,
+  payload,
+) => {
+  const { render, store } = deps;
+  const detail = payload._event.detail;
+  const item = detail?.item || detail;
+  const target = store.selectPreviewImageMenuTarget();
+
+  store.closePreviewImageMenu();
+
+  if (item?.value !== "remove" || !target) {
+    render();
+    return;
+  }
+
+  store.clearPreviewImage({ target });
+  render();
+  await renderDialogPreviewFromStore(deps);
 };
 
 export const handleTransformPreviewImageSelected = async (deps, payload) => {

--- a/src/pages/transforms/transforms.store.js
+++ b/src/pages/transforms/transforms.store.js
@@ -168,6 +168,14 @@ const createPreviewImageSelectorDialog = () => ({
   originalImageId: undefined,
 });
 
+const createPreviewImageMenu = () => ({
+  isOpen: false,
+  x: 0,
+  y: 0,
+  target: undefined,
+  items: [],
+});
+
 const resolvePreviewImageId = (preview, slotKey) => {
   const imageId = preview?.[slotKey]?.imageId;
   return typeof imageId === "string" && imageId.length > 0
@@ -392,6 +400,7 @@ export const createInitialState = () => ({
   dialogPreviewBackgroundImageId: undefined,
   dialogPreviewTargetImageId: undefined,
   imageSelectorDialog: createPreviewImageSelectorDialog(),
+  previewImageMenu: createPreviewImageMenu(),
   fullImagePreviewVisible: false,
   fullImagePreviewImageId: undefined,
   fullImagePreviewFileId: undefined,
@@ -479,6 +488,7 @@ const setDialogState = (state, options = {}) => {
     "target",
   );
   state.imageSelectorDialog = createPreviewImageSelectorDialog();
+  state.previewImageMenu = createPreviewImageMenu();
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewImageId = undefined;
   state.fullImagePreviewFileId = undefined;
@@ -516,6 +526,7 @@ export const closeTransformFormDialog = ({ state }, _payload = {}) => {
   state.dialogPreviewBackgroundImageId = undefined;
   state.dialogPreviewTargetImageId = undefined;
   state.imageSelectorDialog = createPreviewImageSelectorDialog();
+  state.previewImageMenu = createPreviewImageMenu();
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewImageId = undefined;
   state.fullImagePreviewFileId = undefined;
@@ -577,6 +588,10 @@ export const selectDialogPreviewData = ({ state }) => {
   return Object.keys(preview).length > 0 ? preview : undefined;
 };
 
+export const selectPreviewImageMenuTarget = ({ state }) => {
+  return state.previewImageMenu.target;
+};
+
 export const openPreviewImageSelectorDialog = ({ state }, { target } = {}) => {
   const slotConfig = getPreviewSlotConfig(target);
   if (!slotConfig) {
@@ -588,6 +603,37 @@ export const openPreviewImageSelectorDialog = ({ state }, { target } = {}) => {
   const imageId = selectPreviewImageIdFromState(state, target);
   state.imageSelectorDialog.selectedImageId = imageId;
   state.imageSelectorDialog.originalImageId = imageId;
+};
+
+export const openPreviewImageMenu = ({ state }, { target, x, y } = {}) => {
+  const slotConfig = getPreviewSlotConfig(target);
+  const imageId = selectPreviewImageIdFromState(state, target);
+  state.previewImageMenu = createPreviewImageMenu();
+
+  if (!slotConfig || !imageId) {
+    return;
+  }
+
+  state.previewImageMenu.isOpen = true;
+  state.previewImageMenu.x = x;
+  state.previewImageMenu.y = y;
+  state.previewImageMenu.target = target;
+  state.previewImageMenu.items = [
+    { label: "Remove", type: "item", value: "remove" },
+  ];
+};
+
+export const closePreviewImageMenu = ({ state }, _payload = {}) => {
+  state.previewImageMenu = createPreviewImageMenu();
+};
+
+export const clearPreviewImage = ({ state }, { target } = {}) => {
+  const slotConfig = getPreviewSlotConfig(target);
+  if (!slotConfig) {
+    return;
+  }
+
+  setPreviewImageIdInState(state, target, undefined);
 };
 
 export const closePreviewImageSelectorDialog = ({ state }, _payload = {}) => {
@@ -647,6 +693,7 @@ export const selectViewData = (context) => {
     fullImagePreviewVisible: context.state.fullImagePreviewVisible,
     fullImagePreviewImageId: context.state.fullImagePreviewImageId,
     fullImagePreviewFileId: context.state.fullImagePreviewFileId,
+    previewImageMenu: context.state.previewImageMenu,
   };
 };
 

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -67,6 +67,14 @@ refs:
     eventListeners:
       click:
         handler: handleTransformPreviewImageClick
+      contextmenu:
+        handler: handleTransformPreviewImageContextMenu
+  transformPreviewImageMenu:
+    eventListeners:
+      close:
+        handler: handleTransformPreviewImageMenuClose
+      item-click:
+        handler: handleTransformPreviewImageMenuItemClick
   transformPreviewImageSelectorDialog:
     eventListeners:
       close:
@@ -227,6 +235,7 @@ template:
                                     $else:
                                       - 'rtgl-view#transformPreviewImageButton${i} data-target=${item.target} w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
                                           - rtgl-text c=mu-fg s=sm: Select image
+  - rtgl-dropdown-menu#transformPreviewImageMenu :items=${previewImageMenu.items} ?open=${previewImageMenu.isOpen} x=${previewImageMenu.x} y=${previewImageMenu.y}: null
   - rtgl-dialog#transformPreviewImageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
       - $if imageSelectorDialog.open:
           - rtgl-view slot=content d=v w=f g=md:

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -23,6 +23,7 @@ import {
   clearTempSelectedSpriteIds,
   clearPendingCharacterIndex,
   createInitialState,
+  moveCharacter,
   removeCharacter,
   selectCurrentSpriteSelectionGroups,
   selectAddCharacterTransformDropdownItems,
@@ -68,6 +69,7 @@ const createStoreApi = (state) => ({
     state.dropdownMenu.isOpen = false;
     state.dropdownMenu.characterIndex = null;
   },
+  moveCharacter: (payload) => moveCharacter({ state }, payload),
   removeCharacter: (payload) => removeCharacter({ state }, payload),
   selectAddCharacterTransformDropdownItems: () =>
     selectAddCharacterTransformDropdownItems({ state }),
@@ -1225,6 +1227,86 @@ describe("commandLineCharacters.handlers", () => {
     expect(state.dropdownMenu.isOpen).toBe(false);
     expect(state.dropdownMenu.characterIndex).toBeNull();
     expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("moves the character referenced by the dropdown menu", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          { id: "character-1" },
+          { id: "character-2" },
+          { id: "character-3" },
+        ],
+      },
+    );
+    showDropdownMenu(
+      { state },
+      {
+        position: { x: 10, y: 20 },
+        characterIndex: 0,
+      },
+    );
+
+    handleDropdownMenuClickItem(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            item: {
+              value: "move-up",
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.selectedCharacters.map((character) => character.id)).toEqual([
+      "character-2",
+      "character-1",
+      "character-3",
+    ]);
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(state.dropdownMenu.characterIndex).toBeNull();
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          presentationState: {
+            character: {
+              items: [
+                {
+                  id: "character-2",
+                  transformId: undefined,
+                  sprites: [],
+                  spriteName: "",
+                },
+                {
+                  id: "character-1",
+                  transformId: undefined,
+                  sprites: [],
+                  spriteName: "",
+                },
+                {
+                  id: "character-3",
+                  transformId: undefined,
+                  sprites: [],
+                  spriteName: "",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
   });
 
   it("allows sprite groups to be left empty when confirming", () => {

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  moveCharacter,
   selectViewData,
   setAnimations,
   setExistingCharacters,
@@ -9,6 +10,7 @@ import {
   setSelectedCharacterIndex,
   setSelectedSpriteGroupId,
   setTransforms,
+  showDropdownMenu,
   updateCharacterBlurEnabled,
   updateCharacterBlurField,
   updateCharacterOpacity,
@@ -218,6 +220,98 @@ describe("commandLineCharacters.store sprite group filtering", () => {
         selectedSpriteName: "No sprite",
         hasSelection: false,
         backgroundColor: "bg",
+      },
+    ]);
+  });
+
+  it("displays selected characters in reverse order while preserving source indices", () => {
+    const state = createInitialState();
+
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            "character-hero": {
+              id: "character-hero",
+              type: "character",
+              name: "Hero",
+            },
+            "character-rival": {
+              id: "character-rival",
+              type: "character",
+              name: "Rival",
+            },
+          },
+          tree: [{ id: "character-hero" }, { id: "character-rival" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+          },
+          {
+            id: "character-rival",
+          },
+        ],
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(
+      viewData.selectedCharacters.map((character) => character.id),
+    ).toEqual(["character-hero", "character-rival"]);
+    expect(
+      viewData.defaultValues.characters.map((character) => ({
+        id: character.id,
+        characterIndex: character.characterIndex,
+      })),
+    ).toEqual([
+      {
+        id: "character-rival",
+        characterIndex: 1,
+      },
+      {
+        id: "character-hero",
+        characterIndex: 0,
+      },
+    ]);
+
+    showDropdownMenu(
+      { state },
+      {
+        position: { x: 10, y: 20 },
+        characterIndex: 0,
+      },
+    );
+    expect(state.dropdownMenu.items).toEqual([
+      { label: "Move Up", type: "item", value: "move-up" },
+      { label: "Delete", type: "item", value: "delete" },
+    ]);
+
+    moveCharacter({ state }, { index: 0, offset: 1 });
+    expect(state.selectedCharacters.map((character) => character.id)).toEqual([
+      "character-rival",
+      "character-hero",
+    ]);
+    expect(
+      selectViewData({ state }).defaultValues.characters.map((character) => ({
+        id: character.id,
+        characterIndex: character.characterIndex,
+      })),
+    ).toEqual([
+      {
+        id: "character-hero",
+        characterIndex: 1,
+      },
+      {
+        id: "character-rival",
+        characterIndex: 0,
       },
     ]);
   });

--- a/tests/commandLineVisual/commandLineVisual.handlers.test.js
+++ b/tests/commandLineVisual/commandLineVisual.handlers.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleAddVisualFormAction,
   handleAddVisualClick,
   handleAnimationChange,
   handleBlurFieldChange,
@@ -16,10 +17,14 @@ import {
 } from "../../src/components/commandLineVisual/commandLineVisual.handlers.js";
 import {
   addVisual,
+  clearPendingVisualConfig,
   clearPendingVisualLayer,
+  clearPendingVisualTransformId,
   createInitialState,
+  hideAddVisualPopover,
   hideDropdownMenu,
   moveVisual,
+  openAddVisualPopover,
   removeVisual,
   selectDefaultTransformId,
   selectDefaultVisualLayer,
@@ -27,6 +32,7 @@ import {
   selectDropdownMenuVisualIndex,
   selectMode,
   selectPendingVisualLayer,
+  selectPendingVisualTransformId,
   selectSelectedVisuals,
   selectSelectedVisualIndex,
   selectTab,
@@ -36,11 +42,11 @@ import {
   setExistingVisuals,
   setMode,
   setPendingVisualLayer,
+  setPendingVisualTransformId,
   setSelectedVisualIndex,
   setTab,
   setTempSelectedResourceId,
   setTransforms,
-  showAddVisualLayerDropdownMenu,
   showDropdownMenu,
   updateVisualResource,
   updateVisualAnimation,
@@ -52,10 +58,16 @@ import {
 
 const createStoreApi = (state) => ({
   addVisual: (payload) => addVisual({ state }, payload),
+  clearPendingVisualConfig: (payload) =>
+    clearPendingVisualConfig({ state }, payload),
   clearPendingVisualLayer: (payload) =>
     clearPendingVisualLayer({ state }, payload),
+  clearPendingVisualTransformId: (payload) =>
+    clearPendingVisualTransformId({ state }, payload),
+  hideAddVisualPopover: (payload) => hideAddVisualPopover({ state }, payload),
   hideDropdownMenu: (payload) => hideDropdownMenu({ state }, payload),
   moveVisual: (payload) => moveVisual({ state }, payload),
+  openAddVisualPopover: (payload) => openAddVisualPopover({ state }, payload),
   removeVisual: (payload) => removeVisual({ state }, payload),
   selectDefaultTransformId: () => selectDefaultTransformId({ state }),
   selectDefaultVisualLayer: () => selectDefaultVisualLayer({ state }),
@@ -63,6 +75,8 @@ const createStoreApi = (state) => ({
   selectDropdownMenuVisualIndex: () => selectDropdownMenuVisualIndex({ state }),
   selectMode: () => selectMode({ state }),
   selectPendingVisualLayer: () => selectPendingVisualLayer({ state }),
+  selectPendingVisualTransformId: () =>
+    selectPendingVisualTransformId({ state }),
   selectSelectedVisualIndex: () => selectSelectedVisualIndex({ state }),
   selectSelectedVisuals: () => selectSelectedVisuals({ state }),
   selectTab: () => selectTab({ state }),
@@ -71,13 +85,13 @@ const createStoreApi = (state) => ({
     selectTempSelectedResourceType({ state }),
   setMode: (payload) => setMode({ state }, payload),
   setPendingVisualLayer: (payload) => setPendingVisualLayer({ state }, payload),
+  setPendingVisualTransformId: (payload) =>
+    setPendingVisualTransformId({ state }, payload),
   setSelectedVisualIndex: (payload) =>
     setSelectedVisualIndex({ state }, payload),
   setTab: (payload) => setTab({ state }, payload),
   setTempSelectedResourceId: (payload) =>
     setTempSelectedResourceId({ state }, payload),
-  showAddVisualLayerDropdownMenu: (payload) =>
-    showAddVisualLayerDropdownMenu({ state }, payload),
   showDropdownMenu: (payload) => showDropdownMenu({ state }, payload),
   updateVisualAnimation: (payload) => updateVisualAnimation({ state }, payload),
   updateVisualBlurEnabled: (payload) =>
@@ -196,19 +210,39 @@ describe("commandLineVisual.handlers animation controls", () => {
               type: "transform",
               name: "Center",
             },
+            "visual-left": {
+              id: "visual-left",
+              type: "transform",
+              name: "Left",
+            },
           },
-          tree: [{ id: "visual-center" }],
+          tree: [{ id: "visual-center" }, { id: "visual-left" }],
         },
       },
     );
 
-    handleAddVisualClick({
-      store,
-      render,
+    handleAddVisualClick(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          currentTarget: {
+            getBoundingClientRect: () => ({
+              left: 24,
+              bottom: 64,
+            }),
+          },
+        },
+      },
+    );
+    expect(state.addVisualPopover).toMatchObject({
+      isOpen: true,
+      position: { x: 24, y: 64 },
     });
-    expect(selectDropdownMenuType({ state })).toBe("add-visual-layer");
 
-    handleDropdownMenuClickItem(
+    handleAddVisualFormAction(
       {
         store,
         render,
@@ -216,9 +250,10 @@ describe("commandLineVisual.handlers animation controls", () => {
       {
         _event: {
           detail: {
-            item: {
+            actionId: "submit",
+            values: {
+              transformId: "visual-left",
               layer: 70,
-              value: "add-layer:70",
             },
           },
         },
@@ -226,7 +261,9 @@ describe("commandLineVisual.handlers animation controls", () => {
     );
     expect(selectMode({ state })).toBe("resource-select");
     expect(selectSelectedVisualIndex({ state })).toBe(-1);
+    expect(selectPendingVisualTransformId({ state })).toBe("visual-left");
     expect(selectPendingVisualLayer({ state })).toBe(70);
+    expect(state.addVisualPopover.isOpen).toBe(false);
 
     handleResourceItemClick(
       {
@@ -258,7 +295,7 @@ describe("commandLineVisual.handlers animation controls", () => {
               id: "temporary-visual-preview-video",
               resourceId: "visual-video",
               resourceType: "video",
-              transformId: "visual-center",
+              transformId: "visual-left",
               layer: 70,
             },
           ],
@@ -645,7 +682,7 @@ describe("commandLineVisual.handlers animation controls", () => {
     });
   });
 
-  it("adds a new visual with the selected add-menu layer", () => {
+  it("adds a new visual with the selected add-form transform and layer", () => {
     const state = createInitialState();
     const render = vi.fn();
     const dispatchEvent = vi.fn();
@@ -658,6 +695,12 @@ describe("commandLineVisual.handlers animation controls", () => {
       { state },
       {
         layer: 10,
+      },
+    );
+    setPendingVisualTransformId(
+      { state },
+      {
+        transformId: "visual-left",
       },
     );
     setMode({ state }, { mode: "resource-select" });
@@ -681,6 +724,7 @@ describe("commandLineVisual.handlers animation controls", () => {
     expect(selectSelectedVisuals({ state })[0]).toMatchObject({
       resourceId: "visual-image",
       resourceType: "image",
+      transformId: "visual-left",
       layer: 10,
     });
     expect(selectMode({ state })).toBe("current");
@@ -692,6 +736,7 @@ describe("commandLineVisual.handlers animation controls", () => {
     ).toMatchObject({
       resourceId: "visual-image",
       resourceType: "image",
+      transformId: "visual-left",
       layer: 10,
     });
   });

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   addVisual,
+  clearPendingVisualConfig,
   clearPendingVisualLayer,
+  clearPendingVisualTransformId,
   createInitialState,
+  hideAddVisualPopover,
   moveVisual,
+  openAddVisualPopover,
   selectDefaultVisualLayer,
   selectPendingVisualLayer,
+  selectPendingVisualTransformId,
   selectSelectedVisuals,
   selectViewData,
   setAnimations,
@@ -13,10 +18,10 @@ import {
   setImages,
   setLayouts,
   setPendingVisualLayer,
+  setPendingVisualTransformId,
   setTab,
   setTransforms,
   setVideos,
-  showAddVisualLayerDropdownMenu,
   showDropdownMenu,
   updateVisualAnimation,
   updateVisualBlurEnabled,
@@ -384,48 +389,93 @@ describe("commandLineVisual.store animation controls", () => {
     });
   });
 
-  it("builds add visual layer menu options and tracks the selected pending layer", () => {
+  it("builds add visual popover form options and tracks pending values", () => {
     const state = createInitialState();
+    setRepositoryCollections(state);
 
-    showAddVisualLayerDropdownMenu(
+    openAddVisualPopover(
       { state },
       {
         position: { x: 24, y: 48 },
       },
     );
 
-    expect(selectViewData({ state }).dropdownMenu).toMatchObject({
+    let viewData = selectViewData({ state });
+
+    expect(viewData.addVisualPopover).toMatchObject({
       isOpen: true,
       position: { x: 24, y: 48 },
-      type: "add-visual-layer",
-      visualIndex: null,
-      items: [
-        {
-          label: "Behind Background",
-          layer: 10,
-          type: "item",
-          value: "add-layer:10",
-        },
-        {
-          label: "Behind Character",
-          layer: 30,
-          type: "item",
-          value: "add-layer:30",
-        },
-        {
-          label: "Behind Dialogue",
-          layer: 50,
-          type: "item",
-          value: "add-layer:50",
-        },
-        {
-          label: "Foreground",
-          layer: 70,
-          type: "item",
-          value: "add-layer:70",
-        },
-      ],
     });
+    expect(viewData.addVisualDefaultValues).toEqual({
+      transformId: "visual-center",
+      layer: 50,
+    });
+    expect(viewData.addVisualForm.fields).toEqual([
+      {
+        name: "transformId",
+        type: "select",
+        label: "Transform",
+        options: [
+          {
+            label: "Center",
+            value: "visual-center",
+          },
+        ],
+        clearable: false,
+        placeholder: "Select transform",
+      },
+      {
+        name: "layer",
+        type: "select",
+        label: "Layer",
+        options: [
+          {
+            value: 10,
+            label: "Behind Background",
+          },
+          {
+            value: 30,
+            label: "Behind Character",
+          },
+          {
+            value: 50,
+            label: "Behind Dialogue",
+          },
+          {
+            value: 70,
+            label: "Foreground",
+          },
+        ],
+        clearable: false,
+      },
+    ]);
+
+    setPendingVisualTransformId(
+      { state },
+      {
+        transformId: "visual-center",
+      },
+    );
+    setPendingVisualLayer(
+      { state },
+      {
+        layer: 70,
+      },
+    );
+    expect(selectPendingVisualTransformId({ state })).toBe("visual-center");
+    expect(selectPendingVisualLayer({ state })).toBe(70);
+
+    viewData = selectViewData({ state });
+    expect(viewData.addVisualDefaultValues).toEqual({
+      transformId: "visual-center",
+      layer: 70,
+    });
+
+    clearPendingVisualLayer({ state });
+    expect(selectPendingVisualLayer({ state })).toBe(50);
+
+    clearPendingVisualTransformId({ state });
+    expect(selectPendingVisualTransformId({ state })).toBe("visual-center");
 
     setPendingVisualLayer(
       { state },
@@ -433,10 +483,15 @@ describe("commandLineVisual.store animation controls", () => {
         layer: 70,
       },
     );
-    expect(selectPendingVisualLayer({ state })).toBe(70);
+    clearPendingVisualConfig({ state });
+    expect(state.pendingVisualLayer).toBeUndefined();
+    expect(state.pendingVisualTransformId).toBeUndefined();
 
-    clearPendingVisualLayer({ state });
-    expect(selectPendingVisualLayer({ state })).toBe(50);
+    hideAddVisualPopover({ state });
+    expect(selectViewData({ state }).addVisualPopover).toMatchObject({
+      isOpen: false,
+      position: { x: 0, y: 0 },
+    });
   });
 
   it("adds visuals with the provided layer", () => {
@@ -455,6 +510,48 @@ describe("commandLineVisual.store animation controls", () => {
     expect(selectSelectedVisuals({ state })[0]).toMatchObject({
       resourceId: "visual-image",
       resourceType: "image",
+      layer: 10,
+    });
+  });
+
+  it("adds visuals with the provided transform", () => {
+    const state = createInitialState();
+    setRepositoryCollections(state);
+    setTransforms(
+      { state },
+      {
+        transforms: {
+          items: {
+            "visual-center": {
+              id: "visual-center",
+              type: "transform",
+              name: "Center",
+            },
+            "visual-left": {
+              id: "visual-left",
+              type: "transform",
+              name: "Left",
+            },
+          },
+          tree: [{ id: "visual-center" }, { id: "visual-left" }],
+        },
+      },
+    );
+
+    addVisual(
+      { state },
+      {
+        resourceId: "visual-image",
+        resourceType: "image",
+        transformId: "visual-left",
+        layer: 10,
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      resourceId: "visual-image",
+      resourceType: "image",
+      transformId: "visual-left",
       layer: 10,
     });
   });

--- a/tests/transforms/transforms.handlers.test.js
+++ b/tests/transforms/transforms.handlers.test.js
@@ -1,7 +1,49 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleTransformPreviewImageSelected } from "../../src/pages/transforms/transforms.handlers.js";
+import {
+  handleTransformPreviewImageContextMenu,
+  handleTransformPreviewImageMenuItemClick,
+  handleTransformPreviewImageSelected,
+} from "../../src/pages/transforms/transforms.handlers.js";
 
 describe("transforms.handlers", () => {
+  it("opens the preview image context menu from the target slot", () => {
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const store = {
+      openPreviewImageMenu: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleTransformPreviewImageContextMenu(
+      {
+        render,
+        store,
+      },
+      {
+        _event: {
+          clientX: 64,
+          clientY: 96,
+          currentTarget: {
+            dataset: {
+              target: "preview-target",
+            },
+          },
+          preventDefault,
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(store.openPreviewImageMenu).toHaveBeenCalledWith({
+      target: "preview-target",
+      x: 64,
+      y: 96,
+    });
+    expect(render).toHaveBeenCalled();
+  });
+
   it("applies preview image selections and rerenders the route-graphics preview", async () => {
     const canvas = {};
     const backgroundImage = {
@@ -89,6 +131,82 @@ describe("transforms.handlers", () => {
             id: "bg",
             type: "sprite",
             src: "file-bg",
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("removes a preview image selection and rerenders the route-graphics preview", async () => {
+    const canvas = {};
+    const store = {
+      clearPreviewImage: vi.fn(),
+      closePreviewImageMenu: vi.fn(),
+      selectPreviewImageMenuTarget: vi.fn(() => "preview-background"),
+      selectDialogValues: vi.fn(() => ({
+        x: "100",
+        y: "120",
+        scaleX: "1",
+        scaleY: "1",
+        rotation: "0",
+        anchor: {
+          anchorX: 0.5,
+          anchorY: 0.5,
+        },
+      })),
+      selectProjectResolution: vi.fn(() => ({
+        width: 1920,
+        height: 1080,
+      })),
+      selectDialogPreviewBackgroundImage: vi.fn(() => undefined),
+      selectDialogPreviewTargetImage: vi.fn(() => undefined),
+    };
+    const graphicsService = {
+      attachCanvas: vi.fn(),
+      loadAssets: vi.fn(),
+      render: vi.fn(),
+    };
+    const render = vi.fn();
+
+    await handleTransformPreviewImageMenuItemClick(
+      {
+        graphicsService,
+        refs: {
+          canvas,
+        },
+        render,
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            item: {
+              value: "remove",
+            },
+          },
+        },
+      },
+    );
+
+    expect(store.closePreviewImageMenu).toHaveBeenCalled();
+    expect(store.clearPreviewImage).toHaveBeenCalledWith({
+      target: "preview-background",
+    });
+    expect(render).toHaveBeenCalled();
+    expect(graphicsService.attachCanvas).toHaveBeenCalledWith(canvas);
+    expect(graphicsService.loadAssets).not.toHaveBeenCalled();
+    expect(graphicsService.render).toHaveBeenNthCalledWith(1, {
+      elements: [],
+      animations: [],
+      audio: [],
+    });
+    expect(graphicsService.render).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        elements: expect.arrayContaining([
+          expect.objectContaining({
+            id: "bg",
+            type: "rect",
           }),
         ]),
       }),

--- a/tests/transforms/transforms.store.test.js
+++ b/tests/transforms/transforms.store.test.js
@@ -4,10 +4,14 @@ import {
   closePreviewImageSelectorDialog,
   commitPreviewImageSelectorSelection,
   createInitialState,
+  clearPreviewImage,
+  closePreviewImageMenu,
   openPreviewImageSelectorDialog,
+  openPreviewImageMenu,
   openTransformFormDialog,
   openTransformPreviewDialog,
   selectDialogPreviewData,
+  selectPreviewImageMenuTarget,
   selectViewData,
   setImagesData,
   showFullImagePreview,
@@ -84,6 +88,60 @@ describe("transforms.store", () => {
       image: expect.objectContaining({
         previewFileId: "thumb-bg",
       }),
+    });
+  });
+
+  it("opens a remove menu for selected preview images and clears the slot", () => {
+    const state = createInitialState();
+    setImagesData({ state }, { imagesData });
+    openTransformFormDialog({ state });
+    openPreviewImageSelectorDialog(
+      { state },
+      {
+        target: "preview-background",
+      },
+    );
+    applyPreviewImageSelectorSelection(
+      { state },
+      {
+        imageId: "image-bg",
+      },
+    );
+    commitPreviewImageSelectorSelection({ state });
+
+    openPreviewImageMenu(
+      { state },
+      {
+        target: "preview-background",
+        x: 120,
+        y: 240,
+      },
+    );
+
+    expect(selectPreviewImageMenuTarget({ state })).toBe("preview-background");
+    expect(selectViewData({ state }).previewImageMenu).toMatchObject({
+      isOpen: true,
+      x: 120,
+      y: 240,
+      items: [{ label: "Remove", type: "item", value: "remove" }],
+    });
+
+    clearPreviewImage(
+      { state },
+      {
+        target: "preview-background",
+      },
+    );
+    closePreviewImageMenu({ state });
+
+    expect(selectDialogPreviewData({ state })).toBeUndefined();
+    expect(selectViewData({ state }).previewPanel.items[0]).toMatchObject({
+      target: "preview-background",
+      image: undefined,
+    });
+    expect(selectViewData({ state }).previewImageMenu).toMatchObject({
+      isOpen: false,
+      items: [],
     });
   });
 


### PR DESCRIPTION
## Summary
- replace the command-line visual add-layer dropdown with a popover form that selects transform and layer before resource selection
- add right-click remove actions for transform background/target image previews
- update command-line character visuals to avoid full-height image tiles, reverse display order, and support right-click move up/down/delete actions

## Testing
- Focused Vitest coverage for command-line characters, command-line visuals, and transforms
- Push hook: `oxlint && bun prettier --check src`