### PR TITLE
fix(scene-editor): preserve blur clear actions

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -120,7 +120,7 @@ const buildBackgroundDataFromState = (
   const selectedTransformId = store.selectSelectedTransform();
   const selectedColorId = store.selectSelectedColor();
   const selectedOpacity = store.selectSelectedOpacity();
-  const selectedBlur = store.selectSelectedBlur();
+  const selectedBlur = store.selectSelectedBlurActionValue();
   const selectedAnimationMode = store.selectSelectedAnimationMode();
   const selectedAnimationId = store.selectSelectedAnimation();
   const selectedAnimationPlaybackContinuity =
@@ -145,7 +145,7 @@ const buildBackgroundDataFromState = (
     backgroundData.opacity = selectedOpacity;
   }
 
-  if (hasBackgroundTarget && selectedBlur) {
+  if (hasBackgroundTarget && selectedBlur !== undefined) {
     backgroundData.blur = selectedBlur;
   }
 

--- a/src/components/commandLineBackground/commandLineBackground.schema.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.schema.yaml
@@ -14,7 +14,9 @@ propsSchema:
           minimum: 0
           maximum: 1
         blur:
-          type: object
+          type:
+            - object
+            - "null"
           properties:
             x:
               type: number

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -119,19 +119,24 @@ const normalizeBackgroundBlurKernelSize = (value) => {
   }, DEFAULT_BACKGROUND_BLUR.kernelSize);
 };
 
