### PR TITLE
Bundle unstaged UI updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,11 @@ This command:
 Notes:
 
 - `bun run build` may not exist in this repo; use `build:web` for validation.
-- Do not run `bun run build:web` after each change. The user is expected to be running a watch-mode session during active development.
+- Do not run `bun run build:web` for routine validation during active
+  development. The user usually has a watch-mode session running
+  (`bun run watch:web` or `bun run watch:tauri`). Only run `build:web` when the
+  user asks for it, when preparing release/VT output, or when there is a
+  specific build-only issue to verify.
 - Before pushing, run lint/format checks (the push hook also enforces this).
 
 Run tests:

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.5",
-        "@routevn/creator-model": "1.6.0",
+        "@routevn/creator-model": "1.6.2",
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "2.5.1",
@@ -310,7 +310,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.6.0", "", {}, "sha512-KtBCYLWG6lRZm3lJzoCjEs74AezznThZ7/yHOjEZN4aiQJhXuSsxZ8RJ87JMDOf8PYGoem+wzgnSsy3BLdcVJw=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.6.2", "", {}, "sha512-lWKfyY0IXEBemAXPjkBG1XHk2rqNMe9rN0Uh86bWykpTbESXjKJf1ws9nirW8iBggQ3H3avCjOjAcYS8g71pVw=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -77,6 +77,12 @@ This repo currently uses three main test styles:
 - YAML-driven Puty tests in `tests/puty/`
 - Rettangoli VT workflow specs in `vt/specs/`
 
+During active development, the user usually has a watch-mode session running
+(`bun run watch:web` or `bun run watch:tauri`). Do not run `bun run build:web`
+for routine validation of ordinary code or view edits. Prefer targeted tests,
+format checks, lint checks, and the active watch output. Reserve `build:web` for
+explicit user requests, release/VT output, or a specific build-only failure.
+
 Common commands:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.5",
-    "@routevn/creator-model": "1.6.0",
+    "@routevn/creator-model": "1.6.2",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "2.5.1",

--- a/src/components/commandLineScreen/commandLineScreen.handlers.js
+++ b/src/components/commandLineScreen/commandLineScreen.handlers.js
@@ -1,3 +1,45 @@
+const buildScreenDataFromState = (store) => {
+  const transitionAnimationId = store.selectTransitionAnimationId();
+  const opacity = store.selectScreenOpacity();
+  const blur = store.selectScreenBlur();
+
+  const screen = {};
+
+  if (transitionAnimationId) {
+    screen.animations = {
+      resourceId: transitionAnimationId,
+    };
+  }
+
+  if (opacity !== undefined) {
+    screen.opacity = opacity;
+  }
+
+  if (blur) {
+    screen.blur = blur;
+  }
+
+  return screen;
+};
+
+const dispatchTemporaryPresentationStateChange = (deps) => {
+  const { dispatchEvent, store } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("temporary-presentation-state-change", {
+      detail: {
+        presentationState: {
+          screen: buildScreenDataFromState(store),
+        },
+      },
+    }),
+  );
+};
+
 export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
