### PR TITLE
feat: show all scene sections in editor

### DIFF
--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
@@ -36,6 +36,8 @@ propsSchema:
             type: string
           variableType:
             type: string
+    minHeight:
+      type: number
 methods:
   type: object
   properties:
@@ -59,3 +61,11 @@ methods:
       description: Applies a format to the current selection.
       params: []
       returns: void
+    getLines:
+      description: Returns the current editor lines snapshot.
+      params: []
+      returns: array
+    getSelectedLineId:
+      description: Returns the current selected line id.
+      params: []
+      returns: string

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
@@ -36,8 +36,6 @@ propsSchema:
             type: string
           variableType:
             type: string
-    minHeight:
-      type: number
 methods:
   type: object
   properties:

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
@@ -26,4 +26,4 @@ refs:
       furigana-dialog-request:
         handler: handleFuriganaDialogRequest
 template:
-  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets} minHeight=${minHeight}: null
+  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
@@ -26,4 +26,4 @@ refs:
       furigana-dialog-request:
         handler: handleFuriganaDialogRequest
 template:
-  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets} minHeight=${minHeight}: null

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -1188,6 +1188,77 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
   }
 };
 
+const flattenRefs = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenRefs(item));
+  }
+
+  if (typeof value === "object") {
+    return [value];
+  }
+
+  return [];
+};
+
+const getRefElements = (refs) => {
+  return Object.values(refs || {}).flatMap((entry) => flattenRefs(entry));
+};
+
+const findRuntimeSectionIdForLine = (store, lineId) => {
+  if (!lineId) {
+    return undefined;
+  }
+
+  return store
+    .selectScene()
+    ?.sections?.find((section) =>
+      section.lines?.some((line) => line.id === lineId),
+    )?.id;
+};
+
+const getRuntimeLinesEditorRef = (refs, { sectionId, lineId } = {}) => {
+  const refElements = getRefElements(refs).filter(
+    (element) => element?.scrollLineIntoView || element?.getLines,
+  );
+
+  if (sectionId) {
+    const sectionEditor = refElements.find(
+      (element) => element?.dataset?.sectionId === sectionId,
+    );
+    if (sectionEditor) {
+      return sectionEditor;
+    }
+  }
+
+  if (lineId) {
+    const lineEditor = refElements.find((element) => {
+      const lines = element?.getLines?.() || element?.lines;
+      return Array.isArray(lines)
+        ? lines.some((line) => line?.id === lineId)
+        : false;
+    });
+    if (lineEditor) {
+      return lineEditor;
+    }
+  }
+
+  return refs?.linesEditor || refElements[0];
+};
+
+const scrollRuntimeLineIntoView = (refs, { sectionId, lineId } = {}) => {
+  if (!lineId) {
+    return;
+  }
+
+  getRuntimeLinesEditorRef(refs, { sectionId, lineId })?.scrollLineIntoView?.({
+    lineId,
+  });
+};
+
 const syncRuntimeCurrentLineSelection = (deps, payload = {}) => {
   const { refs, store, render } = deps;
   const { sectionId, lineId } = payload;
@@ -1198,25 +1269,29 @@ const syncRuntimeCurrentLineSelection = (deps, payload = {}) => {
     return false;
   }
 
-  if (sectionId && sectionId !== selectedSectionId) {
+  const nextSectionId = sectionId || findRuntimeSectionIdForLine(store, lineId);
+  if (!nextSectionId) {
     return false;
   }
 
-  if (lineId === selectedLineId) {
+  if (lineId === selectedLineId && nextSectionId === selectedSectionId) {
     return false;
   }
 
-  const selectedSection = store
+  const nextSection = store
     .selectScene()
-    ?.sections?.find((section) => section.id === selectedSectionId);
-  const hasLine = selectedSection?.lines?.some((line) => line.id === lineId);
+    ?.sections?.find((section) => section.id === nextSectionId);
+  const hasLine = nextSection?.lines?.some((line) => line.id === lineId);
   if (!hasLine) {
     return false;
   }
 
+  if (nextSectionId !== selectedSectionId) {
+    store.setSelectedSectionId({ selectedSectionId: nextSectionId });
+  }
   store.setSelectedLineId({ selectedLineId: lineId });
   render();
-  refs.linesEditor?.scrollLineIntoView?.({ lineId });
+  scrollRuntimeLineIntoView(refs, { sectionId: nextSectionId, lineId });
   return true;
 };
 
@@ -1366,7 +1441,10 @@ const handleCanvasRollbackWheelFallback = async (deps, payload = {}) => {
 
   store.setSelectedLineId({ selectedLineId: previousLineId });
   render();
-  refs.linesEditor?.scrollLineIntoView?.({ lineId: previousLineId });
+  scrollRuntimeLineIntoView(refs, {
+    sectionId: store.selectSelectedSectionId(),
+    lineId: previousLineId,
+  });
   await renderSceneEditorState(deps, {
     skipAnimations: true,
   });
@@ -1400,7 +1478,10 @@ const handleCanvasForwardNavigationFallback = async (deps, payload = {}) => {
 
   store.setSelectedLineId({ selectedLineId: nextLineId });
   render();
-  refs.linesEditor?.scrollLineIntoView?.({ lineId: nextLineId });
+  scrollRuntimeLineIntoView(refs, {
+    sectionId: store.selectSelectedSectionId(),
+    lineId: nextLineId,
+  });
   await renderSceneEditorState(deps, {
     skipAnimations: true,
   });

--- a/src/internal/ui/sceneEditor/sectionOperations.js
+++ b/src/internal/ui/sceneEditor/sectionOperations.js
@@ -12,7 +12,7 @@ const updateSceneEditorSelectionPayload = (
   appService,
   { sectionId, lineId } = {},
 ) => {
-  if (!appService) {
+  if (!appService?.getPayload || !appService?.setPayload) {
     return;
   }
 
@@ -30,34 +30,49 @@ const updateSceneEditorSelectionPayload = (
   appService.setPayload(nextPayload);
 };
 
+const flattenRefs = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenRefs(item));
+  }
+
+  if (typeof value === "object") {
+    return [value];
+  }
+
+  return [];
+};
+
 export const scrollSceneEditorSectionTabIntoView = (deps, sectionId) => {
   const { refs } = deps;
+  const scheduleFrame =
+    typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame
+      : (callback) => setTimeout(callback, 0);
 
-  requestAnimationFrame(() => {
-    const refElements = Object.values(refs || {}).flatMap((entry) => {
-      if (!entry) {
-        return [];
-      }
-      if (Array.isArray(entry)) {
-        return entry;
-      }
-      if (typeof entry === "object") {
-        return [entry, ...Object.values(entry)];
-      }
-      return [entry];
-    });
-    const tabRef = refElements.find(
-      (element) => element?.dataset?.sectionId === sectionId,
+  scheduleFrame(() => {
+    const refElements = Object.values(refs || {}).flatMap((entry) =>
+      flattenRefs(entry),
     );
-    const tabElement =
-      tabRef ||
-      Array.from(document.querySelectorAll("[data-section-id]")).find(
+    const sectionRef = refElements.find(
+      (element) =>
+        element?.dataset?.sectionBlockId === sectionId ||
+        element?.dataset?.sectionId === sectionId,
+    );
+    const doc = typeof document !== "undefined" ? document : undefined;
+    const sectionElement =
+      sectionRef ||
+      doc?.querySelector?.('[data-section-block-id="' + sectionId + '"]') ||
+      Array.from(doc?.querySelectorAll?.("[data-section-id]") || []).find(
         (element) => element.getAttribute("data-section-id") === sectionId,
       );
 
-    tabElement?.scrollIntoView({
+    sectionElement?.scrollIntoView({
       behavior: "smooth",
-      block: "nearest",
+      block: "start",
       inline: "nearest",
     });
   });
@@ -163,7 +178,11 @@ export const createSceneEditorSectionWithName = async (
   options = {},
 ) => {
   const { store, projectService, render } = deps;
-  const { inheritPresentationFromSelectedLine = true } = options;
+  const {
+    inheritPresentationFromSelectedLine = true,
+    position = "last",
+    positionTargetId,
+  } = options;
   const sceneId = store.selectSceneId();
   const newSectionId = generateId();
   const newLineId = generateId();
@@ -229,7 +248,8 @@ export const createSceneEditorSectionWithName = async (
   await projectService.createSectionItem({
     sceneId,
     sectionId: newSectionId,
-    position: "last",
+    position,
+    positionTargetId,
     data: {
       name: sectionName,
     },

--- a/src/internal/ui/sceneEditor/sectionOperations.js
+++ b/src/internal/ui/sceneEditor/sectionOperations.js
@@ -264,10 +264,7 @@ export const createSceneEditorSectionWithName = async (
   });
 
   syncProjectState(store, projectService);
-  store.setSelectedSectionId({ selectedSectionId: newSectionId });
-  store.setSelectedLineId({ selectedLineId: newLineId });
   render();
-  scrollSceneEditorSectionTabIntoView(deps, newSectionId);
 
   setTimeout(async () => {
     await renderSceneEditorState(deps);

--- a/src/internal/ui/sceneEditorLexical/draftPersistence.js
+++ b/src/internal/ui/sceneEditorLexical/draftPersistence.js
@@ -123,6 +123,31 @@ const getSceneEditorDraftFlushThrottleDelayMs = (
   );
 };
 
+const selectPendingSceneEditorDraftSections = (store) => {
+  const draftSections = store.selectPendingDraftSections?.();
+  if (Array.isArray(draftSections)) {
+    return draftSections.filter(hasPendingSceneEditorDraftChanges);
+  }
+
+  const draftSection = store.selectDraftSection?.();
+  return hasPendingSceneEditorDraftChanges(draftSection) ? [draftSection] : [];
+};
+
+const selectSceneEditorDraftSectionByTarget = (store, draftSection) => {
+  if (!draftSection?.sectionId) {
+    return undefined;
+  }
+
+  return (
+    store.selectDraftSectionBySectionId?.({
+      sectionId: draftSection.sectionId,
+    }) ||
+    (store.selectDraftSection?.()?.sectionId === draftSection.sectionId
+      ? store.selectDraftSection()
+      : undefined)
+  );
+};
+
 export const createSceneEditorDraftPersistence = ({
   syncDraftSectionFromLines = (deps) => deps.store.selectDraftSection(),
   syncDraftSectionFromLiveEditor = (deps) => deps.store.selectDraftSection(),
@@ -131,10 +156,19 @@ export const createSceneEditorDraftPersistence = ({
   nowMs = defaultNowMs,
   timing = DEFAULT_SCENE_EDITOR_DRAFT_SAVE_TIMING,
 } = {}) => {
+  const syncDraftInput = (deps, { liveLines, sectionId } = {}) => {
+    if (Array.isArray(liveLines) && liveLines.length > 0) {
+      return syncDraftSectionFromLines(deps, liveLines, { sectionId });
+    }
+
+    return syncDraftSectionFromLiveEditor(deps, { sectionId });
+  };
+
   const flushSceneEditorDrafts = async (
     deps,
     {
       liveLines,
+      sectionId,
       showErrorAlert = true,
       rescheduleReason = "text",
       force = false,
@@ -143,20 +177,18 @@ export const createSceneEditorDraftPersistence = ({
     } = {},
   ) => {
     const { store } = deps;
+    const targetSectionId = sectionId || store.selectSelectedSectionId?.();
     clearScheduledDraftFlush(store);
-    if (Array.isArray(liveLines) && liveLines.length > 0) {
-      syncDraftSectionFromLines(deps, liveLines);
-    } else {
-      syncDraftSectionFromLiveEditor(deps);
-    }
+    syncDraftInput(deps, { liveLines, sectionId: targetSectionId });
 
-    if (!hasPendingSceneEditorDraftChanges(store.selectDraftSection())) {
+    const pendingDraftSections = selectPendingSceneEditorDraftSections(store);
+    if (pendingDraftSections.length === 0) {
       store.setDraftSavePendingSinceAt({ timestamp: 0 });
       return;
     }
 
     const draftReason = getSceneEditorDraftReason(
-      store.selectDraftSection(),
+      pendingDraftSections[0],
       rescheduleReason,
     );
 
@@ -188,14 +220,16 @@ export const createSceneEditorDraftPersistence = ({
         owner: deps.projectService,
         key: "draft-flush",
         task: async () => {
-          const draftSection =
-            Array.isArray(liveLines) && liveLines.length > 0
-              ? syncDraftSectionFromLines(deps, liveLines) ||
-                store.selectDraftSection()
-              : syncDraftSectionFromLiveEditor(deps) ||
-                store.selectDraftSection();
+          syncDraftInput(deps, { liveLines, sectionId: targetSectionId });
+          const taskDraftSections =
+            selectPendingSceneEditorDraftSections(store);
+          if (taskDraftSections.length === 0) {
+            store.setDraftSavePendingSinceAt({ timestamp: 0 });
+            return;
+          }
+
           const taskDraftReason = getSceneEditorDraftReason(
-            draftSection,
+            taskDraftSections[0],
             draftReason,
           );
           if (
@@ -213,14 +247,6 @@ export const createSceneEditorDraftPersistence = ({
             return;
           }
 
-          const snapshotLines =
-            Array.isArray(liveLines) && liveLines.length > 0
-              ? cloneSceneEditorLines(liveLines)
-              : cloneSceneEditorLines(draftSection?.lines);
-          if (snapshotLines.length === 0) {
-            return;
-          }
-
           const flushStartedAt = nowMs();
           const ownerTiming = getDraftFlushTiming(deps.projectService);
           ownerTiming.lastFlushStartedAt = flushStartedAt;
@@ -230,52 +256,77 @@ export const createSceneEditorDraftPersistence = ({
           store.setDraftSavePendingSinceAt({ timestamp: 0 });
 
           try {
-            await deps.projectService.syncSectionLinesSnapshot({
-              sectionId: draftSection?.sectionId,
-              lines: snapshotLines,
-            });
-            syncStoreProjectState(store, deps.projectService);
-            const currentDraftSection = store.selectDraftSection();
-            const revision = store.selectRepositoryRevision();
-            const isSameDraftTarget =
-              currentDraftSection?.sceneId === draftSection?.sceneId &&
-              currentDraftSection?.sectionId === draftSection?.sectionId;
-            const didDraftAdvance =
-              isSameDraftTarget &&
-              !areSceneEditorLinesEqual(
-                currentDraftSection?.lines,
-                snapshotLines,
-              );
+            let shouldReschedule = false;
+            let nextRescheduleReason = taskDraftReason;
 
-            if (didDraftAdvance) {
-              const nextDraftReason = getSceneEditorDraftReason(
-                currentDraftSection,
-                rescheduleReason,
+            for (const draftSection of taskDraftSections) {
+              const snapshotLines = cloneSceneEditorLines(draftSection?.lines);
+              if (snapshotLines.length === 0) {
+                continue;
+              }
+
+              await deps.projectService.syncSectionLinesSnapshot({
+                sectionId: draftSection?.sectionId,
+                lines: snapshotLines,
+              });
+              syncStoreProjectState(store, deps.projectService);
+              const currentDraftSection = selectSceneEditorDraftSectionByTarget(
+                store,
+                draftSection,
               );
-              store.setDraftSection({
-                draftSection: rebaseSceneEditorDraftSection(
+              const revision = store.selectRepositoryRevision();
+              const isSameDraftTarget =
+                currentDraftSection?.sceneId === draftSection?.sceneId &&
+                currentDraftSection?.sectionId === draftSection?.sectionId;
+              const didDraftAdvance =
+                isSameDraftTarget &&
+                !areSceneEditorLinesEqual(
+                  currentDraftSection?.lines,
+                  snapshotLines,
+                );
+
+              if (didDraftAdvance) {
+                nextRescheduleReason = getSceneEditorDraftReason(
                   currentDraftSection,
-                  {
-                    revision,
-                  },
-                ),
-              });
-              scheduleSceneEditorDraftFlush(deps, {
-                reason: nextDraftReason,
-              });
-              return;
+                  rescheduleReason,
+                );
+                store.setDraftSection({
+                  draftSection: rebaseSceneEditorDraftSection(
+                    currentDraftSection,
+                    {
+                      revision,
+                    },
+                  ),
+                });
+                shouldReschedule = true;
+                continue;
+              }
+
+              if (isSameDraftTarget) {
+                store.setDraftSection({
+                  draftSection: markSceneEditorDraftSectionClean(
+                    currentDraftSection,
+                    {
+                      revision,
+                    },
+                  ),
+                });
+
+                if (
+                  !store.selectSelectedSectionId ||
+                  currentDraftSection?.sectionId ===
+                    store.selectSelectedSectionId?.()
+                ) {
+                  reconcileCurrentEditorSession(deps);
+                }
+              }
             }
 
-            if (isSameDraftTarget) {
-              store.setDraftSection({
-                draftSection: markSceneEditorDraftSectionClean(
-                  currentDraftSection,
-                  {
-                    revision,
-                  },
-                ),
+            if (shouldReschedule) {
+              scheduleSceneEditorDraftFlush(deps, {
+                reason: nextRescheduleReason,
               });
-              reconcileCurrentEditorSession(deps);
+              return;
             }
 
             deps.render();
@@ -306,11 +357,16 @@ export const createSceneEditorDraftPersistence = ({
     const { store } = deps;
     clearScheduledDraftFlush(store);
 
-    const draftSection = store.selectDraftSection();
-    if (!hasPendingSceneEditorDraftChanges(draftSection)) {
+    const pendingDraftSections = selectPendingSceneEditorDraftSections(store);
+    if (pendingDraftSections.length === 0) {
       store.setDraftSavePendingSinceAt({ timestamp: 0 });
       return;
     }
+
+    const draftReason = getSceneEditorDraftReason(
+      pendingDraftSections[0],
+      reason,
+    );
 
     if (store.selectDraftSavePendingSinceAt() <= 0) {
       store.setDraftSavePendingSinceAt({
@@ -320,26 +376,26 @@ export const createSceneEditorDraftPersistence = ({
 
     if (immediate) {
       return flushSceneEditorDrafts(deps, {
-        rescheduleReason: reason,
+        rescheduleReason: draftReason,
         force: true,
       });
     }
 
     const delayMs = getSceneEditorDraftSaveDelayMs(store, {
-      reason,
+      reason: draftReason,
       nowMs,
       timing,
     });
     const timerId = setTimeout(() => {
       void flushSceneEditorDrafts(deps, {
-        rescheduleReason: reason,
+        rescheduleReason: draftReason,
       }).catch(() => {});
     }, delayMs);
     store.setDraftSaveTimerId({ timerId });
   };
 
   const runSceneEditorPersistence = async (deps, task, options = {}) => {
-    if (hasPendingSceneEditorDraftChanges(deps.store.selectDraftSection())) {
+    if (selectPendingSceneEditorDraftSections(deps.store).length > 0) {
       await flushSceneEditorDrafts(deps, {
         deferIfInFlight: true,
         enforceMinInterval: true,

--- a/src/internal/ui/sceneEditorLexical/draftSection.js
+++ b/src/internal/ui/sceneEditorLexical/draftSection.js
@@ -204,6 +204,14 @@ export const overlaySceneWithDraftSection = (scene, draftSection) => {
   };
 };
 
+export const overlaySceneWithDraftSections = (scene, draftSections = []) => {
+  return (Array.isArray(draftSections) ? draftSections : []).reduce(
+    (nextScene, draftSection) =>
+      overlaySceneWithDraftSection(nextScene, draftSection),
+    scene,
+  );
+};
+
 export const areSceneEditorLinesEqual = (leftLines = [], rightLines = []) => {
   if (leftLines.length !== rightLines.length) {
     return false;

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -58,8 +58,201 @@ const clearTemporaryPresentationPreview = ({ store, subject }) => {
   requestTemporaryPresentationCanvasRender(subject);
 };
 
-const getLinesEditorRef = (refs) => {
-  return refs?.linesEditor;
+const flattenRefs = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenRefs(item));
+  }
+
+  if (typeof value === "object") {
+    return [value];
+  }
+
+  return [];
+};
+
+const getRefElements = (refs) => {
+  return Object.values(refs || {}).flatMap((value) => flattenRefs(value));
+};
+
+const isLinesEditorRef = (element) => {
+  return !!(
+    element?.focusLine ||
+    element?.scrollLineIntoView ||
+    element?.focusContainer ||
+    element?.getLines ||
+    element?.getLinesSnapshot
+  );
+};
+
+const getLinesEditorRef = (refs, { sectionId, lineId } = {}) => {
+  const refElements = getRefElements(refs).filter(isLinesEditorRef);
+
+  if (sectionId) {
+    const sectionEditor = refElements.find(
+      (element) => element?.dataset?.sectionId === sectionId,
+    );
+    if (sectionEditor) {
+      return sectionEditor;
+    }
+  }
+
+  if (lineId) {
+    const lineEditor = refElements.find((element) => {
+      const editorLines =
+        element?.getLines?.() ||
+        element?.getLinesSnapshot?.() ||
+        element?.lines;
+      return Array.isArray(editorLines)
+        ? editorLines.some((line) => line?.id === lineId)
+        : false;
+    });
+    if (lineEditor) {
+      return lineEditor;
+    }
+  }
+
+  return refs?.linesEditor || refElements[0];
+};
+
+const forEachLinesEditorRef = (refs, callback) => {
+  getRefElements(refs).filter(isLinesEditorRef).forEach(callback);
+};
+
+const getSectionIdFromPayload = (payload) => {
+  const event = payload?._event;
+  return (
+    event?.currentTarget?.dataset?.sectionId ||
+    event?.target?.closest?.("[data-section-id]")?.dataset?.sectionId ||
+    undefined
+  );
+};
+
+const findSectionIdForLine = (store, lineId) => {
+  if (!lineId) {
+    return undefined;
+  }
+
+  const scene = store.selectScene?.();
+  return scene?.sections?.find((section) =>
+    section.lines?.some((line) => line.id === lineId),
+  )?.id;
+};
+
+const findNextSectionFirstLineTarget = (store, { sectionId, lineId } = {}) => {
+  if (!sectionId || !lineId) {
+    return undefined;
+  }
+
+  const scene = store.selectScene?.();
+  const sections = Array.isArray(scene?.sections) ? scene.sections : [];
+  const sectionIndex = sections.findIndex(
+    (section) => section.id === sectionId,
+  );
+  if (sectionIndex < 0) {
+    return undefined;
+  }
+
+  const currentLines = Array.isArray(sections[sectionIndex]?.lines)
+    ? sections[sectionIndex].lines
+    : [];
+  const lineIndex = currentLines.findIndex((line) => line.id === lineId);
+  if (lineIndex < 0 || lineIndex < currentLines.length - 1) {
+    return undefined;
+  }
+
+  for (const nextSection of sections.slice(sectionIndex + 1)) {
+    const firstLine = Array.isArray(nextSection?.lines)
+      ? nextSection.lines[0]
+      : undefined;
+    if (nextSection?.id && firstLine?.id) {
+      return {
+        sectionId: nextSection.id,
+        lineId: firstLine.id,
+      };
+    }
+  }
+
+  return undefined;
+};
+
+const findPreviousSectionLastLineTarget = (
+  store,
+  { sectionId, lineId } = {},
+) => {
+  if (!sectionId || !lineId) {
+    return undefined;
+  }
+
+  const scene = store.selectScene?.();
+  const sections = Array.isArray(scene?.sections) ? scene.sections : [];
+  const sectionIndex = sections.findIndex(
+    (section) => section.id === sectionId,
+  );
+  if (sectionIndex < 0) {
+    return undefined;
+  }
+
+  const currentLines = Array.isArray(sections[sectionIndex]?.lines)
+    ? sections[sectionIndex].lines
+    : [];
+  const lineIndex = currentLines.findIndex((line) => line.id === lineId);
+  if (lineIndex !== 0) {
+    return undefined;
+  }
+
+  for (let index = sectionIndex - 1; index >= 0; index -= 1) {
+    const previousSection = sections[index];
+    const previousLines = Array.isArray(previousSection?.lines)
+      ? previousSection.lines
+      : [];
+    const lastLine = previousLines[previousLines.length - 1];
+    if (previousSection?.id && lastLine?.id) {
+      return {
+        sectionId: previousSection.id,
+        lineId: lastLine.id,
+      };
+    }
+  }
+
+  return undefined;
+};
+
+const selectEditorTarget = (deps, { sectionId, lineId } = {}) => {
+  const { appService, store } = deps;
+  const nextSectionId = sectionId || findSectionIdForLine(store, lineId);
+
+  if (nextSectionId && nextSectionId !== store.selectSelectedSectionId?.()) {
+    store.setSelectedSectionId?.({ selectedSectionId: nextSectionId });
+  }
+
+  if (lineId) {
+    store.setSelectedLineId?.({ selectedLineId: lineId });
+  }
+
+  if (
+    appService?.getPayload &&
+    appService?.setPayload &&
+    (nextSectionId || lineId)
+  ) {
+    const nextPayload = {
+      ...appService.getPayload(),
+      sectionId: nextSectionId || store.selectSelectedSectionId?.(),
+    };
+
+    if (lineId) {
+      nextPayload.lineId = lineId;
+    } else {
+      delete nextPayload.lineId;
+    }
+
+    appService.setPayload(nextPayload);
+  }
+
+  return nextSectionId;
 };
 
 const createDocumentDraftLine = ({ lineId, sectionId } = {}) => {
@@ -78,11 +271,17 @@ const createDocumentDraftLine = ({ lineId, sectionId } = {}) => {
 
 const getLiveLinesEditorElementFromPayload = (payload) => {
   const findEditorElement = (node) => {
-    if (!node || typeof node.querySelector !== "function") {
+    if (!node) {
       return undefined;
     }
 
-    const wrapper = node.querySelector("rvn-scene-document-editor-lexical");
+    if (node.matches?.("rvn-lexical-scene-document-editor")) {
+      return node;
+    }
+
+    const wrapper = node.matches?.("rvn-scene-document-editor-lexical")
+      ? node
+      : node.querySelector?.("rvn-scene-document-editor-lexical");
     const primitive = wrapper?.shadowRoot?.querySelector?.(
       "rvn-lexical-scene-document-editor",
     );
@@ -109,9 +308,23 @@ const getLiveLinesEditorElementFromPayload = (payload) => {
   return undefined;
 };
 
-const getLiveLinesFromElement = (element) => {
+const getNestedPrimitiveEditor = (element) => {
+  if (!element || typeof element.querySelector !== "function") {
+    return undefined;
+  }
+
   return (
-    element?.getLines?.() || element?.getLinesSnapshot?.() || element?.lines
+    element.shadowRoot?.querySelector?.("rvn-lexical-scene-document-editor") ||
+    element.querySelector?.("rvn-lexical-scene-document-editor")
+  );
+};
+
+const getLiveLinesFromElement = (element) => {
+  const editorElement = getNestedPrimitiveEditor(element) || element;
+  return (
+    editorElement?.getLines?.() ||
+    editorElement?.getLinesSnapshot?.() ||
+    editorElement?.lines
   );
 };
 
@@ -126,9 +339,49 @@ const finalizeActionTargetLine = (store, lineId) => {
   store.clearActionTargetLineId?.();
 };
 
-const syncDraftSectionFromLines = (deps, liveLines) => {
+const reconcileDraftSectionForSection = (deps, sectionId) => {
   const { store } = deps;
-  const draftSection = store.selectDraftSection();
+  const selectedDraftSection = store.selectDraftSection?.();
+  const targetSectionId =
+    sectionId ||
+    store.selectSelectedSectionId?.() ||
+    selectedDraftSection?.sectionId;
+  const existingDraftSection =
+    store.selectDraftSectionBySectionId?.({ sectionId: targetSectionId }) ||
+    (selectedDraftSection?.sectionId === targetSectionId
+      ? selectedDraftSection
+      : undefined);
+  const sceneId = store.selectSceneId?.() || existingDraftSection?.sceneId;
+
+  if (!sceneId || !targetSectionId) {
+    store.clearDraftSection?.();
+    return undefined;
+  }
+
+  const committedScene = store.selectCommittedScene?.();
+  const committedSection = committedScene?.sections?.find(
+    (section) => section.id === targetSectionId,
+  );
+  const draftSourceSection =
+    committedSection ||
+    (existingDraftSection ? { lines: existingDraftSection.lines } : undefined);
+  const nextDraftSection = ensureSceneEditorDraftSection({
+    draftSection: existingDraftSection,
+    sceneId,
+    sectionId: targetSectionId,
+    section: draftSourceSection,
+    revision: store.selectRepositoryRevision?.(),
+  });
+  store.setDraftSection({ draftSection: nextDraftSection });
+  return nextDraftSection;
+};
+
+const syncDraftSectionFromLines = (deps, liveLines, { sectionId } = {}) => {
+  const { store } = deps;
+  const targetSectionId = sectionId || store.selectSelectedSectionId?.();
+  const draftSection =
+    store.selectDraftSectionBySectionId?.({ sectionId: targetSectionId }) ||
+    reconcileDraftSectionForSection(deps, targetSectionId);
 
   if (!draftSection || !Array.isArray(liveLines) || liveLines.length === 0) {
     return draftSection;
@@ -147,14 +400,15 @@ const syncDraftSectionFromLines = (deps, liveLines) => {
   return nextDraftSection;
 };
 
-const syncDraftSectionFromLiveEditor = (deps) => {
+const syncDraftSectionFromLiveEditor = (deps, { sectionId } = {}) => {
   const { refs } = deps;
-  const liveLines = getLinesEditorRef(refs)?.getLines?.();
-  return syncDraftSectionFromLines(deps, liveLines);
+  const linesEditorRef = getLinesEditorRef(refs, { sectionId });
+  const liveLines = getLiveLinesFromElement(linesEditorRef);
+  return syncDraftSectionFromLines(deps, liveLines, { sectionId });
 };
 
 const focusLinesEditorLine = (refs, payload = {}) => {
-  const linesEditorRef = getLinesEditorRef(refs);
+  const linesEditorRef = getLinesEditorRef(refs, payload);
   if (!linesEditorRef) {
     return;
   }
@@ -162,8 +416,8 @@ const focusLinesEditorLine = (refs, payload = {}) => {
   linesEditorRef.focusLine(payload);
 };
 
-const scrollLinesEditorLineIntoView = (refs, lineId) => {
-  const linesEditorRef = getLinesEditorRef(refs);
+const scrollLinesEditorLineIntoView = (refs, lineId, sectionId) => {
+  const linesEditorRef = getLinesEditorRef(refs, { lineId, sectionId });
   if (!linesEditorRef || !lineId) {
     return;
   }
@@ -171,8 +425,8 @@ const scrollLinesEditorLineIntoView = (refs, lineId) => {
   linesEditorRef.scrollLineIntoView({ lineId });
 };
 
-const focusLinesEditorContainer = (refs) => {
-  const linesEditorRef = getLinesEditorRef(refs);
+const focusLinesEditorContainer = (refs, sectionId) => {
+  const linesEditorRef = getLinesEditorRef(refs, { sectionId });
   if (!linesEditorRef?.focusContainer) {
     return;
   }
@@ -193,7 +447,7 @@ const shouldAnimateLineNavigation = (
 
   const scene = store.selectScene();
   const currentSection = scene?.sections?.find(
-    (section) => section.id === store.selectSelectedSectionId(),
+    (section) => section.id === store.selectSelectedSectionId?.(),
   );
   const currentLines = Array.isArray(currentSection?.lines)
     ? currentSection.lines
@@ -258,28 +512,10 @@ const isMissingProjectResolutionError = (error) => {
 };
 
 const reconcileCurrentEditorSession = (deps) => {
-  const { store } = deps;
-  const sceneId = store.selectSceneId();
-  const selectedSectionId = store.selectSelectedSectionId();
-
-  if (!sceneId || !selectedSectionId) {
-    store.clearDraftSection();
-    return undefined;
-  }
-
-  const committedScene = store.selectCommittedScene();
-  const committedSection = committedScene?.sections?.find(
-    (section) => section.id === selectedSectionId,
+  return reconcileDraftSectionForSection(
+    deps,
+    deps.store.selectSelectedSectionId?.(),
   );
-  const nextDraftSection = ensureSceneEditorDraftSection({
-    draftSection: store.selectDraftSection(),
-    sceneId,
-    sectionId: selectedSectionId,
-    section: committedSection,
-    revision: store.selectRepositoryRevision(),
-  });
-  store.setDraftSection({ draftSection: nextDraftSection });
-  return nextDraftSection;
 };
 
 const {
@@ -303,9 +539,10 @@ const refreshSceneEditorStateFromProject = async (deps) => {
 
 const syncSceneEditorProjectPayload = async (deps, payload = {}) => {
   const { store, render, subject } = deps;
-  const hadPendingSessionChanges = hasPendingSceneEditorDraftChanges(
-    store.selectDraftSection(),
-  );
+  const pendingDraftSections = store.selectPendingDraftSections?.() || [];
+  const hadPendingSessionChanges =
+    pendingDraftSections.length > 0 ||
+    hasPendingSceneEditorDraftChanges(store.selectDraftSection());
   const { repositoryState, domainState, revision } = payload;
 
   store.setRepositoryState({ repository: repositoryState });
@@ -402,15 +639,22 @@ export const handleSectionTabClick = async (deps, payload) => {
     return;
   }
 
+  const event = payload?._event;
   const sectionId =
-    payload._event.currentTarget?.dataset?.sectionId ||
-    payload._event.currentTarget?.id?.replace("sectionTab", "") ||
+    event?.currentTarget?.dataset?.sectionId ||
+    event?.currentTarget?.id?.replace("sectionTab", "") ||
     "";
+  if (!sectionId) {
+    return;
+  }
+
   await flushSceneEditorDrafts(deps, { force: true });
   await selectSceneEditorSection(deps, sectionId);
   reconcileCurrentEditorSession(deps);
   deps.render();
 };
+
+export const handleSectionHeaderClick = handleSectionTabClick;
 
 export const handleSectionsTabsWheel = (deps, payload) => {
   const event = payload._event;
@@ -694,9 +938,12 @@ export const handleEditorDataChanged = async (deps, payload) => {
     return;
   }
   const changeReason = payload?._event?.detail?.reason || "text";
+  const sectionId =
+    getSectionIdFromPayload(payload) ||
+    nextLines.find((line) => line?.sectionId)?.sectionId ||
+    store.selectSelectedSectionId?.();
 
-  const draftSection =
-    store.selectDraftSection() || reconcileCurrentEditorSession(deps);
+  const draftSection = reconcileDraftSectionForSection(deps, sectionId);
   if (!draftSection) {
     return;
   }
@@ -707,15 +954,17 @@ export const handleEditorDataChanged = async (deps, payload) => {
     dirty: true,
   });
   store.setDraftSection({ draftSection: nextDraftSection });
+  const detailSelectedLineId = payload?._event?.detail?.selectedLineId;
   const selectedLineId =
-    payload?._event?.detail?.selectedLineId ||
-    store.selectSelectedLineId() ||
+    detailSelectedLineId ||
+    (sectionId === store.selectSelectedSectionId?.()
+      ? store.selectSelectedLineId()
+      : undefined) ||
     nextLines[0]?.id;
-  if (selectedLineId) {
-    store.setSelectedLineId({
-      selectedLineId,
-    });
-  }
+  selectEditorTarget(deps, {
+    sectionId,
+    lineId: selectedLineId,
+  });
   render();
   const focusTarget = payload?._event?.detail?.focusTarget;
   if (
@@ -723,10 +972,14 @@ export const handleEditorDataChanged = async (deps, payload) => {
     changeReason === "structure" &&
     focusTarget.skipPageRestore !== true
   ) {
+    const focusPayload = {
+      ...focusTarget,
+      sectionId,
+    };
     requestAnimationFrame(() => {
-      focusLinesEditorLine(refs, focusTarget);
+      focusLinesEditorLine(refs, focusPayload);
       requestAnimationFrame(() => {
-        focusLinesEditorLine(refs, focusTarget);
+        focusLinesEditorLine(refs, focusPayload);
       });
     });
   }
@@ -743,7 +996,10 @@ export const handleEditorDataChanged = async (deps, payload) => {
 
 export const handleEditorCompositionStateChanged = (deps, payload) => {
   const { store } = deps;
-  const draftSection = store.selectDraftSection();
+  const sectionId = getSectionIdFromPayload(payload);
+  const draftSection =
+    store.selectDraftSectionBySectionId?.({ sectionId }) ||
+    reconcileDraftSectionForSection(deps, sectionId);
   if (!draftSection) {
     return;
   }
@@ -776,21 +1032,53 @@ export const handleEditorBlur = async (deps) => {
 };
 
 export const handleSelectedLineChanged = (deps, payload) => {
-  const { store, render, subject } = deps;
+  const { store, refs, render, subject } = deps;
   const detail = payload?._event?.detail || {};
   const lineId = detail.lineId;
-  if (!lineId || lineId === store.selectSelectedLineId()) {
+  const sectionId =
+    getSectionIdFromPayload(payload) || findSectionIdForLine(store, lineId);
+  const previousLineId = store.selectSelectedLineId();
+  const isSameSelection =
+    lineId === previousLineId &&
+    sectionId === store.selectSelectedSectionId?.();
+  let adjacentSectionTarget;
+  if (isSameSelection && detail.mode === "block") {
+    if (detail.navigationDirection === "down") {
+      adjacentSectionTarget = findNextSectionFirstLineTarget(store, {
+        sectionId,
+        lineId,
+      });
+    } else if (detail.navigationDirection === "up") {
+      adjacentSectionTarget = findPreviousSectionLastLineTarget(store, {
+        sectionId,
+        lineId,
+      });
+    }
+  }
+
+  if (!lineId || (isSameSelection && !adjacentSectionTarget)) {
     return;
   }
 
-  const previousLineId = store.selectSelectedLineId();
-  store.setSelectedLineId({ selectedLineId: lineId });
+  const target = adjacentSectionTarget || { sectionId, lineId };
+  selectEditorTarget(deps, target);
 
   render();
 
+  if (adjacentSectionTarget) {
+    requestAnimationFrame(() => {
+      scrollLinesEditorLineIntoView(
+        refs,
+        adjacentSectionTarget.lineId,
+        adjacentSectionTarget.sectionId,
+      );
+      focusLinesEditorContainer(refs, adjacentSectionTarget.sectionId);
+    });
+  }
+
   dispatchLineNavigationRender(subject, store, {
     previousLineId,
-    nextLineId: lineId,
+    nextLineId: target.lineId,
     skipRender: true,
   });
 };
@@ -817,11 +1105,14 @@ export const handleDialogueCharacterShortcut = async (deps, payload) => {
     return;
   }
 
+  const sectionId =
+    getSectionIdFromPayload(payload) ||
+    findSectionIdForLine(store, lineId) ||
+    store.selectSelectedSectionId?.();
+  selectEditorTarget(deps, { sectionId, lineId });
   const currentSection = store
     .selectScene()
-    ?.sections?.find(
-      (section) => section.id === store.selectSelectedSectionId(),
-    );
+    ?.sections?.find((section) => section.id === sectionId);
   const currentLine =
     currentSection?.lines?.find((line) => line.id === lineId) ||
     store.selectSelectedLine();
@@ -889,8 +1180,10 @@ export const handleAddActionsButtonClick = (deps) => {
   render();
 };
 
-export const handleSectionAddClick = (deps) => {
+export const handleSectionAddClick = (deps, payload) => {
   const { store, render } = deps;
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
   if (isSectionsOverviewOpen(store)) {
     return;
   }
@@ -900,6 +1193,17 @@ export const handleSectionAddClick = (deps) => {
   const defaultName = `Section ${sectionCount + 1}`;
   store.showSectionCreateDialog({ defaultName });
   render();
+};
+
+export const handleSectionMenuClick = (deps, payload) => {
+  const { store } = deps;
+  if (isSectionsOverviewOpen(store)) {
+    return;
+  }
+
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  openSectionTabDropdown(deps, payload._event);
 };
 
 export const handleSectionsOverviewClick = (deps, payload) => {
@@ -966,8 +1270,9 @@ export const handleNewLine = async (deps, payload) => {
 
   const { store, render, subject, refs } = deps;
   const detail = payload?._event?.detail || {};
-  const draftSection =
-    store.selectDraftSection() || reconcileCurrentEditorSession(deps);
+  const sectionId =
+    getSectionIdFromPayload(payload) || store.selectSelectedSectionId?.();
+  const draftSection = reconcileDraftSectionForSection(deps, sectionId);
   if (!draftSection) {
     return;
   }
@@ -1006,7 +1311,10 @@ export const handleNewLine = async (deps, payload) => {
     dirty: true,
   });
   store.setDraftSection({ draftSection: nextDraftSection });
-  store.setSelectedLineId({ selectedLineId: newLine.id });
+  selectEditorTarget(deps, {
+    sectionId: draftSection.sectionId,
+    lineId: newLine.id,
+  });
   render();
   subject.dispatch("sceneEditor.renderCanvas", {
     skipRender: true,
@@ -1015,6 +1323,7 @@ export const handleNewLine = async (deps, payload) => {
   });
 
   const focusTarget = {
+    sectionId: draftSection.sectionId,
     lineId: newLine.id,
     cursorPosition: 0,
   };
@@ -1038,11 +1347,13 @@ export const handleLineNavigation = (deps, payload) => {
 
   const { targetLineId, mode, direction, targetCursorPosition } =
     payload._event.detail;
+  const sectionId =
+    getSectionIdFromPayload(payload) ||
+    findSectionIdForLine(store, targetLineId) ||
+    store.selectSelectedSectionId?.();
   const currentLineId = store.selectSelectedLineId();
 
-  // For block mode, just update the selection and handle scrolling
   if (mode === "block") {
-    // Check if we're trying to move up from the first line
     if (direction === "up" && currentLineId === targetLineId) {
       dispatchLineNavigationRender(subject, store, {
         previousLineId: currentLineId,
@@ -1051,16 +1362,15 @@ export const handleLineNavigation = (deps, payload) => {
       return;
     }
 
-    store.setSelectedLineId({ selectedLineId: targetLineId });
+    selectEditorTarget(deps, { sectionId, lineId: targetLineId });
     render();
 
     if (targetLineId) {
       requestAnimationFrame(() => {
-        scrollLinesEditorLineIntoView(refs, targetLineId);
+        scrollLinesEditorLineIntoView(refs, targetLineId, sectionId);
       });
     }
 
-    // Trigger debounced canvas render
     dispatchLineNavigationRender(subject, store, {
       previousLineId: currentLineId,
       nextLineId: targetLineId,
@@ -1068,7 +1378,6 @@ export const handleLineNavigation = (deps, payload) => {
     return;
   }
 
-  // For text-editor mode, handle cursor navigation
   const resolvedCurrentLineId = currentLineId || targetLineId;
   let nextLineId = targetLineId;
 
@@ -1081,7 +1390,6 @@ export const handleLineNavigation = (deps, payload) => {
     nextLineId = resolvedCurrentLineId;
   }
 
-  // Determine next line based on direction if targetLineId is current line
   if (nextLineId === resolvedCurrentLineId) {
     if (direction === "up" || direction === "end") {
       nextLineId = store.selectPreviousLineId({
@@ -1092,18 +1400,21 @@ export const handleLineNavigation = (deps, payload) => {
     }
   }
 
-  // Handle navigation to different line
   if (nextLineId && nextLineId !== currentLineId) {
-    const linesEditorRef = getLinesEditorRef(refs);
+    const nextSectionId = findSectionIdForLine(store, nextLineId) || sectionId;
+    const linesEditorRef = getLinesEditorRef(refs, {
+      sectionId: nextSectionId,
+      lineId: nextLineId,
+    });
 
-    // Update selectedLineId through the store
-    store.setSelectedLineId({ selectedLineId: nextLineId });
+    selectEditorTarget(deps, { sectionId: nextSectionId, lineId: nextLineId });
     render();
 
     requestAnimationFrame(() => {
       if (linesEditorRef) {
         const isEndNavigation = targetCursorPosition === -1;
         focusLinesEditorLine(refs, {
+          sectionId: nextSectionId,
           lineId: nextLineId,
           cursorPosition: isEndNavigation
             ? Number.MAX_SAFE_INTEGER
@@ -1115,7 +1426,6 @@ export const handleLineNavigation = (deps, payload) => {
         });
       }
 
-      // Trigger debounced canvas render
       dispatchLineNavigationRender(subject, store, {
         previousLineId: currentLineId,
         nextLineId,
@@ -1141,12 +1451,13 @@ export const handleSwapLine = async (deps, payload) => {
     detail.direction === "up" || detail.direction === "down"
       ? detail.direction
       : undefined;
+  const sectionId =
+    getSectionIdFromPayload(payload) || store.selectSelectedSectionId?.();
   const lineId =
     typeof detail.lineId === "string" && detail.lineId
       ? detail.lineId
       : store.selectSelectedLineId();
-  const draftSection =
-    store.selectDraftSection() || reconcileCurrentEditorSession(deps);
+  const draftSection = reconcileDraftSectionForSection(deps, sectionId);
 
   if (!direction || !lineId || !draftSection) {
     return;
@@ -1169,7 +1480,10 @@ export const handleSwapLine = async (deps, payload) => {
     dirty: true,
   });
   store.setDraftSection({ draftSection: nextDraftSection });
-  store.setSelectedLineId({ selectedLineId: lineId });
+  selectEditorTarget(deps, {
+    sectionId: draftSection.sectionId,
+    lineId,
+  });
   render();
   subject.dispatch("sceneEditor.renderCanvas", {
     skipRender: true,
@@ -1178,8 +1492,8 @@ export const handleSwapLine = async (deps, payload) => {
   });
 
   requestAnimationFrame(() => {
-    scrollLinesEditorLineIntoView(refs, lineId);
-    focusLinesEditorContainer(refs);
+    scrollLinesEditorLineIntoView(refs, lineId, draftSection.sectionId);
+    focusLinesEditorContainer(refs, draftSection.sectionId);
   });
 
   scheduleSceneEditorDraftFlush(deps, {
@@ -1227,12 +1541,70 @@ export const handleDropdownMenuClickOverlay = (deps) => {
   render();
 };
 
+const getDefaultSectionName = (store) => {
+  const scene = store.selectScene();
+  const sectionCount = scene?.sections?.length || 0;
+  return `Section ${sectionCount + 1}`;
+};
+
+const moveSceneEditorSectionWithinScene = async (
+  deps,
+  { sectionId, direction } = {},
+) => {
+  const { store, projectService, appService } = deps;
+  const scene = store.selectScene();
+  const sections = Array.isArray(scene?.sections) ? scene.sections : [];
+  const sectionIndex = sections.findIndex(
+    (section) => section.id === sectionId,
+  );
+  const targetSection =
+    direction === "up"
+      ? sections[sectionIndex - 1]
+      : sections[sectionIndex + 1];
+
+  if (!sectionId || !targetSection?.id) {
+    return;
+  }
+
+  await flushSceneEditorDrafts(deps, { force: true });
+  await runSceneEditorPersistence(
+    deps,
+    async () => {
+      assertSceneEditorCommandResult(
+        await projectService.moveSectionItem({
+          sectionId,
+          position: direction === "up" ? "before" : "after",
+          positionTargetId: targetSection.id,
+        }),
+        {
+          appService,
+          fallbackMessage: "Failed to move section",
+        },
+      );
+    },
+    {
+      label: direction === "up" ? "move-section-up" : "move-section-down",
+      meta: {
+        sectionId,
+        targetSectionId: targetSection.id,
+      },
+    },
+  );
+
+  await refreshSceneEditorStateFromProject(deps);
+  await selectSceneEditorSection(deps, sectionId);
+};
+
 export const handleDropdownMenuClickItem = async (deps, payload) => {
   const { store, render, projectService, subject, appService } = deps;
   const item = payload._event.detail.item || payload._event.detail;
   const action = item?.value;
   const dropdownState = store.selectDropdownMenu();
   const sectionId = dropdownState.sectionId;
+  if (item?.disabled === true) {
+    render();
+    return;
+  }
   const actionsType = dropdownState.actionsType;
   const lineId = dropdownState.lineId;
   const sceneId = store.selectSceneId();
@@ -1248,6 +1620,25 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
       render();
       return;
     }
+  }
+
+  if (action === "add-section-above" || action === "add-section-below") {
+    store.showSectionCreateDialog({
+      defaultName: getDefaultSectionName(store),
+      placementPosition: action === "add-section-above" ? "before" : "after",
+      placementTargetSectionId: sectionId,
+    });
+    render();
+    return;
+  }
+
+  if (action === "move-section-up" || action === "move-section-down") {
+    await moveSceneEditorSectionWithinScene(deps, {
+      sectionId,
+      direction: action === "move-section-up" ? "up" : "down",
+    });
+    render();
+    return;
   }
 
   if (action === "delete-section") {
@@ -1325,7 +1716,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
     await deleteSceneEditorLine(deps, lineId);
   } else if (action === "delete-actions") {
     const selectedLineId = store.selectSelectedLineId();
-    const selectedSectionId = store.selectSelectedSectionId();
+    const selectedSectionId = store.selectSelectedSectionId?.();
     const selectedLine = store.selectSelectedLine();
 
     if (actionsType && selectedLineId && selectedSectionId) {
@@ -1442,7 +1833,9 @@ export const handleSceneSettingsFormAction = (deps, payload) => {
   render();
 
   requestAnimationFrame(() => {
-    refs.linesEditor?.hardRefresh?.();
+    forEachLinesEditorRef(refs, (linesEditorRef) => {
+      linesEditorRef?.hardRefresh?.();
+    });
   });
 
   if (previousIsMuted !== isMuted) {
@@ -1584,6 +1977,8 @@ export const handleSectionCreateFormActionClick = async (deps, payload) => {
         {
           inheritPresentationFromSelectedLine:
             values.inheritPresentationFromSelectedLine ?? true,
+          position: sectionCreateDialog.placementPosition || "last",
+          positionTargetId: sectionCreateDialog.placementTargetSectionId,
         },
       );
       reconcileCurrentEditorSession(deps);
@@ -1670,16 +2065,17 @@ export const handlePreviewClick = (deps, payload) => {
 
     try {
       const sceneId = store.selectSceneId();
-      const sectionId = store.selectSelectedSectionId();
+      const sectionId = store.selectSelectedSectionId?.();
       const lineId = store.selectSelectedLineId();
       const liveLinesEditorElement =
         getLiveLinesEditorElementFromPayload(payload) ||
-        getLinesEditorRef(deps.refs);
+        getLinesEditorRef(deps.refs, { sectionId });
       const liveLines = cloneSceneEditorLines(
         getLiveLinesFromElement(liveLinesEditorElement),
       );
 
       await flushSceneEditorDrafts(deps, {
+        sectionId,
         liveLines,
         showErrorAlert: false,
         force: true,
@@ -1712,12 +2108,17 @@ export const handleFormatButtonClick = (deps, payload) => {
   }
 
   cancelSceneEditorDraftFlush(deps);
-  deps.refs.linesEditor?.applyTextFormat?.({ format });
-  const liveLinesEditorElement = getLiveLinesEditorElementFromPayload(payload);
+  const sectionId =
+    getSectionIdFromPayload(payload) || deps.store.selectSelectedSectionId?.();
+  const linesEditorRef = getLinesEditorRef(deps.refs, { sectionId });
+  linesEditorRef?.applyTextFormat?.({ format });
+  const liveLinesEditorElement =
+    getLiveLinesEditorElementFromPayload(payload) || linesEditorRef;
   queueMicrotask(() => {
     syncDraftSectionFromLines(
       deps,
       getLiveLinesFromElement(liveLinesEditorElement),
+      { sectionId },
     );
   });
 };
@@ -1733,7 +2134,8 @@ const deleteSceneEditorLine = async (deps, lineId) => {
   }
   cancelSceneEditorDraftFlush(deps);
 
-  const sectionId = store.selectSelectedSectionId();
+  const sectionId =
+    findSectionIdForLine(store, lineId) || store.selectSelectedSectionId?.();
 
   if (!lineId || !sectionId) {
     return false;
@@ -1755,7 +2157,8 @@ const deleteSceneEditorLine = async (deps, lineId) => {
   }
 
   const draftSection =
-    store.selectDraftSection() || reconcileCurrentEditorSession(deps);
+    store.selectDraftSectionBySectionId?.({ sectionId }) ||
+    reconcileDraftSectionForSection(deps, sectionId);
   if (!draftSection) {
     return false;
   }
@@ -1770,7 +2173,10 @@ const deleteSceneEditorLine = async (deps, lineId) => {
   });
 
   store.setDraftSection({ draftSection: nextDraftSection });
-  store.setSelectedLineId({ selectedLineId: nextSelectedLineId });
+  selectEditorTarget(deps, {
+    sectionId,
+    lineId: nextSelectedLineId,
+  });
   render();
   subject.dispatch("sceneEditor.renderCanvas", {
     skipRender: true,
@@ -1779,13 +2185,13 @@ const deleteSceneEditorLine = async (deps, lineId) => {
   });
 
   if (nextSelectedLineId) {
-    focusLinesEditorContainer(deps.refs);
+    focusLinesEditorContainer(deps.refs, sectionId);
     requestAnimationFrame(() => {
-      scrollLinesEditorLineIntoView(deps.refs, nextSelectedLineId);
-      focusLinesEditorContainer(deps.refs);
+      scrollLinesEditorLineIntoView(deps.refs, nextSelectedLineId, sectionId);
+      focusLinesEditorContainer(deps.refs, sectionId);
     });
   } else {
-    focusLinesEditorContainer(deps.refs);
+    focusLinesEditorContainer(deps.refs, sectionId);
   }
   scheduleSceneEditorDraftFlush(deps, {
     reason: "structure",
@@ -1816,7 +2222,11 @@ export const handleLineContextMenuRequest = (deps, payload) => {
     return;
   }
 
-  store.setSelectedLineId({ selectedLineId: lineId });
+  selectEditorTarget(deps, {
+    sectionId:
+      getSectionIdFromPayload(payload) || findSectionIdForLine(store, lineId),
+    lineId,
+  });
   store.showLineDropdownMenu({
     position: detail.position || { x: 0, y: 0 },
     lineId,

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -1476,7 +1476,6 @@ export const selectViewData = ({ state }) => {
           ? state.selectedLineId
           : undefined,
       editorKey: `document-${section.id}-${state.sceneSettings.showLineNumbers ? "line-numbers-show" : "line-numbers-hide"}`,
-      editorMinHeight: 48,
       documentEditorLines: sectionLines,
       documentLineDecorations: buildSceneDocumentLineDecorations({
         lines: sectionLines,

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -9,7 +9,7 @@ import {
 import { buildSceneDocumentLineDecorations } from "../../internal/ui/sceneEditor/lineViewModels.js";
 import {
   cloneSceneEditorLines,
-  overlaySceneWithDraftSection,
+  overlaySceneWithDraftSections,
 } from "../../internal/ui/sceneEditorLexical/draftSection.js";
 import {
   constructProjectData,
@@ -315,24 +315,53 @@ const prepareProjectDataSourceStateForPreview = (repositoryState = {}) => {
   return sanitizeSceneDialogueContentInlineTextStyleMetadata(repositoryState);
 };
 
-const getDraftSectionForSelection = (state, sceneId, sectionId) => {
-  const draftSection = state.draftSection;
-  if (!draftSection) {
+const getDraftSectionKey = (sceneId, sectionId) => {
+  if (!sceneId || !sectionId) {
     return undefined;
   }
 
-  if (
-    draftSection.sceneId !== sceneId ||
-    draftSection.sectionId !== sectionId
-  ) {
-    return undefined;
-  }
-
-  return draftSection;
+  return String(sceneId) + ":" + String(sectionId);
 };
 
-const overlayDraftSectionOnRepositoryState = (repositoryState, state) => {
-  const draftSection = state.draftSection;
+const getDraftSections = (state) => {
+  const draftSections = Object.values(state.draftSections || {}).filter(
+    (draftSection) => draftSection?.sceneId && draftSection?.sectionId,
+  );
+  const legacyDraftSection = state.draftSection;
+  if (!legacyDraftSection?.sceneId || !legacyDraftSection?.sectionId) {
+    return draftSections;
+  }
+
+  const legacyKey = getDraftSectionKey(
+    legacyDraftSection.sceneId,
+    legacyDraftSection.sectionId,
+  );
+  const hasLegacyDraftSection = draftSections.some(
+    (draftSection) =>
+      getDraftSectionKey(draftSection.sceneId, draftSection.sectionId) ===
+      legacyKey,
+  );
+
+  if (!hasLegacyDraftSection) {
+    draftSections.push(legacyDraftSection);
+  }
+
+  return draftSections;
+};
+
+const getDraftSectionForSelection = (state, sceneId, sectionId) => {
+  const draftSectionKey = getDraftSectionKey(sceneId, sectionId);
+  if (!draftSectionKey) {
+    return undefined;
+  }
+
+  return state.draftSections?.[draftSectionKey];
+};
+
+const overlayDraftSectionOnRepositoryState = (
+  repositoryState,
+  draftSection,
+) => {
   if (!draftSection?.sceneId || !draftSection?.sectionId) {
     return repositoryState;
   }
@@ -391,6 +420,14 @@ const overlayDraftSectionOnRepositoryState = (repositoryState, state) => {
   };
 };
 
+const overlayDraftSectionsOnRepositoryState = (repositoryState, state) => {
+  return getDraftSections(state).reduce(
+    (nextRepositoryState, draftSection) =>
+      overlayDraftSectionOnRepositoryState(nextRepositoryState, draftSection),
+    repositoryState,
+  );
+};
+
 const buildProjectDataSourceState = (state) => {
   const repositoryState = state.repositoryState || {};
   const domainState = state.domainState || {};
@@ -399,7 +436,7 @@ const buildProjectDataSourceState = (state) => {
   const domainLines = domainState.lines || {};
 
   if (Object.keys(domainScenes).length === 0) {
-    return overlayDraftSectionOnRepositoryState(repositoryState, state);
+    return overlayDraftSectionsOnRepositoryState(repositoryState, state);
   }
 
   const sceneIds = Object.keys(domainScenes);
@@ -510,6 +547,8 @@ export const createInitialState = () => ({
     formKey: 0,
     mode: "create",
     sectionId: undefined,
+    placementPosition: undefined,
+    placementTargetSectionId: undefined,
     defaultValues: {
       name: "",
       inheritPresentationFromSelectedLine: true,
@@ -538,6 +577,7 @@ export const createInitialState = () => ({
   repositoryRevision: 0,
   domainState: {},
   draftSection: undefined,
+  draftSections: {},
   draftSaveTimerId: undefined,
   lastDraftFlushStartedAt: 0,
   draftSavePendingSinceAt: 0,
@@ -580,10 +620,37 @@ export const setDomainState = ({ state }, { domainState } = {}) => {
 };
 
 export const setDraftSection = ({ state }, { draftSection } = {}) => {
-  state.draftSection = draftSection;
+  if (!draftSection?.sceneId || !draftSection?.sectionId) {
+    state.draftSection = draftSection;
+    return;
+  }
+
+  if (!state.draftSections) {
+    state.draftSections = {};
+  }
+
+  const draftSectionKey = getDraftSectionKey(
+    draftSection.sceneId,
+    draftSection.sectionId,
+  );
+  state.draftSections[draftSectionKey] = draftSection;
+
+  if (
+    draftSection.sceneId === state.sceneId &&
+    draftSection.sectionId === state.selectedSectionId
+  ) {
+    state.draftSection = draftSection;
+  }
 };
 
 export const clearDraftSection = ({ state }, _payload = {}) => {
+  const draftSectionKey = getDraftSectionKey(
+    state.sceneId,
+    state.selectedSectionId,
+  );
+  if (draftSectionKey && state.draftSections) {
+    delete state.draftSections[draftSectionKey];
+  }
   state.draftSection = undefined;
 };
 
@@ -709,7 +776,27 @@ export const selectDomainState = ({ state }) => {
 };
 
 export const selectDraftSection = ({ state }) => {
-  return state.draftSection;
+  const draftSectionKey = getDraftSectionKey(
+    state.sceneId,
+    state.selectedSectionId,
+  );
+  return state.draftSections?.[draftSectionKey] ?? state.draftSection;
+};
+
+export const selectDraftSectionBySectionId = (
+  { state },
+  { sectionId } = {},
+) => {
+  const draftSectionKey = getDraftSectionKey(state.sceneId, sectionId);
+  if (!draftSectionKey) {
+    return undefined;
+  }
+
+  return state.draftSections?.[draftSectionKey];
+};
+
+export const selectPendingDraftSections = ({ state }) => {
+  return getDraftSections(state).filter((draftSection) => draftSection?.dirty);
 };
 
 export const selectDraftSaveTimerId = ({ state }) => {
@@ -894,7 +981,7 @@ export const selectCommittedScene = ({ state }) => {
 
 export const selectScene = ({ state }) => {
   const baseScene = selectCommittedScene({ state });
-  return overlaySceneWithDraftSection(baseScene, state.draftSection);
+  return overlaySceneWithDraftSections(baseScene, getDraftSections(state));
 };
 
 export const selectSceneId = ({ state }) => {
@@ -995,10 +1082,34 @@ export const showSectionDropdownMenu = (
     state.repositoryState,
     state.sceneId,
   );
+  const sections = Array.isArray(scene?.sections) ? scene.sections : [];
+  const sectionIndex = sections.findIndex(
+    (section) => section.id === sectionId,
+  );
+  const hasPreviousSection = sectionIndex > 0;
+  const hasNextSection =
+    sectionIndex >= 0 && sectionIndex < sections.length - 1;
   const items = [
+    { label: "Add section above", type: "item", value: "add-section-above" },
+    { label: "Add section below", type: "item", value: "add-section-below" },
+  ];
+
+  if (hasPreviousSection) {
+    items.push({ label: "Move up", type: "item", value: "move-section-up" });
+  }
+
+  if (hasNextSection) {
+    items.push({
+      label: "Move down",
+      type: "item",
+      value: "move-section-down",
+    });
+  }
+
+  items.push(
     { label: "Edit", type: "item", value: "edit-section" },
     { label: "Duplicate", type: "item", value: "duplicate-section" },
-  ];
+  );
 
   if (
     sceneOptions.length > 0 &&
@@ -1007,7 +1118,7 @@ export const showSectionDropdownMenu = (
     scene.sections.length > 1
   ) {
     items.push({
-      label: "Move Scene",
+      label: "Move to scene",
       type: "item",
       value: "move-section-scene",
     });
@@ -1108,12 +1219,17 @@ export const hidePopover = ({ state }, _payload = {}) => {
   };
 };
 
-export const showSectionCreateDialog = ({ state }, { defaultName } = {}) => {
+export const showSectionCreateDialog = (
+  { state },
+  { defaultName, placementPosition, placementTargetSectionId } = {},
+) => {
   state.sectionCreateDialog = {
     isOpen: true,
     formKey: (state.sectionCreateDialog?.formKey || 0) + 1,
     mode: "create",
     sectionId: undefined,
+    placementPosition,
+    placementTargetSectionId,
     defaultValues: {
       name: defaultName || "",
       inheritPresentationFromSelectedLine: true,
@@ -1130,6 +1246,8 @@ export const showSectionEditDialog = ({ state }, { sectionId } = {}) => {
     formKey: (state.sectionCreateDialog?.formKey || 0) + 1,
     mode: "edit",
     sectionId,
+    placementPosition: undefined,
+    placementTargetSectionId: undefined,
     defaultValues: {
       name: section?.name || "",
     },
@@ -1141,6 +1259,8 @@ export const hideSectionCreateDialog = ({ state }, _payload = {}) => {
     ...state.sectionCreateDialog,
     isOpen: false,
     sectionId: undefined,
+    placementPosition: undefined,
+    placementTargetSectionId: undefined,
   };
 };
 
@@ -1209,6 +1329,7 @@ export const selectViewData = ({ state }) => {
       sectionsOverviewItems: [],
       documentEditorLines: [],
       documentLineDecorations: [],
+      sectionEditorItems: [],
       textStyles: [],
       mentionTargets: [],
       currentLine: null,
@@ -1340,6 +1461,30 @@ export const selectViewData = ({ state }) => {
     repositoryState,
     sectionLineChanges: state.sectionLineChanges,
   });
+  const sectionEditorItems = sections.map((section, index) => {
+    const sectionLines = Array.isArray(section.lines) ? section.lines : [];
+    const sectionLineChanges =
+      section.id === state.selectedSectionId ? state.sectionLineChanges : {};
+
+    return {
+      ...section,
+      index,
+      name: section.name || `Section ${index + 1}`,
+      isSelected: section.id === state.selectedSectionId,
+      selectedLineId:
+        section.id === state.selectedSectionId
+          ? state.selectedLineId
+          : undefined,
+      editorKey: `document-${section.id}-${state.sceneSettings.showLineNumbers ? "line-numbers-show" : "line-numbers-hide"}`,
+      editorMinHeight: 48,
+      documentEditorLines: sectionLines,
+      documentLineDecorations: buildSceneDocumentLineDecorations({
+        lines: sectionLines,
+        repositoryState,
+        sectionLineChanges,
+      }),
+    };
+  });
 
   const isEditingSection = state.sectionCreateDialog.mode === "edit";
   const moveSectionSceneOptions = buildMoveSectionSceneOptions(
@@ -1458,6 +1603,7 @@ export const selectViewData = ({ state }) => {
     sectionsOverviewOpen: state.sectionsOverviewPanel.isOpen,
     sectionsOverviewItems,
     documentEditorLines,
+    sectionEditorItems,
     textStyles,
     mentionTargets,
     documentLineDecorations,

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -154,7 +154,7 @@ template:
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: -16px; z-index: 5; min-width: 0;"':
                                       - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
                                       - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm: ...
-                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets} minHeight=${section.editorMinHeight}: null
+                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
                           - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null
           - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -1,5 +1,5 @@
 refs:
-  linesEditor:
+  sectionEditor*:
     eventListeners:
       scene-lines-changed:
         handler: handleEditorDataChanged
@@ -23,20 +23,14 @@ refs:
         handler: handleLineContextMenuRequest
       line-context-menu-dismiss:
         handler: handleLineContextMenuDismiss
-  sectionTab*:
+  sectionHeader*:
     eventListeners:
-      click:
-        handler: handleSectionTabClick
       contextmenu:
         handler: handleSectionTabRightClick
-  sectionsTabsScroll:
-    eventListeners:
-      wheel:
-        handler: handleSectionsTabsWheel
-  sectionAdd:
+  sectionMenu*:
     eventListeners:
       click:
-        handler: handleSectionAddClick
+        handler: handleSectionMenuClick
   sectionsOverview:
     eventListeners:
       click:
@@ -144,7 +138,8 @@ template:
                   - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
                   - rtgl-view w=1fg d=h av=c:
                       - rtgl-text w=1fg ellipsis=true: ${scene.name}
-                      - rtgl-button#sceneSettingsButton sq pre=settings v="gh" ml=sm: null
+                      - rtgl-button#sectionsOverview sq pre=hamburger v="gh" ml=sm: null
+                      - rtgl-button#sceneSettingsButton sq pre=settings v="gh": null
               - $if sectionsGraphView:
                   - rtgl-view w=f h=1fg:
                       - rtgl-view d=h w=f:
@@ -153,18 +148,13 @@ template:
                           - rtgl-text: ${sectionsGraph}
                 $else:
                   - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
-                      - rtgl-view d=h g=xs w=f:
-                          - rtgl-view#sectionsTabsScroll d=h sh g=xs:
-                              - $for section, sectionIndex in sections:
-                                      - rtgl-view#sectionTab${sectionIndex} data-section-id=${section.id} w=120 h=32 av=c ah=c bgc=${section.bgc} cur=pointer:
-                                          - rtgl-text s=sm w=80 ta=c ellipsis=true: ${section.name}
-                          - rtgl-view#sectionAdd h=32 av=c ph=lg ah=c cur=pointer bgc=mu:
-                              - rtgl-text s=sm: +
-                          - rtgl-view#sectionsOverview h=32 av=c ph=lg ah=c cur=pointer bgc=mu:
-                              - rtgl-text s=sm: ...
-                          - rtgl-view w=1fg: null
-                      - rtgl-view w=f ph=sm pv=md sv h=1fg:
-                          - rvn-scene-document-editor-lexical#linesEditor key=${linesEditorKey} :lines=${documentEditorLines} :lineDecorations=${documentLineDecorations} :selectedLineId=${selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+                      - 'rtgl-view w=f ph=sm pv=md sv h=1fg style="min-width: 0; scroll-behavior: smooth;"':
+                          - $for section, sectionIndex in sectionEditorItems:
+                              - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
+                                  - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: -16px; z-index: 5; min-width: 0;"':
+                                      - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
+                                      - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm: ...
+                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets} minHeight=${section.editorMinHeight}: null
                           - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null
           - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1264,10 +1264,28 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   set selectedLineId(value) {
-    this.state.selectedLineId = value;
+    const nextSelectedLineId =
+      typeof value === "string" && value.length > 0 ? value : undefined;
+    this.state.selectedLineId = nextSelectedLineId;
+
+    if (!nextSelectedLineId) {
+      this.isEditorFocused = false;
+      this.lastProgrammaticFocusTarget = undefined;
+      this.pendingFocusTarget = undefined;
+      this.programmaticFocusRestoreUntil = 0;
+      this.pendingSelectionSnapshot = undefined;
+      this.hideSelectionPopover();
+      this.closeMentionMenu();
+    }
+
     if (!this.isConnected || !this.refs.editor) {
       return;
     }
+
+    if (!nextSelectedLineId) {
+      this.applyModeState("block");
+    }
+
     this.scheduleRender();
   }
 
@@ -5657,11 +5675,12 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   syncFromEditorState(editorState) {
     const snapshot = this.readEditorSnapshot(editorState);
 
+    const ownsFocus = this.isEditorFocused === true;
     const previousLines = this.state.lines;
     const previousSelectedLineId = this.state.selectedLineId;
     this.state.lines = cloneSceneEditorLines(snapshot.lines);
     this.state.selectedLineId =
-      this.state.mode === "block"
+      this.state.mode === "block" || !ownsFocus
         ? previousSelectedLineId
         : snapshot.selectedLineId;
     this.state.activeFormats = snapshot.activeFormats;
@@ -5718,7 +5737,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       });
 
     const focusTarget = this.pendingFocusTarget;
-    if (didLinesChange && !this.isApplyingExternalLines) {
+    if (didLinesChange && !this.isApplyingExternalLines && ownsFocus) {
       const detail = {
         lines: cloneSceneEditorLines(this.state.lines),
         selectedLineId: this.state.selectedLineId,

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -174,7 +174,6 @@ const STYLES = `
     --right-gutter-width: ${DEFAULT_RIGHT_GUTTER_WIDTH}px;
     --editor-inline-padding: 0px;
     --editor-top-padding: 0px;
-    --editor-min-height: 280px;
   }
 
   rvn-lexical-scene-document-editor * {
@@ -187,12 +186,12 @@ const STYLES = `
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    min-height: var(--editor-min-height, 280px);
+    min-height: 280px;
     outline: none;
   }
 
   .editor {
-    min-height: var(--editor-min-height, 280px);
+    min-height: 280px;
     min-width: 0;
     width: 100%;
     max-width: 100%;
@@ -819,7 +818,6 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       textStyles: [],
       selectedLineId: undefined,
       showLineNumbers: true,
-      minHeight: 280,
       mode: "block",
       plainText: "",
       mentionTargets: [],
@@ -1303,21 +1301,6 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   get showLineNumbers() {
     return this.state.showLineNumbers;
-  }
-
-  set minHeight(value) {
-    const nextMinHeight = Number(value);
-    this.state.minHeight = Number.isFinite(nextMinHeight)
-      ? Math.max(24, nextMinHeight)
-      : 280;
-    if (!this.isConnected || !this.refs.editor) {
-      return;
-    }
-    this.scheduleRender();
-  }
-
-  get minHeight() {
-    return this.state.minHeight;
   }
 
   setMode(mode) {
@@ -5844,7 +5827,6 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       "--right-gutter-width",
       `${this.rightGutterWidth}px`,
     );
-    this.style.setProperty("--editor-min-height", `${this.state.minHeight}px`);
     this.refs.placeholder.hidden = this.state.plainText.length > 0;
     this.refs.placeholder.textContent = this.state.placeholder;
     this.renderGutters();

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -572,6 +572,16 @@ const isPlainShortcutKey = (event, key) => {
   );
 };
 
+const isPlainSpaceKey = (event) => {
+  return (
+    !event?.ctrlKey &&
+    !event?.metaKey &&
+    !event?.altKey &&
+    !event?.isComposing &&
+    (event?.key === " " || event?.key === "Spacebar" || event?.code === "Space")
+  );
+};
+
 const getEventTimestamp = (event) => {
   const timestamp = Number(event?.timeStamp);
   return Number.isFinite(timestamp) ? timestamp : undefined;
@@ -3418,6 +3428,12 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     if (this.state.mode !== "block") {
       return false;
+    }
+
+    if (isPlainSpaceKey(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      return true;
     }
 
     const currentLineId = this.state.selectedLineId || this.state.lines[0]?.id;

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -186,12 +186,10 @@ const STYLES = `
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    min-height: 280px;
     outline: none;
   }
 
   .editor {
-    min-height: 280px;
     min-width: 0;
     width: 100%;
     max-width: 100%;

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -174,6 +174,7 @@ const STYLES = `
     --right-gutter-width: ${DEFAULT_RIGHT_GUTTER_WIDTH}px;
     --editor-inline-padding: 0px;
     --editor-top-padding: 0px;
+    --editor-min-height: 280px;
   }
 
   rvn-lexical-scene-document-editor * {
@@ -186,12 +187,12 @@ const STYLES = `
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    min-height: 280px;
+    min-height: var(--editor-min-height, 280px);
     outline: none;
   }
 
   .editor {
-    min-height: 280px;
+    min-height: var(--editor-min-height, 280px);
     min-width: 0;
     width: 100%;
     max-width: 100%;
@@ -818,6 +819,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       textStyles: [],
       selectedLineId: undefined,
       showLineNumbers: true,
+      minHeight: 280,
       mode: "block",
       plainText: "",
       mentionTargets: [],
@@ -1285,6 +1287,21 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     return this.state.showLineNumbers;
   }
 
+  set minHeight(value) {
+    const nextMinHeight = Number(value);
+    this.state.minHeight = Number.isFinite(nextMinHeight)
+      ? Math.max(24, nextMinHeight)
+      : 280;
+    if (!this.isConnected || !this.refs.editor) {
+      return;
+    }
+    this.scheduleRender();
+  }
+
+  get minHeight() {
+    return this.state.minHeight;
+  }
+
   setMode(mode) {
     const nextMode = mode === "text-editor" ? "text-editor" : "block";
     this.applyModeState(nextMode);
@@ -1581,19 +1598,30 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       Math.max(0, currentIndex + delta),
     );
     const nextLineId = lines[nextIndex]?.id;
+    const navigationDirection =
+      delta > 0 ? "down" : delta < 0 ? "up" : undefined;
+    const isBoundaryNavigation = delta !== 0 && nextIndex === currentIndex;
 
     if (!nextLineId) {
       return;
     }
 
-    this.state.selectedLineId = nextLineId;
-    this.scheduleRender();
-    this.scrollLineIntoView({ lineId: nextLineId });
-    this.dispatchSelectedLineChanged(nextLineId, {
+    const selectionDetail = {
       cursorPosition: undefined,
       isCollapsed: false,
       mode: "block",
-    });
+    };
+    if (navigationDirection) {
+      selectionDetail.navigationDirection = navigationDirection;
+    }
+    if (isBoundaryNavigation) {
+      selectionDetail.isBoundaryNavigation = true;
+    }
+
+    this.state.selectedLineId = nextLineId;
+    this.scheduleRender();
+    this.scrollLineIntoView({ lineId: nextLineId });
+    this.dispatchSelectedLineChanged(nextLineId, selectionDetail);
   }
 
   dispatchShortcutEvent(eventName, detail = {}) {
@@ -5750,14 +5778,22 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         };
       });
 
+    const detail = {
+      lineId,
+      cursorPosition: selectionDetail?.cursorPosition,
+      isCollapsed: selectionDetail?.isCollapsed === true,
+      mode: selectionDetail?.mode || this.state.mode,
+    };
+    if (selectionDetail?.navigationDirection) {
+      detail.navigationDirection = selectionDetail.navigationDirection;
+    }
+    if (selectionDetail?.isBoundaryNavigation === true) {
+      detail.isBoundaryNavigation = true;
+    }
+
     this.dispatchEvent(
       new CustomEvent("selected-line-changed", {
-        detail: {
-          lineId,
-          cursorPosition: selectionDetail?.cursorPosition,
-          isCollapsed: selectionDetail?.isCollapsed === true,
-          mode: selectionDetail?.mode || this.state.mode,
-        },
+        detail,
         bubbles: true,
       }),
     );
@@ -5789,6 +5825,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       "--right-gutter-width",
       `${this.rightGutterWidth}px`,
     );
+    this.style.setProperty("--editor-min-height", `${this.state.minHeight}px`);
     this.refs.placeholder.hidden = this.state.plainText.length > 0;
     this.refs.placeholder.textContent = this.state.placeholder;
     this.renderGutters();

--- a/tests/sceneEditor/lexicalDraftPersistence.test.js
+++ b/tests/sceneEditor/lexicalDraftPersistence.test.js
@@ -559,4 +559,111 @@ describe("scene editor lexical draft persistence", () => {
       vi.useRealTimers();
     }
   });
+
+  it("flushes all dirty draft sections in one pass", async () => {
+    const sectionOneDraft = createDirtyDraftSection([
+      createLine("line-1", "One"),
+    ]);
+    const sectionTwoLine = {
+      ...createLine("line-2", "Two"),
+      sectionId: "section-2",
+    };
+    const sectionTwoDraft = {
+      ...createDirtyDraftSection([sectionTwoLine]),
+      sectionId: "section-2",
+    };
+    const state = {
+      draftSections: {
+        "scene-1:section-1": sectionOneDraft,
+        "scene-1:section-2": sectionTwoDraft,
+      },
+      draftSection: sectionOneDraft,
+      revision: 3,
+      lastDraftFlushStartedAt: 0,
+      draftSavePendingSinceAt: 0,
+      draftSaveTimerId: undefined,
+      draftFlushInFlight: false,
+      selectedSectionId: "section-1",
+    };
+    const store = {
+      selectPendingDraftSections: () =>
+        Object.values(state.draftSections).filter(
+          (draftSection) => draftSection.dirty,
+        ),
+      selectDraftSection: () => state.draftSection,
+      selectDraftSectionBySectionId: ({ sectionId }) =>
+        state.draftSections["scene-1:" + sectionId],
+      setDraftSection: ({ draftSection }) => {
+        state.draftSections["scene-1:" + draftSection.sectionId] = draftSection;
+        if (draftSection.sectionId === state.selectedSectionId) {
+          state.draftSection = draftSection;
+        }
+      },
+      selectSelectedSectionId: () => state.selectedSectionId,
+      selectRepositoryRevision: () => state.revision,
+      selectLastDraftFlushStartedAt: () => state.lastDraftFlushStartedAt,
+      setLastDraftFlushStartedAt: ({ timestamp }) => {
+        state.lastDraftFlushStartedAt = timestamp;
+      },
+      selectDraftSavePendingSinceAt: () => state.draftSavePendingSinceAt,
+      setDraftSavePendingSinceAt: ({ timestamp }) => {
+        state.draftSavePendingSinceAt = timestamp;
+      },
+      selectDraftFlushInFlight: () => state.draftFlushInFlight,
+      setDraftFlushInFlight: ({ value }) => {
+        state.draftFlushInFlight = value === true;
+      },
+      selectDraftSaveTimerId: () => state.draftSaveTimerId,
+      setDraftSaveTimerId: ({ timerId }) => {
+        state.draftSaveTimerId = timerId;
+      },
+      clearDraftSaveTimer: () => {
+        state.draftSaveTimerId = undefined;
+      },
+    };
+    const syncSectionLinesSnapshot = vi.fn(async () => {});
+    const reconcileCurrentEditorSession = vi.fn();
+    const controller = createSceneEditorDraftPersistence({
+      syncDraftSectionFromLiveEditor: () => undefined,
+      syncStoreProjectState: () => {},
+      reconcileCurrentEditorSession,
+      nowMs: () => 2345,
+    });
+
+    await controller.flushSceneEditorDrafts({
+      store,
+      projectService: {
+        syncSectionLinesSnapshot,
+      },
+      render: vi.fn(),
+      appService: {
+        showAlert: vi.fn(),
+      },
+    });
+
+    expect(syncSectionLinesSnapshot).toHaveBeenCalledTimes(2);
+    expect(syncSectionLinesSnapshot).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sectionId: "section-1",
+        lines: [createLine("line-1", "One")],
+      }),
+    );
+    expect(syncSectionLinesSnapshot).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sectionId: "section-2",
+        lines: [sectionTwoLine],
+      }),
+    );
+    expect(state.draftSections["scene-1:section-1"]).toMatchObject({
+      dirty: false,
+      baseRevision: 3,
+    });
+    expect(state.draftSections["scene-1:section-2"]).toMatchObject({
+      dirty: false,
+      baseRevision: 3,
+    });
+    expect(reconcileCurrentEditorSession).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -537,6 +537,88 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("emits block navigation direction when moving down at the last line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      editorElement.scheduleRender = vi.fn();
+      editorElement.scrollLineIntoView = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.moveBlockSelection(1);
+
+      expect(editorElement.state.selectedLineId).toBe("line-2");
+      expect(editorElement.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-2",
+      });
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-2",
+        {
+          cursorPosition: undefined,
+          isBoundaryNavigation: true,
+          isCollapsed: false,
+          mode: "block",
+          navigationDirection: "down",
+        },
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("emits block navigation direction when moving up at the first line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      editorElement.scheduleRender = vi.fn();
+      editorElement.scrollLineIntoView = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.moveBlockSelection(-1);
+
+      expect(editorElement.state.selectedLineId).toBe("line-1");
+      expect(editorElement.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-1",
+      });
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-1",
+        {
+          cursorPosition: undefined,
+          isBoundaryNavigation: true,
+          isCollapsed: false,
+          mode: "block",
+          navigationDirection: "up",
+        },
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("routes block-mode editor keydown through block shortcuts without arming text fallback", async () => {
     const restoreDomGlobals = installDomGlobals();
 

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1634,6 +1634,122 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("clears stale focus restore state when selected line is cleared", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-1",
+      };
+      editorElement.refs = {
+        editor: document.createElement("div"),
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.lastProgrammaticFocusTarget = {
+        lineId: "line-1",
+        cursorPosition: 2,
+      };
+      editorElement.pendingFocusTarget = {
+        lineId: "line-1",
+        cursorPosition: 2,
+      };
+      editorElement.programmaticFocusRestoreUntil = Number.POSITIVE_INFINITY;
+      editorElement.pendingSelectionSnapshot = {
+        lineId: "line-1",
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.applyModeState = vi.fn((mode) => {
+        editorElement.state.mode = mode;
+      });
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.selectedLineId = undefined;
+
+      expect(editorElement.state.selectedLineId).toBeUndefined();
+      expect(editorElement.isEditorFocused).toBe(false);
+      expect(editorElement.lastProgrammaticFocusTarget).toBeUndefined();
+      expect(editorElement.pendingFocusTarget).toBeUndefined();
+      expect(editorElement.programmaticFocusRestoreUntil).toBe(0);
+      expect(editorElement.pendingSelectionSnapshot).toBeUndefined();
+      expect(editorElement.hideSelectionPopover).toHaveBeenCalledOnce();
+      expect(editorElement.closeMentionMenu).toHaveBeenCalledOnce();
+      expect(editorElement.applyModeState).toHaveBeenCalledWith("block");
+      expect(editorElement.scheduleRender).toHaveBeenCalledOnce();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("ignores text selection sync from an unfocused editor", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "first" }],
+            },
+          },
+        },
+        {
+          id: "line-2",
+          actions: {
+            dialogue: {
+              content: [{ text: "second" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [],
+      };
+      editorElement.isEditorFocused = false;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-2",
+        activeFormats: {},
+      }));
+      editorElement.shouldPreserveMentionMenuAfterSelectionLoss = vi.fn(
+        () => false,
+      );
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.selectedLineId).toBe("line-1");
+      expect(editorElement.dispatchSelectedLineChanged).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("preserves block selection when editor state sync has stale native selection", async () => {
     const restoreDomGlobals = installDomGlobals();
 

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -290,6 +290,55 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("suppresses block-mode Space from the window capture path", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.refs = {
+        editor: document.createElement("div"),
+        surface: document.createElement("div"),
+      };
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: undefined,
+        lines: [],
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.getActiveElement = vi.fn(() => document.body);
+
+      const event = {
+        key: " ",
+        code: "Space",
+        defaultPrevented: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        target: document.body,
+        composedPath: vi.fn(() => [document.body, document, window]),
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleWindowKeyDownCapture(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("routes block-mode shortcuts from the window capture path when the host owns focus", async () => {
     const restoreDomGlobals = installDomGlobals();
 

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -224,4 +224,152 @@ describe("sceneEditorLexical.store", () => {
     expect(itemValues).toContain("duplicate-section");
     expect(itemValues).not.toContain("move-section-scene");
   });
+
+  it("builds one document editor item per section with local line numbers", () => {
+    const state = createInitialState();
+    state.selectedSectionId = "section-1";
+    state.selectedLineId = "line-1";
+
+    setSceneId({ state }, { sceneId: "scene-1" });
+    setRepositoryState(
+      { state },
+      {
+        repository: {
+          scenes: {
+            items: {
+              "scene-1": {
+                id: "scene-1",
+                type: "scene",
+                name: "Scene 1",
+                sections: {
+                  items: {
+                    "section-1": {
+                      id: "section-1",
+                      type: "section",
+                      name: "Section 1",
+                      lines: {
+                        items: {
+                          "line-1": { id: "line-1", actions: {} },
+                          "line-2": { id: "line-2", actions: {} },
+                        },
+                        tree: [{ id: "line-1" }, { id: "line-2" }],
+                      },
+                    },
+                    "section-2": {
+                      id: "section-2",
+                      type: "section",
+                      name: "Section 2",
+                      lines: {
+                        items: {
+                          "line-3": { id: "line-3", actions: {} },
+                        },
+                        tree: [{ id: "line-3" }],
+                      },
+                    },
+                  },
+                  tree: [{ id: "section-1" }, { id: "section-2" }],
+                },
+              },
+            },
+            tree: [{ id: "scene-1" }],
+          },
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.sectionEditorItems).toHaveLength(2);
+    expect(viewData.sectionEditorItems[0].selectedLineId).toBe("line-1");
+    expect(viewData.sectionEditorItems[0].documentEditorLines).toHaveLength(2);
+    expect(viewData.sectionEditorItems[0].documentLineDecorations[0]).toEqual(
+      expect.objectContaining({ id: "line-1", lineNumber: 1 }),
+    );
+    expect(viewData.sectionEditorItems[1].selectedLineId).toBeUndefined();
+    expect(viewData.sectionEditorItems[1].documentEditorLines).toHaveLength(1);
+    expect(viewData.sectionEditorItems[1].documentLineDecorations[0]).toEqual(
+      expect.objectContaining({ id: "line-3", lineNumber: 1 }),
+    );
+  });
+
+  it("builds section menu actions for add, reorder, and moving to another scene", () => {
+    const state = createInitialState();
+
+    setSceneId({ state }, { sceneId: "scene-1" });
+    setRepositoryState(
+      { state },
+      {
+        repository: {
+          scenes: {
+            items: {
+              "scene-1": {
+                id: "scene-1",
+                type: "scene",
+                name: "Scene 1",
+                sections: {
+                  items: {
+                    "section-1": {
+                      id: "section-1",
+                      type: "section",
+                      name: "Section 1",
+                      lines: { items: {}, tree: [] },
+                    },
+                    "section-2": {
+                      id: "section-2",
+                      type: "section",
+                      name: "Section 2",
+                      lines: { items: {}, tree: [] },
+                    },
+                  },
+                  tree: [{ id: "section-1" }, { id: "section-2" }],
+                },
+              },
+              "scene-2": {
+                id: "scene-2",
+                type: "scene",
+                name: "Scene 2",
+                sections: { items: {}, tree: [] },
+              },
+            },
+            tree: [{ id: "scene-1" }, { id: "scene-2" }],
+          },
+        },
+      },
+    );
+
+    showSectionDropdownMenu(
+      { state },
+      {
+        sectionId: "section-1",
+        position: { x: 0, y: 0 },
+      },
+    );
+
+    expect(state.dropdownMenu.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Add section above",
+          value: "add-section-above",
+        }),
+        expect.objectContaining({
+          label: "Add section below",
+          value: "add-section-below",
+        }),
+        expect.objectContaining({
+          label: "Move down",
+          value: "move-section-down",
+        }),
+        expect.objectContaining({
+          label: "Move to scene",
+          value: "move-section-scene",
+        }),
+      ]),
+    );
+    expect(state.dropdownMenu.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "move-section-up" }),
+      ]),
+    );
+    expect(state.dropdownMenu.items.some((item) => item.disabled)).toBe(false);
+  });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleActionsDialogClose,
   handleCommandLineSubmit,
+  handleDropdownMenuClickItem,
   handleEditorBlur,
   handleNewLine,
   handleSectionMoveSceneFormActionClick,
+  handleSelectedLineChanged,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
 describe("sceneEditorLexical.handlers actions dialog", () => {
@@ -370,6 +372,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       expect(state.selectedLineId).toBe(createdLine.id);
       expect(linesEditor.focusLine).toHaveBeenCalledTimes(2);
       expect(linesEditor.focusLine).toHaveBeenCalledWith({
+        sectionId: "section-1",
         lineId: createdLine.id,
         cursorPosition: 0,
       });
@@ -427,5 +430,323 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     });
     expect(moveSectionItem).not.toHaveBeenCalled();
     expect(store.hideSectionMoveSceneDialog).not.toHaveBeenCalled();
+  });
+
+  it("selects the originating section when a line is clicked in another editor", () => {
+    const state = {
+      selectedSectionId: "section-1",
+      selectedLineId: "line-1",
+      payload: {
+        sceneId: "scene-1",
+        sectionId: "section-1",
+        lineId: "line-1",
+      },
+    };
+    const store = {
+      selectSelectedSectionId: vi.fn(() => state.selectedSectionId),
+      setSelectedSectionId: vi.fn(({ selectedSectionId }) => {
+        state.selectedSectionId = selectedSectionId;
+      }),
+      selectSelectedLineId: vi.fn(() => state.selectedLineId),
+      setSelectedLineId: vi.fn(({ selectedLineId }) => {
+        state.selectedLineId = selectedLineId;
+      }),
+      selectScene: vi.fn(() => ({ sections: [] })),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+      appService: {
+        getPayload: vi.fn(() => state.payload),
+        setPayload: vi.fn((payload) => {
+          state.payload = payload;
+        }),
+      },
+    };
+
+    handleSelectedLineChanged(deps, {
+      _event: {
+        currentTarget: {
+          dataset: {
+            sectionId: "section-2",
+          },
+        },
+        detail: {
+          lineId: "line-3",
+        },
+      },
+    });
+
+    expect(state.selectedSectionId).toBe("section-2");
+    expect(state.selectedLineId).toBe("line-3");
+    expect(state.payload).toMatchObject({
+      sectionId: "section-2",
+      lineId: "line-3",
+    });
+    expect(deps.render).toHaveBeenCalledOnce();
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      expect.objectContaining({ skipRender: true }),
+    );
+  });
+
+  it("moves block selection from the last line to the next section first line", () => {
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    try {
+      const state = {
+        selectedSectionId: "section-1",
+        selectedLineId: "line-2",
+        payload: {
+          sceneId: "scene-1",
+          sectionId: "section-1",
+          lineId: "line-2",
+        },
+      };
+      const nextSectionEditor = {
+        dataset: { sectionId: "section-2" },
+        focusContainer: vi.fn(),
+        scrollLineIntoView: vi.fn(),
+      };
+      const store = {
+        selectSelectedSectionId: vi.fn(() => state.selectedSectionId),
+        setSelectedSectionId: vi.fn(({ selectedSectionId }) => {
+          state.selectedSectionId = selectedSectionId;
+        }),
+        selectSelectedLineId: vi.fn(() => state.selectedLineId),
+        setSelectedLineId: vi.fn(({ selectedLineId }) => {
+          state.selectedLineId = selectedLineId;
+        }),
+        selectScene: vi.fn(() => ({
+          sections: [
+            {
+              id: "section-1",
+              lines: [{ id: "line-1" }, { id: "line-2" }],
+            },
+            {
+              id: "section-2",
+              lines: [{ id: "line-3" }, { id: "line-4" }],
+            },
+          ],
+        })),
+      };
+      const deps = {
+        store,
+        refs: {
+          sectionEditor0: {
+            dataset: { sectionId: "section-1" },
+            focusContainer: vi.fn(),
+            scrollLineIntoView: vi.fn(),
+          },
+          sectionEditor1: nextSectionEditor,
+        },
+        render: vi.fn(),
+        subject: {
+          dispatch: vi.fn(),
+        },
+        appService: {
+          getPayload: vi.fn(() => state.payload),
+          setPayload: vi.fn((payload) => {
+            state.payload = payload;
+          }),
+        },
+      };
+
+      handleSelectedLineChanged(deps, {
+        _event: {
+          currentTarget: {
+            dataset: {
+              sectionId: "section-1",
+            },
+          },
+          detail: {
+            lineId: "line-2",
+            mode: "block",
+            navigationDirection: "down",
+          },
+        },
+      });
+
+      expect(state.selectedSectionId).toBe("section-2");
+      expect(state.selectedLineId).toBe("line-3");
+      expect(state.payload).toMatchObject({
+        sectionId: "section-2",
+        lineId: "line-3",
+      });
+      expect(deps.render).toHaveBeenCalledOnce();
+      expect(nextSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-3",
+      });
+      expect(nextSectionEditor.focusContainer).toHaveBeenCalled();
+      expect(deps.subject.dispatch).toHaveBeenCalledWith(
+        "sceneEditor.renderCanvas",
+        expect.objectContaining({
+          skipRender: true,
+          syncPresentationState: true,
+        }),
+      );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    }
+  });
+
+  it("moves block selection from the first line to the previous section last line", () => {
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    try {
+      const state = {
+        selectedSectionId: "section-2",
+        selectedLineId: "line-3",
+        payload: {
+          sceneId: "scene-1",
+          sectionId: "section-2",
+          lineId: "line-3",
+        },
+      };
+      const previousSectionEditor = {
+        dataset: { sectionId: "section-1" },
+        focusContainer: vi.fn(),
+        scrollLineIntoView: vi.fn(),
+      };
+      const store = {
+        selectSelectedSectionId: vi.fn(() => state.selectedSectionId),
+        setSelectedSectionId: vi.fn(({ selectedSectionId }) => {
+          state.selectedSectionId = selectedSectionId;
+        }),
+        selectSelectedLineId: vi.fn(() => state.selectedLineId),
+        setSelectedLineId: vi.fn(({ selectedLineId }) => {
+          state.selectedLineId = selectedLineId;
+        }),
+        selectScene: vi.fn(() => ({
+          sections: [
+            {
+              id: "section-1",
+              lines: [{ id: "line-1" }, { id: "line-2" }],
+            },
+            {
+              id: "section-2",
+              lines: [{ id: "line-3" }, { id: "line-4" }],
+            },
+          ],
+        })),
+      };
+      const deps = {
+        store,
+        refs: {
+          sectionEditor0: previousSectionEditor,
+          sectionEditor1: {
+            dataset: { sectionId: "section-2" },
+            focusContainer: vi.fn(),
+            scrollLineIntoView: vi.fn(),
+          },
+        },
+        render: vi.fn(),
+        subject: {
+          dispatch: vi.fn(),
+        },
+        appService: {
+          getPayload: vi.fn(() => state.payload),
+          setPayload: vi.fn((payload) => {
+            state.payload = payload;
+          }),
+        },
+      };
+
+      handleSelectedLineChanged(deps, {
+        _event: {
+          currentTarget: {
+            dataset: {
+              sectionId: "section-2",
+            },
+          },
+          detail: {
+            lineId: "line-3",
+            mode: "block",
+            navigationDirection: "up",
+          },
+        },
+      });
+
+      expect(state.selectedSectionId).toBe("section-1");
+      expect(state.selectedLineId).toBe("line-2");
+      expect(state.payload).toMatchObject({
+        sectionId: "section-1",
+        lineId: "line-2",
+      });
+      expect(deps.render).toHaveBeenCalledOnce();
+      expect(previousSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-2",
+      });
+      expect(previousSectionEditor.focusContainer).toHaveBeenCalled();
+      expect(deps.subject.dispatch).toHaveBeenCalledWith(
+        "sceneEditor.renderCanvas",
+        expect.objectContaining({
+          skipRender: true,
+          syncPresentationState: true,
+        }),
+      );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    }
+  });
+
+  it("opens section create dialog with below placement from the section menu", async () => {
+    const store = {
+      selectDropdownMenu: vi.fn(() => ({
+        sectionId: "section-1",
+      })),
+      hideDropdownMenu: vi.fn(),
+      selectScene: vi.fn(() => ({
+        sections: [{ id: "section-1" }, { id: "section-2" }],
+      })),
+      showSectionCreateDialog: vi.fn(),
+      selectSceneId: vi.fn(() => "scene-1"),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      projectService: {},
+      subject: {
+        dispatch: vi.fn(),
+      },
+      appService: {},
+    };
+
+    await handleDropdownMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "add-section-below",
+          },
+        },
+      },
+    });
+
+    expect(store.hideDropdownMenu).toHaveBeenCalledOnce();
+    expect(store.showSectionCreateDialog).toHaveBeenCalledWith({
+      defaultName: "Section 3",
+      placementPosition: "after",
+      placementTargetSectionId: "section-1",
+    });
+    expect(deps.render).toHaveBeenCalledOnce();
   });
 });

--- a/tests/sceneEditor/sectionOperations.test.js
+++ b/tests/sceneEditor/sectionOperations.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSceneEditorSectionWithName } from "../../src/internal/ui/sceneEditor/sectionOperations.js";
+
+describe("scene editor section operations", () => {
+  it("does not select or scroll to a newly created section", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const store = {
+        selectSceneId: vi.fn(() => "scene-1"),
+        setSelectedSectionId: vi.fn(),
+        setSelectedLineId: vi.fn(),
+      };
+      const projectService = {
+        getState: vi.fn(() => ({
+          layouts: { items: {} },
+          controls: { items: {} },
+        })),
+        createSectionItem: vi.fn(async () => {}),
+        createLineItem: vi.fn(async () => {}),
+      };
+      const render = vi.fn();
+      const syncProjectState = vi.fn();
+
+      await createSceneEditorSectionWithName(
+        { store, projectService, render },
+        "New Section",
+        syncProjectState,
+        {
+          inheritPresentationFromSelectedLine: false,
+          position: "after",
+          positionTargetId: "section-1",
+        },
+      );
+
+      expect(projectService.createSectionItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sceneId: "scene-1",
+          position: "after",
+          positionTargetId: "section-1",
+          data: {
+            name: "New Section",
+          },
+        }),
+      );
+      expect(projectService.createLineItem).toHaveBeenCalledOnce();
+      expect(syncProjectState).toHaveBeenCalledWith(store, projectService);
+      expect(store.setSelectedSectionId).not.toHaveBeenCalled();
+      expect(store.setSelectedLineId).not.toHaveBeenCalled();
+      expect(render).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- render all scene sections in one scrollable editor view with sticky section headers
- add section header menus for add above/below, move up/down, move to scene, and related section actions
- restore the sections overview dialog button beside scene settings
- keep section headers non-clickable to avoid disruptive jumps
- keep the current section/line selection when adding a section
- make Lexical draft persistence and editor targeting section-aware
- support block-mode keyboard navigation across section boundaries in both directions
- suppress plain Space in block mode so the page does not scroll

## Testing
- bunx vitest run tests/sceneEditor/sectionOperations.test.js tests/sceneEditor/lexicalLineEditing.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/sceneEditor.store.test.js
- bun run lint

Not run: bun run build:web