### PR TITLE
fix(scene-editor): refresh variable chip labels

### DIFF
--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -138,6 +138,34 @@ const normalizeMentionTargets = (targets = []) => {
   return result;
 };
 
+const areMentionTargetsEqual = (leftTargets = [], rightTargets = []) => {
+  if (leftTargets.length !== rightTargets.length) {
+    return false;
+  }
+
+  for (let index = 0; index < leftTargets.length; index += 1) {
+    const left = leftTargets[index];
+    const right = rightTargets[index];
+    if (
+      left?.id !== right?.id ||
+      left?.label !== right?.label ||
+      left?.variableType !== right?.variableType
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const hasReferenceContent = (lines = []) => {
+  return cloneSceneEditorLines(lines).some((line) => {
+    return getLineDialogueContent(line).some((item) => {
+      return item?.reference || item?.mention;
+    });
+  });
+};
+
 const STYLES = `
   rvn-lexical-scene-document-editor {
     display: block;
@@ -1220,7 +1248,13 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   set mentionTargets(value) {
-    this.state.mentionTargets = normalizeMentionTargets(value);
+    const nextMentionTargets = normalizeMentionTargets(value);
+    if (areMentionTargetsEqual(this.state.mentionTargets, nextMentionTargets)) {
+      return;
+    }
+
+    this.state.mentionTargets = nextMentionTargets;
+    this.refreshReferenceLabels();
   }
 
   get mentionTargets() {
@@ -4443,6 +4477,22 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       (item) => item.id === resourceId,
     );
     return target?.label ?? resourceId;
+  }
+
+  refreshReferenceLabels() {
+    if (!this.isConnected || !this.refs.editor || this.isComposing) {
+      return;
+    }
+
+    const lines = this.readEditorSnapshot().lines;
+    if (!hasReferenceContent(lines)) {
+      return;
+    }
+
+    this.loadLines(lines, {
+      emitChange: false,
+      restoreSelection: this.getCurrentSelectionSnapshot(),
+    });
   }
 
   createNodesFromContent(content) {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1120,6 +1120,7 @@ describe("lexical scene document editor line editing", () => {
       });
       editorElement.clearDeleteShortcutState = vi.fn();
       editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
 
       const event = {
         preventDefault: vi.fn(),
@@ -3538,6 +3539,107 @@ describe("lexical scene document editor line editing", () => {
         cursorPosition: 0,
       });
       expect(editorElement.pendingFocusTarget).toBeUndefined();
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("refreshes persisted reference chip labels when mention targets load after lines", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "reference-label-refresh-test",
+        nodes: [MentionNode],
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editor.setRootElement(rootElement);
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.editor = editor;
+      editorElement.refs = { editor: rootElement };
+      editorElement.state = {
+        lines: [],
+        mentionTargets: [],
+        selectedLineId: "line-1",
+        mode: "block",
+        mentionMenu: { isOpen: false },
+        activeFormats: {},
+        plainText: "",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.isComposing = false;
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.loadLines(
+        [
+          {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  {
+                    reference: {
+                      resourceId: "playerName",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        { emitChange: false },
+      );
+
+      const textBeforeTargets = editor
+        .getEditorState()
+        .read(() => $getRoot().getTextContent());
+
+      editorElement.mentionTargets = [
+        { id: "playerName", label: "Player Name", variableType: "string" },
+      ];
+
+      const textAfterTargets = editor
+        .getEditorState()
+        .read(() => $getRoot().getTextContent());
+
+      expect(textBeforeTargets).toBe("playerName");
+      expect(textAfterTargets).toBe("Player Name");
+      expect(
+        editorElement.getLinesSnapshot()[0].actions.dialogue.content,
+      ).toEqual([
+        {
+          reference: {
+            resourceId: "playerName",
+          },
+        },
+      ]);
     } finally {
       if (previousRequestAnimationFrame === undefined) {
         delete globalThis.requestAnimationFrame;


### PR DESCRIPTION
## Summary
- refresh Lexical variable chips when mention target labels load after persisted lines
- avoid reloading chips when mention target data has not changed
- add regression coverage for references that initially render by id

## Testing
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js
- bun prettier --check src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js
- bunx oxlint src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js
- git diff --check
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src