### PR TITLE
fix: restore conditional command action

### DIFF
--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -1,7 +1,5 @@
 import { RUNTIME_ACTION_ITEMS } from "../../internal/runtimeActions.js";
 
-const DEFAULT_HIDDEN_MODES = ["conditional"];
-
 const createSection = (label, items) => ({
   label,
   items,
@@ -240,11 +238,11 @@ const PRESENTATION_ACTION_SECTIONS = [
 ];
 
 const getHiddenModes = (attrs = {}) => {
-  const hiddenModes = new Set(DEFAULT_HIDDEN_MODES);
   if (!Array.isArray(attrs.hiddenModes)) {
-    return [...hiddenModes];
+    return [];
   }
 
+  const hiddenModes = new Set();
   for (const mode of attrs.hiddenModes) {
     if (typeof mode === "string" && mode.length > 0) {
       hiddenModes.add(mode);

--- a/src/components/commandLineConditional/commandLineConditional.store.js
+++ b/src/components/commandLineConditional/commandLineConditional.store.js
@@ -14,6 +14,8 @@ const CONDITION_OPERATOR_LABELS = Object.fromEntries(
   CONDITION_OPERATOR_OPTIONS.map((option) => [option.value, option.label]),
 );
 
+const DEFAULT_BRANCH_LABEL = "Default branch";
+
 const BRANCH_ACTION_ALLOWED_MODES = [
   "sectionTransition",
   "resetStoryAtSection",
@@ -106,7 +108,7 @@ const formatConditionValue = (value) => {
 
 const getBranchSummary = (branch, variablesData = {}) => {
   if (!Object.hasOwn(toPlainObject(branch), "when")) {
-    return "Default";
+    return DEFAULT_BRANCH_LABEL;
   }
 
   if (typeof branch.when === "string") {
@@ -328,7 +330,9 @@ export const selectViewData = ({ state, props }) => {
     .filter((branch) => !hasBranchCondition(branch))
     .map(createBranchViewData)[0];
   const editBranchLabel =
-    state.tempBranch.conditionKind === "default" ? "Default" : "Branch";
+    state.tempBranch.conditionKind === "default"
+      ? DEFAULT_BRANCH_LABEL
+      : "Branch";
 
   const breadcrumb = [
     { id: "actions", label: "Actions", click: true },
@@ -379,7 +383,9 @@ export const selectViewData = ({ state, props }) => {
     isEditingDefault: state.tempBranch.conditionKind === "default",
     isEditingUnsupportedCondition,
     editBranchTitle:
-      state.tempBranch.conditionKind === "default" ? "Default" : "Branch",
+      state.tempBranch.conditionKind === "default"
+        ? DEFAULT_BRANCH_LABEL
+        : "Branch",
     hiddenModes: getHiddenModes(props),
     dropdownMenu: state.dropdownMenu,
   };

--- a/src/components/commandLineConditional/commandLineConditional.view.yaml
+++ b/src/components/commandLineConditional/commandLineConditional.view.yaml
@@ -78,7 +78,7 @@ template:
                               - rtgl-text s=sm: ${branch.summary}
                               - rtgl-text s=xs c=mu-fg: ${branch.actionsSummary}
                   - rtgl-button#addBranchButton v=ol w=f mt=md: + Add Branch
-                  - rtgl-text s=sm c=mu-fg mt=md: Default
+                  - rtgl-text s=sm c=mu-fg mt=md: Default branch
                   - $if hasDefaultBranch:
                       - rtgl-view#defaultBranch data-branch-id=${defaultBranch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
                           - rtgl-view d=v w=1fg:

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -6,8 +6,6 @@ import {
 import { buildCharacterSpritePreviewFileIds } from "../../internal/characterSpritePreview.js";
 import { normalizeLineActions } from "../../internal/project/engineActions.js";
 
-const DEFAULT_HIDDEN_MODES = ["conditional"];
-
 export const createInitialState = () => ({
   mode: "actions",
   actions: {},
@@ -34,11 +32,11 @@ export const setUiConfig = ({ state }, { uiConfig } = {}) => {
 };
 
 const getHiddenModes = (attrs = {}) => {
-  const hiddenModes = new Set(DEFAULT_HIDDEN_MODES);
   if (!Array.isArray(attrs.hiddenModes)) {
-    return [...hiddenModes];
+    return [];
   }
 
+  const hiddenModes = new Set();
   for (const mode of attrs.hiddenModes) {
     if (typeof mode === "string" && mode.length > 0) {
       hiddenModes.add(mode);

--- a/tests/commandLineActions/commandLineActions.store.test.js
+++ b/tests/commandLineActions/commandLineActions.store.test.js
@@ -53,7 +53,7 @@ describe("commandLineActions.store", () => {
     expect(iconByMode.decrementSaveLoadPagination).toBe("settings");
     expect(iconByMode.setMenuPage).toBe("settings");
     expect(iconByMode.setMenuEntryPoint).toBe("settings");
-    expect(iconByMode.conditional).toBeUndefined();
+    expect(iconByMode.conditional).toBe("settings");
   });
 
   it("offers resetStoryAtSection in system actions and drops resetStorySession", () => {
@@ -103,7 +103,7 @@ describe("commandLineActions.store", () => {
     }
   });
 
-  it("hides conditional actions from the logic section", () => {
+  it("shows conditional actions in the logic section", () => {
     const systemItems = selectItems({
       props: {
         actionsType: "system",
@@ -115,20 +115,25 @@ describe("commandLineActions.store", () => {
       },
     });
 
-    expect(getSectionModes(systemItems, "Logic")).toEqual(["updateVariable"]);
+    expect(getSectionModes(systemItems, "Logic")).toEqual([
+      "updateVariable",
+      "conditional",
+    ]);
     expect(getSectionModes(presentationItems, "Logic")).toEqual([
       "updateVariable",
+      "conditional",
     ]);
-    expect(systemItems.some((item) => item.mode === "conditional")).toBe(false);
+    expect(systemItems.some((item) => item.mode === "conditional")).toBe(true);
     expect(presentationItems.some((item) => item.mode === "conditional")).toBe(
-      false,
+      true,
     );
   });
 
-  it("keeps conditional hidden even when allowed modes include it", () => {
+  it("honors explicit hidden modes for conditional actions", () => {
     const items = selectItems({
       props: {
         actionsType: "system",
+        hiddenModes: ["conditional"],
         allowedModes: ["conditional", "updateVariable"],
       },
     });

--- a/tests/commandLineConditional/commandLineConditional.store.test.js
+++ b/tests/commandLineConditional/commandLineConditional.store.test.js
@@ -65,7 +65,7 @@ describe("commandLineConditional.store", () => {
     ]);
     expect(viewData.defaultBranch).toMatchObject({
       id: "branch-2",
-      summary: "Default",
+      summary: "Default branch",
       actionsSummary: "1 action",
     });
     expect(viewData.operatorOptions.map((option) => option.value)).toEqual([

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -8,7 +8,7 @@ import {
 } from "../../src/components/systemActions/systemActions.store.js";
 
 describe("systemActions.store", () => {
-  it("hides conditional mode by default for nested action pickers", () => {
+  it("preserves explicit hidden modes for nested action pickers", () => {
     const state = createInitialState();
 
     const viewData = selectViewData({
@@ -18,7 +18,7 @@ describe("systemActions.store", () => {
       },
     });
 
-    expect(viewData.hiddenModes).toEqual(["conditional", "rollbackByOffset"]);
+    expect(viewData.hiddenModes).toEqual(["rollbackByOffset"]);
   });
 
   it("preserves and previews update variable actions", () => {


### PR DESCRIPTION
## Summary
- show the Conditional action in command-line action pickers by default
- keep explicit hiddenModes support for surfaces that still hide conditional actions
- rename the conditional default branch label to `Default branch`

## Testing
- `bunx vitest run tests/commandLineActions/commandLineActions.store.test.js tests/systemActions/systemActions.store.test.js tests/commandLineConditional/commandLineConditional.store.test.js`
- `git diff --check`
- push hook: `oxlint && bun prettier --check src`