### PR TITLE
fix: show previews for inactive scene sections

### DIFF
--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -938,18 +938,50 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
   }
 };
 
+const getSceneSectionIds = (scene) => {
+  const sectionIds = [];
+  const seen = new Set();
+
+  for (const section of scene?.sections || []) {
+    if (!section?.id || seen.has(section.id)) {
+      continue;
+    }
+
+    seen.add(section.id);
+    sectionIds.push(section.id);
+  }
+
+  return sectionIds;
+};
+
 export const updateSceneEditorSectionChanges = async (deps) => {
   const { store, graphicsService } = deps;
-  const sectionId = store.selectSelectedSectionId();
-  if (!sectionId) {
+  const selectedSectionId = store.selectSelectedSectionId();
+  const sectionIds = getSceneSectionIds(store.selectScene?.());
+  if (sectionIds.length === 0 && selectedSectionId) {
+    sectionIds.push(selectedSectionId);
+  }
+  if (sectionIds.length === 0) {
     return;
   }
 
-  const changes = graphicsService.engineSelectSectionLineChanges({
-    sectionId,
-    includePresentationState: true,
+  const changesBySectionId = {};
+  for (const sectionId of sectionIds) {
+    changesBySectionId[sectionId] =
+      graphicsService.engineSelectSectionLineChanges({
+        sectionId,
+        includePresentationState: true,
+      });
+  }
+
+  if (store.setSectionLineChangesBySectionId) {
+    store.setSectionLineChangesBySectionId({ changesBySectionId });
+    return;
+  }
+
+  store.setSectionLineChanges({
+    changes: selectedSectionId ? changesBySectionId[selectedSectionId] : {},
   });
-  store.setSectionLineChanges({ changes });
 };
 
 export const initializeSceneEditorPage = async (deps) => {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -68,8 +68,31 @@ const mergePresentationStates = (
   };
 };
 
+const getSectionLineChangesForSection = (state, sectionId) => {
+  if (sectionId) {
+    if (
+      Object.prototype.hasOwnProperty.call(
+        state.sectionLineChangesBySectionId ?? {},
+        sectionId,
+      )
+    ) {
+      return state.sectionLineChangesBySectionId[sectionId] ?? {};
+    }
+
+    return sectionId === state.selectedSectionId
+      ? (state.sectionLineChanges ?? {})
+      : {};
+  }
+
+  return state.sectionLineChanges ?? {};
+};
+
 const getSectionLinePresentationState = (state, lineId) => {
-  const selectedLineEntry = (state.sectionLineChanges?.lines || []).find(
+  const sectionLineChanges = getSectionLineChangesForSection(
+    state,
+    state.selectedSectionId,
+  );
+  const selectedLineEntry = (sectionLineChanges?.lines || []).find(
     (line) => line.id === lineId,
   );
   if (!selectedLineEntry) {
@@ -590,6 +613,7 @@ export const createInitialState = () => ({
   presentationState: {},
   temporaryPresentationState: {},
   sectionLineChanges: {},
+  sectionLineChangesBySectionId: {},
   isMuted: false,
   isScenePageLoading: true,
   isSceneAssetLoading: false,
@@ -724,8 +748,7 @@ export const selectEffectivePresentationState = ({ state }) => {
   );
 };
 
-export const setSectionLineChanges = ({ state }, { changes } = {}) => {
-  state.sectionLineChanges = changes;
+const syncPresentationStateFromSelectedLineChanges = (state) => {
   const syncedPresentationState = getSectionLinePresentationState(
     state,
     state.selectedLineId,
@@ -733,6 +756,26 @@ export const setSectionLineChanges = ({ state }, { changes } = {}) => {
   if (syncedPresentationState !== undefined) {
     state.presentationState = syncedPresentationState;
   }
+};
+
+export const setSectionLineChanges = ({ state }, { changes } = {}) => {
+  state.sectionLineChanges = changes ?? {};
+  if (state.selectedSectionId) {
+    state.sectionLineChangesBySectionId[state.selectedSectionId] =
+      state.sectionLineChanges;
+  }
+  syncPresentationStateFromSelectedLineChanges(state);
+};
+
+export const setSectionLineChangesBySectionId = (
+  { state },
+  { changesBySectionId } = {},
+) => {
+  state.sectionLineChangesBySectionId = toPlainObject(changesBySectionId);
+  state.sectionLineChanges = state.selectedSectionId
+    ? (state.sectionLineChangesBySectionId[state.selectedSectionId] ?? {})
+    : {};
+  syncPresentationStateFromSelectedLineChanges(state);
 };
 
 export const setScenePageLoading = ({ state }, { isLoading } = {}) => {
@@ -1459,12 +1502,17 @@ export const selectViewData = ({ state }) => {
   const documentLineDecorations = buildSceneDocumentLineDecorations({
     lines: documentEditorLines,
     repositoryState,
-    sectionLineChanges: state.sectionLineChanges,
+    sectionLineChanges: getSectionLineChangesForSection(
+      state,
+      currentSection?.id,
+    ),
   });
   const sectionEditorItems = sections.map((section, index) => {
     const sectionLines = Array.isArray(section.lines) ? section.lines : [];
-    const sectionLineChanges =
-      section.id === state.selectedSectionId ? state.sectionLineChanges : {};
+    const sectionLineChanges = getSectionLineChangesForSection(
+      state,
+      section.id,
+    );
 
     return {
       ...section,

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -156,6 +156,43 @@ describe("renderSceneEditorState", () => {
     });
   });
 
+  it("requests per-line changes for every visible section", async () => {
+    const changesBySectionId = {
+      "section-1": { lines: [{ id: "line-1" }] },
+      "section-2": { lines: [{ id: "line-2" }] },
+    };
+    const engineSelectSectionLineChanges = vi.fn(
+      ({ sectionId }) => changesBySectionId[sectionId],
+    );
+    const setSectionLineChangesBySectionId = vi.fn();
+
+    await updateSceneEditorSectionChanges({
+      store: {
+        selectSelectedSectionId: () => "section-1",
+        selectScene: () => ({
+          sections: [{ id: "section-1" }, { id: "section-2" }],
+        }),
+        setSectionLineChangesBySectionId,
+      },
+      graphicsService: {
+        engineSelectSectionLineChanges,
+      },
+    });
+
+    expect(engineSelectSectionLineChanges).toHaveBeenCalledTimes(2);
+    expect(engineSelectSectionLineChanges).toHaveBeenNthCalledWith(1, {
+      sectionId: "section-1",
+      includePresentationState: true,
+    });
+    expect(engineSelectSectionLineChanges).toHaveBeenNthCalledWith(2, {
+      sectionId: "section-2",
+      includePresentationState: true,
+    });
+    expect(setSectionLineChangesBySectionId).toHaveBeenCalledWith({
+      changesBySectionId,
+    });
+  });
+
   it("coalesces overlapping canvas renders to the latest pending payload", async () => {
     const resolvers = [];
     const renderCanvas = vi.fn(

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -8,6 +8,7 @@ import {
   setRepositoryState,
   setSceneId,
   setPresentationState,
+  setSectionLineChangesBySectionId,
   setTemporaryPresentationState,
   showSectionDropdownMenu,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.store.js";
@@ -290,6 +291,121 @@ describe("sceneEditorLexical.store", () => {
     expect(viewData.sectionEditorItems[1].documentLineDecorations[0]).toEqual(
       expect.objectContaining({ id: "line-3", lineNumber: 1 }),
     );
+  });
+
+  it("uses per-section line changes for inactive section decorations", () => {
+    const state = createInitialState();
+    state.selectedSectionId = "section-1";
+    state.selectedLineId = "line-1";
+
+    setSceneId({ state }, { sceneId: "scene-1" });
+    setRepositoryState(
+      { state },
+      {
+        repository: {
+          characters: {
+            items: {
+              "character-1": {
+                id: "character-1",
+                type: "character",
+                name: "Aki",
+                fileId: "file-character-1",
+              },
+              "character-2": {
+                id: "character-2",
+                type: "character",
+                name: "Bea",
+                fileId: "file-character-2",
+              },
+            },
+            tree: [{ id: "character-1" }, { id: "character-2" }],
+          },
+          scenes: {
+            items: {
+              "scene-1": {
+                id: "scene-1",
+                type: "scene",
+                name: "Scene 1",
+                sections: {
+                  items: {
+                    "section-1": {
+                      id: "section-1",
+                      type: "section",
+                      name: "Section 1",
+                      lines: {
+                        items: {
+                          "line-1": { id: "line-1", actions: {} },
+                        },
+                        tree: [{ id: "line-1" }],
+                      },
+                    },
+                    "section-2": {
+                      id: "section-2",
+                      type: "section",
+                      name: "Section 2",
+                      lines: {
+                        items: {
+                          "line-2": { id: "line-2", actions: {} },
+                        },
+                        tree: [{ id: "line-2" }],
+                      },
+                    },
+                  },
+                  tree: [{ id: "section-1" }, { id: "section-2" }],
+                },
+              },
+            },
+            tree: [{ id: "scene-1" }],
+          },
+        },
+      },
+    );
+    setSectionLineChangesBySectionId(
+      { state },
+      {
+        changesBySectionId: {
+          "section-1": {
+            lines: [
+              {
+                id: "line-1",
+                changes: {},
+                presentationState: {
+                  dialogue: { characterId: "character-1" },
+                },
+              },
+            ],
+          },
+          "section-2": {
+            lines: [
+              {
+                id: "line-2",
+                changes: {
+                  visual: {
+                    changeType: "set",
+                    data: { items: [] },
+                  },
+                },
+                presentationState: {
+                  dialogue: { characterId: "character-2" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(
+      viewData.sectionEditorItems[0].documentLineDecorations[0].characterFileId,
+    ).toBe("file-character-1");
+    expect(
+      viewData.sectionEditorItems[1].documentLineDecorations[0].characterFileId,
+    ).toBe("file-character-2");
+    expect(
+      viewData.sectionEditorItems[1].documentLineDecorations[0].visual,
+    ).toEqual({ changeType: "set", items: [] });
   });
 
   it("builds section menu actions for add, reorder, and moving to another scene", () => {


### PR DESCRIPTION
## Summary
- collect section line changes for every visible scene section, not only the selected section
- store section line changes by section id and feed each section editor its own decoration data
- keep selected-line presentation state sync working from the selected section changes
- add runtime and store coverage for inactive section speaker/right preview decorations

## Testing
- bunx vitest run tests/sceneEditor/runtime.test.js tests/sceneEditor/sceneEditor.store.test.js tests/sceneEditor/lineViewModels.test.js tests/sceneEditor/selectionPresentationState.test.js
- bun run lint

Not run: bun run build:web