### PR TITLE
feat: add layout choice single item containers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.5",
-        "@routevn/creator-model": "1.6.3",
+        "@routevn/creator-model": "1.7.0",
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "2.5.1",
@@ -311,7 +311,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.6.3", "", {}, "sha512-4lBTnh2Exdl24gi1dPRpYl6JNrkW1imuBY91/8qRXXcY9hzttA2awSOLaHe8q7mIcMZhsyzZ/0U2FjWmCbDS2g=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.7.0", "", {}, "sha512-FXeTiHD5oqNYBozJBYKo6u5Iips4V2hLmB0GL91Jb4z5DSqpPYcByjHTknF93dOq80DWzMUmNVipWSia/nGQUw=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.5",
-    "@routevn/creator-model": "1.6.3",
+    "@routevn/creator-model": "1.7.0",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "2.5.1",

--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -185,6 +185,14 @@ layoutSections:
             value: false
           - label: Enabled
             value: true
+  - "$when": 'itemType == "container-ref-choice-single-item"'
+    label: Choice
+    items:
+      - type: select
+        label: Choice
+        name: choiceItemIndex
+        value: "${values.choiceItemIndex}"
+        options: "${choiceItemOptions}"
   - "$when": "supportsChildInteractionInheritance"
     id: childInteraction
     label: Child Interaction

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -60,6 +60,10 @@ import {
 
 const HIDDEN_LAYOUT_ACTION_MODES = new Set(["conditional"]);
 const POSITION_POPOVER_NAMES = new Set(["x", "y"]);
+const CHOICE_ITEM_OPTIONS = Array.from({ length: 20 }, (_item, index) => ({
+  label: `Choice ${index + 1}`,
+  value: index,
+}));
 const POSITION_POPOVER_PRESETS = [
   {
     label: "0",
@@ -1040,6 +1044,7 @@ export const selectViewData = ({ state, props, constants }) => {
         }),
         childInteractionSummary: getChildInteractionSummary(values),
         childInteractionItems: getChildInteractionItems(values),
+        choiceItemOptions: CHOICE_ITEM_OPTIONS,
         hasChildInteractionInheritance: hasChildInteractionInheritance(values),
         canAddChildInteractionInheritance:
           getAvailableChildInteractionItems(values).length > 0,

--- a/src/components/layoutEditPanel/support/layoutEditPanelViewData.js
+++ b/src/components/layoutEditPanel/support/layoutEditPanelViewData.js
@@ -184,6 +184,7 @@ export const toInspectorValues = ({
     paginationMode: values?.paginationMode ?? "continuous",
     paginationSize: values?.paginationSize ?? 3,
     scroll: values?.scroll ?? false,
+    choiceItemIndex: values?.choiceItemIndex ?? 0,
     direction,
     gapX: values?.gapX ?? 0,
     gapY: values?.gapY ?? 0,

--- a/src/components/layoutEditorPreview/support/layoutEditorPreviewData.js
+++ b/src/components/layoutEditorPreview/support/layoutEditorPreviewData.js
@@ -26,6 +26,7 @@ const DIALOGUE_NVL_ITEM_TYPES = new Set([
 ]);
 const CHOICE_ITEM_TYPES = new Set([
   "container-ref-choice-item",
+  "container-ref-choice-single-item",
   "text-ref-choice-item-content",
 ]);
 const HISTORY_ITEM_TYPES = new Set([

--- a/src/internal/layoutEditorElementRegistry.js
+++ b/src/internal/layoutEditorElementRegistry.js
@@ -29,6 +29,7 @@ const TEXT_TYPE_SET = new Set([
 const CONTAINER_TYPE_SET = new Set([
   "container",
   "container-ref-choice-item",
+  "container-ref-choice-single-item",
   "container-ref-save-load-slot",
   "container-ref-dialogue-line",
   "container-ref-history-line",
@@ -41,6 +42,17 @@ const supportsLayoutEditorWidthMode = (itemType) => {
 };
 
 const ABSOLUTE_DIRECTION = "absolute";
+const MAX_CHOICE_SINGLE_ITEM_INDEX = 19;
+
+const normalizeChoiceSingleItemIndex = (value) => {
+  const index = Number(value);
+
+  if (!Number.isInteger(index) || index < 0) {
+    return 0;
+  }
+
+  return Math.min(index, MAX_CHOICE_SINGLE_ITEM_INDEX);
+};
 
 const CREATE_TEMPLATES = {
   container: () => ({
@@ -239,9 +251,25 @@ const CREATE_TEMPLATES = {
     ),
   "container-choice-item": () => ({
     type: "container-ref-choice-item",
-    name: "Container (Choice Item)",
+    name: "Container (Repeated Choice Item)",
     ...BASE_TRANSFORM,
     direction: ABSOLUTE_DIRECTION,
+  }),
+  "container-choice-single-item": () => ({
+    type: "container-ref-choice-single-item",
+    name: "Container (Single Choice Item)",
+    ...BASE_TRANSFORM,
+    direction: ABSOLUTE_DIRECTION,
+    choiceItemIndex: 0,
+    hover: {
+      inheritToChildren: true,
+    },
+    click: {
+      inheritToChildren: true,
+    },
+    rightClick: {
+      inheritToChildren: true,
+    },
   }),
   "container-save-load-slot": () => ({
     type: "container-ref-save-load-slot",
@@ -298,7 +326,7 @@ const CREATE_TEMPLATES = {
     scaleLayoutElementItemForProjectResolution(
       {
         type: "text-ref-choice-item-content",
-        name: "Text (Choice Item Content)",
+        name: "Text (Choice Content)",
         ...BASE_TRANSFORM,
         x: 960,
         y: 24,
@@ -449,6 +477,7 @@ const applySpriteAutoSize = ({ nextItem, imagesData }) => {
 const TYPE_FAMILIES = {
   container: "container",
   "container-ref-choice-item": "container",
+  "container-ref-choice-single-item": "container",
   "container-ref-save-load-slot": "container",
   "container-ref-dialogue-line": "container",
   "container-ref-history-line": "container",
@@ -541,6 +570,9 @@ const FAMILY_CAPABILITIES = {
 };
 
 const ITEM_TYPE_CAPABILITY_OVERRIDES = {
+  "container-ref-choice-single-item": {
+    supportsActions: false,
+  },
   sprite: {
     supportsSpriteBlur: true,
   },
@@ -568,6 +600,10 @@ const TYPE_RULES = {
 
       if (name === "paginationMode" && (value === null || value === "")) {
         return "continuous";
+      }
+
+      if (name === "choiceItemIndex") {
+        return normalizeChoiceSingleItemIndex(value);
       }
 
       return value;
@@ -649,6 +685,11 @@ const PANEL_FEATURES_BY_TYPE = {
     "actions",
     "childInteraction",
   ],
+  "container-ref-choice-single-item": [
+    ...DEFAULT_PANEL_FEATURES,
+    "childInteraction",
+    "scroll",
+  ],
   "container-ref-save-load-slot": [
     ...DEFAULT_PANEL_FEATURES,
     "actions",
@@ -710,6 +751,7 @@ const PANEL_FEATURES_BY_TYPE = {
 const PREVIEW_DEPENDENCIES_BY_TYPE = {
   "fragment-ref": { fragments: true },
   "container-ref-choice-item": { choice: true },
+  "container-ref-choice-single-item": { choice: true },
   "text-ref-choice-item-content": { choice: true },
   "container-ref-save-load-slot": { saveLoad: true },
   "sprite-ref-save-load-slot-image": { saveLoad: true },

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -75,6 +75,25 @@ const SPRITE_RENDER_TYPE_BY_TYPE = {
   "sprite-ref-save-load-slot-image": "sprite",
 };
 
+const CHOICE_SINGLE_ITEM_CONTAINER_TYPE = "container-ref-choice-single-item";
+const MAX_CHOICE_SINGLE_ITEM_INDEX = 19;
+
+const normalizeChoiceSingleItemIndex = (value) => {
+  const index = Number(value);
+
+  if (!Number.isInteger(index) || index < 0) {
+    return 0;
+  }
+
+  return Math.min(index, MAX_CHOICE_SINGLE_ITEM_INDEX);
+};
+
+const createChoiceSingleItemClickInteraction = (choiceItemIndex) => ({
+  payload: {
+    actions: `\${choice.items[${choiceItemIndex}].events.click.actions}`,
+  },
+});
+
 const REPEATING_CONTAINER_CONFIG = {
   "container-ref-choice-item": {
     each: "item, i in choice.items",
@@ -899,9 +918,16 @@ const buildBaseElement = (node, context = {}) => {
   return element;
 };
 
-const getTextNodeContent = (node) => {
+const getTextNodeContent = (node, context = {}) => {
   if (node.content !== undefined) {
     return node.content;
+  }
+
+  if (
+    node.type === "text-ref-choice-item-content" &&
+    Number.isInteger(context.choiceItemIndex)
+  ) {
+    return `\${choice.items[${context.choiceItemIndex}].content}`;
   }
 
   return TEXT_CONTENT_BY_TYPE[node.type] ?? node.text ?? "";
@@ -921,7 +947,7 @@ const applyTextNode = ({ element, node, context }) => {
   }
 
   const renderType = TEXT_RENDER_TYPE_BY_TYPE[node.type] ?? element.type;
-  const content = getTextNodeContent(node);
+  const content = getTextNodeContent(node, context);
   const nextElement = {
     ...element,
     type: renderType,
@@ -1191,6 +1217,7 @@ const applyContainerNode = ({ element, node }) => {
   if (
     node.type !== "container" &&
     node.type !== "fragment-ref" &&
+    node.type !== CHOICE_SINGLE_ITEM_CONTAINER_TYPE &&
     !REPEATING_CONTAINER_CONFIG[node.type] &&
     !SPECIAL_CONTAINER_INTERACTIONS[node.type]
   ) {
@@ -1217,6 +1244,25 @@ const applyContainerNode = ({ element, node }) => {
 
   const repeatingConfig = REPEATING_CONTAINER_CONFIG[node.type];
   if (!repeatingConfig) {
+    if (node.type === CHOICE_SINGLE_ITEM_CONTAINER_TYPE) {
+      const choiceItemIndex = normalizeChoiceSingleItemIndex(
+        node.choiceItemIndex,
+      );
+
+      return {
+        ...nextElement,
+        type: "container",
+        $when: mergeWhenExpressions(
+          nextElement["$when"],
+          `choice.items[${choiceItemIndex}]`,
+        ),
+        click: mergeInteractionPayloadActions(
+          nextElement.click,
+          createChoiceSingleItemClickInteraction(choiceItemIndex),
+        ),
+      };
+    }
+
     const specialContainerInteraction =
       SPECIAL_CONTAINER_INTERACTIONS[node.type];
 
@@ -1264,7 +1310,14 @@ const mapLayoutNode = ({ node, imageItems, context }) => {
             slotId: "${item.slotId}",
           },
         }
-      : context;
+      : effectiveNode.type === CHOICE_SINGLE_ITEM_CONTAINER_TYPE
+        ? {
+            ...context,
+            choiceItemIndex: normalizeChoiceSingleItemIndex(
+              effectiveNode.choiceItemIndex,
+            ),
+          }
+        : context;
   let element = buildBaseElement(node, nodeContext);
 
   element = applyTextNode({

--- a/src/pages/layoutEditor/layoutEditor.constants.yaml
+++ b/src/pages/layoutEditor/layoutEditor.constants.yaml
@@ -63,9 +63,13 @@ contextMenuItems:
     type: item
     createType: text-history-line-content
   - "$when": 'layoutType == "choice"'
-    label: Container (Choice Item)
+    label: Container (Repeated Choice Item)
     type: item
     createType: container-choice-item
+  - "$when": 'layoutType == "choice"'
+    label: Container (Single Choice Item)
+    type: item
+    createType: container-choice-single-item
   - "$when": 'layoutType == "save-load"'
     label: Container (Save/Load Slot)
     type: item
@@ -79,7 +83,7 @@ contextMenuItems:
     type: item
     createType: text-save-load-slot-date
   - "$when": 'layoutType == "choice"'
-    label: Text (Choice Item)
+    label: Text (Choice Content)
     type: item
     createType: text-choice-item-content
   - type: separator
@@ -168,6 +172,14 @@ emptyContextMenuItems:
     label: Text (History Line Content)
     type: item
     createType: text-history-line-content
+  - "$when": 'layoutType == "choice"'
+    label: Container (Repeated Choice Item)
+    type: item
+    createType: container-choice-item
+  - "$when": 'layoutType == "choice"'
+    label: Container (Single Choice Item)
+    type: item
+    createType: container-choice-single-item
 
 controlContextMenuItems:
   - label: Edit

--- a/src/pages/layoutEditor/support/layoutEditorViewData.js
+++ b/src/pages/layoutEditor/support/layoutEditorViewData.js
@@ -5,6 +5,11 @@ import {
 } from "../../../internal/layoutEditorElementRegistry.js";
 import { DEFAULT_PROJECT_RESOLUTION } from "../../../internal/projectResolution.js";
 
+const CHOICE_CONTENT_PARENT_TYPES = new Set([
+  "container-ref-choice-item",
+  "container-ref-choice-single-item",
+]);
+
 export const toLayoutEditorContextMenuItems = (
   items = [],
   projectResolution = DEFAULT_PROJECT_RESOLUTION,
@@ -96,6 +101,25 @@ const toLeafItemContextMenuItems = (items = []) => {
   );
 };
 
+const isChoiceContentCreateMenuItem = (item = {}) => {
+  return (
+    item?.value?.action === "new-child-item" &&
+    item.value.type === "text-ref-choice-item-content"
+  );
+};
+
+const toContainerContextMenuItems = (items = [], parentItem = {}) => {
+  return compactContextMenuItems(
+    (items ?? []).filter((item) => {
+      if (!isChoiceContentCreateMenuItem(item)) {
+        return true;
+      }
+
+      return CHOICE_CONTENT_PARENT_TYPES.has(parentItem.type);
+    }),
+  );
+};
+
 export const toLayoutEditorExplorerItems = (
   items = [],
   { contextMenuItems } = {},
@@ -104,6 +128,8 @@ export const toLayoutEditorExplorerItems = (
 
   return (items ?? []).map((item) => {
     const definition = getLayoutEditorElementDefinition(item.type);
+    const canReceiveChildren =
+      item.type === "folder" || definition.isContainer === true;
     const hasPreviewDependencies =
       Object.keys(definition.previewDependencies).length > 0;
     const svg =
@@ -113,13 +139,13 @@ export const toLayoutEditorExplorerItems = (
       ...item,
       svg,
       contextMenuItems:
-        definition.isContainer === true
-          ? contextMenuItems
+        canReceiveChildren === true
+          ? toContainerContextMenuItems(contextMenuItems, item)
           : leafItemContextMenuItems,
       trailingSvg: hasPreviewDependencies ? "component" : undefined,
       dragOptions: {
         ...item.dragOptions,
-        canReceiveChildren: definition.isContainer,
+        canReceiveChildren,
       },
     };
   });

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -711,7 +711,7 @@ export const createLayoutTemplate = (layoutType, projectResolution) => {
           }),
           [choiceItemContainerId]: createLayoutElement(choiceItemContainerId, {
             type: "container-ref-choice-item",
-            name: "Container (Choice Item)",
+            name: "Container (Repeated Choice Item)",
             x: 0,
             y: 0,
             anchorX: 0,
@@ -731,7 +731,7 @@ export const createLayoutTemplate = (layoutType, projectResolution) => {
           }),
           [choiceTextId]: createLayoutElement(choiceTextId, {
             type: "text-ref-choice-item-content",
-            name: "Text (Choice Item Content)",
+            name: "Text (Choice Content)",
             x: 960,
             y: 10,
             anchorX: 0.5,

--- a/tests/layoutEditor/layoutEditor.store.test.js
+++ b/tests/layoutEditor/layoutEditor.store.test.js
@@ -144,6 +144,33 @@ describe("layoutEditor.store", () => {
     }
   });
 
+  it("keeps choice content text out of the empty choice layout menu", () => {
+    const state = createInitialState();
+
+    setLayout(
+      { state },
+      {
+        id: "layout-choice",
+        layout: {
+          id: "layout-choice",
+          layoutType: "choice",
+        },
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      constants: LAYOUT_EDITOR_CONSTANTS,
+    });
+    const emptyMenuLabels = viewData.emptyContextMenuItems.map(
+      (item) => item.label,
+    );
+
+    expect(emptyMenuLabels).toContain("Container (Repeated Choice Item)");
+    expect(emptyMenuLabels).toContain("Container (Single Choice Item)");
+    expect(emptyMenuLabels).not.toContain("Text (Choice Content)");
+  });
+
   it("adds the component badge to special layout editor items", () => {
     const state = createInitialState();
 

--- a/tests/layoutEditor/layoutEditorViewData.test.js
+++ b/tests/layoutEditor/layoutEditorViewData.test.js
@@ -21,6 +21,26 @@ describe("layoutEditorViewData", () => {
     });
   });
 
+  it("builds choice single item container create actions", () => {
+    const [choiceSingleItem] = toLayoutEditorContextMenuItems([
+      {
+        label: "Container (Single Choice Item)",
+        type: "item",
+        createType: "container-choice-single-item",
+      },
+    ]);
+
+    expect(choiceSingleItem.value).toMatchObject({
+      action: "new-child-item",
+      type: "container-ref-choice-single-item",
+      direction: "absolute",
+      choiceItemIndex: 0,
+      click: {
+        inheritToChildren: true,
+      },
+    });
+  });
+
   it("keeps grouped edit actions for leaf items without an empty add section", () => {
     const contextMenuItems = toLayoutEditorContextMenuItems([
       {
@@ -85,6 +105,140 @@ describe("layoutEditorViewData", () => {
         value: "delete-item",
       },
     ]);
+  });
+
+  it("keeps add actions available for folders", () => {
+    const contextMenuItems = toLayoutEditorContextMenuItems([
+      {
+        label: "Add Element",
+        type: "label",
+      },
+      {
+        label: "Container (Single Choice Item)",
+        type: "item",
+        createType: "container-choice-single-item",
+      },
+      {
+        label: "Text (Choice Content)",
+        type: "item",
+        createType: "text-choice-item-content",
+      },
+      {
+        type: "separator",
+      },
+      {
+        label: "Edit",
+        type: "label",
+      },
+      {
+        label: "Rename",
+        type: "item",
+        value: "rename-item",
+      },
+    ]);
+
+    const [folderItem] = toLayoutEditorExplorerItems(
+      [
+        {
+          id: "folder-1",
+          type: "folder",
+          name: "Group",
+        },
+      ],
+      {
+        contextMenuItems,
+      },
+    );
+
+    expect(folderItem.dragOptions.canReceiveChildren).toBe(true);
+    expect(folderItem.contextMenuItems).toContainEqual(
+      expect.objectContaining({
+        label: "Container (Single Choice Item)",
+        value: expect.objectContaining({
+          action: "new-child-item",
+          type: "container-ref-choice-single-item",
+        }),
+      }),
+    );
+    expect(folderItem.contextMenuItems).not.toContainEqual(
+      expect.objectContaining({
+        label: "Text (Choice Content)",
+      }),
+    );
+  });
+
+  it("only allows choice content text inside choice item containers", () => {
+    const contextMenuItems = toLayoutEditorContextMenuItems([
+      {
+        label: "Add Element",
+        type: "label",
+      },
+      {
+        label: "Text (Choice Content)",
+        type: "item",
+        createType: "text-choice-item-content",
+      },
+      {
+        type: "separator",
+      },
+      {
+        label: "Edit",
+        type: "label",
+      },
+      {
+        label: "Rename",
+        type: "item",
+        value: "rename-item",
+      },
+    ]);
+
+    const [normalContainer, repeatedChoiceItem, singleChoiceItem] =
+      toLayoutEditorExplorerItems(
+        [
+          {
+            id: "container-1",
+            type: "container",
+            name: "Container",
+          },
+          {
+            id: "choice-item-1",
+            type: "container-ref-choice-item",
+            name: "Repeated",
+          },
+          {
+            id: "choice-single-item-1",
+            type: "container-ref-choice-single-item",
+            name: "Single",
+          },
+        ],
+        {
+          contextMenuItems,
+        },
+      );
+
+    expect(normalContainer.contextMenuItems).not.toContainEqual(
+      expect.objectContaining({
+        label: "Text (Choice Content)",
+      }),
+    );
+    expect(repeatedChoiceItem.contextMenuItems).toContainEqual(
+      expect.objectContaining({
+        label: "Text (Choice Content)",
+        value: expect.objectContaining({
+          action: "new-child-item",
+          type: "text-ref-choice-item-content",
+        }),
+      }),
+    );
+    expect(singleChoiceItem.contextMenuItems).toContainEqual(
+      expect.objectContaining({
+        label: "Text (Choice Content)",
+        value: expect.objectContaining({
+          action: "new-child-item",
+          type: "text-ref-choice-item-content",
+        }),
+      }),
+    );
   });
 
   it("uses the spritesheets icon for spritesheet animation elements", () => {

--- a/tests/project/layout.choiceSingleItems.test.js
+++ b/tests/project/layout.choiceSingleItems.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { parseAndRender } from "jempl";
+import { buildLayoutElements } from "../../src/internal/project/layout.js";
+
+const emptyCollection = { items: {}, tree: [] };
+
+const buildChoiceLayoutElements = (layout) => {
+  return buildLayoutElements(
+    layout,
+    {},
+    emptyCollection,
+    emptyCollection,
+    emptyCollection,
+    {
+      layoutId: "choice-layout",
+      layoutType: "choice",
+    },
+  ).elements;
+};
+
+describe("buildLayoutElements choice single item containers", () => {
+  it("projects a choice single item container to a normal container bound to one choice", () => {
+    const elements = buildChoiceLayoutElements([
+      {
+        id: "choice-single-item",
+        type: "container-ref-choice-single-item",
+        direction: "absolute",
+        choiceItemIndex: 1,
+        $when: "variables.showChoices",
+        click: {
+          inheritToChildren: true,
+        },
+        children: [
+          {
+            id: "choice-label",
+            type: "text-ref-choice-item-content",
+            x: 0,
+            y: 0,
+            text: "Choice",
+          },
+        ],
+      },
+    ]);
+
+    expect(elements[0]).toMatchObject({
+      id: "choice-single-item",
+      type: "container",
+      direction: "absolute",
+      $when: "(variables.showChoices) && (choice.items[1])",
+      click: {
+        inheritToChildren: true,
+        payload: {
+          actions: "${choice.items[1].events.click.actions}",
+        },
+      },
+      children: [
+        {
+          id: "choice-label",
+          type: "text",
+          content: "${choice.items[1].content}",
+        },
+      ],
+    });
+  });
+
+  it("renders only when the assigned choice exists", () => {
+    const elements = buildChoiceLayoutElements([
+      {
+        id: "choice-single-item",
+        type: "container-ref-choice-single-item",
+        choiceItemIndex: 1,
+        children: [
+          {
+            id: "choice-label",
+            type: "text-ref-choice-item-content",
+          },
+        ],
+      },
+    ]);
+
+    const rendered = parseAndRender(
+      { elements },
+      {
+        choice: {
+          items: [
+            {
+              content: "First",
+              events: {
+                click: {
+                  actions: {
+                    nextLine: {},
+                  },
+                },
+              },
+            },
+            {
+              content: "Second",
+              events: {
+                click: {
+                  actions: {
+                    sectionTransition: {
+                      sceneId: "scene-2",
+                      sectionId: "section-2",
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(rendered.elements[0].children[0].content).toBe("Second");
+    expect(rendered.elements[0].click.payload.actions).toEqual({
+      sectionTransition: {
+        sceneId: "scene-2",
+        sectionId: "section-2",
+      },
+    });
+
+    const missingChoiceRender = parseAndRender(
+      { elements },
+      {
+        choice: {
+          items: [
+            {
+              content: "First",
+              events: {
+                click: {
+                  actions: {},
+                },
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(missingChoiceRender.elements).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Container (Single Choice Item) for choice layouts, backed by container-ref-choice-single-item
- project single choice item containers to one choice index with inherited click handling and choice content binding
- keep Text (Choice Content) addable only inside repeated/single choice item containers
- rename choice layout menu labels to repeated vs single item and bump @routevn/creator-model to 1.7.0

## Testing
- bunx vitest run tests/layoutEditor/layoutEditorViewData.test.js tests/layoutEditor/layoutEditor.store.test.js tests/project/layout.choiceSingleItems.test.js tests/layoutEditor/layoutEditorPreview.test.js tests/layouts/layouts.handlers.test.js
- bunx vitest run tests/model-api.test.js tests/command-direct-coverage.test.js (in ../routevn-creator-model)
- bunx prettier --check src/internal/layoutEditorElementRegistry.js src/internal/project/layout.js src/pages/layoutEditor/layoutEditor.constants.yaml src/pages/layoutEditor/support/layoutEditorViewData.js src/components/layoutEditPanel/layoutEditPanel.constants.yaml src/components/layoutEditPanel/layoutEditPanel.store.js src/components/layoutEditPanel/support/layoutEditPanelViewData.js src/components/layoutEditorPreview/support/layoutEditorPreviewData.js src/pages/layouts/layouts.handlers.js tests/layoutEditor/layoutEditor.store.test.js tests/layoutEditor/layoutEditorViewData.test.js tests/project/layout.choiceSingleItems.test.js package.json
- git diff --check
- pre-push hook: oxlint && bun prettier --check src