### PR TITLE
feat: expand animation editor tween properties

### DIFF
--- a/src/internal/animationPreview.js
+++ b/src/internal/animationPreview.js
@@ -128,18 +128,18 @@ export const createPropertyFieldConfig = (
         step: 0.5,
       },
     },
-    uProgress: {
-      label: "Progress",
-      defaultValue: 0,
-      slider: {
-        min: 0,
-        max: 1,
-        step: 0.01,
-      },
-      tooltip: {
-        content: "Progress uniforms use a normalized value from 0 to 1.",
-      },
-    },
+    // uProgress: {
+    //   label: "Progress",
+    //   defaultValue: 0,
+    //   slider: {
+    //     min: 0,
+    //     max: 1,
+    //     step: 0.01,
+    //   },
+    //   tooltip: {
+    //     content: "Progress uniforms use a normalized value from 0 to 1.",
+    //   },
+    // },
   };
 };
 

--- a/src/internal/animationPreview.js
+++ b/src/internal/animationPreview.js
@@ -58,18 +58,30 @@ export const createPropertyFieldConfig = (
       label: "Scale X",
       defaultValue: 1,
       slider: {
-        min: 0.1,
+        min: 0,
         max: 5,
-        step: 0.1,
+        step: 0.01,
       },
     },
     scaleY: {
       label: "Scale Y",
       defaultValue: 1,
       slider: {
-        min: 0.1,
+        min: 0,
         max: 5,
-        step: 0.1,
+        step: 0.01,
+      },
+    },
+    rotation: {
+      label: "Rotation",
+      defaultValue: 0,
+      slider: {
+        min: -360,
+        max: 360,
+        step: 1,
+      },
+      tooltip: {
+        content: "Rotation is measured in degrees.",
       },
     },
     translateX: {
@@ -96,6 +108,36 @@ export const createPropertyFieldConfig = (
       tooltip: {
         content:
           "Uses viewport-height units. 1 moves by one full screen height, -1 moves by one full screen height upward.",
+      },
+    },
+    blurX: {
+      label: "Blur X",
+      defaultValue: 0,
+      slider: {
+        min: 0,
+        max: 64,
+        step: 0.5,
+      },
+    },
+    blurY: {
+      label: "Blur Y",
+      defaultValue: 0,
+      slider: {
+        min: 0,
+        max: 64,
+        step: 0.5,
+      },
+    },
+    uProgress: {
+      label: "Progress",
+      defaultValue: 0,
+      slider: {
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      tooltip: {
+        content: "Progress uniforms use a normalized value from 0 to 1.",
       },
     },
   };

--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -13,14 +13,29 @@ export const PREVIEW_TRANSITION_NEXT_FILL = "#000000";
 export const AUTO_TWEEN_DEFAULT_DURATION = 1000;
 export const AUTO_TWEEN_DEFAULT_EASING = "linear";
 
-export const UPDATE_PROPERTY_KEYS = ["alpha", "x", "y", "scaleX", "scaleY"];
+export const UPDATE_PROPERTY_KEYS = [
+  "alpha",
+  "x",
+  "y",
+  "translateX",
+  "translateY",
+  "scaleX",
+  "scaleY",
+  "rotation",
+  "blurX",
+  "blurY",
+  "uProgress",
+];
 
 export const TRANSITION_PROPERTY_KEYS = [
+  "x",
+  "y",
   "translateX",
   "translateY",
   "alpha",
   "scaleX",
   "scaleY",
+  "rotation",
 ];
 
 export const SUPPORTED_EASING_NAMES = Object.freeze([

--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -24,7 +24,7 @@ export const UPDATE_PROPERTY_KEYS = [
   "rotation",
   "blurX",
   "blurY",
-  "uProgress",
+  // "uProgress",
 ];
 
 export const TRANSITION_PROPERTY_KEYS = [

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -151,18 +151,18 @@ const createPropertyFieldConfig = (
         step: 0.5,
       },
     },
-    uProgress: {
-      label: "Progress",
-      defaultValue: 0,
-      slider: {
-        min: 0,
-        max: 1,
-        step: 0.01,
-      },
-      tooltip: {
-        content: "Progress uniforms use a normalized value from 0 to 1.",
-      },
-    },
+    // uProgress: {
+    //   label: "Progress",
+    //   defaultValue: 0,
+    //   slider: {
+    //     min: 0,
+    //     max: 1,
+    //     step: 0.01,
+    //   },
+    //   tooltip: {
+    //     content: "Progress uniforms use a normalized value from 0 to 1.",
+    //   },
+    // },
   };
 };
 

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -81,18 +81,30 @@ const createPropertyFieldConfig = (
       label: "Scale X",
       defaultValue: 1,
       slider: {
-        min: 0.1,
+        min: 0,
         max: 5,
-        step: 0.1,
+        step: 0.01,
       },
     },
     scaleY: {
       label: "Scale Y",
       defaultValue: 1,
       slider: {
-        min: 0.1,
+        min: 0,
         max: 5,
-        step: 0.1,
+        step: 0.01,
+      },
+    },
+    rotation: {
+      label: "Rotation",
+      defaultValue: 0,
+      slider: {
+        min: -360,
+        max: 360,
+        step: 1,
+      },
+      tooltip: {
+        content: "Rotation is measured in degrees.",
       },
     },
     translateX: {
@@ -119,6 +131,36 @@ const createPropertyFieldConfig = (
       tooltip: {
         content:
           "Uses viewport-height units. 1 moves by one full screen height, -1 moves by one full screen height upward.",
+      },
+    },
+    blurX: {
+      label: "Blur X",
+      defaultValue: 0,
+      slider: {
+        min: 0,
+        max: 64,
+        step: 0.5,
+      },
+    },
+    blurY: {
+      label: "Blur Y",
+      defaultValue: 0,
+      slider: {
+        min: 0,
+        max: 64,
+        step: 0.5,
+      },
+    },
+    uProgress: {
+      label: "Progress",
+      defaultValue: 0,
+      slider: {
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      tooltip: {
+        content: "Progress uniforms use a normalized value from 0 to 1.",
       },
     },
   };
@@ -957,11 +999,27 @@ const getPropertyOptionsForSide = (side, propertyFieldConfig) => {
   );
 };
 
+const PROPERTY_CONFLICTS = Object.freeze({
+  x: ["translateX"],
+  translateX: ["x"],
+  y: ["translateY"],
+  translateY: ["y"],
+});
+
+const hasPropertyConflict = (properties = {}, property) => {
+  return (PROPERTY_CONFLICTS[property] ?? []).some((conflictingProperty) =>
+    Object.prototype.hasOwnProperty.call(properties, conflictingProperty),
+  );
+};
+
 const getAvailableProperties = (state, side, propertyFieldConfig) => {
   const currentProperties = getSectionProperties(state, side);
 
   return getPropertyOptionsForSide(side, propertyFieldConfig).filter((item) => {
-    return !Object.keys(currentProperties).includes(item.value);
+    return (
+      !Object.prototype.hasOwnProperty.call(currentProperties, item.value) &&
+      !hasPropertyConflict(currentProperties, item.value)
+    );
   });
 };
 
@@ -1461,7 +1519,12 @@ export const addProperty = (
 ) => {
   const properties = getMutableSectionProperties(state, side);
 
-  if (!property || !properties || properties[property]) {
+  if (
+    !property ||
+    !properties ||
+    properties[property] ||
+    hasPropertyConflict(properties, property)
+  ) {
     return;
   }
 

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -720,10 +720,7 @@ export const handleSceneFormAction = async (deps, payload) => {
   const { store, render, projectService, appService } = deps;
   const actionId = payload._event.detail.actionId;
 
-  if (actionId === "cancel") {
-    store.resetSceneForm();
-    render();
-  } else if (actionId === "submit") {
+  if (actionId === "submit") {
     if (!store.getState().showSceneForm) {
       return;
     }

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -335,20 +335,15 @@ export const selectViewData = ({ state }) => {
   }
 
   const sceneFormFields = {
-    title: "Create New Scene",
+    title: "Create Scene",
     fields: sceneFormFieldsList,
     actions: {
       layout: "",
       buttons: [
         {
-          id: "cancel",
-          variant: "se",
-          label: "Cancel",
-        },
-        {
           id: "submit",
           variant: "pr",
-          label: "Create Scene",
+          label: "Create",
         },
       ],
     },

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -188,7 +188,6 @@ describe("animationEditor.store", () => {
       "rotation",
       "blurX",
       "blurY",
-      "uProgress",
     ]);
 
     updatePopoverFormValues(
@@ -229,26 +228,6 @@ describe("animationEditor.store", () => {
       min: 0,
       max: 64,
       step: 0.5,
-    });
-
-    updatePopoverFormValues(
-      { state },
-      {
-        formValues: {
-          property: "uProgress",
-        },
-      },
-    );
-    viewData = selectViewData({ state });
-    expect(
-      viewData.addPropertyForm.fields.find(
-        (field) => field.name === "initialValue",
-      ),
-    ).toMatchObject({
-      defaultValue: 0,
-      min: 0,
-      max: 1,
-      step: 0.01,
     });
   });
 

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -5,6 +5,7 @@ import {
   PREVIEW_UPDATE_ELEMENT_ID,
 } from "../../src/pages/animationEditor/animationEditor.constants.js";
 import {
+  addProperty,
   commitPendingTransitionMask,
   createInitialState,
   enableTransitionMask,
@@ -156,6 +157,193 @@ describe("animationEditor.store", () => {
       max: 1080,
       step: 0.01,
     });
+  });
+
+  it("exposes supported update properties with tuned value ranges", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "update",
+        },
+      },
+    );
+
+    let viewData = selectViewData({ state });
+    const propertyField = viewData.addPropertyForm.fields.find(
+      (field) => field.name === "property",
+    );
+
+    expect(propertyField.options.map((option) => option.value)).toEqual([
+      "alpha",
+      "x",
+      "y",
+      "translateX",
+      "translateY",
+      "scaleX",
+      "scaleY",
+      "rotation",
+      "blurX",
+      "blurY",
+      "uProgress",
+    ]);
+
+    updatePopoverFormValues(
+      { state },
+      {
+        formValues: {
+          property: "rotation",
+        },
+      },
+    );
+    viewData = selectViewData({ state });
+    expect(
+      viewData.addPropertyForm.fields.find(
+        (field) => field.name === "initialValue",
+      ),
+    ).toMatchObject({
+      defaultValue: 0,
+      min: -360,
+      max: 360,
+      step: 1,
+    });
+
+    updatePopoverFormValues(
+      { state },
+      {
+        formValues: {
+          property: "blurX",
+        },
+      },
+    );
+    viewData = selectViewData({ state });
+    expect(
+      viewData.addPropertyForm.fields.find(
+        (field) => field.name === "initialValue",
+      ),
+    ).toMatchObject({
+      defaultValue: 0,
+      min: 0,
+      max: 64,
+      step: 0.5,
+    });
+
+    updatePopoverFormValues(
+      { state },
+      {
+        formValues: {
+          property: "uProgress",
+        },
+      },
+    );
+    viewData = selectViewData({ state });
+    expect(
+      viewData.addPropertyForm.fields.find(
+        (field) => field.name === "initialValue",
+      ),
+    ).toMatchObject({
+      defaultValue: 0,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    });
+  });
+
+  it("exposes supported transition properties", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "transition" });
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "prev",
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    const propertyField = viewData.addPropertyForm.fields.find(
+      (field) => field.name === "property",
+    );
+
+    expect(propertyField.options.map((option) => option.value)).toEqual([
+      "x",
+      "y",
+      "translateX",
+      "translateY",
+      "alpha",
+      "scaleX",
+      "scaleY",
+      "rotation",
+    ]);
+  });
+
+  it("prevents absolute and viewport translation properties from sharing a tween axis", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+
+    addProperty(
+      { state },
+      {
+        side: "update",
+        property: "x",
+        tweenMode: "keyframes",
+      },
+    );
+    addProperty(
+      { state },
+      {
+        side: "update",
+        property: "translateX",
+        tweenMode: "keyframes",
+      },
+    );
+    addProperty(
+      { state },
+      {
+        side: "update",
+        property: "translateY",
+        tweenMode: "keyframes",
+      },
+    );
+    addProperty(
+      { state },
+      {
+        side: "update",
+        property: "y",
+        tweenMode: "keyframes",
+      },
+    );
+
+    expect(Object.keys(state.tweenBySection.update)).toEqual([
+      "x",
+      "translateY",
+    ]);
+
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "update",
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    const propertyField = viewData.addPropertyForm.fields.find(
+      (field) => field.name === "property",
+    );
+    const availableValues = propertyField.options.map((option) => option.value);
+
+    expect(availableValues).not.toContain("x");
+    expect(availableValues).not.toContain("translateX");
+    expect(availableValues).not.toContain("y");
+    expect(availableValues).not.toContain("translateY");
   });
 
   it("creates a single add-property initial value field for the selected property", () => {


### PR DESCRIPTION
## Summary
- add full animation editor tween property options for update and transition timelines
- hide and block conflicting x/translateX and y/translateY properties
- remove Cancel from the create scene popover and rename its title/action

## Testing
- bunx vitest run tests/animationEditor
- bunx vitest run tests/scenes
- push hook: oxlint && bun prettier --check src