-const normalizeBackgroundBlur = (blur = {}) => ({
-  x: normalizeBackgroundBlurNumber(blur.x, DEFAULT_BACKGROUND_BLUR.x),
-  y: normalizeBackgroundBlurNumber(blur.y, DEFAULT_BACKGROUND_BLUR.y),
-  quality: normalizeBackgroundBlurNumber(
-    blur.quality,
-    DEFAULT_BACKGROUND_BLUR.quality,
-  ),
-  kernelSize: normalizeBackgroundBlurKernelSize(blur.kernelSize),
-  repeatEdgePixels: normalizeBackgroundBlurBoolean(
-    blur.repeatEdgePixels,
-    DEFAULT_BACKGROUND_BLUR.repeatEdgePixels,
-  ),
-});
+const normalizeBackgroundBlur = (blur = {}) => {
+  const source =
+    blur && typeof blur === "object" && !Array.isArray(blur) ? blur : {};
+
+  return {
+    x: normalizeBackgroundBlurNumber(source.x, DEFAULT_BACKGROUND_BLUR.x),
+    y: normalizeBackgroundBlurNumber(source.y, DEFAULT_BACKGROUND_BLUR.y),
+    quality: normalizeBackgroundBlurNumber(
+      source.quality,
+      DEFAULT_BACKGROUND_BLUR.quality,
+    ),
+    kernelSize: normalizeBackgroundBlurKernelSize(source.kernelSize),
+    repeatEdgePixels: normalizeBackgroundBlurBoolean(
+      source.repeatEdgePixels,
+      DEFAULT_BACKGROUND_BLUR.repeatEdgePixels,
+    ),
+  };
+};
 
 export const createInitialState = () => ({
   mode: "current",
@@ -150,6 +155,7 @@ export const createInitialState = () => ({
   selectedColorId: undefined,
   selectedOpacity: undefined,
   selectedBlurEnabled: false,
+  selectedBlurExplicit: false,
   selectedBlur: { ...DEFAULT_BACKGROUND_BLUR },
   selectedAnimationMode: "none",
   selectedAnimationId: undefined,
@@ -330,14 +336,22 @@ export const selectSelectedOpacity = ({ state }) => {
 
 export const setSelectedBlurEnabled = ({ state }, { enabled } = {}) => {
   state.selectedBlurEnabled = enabled === true || enabled === "true";
+  state.selectedBlurExplicit = true;
 };
 
 export const setSelectedBlur = ({ state }, { blur } = {}) => {
+  state.selectedBlurExplicit = true;
+  if (blur === null) {
+    state.selectedBlurEnabled = false;
+    return;
+  }
+
   state.selectedBlurEnabled = true;
   state.selectedBlur = normalizeBackgroundBlur(blur);
 };
 
 export const setSelectedBlurField = ({ state }, { fieldName, value } = {}) => {
+  state.selectedBlurExplicit = true;
   state.selectedBlur = normalizeBackgroundBlur({
     ...state.selectedBlur,
     [fieldName]: value,
@@ -348,6 +362,18 @@ export const selectSelectedBlur = ({ state }) => {
   return state.selectedBlurEnabled
     ? normalizeBackgroundBlur(state.selectedBlur)
     : undefined;
+};
+
+export const selectSelectedBlurActionValue = ({ state }) => {
+  if (state.selectedBlurEnabled) {
+    return normalizeBackgroundBlur(state.selectedBlur);
+  }
+
+  if (state.selectedBlurExplicit) {
+    return null;
+  }
+
+  return undefined;
 };
 
 export const setSelectedAnimationPlaybackContinuity = (

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -180,8 +180,8 @@ const buildCharacterItemsFromState = (
       item.opacity = char.opacity;
     }
 
-    if (char.blur) {
-      item.blur = { ...char.blur };
+    if (char.blur !== undefined) {
+      item.blur = char.blur === null ? null : { ...char.blur };
     }
 
     if (shouldUseTemporarySprites && index === selectedCharacterIndex) {

--- a/src/components/commandLineCharacters/commandLineCharacters.schema.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.schema.yaml
@@ -19,7 +19,9 @@ propsSchema:
                 minimum: 0
                 maximum: 1
               blur:
-                type: object
+                type:
+                  - object
+                  - "null"
                 properties:
                   x:
                     type: number

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -445,7 +445,7 @@ export const updateCharacterBlurEnabled = (
   }
 
   if (!normalizeCommandLineItemBlurEnabled(enabled)) {
-    delete character.blur;
+    character.blur = null;
     return;
   }
 

--- a/src/components/commandLineScreen/commandLineScreen.handlers.js
+++ b/src/components/commandLineScreen/commandLineScreen.handlers.js
@@ -1,7 +1,7 @@
 const buildScreenDataFromState = (store) => {
   const transitionAnimationId = store.selectTransitionAnimationId();
   const opacity = store.selectScreenOpacity();
-  const blur = store.selectScreenBlur();
+  const blur = store.selectScreenBlurActionValue();
 
   const screen = {};
 
@@ -15,7 +15,7 @@ const buildScreenDataFromState = (store) => {
     screen.opacity = opacity;
   }
 
-  if (blur) {
+  if (blur !== undefined) {
     screen.blur = blur;
   }
 
@@ -44,21 +44,26 @@ export const handleAfterMount = async (deps) => {
   const { projectService, store, props, render } = deps;
   await projectService.ensureRepository();
   const { animations } = projectService.getRepositoryState();
+  const screen = props?.screen ?? {};
+  const formValues = {
+    transitionAnimationId: screen?.animations?.resourceId,
+    opacity: screen?.opacity,
+  };
+
+  if (Object.hasOwn(screen, "blur")) {
+    formValues.blur = Boolean(screen.blur);
+    formValues.blurX = screen.blur?.x;
+    formValues.blurY = screen.blur?.y;
+    formValues.blurQuality = screen.blur?.quality;
+    formValues.blurKernelSize = screen.blur?.kernelSize;
+    formValues.blurRepeatEdgePixels = screen.blur?.repeatEdgePixels;
+  }
 
   store.setAnimations({
     animations,
   });
   store.setFormValues({
-    values: {
-      transitionAnimationId: props?.screen?.animations?.resourceId,
-      opacity: props?.screen?.opacity,
-      blur: Boolean(props?.screen?.blur),
-      blurX: props?.screen?.blur?.x,
-      blurY: props?.screen?.blur?.y,
-      blurQuality: props?.screen?.blur?.quality,
-      blurKernelSize: props?.screen?.blur?.kernelSize,
-      blurRepeatEdgePixels: props?.screen?.blur?.repeatEdgePixels,
-    },
+    values: formValues,
   });
   render();
 };

--- a/src/components/commandLineScreen/commandLineScreen.schema.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.schema.yaml
@@ -15,7 +15,9 @@ propsSchema:
           minimum: 0
           maximum: 1
         blur:
-          type: object
+          type:
+            - object
+            - "null"
           properties:
             x:
               type: number

--- a/src/components/commandLineScreen/commandLineScreen.store.js
+++ b/src/components/commandLineScreen/commandLineScreen.store.js
@@ -62,22 +62,48 @@ const normalizeScreenBlurKernelSize = (value) => {
   }, DEFAULT_SCREEN_BLUR.kernelSize);
 };
 
-const normalizeScreenBlur = (blur = {}) => ({
-  x: normalizeScreenBlurNumber(blur.x, DEFAULT_SCREEN_BLUR.x),
-  y: normalizeScreenBlurNumber(blur.y, DEFAULT_SCREEN_BLUR.y),
-  quality: normalizeScreenBlurNumber(blur.quality, DEFAULT_SCREEN_BLUR.quality),
-  kernelSize: normalizeScreenBlurKernelSize(blur.kernelSize),
-  repeatEdgePixels: normalizeScreenBlurBoolean(
-    blur.repeatEdgePixels,
-    DEFAULT_SCREEN_BLUR.repeatEdgePixels,
-  ),
-});
+const normalizeScreenBlur = (blur = {}) => {
+  const source =
+    blur && typeof blur === "object" && !Array.isArray(blur) ? blur : {};
+
+  return {
+    x: normalizeScreenBlurNumber(source.x, DEFAULT_SCREEN_BLUR.x),
+    y: normalizeScreenBlurNumber(source.y, DEFAULT_SCREEN_BLUR.y),
+    quality: normalizeScreenBlurNumber(
+      source.quality,
+      DEFAULT_SCREEN_BLUR.quality,
+    ),
+    kernelSize: normalizeScreenBlurKernelSize(source.kernelSize),
+    repeatEdgePixels: normalizeScreenBlurBoolean(
+      source.repeatEdgePixels,
+      DEFAULT_SCREEN_BLUR.repeatEdgePixels,
+    ),
+  };
+};
 
 const normalizeScreenBlurEnabled = (value) => {
   return value === true || value === "true";
 };
 
+const hasFormValue = (formValues, fieldName) => {
+  return Object.prototype.hasOwnProperty.call(formValues ?? {}, fieldName);
+};
+
 const normalizeScreenFormValues = (values = {}) => {
+  const nextValues = {
+    ...values,
+    opacity: normalizeScreenOpacity(values.opacity),
+  };
+
+  if (!hasFormValue(values, "blur")) {
+    delete nextValues.blurX;
+    delete nextValues.blurY;
+    delete nextValues.blurQuality;
+    delete nextValues.blurKernelSize;
+    delete nextValues.blurRepeatEdgePixels;
+    return nextValues;
+  }
+
   const blur = normalizeScreenBlur({
     x: values.blurX,
     y: values.blurY,
@@ -86,16 +112,14 @@ const normalizeScreenFormValues = (values = {}) => {
     repeatEdgePixels: values.blurRepeatEdgePixels,
   });
 
-  return {
-    ...values,
-    opacity: normalizeScreenOpacity(values.opacity),
-    blur: normalizeScreenBlurEnabled(values.blur),
-    blurX: blur.x,
-    blurY: blur.y,
-    blurQuality: blur.quality,
-    blurKernelSize: blur.kernelSize,
-    blurRepeatEdgePixels: blur.repeatEdgePixels,
-  };
+  nextValues.blur = normalizeScreenBlurEnabled(values.blur);
+  nextValues.blurX = blur.x;
+  nextValues.blurY = blur.y;
+  nextValues.blurQuality = blur.quality;
+  nextValues.blurKernelSize = blur.kernelSize;
+  nextValues.blurRepeatEdgePixels = blur.repeatEdgePixels;
+
+  return nextValues;
 };
 
 const getScreenFormValuesFromAction = (screen = {}) => {
@@ -111,10 +135,6 @@ const getScreenFormValuesFromAction = (screen = {}) => {
     blurKernelSize: blur.kernelSize,
     blurRepeatEdgePixels: blur.repeatEdgePixels,
   };
-};
-
-const hasFormValue = (formValues, fieldName) => {
-  return Object.prototype.hasOwnProperty.call(formValues ?? {}, fieldName);
 };
 
 const getSelectedFormValue = (formValues, fallbackValues, fieldName) => {
@@ -231,6 +251,18 @@ export const selectScreenBlur = ({ state }) => {
     kernelSize: state.formValues?.blurKernelSize,
     repeatEdgePixels: state.formValues?.blurRepeatEdgePixels,
   });
+};
+
+export const selectScreenBlurActionValue = ({ state }) => {
+  if (normalizeScreenBlurEnabled(state.formValues?.blur)) {
+    return selectScreenBlur({ state });
+  }
+
+  if (hasFormValue(state.formValues, "blur")) {
+    return null;
+  }
+
+  return undefined;
 };
 
 export const selectViewData = ({ state, props }) => {

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -60,8 +60,8 @@ const buildVisualItem = (visual = {}) => {
     item.opacity = visual.opacity;
   }
 
-  if (visual.blur) {
-    item.blur = { ...visual.blur };
+  if (visual.blur !== undefined) {
+    item.blur = visual.blur === null ? null : { ...visual.blur };
   }
 
   if (visual.animations?.resourceId) {

--- a/src/components/commandLineVisual/commandLineVisual.schema.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.schema.yaml
@@ -31,7 +31,9 @@ propsSchema:
                 minimum: 0
                 maximum: 1
               blur:
-                type: object
+                type:
+                  - object
+                  - "null"
                 properties:
                   x:
                     type: number

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -652,7 +652,7 @@ export const updateVisualBlurEnabled = ({ state }, { index, enabled } = {}) => {
   }
 
   if (!normalizeCommandLineItemBlurEnabled(enabled)) {
-    delete visual.blur;
+    visual.blur = null;
     return;
   }
 

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -122,6 +122,23 @@ const resolveBackgroundPreviewAction = ({ actions, presentationState }) => {
   }
 
   const previewBackground = { ...actionBackground };
+  const hasAppearanceOnlyChange =
+    Object.hasOwn(actionBackground, "opacity") ||
+    Object.hasOwn(actionBackground, "blur");
+  if (
+    hasAppearanceOnlyChange &&
+    !previewBackground.resourceId &&
+    effectiveBackground?.resourceId
+  ) {
+    previewBackground.resourceId = effectiveBackground.resourceId;
+  }
+  if (
+    hasAppearanceOnlyChange &&
+    !previewBackground.colorId &&
+    effectiveBackground?.colorId
+  ) {
+    previewBackground.colorId = effectiveBackground.colorId;
+  }
   if (!previewBackground.resourceId && actionBackground.colorId) {
     previewBackground.resourceId = effectiveBackground?.resourceId;
   }
@@ -393,7 +410,7 @@ const isDisplayableScreenAction = (screenAction) => {
   return Boolean(
     screenAction?.animations?.resourceId ||
       screenAction?.opacity !== undefined ||
-      screenAction?.blur,
+      Object.hasOwn(screenAction ?? {}, "blur"),
   );
 };
 

--- a/src/internal/commandLineItemEffects.js
+++ b/src/internal/commandLineItemEffects.js
@@ -84,25 +84,30 @@ const normalizeCommandLineItemBlurKernelSize = (value) => {
   );
 };
 
-export const normalizeCommandLineItemBlur = (blur = {}) => ({
-  x: normalizeCommandLineItemBlurNumber(
-    blur.x,
-    DEFAULT_COMMAND_LINE_ITEM_BLUR.x,
-  ),
-  y: normalizeCommandLineItemBlurNumber(
-    blur.y,
-    DEFAULT_COMMAND_LINE_ITEM_BLUR.y,
-  ),
-  quality: normalizeCommandLineItemBlurNumber(
-    blur.quality,
-    DEFAULT_COMMAND_LINE_ITEM_BLUR.quality,
-  ),
-  kernelSize: normalizeCommandLineItemBlurKernelSize(blur.kernelSize),
-  repeatEdgePixels: normalizeCommandLineItemBlurBoolean(
-    blur.repeatEdgePixels,
-    DEFAULT_COMMAND_LINE_ITEM_BLUR.repeatEdgePixels,
-  ),
-});
+export const normalizeCommandLineItemBlur = (blur = {}) => {
+  const source =
+    blur && typeof blur === "object" && !Array.isArray(blur) ? blur : {};
+
+  return {
+    x: normalizeCommandLineItemBlurNumber(
+      source.x,
+      DEFAULT_COMMAND_LINE_ITEM_BLUR.x,
+    ),
+    y: normalizeCommandLineItemBlurNumber(
+      source.y,
+      DEFAULT_COMMAND_LINE_ITEM_BLUR.y,
+    ),
+    quality: normalizeCommandLineItemBlurNumber(
+      source.quality,
+      DEFAULT_COMMAND_LINE_ITEM_BLUR.quality,
+    ),
+    kernelSize: normalizeCommandLineItemBlurKernelSize(source.kernelSize),
+    repeatEdgePixels: normalizeCommandLineItemBlurBoolean(
+      source.repeatEdgePixels,
+      DEFAULT_COMMAND_LINE_ITEM_BLUR.repeatEdgePixels,
+    ),
+  };
+};
 
 export const normalizeCommandLineItemBlurEnabled = (value) => {
   return value === true || value === "true";
@@ -137,7 +142,9 @@ export const normalizeCommandLineItemEffects = (item = {}) => {
     nextItem.opacity = opacity;
   }
 
-  if (
+  if (nextItem.blur === null) {
+    nextItem.blur = null;
+  } else if (
     nextItem.blur &&
     typeof nextItem.blur === "object" &&
     !Array.isArray(nextItem.blur)

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -14,6 +14,7 @@ import {
   selectSelectedAnimationPlaybackContinuity,
   selectSelectedAnimationMode,
   selectSelectedBlur,
+  selectSelectedBlurActionValue,
   selectSelectedColor,
   selectSelectedOpacity,
   selectSelectedResource,
@@ -52,6 +53,7 @@ const createStoreApi = (state) => ({
     selectSelectedAnimationPlaybackContinuity({ state }),
   selectSelectedAnimationMode: () => selectSelectedAnimationMode({ state }),
   selectSelectedBlur: () => selectSelectedBlur({ state }),
+  selectSelectedBlurActionValue: () => selectSelectedBlurActionValue({ state }),
   selectSelectedColor: () => selectSelectedColor({ state }),
   selectSelectedOpacity: () => selectSelectedOpacity({ state }),
   selectSelectedResource: () => selectSelectedResource({ state }),
@@ -393,7 +395,7 @@ describe("commandLineBackground.handlers", () => {
     expect(render).toHaveBeenCalledTimes(2);
   });
 
-  it("submits blur when enabled and omits it when disabled", () => {
+  it("submits blur when enabled and clears it when disabled", () => {
     const state = createInitialState();
     const render = vi.fn();
     const dispatchEvent = vi.fn();
@@ -515,6 +517,7 @@ describe("commandLineBackground.handlers", () => {
     expect(dispatchEvent.mock.calls[1][0].detail).toEqual({
       background: {
         resourceId: "bg-school",
+        blur: null,
       },
     });
     expect(render).toHaveBeenCalledTimes(4);

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  selectSelectedBlurActionValue,
   selectViewData,
   setRepositoryState,
   setSelectedAnimation,
@@ -335,6 +336,22 @@ describe("commandLineBackground.store", () => {
     expect(viewData.dialogueForm.defaultValues.blurRepeatEdgePixels).toBe(
       false,
     );
+  });
+
+  it("keeps background blur null as an explicit clear value", () => {
+    const state = createInitialState();
+
+    setSelectedBlur(
+      { state },
+      {
+        blur: null,
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.dialogueForm.defaultValues.blur).toBe(false);
+    expect(selectSelectedBlurActionValue({ state })).toBeNull();
   });
 
   it("normalizes invalid background blur kernel size to a supported option", () => {

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -583,6 +583,71 @@ describe("commandLineCharacters.handlers", () => {
     expect(render).toHaveBeenCalledTimes(4);
   });
 
+  it("emits null when character blur is disabled", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+            transformId: "character-center",
+            sprites: [],
+            blur: {
+              x: 6,
+              y: 9,
+              quality: 3,
+              kernelSize: 9,
+              repeatEdgePixels: true,
+            },
+          },
+        ],
+      },
+    );
+
+    handleBlurToggleChange(
+      {
+        store,
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: false,
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedCharacters({ state })[0].blur).toBeNull();
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        character: {
+          items: [
+            {
+              id: "character-hero",
+              transformId: "character-center",
+              sprites: [],
+              spriteName: "",
+              blur: null,
+            },
+          ],
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
   it("submits opacity and blur for selected characters", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -384,7 +384,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     expect(state.selectedCharacters[0].opacity).toBe(0);
 
     updateCharacterBlurEnabled({ state }, { index: 0, enabled: false });
-    expect(state.selectedCharacters[0].blur).toBeUndefined();
+    expect(state.selectedCharacters[0].blur).toBeNull();
 
     updateCharacterBlurEnabled({ state }, { index: 0, enabled: true });
     updateCharacterBlurField(

--- a/tests/commandLineScreen/commandLineScreen.handlers.test.js
+++ b/tests/commandLineScreen/commandLineScreen.handlers.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createInitialState,
   selectScreenBlur,
+  selectScreenBlurActionValue,
   selectScreenOpacity,
   selectTransitionAnimationId,
   setFormValues,
@@ -13,6 +14,7 @@ import {
 
 const createStoreApi = (state) => ({
   selectScreenBlur: () => selectScreenBlur({ state }),
+  selectScreenBlurActionValue: () => selectScreenBlurActionValue({ state }),
   selectScreenOpacity: () => selectScreenOpacity({ state }),
   selectTransitionAnimationId: () => selectTransitionAnimationId({ state }),
   setFormValues: (payload) => setFormValues({ state }, payload),
@@ -145,7 +147,7 @@ describe("commandLineScreen.handlers", () => {
     });
   });
 
-  it("omits screen opacity and blur when cleared", () => {
+  it("omits screen opacity and clears blur when disabled", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();
 
@@ -174,6 +176,7 @@ describe("commandLineScreen.handlers", () => {
         animations: {
           resourceId: "screen-crossfade",
         },
+        blur: null,
       },
     });
   });

--- a/tests/commandLineScreen/commandLineScreen.store.test.js
+++ b/tests/commandLineScreen/commandLineScreen.store.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   selectScreenBlur,
+  selectScreenBlurActionValue,
   selectScreenOpacity,
   selectViewData,
   setAnimations,
@@ -232,6 +233,31 @@ describe("commandLineScreen.store", () => {
     expect(viewData.defaultValues.blurQuality).toBe(2);
     expect(viewData.defaultValues.blurKernelSize).toBe(13);
     expect(viewData.defaultValues.blurRepeatEdgePixels).toBe(false);
+  });
+
+  it("uses screen blur null props as an explicit clear value", () => {
+    const state = createInitialState();
+
+    setFormValues(
+      { state },
+      {
+        values: {
+          blur: false,
+        },
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        screen: {
+          blur: null,
+        },
+      },
+    });
+
+    expect(viewData.defaultValues.blur).toBe(false);
+    expect(selectScreenBlurActionValue({ state })).toBeNull();
   });
 
   it("normalizes invalid screen blur kernel size to a supported option", () => {

--- a/tests/commandLineVisual/commandLineVisual.handlers.test.js
+++ b/tests/commandLineVisual/commandLineVisual.handlers.test.js
@@ -586,6 +586,74 @@ describe("commandLineVisual.handlers animation controls", () => {
     expect(render).toHaveBeenCalledTimes(4);
   });
 
+  it("emits null when visual blur is disabled", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            resourceType: "image",
+            transformId: "visual-center",
+            layer: 50,
+            blur: {
+              x: 6,
+              y: 9,
+              quality: 3,
+              kernelSize: 9,
+              repeatEdgePixels: true,
+            },
+          },
+        ],
+      },
+    );
+
+    handleBlurToggleChange(
+      {
+        store,
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              index: "0",
+            },
+          },
+          detail: {
+            value: false,
+          },
+        },
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0].blur).toBeNull();
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        visual: {
+          items: [
+            {
+              id: "visual-1",
+              resourceId: "visual-image",
+              resourceType: "image",
+              transformId: "visual-center",
+              layer: 50,
+              blur: null,
+            },
+          ],
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
   it("moves visuals from the context menu and emits reordered preview data", () => {
     const state = createInitialState();
     const render = vi.fn();

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -365,7 +365,7 @@ describe("commandLineVisual.store animation controls", () => {
     expect(selectSelectedVisuals({ state })[0].opacity).toBe(1);
 
     updateVisualBlurEnabled({ state }, { index: 0, enabled: false });
-    expect(selectSelectedVisuals({ state })[0].blur).toBeUndefined();
+    expect(selectSelectedVisuals({ state })[0].blur).toBeNull();
 
     updateVisualBlurEnabled({ state }, { index: 0, enabled: true });
     updateVisualBlurField(

--- a/tests/project/engineActions.test.js
+++ b/tests/project/engineActions.test.js
@@ -170,4 +170,56 @@ describe("normalizeLineActions", () => {
       },
     });
   });
+
+  it("preserves blur null clear actions", () => {
+    expect(
+      normalizeLineActions({
+        background: {
+          blur: null,
+        },
+        screen: {
+          blur: null,
+        },
+        visual: {
+          items: [
+            {
+              id: "visual-1",
+              blur: null,
+            },
+          ],
+        },
+        character: {
+          items: [
+            {
+              id: "character-1",
+              blur: null,
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      background: {
+        blur: null,
+      },
+      screen: {
+        blur: null,
+      },
+      visual: {
+        items: [
+          {
+            id: "visual-1",
+            blur: null,
+          },
+        ],
+      },
+      character: {
+        items: [
+          {
+            id: "character-1",
+            blur: null,
+          },
+        ],
+      },
+    });
+  });
 });

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -249,6 +249,77 @@ describe("systemActions.store", () => {
     });
   });
 
+  it("previews screen blur clear actions", () => {
+    const state = createInitialState();
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actions: {
+          screen: {
+            blur: null,
+          },
+        },
+      },
+    });
+
+    expect(actions.screen).toEqual({
+      blur: null,
+    });
+    expect(preview.screen).toMatchObject({
+      label: "Screen",
+    });
+  });
+
+  it("previews background appearance-only actions against current background", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          images: {
+            items: {
+              "bg-school": {
+                id: "bg-school",
+                type: "image",
+                name: "School",
+                fileId: "file-school",
+              },
+            },
+            tree: [{ id: "bg-school" }],
+          },
+        },
+      },
+    );
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actions: {
+          background: {
+            blur: null,
+          },
+        },
+        presentationState: {
+          background: {
+            resourceId: "bg-school",
+          },
+        },
+      },
+    });
+
+    expect(actions.background).toEqual({
+      resourceId: "bg-school",
+      blur: null,
+    });
+    expect(preview.background).toMatchObject({
+      id: "bg-school",
+      name: "School",
+      type: "image",
+    });
+  });
+
   it("includes custom character name and persist character labels in dialogue preview when a character is selected", () => {
     const state = createInitialState();
 


### PR DESCRIPTION
## Summary
- emit `blur: null` from background/screen/character/visual editors when blur is explicitly disabled
- keep omitted blur as inherited/no-op so unrelated action edits do not clear blur
- allow command action schemas and previews to preserve blur clear actions
- add focused coverage for blur clear serialization and preview behavior

## Testing
- `bunx vitest run tests/commandLineBackground/commandLineBackground.handlers.test.js tests/commandLineBackground/commandLineBackground.store.test.js tests/commandLineScreen/commandLineScreen.handlers.test.js tests/commandLineScreen/commandLineScreen.store.test.js tests/commandLineVisual/commandLineVisual.handlers.test.js tests/commandLineVisual/commandLineVisual.store.test.js tests/commandLineCharacters/commandLineCharacters.handlers.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js tests/project/engineActions.test.js tests/systemActions/systemActions.store.test.js`
- `bun prettier --check` on changed files
- `bunx oxlint` on changed JS files
- `git diff --check`
- push hook: `oxlint && bun prettier --check src`
- `bun run check:contracts` fails on existing repo-wide RTGL diagnostics unrelated to this change