@@ -30,29 +72,12 @@ export const handleFormChange = (deps, payload) => {
 
   store.setFormValues({ values });
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSubmitClick = (deps) => {
   const { dispatchEvent, store } = deps;
-  const transitionAnimationId = store.selectTransitionAnimationId();
-  const opacity = store.selectScreenOpacity();
-  const blur = store.selectScreenBlur();
-
-  const screen = {};
-
-  if (transitionAnimationId) {
-    screen.animations = {
-      resourceId: transitionAnimationId,
-    };
-  }
-
-  if (opacity !== undefined) {
-    screen.opacity = opacity;
-  }
-
-  if (blur) {
-    screen.blur = blur;
-  }
+  const screen = buildScreenDataFromState(store);
 
   dispatchEvent(
     new CustomEvent("submit", {

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -17,7 +17,10 @@ import {
   runResourcePageMutation,
   showResourcePageError,
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
-import { createFileExplorerKeyboardScopeHandlers } from "../../internal/ui/fileExplorerKeyboardScope.js";
+import {
+  createFileExplorerKeyboardScopeHandlers,
+  isTextEntryKeyEvent,
+} from "../../internal/ui/fileExplorerKeyboardScope.js";
 import {
   handleResourceZoomShortcutKeyDown,
   isResourceZoomShortcutKeyEvent,
@@ -182,6 +185,79 @@ const openSpritePreviewById = ({ deps, itemId, syncExplorer = false } = {}) => {
   render();
   refs.groupview?.scrollItemIntoView?.({ itemId });
   focusPreviewOverlay(deps);
+};
+
+const closeSpritePreview = (deps) => {
+  const { store, render } = deps;
+
+  store.hideFullImagePreview();
+  render();
+  focusGroupView(deps);
+};
+
+const navigateSpritePreview = (deps, { direction, distance, clamp } = {}) => {
+  const { store } = deps;
+  const selectedItemId = store.selectSelectedItemId();
+  if (!selectedItemId || !direction) {
+    return false;
+  }
+
+  const adjacentPayload = {
+    itemId: selectedItemId,
+    direction,
+  };
+  if (distance !== undefined) {
+    adjacentPayload.distance = distance;
+  }
+  if (clamp !== undefined) {
+    adjacentPayload.clamp = clamp;
+  }
+
+  const nextItemId = store.selectAdjacentSpriteItemId(adjacentPayload);
+  if (!nextItemId) {
+    return false;
+  }
+
+  openSpritePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
+  return true;
+};
+
+const resolvePreviewNavigationDirection = (event) => {
+  if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+    return { direction: "next" };
+  }
+
+  if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+    return { direction: "previous" };
+  }
+
+  if (event.altKey || event.metaKey) {
+    return undefined;
+  }
+
+  if (event.ctrlKey) {
+    const key = String(event.key ?? "").toLowerCase();
+    if (key === "d") {
+      return { direction: "next", distance: 10, clamp: true };
+    }
+
+    if (key === "u") {
+      return { direction: "previous", distance: 10, clamp: true };
+    }
+
+    return undefined;
+  }
+
+  const key = String(event.key ?? "").toLowerCase();
+  if (key === "j" || key === "l") {
+    return { direction: "next" };
+  }
+
+  if (key === "k" || key === "h") {
+    return { direction: "previous" };
+  }
+
+  return undefined;
 };
 
 const openEditDialogForSprite = ({
@@ -532,10 +608,24 @@ export const handleSpriteItemPreview = (deps, payload) => {
 };
 
 export const handlePreviewOverlayClick = (deps) => {
-  const { store, render } = deps;
-  store.hideFullImagePreview();
-  render();
-  focusGroupView(deps);
+  closeSpritePreview(deps);
+};
+
+export const handlePreviewImageFrameClick = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  closeSpritePreview(deps);
+};
+
+export const handlePreviewPreviousClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  navigateSpritePreview(deps, { direction: "previous" });
+};
+
+export const handlePreviewNextClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  navigateSpritePreview(deps, { direction: "next" });
 };
 
 export const handlePreviewOverlayKeyDown = (deps, payload) => {
@@ -546,43 +636,26 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
     return;
   }
 
+  if (isTextEntryKeyEvent(event)) {
+    return;
+  }
+
   if (event.key === "Escape" || event.key === "Enter") {
     event.preventDefault();
     event.stopPropagation();
-    store.hideFullImagePreview();
-    deps.render();
-    focusGroupView(deps);
+    closeSpritePreview(deps);
     return;
   }
 
-  let direction;
-  if (event.key === "ArrowDown") {
-    direction = "next";
-  } else if (event.key === "ArrowUp") {
-    direction = "previous";
-  }
-
-  if (!direction) {
-    return;
-  }
-
-  const selectedItemId = store.selectSelectedItemId();
-  if (!selectedItemId) {
+  const navigation = resolvePreviewNavigationDirection(event);
+  if (!navigation?.direction) {
     return;
   }
 
   event.preventDefault();
   event.stopPropagation();
 
-  const nextItemId = store.selectAdjacentSpriteItemId({
-    itemId: selectedItemId,
-    direction,
-  });
-  if (!nextItemId) {
-    return;
-  }
-
-  openSpritePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
+  navigateSpritePreview(deps, navigation);
 };
 
 export const handleFileExplorerKeyboardScopeKeyDown = (deps, payload) => {

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -37,6 +37,12 @@ const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
 const IMAGE_CARD_MAX_WIDTH = 400;
 const IMAGE_CARD_HEIGHT = 225;
+const PREVIEW_FRAME_STYLE = [
+  "width: 92vw",
+  "height: 92vh",
+  "max-width: 92vw",
+  "max-height: 92vh",
+].join("; ");
 
 const folderContextMenuItems = [
   { label: "New Folder", type: "item", value: "new-child-folder" },
@@ -194,6 +200,51 @@ const buildPendingMediaItem = (item) => ({
   canPreview: false,
 });
 
+const selectVisibleSpriteIds = ({ mediaGroups, items } = {}) => {
+  return (mediaGroups ?? []).flatMap((group) =>
+    (group.children ?? [])
+      .map((child) => child.id)
+      .filter((childItemId) => items?.[childItemId]?.type === "image"),
+  );
+};
+
+const resolveAdjacentSpriteItemId = ({
+  visibleSpriteIds,
+  itemId,
+  direction,
+  distance = 1,
+  clamp = false,
+} = {}) => {
+  const step =
+    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
+  if (!step) {
+    return undefined;
+  }
+
+  const numericDistance = Number(distance);
+  const itemDistance =
+    Number.isFinite(numericDistance) && numericDistance > 0
+      ? Math.floor(numericDistance)
+      : 1;
+  const spriteIds = visibleSpriteIds ?? [];
+
+  if (spriteIds.length === 0) {
+    return undefined;
+  }
+
+  const currentIndex = spriteIds.indexOf(itemId);
+  if (currentIndex === -1) {
+    return step > 0 ? spriteIds[0] : spriteIds[spriteIds.length - 1];
+  }
+
+  let nextIndex = currentIndex + step * itemDistance;
+  if (clamp) {
+    nextIndex = Math.max(0, Math.min(nextIndex, spriteIds.length - 1));
+  }
+
+  return spriteIds[nextIndex];
+};
+
 export const createInitialState = () => ({
   spritesData: EMPTY_TREE,
   ...createTagState(),
@@ -311,6 +362,8 @@ export const clearCharacterSpritesView = ({ state }) => {
   state.pendingUploads = [];
   state.selectedItemId = undefined;
   state.selectedFolderId = undefined;
+  state.fullImagePreviewVisible = false;
+  state.fullImagePreviewFileId = undefined;
   state.isEditDialogOpen = false;
   state.editItemId = undefined;
   state.editDefaultValues = {
@@ -490,43 +543,25 @@ export const selectCharacterId = ({ state }) => {
 
 export const selectAdjacentSpriteItemId = (
   { state },
-  { itemId, direction } = {},
+  { itemId, direction, distance = 1, clamp = false } = {},
 ) => {
-  const step =
-    direction === "next" ? 1 : direction === "previous" ? -1 : undefined;
-  if (!step) {
-    return undefined;
-  }
-
-  const visibleSpriteIds = (
-    selectViewData({ state }).mediaGroups ?? []
-  ).flatMap((group) =>
-    (group.children ?? [])
-      .map((child) => child.id)
-      .filter(
-        (childItemId) =>
-          state.spritesData.items?.[childItemId]?.type === "image",
-      ),
-  );
-
-  if (visibleSpriteIds.length === 0) {
-    return undefined;
-  }
-
-  const currentIndex = visibleSpriteIds.indexOf(itemId);
-  if (currentIndex === -1) {
-    return step > 0
-      ? visibleSpriteIds[0]
-      : visibleSpriteIds[visibleSpriteIds.length - 1];
-  }
-
-  return visibleSpriteIds[currentIndex + step];
+  const viewData = selectViewData({ state });
+  return resolveAdjacentSpriteItemId({
+    visibleSpriteIds: selectVisibleSpriteIds({
+      mediaGroups: viewData.mediaGroups,
+      items: state.spritesData?.items,
+    }),
+    itemId,
+    direction,
+    distance,
+    clamp,
+  });
 };
 
 export const showFullImagePreview = ({ state }, { itemId } = {}) => {
   const item = state.spritesData.items?.[itemId];
 
-  if (item?.fileId) {
+  if (item?.type === "image" && item.fileId) {
     state.fullImagePreviewVisible = true;
     state.fullImagePreviewFileId = item.fileId;
   }
@@ -604,6 +639,24 @@ export const selectViewData = ({ state }) => {
     selectedItem?.type === "image"
       ? buildDetailFields(selectedItem)
       : buildFolderDetailFields(selectedFolder);
+  const visibleSpriteIds = selectVisibleSpriteIds({
+    mediaGroups,
+    items: state.spritesData?.items,
+  });
+  const previousItemId = state.selectedItemId
+    ? resolveAdjacentSpriteItemId({
+        visibleSpriteIds,
+        itemId: state.selectedItemId,
+        direction: "previous",
+      })
+    : undefined;
+  const nextItemId = state.selectedItemId
+    ? resolveAdjacentSpriteItemId({
+        visibleSpriteIds,
+        itemId: state.selectedItemId,
+        direction: "next",
+      })
+    : undefined;
 
   return {
     flatItems,
@@ -637,6 +690,9 @@ export const selectViewData = ({ state }) => {
     maxWidth: IMAGE_CARD_MAX_WIDTH,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
+    fullImagePreviewFrameStyle: PREVIEW_FRAME_STYLE,
+    fullImagePreviewPreviousVisible: Boolean(previousItemId),
+    fullImagePreviewNextVisible: Boolean(nextItemId),
     folderContextMenuItems,
     itemContextMenuItems,
     emptyContextMenuItems,

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -63,6 +63,23 @@ refs:
         handler: handlePreviewOverlayClick
       keydown:
         handler: handlePreviewOverlayKeyDown
+  previewImageFrame:
+    eventListeners:
+      click:
+        handler: handlePreviewImageFrameClick
+        stopPropagation: true
+  previewPrevious:
+    eventListeners:
+      click:
+        handler: handlePreviewPreviousClick
+        preventDefault: true
+        stopPropagation: true
+  previewNext:
+    eventListeners:
+      click:
+        handler: handlePreviewNextClick
+        preventDefault: true
+        stopPropagation: true
   editDialog:
     eventListeners:
       close:
@@ -115,6 +132,29 @@ refs:
     eventListeners:
       form-action:
         handler: handleCreateTagFormAction
+styles:
+  ".imagePreviewEdge":
+    position: absolute
+    top: "0"
+    bottom: "0"
+    width: 28%
+    min-width: 72px
+    z-index: "1"
+    opacity: "0"
+    transition: opacity 140ms ease
+    cursor: pointer
+  ".imagePreviewEdge:hover":
+    opacity: "1"
+  ".imagePreviewEdgePrevious":
+    left: "0"
+    background: linear-gradient(to right, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
+  ".imagePreviewEdgeNext":
+    right: "0"
+    background: linear-gradient(to left, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
+  ".imagePreviewFrame":
+    position: relative
+    overflow: hidden
+    cursor: default
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -178,8 +218,13 @@ template:
   - rtgl-dialog#createTagDialog ?open=${isCreateTagDialogOpen} s=sm:
       - rtgl-form#createTagForm key=${isCreateTagDialogOpen} slot=content :defaultValues=${createTagDefaultValues} :form=${createTagForm} w=f: null
   - $when: fullImagePreviewVisible
-    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: pointer; outline: none;"':
-      - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null
+    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none;"':
+      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: rgba(0, 0, 0, 0.9);"': null
       - $if fullImagePreviewFileId:
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
-              - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null
+              - 'div#previewImageFrame.imagePreviewFrame style="${fullImagePreviewFrameStyle}"':
+                  - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
+                  - $if fullImagePreviewPreviousVisible:
+                      - div#previewPrevious.imagePreviewEdge.imagePreviewEdgePrevious role=button aria-label="Previous sprite": null
+                  - $if fullImagePreviewNextVisible:
+                      - div#previewNext.imagePreviewEdge.imagePreviewEdgeNext role=button aria-label="Next sprite": null

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -1,6 +1,5 @@
 export const createInitialState = () => ({
   isTouchMode: false,
-  mobileAppName: "Creator",
   localTitle: "Projects",
   cloudTitle: "Cloud Projects",
   showCloudProjects: false,
@@ -548,8 +547,10 @@ export const selectViewData = ({ state }) => {
     ...state,
     profileDisplayName,
     avatarImageSrc,
-    showMobileTopNav: Boolean(state.isTouchMode),
-    showDesktopTopActions: !state.isTouchMode,
+    showMobileProjectActions: Boolean(state.isTouchMode),
+    showProjectAccountActions: Boolean(
+      state.showCloudProjects && !state.isTouchMode,
+    ),
     deleteDialogTitle: "Remove Project",
     deleteDialogMessage: `Are you sure you want to remove ${deleteDialogProjectName} from the list? The project folder will still remain on disk. Delete the folder yourself if you want to permanently remove the project files.`,
     deleteDialogConfirmLabel: "Remove",

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -117,37 +117,27 @@ refs:
         handler: handleDeleteDialogConfirm
 template:
   - rtgl-view h=100vh w=100vw d=v:
-      - 'rtgl-view pos=fix w=100vw h=48 bgc=bg ph=lg ah=c av=c style="left: 0; top: 0; z-index: 10;"':
-          - rtgl-view sm-w=f w=640 h=f d=h av=c:
-              - $if showMobileTopNav:
-                  - rtgl-view w=f h=f d=h av=c g=sm:
-                      - rtgl-image h=22 w=120 sm-w=96 of=con src="/public/logo1.png": null
-                      - rtgl-text s=sm c=mu-fg: ${mobileAppName}
-                      - rtgl-view w=1fg: null
-                      - rtgl-button#mobileCreateMenuButton sq pre=plus v="gh": null
-                $else:
-                  - rtgl-image h=22 w=120 sm-w=96 of=con src="/public/logo1.png": null
-                  - rtgl-view w=1fg: null
-                  - $if showCloudProjects:
-                      - $if isLoggedIn:
-                          - rtgl-view#avatarButton d=h av=c g=sm p=xs br=md cur=pointer h-bgc=mu:
-                              - rtgl-text s=sm: ${profileDisplayName}
-                              - rtgl-image wh=36 br=f bw=xs bc=bo of=cov src=${avatarImageSrc}: null
-                        $else:
-                          - rtgl-button#loginButton variant=se: ${loginButtonText}
       - 'rtgl-view w=f h=f d=v style="min-height: 0;"':
-          - rtgl-view h=64: null
           - 'rtgl-view w=f ah=c bgc=bg':
               - 'rtgl-view w=f d=v ph=lg style="max-width: 1280px;"':
                   - 'rtgl-view w=f ah=c':
-                      - 'rtgl-view sm-w=f w=640 d=h av=c pt=sm pb=md':
+                      - 'rtgl-view sm-w=f w=640 d=h av=c pt=lg pb=md g=sm':
                           - rtgl-text s=h3: ${localTitle}
                           - rtgl-view w=1fg: null
-                          - $if showDesktopTopActions:
+                          - $if showMobileProjectActions:
+                              - rtgl-button#mobileCreateMenuButton sq pre=plus v="gh": null
+                            $else:
                               - rtgl-view d=h g=sm:
                                   - rtgl-button#createButton data-testid=create-project-button: ${createButtonText}
                                   - $if platform != 'web':
                                       - rtgl-button#openButton variant=se: ${openButtonText}
+                          - $if showProjectAccountActions:
+                              - $if isLoggedIn:
+                                  - rtgl-view#avatarButton d=h av=c g=sm p=xs br=md cur=pointer h-bgc=mu:
+                                      - rtgl-text s=sm: ${profileDisplayName}
+                                      - rtgl-image wh=36 br=f bw=xs bc=bo of=cov src=${avatarImageSrc}: null
+                                $else:
+                                  - rtgl-button#loginButton variant=se: ${loginButtonText}
           - 'rtgl-view w=f h=1fg ah=c sv style="min-height: 0;"':
               - 'rtgl-view w=f d=v ph=lg style="max-width: 1280px;"':
                   - 'rtgl-view w=f ah=c':

--- a/tests/characterSprites/characterSprites.handlers.test.js
+++ b/tests/characterSprites/characterSprites.handlers.test.js
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handlePreviewNextClick,
+  handlePreviewOverlayKeyDown,
+  handlePreviewPreviousClick,
+} from "../../src/pages/characterSprites/characterSprites.handlers.js";
+
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+const createPreviewDeps = ({
+  selectedItemId = "sprite-1",
+  previewVisible = true,
+} = {}) => {
+  const store = {
+    getState: vi.fn(() => ({
+      fullImagePreviewVisible: previewVisible,
+    })),
+    selectSelectedItemId: vi.fn(() => selectedItemId),
+    selectAdjacentSpriteItemId: vi.fn(({ direction }) => {
+      return direction === "next" ? "sprite-2" : "sprite-0";
+    }),
+    selectSpriteItemById: vi.fn(({ itemId }) => ({
+      id: itemId,
+      type: "image",
+      fileId: `${itemId}-file`,
+    })),
+    setSelectedItemId: vi.fn(),
+    showFullImagePreview: vi.fn(),
+  };
+
+  return {
+    store,
+    render: vi.fn(),
+    refs: {
+      fileExplorer: {
+        selectItem: vi.fn(),
+      },
+      groupview: {
+        scrollItemIntoView: vi.fn(),
+      },
+      previewOverlay: {
+        focus: vi.fn(),
+      },
+    },
+  };
+};
+
+const createEvent = (key, overrides = {}) => ({
+  key,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+  ...overrides,
+});
+
+describe("characterSprites preview handlers", () => {
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  });
+
+  it("navigates preview items from the left and right overlay edges", () => {
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+    const deps = createPreviewDeps();
+    const nextEvent = createEvent("click");
+    const previousEvent = createEvent("click");
+
+    handlePreviewNextClick(deps, {
+      _event: nextEvent,
+    });
+    handlePreviewPreviousClick(deps, {
+      _event: previousEvent,
+    });
+
+    expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenNthCalledWith(1, {
+      itemId: "sprite-1",
+      direction: "next",
+    });
+    expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenNthCalledWith(2, {
+      itemId: "sprite-1",
+      direction: "previous",
+    });
+    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: "sprite-2",
+    });
+    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: "sprite-0",
+    });
+    expect(nextEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(nextEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(previousEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(previousEvent.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports image-preview keyboard parity and ignores text entry targets", () => {
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+    const deps = createPreviewDeps();
+
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("ArrowRight"),
+    });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("ArrowLeft"),
+    });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("d", {
+        ctrlKey: true,
+      }),
+    });
+
+    expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenNthCalledWith(1, {
+      itemId: "sprite-1",
+      direction: "next",
+    });
+    expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenNthCalledWith(2, {
+      itemId: "sprite-1",
+      direction: "previous",
+    });
+    expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenNthCalledWith(3, {
+      itemId: "sprite-1",
+      direction: "next",
+      distance: 10,
+      clamp: true,
+    });
+
+    const inputEvent = createEvent("ArrowRight", {
+      target: {
+        tagName: "INPUT",
+      },
+    });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: inputEvent,
+    });
+
+    expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenCalledTimes(3);
+    expect(inputEvent.preventDefault).not.toHaveBeenCalled();
+    expect(inputEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when the preview is hidden", () => {
+    const deps = createPreviewDeps({
+      previewVisible: false,
+    });
+    const event = createEvent("ArrowRight");
+
+    handlePreviewOverlayKeyDown(deps, {
+      _event: event,
+    });
+
+    expect(deps.store.selectSelectedItemId).not.toHaveBeenCalled();
+    expect(deps.store.selectAdjacentSpriteItemId).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+});

--- a/tests/characterSprites/characterSprites.store.test.js
+++ b/tests/characterSprites/characterSprites.store.test.js
@@ -4,7 +4,10 @@ import {
   createInitialState,
   removePendingUploads,
   setActiveTagIds,
+  selectAdjacentSpriteItemId,
   selectViewData,
+  setSelectedItemId,
+  showFullImagePreview,
 } from "../../src/pages/characterSprites/characterSprites.store.js";
 
 describe("characterSprites store", () => {
@@ -157,5 +160,151 @@ describe("characterSprites store", () => {
     expect(
       searchOnlyViewData.mediaGroups[0].children.map((child) => child.id),
     ).toEqual(["sprite-2"]);
+  });
+
+  it("uses the original file and exposes adjacent controls for the full preview overlay", () => {
+    const state = createInitialState();
+    state.characterName = "Hero";
+    state.spritesData = {
+      tree: [
+        {
+          id: "folder-1",
+          children: [
+            { id: "sprite-1" },
+            { id: "sprite-2" },
+            { id: "sprite-3" },
+          ],
+        },
+      ],
+      items: {
+        "folder-1": {
+          id: "folder-1",
+          type: "folder",
+          name: "Main",
+        },
+        "sprite-1": {
+          id: "sprite-1",
+          type: "image",
+          name: "Hero Idle",
+          fileId: "file-1",
+        },
+        "sprite-2": {
+          id: "sprite-2",
+          type: "image",
+          name: "Hero Smile",
+          fileId: "original-file",
+          thumbnailFileId: "thumbnail-file",
+        },
+        "sprite-3": {
+          id: "sprite-3",
+          type: "image",
+          name: "Hero Sad",
+          fileId: "file-3",
+        },
+      },
+    };
+
+    setSelectedItemId(
+      { state },
+      {
+        itemId: "sprite-2",
+      },
+    );
+    showFullImagePreview(
+      { state },
+      {
+        itemId: "sprite-2",
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    expect(state.fullImagePreviewVisible).toBe(true);
+    expect(state.fullImagePreviewFileId).toBe("original-file");
+    expect(viewData.fullImagePreviewFrameStyle).toContain("width: 92vw");
+    expect(viewData.fullImagePreviewPreviousVisible).toBe(true);
+    expect(viewData.fullImagePreviewNextVisible).toBe(true);
+  });
+
+  it("jumps adjacent sprite selection by distance and clamps to visible bounds", () => {
+    const state = createInitialState();
+    state.characterName = "Hero";
+    state.spritesData = {
+      tree: [
+        {
+          id: "folder-1",
+          children: [
+            { id: "sprite-1" },
+            { id: "sprite-2" },
+            { id: "sprite-3" },
+            { id: "sprite-4" },
+            { id: "sprite-5" },
+          ],
+        },
+      ],
+      items: {
+        "folder-1": {
+          id: "folder-1",
+          type: "folder",
+          name: "Main",
+        },
+        "sprite-1": {
+          id: "sprite-1",
+          type: "image",
+          name: "Hero 1",
+        },
+        "sprite-2": {
+          id: "sprite-2",
+          type: "image",
+          name: "Hero 2",
+        },
+        "sprite-3": {
+          id: "sprite-3",
+          type: "image",
+          name: "Hero 3",
+        },
+        "sprite-4": {
+          id: "sprite-4",
+          type: "image",
+          name: "Hero 4",
+        },
+        "sprite-5": {
+          id: "sprite-5",
+          type: "image",
+          name: "Hero 5",
+        },
+      },
+    };
+
+    expect(
+      selectAdjacentSpriteItemId(
+        { state },
+        {
+          itemId: "sprite-2",
+          direction: "next",
+          distance: 10,
+          clamp: true,
+        },
+      ),
+    ).toBe("sprite-5");
+    expect(
+      selectAdjacentSpriteItemId(
+        { state },
+        {
+          itemId: "sprite-2",
+          direction: "previous",
+          distance: 10,
+          clamp: true,
+        },
+      ),
+    ).toBe("sprite-1");
+    expect(
+      selectAdjacentSpriteItemId(
+        { state },
+        {
+          itemId: "sprite-5",
+          direction: "next",
+        },
+      ),
+    ).toBeUndefined();
   });
 });

--- a/tests/commandLineScreen/commandLineScreen.handlers.test.js
+++ b/tests/commandLineScreen/commandLineScreen.handlers.test.js
@@ -6,7 +6,10 @@ import {
   selectTransitionAnimationId,
   setFormValues,
 } from "../../src/components/commandLineScreen/commandLineScreen.store.js";
-import { handleSubmitClick } from "../../src/components/commandLineScreen/commandLineScreen.handlers.js";
+import {
+  handleFormChange,
+  handleSubmitClick,
+} from "../../src/components/commandLineScreen/commandLineScreen.handlers.js";
 
 const createStoreApi = (state) => ({
   selectScreenBlur: () => selectScreenBlur({ state }),
@@ -16,6 +19,59 @@ const createStoreApi = (state) => ({
 });
 
 describe("commandLineScreen.handlers", () => {
+  it("emits temporary presentation state when opacity and blur change", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    handleFormChange(
+      {
+        dispatchEvent,
+        render,
+        store: createStoreApi(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              transitionAnimationId: "screen-crossfade",
+              opacity: "0.5",
+              blur: true,
+              blurX: "8",
+              blurY: 10,
+              blurQuality: 4,
+              blurKernelSize: 11,
+              blurRepeatEdgePixels: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        screen: {
+          animations: {
+            resourceId: "screen-crossfade",
+          },
+          opacity: 0.5,
+          blur: {
+            x: 8,
+            y: 10,
+            quality: 4,
+            kernelSize: 11,
+            repeatEdgePixels: false,
+          },
+        },
+      },
+    });
+  });
+
   it("submits a screen animation payload", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();

--- a/tests/images/images.handlers.test.js
+++ b/tests/images/images.handlers.test.js
@@ -117,6 +117,7 @@ describe("images handlers", () => {
         setTagsData: vi.fn(),
         setItems: vi.fn(),
         setSelectedItemId: vi.fn(),
+        setSelectedFolderId: vi.fn(),
       },
       render: vi.fn(),
       refs: {
@@ -394,6 +395,7 @@ describe("images handlers", () => {
         setTagsData: vi.fn(),
         setItems: vi.fn(),
         setSelectedItemId: vi.fn(),
+        setSelectedFolderId: vi.fn(),
       },
       refs: {
         fileExplorer: {


### PR DESCRIPTION
## Summary
- update `@routevn/creator-model` to `1.6.2`
- make screen opacity/blur form edits emit temporary presentation preview state
- add character sprite preview navigation with edge buttons, arrow/hjkl keys, and ctrl-d/ctrl-u jumps
- simplify projects header actions and document focused development validation

## Testing
- `bun install --frozen-lockfile`
- `bun prettier --check <touched files>`
- `bunx oxlint <touched JS/test files>`
- `bunx vitest run <focused tests>`
- push hook: `oxlint && bun prettier --check src`