### PR TITLE
chore: bump Tauri app version to 1.4.2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump `src-tauri/tauri.conf.json` app version from `1.4.1` to `1.4.2`

## Testing
- parsed `src-tauri/tauri.conf.json` as JSON
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`