### PR TITLE
chore: bump creator model and fix Windows dev in WSL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.5",
-        "@routevn/creator-model": "1.6.2",
+        "@routevn/creator-model": "1.6.3",
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "2.5.1",
@@ -311,7 +311,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.6.2", "", {}, "sha512-lWKfyY0IXEBemAXPjkBG1XHk2rqNMe9rN0Uh86bWykpTbESXjKJf1ws9nirW8iBggQ3H3avCjOjAcYS8g71pVw=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.6.3", "", {}, "sha512-4lBTnh2Exdl24gi1dPRpYl6JNrkW1imuBY91/8qRXXcY9hzttA2awSOLaHe8q7mIcMZhsyzZ/0U2FjWmCbDS2g=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.5",
-    "@routevn/creator-model": "1.6.2",
+    "@routevn/creator-model": "1.6.3",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tauri": "tauri",
     "tauri:dev:linux": "tauri dev --target $(rustc --print host-tuple)",
     "tauri:dev:mac": "tauri dev --target aarch64-apple-darwin",
-    "tauri:dev:win": "tauri dev --target x86_64-pc-windows-gnu",
+    "tauri:dev:win": "CARGO_BUILD_JOBS=2 tauri dev --runner ../scripts/tauri-wsl-windows-runner.sh --target x86_64-pc-windows-msvc",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
     "tauri:build:appimage": "./scripts/tauri-build-appimage.sh",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",

--- a/scripts/tauri-wsl-windows-runner.sh
+++ b/scripts/tauri-wsl-windows-runner.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+is_wsl=false
+if [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/null; then
+  is_wsl=true
+fi
+
+if [[ "${is_wsl}" != true ]] || [[ "${1:-}" != "run" ]]; then
+  exec cargo-xwin "$@"
+fi
+
+build_args=("$@")
+build_args[0]="build"
+
+cargo_args=()
+app_args=()
+after_separator=false
+
+for arg in "${build_args[@]}"; do
+  if [[ "${arg}" == "--" && "${after_separator}" == false ]]; then
+    after_separator=true
+    continue
+  fi
+
+  if [[ "${after_separator}" == true ]]; then
+    app_args+=("${arg}")
+  else
+    cargo_args+=("${arg}")
+  fi
+done
+
+cargo-xwin "${cargo_args[@]}"
+
+target="x86_64-pc-windows-msvc"
+profile_dir="debug"
+manifest_path=""
+target_dir=""
+
+for ((index = 0; index < ${#cargo_args[@]}; index++)); do
+  case "${cargo_args[$index]}" in
+    --target)
+      index=$((index + 1))
+      target="${cargo_args[$index]}"
+      ;;
+    --target=*)
+      target="${cargo_args[$index]#--target=}"
+      ;;
+    --manifest-path)
+      index=$((index + 1))
+      manifest_path="${cargo_args[$index]}"
+      ;;
+    --manifest-path=*)
+      manifest_path="${cargo_args[$index]#--manifest-path=}"
+      ;;
+    --target-dir)
+      index=$((index + 1))
+      target_dir="${cargo_args[$index]}"
+      ;;
+    --target-dir=*)
+      target_dir="${cargo_args[$index]#--target-dir=}"
+      ;;
+    --release | -r)
+      profile_dir="release"
+      ;;
+    --profile)
+      index=$((index + 1))
+      profile_dir="${cargo_args[$index]}"
+      ;;
+    --profile=*)
+      profile_dir="${cargo_args[$index]#--profile=}"
+      ;;
+  esac
+done
+
+if [[ "${profile_dir}" == "dev" ]]; then
+  profile_dir="debug"
+fi
+
+if [[ -n "${manifest_path}" ]]; then
+  manifest_dir="$(dirname "$(realpath "${manifest_path}")")"
+else
+  manifest_dir="$(pwd)"
+fi
+
+if [[ -n "${target_dir}" ]]; then
+  target_root="$(realpath "${target_dir}")"
+elif [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  target_root="$(realpath "${CARGO_TARGET_DIR}")"
+else
+  target_root="${manifest_dir}/target"
+fi
+
+exe_path="${target_root}/${target}/${profile_dir}/app.exe"
+if [[ ! -f "${exe_path}" ]]; then
+  exe_path="$(find "${target_root}/${target}/${profile_dir}" -maxdepth 1 -type f -name "*.exe" -print -quit)"
+fi
+
+if [[ -z "${exe_path}" ]] || [[ ! -f "${exe_path}" ]]; then
+  echo "Could not find built Windows executable under ${target_root}/${target}/${profile_dir}" >&2
+  exit 1
+fi
+
+cmd_runner="$(command -v cmd.exe || true)"
+if [[ -z "${cmd_runner}" ]]; then
+  for candidate in /mnt/c/Windows/System32/cmd.exe /mnt/c/WINDOWS/System32/cmd.exe; do
+    if [[ -x "${candidate}" ]]; then
+      cmd_runner="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${cmd_runner}" ]]; then
+  echo "cmd.exe is not available. Run this command from WSL with Windows interop enabled." >&2
+  exit 1
+fi
+
+windows_exe="$(wslpath -w "${exe_path}")"
+windows_dir="$(wslpath -w "$(dirname "${exe_path}")")"
+
+echo "Launching Windows app through WSL interop: ${windows_exe}"
+if [[ "${windows_dir}" == \\\\* ]]; then
+  "${cmd_runner}" /C start "" /WAIT "${windows_exe}" "${app_args[@]}"
+else
+  "${cmd_runner}" /C start "" /D "${windows_dir}" /WAIT "${windows_exe}" "${app_args[@]}"
+fi


### PR DESCRIPTION
## Summary
- bump creator model to 1.6.3
- switch Windows Tauri dev from the MinGW GNU target to cargo-xwin/MSVC
- add a WSL-aware Tauri runner that builds with cargo-xwin and launches app.exe through Windows interop instead of Wine

## Testing
- push hook: oxlint
- push hook: bun prettier --check src
- bash -n scripts/tauri-wsl-windows-runner.sh
- package.json parse check
- user confirmed cargo-xwin/MSVC build completes before the WSL launch fallback fix