### PR TITLE
Add custom transform editor for scene actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "jszip": "3.10.1",
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
-        "route-engine-js": "1.20.4",
+        "route-engine-js": "1.22.0",
         "route-graphics": "1.20.1",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
@@ -729,7 +729,7 @@
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
-    "route-engine-js": ["route-engine-js@1.20.4", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-OUjOnUq3EyDVddWR0CtIsGWao/8gL7DSYtnb1z2ojOFu4EKM3wOjnSM3okbBsGP4hOqYA9qrCyJ6QP6tkP92ow=="],
+    "route-engine-js": ["route-engine-js@1.22.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-rIxlqmgax2tE1CiFUgNTloqoqy7V8R+Fn0f2yCI4FE2/QB0lKT0CIk2hJNlEdlRi3yHXbRQWNeQkWW6gstkj1w=="],
 
     "route-graphics": ["route-graphics@1.20.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-auJzJ9dXHvCgbxqfPjMNc3qQCxippqEps6NnAR2UY3jzG9fuBH3gTAbD76WchoRR0ctrNqAi0r4oOJHW4k+uJw=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jszip": "3.10.1",
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
-    "route-engine-js": "1.20.4",
+    "route-engine-js": "1.22.0",
     "route-graphics": "1.20.1",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",

--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -1,4 +1,8 @@
 import { toFlatItems } from "../../internal/project/tree.js";
+import {
+  BACKGROUND_TRANSFORM_FIELDS,
+  createBackgroundWithInlineTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 
 const createEmptyCollection = () => ({
   items: {},
@@ -109,6 +113,12 @@ const getDomainStateFromRepository = (repository) => {
   return repository.getState();
 };
 
+const hasBackgroundInlineTransform = (background = {}) => {
+  return BACKGROUND_TRANSFORM_FIELDS.some(
+    (field) => background?.[field] !== undefined,
+  );
+};
+
 const buildBackgroundDataFromState = (
   store,
   { includeTemporaryResource = false } = {},
@@ -118,6 +128,8 @@ const buildBackgroundDataFromState = (
       ? (store.selectTempSelectedResource?.() ?? store.selectSelectedResource())
       : store.selectSelectedResource();
   const selectedTransformId = store.selectSelectedTransform();
+  const customTransformEnabled = store.selectCustomTransformEnabled();
+  const selectedCustomTransform = store.selectCustomTransform?.();
   const selectedColorId = store.selectSelectedColor();
   const selectedOpacity = store.selectSelectedOpacity();
   const selectedBlur = store.selectSelectedBlurActionValue();
@@ -149,7 +161,18 @@ const buildBackgroundDataFromState = (
     backgroundData.blur = selectedBlur;
   }
 
-  if (hasBackgroundTarget && selectedTransformId) {
+  if (
+    hasBackgroundTarget &&
+    customTransformEnabled &&
+    selectedCustomTransform
+  ) {
+    Object.assign(
+      backgroundData,
+      createBackgroundWithInlineTransform({}, selectedCustomTransform),
+    );
+  }
+
+  if (hasBackgroundTarget && !customTransformEnabled && selectedTransformId) {
     backgroundData.transformId = selectedTransformId;
   }
 
@@ -188,6 +211,72 @@ const dispatchTemporaryPresentationStateChange = (deps) => {
         },
       },
     }),
+  );
+};
+
+export const handleCustomTransformButtonClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { dispatchEvent, store, render } = deps;
+
+  store.openCustomTransformEditor?.();
+  render?.();
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
+  const background = buildBackgroundDataFromState(store, {
+    includeTemporaryResource: true,
+  });
+
+  dispatchEvent(
+    new CustomEvent("background-transform-customize", {
+      detail: {
+        background,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleSetCustomTransform = (deps, { transform } = {}) => {
+  const { store, render } = deps;
+  store.setCustomTransformEnabled?.({
+    enabled: true,
+  });
+  store.setCustomTransform?.({
+    transform,
+  });
+  render?.();
+};
+
+export const handleCustomTransformDoneButtonClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { dispatchEvent, store, render } = deps;
+
+  store.closeCustomTransformEditor?.();
+  render?.();
+
+  dispatchEvent?.(
+    new CustomEvent("background-transform-editor-done", {
+      detail: {},
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
+  const canvasHost = refs?.backgroundTransformPreviewCanvasHost;
+  return (
+    canvasHost?.getCanvasRoot?.() ||
+    canvasHost?.shadowRoot?.querySelector?.("#canvas") ||
+    canvasHost?.querySelector?.("#canvas")
   );
 };
 
@@ -251,7 +340,14 @@ export const handleBeforeMount = (deps) => {
     });
   }
 
-  if (transformId) {
+  if (hasBackgroundInlineTransform(props.background)) {
+    store.setCustomTransformEnabled({
+      enabled: true,
+    });
+    store.setCustomTransform({
+      transform: props.background,
+    });
+  } else if (transformId) {
     store.setSelectedTransform({
       transformId,
     });
@@ -411,6 +507,28 @@ export const handleFormInputChange = (deps, payload) => {
     store.setSelectedAnimation({
       animationId: fieldValue,
     });
+    render();
+    dispatchTemporaryPresentationStateChange(deps);
+    return;
+  }
+
+  if (name === "customTransform") {
+    const customTransformWasEnabled = store.selectCustomTransformEnabled();
+    const customTransformEnabled = fieldValue === true || fieldValue === "true";
+
+    store.setCustomTransformEnabled({
+      enabled: fieldValue,
+    });
+
+    if (!customTransformWasEnabled && customTransformEnabled) {
+      const selectedTransform = store.selectSelectedTransformResource?.();
+      if (selectedTransform) {
+        store.setCustomTransform?.({
+          transform: selectedTransform,
+        });
+      }
+    }
+
     render();
     dispatchTemporaryPresentationStateChange(deps);
     return;

--- a/src/components/commandLineBackground/commandLineBackground.schema.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.schema.yaml
@@ -2,6 +2,8 @@ componentName: rvn-command-line-background
 propsSchema:
   type: object
   properties:
+    backgroundTransformEditor:
+      type: object
     background:
       type: object
       properties:
@@ -37,6 +39,24 @@ propsSchema:
               type: boolean
         transformId:
           type: string
+        x:
+          type: number
+        y:
+          type: number
+        anchorX:
+          type: number
+        anchorY:
+          type: number
+        scaleX:
+          type: number
+        scaleY:
+          type: number
+        rotation:
+          type: number
+        originX:
+          type: number
+        originY:
+          type: number
         animations:
           type: object
           properties:

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -1,4 +1,8 @@
 import { toFlatGroups, toFlatItems } from "../../internal/project/tree.js";
+import {
+  formatBackgroundTransformEditorMetric,
+  normalizeBackgroundTransformEditorTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 
 const tabs = [
   {
@@ -147,6 +151,9 @@ export const createInitialState = () => ({
   animationItems: createEmptyCollection(),
   transformItems: createEmptyCollection(),
   colorItems: createEmptyCollection(),
+  customTransformEnabled: false,
+  selectedCustomTransform: undefined,
+  customTransformEditorOpen: false,
   selectedResourceId: undefined,
   selectedResourceType: undefined,
   tempSelectedResourceId: undefined,
@@ -315,6 +322,46 @@ export const setSelectedTransform = ({ state }, { transformId } = {}) => {
 
 export const selectSelectedTransform = ({ state }) => {
   return state.selectedTransformId;
+};
+
+export const selectSelectedTransformResource = ({ state }) => {
+  if (!state.selectedTransformId) {
+    return undefined;
+  }
+
+  return toFlatItems(state.transformItems).find(
+    (item) => item.id === state.selectedTransformId,
+  );
+};
+
+export const setCustomTransformEnabled = ({ state }, { enabled } = {}) => {
+  state.customTransformEnabled = enabled === true || enabled === "true";
+};
+
+export const selectCustomTransformEnabled = ({ state }) => {
+  return state.customTransformEnabled;
+};
+
+export const setCustomTransform = ({ state }, { transform } = {}) => {
+  state.selectedCustomTransform = transform
+    ? normalizeBackgroundTransformEditorTransform(transform)
+    : undefined;
+};
+
+export const selectCustomTransform = ({ state }) => {
+  return state.selectedCustomTransform;
+};
+
+export const openCustomTransformEditor = ({ state }, _payload = {}) => {
+  state.customTransformEditorOpen = true;
+};
+
+export const closeCustomTransformEditor = ({ state }, _payload = {}) => {
+  state.customTransformEditorOpen = false;
+};
+
+export const selectCustomTransformEditorOpen = ({ state }) => {
+  return state.customTransformEditorOpen === true;
 };
 
 export const setSelectedColor = ({ state }, { colorId } = {}) => {
@@ -489,7 +536,59 @@ const selectResourceById = ({ state }, { resourceId, resourceType } = {}) => {
   };
 };
 
-export const selectViewData = ({ state }) => {
+const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
+  const editor = props.backgroundTransformEditor ?? {};
+  const transform = normalizeBackgroundTransformEditorTransform(
+    editor.transform ?? state.selectedCustomTransform,
+  );
+  const metrics = editor.metrics ?? {
+    x: formatBackgroundTransformEditorMetric(transform.x),
+    y: formatBackgroundTransformEditorMetric(transform.y),
+    scaleX: formatBackgroundTransformEditorMetric(transform.scaleX),
+    scaleY: formatBackgroundTransformEditorMetric(transform.scaleY),
+    rotation: formatBackgroundTransformEditorMetric(transform.rotation),
+  };
+
+  return {
+    isOpen: state.customTransformEditorOpen === true || editor.isOpen === true,
+    canvasAspectRatio: editor.canvasAspectRatio ?? "16 / 9",
+    previewMaxWidth:
+      editor.previewMaxWidth ??
+      "min(calc(100vw - 48px), calc((100vh - 170px) * 1.7777777778))",
+    metrics,
+  };
+};
+
+const createCustomTransformDetails = ({ state }) => {
+  const transform = normalizeBackgroundTransformEditorTransform(
+    state.selectedCustomTransform,
+  );
+
+  return [
+    {
+      label: "Position",
+      value: `${formatBackgroundTransformEditorMetric(transform.x)}, ${formatBackgroundTransformEditorMetric(transform.y)}`,
+    },
+    {
+      label: "Scale",
+      value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
+    },
+    {
+      label: "Rotation",
+      value: formatBackgroundTransformEditorMetric(transform.rotation),
+    },
+    {
+      label: "Anchor",
+      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
+    },
+    {
+      label: "Origin",
+      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
+    },
+  ];
+};
+
+export const selectViewData = ({ state, props = {} }) => {
   const itemsMap = {
     image: state.imageItems,
     layout: state.layoutItems,
@@ -588,12 +687,28 @@ export const selectViewData = ({ state }) => {
       options: colorOptions,
     },
     {
-      name: "transformId",
+      name: "customTransform",
       label: "Transform",
+      type: "segmented-control",
+      clearable: false,
+      options: [
+        { value: false, label: "Predefined" },
+        { value: true, label: "Custom" },
+      ],
+    },
+    {
+      $when: "customTransform == false",
+      name: "transformId",
+      label: "Predefined Transform",
       type: "select",
       clearable: true,
       placeholder: "Select transform",
       options: transformOptions,
+    },
+    {
+      $when: "customTransform == true",
+      type: "slot",
+      slot: "custom-transform",
     },
     {
       name: "opacity",
@@ -691,6 +806,7 @@ export const selectViewData = ({ state }) => {
   const defaultValues = {
     background: selectedResource?.fileId || "",
     colorId: state.selectedColorId,
+    customTransform: state.customTransformEnabled,
     transformId: state.selectedTransformId,
     opacity: state.selectedOpacity ?? DEFAULT_BACKGROUND_OPACITY,
     blur: state.selectedBlurEnabled,
@@ -713,8 +829,13 @@ export const selectViewData = ({ state }) => {
     groups: flatGroups,
     tempSelectedResourceId: state.tempSelectedResourceId,
     selectedResource,
+    customTransformDetails: createCustomTransformDetails({ state }),
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
+    backgroundTransformEditor: createBackgroundTransformEditorViewData({
+      state,
+      props,
+    }),
     searchQuery: state.searchQuery,
     searchPlaceholder: "Search...",
     dialogueForm: {
@@ -722,7 +843,12 @@ export const selectViewData = ({ state }) => {
         selectedResource?.resourceType ?? "none",
         selectedResource?.resourceId ?? "none",
         state.selectedColorId ?? "none",
+        state.customTransformEnabled ? "custom-transform" : "preset-transform",
         state.selectedTransformId ?? "none",
+        JSON.stringify(state.selectedCustomTransform ?? {}),
+        state.customTransformEditorOpen
+          ? "custom-transform-editor-open"
+          : "custom-transform-editor-closed",
         state.selectedOpacity ?? DEFAULT_BACKGROUND_OPACITY,
         state.selectedBlurEnabled ? "blur" : "no-blur",
         state.selectedBlur.x,

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -35,6 +35,19 @@ refs:
         handler: handleFormExtra
       form-change:
         handler: handleFormInputChange
+  customTransformButton:
+    eventListeners:
+      click:
+        handler: handleCustomTransformButtonClick
+  customTransformChip*:
+    eventListeners:
+      click:
+        handler: handleCustomTransformButtonClick
+  backgroundTransformPreviewCanvasHost: {}
+  backgroundTransformEditorDoneButton:
+    eventListeners:
+      click:
+        handler: handleCustomTransformDoneButtonClick
   backgroundImage:
     eventListeners:
       click:
@@ -50,7 +63,7 @@ refs:
       click:
         action: hideFullImagePreview
 template:
-  - rtgl-view w=f h=f p=lg:
+  - 'rtgl-view w=f h=f p=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - rtgl-view d=h g=md: null
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
@@ -88,8 +101,39 @@ template:
                     $else:
                       - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
                           - rtgl-text s=md c=mu-fg: Select Background
+                  - rtgl-view slot=custom-transform d=h av=c w=f g=md:
+                      - rtgl-view d=h av=c w=1fg g=sm wrap:
+                          - $for item, i in customTransformDetails:
+                              - 'rtgl-view#customTransformChip${i} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
+                                  - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
+                                  - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
+                      - rtgl-button#customTransformButton v=se: Edit
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
+      - $if backgroundTransformEditor.isOpen:
+          - 'rtgl-view pos=abs edge=f z=20 bgc=bg d=v style="pointer-events: auto; min-width: 0; min-height: 0;"':
+              - rtgl-view h=48 bwb=xs w=f d=h av=c ph=md g=md:
+                  - rtgl-text s=sm w=1fg: Transform
+                  - rtgl-button#backgroundTransformEditorDoneButton v=pr: Done
+              - 'rtgl-view w=f h=1fg p=lg ah=c av=c style="min-width: 0; min-height: 0;"':
+                  - 'rtgl-view h=f style="width: ${backgroundTransformEditor.previewMaxWidth}; max-width: 100%; min-width: 0; min-height: 0;"':
+                      - rvn-scene-editor-preview-canvas#backgroundTransformPreviewCanvasHost canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}": null
+              - rtgl-view w=f bwt=xs d=h av=c ph=md pv=sm g=lg bgc=bg wrap:
+                  - rtgl-view d=h av=c g=xs:
+                      - rtgl-text s=xs c=mu-fg: x
+                      - rtgl-text s=sm: ${backgroundTransformEditor.metrics.x}
+                  - rtgl-view d=h av=c g=xs:
+                      - rtgl-text s=xs c=mu-fg: y
+                      - rtgl-text s=sm: ${backgroundTransformEditor.metrics.y}
+                  - rtgl-view d=h av=c g=xs:
+                      - rtgl-text s=xs c=mu-fg: scaleX
+                      - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleX}
+                  - rtgl-view d=h av=c g=xs:
+                      - rtgl-text s=xs c=mu-fg: scaleY
+                      - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleY}
+                  - rtgl-view d=h av=c g=xs:
+                      - rtgl-text s=xs c=mu-fg: rotation
+                      - rtgl-text s=sm: ${backgroundTransformEditor.metrics.rotation}
       - $if mode == 'gallery':
           - rtgl-view d=h w=f av=c g=md:
               - rtgl-tabs#tabs selected-tab=${tab} :items=${tabs}: null
@@ -134,6 +178,7 @@ template:
                                               - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
+
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -6,6 +6,33 @@ const getCharacterIndexFromEvent = (event) => {
 const getEventValue = (event) =>
   event?.detail?.value ?? event?.currentTarget?.value ?? event?.target?.value;
 
+const TRANSFORM_FIELDS = [
+  "x",
+  "y",
+  "anchorX",
+  "anchorY",
+  "scaleX",
+  "scaleY",
+  "rotation",
+  "originX",
+  "originY",
+];
+
+const hasInlineTransform = (item = {}) =>
+  TRANSFORM_FIELDS.some((field) => item?.[field] !== undefined);
+
+const assignInlineTransformFields = (target, source = {}) => {
+  if (!hasInlineTransform(source)) {
+    return;
+  }
+
+  for (const field of TRANSFORM_FIELDS) {
+    if (source[field] !== undefined) {
+      target[field] = source[field];
+    }
+  }
+};
+
 const getDropdownPositionFromEvent = (event) => {
   const rect = event?.currentTarget?.getBoundingClientRect?.();
   if (rect) {
@@ -176,6 +203,8 @@ const buildCharacterItemsFromState = (
       spriteName: char.spriteName || "",
     };
 
+    assignInlineTransformFields(item, char);
+
     if (char.opacity !== undefined) {
       item.opacity = char.opacity;
     }
@@ -321,6 +350,85 @@ export const handleTransformChange = (deps, payload) => {
   store.updateCharacterTransform({ index, transform: value });
   render();
   dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleTransformModeChange = (deps, payload) => {
+  const { store, render } = deps;
+  const index = getCharacterIndexFromEvent(payload._event);
+  if (index === undefined) {
+    return;
+  }
+
+  store.updateCharacterCustomTransformEnabled({
+    index,
+    enabled: getEventValue(payload._event),
+  });
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleCustomTransformButtonClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { dispatchEvent, store, render } = deps;
+  const index = getCharacterIndexFromEvent(payload._event);
+  const character = store.selectSelectedCharacters()?.[index];
+  if (index === undefined || !character) {
+    return;
+  }
+
+  const item = buildCharacterItemsFromState(store)[index];
+  store.openCustomTransformEditor?.();
+  render();
+  dispatchEvent(
+    new CustomEvent("action-transform-customize", {
+      detail: {
+        targetType: "character",
+        actionKey: "character",
+        itemIndex: index,
+        item,
+        action: buildCharacterDataFromState(store, {
+          includeTemporarySprites: true,
+        }).character,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleSetCustomTransform = (deps, { index, transform } = {}) => {
+  const { store, render } = deps;
+  store.updateCharacterCustomTransform({ index, transform });
+  store.closeCustomTransformEditor?.();
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleCustomTransformDoneButtonClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { dispatchEvent, store, render } = deps;
+  store.closeCustomTransformEditor?.();
+  render();
+  dispatchEvent(
+    new CustomEvent("action-transform-editor-done", {
+      detail: {},
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
+  const canvasHost = refs?.backgroundTransformPreviewCanvasHost;
+  return (
+    canvasHost?.getCanvasRoot?.() ||
+    canvasHost?.shadowRoot?.querySelector?.("#canvas") ||
+    canvasHost?.querySelector?.("#canvas")
+  );
 };
 
 export const handleAnimationChange = (deps, payload) => {

--- a/src/components/commandLineCharacters/commandLineCharacters.schema.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.schema.yaml
@@ -2,6 +2,8 @@ componentName: rvn-command-line-characters
 propsSchema:
   type: object
   properties:
+    backgroundTransformEditor:
+      type: object
     character:
       type: object
       properties:
@@ -14,6 +16,24 @@ propsSchema:
                 type: string
               transformId:
                 type: string
+              x:
+                type: number
+              y:
+                type: number
+              anchorX:
+                type: number
+              anchorY:
+                type: number
+              scaleX:
+                type: number
+              scaleY:
+                type: number
+              rotation:
+                type: number
+              originX:
+                type: number
+              originY:
+                type: number
               opacity:
                 type: number
                 minimum: 0

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -12,6 +12,14 @@ import {
   normalizeCommandLineItemEffects,
   normalizeCommandLineItemOpacity,
 } from "../../internal/commandLineItemEffects.js";
+import {
+  BACKGROUND_TRANSFORM_FIELDS,
+  createActionItemWithInlineTransform,
+  formatBackgroundTransformEditorMetric,
+  hasInlineTransform,
+  normalizeBackgroundTransformEditorTransform,
+  removeInlineTransformFields,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 
 const createEmptyCollection = () => ({
   items: {},
@@ -23,6 +31,10 @@ const UNGROUPED_SPRITE_GROUP_ID = "__ungrouped_sprites__";
 const UNGROUPED_GROUP_LABEL = "Ungrouped";
 const DEFAULT_SPRITE_GROUP_ID = "base";
 const DEFAULT_SPRITE_GROUP_NAME = "Sprite";
+const TRANSFORM_MODE_OPTIONS = [
+  { value: false, label: "Predefined" },
+  { value: true, label: "Custom" },
+];
 const createCharacterContextDropdownItems = (
   characterIndex,
   characters = [],
@@ -225,6 +237,7 @@ export const createInitialState = () => ({
   searchQuery: "",
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
+  customTransformEditorOpen: false,
   dropdownMenu: {
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -251,6 +264,88 @@ export const setAnimations = ({ state }, { animations } = {}) => {
   state.selectedCharacters = state.selectedCharacters.map((character) =>
     normalizeSelectedCharacter(character, state.animations),
   );
+};
+
+const getTransformItems = (state) =>
+  toFlatItems(state.transforms).filter((item) => item.type === "transform");
+
+const getDefaultTransformId = (state) => {
+  const transformItems = getTransformItems(state);
+  return transformItems.length > 0 ? transformItems[0].id : undefined;
+};
+
+const getTransformResourceById = (state, transformId) => {
+  if (!transformId) {
+    return undefined;
+  }
+
+  return getTransformItems(state).find((item) => item.id === transformId);
+};
+
+const getSelectedTransformResource = (state, character = {}) => {
+  return getTransformResourceById(
+    state,
+    character.transformId ?? getDefaultTransformId(state),
+  );
+};
+
+const createCustomTransformDetails = (character = {}) => {
+  const transform = normalizeBackgroundTransformEditorTransform(character);
+
+  return [
+    {
+      label: "Position",
+      value: `${formatBackgroundTransformEditorMetric(transform.x)}, ${formatBackgroundTransformEditorMetric(transform.y)}`,
+    },
+    {
+      label: "Scale",
+      value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
+    },
+    {
+      label: "Rotation",
+      value: formatBackgroundTransformEditorMetric(transform.rotation),
+    },
+    {
+      label: "Anchor",
+      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
+    },
+    {
+      label: "Origin",
+      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
+    },
+  ];
+};
+
+const applyCharacterInlineTransform = (character, transform) => {
+  const nextCharacter = createActionItemWithInlineTransform(
+    character,
+    transform,
+    { preserveTransformId: true },
+  );
+
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    character[field] = nextCharacter[field];
+  }
+};
+
+const clearCharacterInlineTransform = (character) => {
+  const nextCharacter = removeInlineTransformFields(character);
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    delete character[field];
+  }
+  if (!character.transformId) {
+    character.transformId = nextCharacter.transformId;
+  }
+};
+
+const getInlineTransformFields = (item = {}) => {
+  const fields = {};
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    if (item[field] !== undefined) {
+      fields[field] = item[field];
+    }
+  }
+  return fields;
 };
 
 const getCharacterItemById = ({ state, characterId } = {}) => {
@@ -291,14 +386,31 @@ const resolveSelectedSpriteGroupId = ({
   return spriteSelectionGroups?.[0]?.id;
 };
 
-export const addCharacter = ({ state }, { id, transformId } = {}) => {
-  // Get the first available transform as default
-  const transformItems = toFlatItems(state.transforms).filter(
-    (item) => item.type === "transform",
+const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
+  const editor = props.backgroundTransformEditor ?? {};
+  const transform = normalizeBackgroundTransformEditorTransform(
+    editor.transform,
   );
-  const defaultTransform =
-    transformId ??
-    (transformItems.length > 0 ? transformItems[0].id : undefined);
+  const metrics = editor.metrics ?? {
+    x: formatBackgroundTransformEditorMetric(transform.x),
+    y: formatBackgroundTransformEditorMetric(transform.y),
+    scaleX: formatBackgroundTransformEditorMetric(transform.scaleX),
+    scaleY: formatBackgroundTransformEditorMetric(transform.scaleY),
+    rotation: formatBackgroundTransformEditorMetric(transform.rotation),
+  };
+
+  return {
+    isOpen: state.customTransformEditorOpen === true || editor.isOpen === true,
+    canvasAspectRatio: editor.canvasAspectRatio ?? "16 / 9",
+    previewMaxWidth:
+      editor.previewMaxWidth ??
+      "min(calc(100vw - 48px), calc((100vh - 170px) * 1.7777777778))",
+    metrics,
+  };
+};
+
+export const addCharacter = ({ state }, { id, transformId } = {}) => {
+  const defaultTransform = transformId ?? getDefaultTransformId(state);
 
   // Store raw character data (same structure as from props)
   state.selectedCharacters.push({
@@ -388,9 +500,62 @@ export const updateCharacterTransform = (
   { state },
   { index, transform } = {},
 ) => {
-  if (state.selectedCharacters[index]) {
-    state.selectedCharacters[index].transformId = transform;
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
   }
+
+  character.transformId = transform;
+  clearCharacterInlineTransform(character);
+};
+
+export const updateCharacterCustomTransformEnabled = (
+  { state },
+  { index, enabled } = {},
+) => {
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
+  }
+
+  const customEnabled = enabled === true || enabled === "true";
+  if (!customEnabled) {
+    clearCharacterInlineTransform(character);
+    character.transformId =
+      character.transformId ?? getDefaultTransformId(state);
+    return;
+  }
+
+  const selectedTransform = getSelectedTransformResource(state, character);
+  applyCharacterInlineTransform(character, {
+    ...normalizeBackgroundTransformEditorTransform(selectedTransform),
+    ...character,
+  });
+};
+
+export const updateCharacterCustomTransform = (
+  { state },
+  { index, transform } = {},
+) => {
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
+  }
+
+  character.transformId = character.transformId ?? getDefaultTransformId(state);
+  applyCharacterInlineTransform(character, transform);
+};
+
+export const openCustomTransformEditor = ({ state }, _payload = {}) => {
+  state.customTransformEditorOpen = true;
+};
+
+export const closeCustomTransformEditor = ({ state }, _payload = {}) => {
+  state.customTransformEditorOpen = false;
+};
+
+export const selectCustomTransformEditorOpen = ({ state }) => {
+  return state.customTransformEditorOpen === true;
 };
 
 export const updateCharacterAnimation = (
@@ -751,6 +916,7 @@ export const selectCharactersWithRepositoryData = ({ state }) => {
         id: char.id,
         name: "Unknown Character",
         transformId: char.transformId,
+        ...getInlineTransformFields(char),
         animations: char.animations,
         animationMode: char.animationMode,
         opacity: char.opacity,
@@ -779,6 +945,7 @@ export const selectCharactersWithRepositoryData = ({ state }) => {
     return {
       ...characterData,
       transformId: char.transformId,
+      ...getInlineTransformFields(char),
       animations: char.animations,
       animationMode: char.animationMode,
       opacity: char.opacity,
@@ -805,7 +972,7 @@ const form = {
   ],
 };
 
-export const selectViewData = ({ state }) => {
+export const selectViewData = ({ state, props = {} }) => {
   const searchQuery = (state.searchQuery ?? "").toLowerCase().trim();
   const matchesSearch = (item) => {
     if (!searchQuery) {
@@ -919,9 +1086,7 @@ export const selectViewData = ({ state }) => {
   let selectedSpriteGroupName = "";
 
   // Get transform options from repository instead of hardcoded values
-  const transformItems = toFlatItems(state.transforms).filter(
-    (item) => item.type === "transform",
-  );
+  const transformItems = getTransformItems(state);
   const transformOptions = transformItems.map((transform) => ({
     label: transform.name,
     value: transform.id,
@@ -1050,6 +1215,8 @@ export const selectViewData = ({ state }) => {
       transformId:
         char.transformId ||
         (transformOptions.length > 0 ? transformOptions[0].value : undefined),
+      customTransform: hasInlineTransform(char),
+      customTransformDetails: createCustomTransformDetails(char),
       animationId: char.animations?.resourceId,
       opacity: char.opacity ?? DEFAULT_COMMAND_LINE_ITEM_OPACITY,
       blurEnabled: Boolean(char.blur),
@@ -1064,6 +1231,7 @@ export const selectViewData = ({ state }) => {
     characters: characterControls.slice().reverse(),
     transformOptions,
     animationOptions,
+    transformModeOptions: TRANSFORM_MODE_OPTIONS,
     blurToggleOptions: COMMAND_LINE_ITEM_BLUR_TOGGLE_OPTIONS,
     blurKernelSizeOptions: COMMAND_LINE_ITEM_BLUR_KERNEL_SIZE_SELECT_OPTIONS,
     blurRepeatEdgeOptions: COMMAND_LINE_ITEM_BLUR_REPEAT_EDGE_OPTIONS,
@@ -1087,6 +1255,10 @@ export const selectViewData = ({ state }) => {
     searchPlaceholder: "Search...",
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
+    backgroundTransformEditor: createBackgroundTransformEditorViewData({
+      state,
+      props,
+    }),
     breadcrumb,
     form,
     defaultValues,

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -66,6 +66,23 @@ refs:
     eventListeners:
       value-change:
         handler: handleTransformChange
+  customTransformMode*:
+    eventListeners:
+      value-change:
+        handler: handleTransformModeChange
+  customTransformButton*:
+    eventListeners:
+      click:
+        handler: handleCustomTransformButtonClick
+  customTransformChip*:
+    eventListeners:
+      click:
+        handler: handleCustomTransformButtonClick
+  backgroundTransformPreviewCanvasHost: {}
+  backgroundTransformEditorDoneButton:
+    eventListeners:
+      click:
+        handler: handleCustomTransformDoneButtonClick
   animation*:
     eventListeners:
       value-change:
@@ -107,7 +124,7 @@ refs:
       click:
         handler: handleCharacterItemClick
 template:
-  - rtgl-view w=f h=f p=lg:
+  - 'rtgl-view w=f h=f p=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - $if mode == 'current':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
@@ -127,7 +144,18 @@ template:
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${character.displayName}
                                   - rtgl-view w=1fg g=sm:
                                       - rtgl-text s=sm c=mu-fg: Transform
-                                      - rtgl-select#transform${i} data-index=${character.characterIndex} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
+                                      - rtgl-segmented-control#customTransformMode${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.customTransform} :options=${defaultValues.transformModeOptions}: null
+                                      - $if character.customTransform:
+                                          - rtgl-view d=h av=c w=f g=md:
+                                              - rtgl-view d=h av=c w=1fg g=sm wrap:
+                                                  - $for item, j in character.customTransformDetails:
+                                                      - 'rtgl-view#customTransformChip${i}x${j} data-index=${character.characterIndex} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
+                                                          - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
+                                                          - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
+                                              - rtgl-button#customTransformButton${i} data-index=${character.characterIndex} v=se: Edit
+                                        $else:
+                                          - rtgl-text s=sm c=mu-fg: Predefined Transform
+                                          - rtgl-select#transform${i} data-index=${character.characterIndex} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
                                       - rtgl-text s=sm c=mu-fg: Opacity
                                       - rtgl-slider-input#opacity${i} data-index=${character.characterIndex} key=${character.id} min=0 max=1 step=0.01 w=f value=${character.opacity}: null
                                       - rtgl-text s=sm c=mu-fg: Blur
@@ -211,6 +239,30 @@ template:
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
+  - $if backgroundTransformEditor.isOpen:
+      - 'rtgl-view pos=abs edge=f z=20 bgc=bg d=v style="pointer-events: auto; min-width: 0; min-height: 0;"':
+          - rtgl-view h=48 bwb=xs w=f d=h av=c ph=md g=md:
+              - rtgl-text s=sm w=1fg: Transform
+              - rtgl-button#backgroundTransformEditorDoneButton v=pr: Done
+          - 'rtgl-view w=f h=1fg p=lg ah=c av=c style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view h=f style="width: ${backgroundTransformEditor.previewMaxWidth}; max-width: 100%; min-width: 0; min-height: 0;"':
+                  - rvn-scene-editor-preview-canvas#backgroundTransformPreviewCanvasHost canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}": null
+          - rtgl-view w=f bwt=xs d=h av=c ph=md pv=sm g=lg bgc=bg wrap:
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: x
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.x}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: y
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.y}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: scaleX
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleX}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: scaleY
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleY}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: rotation
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.rotation}
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -44,13 +44,39 @@ const orderVisualItemsForSave = (items = []) =>
     })
     .map(({ item }) => item);
 
+const TRANSFORM_FIELDS = [
+  "x",
+  "y",
+  "anchorX",
+  "anchorY",
+  "scaleX",
+  "scaleY",
+  "rotation",
+  "originX",
+  "originY",
+];
+
+const hasInlineTransform = (item = {}) =>
+  TRANSFORM_FIELDS.some((field) => item?.[field] !== undefined);
+
 const buildVisualItem = (visual = {}) => {
   const item = {
     id: visual.id,
     resourceId: visual.resourceId,
-    transformId: visual.transformId,
     layer: normalizeVisualLayer(visual.layer),
   };
+
+  if (visual.transformId) {
+    item.transformId = visual.transformId;
+  }
+
+  if (hasInlineTransform(visual)) {
+    for (const field of TRANSFORM_FIELDS) {
+      if (visual[field] !== undefined) {
+        item[field] = visual[field];
+      }
+    }
+  }
 
   if (visual.resourceType) {
     item.resourceType = visual.resourceType;
@@ -237,6 +263,85 @@ export const handleTransformChange = (deps, payload) => {
   store.updateVisualTransform({ index, transform: value });
   render();
   dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleTransformModeChange = (deps, payload) => {
+  const { store, render } = deps;
+  const index = getIndexFromEvent(payload._event);
+  if (index === undefined) {
+    return;
+  }
+
+  store.updateVisualCustomTransformEnabled({
+    index,
+    enabled: getEventValue(payload._event),
+  });
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleCustomTransformButtonClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { dispatchEvent, store, render } = deps;
+  const index = getIndexFromEvent(payload._event);
+  const visual = store.selectSelectedVisuals()?.[index];
+  if (index === undefined || !visual) {
+    return;
+  }
+
+  const item = buildVisualItem(visual);
+  store.openCustomTransformEditor?.();
+  render();
+  dispatchEvent(
+    new CustomEvent("action-transform-customize", {
+      detail: {
+        targetType: "visual",
+        actionKey: "visual",
+        itemIndex: index,
+        item,
+        action: buildVisualDataFromState(store, {
+          includeTemporaryResource: true,
+        }).visual,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleSetCustomTransform = (deps, { index, transform } = {}) => {
+  const { store, render } = deps;
+  store.updateVisualCustomTransform({ index, transform });
+  store.closeCustomTransformEditor?.();
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleCustomTransformDoneButtonClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { dispatchEvent, store, render } = deps;
+  store.closeCustomTransformEditor?.();
+  render();
+  dispatchEvent(
+    new CustomEvent("action-transform-editor-done", {
+      detail: {},
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
+  const canvasHost = refs?.backgroundTransformPreviewCanvasHost;
+  return (
+    canvasHost?.getCanvasRoot?.() ||
+    canvasHost?.shadowRoot?.querySelector?.("#canvas") ||
+    canvasHost?.querySelector?.("#canvas")
+  );
 };
 
 export const handleAnimationChange = (deps, payload) => {

--- a/src/components/commandLineVisual/commandLineVisual.schema.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.schema.yaml
@@ -2,6 +2,8 @@ componentName: rvn-command-line-visual
 propsSchema:
   type: object
   properties:
+    backgroundTransformEditor:
+      type: object
     visual:
       type: object
       properties:
@@ -18,6 +20,24 @@ propsSchema:
                 type: string
               transformId:
                 type: string
+              x:
+                type: number
+              y:
+                type: number
+              anchorX:
+                type: number
+              anchorY:
+                type: number
+              scaleX:
+                type: number
+              scaleY:
+                type: number
+              rotation:
+                type: number
+              originX:
+                type: number
+              originY:
+                type: number
               layer:
                 type: number
                 enum:

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -12,6 +12,14 @@ import {
   normalizeCommandLineItemEffects,
   normalizeCommandLineItemOpacity,
 } from "../../internal/commandLineItemEffects.js";
+import {
+  BACKGROUND_TRANSFORM_FIELDS,
+  createActionItemWithInlineTransform,
+  formatBackgroundTransformEditorMetric,
+  hasInlineTransform,
+  normalizeBackgroundTransformEditorTransform,
+  removeInlineTransformFields,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 
 const RESOURCE_TYPES = [
   { type: "image", label: "Images" },
@@ -51,6 +59,10 @@ const VISUAL_LAYER_VALUES = VISUAL_LAYER_OPTIONS.map((option) => option.value);
 const VISUAL_LAYER_DISPLAY_OPTIONS = VISUAL_LAYER_OPTIONS.slice().sort(
   (a, b) => b.value - a.value,
 );
+const TRANSFORM_MODE_OPTIONS = [
+  { value: false, label: "Predefined" },
+  { value: true, label: "Custom" },
+];
 
 const createEmptyCollection = () => ({
   items: {},
@@ -460,6 +472,7 @@ export const createInitialState = () => ({
   searchQuery: "",
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
+  customTransformEditorOpen: false,
   dropdownMenu: {
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -507,12 +520,98 @@ const generateVisualId = () => {
   return generatePrefixedId("visual-");
 };
 
+const getTransformItems = (state) =>
+  toFlatItems(state.transforms).filter((item) => item.type === "transform");
+
 const getDefaultTransformId = (state) => {
-  const transformItems = toFlatItems(state.transforms).filter(
-    (item) => item.type === "transform",
-  );
+  const transformItems = getTransformItems(state);
 
   return transformItems.length > 0 ? transformItems[0].id : undefined;
+};
+
+const getTransformResourceById = (state, transformId) => {
+  if (!transformId) {
+    return undefined;
+  }
+
+  return getTransformItems(state).find((item) => item.id === transformId);
+};
+
+const getSelectedTransformResource = (state, visual = {}) => {
+  return getTransformResourceById(
+    state,
+    visual.transformId ?? getDefaultTransformId(state),
+  );
+};
+
+const createCustomTransformDetails = (visual = {}) => {
+  const transform = normalizeBackgroundTransformEditorTransform(visual);
+
+  return [
+    {
+      label: "Position",
+      value: `${formatBackgroundTransformEditorMetric(transform.x)}, ${formatBackgroundTransformEditorMetric(transform.y)}`,
+    },
+    {
+      label: "Scale",
+      value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
+    },
+    {
+      label: "Rotation",
+      value: formatBackgroundTransformEditorMetric(transform.rotation),
+    },
+    {
+      label: "Anchor",
+      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
+    },
+    {
+      label: "Origin",
+      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
+    },
+  ];
+};
+
+const applyVisualInlineTransform = (visual, transform) => {
+  const nextVisual = createActionItemWithInlineTransform(visual, transform, {
+    preserveTransformId: true,
+  });
+
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    visual[field] = nextVisual[field];
+  }
+};
+
+const clearVisualInlineTransform = (visual) => {
+  const nextVisual = removeInlineTransformFields(visual);
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    delete visual[field];
+  }
+  if (!visual.transformId) {
+    visual.transformId = nextVisual.transformId;
+  }
+};
+
+const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
+  const editor = props.backgroundTransformEditor ?? {};
+  const transform = normalizeBackgroundTransformEditorTransform(
+    editor.transform,
+  );
+  const metrics = editor.metrics ?? {
+    x: formatBackgroundTransformEditorMetric(transform.x),
+    y: formatBackgroundTransformEditorMetric(transform.y),
+    scaleX: formatBackgroundTransformEditorMetric(transform.scaleX),
+    scaleY: formatBackgroundTransformEditorMetric(transform.scaleY),
+    rotation: formatBackgroundTransformEditorMetric(transform.rotation),
+  };
+
+  return {
+    isOpen: state.customTransformEditorOpen === true || editor.isOpen === true,
+    canvasAspectRatio: editor.canvasAspectRatio ?? "16 / 9",
+    previewMaxWidth:
+      editor.previewMaxWidth ??
+      "min(calc(100vw - 48px), calc((100vh - 170px) * 1.7777777778))",
+    metrics,
+  };
 };
 
 export const addVisual = (
@@ -591,9 +690,61 @@ export const moveVisual = ({ state }, { index, offset } = {}) => {
 };
 
 export const updateVisualTransform = ({ state }, { index, transform } = {}) => {
-  if (state.selectedVisuals[index]) {
-    state.selectedVisuals[index].transformId = transform;
+  const visual = state.selectedVisuals[index];
+  if (!visual) {
+    return;
   }
+
+  visual.transformId = transform;
+  clearVisualInlineTransform(visual);
+};
+
+export const updateVisualCustomTransformEnabled = (
+  { state },
+  { index, enabled } = {},
+) => {
+  const visual = state.selectedVisuals[index];
+  if (!visual) {
+    return;
+  }
+
+  const customEnabled = enabled === true || enabled === "true";
+  if (!customEnabled) {
+    clearVisualInlineTransform(visual);
+    visual.transformId = visual.transformId ?? getDefaultTransformId(state);
+    return;
+  }
+
+  const selectedTransform = getSelectedTransformResource(state, visual);
+  applyVisualInlineTransform(visual, {
+    ...normalizeBackgroundTransformEditorTransform(selectedTransform),
+    ...visual,
+  });
+};
+
+export const updateVisualCustomTransform = (
+  { state },
+  { index, transform } = {},
+) => {
+  const visual = state.selectedVisuals[index];
+  if (!visual) {
+    return;
+  }
+
+  visual.transformId = visual.transformId ?? getDefaultTransformId(state);
+  applyVisualInlineTransform(visual, transform);
+};
+
+export const openCustomTransformEditor = ({ state }, _payload = {}) => {
+  state.customTransformEditorOpen = true;
+};
+
+export const closeCustomTransformEditor = ({ state }, _payload = {}) => {
+  state.customTransformEditorOpen = false;
+};
+
+export const selectCustomTransformEditorOpen = ({ state }) => {
+  return state.customTransformEditorOpen === true;
 };
 
 export const updateVisualAnimation = (
@@ -869,7 +1020,7 @@ export const selectVisualsWithRepositoryData = ({ state }) => {
   });
 };
 
-export const selectViewData = ({ state }) => {
+export const selectViewData = ({ state, props = {} }) => {
   const activeResourceType = getActiveResourceType(state);
   const activeResourceCollection =
     selectResourceCollection(state, activeResourceType) ??
@@ -962,9 +1113,7 @@ export const selectViewData = ({ state }) => {
   ).filter((item) => item.type === "folder");
 
   // Get transform options
-  const transformItems = toFlatItems(state.transforms).filter(
-    (item) => item.type === "transform",
-  );
+  const transformItems = getTransformItems(state);
   const transformOptions = transformItems.map((transform) => ({
     label: transform.name,
     value: transform.id,
@@ -1020,6 +1169,8 @@ export const selectViewData = ({ state }) => {
       transformId:
         visual.transformId ||
         (transformOptions.length > 0 ? transformOptions[0].value : undefined),
+      customTransform: hasInlineTransform(visual),
+      customTransformDetails: createCustomTransformDetails(visual),
       animationId: visual.animations?.resourceId,
       layer: normalizeVisualLayer(visual.layer),
       opacity: visual.opacity ?? DEFAULT_COMMAND_LINE_ITEM_OPACITY,
@@ -1049,6 +1200,7 @@ export const selectViewData = ({ state }) => {
     transformOptions,
     animationOptions,
     layerOptions: VISUAL_LAYER_OPTIONS,
+    transformModeOptions: TRANSFORM_MODE_OPTIONS,
     blurToggleOptions: COMMAND_LINE_ITEM_BLUR_TOGGLE_OPTIONS,
     blurKernelSizeOptions: COMMAND_LINE_ITEM_BLUR_KERNEL_SIZE_SELECT_OPTIONS,
     blurRepeatEdgeOptions: COMMAND_LINE_ITEM_BLUR_REPEAT_EDGE_OPTIONS,
@@ -1072,6 +1224,10 @@ export const selectViewData = ({ state }) => {
     searchPlaceholder: "Search...",
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
+    backgroundTransformEditor: createBackgroundTransformEditorViewData({
+      state,
+      props,
+    }),
     breadcrumb,
     defaultValues,
     dropdownMenu: state.dropdownMenu,

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -68,6 +68,23 @@ refs:
     eventListeners:
       value-change:
         handler: handleTransformChange
+  customTransformMode*:
+    eventListeners:
+      value-change:
+        handler: handleTransformModeChange
+  customTransformButton*:
+    eventListeners:
+      click:
+        handler: handleCustomTransformButtonClick
+  customTransformChip*:
+    eventListeners:
+      click:
+        handler: handleCustomTransformButtonClick
+  backgroundTransformPreviewCanvasHost: {}
+  backgroundTransformEditorDoneButton:
+    eventListeners:
+      click:
+        handler: handleCustomTransformDoneButtonClick
   animation*:
     eventListeners:
       value-change:
@@ -105,7 +122,7 @@ refs:
       value-change:
         handler: handleBlurFieldChange
 template:
-  - rtgl-view w=f h=f p=lg:
+  - 'rtgl-view w=f h=f p=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - $if mode == 'current':
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
@@ -165,7 +182,18 @@ template:
                                                       - rtgl-text s=xs c=mu-fg: Repeat Edge
                                                       - rtgl-segmented-control#blurRepeatEdgePixels${groupIndex}x${i} data-index=${visual.visualIndex} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${visual.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}: null
                                           - rtgl-text s=sm c=mu-fg: Transform
-                                          - rtgl-select#transform${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear: null
+                                          - rtgl-segmented-control#customTransformMode${groupIndex}x${i} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.customTransform} :options=${defaultValues.transformModeOptions}: null
+                                          - $if visual.customTransform:
+                                              - rtgl-view d=h av=c w=f g=md:
+                                                  - rtgl-view d=h av=c w=1fg g=sm wrap:
+                                                      - $for item, j in visual.customTransformDetails:
+                                                          - 'rtgl-view#customTransformChip${groupIndex}x${i}x${j} data-index=${visual.visualIndex} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
+                                                              - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
+                                                              - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
+                                                  - rtgl-button#customTransformButton${groupIndex}x${i} data-index=${visual.visualIndex} v=se: Edit
+                                            $else:
+                                              - rtgl-text s=sm c=mu-fg: Predefined Transform
+                                              - rtgl-select#transform${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear: null
                                           - rtgl-text s=sm c=mu-fg: Animation
                                           - rtgl-select#animation${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.animationId} :options=${defaultValues.animationOptions} :selectedValue=${visual.animationId} w=f placeholder="Select animation": null
                   - rtgl-button#addVisualButton v=ol w=f mt=md: + Add Visual
@@ -217,6 +245,30 @@ template:
   - rtgl-popover#addVisualPopover ?open=${addVisualPopover.isOpen} x=${addVisualPopover.position.x} y=${addVisualPopover.position.y} place=bs:
       - rtgl-form#addVisualForm key=${addVisualPopover.key} slot=content :defaultValues=${addVisualDefaultValues} :form=${addVisualForm} w=320: null
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
+  - $if backgroundTransformEditor.isOpen:
+      - 'rtgl-view pos=abs edge=f z=20 bgc=bg d=v style="pointer-events: auto; min-width: 0; min-height: 0;"':
+          - rtgl-view h=48 bwb=xs w=f d=h av=c ph=md g=md:
+              - rtgl-text s=sm w=1fg: Transform
+              - rtgl-button#backgroundTransformEditorDoneButton v=pr: Done
+          - 'rtgl-view w=f h=1fg p=lg ah=c av=c style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view h=f style="width: ${backgroundTransformEditor.previewMaxWidth}; max-width: 100%; min-width: 0; min-height: 0;"':
+                  - rvn-scene-editor-preview-canvas#backgroundTransformPreviewCanvasHost canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}": null
+          - rtgl-view w=f bwt=xs d=h av=c ph=md pv=sm g=lg bgc=bg wrap:
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: x
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.x}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: y
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.y}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: scaleX
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleX}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: scaleY
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleY}
+              - rtgl-view d=h av=c g=xs:
+                  - rtgl-text s=xs c=mu-fg: rotation
+                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.rotation}
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -1,4 +1,8 @@
 import { normalizeLineActions } from "../../internal/project/engineActions.js";
+import {
+  createActionItemWithInlineTransform,
+  createBackgroundWithInlineTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 import { getRoutevnCreatorSystemActionDocsUrl } from "../../internal/routevnUrls.js";
 
 const toPlainObject = (value) => {
@@ -72,6 +76,14 @@ export const handleOnUpdate = (deps, changes) => {
   const { render, store } = deps;
   const { newProps } = changes;
   store.updateActions(normalizeActionsObject(newProps.actions));
+
+  if (
+    !isBooleanPropEnabled(newProps?.suppressDialogClose) &&
+    newProps?.backgroundTransformEditor?.suppressActionsDialogClose !== true
+  ) {
+    store.setSuppressDialogClose?.({ suppressDialogClose: false });
+  }
+
   render();
 };
 
@@ -100,6 +112,132 @@ export const handleTemporaryPresentationStateChange = (deps, payload) => {
     payload?._event?.detail?.presentationState,
   );
   dispatchTemporaryPresentationStateChange(deps, presentationState);
+};
+
+export const handleBackgroundTransformCustomize = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { refs, store } = deps;
+
+  store?.setSuppressDialogClose?.({ suppressDialogClose: true });
+  refs?.actionsDialog?.transformedHandlers?.handleSuppressClose?.();
+
+  deps.dispatchEvent(
+    new CustomEvent("background-transform-customize", {
+      detail: toPlainObject(payload?._event?.detail),
+    }),
+  );
+};
+
+export const handleBackgroundTransformEditorDone = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  deps.dispatchEvent(
+    new CustomEvent("background-transform-editor-done", {
+      detail: toPlainObject(payload?._event?.detail),
+    }),
+  );
+};
+
+export const handleActionTransformCustomize = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { refs, store } = deps;
+
+  store?.setSuppressDialogClose?.({ suppressDialogClose: true });
+  refs?.actionsDialog?.transformedHandlers?.handleSuppressClose?.();
+
+  deps.dispatchEvent(
+    new CustomEvent("action-transform-customize", {
+      detail: toPlainObject(payload?._event?.detail),
+    }),
+  );
+};
+
+export const handleActionTransformEditorDone = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  deps.dispatchEvent(
+    new CustomEvent("action-transform-editor-done", {
+      detail: toPlainObject(payload?._event?.detail),
+    }),
+  );
+};
+
+export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
+  return (
+    refs?.commandLineBackground?.transformedHandlers?.handleGetBackgroundTransformPreviewCanvasRoot?.() ||
+    refs?.commandLineVisual?.transformedHandlers?.handleGetBackgroundTransformPreviewCanvasRoot?.() ||
+    refs?.commandLineCharacters?.transformedHandlers?.handleGetBackgroundTransformPreviewCanvasRoot?.()
+  );
+};
+
+export const handleSetBackgroundCustomTransform = (
+  deps,
+  { background, transform } = {},
+) => {
+  const { refs, store } = deps;
+  const nextBackground = createBackgroundWithInlineTransform(
+    background ?? store.selectAction().background,
+    transform,
+  );
+
+  refs?.commandLineBackground?.transformedHandlers?.handleSetCustomTransform?.({
+    transform: nextBackground,
+  });
+  dispatchTemporaryPresentationStateChange(deps, {
+    background: nextBackground,
+  });
+};
+
+const resolveActionTransformIndex = (items = [], { itemIndex, item } = {}) => {
+  if (Number.isInteger(itemIndex)) {
+    return itemIndex;
+  }
+
+  if (item?.id) {
+    return items.findIndex((candidate) => candidate?.id === item.id);
+  }
+
+  return -1;
+};
+
+export const handleSetActionCustomTransform = (
+  deps,
+  { targetType, itemIndex, item, transform } = {},
+) => {
+  const { refs, store } = deps;
+  const actionKey = targetType === "character" ? "character" : "visual";
+  const action = toPlainObject(store.selectAction()?.[actionKey]);
+  const items = Array.isArray(action.items) ? [...action.items] : [];
+  const resolvedIndex = resolveActionTransformIndex(items, { itemIndex, item });
+  const sourceItem = item ?? items[resolvedIndex];
+
+  if (!sourceItem || resolvedIndex < 0) {
+    return;
+  }
+
+  const nextItem = createActionItemWithInlineTransform(sourceItem, transform, {
+    preserveTransformId: true,
+  });
+  items[resolvedIndex] = nextItem;
+
+  if (actionKey === "character") {
+    refs?.commandLineCharacters?.transformedHandlers?.handleSetCustomTransform?.(
+      {
+        index: resolvedIndex,
+        transform,
+      },
+    );
+  } else {
+    refs?.commandLineVisual?.transformedHandlers?.handleSetCustomTransform?.({
+      index: resolvedIndex,
+      transform,
+    });
+  }
+
+  dispatchTemporaryPresentationStateChange(deps, {
+    [actionKey]: {
+      ...action,
+      items,
+    },
+  });
 };
 
 export const handleCommandLineSubmit = (deps, payload) => {
@@ -141,8 +279,20 @@ export const handleHelpFloatingButtonClick = (deps, payload) => {
   appService.openUrl(getRoutevnCreatorSystemActionDocsUrl(mode));
 };
 
-export const handleActionsDialogClose = (deps) => {
-  const { store, render, dispatchEvent } = deps;
+const isBooleanPropEnabled = (value) => {
+  return value === true || value === "true";
+};
+
+export const handleActionsDialogClose = (deps, payload) => {
+  const { props, store, render, dispatchEvent } = deps;
+  if (
+    isBooleanPropEnabled(props?.suppressDialogClose) ||
+    store.selectSuppressDialogClose?.() === true
+  ) {
+    payload?._event?.preventDefault?.();
+    payload?._event?.stopPropagation?.();
+    return;
+  }
   dispatchTemporaryPresentationStateChange(deps, {});
   store.hideActionsDialog();
   render();

--- a/src/components/systemActions/systemActions.schema.yaml
+++ b/src/components/systemActions/systemActions.schema.yaml
@@ -12,6 +12,8 @@ propsSchema:
       type: string
     presentationState:
       type: object
+    backgroundTransformEditor:
+      type: object
     actionType:
       type: string
       enum:
@@ -35,4 +37,6 @@ propsSchema:
     showSelected:
       type: boolean
     showEmbeddedClose:
+      type: boolean
+    suppressDialogClose:
       type: boolean

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -11,6 +11,7 @@ export const createInitialState = () => ({
   actions: {},
   isTouchMode: false,
   isActionsDialogOpen: false,
+  suppressDialogClose: false,
   dropdownMenu: {
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -245,6 +246,11 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       : (attrs.dialogPanelWidth ?? "50vw"),
     hiddenModes,
     allowedModes,
+    suppressDialogClose:
+      state.suppressDialogClose === true ||
+      parseBooleanProp(attrs.suppressDialogClose, false) ||
+      attrs.backgroundTransformEditor?.suppressActionsDialogClose === true,
+    backgroundTransformEditor: attrs.backgroundTransformEditor ?? {},
     isRuntimeActionMode: isRuntimeActionMode(state.mode),
   };
 };
@@ -286,6 +292,7 @@ export const showActionsDialog = ({ state }, _payload = {}) => {
 
 export const hideActionsDialog = ({ state }, _payload = {}) => {
   state.isActionsDialogOpen = false;
+  state.suppressDialogClose = false;
   state.mode = "hidden";
 };
 
@@ -295,6 +302,17 @@ export const setMode = ({ state }, payload = {}) => {
     return;
   }
   state.mode = mode;
+};
+
+export const setSuppressDialogClose = (
+  { state },
+  { suppressDialogClose } = {},
+) => {
+  state.suppressDialogClose = suppressDialogClose === true;
+};
+
+export const selectSuppressDialogClose = ({ state }) => {
+  return state.suppressDialogClose === true;
 };
 
 const resolveDialogueModeLabel = (dialogue, layoutsItems) => {

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -7,6 +7,14 @@ refs:
         handler: handleActionClicked
       temporary-presentation-state-change:
         handler: handleTemporaryPresentationStateChange
+      background-transform-customize:
+        handler: handleBackgroundTransformCustomize
+      background-transform-editor-done:
+        handler: handleBackgroundTransformEditorDone
+      action-transform-customize:
+        handler: handleActionTransformCustomize
+      action-transform-editor-done:
+        handler: handleActionTransformEditorDone
       submit:
         handler: handleCommandLineSubmit
   addActionButton:
@@ -214,7 +222,7 @@ template:
           - $if showEmbeddedClose:
               - rtgl-view d=h av=c ah=e w=f g=lg:
                   - rtgl-button#embeddedCloseButton: Confirm
-  - rvn-system-actions-dialog-surface#actionsDialog key=${mode} :open=${isActionsDialogOpen} variant=${dialogVariant} :dialogWidth=${actionsDialogWidth} :dialogHeight=${actionsDialogHeight} :panelWidth=${actionsDialogPanelWidth}:
+  - rvn-system-actions-dialog-surface#actionsDialog key=${mode} :open=${isActionsDialogOpen} variant=${dialogVariant} :dialogWidth=${actionsDialogWidth} :dialogHeight=${actionsDialogHeight} :panelWidth=${actionsDialogPanelWidth} :suppressClose=${suppressDialogClose}:
       - $if isActionsDialogOpen:
           - 'rtgl-view slot=content w=f h=f pos=rel style="min-width: 0; min-height: 0;"':
               - 'rtgl-view#helpFloatingButton pos=abs z=10 w=28 h=28 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="top: 10px; right: 10px; box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);"':
@@ -228,7 +236,7 @@ template:
                 $elif mode == "input":
                   - rvn-command-line-input#commandLineInput :layouts=${inputLayouts} :layoutsData=${repositoryState.layouts} :form=${actions.form}: null
                 $elif mode == "background":
-                  - rvn-command-line-background#commandLineBackground data-mode="background" :background=${actions.background}: null
+                  - rvn-command-line-background#commandLineBackground data-mode="background" :background=${actions.background} :backgroundTransformEditor=${backgroundTransformEditor}: null
                 $elif mode == "screen":
                   - rvn-command-line-screen#commandLineScreen :screen=${actions.screen}: null
                 $elif mode == "bgm":
@@ -236,7 +244,7 @@ template:
                 $elif mode == "sfx":
                   - rvn-command-line-sound-effects#commandLineSoundEffects :sfx=${actions.sfx}: null
                 $elif mode == "character":
-                  - rvn-command-line-characters#commandLineCharacters :character=${actions.character} :presentationState=${presentationState}: null
+                  - rvn-command-line-characters#commandLineCharacters :character=${actions.character} :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor}: null
                 $elif mode == "sectionTransition":
                   - rvn-command-line-section-transition#commandLineSectionTransition :sectionTransition=${actions.sectionTransition} :currentSceneId=${currentSceneId}: null
                 $elif mode == "resetStoryAtSection":
@@ -270,7 +278,7 @@ template:
                 $elif mode == "loadSlot":
                   - rvn-command-line-load-slot#commandLineLoadSlot :loadSlot=${actions.loadSlot}: null
                 $elif mode == "visual":
-                  - rvn-command-line-visual#commandLineVisual :visual=${actions.visual} :presentationState=${presentationState}: null
+                  - rvn-command-line-visual#commandLineVisual :visual=${actions.visual} :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor}: null
                 $elif mode == "setNextLineConfig":
                   - rvn-command-line-set-next-line-config#commandLineSetNextLineConfig :setNextLineConfig=${actions.setNextLineConfig}: null
                 $elif mode == "updateVariable":

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js
@@ -2,10 +2,34 @@ const dispatchClose = ({ dispatchEvent }) => {
   dispatchEvent(new CustomEvent("close", { detail: {}, bubbles: true }));
 };
 
+const isCloseSuppressed = ({ props = {}, store } = {}) => {
+  return (
+    props.suppressClose === true ||
+    props.suppressClose === "true" ||
+    store?.selectSuppressClose?.() === true
+  );
+};
+
 export const handleSurfaceClose = (deps, payload = {}) => {
   payload._event?.stopPropagation?.();
   payload._event?.preventDefault?.();
+
+  if (isCloseSuppressed(deps)) {
+    return;
+  }
+
   dispatchClose(deps);
+};
+
+export const handleSuppressClose = (deps, _payload = {}) => {
+  deps.store?.setSuppressClose?.({ suppressClose: true });
+};
+
+export const handleOnUpdate = (deps, changes = {}) => {
+  const { newProps } = changes;
+  if (newProps?.suppressClose !== true && newProps?.suppressClose !== "true") {
+    deps.store?.setSuppressClose?.({ suppressClose: false });
+  }
 };
 
 export const handleDocumentKeyDown = (deps, payload = {}) => {
@@ -18,5 +42,10 @@ export const handleDocumentKeyDown = (deps, payload = {}) => {
 
   event.preventDefault?.();
   event.stopPropagation?.();
+
+  if (isCloseSuppressed(deps)) {
+    return;
+  }
+
   dispatchClose(deps);
 };

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.schema.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.schema.yaml
@@ -15,6 +15,8 @@ propsSchema:
       type: string
     panelWidth:
       type: string
+    suppressClose:
+      type: boolean
 events:
   close:
     type: object

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
@@ -1,9 +1,21 @@
-export const createInitialState = () => ({});
+export const createInitialState = () => ({
+  suppressClose: false,
+});
 
 const normalizeVariant = (variant) =>
   variant === "scene-editor-left" ? "scene-editor-left" : "default";
 
-export const selectViewData = ({ props }) => {
+const isBooleanPropEnabled = (value) => value === true || value === "true";
+
+export const setSuppressClose = ({ state }, { suppressClose } = {}) => {
+  state.suppressClose = suppressClose === true;
+};
+
+export const selectSuppressClose = ({ state }) => {
+  return state.suppressClose === true;
+};
+
+export const selectViewData = ({ state, props }) => {
   const variant = normalizeVariant(props.variant);
 
   return {
@@ -13,6 +25,8 @@ export const selectViewData = ({ props }) => {
     dialogWidth: props.dialogWidth ?? "800",
     dialogHeight: props.dialogHeight ?? "80vh",
     panelWidth: props.panelWidth ?? "50vw",
+    suppressClose:
+      state.suppressClose === true || isBooleanPropEnabled(props.suppressClose),
     overlayHorizontalInset: "64px",
     overlayBackground: "rgba(0, 0, 0, 0.42)",
     panelHorizontalInset: "96px",

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -499,6 +499,7 @@ export const createGraphicsService = async ({
   let deferredAudioRenderKeySignature = "";
   let suppressedEngineRenderEffects = 0;
   let isEngineAudioMuted = false;
+  let runtimeInteractionsEnabled = true;
 
   const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
 
@@ -555,6 +556,28 @@ export const createGraphicsService = async ({
     }
 
     await Promise.all(loadPromises);
+  };
+
+  const setRuntimeInteractionsEnabled = (value) => {
+    const nextRuntimeInteractionsEnabled = value !== false;
+
+    if (runtimeInteractionsEnabled === nextRuntimeInteractionsEnabled) {
+      return;
+    }
+
+    runtimeInteractionsEnabled = nextRuntimeInteractionsEnabled;
+    if (!nextRuntimeInteractionsEnabled) {
+      clearAllPendingClickInteractions();
+    }
+  };
+
+  const ensureTicker = () => {
+    if (!ticker) {
+      ticker = new Ticker();
+    }
+
+    ticker.start();
+    return ticker;
   };
 
   const ensureAudioAssetsLoaded = async (assetKeys = []) => {
@@ -1486,6 +1509,7 @@ export const createGraphicsService = async ({
         assetLoadRuntimeVersion += 1;
         invalidateDeferredAudioRender();
         clearAllPendingClickInteractions();
+        runtimeInteractionsEnabled = true;
         loadedAssetTypes = new Map();
         assetBufferManager = createAssetBufferManager();
         routeGraphics = createRouteGraphics();
@@ -1523,6 +1547,10 @@ export const createGraphicsService = async ({
                     targetId: eventId,
                   });
                 }
+              }
+
+              if (!runtimeInteractionsEnabled) {
+                return;
               }
 
               if (!engine) {
@@ -1590,7 +1618,7 @@ export const createGraphicsService = async ({
     },
     hasLoadedAsset,
     initRouteEngine: (projectData, options = {}) => {
-      ticker.start();
+      const routeEngineTicker = ensureTicker();
       routeEngineProjectData = projectData;
       enableGlobalKeyboardBindings =
         options.enableGlobalKeyboardBindings ?? true;
@@ -1626,7 +1654,7 @@ export const createGraphicsService = async ({
         },
         namespace,
         persistence,
-        ticker,
+        ticker: routeEngineTicker,
       });
       engine = createRouteEngine({ handlePendingEffects });
       const initEngine = () => {
@@ -1716,6 +1744,7 @@ export const createGraphicsService = async ({
       engine.handleActions(actions, eventContext);
     },
     setEngineAudioMuted,
+    setRuntimeInteractionsEnabled,
 
     setAnimationPlaybackMode: (mode) => {
       routeGraphics?.setAnimationPlaybackMode?.(mode);

--- a/src/internal/ui/sceneEditor/backgroundTransformEditor.js
+++ b/src/internal/ui/sceneEditor/backgroundTransformEditor.js
@@ -1,0 +1,727 @@
+const BACKGROUND_TRANSFORM_EDITOR_TRANSFORM_ID =
+  "__background_transform_editor__";
+
+const TRANSFORM_EDITOR_TARGET_TYPE = {
+  BACKGROUND: "background",
+  VISUAL: "visual",
+  CHARACTER: "character",
+};
+
+const BACKGROUND_RESOURCE_TARGET_IDS = [
+  "bg-cg-background-sprite",
+  "bg-cg-background-video",
+  "bg-cg-background-container",
+];
+
+export const BACKGROUND_TRANSFORM_FIELDS = [
+  "x",
+  "y",
+  "anchorX",
+  "anchorY",
+  "scaleX",
+  "scaleY",
+  "rotation",
+  "originX",
+  "originY",
+];
+
+export const ACTION_TRANSFORM_TARGET_TYPES = TRANSFORM_EDITOR_TARGET_TYPE;
+
+const BACKGROUND_COLOR_TARGET_IDS = ["bg-cg-background-color"];
+
+const RUNTIME_INTERACTION_FIELD_NAMES = [
+  "click",
+  "rightClick",
+  "scrollUp",
+  "scrollDown",
+  "hover",
+  "drag",
+  "change",
+  "submit",
+  "focusEvent",
+  "blurEvent",
+  "selectionChange",
+  "compositionStart",
+  "compositionUpdate",
+  "compositionEnd",
+];
+
+const DEFAULT_TRANSFORM = {
+  x: 0,
+  y: 0,
+  anchorX: 0.5,
+  anchorY: 0.5,
+  rotation: 0,
+  scaleX: 1,
+  scaleY: 1,
+  originX: 0,
+  originY: 0,
+};
+
+const OVERLAY_BORDER = {
+  color: "#ffffff",
+  width: 2,
+  alpha: 1,
+};
+
+const OVERLAY_FILL = {
+  color: "#ffffff",
+  alpha: 0.001,
+};
+
+const OVERLAY_ANCHOR_FILL = {
+  color: "#ffffff",
+  alpha: 1,
+};
+
+const OVERLAY_ANCHOR_BORDER = {
+  color: "#111111",
+  width: 1,
+  alpha: 1,
+};
+
+const OVERLAY_ANCHOR_SIZE = 8;
+const OVERLAY_RESIZE_HANDLE_SIZE = 12;
+const RESIZE_EDGES = ["left", "right", "top", "bottom"];
+
+const toPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+};
+
+const toFiniteNumber = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export const normalizeBackgroundTransformEditorTransform = (
+  value = {},
+  defaults = DEFAULT_TRANSFORM,
+) => {
+  const source = toPlainObject(value);
+  const fallback = {
+    ...DEFAULT_TRANSFORM,
+    ...toPlainObject(defaults),
+  };
+
+  return {
+    x: toFiniteNumber(source.x, fallback.x),
+    y: toFiniteNumber(source.y, fallback.y),
+    anchorX: toFiniteNumber(source.anchorX, fallback.anchorX),
+    anchorY: toFiniteNumber(source.anchorY, fallback.anchorY),
+    rotation: toFiniteNumber(source.rotation, fallback.rotation),
+    scaleX: toFiniteNumber(source.scaleX, fallback.scaleX),
+    scaleY: toFiniteNumber(source.scaleY, fallback.scaleY),
+    originX: toFiniteNumber(source.originX, fallback.originX),
+    originY: toFiniteNumber(source.originY, fallback.originY),
+  };
+};
+
+export const createBackgroundWithInlineTransform = (
+  background = {},
+  transform = {},
+) => {
+  const nextBackground = { ...toPlainObject(background) };
+  const normalizedTransform =
+    normalizeBackgroundTransformEditorTransform(transform);
+
+  delete nextBackground.transformId;
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    nextBackground[field] = normalizedTransform[field];
+  }
+
+  return nextBackground;
+};
+
+export const hasInlineTransform = (value = {}) => {
+  const source = toPlainObject(value);
+  return BACKGROUND_TRANSFORM_FIELDS.some((field) =>
+    Object.prototype.hasOwnProperty.call(source, field),
+  );
+};
+
+export const createActionItemWithInlineTransform = (
+  item = {},
+  transform = {},
+  { preserveTransformId = false } = {},
+) => {
+  const nextItem = { ...toPlainObject(item) };
+  const normalizedTransform =
+    normalizeBackgroundTransformEditorTransform(transform);
+
+  if (!preserveTransformId) {
+    delete nextItem.transformId;
+  }
+
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    nextItem[field] = normalizedTransform[field];
+  }
+
+  return nextItem;
+};
+
+export const removeInlineTransformFields = (item = {}) => {
+  const nextItem = { ...toPlainObject(item) };
+
+  for (const field of BACKGROUND_TRANSFORM_FIELDS) {
+    delete nextItem[field];
+  }
+
+  return nextItem;
+};
+
+export const formatBackgroundTransformEditorMetric = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return "0";
+  }
+
+  return String(Math.round(parsed * 100) / 100);
+};
+
+const findSelectedLine = (projectData, { sceneId, sectionId, lineId } = {}) => {
+  if (!sceneId || !sectionId || !lineId) {
+    return undefined;
+  }
+
+  return projectData?.story?.scenes?.[sceneId]?.sections?.[
+    sectionId
+  ]?.lines?.find((line) => line?.id === lineId);
+};
+
+const getTransformEditorTargetType = (editorState = {}) => {
+  const targetType =
+    editorState.targetType ?? TRANSFORM_EDITOR_TARGET_TYPE.BACKGROUND;
+  return Object.values(TRANSFORM_EDITOR_TARGET_TYPE).includes(targetType)
+    ? targetType
+    : TRANSFORM_EDITOR_TARGET_TYPE.BACKGROUND;
+};
+
+const getActionKeyForTransformEditorTarget = (editorState = {}) => {
+  const targetType = getTransformEditorTargetType(editorState);
+
+  if (targetType === TRANSFORM_EDITOR_TARGET_TYPE.VISUAL) {
+    return "visual";
+  }
+
+  if (targetType === TRANSFORM_EDITOR_TARGET_TYPE.CHARACTER) {
+    return "character";
+  }
+
+  return "background";
+};
+
+const resolveActionItemIndex = (items = [], editorState = {}) => {
+  const targetType = getTransformEditorTargetType(editorState);
+  const editorItem = toPlainObject(editorState.item);
+
+  if (targetType === TRANSFORM_EDITOR_TARGET_TYPE.VISUAL && editorItem.id) {
+    const visualIndex = items.findIndex((item) => item?.id === editorItem.id);
+    if (visualIndex >= 0) {
+      return visualIndex;
+    }
+  }
+
+  return Number.isInteger(editorState.itemIndex) ? editorState.itemIndex : -1;
+};
+
+const applyActionItemTransformEditorToLine = (
+  selectedLine,
+  editorState = {},
+) => {
+  const actionKey = getActionKeyForTransformEditorTarget(editorState);
+  if (actionKey === "background") {
+    const inlineBackground = createBackgroundWithInlineTransform(
+      selectedLine.actions?.background,
+      editorState.transform,
+    );
+
+    selectedLine.actions.background = {
+      ...inlineBackground,
+      transformId: BACKGROUND_TRANSFORM_EDITOR_TRANSFORM_ID,
+    };
+    return;
+  }
+
+  const action = toPlainObject(selectedLine.actions?.[actionKey]);
+  const items = Array.isArray(action.items) ? [...action.items] : [];
+  const itemIndex = resolveActionItemIndex(items, editorState);
+  const item = items[itemIndex];
+  if (!item) {
+    return;
+  }
+
+  const inlineItem = createActionItemWithInlineTransform(
+    item,
+    editorState.transform,
+    { preserveTransformId: true },
+  );
+  inlineItem.transformId =
+    inlineItem.transformId ?? BACKGROUND_TRANSFORM_EDITOR_TRANSFORM_ID;
+
+  items[itemIndex] = inlineItem;
+  selectedLine.actions[actionKey] = {
+    ...action,
+    items,
+  };
+};
+
+export const createProjectDataWithBackgroundTransformEditor = (
+  projectData,
+  selection,
+  editorState = {},
+) => {
+  if (editorState?.isOpen !== true) {
+    return projectData;
+  }
+
+  const selectedLine = findSelectedLine(projectData, selection);
+  if (!selectedLine) {
+    return projectData;
+  }
+
+  const nextProjectData = structuredClone(projectData);
+  const nextSelectedLine = findSelectedLine(nextProjectData, selection);
+  const nextResources = toPlainObject(nextProjectData.resources);
+  const nextTransforms = toPlainObject(nextResources.transforms);
+
+  nextProjectData.resources = nextResources;
+  nextResources.transforms = nextTransforms;
+  nextTransforms[BACKGROUND_TRANSFORM_EDITOR_TRANSFORM_ID] =
+    normalizeBackgroundTransformEditorTransform(editorState.transform);
+
+  nextSelectedLine.actions = toPlainObject(nextSelectedLine.actions);
+  applyActionItemTransformEditorToLine(nextSelectedLine, editorState);
+
+  return nextProjectData;
+};
+
+const stripElementRuntimeInteractions = (element) => {
+  if (!element || typeof element !== "object") {
+    return element;
+  }
+
+  const nextElement = { ...element };
+  for (const fieldName of RUNTIME_INTERACTION_FIELD_NAMES) {
+    delete nextElement[fieldName];
+  }
+
+  if (Array.isArray(nextElement.children)) {
+    nextElement.children = nextElement.children.map(
+      stripElementRuntimeInteractions,
+    );
+  }
+
+  return nextElement;
+};
+
+const stripRenderStateGlobalInteractions = (global = {}) => {
+  if (!global || typeof global !== "object" || Array.isArray(global)) {
+    return global;
+  }
+
+  const nextGlobal = { ...global };
+  delete nextGlobal.keyboard;
+  return nextGlobal;
+};
+
+const toElementList = (elements) => {
+  if (Array.isArray(elements)) {
+    return elements.filter(Boolean);
+  }
+
+  return elements ? [elements] : [];
+};
+
+const collectMatchingPaths = (
+  elements,
+  selectedIds,
+  parentPath = [],
+  matchingPaths = [],
+) => {
+  toElementList(elements).forEach((element) => {
+    const path = [...parentPath, element];
+
+    if (selectedIds.includes(element?.id)) {
+      matchingPaths.push(path);
+    }
+
+    if (Array.isArray(element?.children) && element.children.length > 0) {
+      collectMatchingPaths(element.children, selectedIds, path, matchingPaths);
+    }
+  });
+
+  return matchingPaths;
+};
+
+const getRenderableWidth = (element = {}) => {
+  const width = Number(element.width ?? element.measuredWidth);
+  return Number.isFinite(width) && width > 0 ? width : undefined;
+};
+
+const getRenderableHeight = (element = {}) => {
+  const height = Number(element.height ?? element.measuredHeight);
+  return Number.isFinite(height) && height > 0 ? height : undefined;
+};
+
+const hasRenderableBounds = (element = {}) => {
+  return (
+    getRenderableWidth(element) !== undefined &&
+    getRenderableHeight(element) !== undefined
+  );
+};
+
+const getElementOrigin = (element = {}) => {
+  return {
+    x: Number.isFinite(element.originX) ? element.originX : 0,
+    y: Number.isFinite(element.originY) ? element.originY : 0,
+  };
+};
+
+const getElementAnchorRatios = (element = {}) => {
+  const { x: originX, y: originY } = getElementOrigin(element);
+
+  return {
+    anchorX: Number.isFinite(getRenderableWidth(element))
+      ? originX / getRenderableWidth(element)
+      : 0,
+    anchorY: Number.isFinite(getRenderableHeight(element))
+      ? originY / getRenderableHeight(element)
+      : 0,
+  };
+};
+
+const getTransformEditorAnchorRatios = (editorState = {}, element = {}) => {
+  const fallback = getElementAnchorRatios(element);
+  const transform = toPlainObject(editorState.transform);
+  const anchorX = Number(transform.anchorX);
+  const anchorY = Number(transform.anchorY);
+
+  return {
+    anchorX: Number.isFinite(anchorX) ? anchorX : fallback.anchorX,
+    anchorY: Number.isFinite(anchorY) ? anchorY : fallback.anchorY,
+  };
+};
+
+const buildOverlayRect = ({ element, draggable }) => {
+  if (!hasRenderableBounds(element)) {
+    return undefined;
+  }
+
+  const overlayRect = {
+    id: "selected-border",
+    type: "rect",
+    x: 0,
+    y: 0,
+    width: getRenderableWidth(element),
+    height: getRenderableHeight(element),
+    fill: OVERLAY_FILL,
+    border: OVERLAY_BORDER,
+  };
+
+  if (draggable) {
+    overlayRect.hover = {
+      cursor: "all-scroll",
+    };
+    overlayRect.drag = {
+      start: {
+        payload: {},
+      },
+      move: {
+        payload: {},
+      },
+      end: {
+        payload: {},
+      },
+    };
+  }
+
+  return overlayRect;
+};
+
+const buildOverlayAnchorMarker = ({ element, anchorRatios }) => {
+  if (!hasRenderableBounds(element)) {
+    return undefined;
+  }
+
+  const width = getRenderableWidth(element);
+  const height = getRenderableHeight(element);
+  const anchorX = Number.isFinite(anchorRatios?.anchorX)
+    ? anchorRatios.anchorX
+    : getElementAnchorRatios(element).anchorX;
+  const anchorY = Number.isFinite(anchorRatios?.anchorY)
+    ? anchorRatios.anchorY
+    : getElementAnchorRatios(element).anchorY;
+
+  return {
+    id: "selected-border-anchor",
+    type: "rect",
+    x: width * anchorX - OVERLAY_ANCHOR_SIZE / 2,
+    y: height * anchorY - OVERLAY_ANCHOR_SIZE / 2,
+    width: OVERLAY_ANCHOR_SIZE,
+    height: OVERLAY_ANCHOR_SIZE,
+    fill: OVERLAY_ANCHOR_FILL,
+    border: OVERLAY_ANCHOR_BORDER,
+  };
+};
+
+const buildOverlayResizeHandle = ({ element, edge }) => {
+  if (!hasRenderableBounds(element)) {
+    return undefined;
+  }
+
+  const width = getRenderableWidth(element);
+  const height = getRenderableHeight(element);
+  const vertical = edge === "left" || edge === "right";
+
+  return {
+    id: `selected-border-resize-${edge}`,
+    type: "rect",
+    x:
+      edge === "left"
+        ? -OVERLAY_RESIZE_HANDLE_SIZE / 2
+        : edge === "right"
+          ? width - OVERLAY_RESIZE_HANDLE_SIZE / 2
+          : 0,
+    y:
+      edge === "top"
+        ? -OVERLAY_RESIZE_HANDLE_SIZE / 2
+        : edge === "bottom"
+          ? height - OVERLAY_RESIZE_HANDLE_SIZE / 2
+          : 0,
+    width: vertical ? OVERLAY_RESIZE_HANDLE_SIZE : width,
+    height: vertical ? height : OVERLAY_RESIZE_HANDLE_SIZE,
+    fill: OVERLAY_FILL,
+    hover: {
+      cursor: vertical ? "ew-resize" : "ns-resize",
+    },
+    drag: {
+      start: {
+        payload: {},
+      },
+      move: {
+        payload: {},
+      },
+      end: {
+        payload: {},
+      },
+    },
+  };
+};
+
+const buildOverlayResizeHandles = ({ element }) => {
+  return RESIZE_EDGES.map((edge) =>
+    buildOverlayResizeHandle({ element, edge }),
+  ).filter(Boolean);
+};
+
+const buildOverlayElementContainer = ({ element, id, children }) => {
+  const { x: originX, y: originY } = getElementOrigin(element);
+  const { anchorX, anchorY } = getElementAnchorRatios(element);
+  const overlayContainer = {
+    id,
+    type: "container",
+    x: (element.x ?? 0) + originX,
+    y: (element.y ?? 0) + originY,
+    width: getRenderableWidth(element),
+    height: getRenderableHeight(element),
+    anchorX,
+    anchorY,
+    children,
+  };
+
+  if (typeof element.rotation === "number") {
+    overlayContainer.rotation = element.rotation;
+  }
+
+  if (typeof element.scaleX === "number") {
+    overlayContainer.scaleX = element.scaleX;
+  }
+
+  if (typeof element.scaleY === "number") {
+    overlayContainer.scaleY = element.scaleY;
+  }
+
+  return overlayContainer;
+};
+
+const buildOverlayTree = ({ path, draggable, editorState }) => {
+  const selectedElement = path[path.length - 1];
+  const overlayRect = buildOverlayRect({
+    element: selectedElement,
+    draggable,
+  });
+  const anchorMarker = buildOverlayAnchorMarker({
+    element: selectedElement,
+    anchorRatios: getTransformEditorAnchorRatios(editorState, selectedElement),
+  });
+
+  if (!overlayRect || !anchorMarker) {
+    return undefined;
+  }
+
+  let overlayTree = buildOverlayElementContainer({
+    element: selectedElement,
+    id: "selected-border-group",
+    children: [
+      overlayRect,
+      ...buildOverlayResizeHandles({ element: selectedElement }),
+      anchorMarker,
+    ],
+  });
+
+  for (let index = path.length - 2; index >= 0; index -= 1) {
+    const ancestor = path[index];
+
+    overlayTree = buildOverlayElementContainer({
+      element: ancestor,
+      id: `selected-border-container-${index}`,
+      children: [overlayTree],
+    });
+  }
+
+  return overlayTree;
+};
+
+const getBackgroundTargetIds = (editorState = {}) => {
+  const background = toPlainObject(editorState.background);
+  const targetIds = [...BACKGROUND_RESOURCE_TARGET_IDS];
+
+  if (background.resourceId) {
+    targetIds.push(`bg-cg-${background.resourceId}`);
+  } else if (background.colorId) {
+    targetIds.push(...BACKGROUND_COLOR_TARGET_IDS);
+  }
+
+  return targetIds;
+};
+
+const getActionItemTargetIds = (editorState = {}) => {
+  const targetType = getTransformEditorTargetType(editorState);
+  const targetIds = [];
+
+  if (editorState.targetId) {
+    targetIds.push(editorState.targetId);
+  }
+
+  const item = toPlainObject(editorState.item);
+  if (targetType === TRANSFORM_EDITOR_TARGET_TYPE.VISUAL && item.id) {
+    targetIds.push(`visual-${item.id}`);
+  }
+
+  if (targetType === TRANSFORM_EDITOR_TARGET_TYPE.CHARACTER && item.id) {
+    targetIds.push(`character-container-${item.id}`);
+  }
+
+  return [...new Set(targetIds)];
+};
+
+const getTransformEditorTargetIds = (editorState = {}) => {
+  if (
+    getTransformEditorTargetType(editorState) ===
+    TRANSFORM_EDITOR_TARGET_TYPE.BACKGROUND
+  ) {
+    return getBackgroundTargetIds(editorState);
+  }
+
+  return getActionItemTargetIds(editorState);
+};
+
+const selectPrimaryMatchingPath = (matchingPaths, targetIds) => {
+  const pathsWithBounds = matchingPaths.filter((path) =>
+    hasRenderableBounds(path[path.length - 1]),
+  );
+
+  for (const targetId of targetIds) {
+    const exactMatch = pathsWithBounds.find(
+      (path) => path[path.length - 1]?.id === targetId,
+    );
+    if (exactMatch) {
+      return exactMatch;
+    }
+  }
+
+  return pathsWithBounds[0];
+};
+
+const selectBackgroundElementPath = (parsedElements, editorState = {}) => {
+  const targetIds = getTransformEditorTargetIds(editorState);
+  const matchingPaths = collectMatchingPaths(parsedElements, targetIds);
+  return selectPrimaryMatchingPath(matchingPaths, targetIds);
+};
+
+const toSelectedElementMetrics = (path, editorState = {}) => {
+  const element = path?.[path.length - 1];
+  if (!element || !hasRenderableBounds(element)) {
+    return undefined;
+  }
+  const { anchorX, anchorY } = getTransformEditorAnchorRatios(
+    editorState,
+    element,
+  );
+  const transform = toPlainObject(editorState.transform);
+  const scaleX = Number(transform.scaleX);
+  const scaleY = Number(transform.scaleY);
+
+  return {
+    width: getRenderableWidth(element),
+    height: getRenderableHeight(element),
+    anchorX,
+    anchorY,
+    scaleX: Number.isFinite(scaleX)
+      ? scaleX
+      : Number.isFinite(element.scaleX)
+        ? element.scaleX
+        : 1,
+    scaleY: Number.isFinite(scaleY)
+      ? scaleY
+      : Number.isFinite(element.scaleY)
+        ? element.scaleY
+        : 1,
+  };
+};
+
+export const createBackgroundTransformEditorCanvasState = ({
+  renderState = {},
+  graphicsService,
+  editorState = {},
+} = {}) => {
+  const renderedElements = toElementList(renderState.elements).map(
+    stripElementRuntimeInteractions,
+  );
+  const parsedState = graphicsService?.parse?.({
+    elements: renderedElements,
+  });
+  const selectedPath = selectBackgroundElementPath(
+    parsedState?.elements,
+    editorState,
+  );
+  const overlayElement = selectedPath
+    ? buildOverlayTree({
+        path: selectedPath,
+        draggable: true,
+        editorState,
+      })
+    : undefined;
+
+  return {
+    renderState: {
+      ...renderState,
+      global: stripRenderStateGlobalInteractions(renderState.global),
+      audio: [],
+      animations: [],
+      elements: [...renderedElements, overlayElement].filter(Boolean),
+    },
+    selectedElementMetrics: toSelectedElementMetrics(selectedPath, editorState),
+  };
+};
+
+export const createBackgroundTransformEditorRenderState = (payload = {}) => {
+  return createBackgroundTransformEditorCanvasState(payload).renderState;
+};
+
+export const selectBackgroundTransformEditorElementMetrics = (payload = {}) => {
+  return createBackgroundTransformEditorCanvasState(payload)
+    .selectedElementMetrics;
+};

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -26,6 +26,10 @@ import {
 } from "../../project/routeEngineProjectData.js";
 import { prepareRuntimeInteractionExecution } from "../../runtime/graphicsEngineRuntime.js";
 import {
+  createBackgroundTransformEditorCanvasState,
+  createProjectDataWithBackgroundTransformEditor,
+} from "./backgroundTransformEditor.js";
+import {
   debugLog,
   getDebugDurationMs,
   getDebugNow,
@@ -110,18 +114,37 @@ const createRuntimeCurrentLineRenderStateHandler = (deps) => {
   };
 };
 
-const getCurrentCanvasRoot = (refs) => {
-  const previewCanvasHost = refs?.previewCanvasHost;
+const getCanvasRootFromHost = (canvasHost) => {
   const canvasRoot =
-    previewCanvasHost?.getCanvasRoot?.() ||
-    previewCanvasHost?.shadowRoot?.querySelector?.("#canvas") ||
-    previewCanvasHost?.querySelector?.("#canvas");
+    canvasHost?.getCanvasRoot?.() ||
+    canvasHost?.shadowRoot?.querySelector?.("#canvas") ||
+    canvasHost?.querySelector?.("#canvas");
 
   if (canvasRoot?.isConnected) {
     return canvasRoot;
   }
 
   return canvasRoot;
+};
+
+const getBackgroundTransformEditorCanvasRoot = (refs) => {
+  const nestedCanvasRoot =
+    refs?.systemActions?.transformedHandlers?.handleGetBackgroundTransformPreviewCanvasRoot?.();
+  if (nestedCanvasRoot?.isConnected) {
+    return nestedCanvasRoot;
+  }
+
+  return getCanvasRootFromHost(refs?.backgroundTransformPreviewCanvasHost);
+};
+
+const getCurrentCanvasRoot = (refs) => {
+  const transformEditorCanvasRoot =
+    getBackgroundTransformEditorCanvasRoot(refs);
+  if (transformEditorCanvasRoot?.isConnected) {
+    return transformEditorCanvasRoot;
+  }
+
+  return getCanvasRootFromHost(refs?.previewCanvasHost);
 };
 
 const waitForMountedCanvasRoot = async (refs, maxFrames = 10) => {
@@ -804,7 +827,12 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     ? getDebugDurationMs(projectDataSelectionStartedAt)
     : undefined;
   const isMuted = store.selectIsMuted();
+  const backgroundTransformEditorOpen =
+    store.selectIsBackgroundTransformEditorOpen?.() === true;
   graphicsService.setEngineAudioMuted?.(isMuted);
+  graphicsService.setRuntimeInteractionsEnabled?.(
+    !backgroundTransformEditorOpen,
+  );
 
   const onRenderState = createRuntimeCurrentLineRenderStateHandler(deps);
   const engineInitStartedAt = perfEnabled ? getDebugNow() : 0;
@@ -826,11 +854,16 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     : undefined;
   const temporaryPresentationState = selectTemporaryPresentationState(store);
   const temporaryPresentationStateStartedAt = perfEnabled ? getDebugNow() : 0;
-  const renderProjectData = await prepareTemporaryPresentationProjectData(
+  let renderProjectData = await prepareTemporaryPresentationProjectData(
     deps,
     projectData,
     selection,
     temporaryPresentationState,
+  );
+  renderProjectData = createProjectDataWithBackgroundTransformEditor(
+    renderProjectData,
+    selection,
+    store.selectBackgroundTransformEditor?.(),
   );
   if (renderProjectData !== projectData) {
     initRouteEngineWithDiagnostics(graphicsService, renderProjectData, {
@@ -886,10 +919,23 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
   if (!skipCanvasPaint) {
     await attachGraphicsCanvasToMountedRoot(deps, 2);
     const canvasPaintStartedAt = perfEnabled ? getDebugNow() : 0;
-    graphicsService.engineRenderCurrentState({
-      skipAudio: isMuted,
-      skipAnimations,
-    });
+    if (backgroundTransformEditorOpen) {
+      const backgroundTransformCanvasState =
+        createBackgroundTransformEditorCanvasState({
+          renderState: currentRenderState,
+          graphicsService,
+          editorState: store.selectBackgroundTransformEditor?.(),
+        });
+      store.setBackgroundTransformEditorSelectedElementMetrics?.({
+        metrics: backgroundTransformCanvasState.selectedElementMetrics,
+      });
+      graphicsService.render(backgroundTransformCanvasState.renderState);
+    } else {
+      graphicsService.engineRenderCurrentState({
+        skipAudio: isMuted,
+        skipAnimations,
+      });
+    }
     if (perfEnabled) {
       canvasPaintDurationMs = getDebugDurationMs(canvasPaintStartedAt);
     }
@@ -1457,6 +1503,9 @@ const handleCanvasWheelFocusBlur = (deps, event) => {
 
 const handleCanvasRollbackWheelFallback = async (deps, payload = {}) => {
   const { refs, store, render } = deps;
+  if (store.selectIsBackgroundTransformEditorOpen?.()) {
+    return;
+  }
   const { lineIdAtWheel } = payload;
   const currentLineId = store.selectSelectedLineId();
 
@@ -1490,6 +1539,9 @@ const hasSelectedLineScreenTransition = (store) => {
 
 const handleCanvasForwardNavigationFallback = async (deps, payload = {}) => {
   const { refs, store, render } = deps;
+  if (store.selectIsBackgroundTransformEditorOpen?.()) {
+    return;
+  }
   const { lineIdAtInput } = payload;
   const currentLineId = store.selectSelectedLineId();
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1,3 +1,4 @@
+import { filter, tap } from "rxjs";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import { generateId } from "../../internal/id.js";
 import {
@@ -24,6 +25,11 @@ import {
   updateSceneEditorSectionChanges,
 } from "../../internal/ui/sceneEditor/runtime.js";
 import {
+  createActionItemWithInlineTransform,
+  createBackgroundWithInlineTransform,
+  normalizeBackgroundTransformEditorTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
+import {
   createSceneEditorSectionWithName,
   isSectionsOverviewOpen,
   reconcileSceneEditorSelection,
@@ -35,6 +41,8 @@ const MISSING_PROJECT_RESOLUTION_MESSAGE =
   "Project is missing required resolution settings.";
 const SHOW_LINE_NUMBERS_CONFIG_KEY = "sceneEditor.showLineNumbers";
 const IS_MUTED_CONFIG_KEY = "sceneEditor.isMuted";
+const BACKGROUND_TRANSFORM_RESIZE_TARGET_PREFIX = "selected-border-resize-";
+const MIN_BACKGROUND_TRANSFORM_SCALE = 0.01;
 
 const toPlainObject = (value) => {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -572,6 +580,624 @@ const syncSceneEditorProjectPayload = async (deps, payload = {}) => {
   });
 };
 
+const BACKGROUND_TRANSFORM_EDITOR_RENDER_PAYLOAD = {
+  skipRender: true,
+  skipAnimations: true,
+  skipAudio: true,
+};
+
+const requestBackgroundTransformEditorCanvasRender = (subject) => {
+  subject?.dispatch?.(
+    "sceneEditor.renderCanvas",
+    BACKGROUND_TRANSFORM_EDITOR_RENDER_PAYLOAD,
+  );
+};
+
+const renderBackgroundTransformEditorCanvasNow = (deps) => {
+  void renderSceneEditorState(
+    deps,
+    BACKGROUND_TRANSFORM_EDITOR_RENDER_PAYLOAD,
+  ).catch((error) => {
+    console.error(
+      "[sceneEditor] Background transform preview render failed",
+      error,
+    );
+  });
+};
+
+const getRepositoryItemById = (collection, itemId) => {
+  if (!itemId) {
+    return undefined;
+  }
+
+  return collection?.items?.[itemId] ?? collection?.[itemId];
+};
+
+const getBackgroundResourceDimensions = (repositoryState = {}, resourceId) => {
+  const resource =
+    getRepositoryItemById(repositoryState.images, resourceId) ??
+    getRepositoryItemById(repositoryState.videos, resourceId);
+  const width = Number(resource?.width);
+  const height = Number(resource?.height);
+
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : undefined,
+    height: Number.isFinite(height) && height > 0 ? height : undefined,
+  };
+};
+
+const getDefaultBackgroundTransform = (store, background = {}) => {
+  const repositoryState = store.selectRepositoryState?.() ?? {};
+  const resolution = repositoryState.project?.resolution;
+  const resourceId = background.resourceId;
+  const isLayoutBackground =
+    !!resourceId &&
+    !!getRepositoryItemById(repositoryState.layouts, resourceId);
+  const width = Number(resolution?.width);
+  const height = Number(resolution?.height);
+  const dimensions = getBackgroundResourceDimensions(
+    repositoryState,
+    resourceId,
+  );
+  const defaultOriginX = isLayoutBackground
+    ? 0
+    : (dimensions.width ?? (Number.isFinite(width) ? width : 0)) / 2;
+  const defaultOriginY = isLayoutBackground
+    ? 0
+    : (dimensions.height ?? (Number.isFinite(height) ? height : 0)) / 2;
+
+  return normalizeBackgroundTransformEditorTransform({
+    x: isLayoutBackground ? 0 : Number.isFinite(width) ? width / 2 : 0,
+    y: isLayoutBackground ? 0 : Number.isFinite(height) ? height / 2 : 0,
+    anchorX: isLayoutBackground ? 0 : 0.5,
+    anchorY: isLayoutBackground ? 0 : 0.5,
+    scaleX: 1,
+    scaleY: 1,
+    rotation: 0,
+    originX: defaultOriginX,
+    originY: defaultOriginY,
+  });
+};
+
+const selectTransformResourceById = (store, transformId) => {
+  if (!transformId) {
+    return undefined;
+  }
+
+  const transforms = store.selectRepositoryState?.()?.transforms;
+  return transforms?.items?.[transformId] ?? transforms?.[transformId];
+};
+
+const reopenBackgroundCommandLine = ({ refs, store, background } = {}) => {
+  const selectedLine = store.selectSelectedLine?.();
+  const actions = {
+    ...toPlainObject(selectedLine?.actions),
+    background: toPlainObject(background),
+  };
+
+  refs?.systemActions?.transformedHandlers?.open?.({
+    mode: "background",
+    actions,
+  });
+};
+
+const getDuplicateActionItemIds = (items = []) => {
+  const counts = new Map();
+  for (const item of items) {
+    if (item?.id) {
+      counts.set(item.id, (counts.get(item.id) ?? 0) + 1);
+    }
+  }
+
+  return new Set(
+    Array.from(counts.entries())
+      .filter(([, count]) => count > 1)
+      .map(([id]) => id),
+  );
+};
+
+const getCharacterTransformEditorTargetId = (
+  item = {},
+  index = 0,
+  items = [],
+) => {
+  const duplicateIds = getDuplicateActionItemIds(items);
+  if (!duplicateIds.has(item.id)) {
+    return `character-container-${item.id}`;
+  }
+
+  const spritePartIds = item.sprites?.map(({ resourceId }) => resourceId) || [];
+  return spritePartIds.length > 0
+    ? `character-container-${item.id}-${index}-${spritePartIds.join("-")}`
+    : `character-container-${item.id}`;
+};
+
+const getActionTransformEditorTargetId = ({
+  targetType,
+  item,
+  itemIndex,
+  action,
+} = {}) => {
+  if (targetType === "visual") {
+    return item?.id ? `visual-${item.id}` : undefined;
+  }
+
+  if (targetType === "character") {
+    return getCharacterTransformEditorTargetId(
+      item,
+      itemIndex,
+      action?.items ?? [],
+    );
+  }
+
+  return undefined;
+};
+
+const replaceActionItem = ({ action, itemIndex, item } = {}) => {
+  const items = Array.isArray(action?.items) ? [...action.items] : [];
+  if (!Number.isInteger(itemIndex) || !items[itemIndex]) {
+    return toPlainObject(action);
+  }
+
+  items[itemIndex] = item;
+  return {
+    ...toPlainObject(action),
+    items,
+  };
+};
+
+const reopenActionTransformCommandLine = ({
+  refs,
+  store,
+  actionKey,
+  itemIndex,
+  item,
+  action,
+} = {}) => {
+  const selectedLine = store.selectSelectedLine?.();
+  const actions = {
+    ...toPlainObject(selectedLine?.actions),
+  };
+  actions[actionKey] = action
+    ? toPlainObject(action)
+    : replaceActionItem({
+        action: actions[actionKey],
+        itemIndex,
+        item,
+      });
+
+  refs?.systemActions?.transformedHandlers?.open?.({
+    mode: actionKey,
+    actions,
+  });
+};
+
+const selectInitialBackgroundTransformEditorTransform = (
+  store,
+  background = {},
+) => {
+  const selectedLine = store.selectSelectedLine?.();
+  const transformId =
+    background.transformId ?? selectedLine?.actions?.background?.transformId;
+  const transform = selectTransformResourceById(store, transformId);
+
+  return normalizeBackgroundTransformEditorTransform({
+    ...getDefaultBackgroundTransform(store, background),
+    ...toPlainObject(transform),
+    ...toPlainObject(background),
+  });
+};
+
+const selectInitialActionTransformEditorTransform = (store, item = {}) => {
+  const transform = selectTransformResourceById(store, item.transformId);
+
+  return normalizeBackgroundTransformEditorTransform({
+    ...toPlainObject(transform),
+    ...toPlainObject(item),
+  });
+};
+
+const getBackgroundTransformDragModeFromTargetId = (targetId) => {
+  if (targetId === "selected-border") {
+    return "move";
+  }
+
+  if (targetId?.startsWith(BACKGROUND_TRANSFORM_RESIZE_TARGET_PREFIX)) {
+    return targetId.slice(BACKGROUND_TRANSFORM_RESIZE_TARGET_PREFIX.length);
+  }
+
+  return undefined;
+};
+
+const isBackgroundTransformResizeMode = (dragMode) => {
+  return (
+    dragMode === "left" ||
+    dragMode === "right" ||
+    dragMode === "top" ||
+    dragMode === "bottom"
+  );
+};
+
+const getPositiveNumber = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const getBackgroundTransformUniformScale = (transform = {}) => {
+  return Math.max(
+    Math.abs(getPositiveNumber(transform.scaleX, 1)),
+    Math.abs(getPositiveNumber(transform.scaleY, 1)),
+    MIN_BACKGROUND_TRANSFORM_SCALE,
+  );
+};
+
+const getPositiveScale = (value) => {
+  return getPositiveNumber(Math.abs(Number(value)), 1);
+};
+
+const getResizeScaleDenominator = (
+  resizeEdge,
+  metrics = {},
+  { scaleX = 1, scaleY = 1 } = {},
+) => {
+  const width = getPositiveNumber(metrics.width, 1) / getPositiveScale(scaleX);
+  const height =
+    getPositiveNumber(metrics.height, 1) / getPositiveScale(scaleY);
+  const anchorX = Number.isFinite(metrics.anchorX) ? metrics.anchorX : 0.5;
+  const anchorY = Number.isFinite(metrics.anchorY) ? metrics.anchorY : 0.5;
+  let distance = 1;
+
+  if (resizeEdge === "left") {
+    distance = width * anchorX;
+  } else if (resizeEdge === "right") {
+    distance = width * (1 - anchorX);
+  } else if (resizeEdge === "top") {
+    distance = height * anchorY;
+  } else if (resizeEdge === "bottom") {
+    distance = height * (1 - anchorY);
+  }
+
+  return distance > 0 ? distance : undefined;
+};
+
+const getResizePointerDelta = (resizeEdge, dragStartPosition, x, y) => {
+  if (resizeEdge === "left") {
+    return dragStartPosition.x - x;
+  }
+
+  if (resizeEdge === "right") {
+    return x - dragStartPosition.x;
+  }
+
+  if (resizeEdge === "top") {
+    return dragStartPosition.y - y;
+  }
+
+  if (resizeEdge === "bottom") {
+    return y - dragStartPosition.y;
+  }
+
+  return 0;
+};
+
+export const applyBackgroundTransformResizeChange = ({
+  transform,
+  dragStartPosition,
+  x,
+  y,
+} = {}) => {
+  const resizeEdge = dragStartPosition?.resizeEdge;
+  if (
+    !isBackgroundTransformResizeMode(resizeEdge) ||
+    typeof x !== "number" ||
+    typeof y !== "number"
+  ) {
+    return transform;
+  }
+
+  const startScale = getBackgroundTransformUniformScale({
+    scaleX: dragStartPosition.transformStartScaleX,
+    scaleY: dragStartPosition.transformStartScaleY,
+  });
+  const denominator = getResizeScaleDenominator(
+    resizeEdge,
+    dragStartPosition.selectedElementMetrics,
+    {
+      scaleX: dragStartPosition.transformStartScaleX,
+      scaleY: dragStartPosition.transformStartScaleY,
+    },
+  );
+  if (!denominator) {
+    return transform;
+  }
+
+  const scaleDelta =
+    getResizePointerDelta(resizeEdge, dragStartPosition, x, y) / denominator;
+  const nextScale = Math.max(
+    MIN_BACKGROUND_TRANSFORM_SCALE,
+    startScale + scaleDelta,
+  );
+
+  return normalizeBackgroundTransformEditorTransform({
+    ...transform,
+    scaleX: nextScale,
+    scaleY: nextScale,
+  });
+};
+
+const applyBackgroundTransformDragChange = ({
+  transform,
+  dragStartPosition,
+  x,
+  y,
+} = {}) => {
+  if (!dragStartPosition || typeof x !== "number" || typeof y !== "number") {
+    return transform;
+  }
+
+  return normalizeBackgroundTransformEditorTransform({
+    ...transform,
+    x: dragStartPosition.transformStartX + x - dragStartPosition.x,
+    y: dragStartPosition.transformStartY + y - dragStartPosition.y,
+  });
+};
+
+const handleBackgroundTransformBorderDragStart = (deps, payload = {}) => {
+  if (!deps.store.selectIsBackgroundTransformEditorOpen?.()) {
+    return;
+  }
+
+  if (!getBackgroundTransformDragModeFromTargetId(payload.targetId)) {
+    return;
+  }
+
+  deps.store.clearBackgroundTransformEditorDragStartPosition?.();
+};
+
+const handleBackgroundTransformBorderDragMove = (deps, payload = {}) => {
+  const { store, render } = deps;
+  if (!store.selectIsBackgroundTransformEditorOpen?.()) {
+    return;
+  }
+
+  if (typeof payload.x !== "number" || typeof payload.y !== "number") {
+    return;
+  }
+
+  const dragMode = getBackgroundTransformDragModeFromTargetId(payload.targetId);
+  if (!dragMode) {
+    return;
+  }
+
+  const editor = store.selectBackgroundTransformEditor?.();
+  const transform = normalizeBackgroundTransformEditorTransform(
+    editor?.transform,
+  );
+  if (!editor?.dragStartPosition) {
+    if (
+      isBackgroundTransformResizeMode(dragMode) &&
+      !editor?.selectedElementMetrics
+    ) {
+      return;
+    }
+
+    store.setBackgroundTransformEditorDragStartPosition?.({
+      dragStartPosition: {
+        x: payload.x,
+        y: payload.y,
+        resizeEdge: isBackgroundTransformResizeMode(dragMode)
+          ? dragMode
+          : undefined,
+        selectedElementMetrics: editor?.selectedElementMetrics,
+        transformStartX: transform.x,
+        transformStartY: transform.y,
+        transformStartScaleX: transform.scaleX,
+        transformStartScaleY: transform.scaleY,
+      },
+    });
+    return;
+  }
+
+  const updatedTransform = editor.dragStartPosition.resizeEdge
+    ? applyBackgroundTransformResizeChange({
+        transform,
+        dragStartPosition: editor.dragStartPosition,
+        x: payload.x,
+        y: payload.y,
+      })
+    : applyBackgroundTransformDragChange({
+        transform,
+        dragStartPosition: editor.dragStartPosition,
+        x: payload.x,
+        y: payload.y,
+      });
+
+  store.setBackgroundTransformEditorTransform?.({
+    transform: updatedTransform,
+  });
+  render();
+  renderBackgroundTransformEditorCanvasNow(deps);
+};
+
+const handleBackgroundTransformBorderDragEnd = (deps) => {
+  if (!deps.store.selectIsBackgroundTransformEditorOpen?.()) {
+    return;
+  }
+
+  deps.store.clearBackgroundTransformEditorDragStartPosition?.();
+  requestBackgroundTransformEditorCanvasRender(deps.subject);
+};
+
+const mountBackgroundTransformEditorSubscriptions = (deps) => {
+  const { subject } = deps;
+  const streams = [
+    subject.pipe(
+      filter(({ action }) => action === "border-drag-start"),
+      tap(({ payload }) =>
+        handleBackgroundTransformBorderDragStart(deps, payload),
+      ),
+    ),
+    subject.pipe(
+      filter(({ action }) => action === "border-drag-move"),
+      tap(({ payload }) =>
+        handleBackgroundTransformBorderDragMove(deps, payload),
+      ),
+    ),
+    subject.pipe(
+      filter(({ action }) => action === "border-drag-end"),
+      tap(() => handleBackgroundTransformBorderDragEnd(deps)),
+    ),
+  ];
+  const active = streams.map((stream) => stream.subscribe());
+  return () => active.forEach((subscription) => subscription?.unsubscribe?.());
+};
+
+export const handleBackgroundTransformCustomize = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { refs, store, render, subject } = deps;
+  const background = toPlainObject(payload?._event?.detail?.background);
+  const transform = selectInitialBackgroundTransformEditorTransform(
+    store,
+    background,
+  );
+
+  store.setTemporaryPresentationState?.({
+    presentationState: {
+      background,
+    },
+  });
+  store.openBackgroundTransformEditor?.({
+    background,
+    transform,
+  });
+  render();
+  reopenBackgroundCommandLine({ refs, store, background });
+  requestBackgroundTransformEditorCanvasRender(subject);
+};
+
+const closeActionTransformEditor = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { refs, store, render, subject } = deps;
+  store.suppressNextActionsDialogClose?.();
+  const editor = store.selectBackgroundTransformEditor?.();
+  const actionKey = editor?.actionKey === "character" ? "character" : "visual";
+  const nextItem = createActionItemWithInlineTransform(
+    editor?.item,
+    editor?.transform,
+    { preserveTransformId: true },
+  );
+
+  refs?.systemActions?.transformedHandlers?.handleSetActionCustomTransform?.({
+    targetType: editor?.targetType,
+    itemIndex: editor?.itemIndex,
+    item: editor?.item,
+    transform: editor?.transform,
+  });
+  store.closeBackgroundTransformEditor?.();
+  render();
+  reopenActionTransformCommandLine({
+    refs,
+    store,
+    actionKey,
+    itemIndex: editor?.itemIndex,
+    item: nextItem,
+  });
+  requestBackgroundTransformEditorCanvasRender(subject);
+  globalThis.setTimeout?.(() => {
+    store.clearSuppressNextActionsDialogClose?.();
+    render();
+  }, 50);
+};
+
+export const handleBackgroundTransformEditorCloseClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { refs, store, render, subject } = deps;
+  const editor = store.selectBackgroundTransformEditor?.();
+  if (editor?.targetType && editor.targetType !== "background") {
+    closeActionTransformEditor(deps, payload);
+    return;
+  }
+
+  store.suppressNextActionsDialogClose?.();
+  const nextBackground = createBackgroundWithInlineTransform(
+    editor?.background,
+    editor?.transform,
+  );
+  refs?.systemActions?.transformedHandlers?.handleSetBackgroundCustomTransform?.(
+    {
+      background: editor?.background,
+      transform: editor?.transform,
+    },
+  );
+  store.closeBackgroundTransformEditor?.();
+  render();
+  reopenBackgroundCommandLine({
+    refs,
+    store,
+    background: nextBackground,
+  });
+  requestBackgroundTransformEditorCanvasRender(subject);
+  globalThis.setTimeout?.(() => {
+    store.clearSuppressNextActionsDialogClose?.();
+    render();
+  }, 50);
+};
+
+export const handleBackgroundTransformEditorDone = (deps, payload) => {
+  handleBackgroundTransformEditorCloseClick(deps, payload);
+};
+
+export const handleActionTransformCustomize = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { refs, store, render, subject } = deps;
+  const detail = toPlainObject(payload?._event?.detail);
+  const targetType = detail.targetType === "character" ? "character" : "visual";
+  const actionKey = detail.actionKey === "character" ? "character" : "visual";
+  const selectedLine = store.selectSelectedLine?.();
+  const action = toPlainObject(
+    detail.action ?? selectedLine?.actions?.[actionKey],
+  );
+  const itemIndex = detail.itemIndex;
+  const item = toPlainObject(detail.item ?? action.items?.[itemIndex]);
+  const transform = selectInitialActionTransformEditorTransform(store, item);
+  const targetId = getActionTransformEditorTargetId({
+    targetType,
+    item,
+    itemIndex,
+    action,
+  });
+
+  store.setTemporaryPresentationState?.({
+    presentationState: {
+      [actionKey]: action,
+    },
+  });
+  store.openBackgroundTransformEditor?.({
+    targetType,
+    actionKey,
+    itemIndex,
+    item,
+    targetId,
+    transform,
+  });
+  render();
+  reopenActionTransformCommandLine({
+    refs,
+    store,
+    actionKey,
+    action,
+  });
+  requestBackgroundTransformEditorCanvasRender(subject);
+};
+
+export const handleActionTransformEditorDone = (deps, payload) => {
+  closeActionTransformEditor(deps, payload);
+};
+
 export const handleBeforeMount = (deps) => {
   const { projectService, appService, store } = deps;
   store.setScenePageLoading({ isLoading: true });
@@ -584,6 +1210,8 @@ export const handleBeforeMount = (deps) => {
   });
 
   const cleanupRuntimeSubscriptions = mountSceneEditorSubscriptions(deps);
+  const cleanupBackgroundTransformEditorSubscriptions =
+    mountBackgroundTransformEditorSubscriptions(deps);
   const projectSubscription = createProjectStateStream({
     projectService,
     emitCurrent: false,
@@ -596,6 +1224,7 @@ export const handleBeforeMount = (deps) => {
   return async () => {
     projectSubscription.unsubscribe();
     cleanupRuntimeSubscriptions();
+    cleanupBackgroundTransformEditorSubscriptions();
     await flushSceneEditorDrafts(deps, { force: true });
     await projectService.clearActiveSceneId().catch(() => {});
     await resetSceneEditorRuntime(deps);
@@ -1515,11 +2144,21 @@ export const handleSectionTabRightClick = (deps, payload) => {
 
 export const handleActionsDialogClose = (deps) => {
   const { render, store, subject } = deps;
+  if (store.selectSuppressNextActionsDialogClose?.()) {
+    store.clearSuppressNextActionsDialogClose?.();
+    return;
+  }
+
+  if (store.selectIsBackgroundTransformEditorOpen?.()) {
+    return;
+  }
+
   const lineId = store.selectActionTargetLineId?.();
   if (lineId) {
     store.setSelectedLineId({ selectedLineId: lineId });
   }
   store.clearActionTargetLineId?.();
+  store.closeBackgroundTransformEditor?.();
   clearTemporaryPresentationPreview({ store, subject });
   render();
 };

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -16,6 +16,10 @@ import {
   getSectionPresentation,
 } from "../../internal/project/projection.js";
 import {
+  formatBackgroundTransformEditorMetric,
+  normalizeBackgroundTransformEditorTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
+import {
   DEFAULT_PROJECT_RESOLUTION,
   formatProjectResolutionAspectRatio,
   requireProjectResolution,
@@ -612,6 +616,19 @@ export const createInitialState = () => ({
   skipNextEditorBlurDraftFlush: false,
   presentationState: {},
   temporaryPresentationState: {},
+  backgroundTransformEditor: {
+    isOpen: false,
+    transform: normalizeBackgroundTransformEditorTransform(),
+    dragStartPosition: undefined,
+    selectedElementMetrics: undefined,
+    background: {},
+    targetType: "background",
+    actionKey: "background",
+    itemIndex: undefined,
+    item: undefined,
+    targetId: undefined,
+    suppressNextActionsDialogClose: false,
+  },
   sectionLineChanges: {},
   sectionLineChangesBySectionId: {},
   isMuted: false,
@@ -746,6 +763,91 @@ export const selectEffectivePresentationState = ({ state }) => {
     state.presentationState,
     state.temporaryPresentationState,
   );
+};
+
+export const openBackgroundTransformEditor = (
+  { state },
+  {
+    background,
+    transform,
+    targetType = "background",
+    actionKey = "background",
+    itemIndex,
+    item,
+    targetId,
+  } = {},
+) => {
+  state.backgroundTransformEditor.isOpen = true;
+  state.backgroundTransformEditor.background = toPlainObject(background);
+  state.backgroundTransformEditor.targetType = targetType;
+  state.backgroundTransformEditor.actionKey = actionKey;
+  state.backgroundTransformEditor.itemIndex = itemIndex;
+  state.backgroundTransformEditor.item = item ? toPlainObject(item) : undefined;
+  state.backgroundTransformEditor.targetId = targetId;
+  state.backgroundTransformEditor.transform =
+    normalizeBackgroundTransformEditorTransform(transform);
+  state.backgroundTransformEditor.dragStartPosition = undefined;
+  state.backgroundTransformEditor.selectedElementMetrics = undefined;
+};
+
+export const closeBackgroundTransformEditor = ({ state }, _payload = {}) => {
+  state.backgroundTransformEditor.isOpen = false;
+  state.backgroundTransformEditor.dragStartPosition = undefined;
+  state.backgroundTransformEditor.selectedElementMetrics = undefined;
+};
+
+export const setBackgroundTransformEditorSelectedElementMetrics = (
+  { state },
+  { metrics } = {},
+) => {
+  state.backgroundTransformEditor.selectedElementMetrics = metrics;
+};
+
+export const setBackgroundTransformEditorTransform = (
+  { state },
+  { transform } = {},
+) => {
+  state.backgroundTransformEditor.transform =
+    normalizeBackgroundTransformEditorTransform(transform);
+};
+
+export const setBackgroundTransformEditorDragStartPosition = (
+  { state },
+  { dragStartPosition } = {},
+) => {
+  state.backgroundTransformEditor.dragStartPosition = dragStartPosition;
+};
+
+export const clearBackgroundTransformEditorDragStartPosition = (
+  { state },
+  _payload = {},
+) => {
+  state.backgroundTransformEditor.dragStartPosition = undefined;
+};
+
+export const suppressNextActionsDialogClose = ({ state }, _payload = {}) => {
+  state.backgroundTransformEditor.suppressNextActionsDialogClose = true;
+};
+
+export const clearSuppressNextActionsDialogClose = (
+  { state },
+  _payload = {},
+) => {
+  state.backgroundTransformEditor.suppressNextActionsDialogClose = false;
+};
+
+export const selectSuppressNextActionsDialogClose = ({ state }) => {
+  return (
+    state.backgroundTransformEditor.suppressNextActionsDialogClose === true
+  );
+};
+
+export const selectBackgroundTransformEditor = ({ state }) => {
+  return state.backgroundTransformEditor;
+};
+
+export const selectIsBackgroundTransformEditorOpen = ({ state }) => {
+  return state.backgroundTransformEditor.isOpen === true;
 };
 
 const syncPresentationStateFromSelectedLineChanges = (state) => {
@@ -1362,6 +1464,51 @@ const selectCanvasAspectRatio = ({ state }) => {
   return formatProjectResolutionAspectRatio(projectResolution);
 };
 
+const selectCanvasAspectRatioWidthMultiplier = ({ state }) => {
+  const projectResolution = state.repositoryState?.project?.resolution
+    ? requireProjectResolution(
+        state.repositoryState.project.resolution,
+        "Project resolution",
+      )
+    : DEFAULT_PROJECT_RESOLUTION;
+  const width = Number(projectResolution.width);
+  const height = Number(projectResolution.height);
+  const ratio = width / height;
+
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : 16 / 9;
+};
+
+const selectSystemActionsDialogPanelWidth = ({ state }) => {
+  return state.backgroundTransformEditor.isOpen === true
+    ? "calc(100vw - 64px)"
+    : "calc((100vw - 64px) / 2)";
+};
+const selectBackgroundTransformEditorViewData = ({ state }) => {
+  const editor = state.backgroundTransformEditor;
+  const transform = normalizeBackgroundTransformEditorTransform(
+    editor.transform,
+  );
+  const widthMultiplier = selectCanvasAspectRatioWidthMultiplier({ state });
+
+  return {
+    isOpen: editor.isOpen === true,
+    transform,
+    previewMaxWidth: `min(calc(100vw - 48px), calc((100vh - 170px) * ${widthMultiplier}))`,
+    canvasAspectRatio: selectCanvasAspectRatio({ state }),
+    suppressNextActionsDialogClose:
+      editor.suppressNextActionsDialogClose === true,
+    suppressActionsDialogClose:
+      editor.isOpen === true || editor.suppressNextActionsDialogClose === true,
+    metrics: {
+      x: formatBackgroundTransformEditorMetric(transform.x),
+      y: formatBackgroundTransformEditorMetric(transform.y),
+      scaleX: formatBackgroundTransformEditorMetric(transform.scaleX),
+      scaleY: formatBackgroundTransformEditorMetric(transform.scaleY),
+      rotation: formatBackgroundTransformEditorMetric(transform.rotation),
+    },
+  };
+};
+
 export const selectViewData = ({ state }) => {
   const scene = selectScene({ state });
   if (!scene) {
@@ -1397,6 +1544,9 @@ export const selectViewData = ({ state }) => {
       previewSectionId: state.previewSectionId,
       previewLineId: state.previewLineId,
       canvasAspectRatio: selectCanvasAspectRatio({ state }),
+      systemActionsDialogPanelWidth: selectSystemActionsDialogPanelWidth({
+        state,
+      }),
       sectionLineChanges: state.sectionLineChanges,
       sectionCreateDialog: state.sectionCreateDialog,
       sectionCreateForm: { fields: [], actions: { buttons: [] } },
@@ -1409,6 +1559,9 @@ export const selectViewData = ({ state }) => {
       isScenePageLoading: state.isScenePageLoading,
       isSceneAssetLoading: state.isSceneAssetLoading,
       deadEndTooltip: state.deadEndTooltip,
+      backgroundTransformEditor: selectBackgroundTransformEditorViewData({
+        state,
+      }),
     };
   }
 
@@ -1677,6 +1830,9 @@ export const selectViewData = ({ state }) => {
     previewSectionId: state.previewSectionId,
     previewLineId: state.previewLineId,
     canvasAspectRatio: selectCanvasAspectRatio({ state }),
+    systemActionsDialogPanelWidth: selectSystemActionsDialogPanelWidth({
+      state,
+    }),
     presentationState: selectEffectivePresentationState({ state }),
     sectionLineChanges: state.sectionLineChanges,
     sectionCreateDialog: state.sectionCreateDialog,
@@ -1690,6 +1846,9 @@ export const selectViewData = ({ state }) => {
     isScenePageLoading: state.isScenePageLoading,
     isSceneAssetLoading: state.isSceneAssetLoading,
     deadEndTooltip: state.deadEndTooltip,
+    backgroundTransformEditor: selectBackgroundTransformEditorViewData({
+      state,
+    }),
   };
 };
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -99,6 +99,14 @@ refs:
         handler: handleCommandLineSubmit
       temporary-presentation-state-change:
         handler: handleTemporaryPresentationStateChange
+      background-transform-customize:
+        handler: handleBackgroundTransformCustomize
+      background-transform-editor-done:
+        handler: handleBackgroundTransformEditorDone
+      action-transform-customize:
+        handler: handleActionTransformCustomize
+      action-transform-editor-done:
+        handler: handleActionTransformEditorDone
       close:
         handler: handleActionsDialogClose
   backButton:
@@ -161,18 +169,19 @@ template:
               - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h jc=e g=sm:
                   - rtgl-button#previewButton: Preview
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
-                  - 'rtgl-view w=f style="min-width: 0;"':
-                      - 'rtgl-view pos=rel w=f':
-                          - rvn-scene-editor-preview-canvas#previewCanvasHost canvas-aspect-ratio="${canvasAspectRatio}": null
-                          - $if isSceneAssetLoading:
-                              - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
-                                  - rtgl-text s=h3: Loading assets...
+                  - $if backgroundTransformEditor.isOpen == false:
+                      - 'rtgl-view w=f style="min-width: 0;"':
+                          - 'rtgl-view pos=rel w=f':
+                              - rvn-scene-editor-preview-canvas#previewCanvasHost canvas-aspect-ratio="${canvasAspectRatio}": null
+                              - $if isSceneAssetLoading:
+                                  - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
+                                      - rtgl-text s=h3: Loading assets...
                   - rtgl-view w=f h=1 bgc=mu: null
                   - rtgl-view w=f m=md:
                       - rtgl-view d=h av=c:
                           - rtgl-text s=sm c=mu-fg: State
                       - rtgl-view g=md w=f pv=md:
-                          - 'rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} dialog-variant=scene-editor-left dialog-panel-width="calc((100vw - 64px) / 2)"': null
+                          - 'rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor} dialog-variant=scene-editor-left dialog-panel-width="${systemActionsDialogPanelWidth}" :suppressDialogClose=${backgroundTransformEditor.suppressActionsDialogClose}': null
       - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
       - rtgl-popover#popover ?open=${popover.isOpen} x=${popover.position.x} y=${popover.position.y}:
           - rtgl-form#form slot=content :form=${form}: null

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleBeforeMount,
+  handleCustomTransformButtonClick,
+  handleCustomTransformDoneButtonClick,
+  handleGetBackgroundTransformPreviewCanvasRoot,
   handleFormInputChange,
   handleResourceItemClick,
   handleSubmitClick,
@@ -8,6 +11,9 @@ import {
 import {
   createInitialState,
   selectBackgroundLoop,
+  selectCustomTransform,
+  selectCustomTransformEnabled,
+  selectCustomTransformEditorOpen,
   selectMode,
   selectPendingResourceId,
   selectSelectedAnimation,
@@ -19,9 +25,14 @@ import {
   selectSelectedOpacity,
   selectSelectedResource,
   selectSelectedTransform,
+  selectSelectedTransformResource,
   selectTab,
   selectTempSelectedResource,
+  closeCustomTransformEditor,
+  openCustomTransformEditor,
   setBackgroundLoop,
+  setCustomTransform,
+  setCustomTransformEnabled,
   setMode,
   setRepositoryState,
   setSearchQuery,
@@ -46,6 +57,10 @@ const createEmptyCollection = () => ({
 
 const createStoreApi = (state) => ({
   selectBackgroundLoop: () => selectBackgroundLoop({ state }),
+  selectCustomTransform: () => selectCustomTransform({ state }),
+  selectCustomTransformEnabled: () => selectCustomTransformEnabled({ state }),
+  selectCustomTransformEditorOpen: () =>
+    selectCustomTransformEditorOpen({ state }),
   selectMode: () => selectMode({ state }),
   selectPendingResourceId: () => selectPendingResourceId({ state }),
   selectSelectedAnimation: () => selectSelectedAnimation({ state }),
@@ -58,9 +73,18 @@ const createStoreApi = (state) => ({
   selectSelectedOpacity: () => selectSelectedOpacity({ state }),
   selectSelectedResource: () => selectSelectedResource({ state }),
   selectSelectedTransform: () => selectSelectedTransform({ state }),
+  selectSelectedTransformResource: () =>
+    selectSelectedTransformResource({ state }),
   selectTab: () => selectTab({ state }),
   selectTempSelectedResource: () => selectTempSelectedResource({ state }),
+  closeCustomTransformEditor: (payload) =>
+    closeCustomTransformEditor({ state }, payload),
+  openCustomTransformEditor: (payload) =>
+    openCustomTransformEditor({ state }, payload),
   setBackgroundLoop: (payload) => setBackgroundLoop({ state }, payload),
+  setCustomTransform: (payload) => setCustomTransform({ state }, payload),
+  setCustomTransformEnabled: (payload) =>
+    setCustomTransformEnabled({ state }, payload),
   setMode: (payload) => setMode({ state }, payload),
   setPendingResourceId: ({ resourceId }) => {
     state.pendingResourceId = resourceId;
@@ -120,6 +144,13 @@ const setRepositoryCollections = (state) => {
             id: "bg-center",
             type: "transform",
             name: "Center",
+            x: 100,
+            y: 120,
+            anchorX: 0.5,
+            anchorY: 0.5,
+            scaleX: 1.2,
+            scaleY: 1.1,
+            rotation: 8,
           },
         },
         tree: [{ id: "bg-center" }],
@@ -170,6 +201,43 @@ describe("commandLineBackground.handlers", () => {
     expect(selectSelectedAnimation({ state })).toBe("bg-fade");
     expect(selectSelectedAnimationPlaybackContinuity({ state })).toBe("render");
     expect(selectBackgroundLoop({ state })).toBe(true);
+  });
+
+  it("hydrates existing inline custom transform state before mount", () => {
+    const state = createInitialState();
+
+    handleBeforeMount({
+      store: createStoreApi(state),
+      props: {
+        background: {
+          resourceId: "bg-school",
+          x: 100,
+          y: 120,
+          anchorX: 0,
+          anchorY: 1,
+          scaleX: 1.2,
+          scaleY: 0.8,
+          rotation: -8,
+          originX: 64,
+          originY: 128,
+        },
+      },
+    });
+
+    expect(selectPendingResourceId({ state })).toBe("bg-school");
+    expect(selectCustomTransformEnabled({ state })).toBe(true);
+    expect(selectSelectedTransform({ state })).toBeUndefined();
+    expect(selectCustomTransform({ state })).toEqual({
+      x: 100,
+      y: 120,
+      anchorX: 0,
+      anchorY: 1,
+      scaleX: 1.2,
+      scaleY: 0.8,
+      rotation: -8,
+      originX: 64,
+      originY: 128,
+    });
   });
 
   it("submits transformId when selected and omits it when cleared", () => {
@@ -251,6 +319,139 @@ describe("commandLineBackground.handlers", () => {
       },
     });
     expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("submits inline transform fields when custom transform is enabled", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedTransform(
+      { state },
+      {
+        transformId: "bg-center",
+      },
+    );
+    setCustomTransformEnabled(
+      { state },
+      {
+        enabled: true,
+      },
+    );
+    setCustomTransform(
+      { state },
+      {
+        transform: {
+          x: 100,
+          y: 120,
+          anchorX: 0,
+          anchorY: 1,
+          scaleX: 1.2,
+          scaleY: 1.2,
+          rotation: -8,
+          originX: 64,
+          originY: 128,
+        },
+      },
+    );
+
+    handleSubmitClick(
+      {
+        dispatchEvent,
+        store: createStoreApi(state),
+      },
+      {},
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+        x: 100,
+        y: 120,
+        anchorX: 0,
+        anchorY: 1,
+        scaleX: 1.2,
+        scaleY: 1.2,
+        rotation: -8,
+        originX: 64,
+        originY: 128,
+      },
+    });
+  });
+
+  it("copies the selected transform into custom transform when enabled", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedTransform(
+      { state },
+      {
+        transformId: "bg-center",
+      },
+    );
+
+    handleFormInputChange(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            name: "customTransform",
+            value: true,
+          },
+        },
+      },
+    );
+
+    expect(selectCustomTransformEnabled({ state })).toBe(true);
+    expect(selectCustomTransform({ state })).toEqual({
+      x: 100,
+      y: 120,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      scaleX: 1.2,
+      scaleY: 1.1,
+      rotation: 8,
+      originX: 0,
+      originY: 0,
+    });
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+          x: 100,
+          y: 120,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 1.2,
+          scaleY: 1.1,
+          rotation: 8,
+          originX: 0,
+          originY: 0,
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it("emits temporary presentation state when background form fields change", () => {
@@ -751,5 +952,110 @@ describe("commandLineBackground.handlers", () => {
       },
     });
     expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the local transform editor and emits customize from inside the background command line", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+
+    setRepositoryCollections(state);
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setSelectedTransform(
+      { state },
+      {
+        transformId: "bg-center",
+      },
+    );
+
+    handleCustomTransformButtonClick(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: event,
+      },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(selectCustomTransformEditorOpen({ state })).toBe(true);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "background-transform-customize",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      background: {
+        resourceId: "bg-school",
+        transformId: "bg-center",
+      },
+    });
+  });
+
+  it("closes the local transform editor and emits done without submitting the command line", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+
+    openCustomTransformEditor({ state });
+
+    handleCustomTransformDoneButtonClick(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: event,
+      },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(selectCustomTransformEditorOpen({ state })).toBe(false);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "background-transform-editor-done",
+    );
+    expect(dispatchEvent.mock.calls[0][0].bubbles).toBe(true);
+    expect(dispatchEvent.mock.calls[0][0].composed).toBe(true);
+  });
+
+  it("exposes the nested background transform preview canvas root", () => {
+    const canvasRoot = {};
+    const getCanvasRoot = vi.fn(() => canvasRoot);
+
+    expect(
+      handleGetBackgroundTransformPreviewCanvasRoot({
+        refs: {
+          backgroundTransformPreviewCanvasHost: {
+            getCanvasRoot,
+          },
+        },
+      }),
+    ).toBe(canvasRoot);
+    expect(getCanvasRoot).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -4,6 +4,8 @@ import {
   selectSelectedBlurActionValue,
   selectViewData,
   setRepositoryState,
+  setCustomTransform,
+  setCustomTransformEnabled,
   setSelectedAnimation,
   setSelectedBlur,
   setSelectedOpacity,
@@ -106,7 +108,7 @@ describe("commandLineBackground.store", () => {
     );
 
     expect(transformField).toMatchObject({
-      label: "Transform",
+      label: "Predefined Transform",
       type: "select",
       clearable: true,
       placeholder: "Select transform",
@@ -295,6 +297,64 @@ describe("commandLineBackground.store", () => {
     );
   });
 
+  it("shows the custom transform slot when custom transform is enabled", () => {
+    const state = createInitialState();
+
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+    setCustomTransformEnabled(
+      { state },
+      {
+        enabled: true,
+      },
+    );
+    setCustomTransform(
+      { state },
+      {
+        transform: {
+          x: 100,
+          y: 120,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 1.2,
+          scaleY: 1.2,
+          rotation: 0,
+          originX: 320,
+          originY: 180,
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    const transformField = viewData.dialogueForm.form.fields.find(
+      (field) => field.name === "transformId",
+    );
+    const customTransformSlot = viewData.dialogueForm.form.fields.find(
+      (field) => field.slot === "custom-transform",
+    );
+
+    expect(viewData.dialogueForm.defaultValues.customTransform).toBe(true);
+    expect(transformField).toMatchObject({
+      $when: "customTransform == false",
+    });
+    expect(customTransformSlot).toMatchObject({
+      $when: "customTransform == true",
+      type: "slot",
+    });
+    expect(viewData.customTransformDetails).toEqual([
+      { label: "Position", value: "100, 120" },
+      { label: "Scale", value: "1.2 x 1.2" },
+      { label: "Rotation", value: "0" },
+      { label: "Anchor", value: "0.5, 0.5" },
+      { label: "Origin", value: "320, 180" },
+    ]);
+  });
+
   it("uses a selected background opacity when provided", () => {
     const state = createInitialState();
 
@@ -369,5 +429,40 @@ describe("commandLineBackground.store", () => {
     const viewData = selectViewData({ state });
 
     expect(viewData.dialogueForm.defaultValues.blurKernelSize).toBe(11);
+  });
+
+  it("passes background transform editor view data through to the nested preview", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        backgroundTransformEditor: {
+          isOpen: true,
+          canvasAspectRatio: "4 / 3",
+          previewMaxWidth: "640px",
+          metrics: {
+            x: "10.00",
+            y: "20.00",
+            scaleX: "1.20",
+            scaleY: "1.20",
+            rotation: "8.00",
+          },
+        },
+      },
+    });
+
+    expect(viewData.backgroundTransformEditor).toEqual({
+      isOpen: true,
+      canvasAspectRatio: "4 / 3",
+      previewMaxWidth: "640px",
+      metrics: {
+        x: "10.00",
+        y: "20.00",
+        scaleX: "1.20",
+        scaleY: "1.20",
+        rotation: "8.00",
+      },
+    });
   });
 });

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -13,6 +13,8 @@ import {
   showDropdownMenu,
   updateCharacterBlurEnabled,
   updateCharacterBlurField,
+  updateCharacterCustomTransform,
+  updateCharacterCustomTransformEnabled,
   updateCharacterOpacity,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
 
@@ -481,5 +483,102 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       "sprite-body",
     ]);
     expect(viewData.spriteItems).toHaveLength(2);
+  });
+});
+
+describe("commandLineCharacters.store custom transforms", () => {
+  it("copies the selected predefined transform into character custom transform fields", () => {
+    const state = createInitialState();
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            "character-hero": {
+              id: "character-hero",
+              type: "character",
+              name: "Hero",
+            },
+          },
+          tree: [{ id: "character-hero" }],
+        },
+      },
+    );
+    setTransforms(
+      { state },
+      {
+        transforms: {
+          items: {
+            "character-center": {
+              id: "character-center",
+              type: "transform",
+              name: "Center",
+              x: 960,
+              y: 540,
+              scaleX: 1,
+              scaleY: 1,
+              rotation: 0,
+              anchorX: 0.5,
+              anchorY: 0.5,
+              originX: 100,
+              originY: 80,
+            },
+          },
+          tree: [{ id: "character-center" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+            transformId: "character-center",
+            sprites: [],
+          },
+        ],
+      },
+    );
+
+    updateCharacterCustomTransformEnabled(
+      { state },
+      {
+        index: 0,
+        enabled: true,
+      },
+    );
+    updateCharacterCustomTransform(
+      { state },
+      {
+        index: 0,
+        transform: {
+          x: 980,
+          y: 560,
+          scaleX: 1.25,
+          scaleY: 1.25,
+          rotation: 5,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          originX: 100,
+          originY: 80,
+        },
+      },
+    );
+
+    expect(selectViewData({ state }).defaultValues.characters[0]).toMatchObject(
+      {
+        transformId: "character-center",
+        customTransform: true,
+        x: 980,
+        y: 560,
+        scaleX: 1.25,
+        scaleY: 1.25,
+        customTransformDetails: expect.arrayContaining([
+          { label: "Position", value: "980, 560" },
+          { label: "Scale", value: "1.25 x 1.25" },
+        ]),
+      },
+    );
   });
 });

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -26,6 +26,8 @@ import {
   updateVisualAnimation,
   updateVisualBlurEnabled,
   updateVisualBlurField,
+  updateVisualCustomTransform,
+  updateVisualCustomTransformEnabled,
   updateVisualLayer,
   updateVisualOpacity,
 } from "../../src/components/commandLineVisual/commandLineVisual.store.js";
@@ -858,5 +860,90 @@ describe("commandLineVisual.store animation controls", () => {
         group.children.map((child) => child.id),
       ),
     ).toEqual(["visual-layout"]);
+  });
+});
+
+describe("commandLineVisual.store custom transforms", () => {
+  it("copies the selected predefined transform into visual custom transform fields", () => {
+    const state = createInitialState();
+    setRepositoryCollections(state);
+    setTransforms(
+      { state },
+      {
+        transforms: {
+          items: {
+            "visual-center": {
+              id: "visual-center",
+              type: "transform",
+              name: "Center",
+              x: 960,
+              y: 540,
+              scaleX: 1,
+              scaleY: 1,
+              rotation: 0,
+              anchorX: 0.5,
+              anchorY: 0.5,
+              originX: 100,
+              originY: 80,
+            },
+          },
+          tree: [{ id: "visual-center" }],
+        },
+      },
+    );
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            resourceType: "image",
+            transformId: "visual-center",
+          },
+        ],
+      },
+    );
+
+    updateVisualCustomTransformEnabled(
+      { state },
+      {
+        index: 0,
+        enabled: true,
+      },
+    );
+    updateVisualCustomTransform(
+      { state },
+      {
+        index: 0,
+        transform: {
+          x: 1000,
+          y: 600,
+          scaleX: 1.5,
+          scaleY: 1.5,
+          rotation: 10,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          originX: 100,
+          originY: 80,
+        },
+      },
+    );
+
+    expect(selectSelectedVisuals({ state })[0]).toMatchObject({
+      transformId: "visual-center",
+      x: 1000,
+      y: 600,
+      scaleX: 1.5,
+      scaleY: 1.5,
+      rotation: 10,
+    });
+    expect(selectViewData({ state }).defaultValues.visuals[0]).toMatchObject({
+      customTransform: true,
+      customTransformDetails: expect.arrayContaining([
+        { label: "Position", value: "1000, 600" },
+        { label: "Scale", value: "1.5 x 1.5" },
+      ]),
+    });
   });
 });

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -303,6 +303,44 @@ describe("graphicsService", () => {
     }).not.toThrow();
   });
 
+  it("recreates a missing ticker before route engine init", async () => {
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+    await service.destroy();
+
+    expect(() => {
+      service.initRouteEngine({
+        screen: { width: 1920, height: 1080 },
+      });
+    }).not.toThrow();
+    expect(createRouteEngineMock).toHaveBeenCalled();
+    expect(createEffectsHandlerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ticker: expect.objectContaining({
+          start: expect.any(Function),
+        }),
+      }),
+    );
+
+    await service.destroy();
+  });
+
   it("routes tauri Pixi media through the provided localhost origin", async () => {
     const filePath = "/Users/test/project/files/image-1";
     const localhostOrigin = "http://127.0.0.1:45123";

--- a/tests/sceneEditor/backgroundTransformEditor.test.js
+++ b/tests/sceneEditor/backgroundTransformEditor.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { createBackgroundTransformEditorCanvasState } from "../../src/internal/ui/sceneEditor/backgroundTransformEditor.js";
+
+describe("backgroundTransformEditor", () => {
+  it("adds an origin marker to the selected background overlay", () => {
+    const canvasState = createBackgroundTransformEditorCanvasState({
+      renderState: {
+        elements: [
+          {
+            id: "bg-cg-background-sprite",
+            type: "rect",
+            x: 10,
+            y: 20,
+            width: 100,
+            height: 40,
+            originX: 50,
+            originY: 20,
+          },
+        ],
+      },
+      graphicsService: {
+        parse: ({ elements }) => ({ elements }),
+      },
+      editorState: {
+        background: {
+          resourceId: "background-sprite",
+        },
+      },
+    });
+
+    const overlay = canvasState.renderState.elements[1];
+
+    expect(overlay.id).toBe("selected-border-group");
+    expect(overlay.children.map((child) => child.id)).toEqual([
+      "selected-border",
+      "selected-border-resize-left",
+      "selected-border-resize-right",
+      "selected-border-resize-top",
+      "selected-border-resize-bottom",
+      "selected-border-anchor",
+    ]);
+    expect(overlay.children[5]).toEqual({
+      id: "selected-border-anchor",
+      type: "rect",
+      x: 46,
+      y: 16,
+      width: 8,
+      height: 8,
+      fill: {
+        color: "#ffffff",
+        alpha: 1,
+      },
+      border: {
+        color: "#111111",
+        width: 1,
+        alpha: 1,
+      },
+    });
+  });
+
+  it("uses transform anchor ratios for the marker and resize metrics", () => {
+    const canvasState = createBackgroundTransformEditorCanvasState({
+      renderState: {
+        elements: [
+          {
+            id: "bg-cg-background-sprite",
+            type: "rect",
+            x: 10,
+            y: 20,
+            width: 200,
+            height: 100,
+            originX: 50,
+            originY: 25,
+          },
+        ],
+      },
+      graphicsService: {
+        parse: ({ elements }) => ({ elements }),
+      },
+      editorState: {
+        background: {
+          resourceId: "background-sprite",
+        },
+        transform: {
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 2,
+          scaleY: 2,
+        },
+      },
+    });
+
+    const overlay = canvasState.renderState.elements[1];
+
+    expect(overlay.children[5]).toMatchObject({
+      id: "selected-border-anchor",
+      x: 96,
+      y: 46,
+    });
+    expect(canvasState.selectedElementMetrics).toEqual({
+      width: 200,
+      height: 100,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      scaleX: 2,
+      scaleY: 2,
+    });
+  });
+});

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyBackgroundTransformResizeChange,
   handleActionsDialogClose,
+  handleBackgroundTransformEditorCloseClick,
   handleCommandLineSubmit,
   handleDropdownMenuClickItem,
   handleEditorBlur,
@@ -9,7 +11,200 @@ import {
   handleSelectedLineChanged,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
+describe("sceneEditorLexical.handlers transform editor resize", () => {
+  it("keeps x and y fixed while scaling from the anchor", () => {
+    const transform = {
+      x: 100,
+      y: 120,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      scaleX: 2,
+      scaleY: 2,
+      rotation: 0,
+      originX: 50,
+      originY: 25,
+    };
+
+    const updatedTransform = applyBackgroundTransformResizeChange({
+      transform,
+      dragStartPosition: {
+        x: 300,
+        y: 0,
+        resizeEdge: "right",
+        selectedElementMetrics: {
+          width: 200,
+          height: 100,
+          anchorX: 0.5,
+          anchorY: 0.5,
+        },
+        transformStartScaleX: 2,
+        transformStartScaleY: 2,
+      },
+      x: 350,
+      y: 0,
+    });
+
+    expect(updatedTransform).toEqual({
+      ...transform,
+      scaleX: 3,
+      scaleY: 3,
+    });
+  });
+});
+
 describe("sceneEditorLexical.handlers actions dialog", () => {
+  it("closes only the background transform editor when Done is clicked", () => {
+    const handleSetBackgroundCustomTransform = vi.fn();
+    const open = vi.fn();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const stopImmediatePropagation = vi.fn();
+    const editor = {
+      background: {
+        resourceId: "bg-school",
+        transformId: "bg-center",
+      },
+      transform: {
+        x: 100,
+        y: 120,
+      },
+    };
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((callback) => {
+        callback();
+        return 1;
+      });
+    const deps = {
+      refs: {
+        systemActions: {
+          transformedHandlers: {
+            handleSetBackgroundCustomTransform,
+            open,
+          },
+        },
+      },
+      store: {
+        selectBackgroundTransformEditor: vi.fn(() => editor),
+        selectSelectedLine: vi.fn(() => ({
+          actions: {
+            background: {
+              resourceId: "bg-school",
+              transformId: "bg-center",
+            },
+          },
+        })),
+        closeBackgroundTransformEditor: vi.fn(),
+        suppressNextActionsDialogClose: vi.fn(),
+        clearSuppressNextActionsDialogClose: vi.fn(),
+      },
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    try {
+      handleBackgroundTransformEditorCloseClick(deps, {
+        _event: {
+          preventDefault,
+          stopPropagation,
+          stopImmediatePropagation,
+        },
+      });
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(deps.store.suppressNextActionsDialogClose).toHaveBeenCalledTimes(1);
+    expect(
+      deps.store.clearSuppressNextActionsDialogClose,
+    ).toHaveBeenCalledTimes(1);
+    expect(handleSetBackgroundCustomTransform).toHaveBeenCalledWith({
+      background: editor.background,
+      transform: editor.transform,
+    });
+    expect(open).toHaveBeenCalledWith({
+      mode: "background",
+      actions: {
+        background: {
+          resourceId: "bg-school",
+          x: 100,
+          y: 120,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 1,
+          scaleY: 1,
+          rotation: 0,
+          originX: 0,
+          originY: 0,
+        },
+      },
+    });
+    expect(deps.store.closeBackgroundTransformEditor).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(2);
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      {
+        skipRender: true,
+        skipAnimations: true,
+        skipAudio: true,
+      },
+    );
+  });
+
+  it("ignores actions dialog close events suppressed by transform Done", () => {
+    const store = {
+      selectSuppressNextActionsDialogClose: vi.fn(() => true),
+      clearSuppressNextActionsDialogClose: vi.fn(),
+      selectActionTargetLineId: vi.fn(),
+      clearActionTargetLineId: vi.fn(),
+      clearTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    handleActionsDialogClose(deps);
+
+    expect(store.clearSuppressNextActionsDialogClose).toHaveBeenCalledTimes(1);
+    expect(store.clearTemporaryPresentationState).not.toHaveBeenCalled();
+    expect(store.clearActionTargetLineId).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.subject.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("ignores actions dialog close events while the transform editor is open", () => {
+    const store = {
+      selectSuppressNextActionsDialogClose: vi.fn(() => false),
+      selectIsBackgroundTransformEditorOpen: vi.fn(() => true),
+      selectActionTargetLineId: vi.fn(),
+      clearActionTargetLineId: vi.fn(),
+      clearTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    handleActionsDialogClose(deps);
+
+    expect(store.clearTemporaryPresentationState).not.toHaveBeenCalled();
+    expect(store.clearActionTargetLineId).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.subject.dispatch).not.toHaveBeenCalled();
+  });
+
   it("clears temporary presentation state and refreshes the canvas when the actions dialog closes", () => {
     const store = {
       selectActionTargetLineId: vi.fn(() => "line-2"),

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createInitialState,
   selectAction,
@@ -6,9 +6,13 @@ import {
 } from "../../src/components/systemActions/systemActions.store.js";
 import {
   handleActionsDialogClose,
+  handleBackgroundTransformCustomize,
+  handleBackgroundTransformEditorDone,
+  handleGetBackgroundTransformPreviewCanvasRoot,
   handleEmbeddedCloseClick,
   handleCommandLineSubmit,
   handleTemporaryPresentationStateChange,
+  handleSetBackgroundCustomTransform,
   open,
 } from "../../src/components/systemActions/systemActions.handlers.js";
 
@@ -241,6 +245,92 @@ describe("systemActions.handlers", () => {
     });
   });
 
+  it("keeps the background command editor open when applying a custom transform", () => {
+    const state = createInitialState();
+    const dispatchedEvents = [];
+    const setChildCustomTransform = vi.fn();
+    const updateActionsSpy = vi.fn();
+    const render = vi.fn();
+
+    updateActions(
+      { state },
+      {
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+        },
+      },
+    );
+
+    handleSetBackgroundCustomTransform(
+      {
+        refs: {
+          commandLineBackground: {
+            transformedHandlers: {
+              handleSetCustomTransform: setChildCustomTransform,
+            },
+          },
+        },
+        store: {
+          selectAction: () => selectAction({ state }),
+          updateActions: updateActionsSpy,
+        },
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+        },
+        transform: {
+          x: 100,
+          y: 120,
+          anchorX: 0,
+          anchorY: 1,
+          scaleX: 1.2,
+          scaleY: 1.2,
+          rotation: -8,
+          originX: 64,
+          originY: 128,
+        },
+      },
+    );
+
+    const nextBackground = {
+      resourceId: "bg-school",
+      x: 100,
+      y: 120,
+      anchorX: 0,
+      anchorY: 1,
+      scaleX: 1.2,
+      scaleY: 1.2,
+      rotation: -8,
+      originX: 64,
+      originY: 128,
+    };
+
+    expect(selectAction({ state }).background).toEqual({
+      resourceId: "bg-school",
+      transformId: "bg-center",
+    });
+    expect(updateActionsSpy).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+    expect(setChildCustomTransform).toHaveBeenCalledWith({
+      transform: nextBackground,
+    });
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe(
+      "temporary-presentation-state-change",
+    );
+    expect(dispatchedEvents[0].detail).toEqual({
+      presentationState: {
+        background: nextBackground,
+      },
+    });
+  });
+
   it("emits close from embedded system action editors", () => {
     const dispatchedEvents = [];
     let stopPropagationCalled = false;
@@ -269,6 +359,141 @@ describe("systemActions.handlers", () => {
       presentationState: {},
     });
     expect(dispatchedEvents[1].type).toBe("close");
+  });
+
+  it("ignores dialog close while close is suppressed by a transform editor", () => {
+    const dispatchedEvents = [];
+    const state = createInitialState();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    const deps = {
+      props: {
+        suppressDialogClose: true,
+      },
+      store: {
+        hideActionsDialog: vi.fn(() => {
+          state.isActionsDialogOpen = false;
+        }),
+        setMode: vi.fn(({ mode }) => {
+          state.mode = mode;
+        }),
+      },
+      render: vi.fn(),
+      dispatchEvent: (event) => {
+        dispatchedEvents.push(event);
+      },
+    };
+
+    state.isActionsDialogOpen = true;
+    state.mode = "background";
+
+    handleActionsDialogClose(deps, {
+      _event: {
+        preventDefault,
+        stopPropagation,
+      },
+    });
+
+    expect(state.isActionsDialogOpen).toBe(true);
+    expect(state.mode).toBe("background");
+    expect(deps.store.hideActionsDialog).not.toHaveBeenCalled();
+    expect(deps.store.setMode).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(dispatchedEvents).toHaveLength(0);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("arms local close suppression before forwarding background transform Customize", () => {
+    const dispatchedEvents = [];
+    const setSuppressDialogClose = vi.fn();
+    const handleSuppressClose = vi.fn();
+    const stopPropagation = vi.fn();
+
+    handleBackgroundTransformCustomize(
+      {
+        refs: {
+          actionsDialog: {
+            transformedHandlers: {
+              handleSuppressClose,
+            },
+          },
+        },
+        store: {
+          setSuppressDialogClose,
+        },
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        _event: {
+          stopPropagation,
+          detail: {
+            background: {
+              resourceId: "bg-title",
+            },
+          },
+        },
+      },
+    );
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(setSuppressDialogClose).toHaveBeenCalledWith({
+      suppressDialogClose: true,
+    });
+    expect(handleSuppressClose).toHaveBeenCalledTimes(1);
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("background-transform-customize");
+    expect(dispatchedEvents[0].detail).toEqual({
+      background: {
+        resourceId: "bg-title",
+      },
+    });
+  });
+
+  it("ignores dialog close while local close suppression is active", () => {
+    const dispatchedEvents = [];
+    const state = createInitialState();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    const deps = {
+      props: {},
+      store: {
+        selectSuppressDialogClose: vi.fn(() => true),
+        hideActionsDialog: vi.fn(() => {
+          state.isActionsDialogOpen = false;
+        }),
+        setMode: vi.fn(({ mode }) => {
+          state.mode = mode;
+        }),
+      },
+      render: vi.fn(),
+      dispatchEvent: (event) => {
+        dispatchedEvents.push(event);
+      },
+    };
+
+    state.isActionsDialogOpen = true;
+    state.mode = "background";
+
+    handleActionsDialogClose(deps, {
+      _event: {
+        preventDefault,
+        stopPropagation,
+      },
+    });
+
+    expect(state.isActionsDialogOpen).toBe(true);
+    expect(state.mode).toBe("background");
+    expect(deps.store.hideActionsDialog).not.toHaveBeenCalled();
+    expect(deps.store.setMode).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(dispatchedEvents).toHaveLength(0);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
   });
 
   it("clears temporary presentation state when the actions dialog closes", () => {
@@ -384,5 +609,51 @@ describe("systemActions.handlers", () => {
         operations: [],
       },
     });
+  });
+
+  it("forwards background transform editor Done from the nested background command line", () => {
+    const dispatchedEvents = [];
+    const stopPropagation = vi.fn();
+
+    handleBackgroundTransformEditorDone(
+      {
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        _event: {
+          stopPropagation,
+          detail: {
+            done: true,
+          },
+        },
+      },
+    );
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("background-transform-editor-done");
+    expect(dispatchedEvents[0].detail).toEqual({
+      done: true,
+    });
+  });
+
+  it("exposes the nested background command line transform preview canvas root", () => {
+    const canvasRoot = {};
+    const getCanvasRoot = vi.fn(() => canvasRoot);
+
+    expect(
+      handleGetBackgroundTransformPreviewCanvasRoot({
+        refs: {
+          commandLineBackground: {
+            transformedHandlers: {
+              handleGetBackgroundTransformPreviewCanvasRoot: getCanvasRoot,
+            },
+          },
+        },
+      }),
+    ).toBe(canvasRoot);
+    expect(getCanvasRoot).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -52,11 +52,20 @@ describe("systemActions view", () => {
     expect(systemActionsView).toContain(
       "rvn-system-actions-dialog-surface#actionsDialog",
     );
+    expect(systemActionsView).toContain(
+      ":suppressClose=${suppressDialogClose}",
+    );
     expect(sceneEditorLexicalView).toContain(
       "dialog-variant=scene-editor-left",
     );
+    expect(systemActionsView).toContain(
+      ":backgroundTransformEditor=${backgroundTransformEditor}",
+    );
     expect(sceneEditorLexicalView).toContain(
-      'dialog-panel-width="calc((100vw - 64px) / 2)"',
+      ":backgroundTransformEditor=${backgroundTransformEditor}",
+    );
+    expect(sceneEditorLexicalView).toContain(
+      'dialog-panel-width="${systemActionsDialogPanelWidth}"',
     );
   });
 });

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js
@@ -32,6 +32,35 @@ describe("systemActionsDialogSurface.handlers", () => {
     expect(dispatchedEvents[0].type).toBe("close");
   });
 
+  it("does not emit close while close is suppressed", () => {
+    const dispatchedEvents = [];
+    let stopPropagationCalled = false;
+    let preventDefaultCalled = false;
+
+    handleSurfaceClose(
+      {
+        props: {
+          suppressClose: true,
+        },
+        dispatchEvent: (event) => dispatchedEvents.push(event),
+      },
+      {
+        _event: {
+          stopPropagation: () => {
+            stopPropagationCalled = true;
+          },
+          preventDefault: () => {
+            preventDefaultCalled = true;
+          },
+        },
+      },
+    );
+
+    expect(stopPropagationCalled).toBe(true);
+    expect(preventDefaultCalled).toBe(true);
+    expect(dispatchedEvents).toHaveLength(0);
+  });
+
   it("closes on Escape only while open", () => {
     const dispatchedEvents = [];
     let preventDefaultCalled = false;
@@ -72,6 +101,25 @@ describe("systemActionsDialogSurface.handlers", () => {
       {
         _event: {
           key: "Escape",
+        },
+      },
+    );
+
+    expect(dispatchedEvents).toHaveLength(1);
+
+    handleDocumentKeyDown(
+      {
+        props: {
+          open: true,
+          suppressClose: true,
+        },
+        dispatchEvent: (event) => dispatchedEvents.push(event),
+      },
+      {
+        _event: {
+          key: "Escape",
+          preventDefault: () => {},
+          stopPropagation: () => {},
         },
       },
     );

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
@@ -18,6 +18,7 @@ describe("systemActionsDialogSurface.store", () => {
       dialogWidth: "800",
       dialogHeight: "80vh",
       panelWidth: "50vw",
+      suppressClose: false,
       overlayHorizontalInset: "64px",
       overlayBackground: "rgba(0, 0, 0, 0.42)",
       panelHorizontalInset: "96px",
@@ -35,6 +36,7 @@ describe("systemActionsDialogSurface.store", () => {
         dialogWidth: "100vw",
         dialogHeight: "100vh",
         panelWidth: "calc((100vw - 64px) / 2)",
+        suppressClose: true,
       },
     });
 
@@ -43,6 +45,7 @@ describe("systemActionsDialogSurface.store", () => {
       variant: "scene-editor-left",
       isSceneEditorLeft: true,
       panelWidth: "calc((100vw - 64px) / 2)",
+      suppressClose: true,
       overlayHorizontalInset: "64px",
       overlayBackground: "rgba(0, 0, 0, 0.42)",
       panelHorizontalInset: "96px",


### PR DESCRIPTION
## Summary
- bump `route-engine-js` to 1.22.0 and add inline transform helpers for background, visual, and character actions
- add Predefined/Custom transform mode, transform chips, and the full preview editor for command-line background, visuals, and characters
- keep the action dialog open while editing transforms and disable regular preview interactions while the transform editor is active

## Testing
- `bunx vitest run tests/commandLineBackground/commandLineBackground.handlers.test.js tests/commandLineBackground/commandLineBackground.store.test.js tests/commandLineVisual/commandLineVisual.store.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js tests/graphicsService/graphicsService.test.js tests/sceneEditor/backgroundTransformEditor.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/systemActions/systemActions.handlers.test.js tests/systemActions/systemActions.view.test.js tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js`
- `bunx prettier --check ...`
- `bunx oxlint ...`
- `bun run build:web`
- pre-push hook: `oxlint && bun prettier --check src`