### PR TITLE
Add import package flow for transforms and animations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 5. [Insieme 2.1.0 Hard Cutover Checklist](./insieme-2.1.0-hard-cutover-checklist.md)
 6. [Animation Editor Transition Mask Plan](./animation-editor-transition-mask-plan.md)
 7. [Resource Tags Spec](./resource-tags-spec.md)
+8. [Import Packages](./import-packages.md)
 
 ## Runbooks
 

--- a/docs/import-packages.md
+++ b/docs/import-packages.md
@@ -1,0 +1,260 @@
+# Import Packages
+
+## Purpose
+
+This document defines the initial RouteVN import package shape and the asset
+store import-link flow.
+
+Import packages let users import reusable project resources from a copied URL.
+The first implementation can support one resource type at a time, but the
+package shape should stay general enough for images, sounds, videos, fonts,
+spritesheets, transforms, animations, particles, colors, text styles, layouts,
+controls, and variables.
+
+## Shape
+
+An import package is a wrapper around a partial repository.
+
+```json
+{
+  "schema": "routevn.import-pack.v1",
+  "package": {
+    "id": "example.fx-pack",
+    "name": "FX Pack",
+    "version": "1.0.0",
+    "description": "Particles, textures, and transition animations."
+  },
+  "repository": {
+    "files": {
+      "items": {}
+    },
+    "images": {
+      "items": {},
+      "tree": []
+    },
+    "transforms": {
+      "items": {},
+      "tree": []
+    },
+    "animations": {
+      "items": {},
+      "tree": []
+    },
+    "particles": {
+      "items": {},
+      "tree": []
+    }
+  }
+}
+```
+
+Only included repository roots are imported.
+
+The package should reuse RouteVN's normal `{ items, tree }` collection shape.
+Folders are normal items with `type: "folder"`; there is no separate `folders`
+section and no separate `resources` array.
+
+## Package-Local IDs
+
+All ids inside the package are package-local ids.
+
+They may appear in normal repository fields such as `id`, `fileId`,
+`thumbnailFileId`, `imageId`, `texture`, `resourceId`, `transformId`,
+`animationId`, and `particleId`.
+
+During import, the client maps package-local ids to real project ids.
+
+```text
+file.spark -> generated-file-id
+image.spark -> generated-or-existing-image-id
+transform.center -> generated-transform-id
+```
+
+Saved project data must contain real project ids only.
+
+## Files
+
+File-backed resources point to `repository.files.items` records. File records
+extend the normal file metadata with import-only `source` data.
+
+```json
+{
+  "repository": {
+    "files": {
+      "items": {
+        "file.spark": {
+          "id": "file.spark",
+          "type": "image",
+          "mimeType": "image/png",
+          "sha256": "optional",
+          "source": {
+            "url": "assets/spark.png"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`source.url` may be absolute or relative to the manifest URL. If `sha256` is
+present, the importer should verify the downloaded bytes.
+
+## Folders
+
+Packages should not create destination folders by default. The import flow asks
+the user to choose a destination folder for each imported resource type and for
+file-backed dependencies such as images or sounds.
+
+```json
+{
+  "transforms": {
+    "items": {
+      "transform.center": {
+        "id": "transform.center",
+        "type": "transform",
+        "name": "Center",
+        "x": 960,
+        "y": 540,
+        "scaleX": 1,
+        "scaleY": 1,
+        "anchorX": 0.5,
+        "anchorY": 0.5,
+        "rotation": 0
+      }
+    },
+    "tree": [{ "id": "transform.center" }]
+  }
+}
+```
+
+Default import behavior:
+
+- show only existing project folders as destination choices
+- require a real destination folder for each imported resource type
+- append imported items to the selected folder
+- do not add a synthetic `Root` folder option
+- do not create a package root folder
+- skip resource types with no imported items
+- do not move existing project resources selected as substitutions
+
+Package folders may still be present in future generalized packages, but the
+first importer should treat them as package organization only unless a later
+flow explicitly supports folder creation or merging.
+
+## Media Substitution
+
+Users should always be able to replace file-backed resources during import.
+
+The package describes default media. The local import session decides whether a
+media resource is imported, renamed, skipped, or mapped to an existing project
+resource.
+
+This local choice is not part of the package format.
+
+```json
+{
+  "resourceChoices": {
+    "image.spark": {
+      "mode": "existing",
+      "projectResourceId": "existing-image-id"
+    }
+  }
+}
+```
+
+If a package image is mapped to an existing image, dependent resources should use
+the existing project image id and the client should avoid downloading unused
+default files.
+
+## Asset Store Import Links
+
+The asset store should expose a stable import link for each importable package.
+The user copies this link and pastes it into RouteVN Creator.
+
+Expected flow:
+
+1. The user opens the asset store.
+2. The user copies an import link for one asset or pack.
+3. The user pastes the link into RouteVN Creator.
+4. The client fetches the import package manifest.
+5. The client shows an import review flow.
+6. The user confirms placement, renames, and media substitutions.
+7. The client imports the resolved resources into the current project.
+
+Basic URL contract:
+
+```text
+GET https://assets.routevn.example/import/example.fx-pack
+Accept: application/json
+```
+
+Response:
+
+```http
+Content-Type: application/json
+```
+
+The response body is a `routevn.import-pack.v1` package.
+
+The import link may point directly to the manifest or redirect to the manifest.
+The link should identify one importable package, not a general catalog page.
+
+## Auth
+
+Public packages can use unauthenticated links.
+
+For authenticated packages, prefer a signed import link generated by the asset
+store after the user logs in or purchases the asset.
+
+```text
+https://assets.routevn.example/import/example.fx-pack?token=...
+```
+
+The token should authorize fetching the manifest and protected file URLs. It
+should be scoped to one package and may expire.
+
+The first implementation should not require RouteVN Creator to understand the
+asset store's full account system. Full first-party account auth can be added
+later with authorization headers if needed.
+
+The client should not rely on browser cookies from the asset store page,
+especially in the desktop app.
+
+## Validation
+
+The client should treat import links as untrusted network input:
+
+- fetch with explicit size limits
+- require a supported `schema`
+- resolve relative file URLs against the manifest URL
+- validate all files through normal upload/file-type rules
+- verify hashes when `sha256` is provided
+- show stable user-facing errors for network, auth, validation, and file failures
+
+Recommended initial errors:
+
+- `Package could not be loaded.`
+- `This package format is not supported.`
+- `This package requires authorization.`
+- `A package file could not be downloaded.`
+- `A package file has an unsupported type.`
+- `A package file failed integrity validation.`
+
+## MVP Scope
+
+The first implementation can support a narrow path:
+
+- paste an absolute `http` or `https` package URL
+- import transform packages and animation packages by URL
+- accept either a full import package, a resource collection, or a single
+  resource item for the supported resource type
+- let the user choose the destination resource folder before importing
+- download image dependencies and let the user choose the destination image
+  folder when image dependencies exist
+- rewrite imported transform preview image references and animation mask image
+  references to the newly imported images
+- skip substitutions and generalized multi-resource import for now
+
+Future iterations can broaden this to package-level folder import, existing
+resource substitution, and additional resource types.

--- a/src/components/catalogResourcesView/catalogResourcesView.handlers.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.handlers.js
@@ -233,6 +233,22 @@ export const handleAddButtonClick = (deps, payload) => {
   );
 };
 
+export const handleImportButtonClick = (deps, payload) => {
+  const { dispatchEvent } = deps;
+  payload._event.stopPropagation();
+
+  dispatchEvent(
+    new CustomEvent("import-click", {
+      detail: {
+        x: payload._event.clientX,
+        y: payload._event.clientY,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
 export const handleItemContextMenu = (deps, payload) => {
   const { store, render } = deps;
   payload._event.preventDefault();

--- a/src/components/catalogResourcesView/catalogResourcesView.schema.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.schema.yaml
@@ -67,6 +67,12 @@ propsSchema:
     canAdd:
       type: boolean
       description: Whether add actions should be shown
+    importText:
+      type: string
+      description: Text to display in the top import action
+    canImport:
+      type: boolean
+      description: Whether the top import action should be shown
     mobileLayout:
       type: boolean
       description: Whether cards should use the touch/mobile full-width layout

--- a/src/components/catalogResourcesView/catalogResourcesView.store.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.store.js
@@ -162,8 +162,13 @@ export const selectViewData = ({ state, props }) => {
   });
 
   const groups = (props.groups ?? []).map((group) => {
-    const isCollapsed = state.collapsedIds.includes(group.id);
-    const children = isCollapsed ? [] : (group.children ?? []);
+    const groupChildren = group.children ?? [];
+    const hasSelectedItem = groupChildren.some(
+      (item) => item.id === props.selectedItemId,
+    );
+    const isCollapsed =
+      state.collapsedIds.includes(group.id) && !hasSelectedItem;
+    const children = isCollapsed ? [] : groupChildren;
 
     return {
       ...group,
@@ -242,6 +247,8 @@ export const selectViewData = ({ state, props }) => {
           : `No items found matching "${searchQuery}"`),
     addText: props.addText ?? "Add",
     canAdd: parseBooleanProp(props.canAdd, true),
+    importText: props.importText ?? "Import",
+    canImport: parseBooleanProp(props.canImport),
     mobileLayout,
     dropdownMenu: state.dropdownMenu,
   };

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -59,6 +59,10 @@ refs:
     eventListeners:
       click:
         handler: handleAddButtonClick
+  importBtn:
+    eventListeners:
+      click:
+        handler: handleImportButtonClick
   groupToggle*:
     eventListeners:
       click:
@@ -89,6 +93,8 @@ template:
               - $if showTagFilter:
                   - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
                       - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
+              - $if canImport:
+                  - rtgl-button#importBtn s=sm pre=upload v=se: ${importText}
       - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:

--- a/src/internal/importPackages.js
+++ b/src/internal/importPackages.js
@@ -1,0 +1,187 @@
+export const IMPORT_PACK_SCHEMA = "routevn.import-pack.v1";
+export const IMPORT_FOLDER_ROOT_VALUE = "_root";
+
+const IMPORT_PACKAGE_VALIDATION_ERROR_NAME = "ImportPackageValidationError";
+
+export const createImportPackageValidationError = (message) => {
+  const error = new Error(message);
+  error.name = IMPORT_PACKAGE_VALIDATION_ERROR_NAME;
+  return error;
+};
+
+export const isImportPackageValidationError = (error) => {
+  return error?.name === IMPORT_PACKAGE_VALIDATION_ERROR_NAME;
+};
+
+export const isPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+};
+
+export const isValidHttpUrl = (value) => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const isJsonLikeContentType = (contentType = "") => {
+  const normalized = contentType.toLowerCase();
+  return (
+    !normalized ||
+    normalized.includes("json") ||
+    normalized.startsWith("text/plain")
+  );
+};
+
+export const validateImportPackageObject = (input) => {
+  if (!isPlainObject(input)) {
+    throw createImportPackageValidationError(
+      "Import package must be a JSON object.",
+    );
+  }
+
+  if (input.schema !== undefined && input.schema !== IMPORT_PACK_SCHEMA) {
+    throw createImportPackageValidationError(
+      "Unsupported import package schema.",
+    );
+  }
+
+  if (input.schema === IMPORT_PACK_SCHEMA && !isPlainObject(input.repository)) {
+    throw createImportPackageValidationError(
+      "Import package repository is missing.",
+    );
+  }
+
+  return input;
+};
+
+export const fetchImportPackageJson = async ({ url } = {}) => {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw createImportPackageValidationError("Package could not be loaded.");
+  }
+
+  const contentType = response.headers?.get?.("content-type") ?? "";
+  if (!isJsonLikeContentType(contentType)) {
+    throw createImportPackageValidationError("Import URL must return JSON.");
+  }
+
+  let input;
+  try {
+    input = await response.json();
+  } catch {
+    throw createImportPackageValidationError(
+      "Import URL did not return valid JSON.",
+    );
+  }
+
+  return validateImportPackageObject(input);
+};
+
+export const getImportFileRecords = (importInput) => {
+  if (isPlainObject(importInput?.files)) {
+    return importInput.files;
+  }
+
+  if (isPlainObject(importInput?.repository?.files?.items)) {
+    return importInput.repository.files.items;
+  }
+
+  return {};
+};
+
+export const getImportFileDescriptor = (importInput, fileId) => {
+  if (!fileId) {
+    return undefined;
+  }
+
+  return getImportFileRecords(importInput)[fileId];
+};
+
+export const getImportFileUrl = (fileDescriptor = {}) => {
+  return fileDescriptor.url ?? fileDescriptor.source?.url;
+};
+
+export const validateImportFileDescriptor = ({
+  importInput,
+  fileId,
+  label = "File dependency",
+} = {}) => {
+  if (!fileId) {
+    throw createImportPackageValidationError(`${label} is missing a file id.`);
+  }
+
+  const fileDescriptor = getImportFileDescriptor(importInput, fileId);
+  if (!isPlainObject(fileDescriptor)) {
+    throw createImportPackageValidationError(
+      `${label} is missing a file record.`,
+    );
+  }
+
+  const fileUrl = getImportFileUrl(fileDescriptor);
+  if (!fileUrl) {
+    throw createImportPackageValidationError(`${label} is missing a file URL.`);
+  }
+
+  if (!isValidHttpUrl(fileUrl)) {
+    throw createImportPackageValidationError(
+      `${label} has an invalid file URL.`,
+    );
+  }
+
+  return fileDescriptor;
+};
+
+export const normalizeImportParentId = (folderId) => {
+  return !folderId || folderId === IMPORT_FOLDER_ROOT_VALUE
+    ? undefined
+    : folderId;
+};
+
+export const getFileNameFromUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url);
+    const fileName = parsedUrl.pathname.split("/").filter(Boolean).pop();
+    return fileName || "imported-file";
+  } catch {
+    return "imported-file";
+  }
+};
+
+export const createImportFile = ({ blob, fileName, mimeType }) => {
+  if (typeof File === "function") {
+    return new File([blob], fileName, {
+      type: mimeType,
+    });
+  }
+
+  blob.name = fileName;
+  return blob;
+};
+
+export const downloadImportFile = async (fileDescriptor = {}) => {
+  const fileUrl = getImportFileUrl(fileDescriptor);
+  if (!fileUrl) {
+    throw new Error("Import file URL is missing");
+  }
+
+  const response = await fetch(fileUrl);
+  if (!response.ok) {
+    throw new Error("Import file could not be downloaded");
+  }
+
+  const blob = await response.blob();
+  const mimeType = fileDescriptor.mimeType ?? blob.type;
+  return createImportFile({
+    blob,
+    fileName: fileDescriptor.name ?? getFileNameFromUrl(fileUrl),
+    mimeType,
+  });
+};

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -1,4 +1,16 @@
 import { generateId } from "../../internal/id.js";
+import {
+  IMPORT_PACK_SCHEMA,
+  downloadImportFile,
+  fetchImportPackageJson,
+  isImportPackageValidationError,
+  isPlainObject,
+  isValidHttpUrl,
+  normalizeImportParentId,
+  validateImportFileDescriptor,
+  validateImportPackageObject,
+} from "../../internal/importPackages.js";
+import { toFlatItems } from "../../internal/project/tree.js";
 import { createAnimationEditorPayload } from "../../internal/animationEditorRoute.js";
 import { createResourceFileExplorerHandlers } from "../../internal/ui/fileExplorer.js";
 import { createCatalogPageHandlers } from "../../internal/ui/resourcePages/catalog/createCatalogPageHandlers.js";
@@ -13,6 +25,378 @@ import {
   renderSelectedAnimationPreview,
   stopAnimationPreviewPlayback,
 } from "./support/animationPreviewRuntime.js";
+
+const DEFAULT_IMPORTED_ANIMATION_NAME = "Imported Animation";
+
+const clonePlainData = (value) => {
+  return isPlainObject(value) ? structuredClone(value) : {};
+};
+
+const getAnimationItemsFromCollection = (collection) => {
+  if (!isPlainObject(collection)) {
+    return [];
+  }
+
+  const treeItems = Array.isArray(collection.tree)
+    ? toFlatItems(collection)
+    : [];
+  const sourceItems =
+    treeItems.length > 0 ? treeItems : Object.values(collection.items ?? {});
+
+  return sourceItems.filter((item) => item?.type === "animation");
+};
+
+const sortPrimaryAnimationFirst = (items, input) => {
+  const primary = input?.primary;
+  if (primary?.resourceType !== "animations" || !primary.id) {
+    return items;
+  }
+
+  const primaryIndex = items.findIndex((item) => item.id === primary.id);
+  if (primaryIndex <= 0) {
+    return items;
+  }
+
+  const nextItems = [...items];
+  const [primaryItem] = nextItems.splice(primaryIndex, 1);
+  nextItems.unshift(primaryItem);
+  return nextItems;
+};
+
+const resolveAnimationImportItems = (input) => {
+  if (!isPlainObject(input)) {
+    return [];
+  }
+
+  if (input.schema === IMPORT_PACK_SCHEMA && input.repository?.animations) {
+    return sortPrimaryAnimationFirst(
+      getAnimationItemsFromCollection(input.repository.animations),
+      input,
+    );
+  }
+
+  if (input.repository?.animations) {
+    return getAnimationItemsFromCollection(input.repository.animations);
+  }
+
+  if (input.items || input.tree) {
+    return getAnimationItemsFromCollection(input);
+  }
+
+  return input.type === "animation" ? [input] : [];
+};
+
+const collectMaskImageIds = (mask, imageIds) => {
+  if (!isPlainObject(mask)) {
+    return;
+  }
+
+  if (mask.imageId) {
+    imageIds.add(mask.imageId);
+  }
+
+  for (const imageId of mask.imageIds ?? []) {
+    if (imageId) {
+      imageIds.add(imageId);
+    }
+  }
+
+  for (const item of mask.items ?? []) {
+    if (item?.imageId) {
+      imageIds.add(item.imageId);
+    }
+  }
+};
+
+const collectAnimationImageIds = (animationItems = []) => {
+  const imageIds = new Set();
+  for (const item of animationItems) {
+    collectMaskImageIds(item?.animation?.mask, imageIds);
+  }
+  return imageIds;
+};
+
+const getImportImageItems = (importInput, imageIds) => {
+  const items = importInput?.repository?.images?.items;
+  if (!isPlainObject(items) || imageIds.size === 0) {
+    return [];
+  }
+
+  return Object.values(items).filter(
+    (item) => item?.type === "image" && imageIds.has(item.id),
+  );
+};
+
+const hasImportImageDependencies = (importInput, animationItems) => {
+  const imageIds = collectAnimationImageIds(animationItems);
+  return getImportImageItems(importInput, imageIds).length > 0;
+};
+
+const getImportImageItemsById = (importInput) => {
+  return isPlainObject(importInput?.repository?.images?.items)
+    ? importInput.repository.images.items
+    : {};
+};
+
+const getImportItemLabel = (item, fallback) => {
+  return item?.name ?? item?.id ?? fallback;
+};
+
+const getAnimationItemValidationMessage = (item) => {
+  if (!isPlainObject(item) || item.type !== "animation") {
+    return "No animation found to import.";
+  }
+
+  const label = getImportItemLabel(item, "Imported animation");
+  if (item.name !== undefined && typeof item.name !== "string") {
+    return `Animation "${label}" name must be text.`;
+  }
+
+  if (item.description !== undefined && typeof item.description !== "string") {
+    return `Animation "${label}" description must be text.`;
+  }
+
+  if (
+    item.tagIds !== undefined &&
+    (!Array.isArray(item.tagIds) ||
+      item.tagIds.some((tagId) => typeof tagId !== "string"))
+  ) {
+    return `Animation "${label}" tags must be text ids.`;
+  }
+
+  if (!isPlainObject(item.animation)) {
+    return `Animation "${label}" is missing animation data.`;
+  }
+
+  if (!["update", "transition"].includes(item.animation.type)) {
+    return `Animation "${label}" has an unsupported animation type.`;
+  }
+
+  return undefined;
+};
+
+const getAnimationImageDependencyValidationMessage = ({
+  importInput,
+  animationItems,
+} = {}) => {
+  const imageIds = collectAnimationImageIds(animationItems);
+  if (imageIds.size === 0) {
+    return undefined;
+  }
+
+  const imageItemsById = getImportImageItemsById(importInput);
+  for (const imageId of imageIds) {
+    const imageItem = imageItemsById[imageId];
+    if (!isPlainObject(imageItem) || imageItem.type !== "image") {
+      return `Image dependency "${imageId}" is missing from the package.`;
+    }
+
+    const label = `Image dependency "${getImportItemLabel(imageItem, imageId)}"`;
+    try {
+      validateImportFileDescriptor({
+        importInput,
+        fileId: imageItem.fileId,
+        label,
+      });
+    } catch (error) {
+      return getImportErrorMessage(
+        error,
+        `${label} has invalid file metadata.`,
+      );
+    }
+  }
+
+  return undefined;
+};
+
+const getAnimationImportValidationMessage = ({
+  importInput,
+  animationItems,
+} = {}) => {
+  try {
+    validateImportPackageObject(importInput);
+  } catch (error) {
+    return getImportErrorMessage(error, "Import package is invalid.");
+  }
+
+  if (animationItems.length === 0) {
+    return "No animation found to import.";
+  }
+
+  for (const item of animationItems) {
+    const itemMessage = getAnimationItemValidationMessage(item);
+    if (itemMessage) {
+      return itemMessage;
+    }
+  }
+
+  return getAnimationImageDependencyValidationMessage({
+    importInput,
+    animationItems,
+  });
+};
+
+const importImageDependencies = async ({
+  importInput,
+  projectService,
+  imageParentId,
+  animationItems,
+} = {}) => {
+  const imageIdMap = new Map();
+  const imageIds = collectAnimationImageIds(animationItems);
+  const imageItems = getImportImageItems(importInput, imageIds);
+
+  for (const imageItem of imageItems) {
+    const fileDescriptor = validateImportFileDescriptor({
+      importInput,
+      fileId: imageItem.fileId,
+      label: `Image dependency "${imageItem.name ?? imageItem.id}"`,
+    });
+
+    const file = await downloadImportFile(fileDescriptor);
+    const imageId = generateId();
+    const result = await projectService.importImageFile({
+      file,
+      imageId,
+      parentId: imageParentId,
+    });
+
+    if (result?.valid === false) {
+      throw result;
+    }
+
+    imageIdMap.set(imageItem.id, result?.imageId ?? imageId);
+  }
+
+  return imageIdMap;
+};
+
+const resolveImageId = (imageId, imageIdMap) => {
+  return imageIdMap.get(imageId) ?? imageId;
+};
+
+const rewriteMaskImageRefs = (mask, imageIdMap) => {
+  if (!isPlainObject(mask) || imageIdMap.size === 0) {
+    return mask;
+  }
+
+  const nextMask = { ...mask };
+  if (nextMask.imageId) {
+    nextMask.imageId = resolveImageId(nextMask.imageId, imageIdMap);
+  }
+
+  if (Array.isArray(nextMask.imageIds)) {
+    nextMask.imageIds = nextMask.imageIds.map((imageId) =>
+      resolveImageId(imageId, imageIdMap),
+    );
+  }
+
+  if (Array.isArray(nextMask.items)) {
+    nextMask.items = nextMask.items.map((item) => {
+      if (!item?.imageId) {
+        return item;
+      }
+
+      return {
+        ...item,
+        imageId: resolveImageId(item.imageId, imageIdMap),
+      };
+    });
+  }
+
+  return nextMask;
+};
+
+const removeImportedResourceMetadata = (data) => {
+  delete data.id;
+  delete data.parentId;
+  delete data._level;
+  delete data.fullLabel;
+  delete data.hasChildren;
+  delete data.children;
+};
+
+const normalizeImportedAnimationData = (item, { imageIdMap } = {}) => {
+  const data = clonePlainData(item);
+  removeImportedResourceMetadata(data);
+
+  data.type = "animation";
+  data.name = data.name ?? DEFAULT_IMPORTED_ANIMATION_NAME;
+  data.description = data.description ?? "";
+  data.tagIds = Array.isArray(data.tagIds) ? data.tagIds : [];
+
+  if (!isPlainObject(data.animation)) {
+    data.animation = {
+      type: "update",
+      tween: {},
+    };
+  }
+
+  if (data.animation.type === "transition" && data.animation.mask) {
+    data.animation = {
+      ...data.animation,
+      mask: rewriteMaskImageRefs(data.animation.mask, imageIdMap ?? new Map()),
+    };
+  }
+
+  return data;
+};
+
+const resolveAnimationImportInput = async ({ appService, values } = {}) => {
+  const url = `${values?.url ?? ""}`.trim();
+  if (!url) {
+    showImportError(appService, "Import URL is required.");
+    return;
+  }
+
+  if (!isValidHttpUrl(url)) {
+    showImportError(appService, "Enter a valid http(s) URL.");
+    return;
+  }
+
+  try {
+    return await fetchImportPackageJson({ url });
+  } catch (error) {
+    showImportError(
+      appService,
+      isImportPackageValidationError(error)
+        ? error.message
+        : "Package could not be loaded.",
+    );
+    return;
+  }
+};
+
+const showImportError = (appService, message) => {
+  if (typeof appService?.showAlert === "function") {
+    appService.showAlert({
+      message,
+      title: "Error",
+    });
+    return;
+  }
+
+  appService?.showToast?.({ message });
+};
+
+const showImportSuccess = (appService, count) => {
+  appService?.showToast?.({
+    message: count === 1 ? "Animation imported." : "Animations imported.",
+  });
+};
+
+const clearImportVisibilityFilters = (store) => {
+  store.setSearchQuery?.({ value: "" });
+  store.setActiveTagIds?.({ tagIds: [] });
+};
+
+const getImportErrorMessage = (error, fallback) => {
+  return error?.error?.message ?? error?.message ?? fallback;
+};
+
+const getImportValidationMessage = () => {
+  return "Import URL is required.";
+};
 
 const navigateToAnimationEditor = ({
   appService,
@@ -323,6 +707,152 @@ export const handleAddAnimationClick = async (deps, payload) => {
   const { groupId } = payload._event.detail;
   store.openAddDialog({ groupId });
   render();
+};
+
+export const handleImportAnimationClick = (deps) => {
+  const { render, store } = deps;
+
+  store.openImportDialog();
+  render();
+};
+
+export const handleImportDialogClose = (deps) => {
+  const { render, store } = deps;
+  store.closeImportDialog();
+  render();
+};
+
+export const handleImportFormActionClick = async (deps, payload) => {
+  const { appService, projectService, store, render } = deps;
+  const { actionId, values, valid } = payload._event.detail;
+
+  if (actionId === "cancel") {
+    store.closeImportDialog();
+    render();
+    return;
+  }
+
+  if (actionId === "back") {
+    store.openImportSourceStep();
+    render();
+    return;
+  }
+
+  if (actionId === "continue") {
+    if (valid === false) {
+      showImportError(appService, getImportValidationMessage());
+      return;
+    }
+
+    const importInput = await resolveAnimationImportInput({
+      appService,
+      values,
+    });
+    if (!importInput) {
+      return;
+    }
+
+    const importItems = resolveAnimationImportItems(importInput);
+    const validationMessage = getAnimationImportValidationMessage({
+      importInput,
+      animationItems: importItems,
+    });
+    if (validationMessage) {
+      showImportError(appService, validationMessage);
+      return;
+    }
+
+    store.openImportDestinationStep({
+      importInput,
+      sourceValues: values,
+      includeImages: hasImportImageDependencies(importInput, importItems),
+    });
+    render();
+    return;
+  }
+
+  if (actionId !== "import") {
+    return;
+  }
+
+  if (valid === false) {
+    showImportError(appService, "Choose destination folders.");
+    return;
+  }
+
+  store.setImportDestinationValues?.({ values });
+  const importInput = store.selectImportDialogPendingInput?.();
+  if (!importInput) {
+    showImportError(
+      appService,
+      "Import package is missing. Click Back and continue again.",
+    );
+    return;
+  }
+
+  const importItems = resolveAnimationImportItems(importInput);
+  const validationMessage = getAnimationImportValidationMessage({
+    importInput,
+    animationItems: importItems,
+  });
+  if (validationMessage) {
+    showImportError(appService, validationMessage);
+    return;
+  }
+
+  const imageParentId = normalizeImportParentId(
+    values?.imageFolderId ?? store.selectImportDialogImageFolderId?.(),
+  );
+  let imageIdMap = new Map();
+  try {
+    imageIdMap = await importImageDependencies({
+      importInput,
+      projectService,
+      imageParentId,
+      animationItems: importItems,
+    });
+  } catch (error) {
+    showImportError(
+      appService,
+      getImportErrorMessage(error, "Image dependencies could not be imported."),
+    );
+    return;
+  }
+
+  const targetGroupId = normalizeImportParentId(
+    values?.animationFolderId ?? store.selectImportDialogTargetGroupId?.(),
+  );
+  const importedAnimationIds = [];
+
+  for (const item of importItems) {
+    const animationId = generateId();
+    const importAttempt = await runResourcePageMutation({
+      appService,
+      fallbackMessage: "Failed to import animation.",
+      action: () =>
+        projectService.createAnimation({
+          animationId,
+          data: normalizeImportedAnimationData(item, {
+            imageIdMap,
+          }),
+          parentId: targetGroupId,
+          position: "last",
+        }),
+    });
+
+    if (!importAttempt.ok) {
+      return;
+    }
+
+    importedAnimationIds.push(animationId);
+  }
+
+  store.closeImportDialog();
+  clearImportVisibilityFilters(store);
+  showImportSuccess(appService, importedAnimationIds.length);
+  await handleDataChanged(deps, {
+    selectedItemId: importedAnimationIds[0],
+  });
 };
 
 export const handleAnimationItemDoubleClick = (deps, payload) => {

--- a/src/pages/animations/animations.store.js
+++ b/src/pages/animations/animations.store.js
@@ -95,6 +95,115 @@ const addForm = {
   },
 };
 
+const IMPORT_FOLDER_ROOT_VALUE = "_root";
+const IMPORT_DIALOG_SOURCE_STEP = "source";
+const IMPORT_DIALOG_DESTINATION_STEP = "destination";
+
+const createImportFolderOptions = (collection) =>
+  toFlatItems(collection)
+    .filter((item) => item.type === "folder")
+    .map((folder) => ({
+      value: folder.id,
+      label: folder.fullLabel || folder.name || folder.id,
+    }));
+
+const createAnimationImportSourceForm = () => ({
+  title: "Import Animation",
+  fields: [
+    {
+      name: "url",
+      type: "input-text",
+      label: "URL",
+      required: {
+        message: "Import URL is required.",
+      },
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "continue",
+        variant: "pr",
+        label: "Continue",
+        validate: true,
+      },
+    ],
+  },
+});
+
+const createAnimationImportDestinationForm = ({
+  animationFolderOptions = [],
+  imageFolderOptions = [],
+  includeImages = false,
+} = {}) => {
+  const fields = [
+    {
+      name: "animationFolderId",
+      type: "select",
+      label: "Animation Folder",
+      clearable: false,
+      required: true,
+      options: animationFolderOptions,
+    },
+  ];
+
+  if (includeImages) {
+    fields.push({
+      name: "imageFolderId",
+      type: "select",
+      label: "Image Folder",
+      clearable: false,
+      required: true,
+      options: imageFolderOptions,
+    });
+  }
+
+  return {
+    title: "Choose Folders",
+    fields,
+    actions: {
+      layout: "",
+      buttons: [
+        {
+          id: "back",
+          variant: "se",
+          label: "Back",
+        },
+        {
+          id: "import",
+          variant: "pr",
+          label: "Import Animation",
+          validate: true,
+        },
+      ],
+    },
+  };
+};
+
+const createImportSourceDefaultValues = () => ({
+  url: "",
+});
+
+const resolveImportFolderValue = (folderId) => {
+  return folderId ? folderId : undefined;
+};
+
+const createImportDestinationDefaultValues = ({
+  animationFolderId,
+  imageFolderId,
+} = {}) => ({
+  animationFolderId: resolveImportFolderValue(animationFolderId),
+  imageFolderId: resolveImportFolderValue(imageFolderId),
+});
+
+const createImportDestinationFormForState = (state) =>
+  createAnimationImportDestinationForm({
+    animationFolderOptions: createImportFolderOptions(state.data),
+    imageFolderOptions: createImportFolderOptions(state.imagesData),
+    includeImages: state.importDialogIncludeImages,
+  });
+
 const animationExplorerItemContextMenuItems = [
   { label: "Edit", type: "item", value: "edit-item" },
   { label: "Rename", type: "item", value: "rename-item" },
@@ -159,6 +268,10 @@ const {
     return {
       ...baseViewData,
       isAddDialogOpen: state.isAddDialogOpen,
+      isImportDialogOpen: state.isImportDialogOpen,
+      importForm: state.importForm,
+      importDialogDefaultValues: state.importDialogDefaultValues,
+      importDialogKey: `${state.isImportDialogOpen}-${state.importDialogStep}`,
       addForm,
       addFormDefaults: {
         name: "",
@@ -187,6 +300,15 @@ const {
 export const createInitialState = () => ({
   ...createCatalogInitialState(),
   isAddDialogOpen: false,
+  isImportDialogOpen: false,
+  importDialogStep: IMPORT_DIALOG_SOURCE_STEP,
+  importDialogTargetGroupId: undefined,
+  importDialogImageFolderId: undefined,
+  importDialogIncludeImages: false,
+  importDialogPendingInput: undefined,
+  importDialogSourceValues: createImportSourceDefaultValues(),
+  importForm: createAnimationImportSourceForm(),
+  importDialogDefaultValues: createImportSourceDefaultValues(),
   targetGroupId: undefined,
   isEditDialogOpen: false,
   editItemId: undefined,
@@ -300,6 +422,72 @@ export const selectAnimationDisplayItemById = ({ state }, { itemId } = {}) => {
     (item) => item.id === itemId && item.type === "animation",
   );
   return rawItem ? toAnimationDisplayItem(rawItem) : undefined;
+};
+
+export const openImportDialog = ({ state }, { targetGroupId } = {}) => {
+  state.isImportDialogOpen = true;
+  state.importDialogStep = IMPORT_DIALOG_SOURCE_STEP;
+  state.importDialogTargetGroupId =
+    targetGroupId === IMPORT_FOLDER_ROOT_VALUE ? undefined : targetGroupId;
+  state.importDialogImageFolderId = undefined;
+  state.importDialogIncludeImages = false;
+  state.importDialogPendingInput = undefined;
+  state.importDialogSourceValues = createImportSourceDefaultValues();
+  state.importDialogDefaultValues = createImportSourceDefaultValues();
+  state.importForm = createAnimationImportSourceForm();
+};
+
+export const openImportDestinationStep = (
+  { state },
+  { importInput, sourceValues, includeImages = false } = {},
+) => {
+  state.importDialogStep = IMPORT_DIALOG_DESTINATION_STEP;
+  state.importDialogPendingInput = importInput;
+  state.importDialogSourceValues =
+    sourceValues ?? createImportSourceDefaultValues();
+  state.importDialogIncludeImages = includeImages;
+  state.importDialogDefaultValues = createImportDestinationDefaultValues({
+    animationFolderId: state.importDialogTargetGroupId,
+    imageFolderId: state.importDialogImageFolderId,
+  });
+  state.importForm = createImportDestinationFormForState(state);
+};
+
+export const openImportSourceStep = ({ state }, _payload = {}) => {
+  state.importDialogStep = IMPORT_DIALOG_SOURCE_STEP;
+  state.importDialogPendingInput = undefined;
+  state.importDialogIncludeImages = false;
+  state.importDialogDefaultValues = state.importDialogSourceValues;
+  state.importForm = createAnimationImportSourceForm();
+};
+
+export const closeImportDialog = ({ state }, _payload = {}) => {
+  state.isImportDialogOpen = false;
+  state.importDialogStep = IMPORT_DIALOG_SOURCE_STEP;
+  state.importDialogTargetGroupId = undefined;
+  state.importDialogImageFolderId = undefined;
+  state.importDialogIncludeImages = false;
+  state.importDialogPendingInput = undefined;
+  state.importDialogSourceValues = createImportSourceDefaultValues();
+  state.importDialogDefaultValues = createImportSourceDefaultValues();
+  state.importForm = createAnimationImportSourceForm();
+};
+
+export const setImportDestinationValues = ({ state }, { values } = {}) => {
+  state.importDialogTargetGroupId = values?.animationFolderId;
+  state.importDialogImageFolderId = values?.imageFolderId;
+};
+
+export const selectImportDialogTargetGroupId = ({ state }) => {
+  return state.importDialogTargetGroupId;
+};
+
+export const selectImportDialogImageFolderId = ({ state }) => {
+  return state.importDialogImageFolderId;
+};
+
+export const selectImportDialogPendingInput = ({ state }) => {
+  return state.importDialogPendingInput;
 };
 
 export const openAddDialog = ({ state }, { groupId } = {}) => {

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -17,6 +17,8 @@ refs:
         handler: handleAnimationItemEdit
       add-click:
         handler: handleAddAnimationClick
+      import-click:
+        handler: handleImportAnimationClick
       item-dblclick:
         handler: handleAnimationItemDoubleClick
       search-input:
@@ -51,6 +53,14 @@ refs:
         handler: handleFileExplorerKeyboardScopeClick
       keydown:
         handler: handleFileExplorerKeyboardScopeKeyDown
+  importDialog:
+    eventListeners:
+      close:
+        handler: handleImportDialogClose
+  importForm:
+    eventListeners:
+      form-action:
+        handler: handleImportFormActionClick
   addDialog:
     eventListeners:
       close:
@@ -114,9 +124,9 @@ template:
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
                   - $if showMobileTopTabs:
                       - 'rtgl-view d=v w=f h=f style="min-width: 0; min-height: 0;"':
-                          - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} show-menu-button show-search=false search-in-filter-popover show-tag-filter :mobileLayout=${mobileLayout} :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :addText=${addText} :itemContextMenuItems=${centerItemContextMenuItems}': null
+                          - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} show-menu-button show-search=false search-in-filter-popover show-tag-filter :mobileLayout=${mobileLayout} :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :addText=${addText} canImport importText="Import" :itemContextMenuItems=${centerItemContextMenuItems}': null
                     $else:
-                      - rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} search-in-filter-popover show-tag-filter fixed-items-per-row=1 :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :addText=${addText} :itemContextMenuItems=${centerItemContextMenuItems}: null
+                      - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} search-in-filter-popover show-tag-filter fixed-items-per-row=1 :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :addText=${addText} canImport importText="Import" :itemContextMenuItems=${centerItemContextMenuItems}': null
           - $if showDetailPanel:
               - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
                   - rtgl-view wh=f slot="content":
@@ -180,6 +190,8 @@ template:
                           - rtgl-text: ${selectedItemDuration}
   - rtgl-dialog#folderNameDialog ?open=${isFolderNameDialogOpen} s=sm:
       - rtgl-form#folderNameForm key=${folderNameDialogItemId} slot=content :defaultValues=${folderNameDialogDefaultValues} :form=${folderNameForm} w=f: null
+  - rtgl-dialog#importDialog ?open=${isImportDialogOpen} s=md:
+      - rtgl-form#importForm key=${importDialogKey} slot=content :defaultValues=${importDialogDefaultValues} :form=${importForm} w=f: null
   - rtgl-dialog#addDialog ?open=${isAddDialogOpen} s=md:
       - rtgl-form#addForm key=${isAddDialogOpen} slot=content :defaultValues=${addFormDefaults} :form=${addForm} w=f: null
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -1,5 +1,16 @@
 import { generateId } from "../../internal/id.js";
 import {
+  IMPORT_PACK_SCHEMA,
+  downloadImportFile,
+  fetchImportPackageJson,
+  isImportPackageValidationError,
+  isPlainObject,
+  isValidHttpUrl,
+  normalizeImportParentId,
+  validateImportFileDescriptor,
+  validateImportPackageObject,
+} from "../../internal/importPackages.js";
+import {
   captureCanvasImage,
   captureCanvasThumbnailImage,
 } from "../../internal/runtime/graphicsEngineRuntime.js";
@@ -16,6 +27,7 @@ import { TRANSFORM_TAG_SCOPE_KEY } from "./transforms.store.js";
 const MARKER_SIZE = 30;
 const BG_COLOR = "#4a4a4a";
 const FALLBACK_TARGET_SIZE = 200;
+const DEFAULT_IMPORTED_TRANSFORM_NAME = "Imported Transform";
 
 const createEmptyPreviewState = () => ({
   elements: [],
@@ -203,6 +215,355 @@ const createTransformPayload = (values = {}) => {
     anchorY: parseFloat(anchor.anchorY ?? 0),
     rotation: parseInt(values.rotation ?? 0, 10) || 0,
   };
+};
+
+const toFiniteNumber = (value, fallback) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : fallback;
+};
+
+const rewritePreviewImageRefs = (preview, imageIdMap = new Map()) => {
+  if (!isPlainObject(preview)) {
+    return undefined;
+  }
+
+  const nextPreview = {};
+  for (const [slotKey, slotValue] of Object.entries(preview)) {
+    if (!isPlainObject(slotValue) || !slotValue.imageId) {
+      continue;
+    }
+
+    const mappedImageId = imageIdMap.get(slotValue.imageId);
+    if (!mappedImageId) {
+      continue;
+    }
+
+    nextPreview[slotKey] = {
+      ...slotValue,
+      imageId: mappedImageId,
+    };
+  }
+
+  return Object.keys(nextPreview).length > 0 ? nextPreview : undefined;
+};
+
+const normalizeImportedTransformData = (item = {}, { imageIdMap } = {}) => {
+  const anchor = isPlainObject(item.anchor) ? item.anchor : {};
+  const transformData = {
+    name: `${item.name ?? ""}`.trim() || DEFAULT_IMPORTED_TRANSFORM_NAME,
+    description: item.description ?? "",
+    x: Math.round(toFiniteNumber(item.x, 0)),
+    y: Math.round(toFiniteNumber(item.y, 0)),
+    scaleX: toFiniteNumber(item.scaleX, 1),
+    scaleY: toFiniteNumber(item.scaleY, 1),
+    anchorX: toFiniteNumber(item.anchorX ?? anchor.anchorX, 0),
+    anchorY: toFiniteNumber(item.anchorY ?? anchor.anchorY, 0),
+    rotation: toFiniteNumber(item.rotation, 0),
+  };
+
+  const preview = rewritePreviewImageRefs(item.preview, imageIdMap);
+  if (preview) {
+    transformData.preview = preview;
+  }
+
+  const tagIds = Array.isArray(item.tagIds)
+    ? item.tagIds.filter((tagId) => typeof tagId === "string" && tagId)
+    : [];
+  if (tagIds.length > 0) {
+    transformData.tagIds = tagIds;
+  }
+
+  return transformData;
+};
+
+const findTransformItemInTree = (collection = {}) => {
+  const items = collection?.items ?? {};
+  const visit = (nodes = []) => {
+    for (const node of nodes) {
+      const item = items[node?.id];
+      if (item?.type === "transform") {
+        return item;
+      }
+
+      const childItem = visit(node?.children ?? []);
+      if (childItem) {
+        return childItem;
+      }
+    }
+
+    return undefined;
+  };
+
+  return (
+    visit(collection?.tree ?? []) ??
+    Object.values(items).find((item) => item?.type === "transform")
+  );
+};
+
+const resolvePrimaryTransformImportItem = (input) => {
+  const primary = input?.primary;
+  if (primary?.resourceType !== "transforms" || !primary.id) {
+    return undefined;
+  }
+
+  const item = input.repository?.transforms?.items?.[primary.id];
+  return item?.type === "transform" ? item : undefined;
+};
+
+const resolveTransformImportItem = (input) => {
+  if (!isPlainObject(input)) {
+    return undefined;
+  }
+
+  const primaryItem = resolvePrimaryTransformImportItem(input);
+  if (primaryItem) {
+    return primaryItem;
+  }
+
+  if (input.schema === IMPORT_PACK_SCHEMA) {
+    return findTransformItemInTree(input.repository?.transforms);
+  }
+
+  if (input.items || input.tree) {
+    return findTransformItemInTree(input);
+  }
+
+  if (input.repository?.transforms) {
+    return findTransformItemInTree(input.repository.transforms);
+  }
+
+  return input.type === "transform" ? input : undefined;
+};
+
+const getImportImageItemsById = (importInput) => {
+  return isPlainObject(importInput?.repository?.images?.items)
+    ? importInput.repository.images.items
+    : {};
+};
+
+const getImportImageItems = (importInput, imageIds) => {
+  const items = getImportImageItemsById(importInput);
+  if (imageIds.size === 0) {
+    return [];
+  }
+
+  return [...imageIds]
+    .map((imageId) => items[imageId])
+    .filter((item) => item?.type === "image");
+};
+
+const hasImportImageDependencies = (transformItem) => {
+  return collectTransformPreviewImageIds(transformItem?.preview).size > 0;
+};
+
+const collectTransformPreviewImageIds = (preview) => {
+  const imageIds = new Set();
+  if (!isPlainObject(preview)) {
+    return imageIds;
+  }
+
+  for (const slotValue of Object.values(preview)) {
+    if (slotValue?.imageId) {
+      imageIds.add(slotValue.imageId);
+    }
+  }
+
+  return imageIds;
+};
+
+const getImportItemLabel = (item, fallback) => {
+  return item?.name ?? item?.id ?? fallback;
+};
+
+const getTransformItemValidationMessage = (item) => {
+  if (!isPlainObject(item) || item.type !== "transform") {
+    return "No transform found to import.";
+  }
+
+  const label = getImportItemLabel(item, "Imported transform");
+  if (item.name !== undefined && typeof item.name !== "string") {
+    return `Transform "${label}" name must be text.`;
+  }
+
+  if (item.description !== undefined && typeof item.description !== "string") {
+    return `Transform "${label}" description must be text.`;
+  }
+
+  if (
+    item.tagIds !== undefined &&
+    (!Array.isArray(item.tagIds) ||
+      item.tagIds.some((tagId) => typeof tagId !== "string"))
+  ) {
+    return `Transform "${label}" tags must be text ids.`;
+  }
+
+  const numberFields = [
+    ["x", "x"],
+    ["y", "y"],
+    ["scaleX", "scale X"],
+    ["scaleY", "scale Y"],
+    ["anchorX", "anchor X"],
+    ["anchorY", "anchor Y"],
+    ["rotation", "rotation"],
+  ];
+  for (const [field, fieldLabel] of numberFields) {
+    if (item[field] !== undefined && !Number.isFinite(Number(item[field]))) {
+      return `Transform "${label}" ${fieldLabel} must be a number.`;
+    }
+  }
+
+  if (item.preview !== undefined && !isPlainObject(item.preview)) {
+    return `Transform "${label}" preview must be an object.`;
+  }
+
+  return undefined;
+};
+
+const getTransformImageDependencyValidationMessage = ({
+  importInput,
+  transformItem,
+} = {}) => {
+  const imageItemsById = getImportImageItemsById(importInput);
+  const previewImageIds = collectTransformPreviewImageIds(
+    transformItem?.preview,
+  );
+
+  for (const imageId of previewImageIds) {
+    const imageItem = imageItemsById[imageId];
+    if (!isPlainObject(imageItem) || imageItem.type !== "image") {
+      return `Image dependency "${imageId}" is missing from the package.`;
+    }
+
+    const label = `Image dependency "${getImportItemLabel(imageItem, imageItem.id)}"`;
+    try {
+      validateImportFileDescriptor({
+        importInput,
+        fileId: imageItem.fileId,
+        label,
+      });
+    } catch (error) {
+      return getImportErrorMessage(
+        error,
+        `${label} has invalid file metadata.`,
+      );
+    }
+  }
+
+  return undefined;
+};
+
+const getTransformImportValidationMessage = ({
+  importInput,
+  transformItem,
+}) => {
+  try {
+    validateImportPackageObject(importInput);
+  } catch (error) {
+    return getImportErrorMessage(error, "Import package is invalid.");
+  }
+
+  const itemMessage = getTransformItemValidationMessage(transformItem);
+  if (itemMessage) {
+    return itemMessage;
+  }
+
+  return getTransformImageDependencyValidationMessage({
+    importInput,
+    transformItem,
+  });
+};
+
+const importImageDependencies = async ({
+  importInput,
+  projectService,
+  imageParentId,
+  transformItem,
+} = {}) => {
+  const imageIdMap = new Map();
+  const imageItems = getImportImageItems(
+    importInput,
+    collectTransformPreviewImageIds(transformItem?.preview),
+  );
+
+  for (const imageItem of imageItems) {
+    const fileDescriptor = validateImportFileDescriptor({
+      importInput,
+      fileId: imageItem.fileId,
+      label: `Image dependency "${imageItem.name ?? imageItem.id}"`,
+    });
+
+    const file = await downloadImportFile(fileDescriptor);
+    const imageId = generateId();
+    const result = await projectService.importImageFile({
+      file,
+      imageId,
+      parentId: imageParentId,
+    });
+
+    if (result?.valid === false) {
+      throw result;
+    }
+
+    imageIdMap.set(imageItem.id, result?.imageId ?? imageId);
+  }
+
+  return imageIdMap;
+};
+
+const resolveTransformImportInput = async ({ appService, values } = {}) => {
+  const url = `${values?.url ?? ""}`.trim();
+  if (!url) {
+    showImportError(appService, "Import URL is required.");
+    return;
+  }
+
+  if (!isValidHttpUrl(url)) {
+    showImportError(appService, "Enter a valid http(s) URL.");
+    return;
+  }
+
+  try {
+    return await fetchImportPackageJson({ url });
+  } catch (error) {
+    showImportError(
+      appService,
+      isImportPackageValidationError(error)
+        ? error.message
+        : "Package could not be loaded.",
+    );
+    return;
+  }
+};
+
+const showImportError = (appService, message) => {
+  if (typeof appService?.showAlert === "function") {
+    appService.showAlert({
+      message,
+      title: "Error",
+    });
+    return;
+  }
+
+  appService?.showToast?.({ message });
+};
+
+const showImportSuccess = (appService) => {
+  appService?.showToast?.({
+    message: "Transform imported.",
+  });
+};
+
+const clearImportVisibilityFilters = (store) => {
+  store.setSearchQuery?.({ value: "" });
+  store.setActiveTagIds?.({ tagIds: [] });
+};
+
+const getImportErrorMessage = (error, fallback) => {
+  return error?.error?.message ?? error?.message ?? fallback;
+};
+
+const getImportValidationMessage = () => {
+  return "Import URL is required.";
 };
 
 const loadTransformPreviewAssets = async ({
@@ -564,6 +925,150 @@ export const handleAddTransformClick = async (deps, payload) => {
   await openTransformDialog({
     deps,
     targetGroupId: groupId,
+  });
+};
+
+export const handleImportTransformClick = (deps) => {
+  const { render, store } = deps;
+
+  store.openImportDialog();
+  render();
+};
+
+export const handleImportDialogClose = (deps) => {
+  const { render, store } = deps;
+  store.closeImportDialog();
+  render();
+};
+
+export const handleImportFormActionClick = async (deps, payload) => {
+  const { appService, projectService, render, store } = deps;
+  const { actionId, values, valid } = payload._event.detail;
+
+  if (actionId === "cancel") {
+    store.closeImportDialog();
+    render();
+    return;
+  }
+
+  if (actionId === "back") {
+    store.openImportSourceStep();
+    render();
+    return;
+  }
+
+  if (actionId === "continue") {
+    if (valid === false) {
+      showImportError(appService, getImportValidationMessage(values));
+      return;
+    }
+
+    const importInput = await resolveTransformImportInput({
+      appService,
+      values,
+    });
+    if (!importInput) {
+      return;
+    }
+
+    const importItem = resolveTransformImportItem(importInput);
+    const validationMessage = getTransformImportValidationMessage({
+      importInput,
+      transformItem: importItem,
+    });
+    if (validationMessage) {
+      showImportError(appService, validationMessage);
+      return;
+    }
+
+    store.openImportDestinationStep({
+      importInput,
+      sourceValues: values,
+      includeImages: hasImportImageDependencies(importItem),
+    });
+    render();
+    return;
+  }
+
+  if (actionId !== "import") {
+    return;
+  }
+
+  if (valid === false) {
+    showImportError(appService, "Choose destination folders.");
+    return;
+  }
+
+  store.setImportDestinationValues?.({ values });
+  const importInput = store.selectImportDialogPendingInput?.();
+  if (!importInput) {
+    showImportError(
+      appService,
+      "Import package is missing. Click Back and continue again.",
+    );
+    return;
+  }
+
+  const importItem = resolveTransformImportItem(importInput);
+  const validationMessage = getTransformImportValidationMessage({
+    importInput,
+    transformItem: importItem,
+  });
+  if (validationMessage) {
+    showImportError(appService, validationMessage);
+    return;
+  }
+
+  const imageParentId = normalizeImportParentId(
+    values?.imageFolderId ?? store.selectImportDialogImageFolderId?.(),
+  );
+  let imageIdMap = new Map();
+  try {
+    imageIdMap = await importImageDependencies({
+      importInput,
+      projectService,
+      imageParentId,
+      transformItem: importItem,
+    });
+  } catch (error) {
+    showImportError(
+      appService,
+      error?.message ?? "Image dependencies could not be imported.",
+    );
+    return;
+  }
+
+  const transformData = normalizeImportedTransformData(importItem, {
+    imageIdMap,
+  });
+  const transformId = generateId();
+  const targetGroupId = normalizeImportParentId(
+    values?.transformFolderId ?? store.selectImportDialogTargetGroupId?.(),
+  );
+  const importAttempt = await runResourcePageMutation({
+    appService,
+    fallbackMessage: "Failed to import transform.",
+    action: () =>
+      projectService.createTransform({
+        transformId,
+        data: {
+          type: "transform",
+          ...transformData,
+        },
+        parentId: targetGroupId,
+        position: "last",
+      }),
+  });
+
+  if (!importAttempt.ok) {
+    return;
+  }
+
+  store.closeImportDialog();
+  clearImportVisibilityFilters(store);
+  showImportSuccess(appService);
+  await handleDataChanged(deps, {
+    selectedItemId: transformId,
   });
 };
 

--- a/src/pages/transforms/transforms.store.js
+++ b/src/pages/transforms/transforms.store.js
@@ -147,6 +147,117 @@ const createTransformForm = ({
   };
 };
 
+const IMPORT_FOLDER_ROOT_VALUE = "_root";
+const IMPORT_DIALOG_SOURCE_STEP = "source";
+const IMPORT_DIALOG_DESTINATION_STEP = "destination";
+
+const createImportFolderOptions = (collection) =>
+  toFlatItems(collection)
+    .filter((item) => item.type === "folder")
+    .map((folder) => ({
+      value: folder.id,
+      label: folder.fullLabel || folder.name || folder.id,
+    }));
+
+const createTransformImportSourceForm = () => ({
+  title: "Import Transform",
+  fields: [
+    {
+      name: "url",
+      type: "input-text",
+      label: "URL",
+      required: {
+        message: "Import URL is required.",
+      },
+    },
+  ],
+  actions: {
+    layout: "",
+    buttons: [
+      {
+        id: "continue",
+        variant: "pr",
+        label: "Continue",
+        validate: true,
+      },
+    ],
+  },
+});
+
+const createTransformImportDestinationForm = ({
+  transformFolderOptions = [],
+  imageFolderOptions = [],
+  includeImages = false,
+} = {}) => {
+  const fields = [
+    {
+      name: "transformFolderId",
+      type: "select",
+      label: "Transform Folder",
+      clearable: false,
+      required: true,
+      options: transformFolderOptions,
+    },
+  ];
+
+  if (includeImages) {
+    fields.push({
+      name: "imageFolderId",
+      type: "select",
+      label: "Image Folder",
+      clearable: false,
+      required: true,
+      options: imageFolderOptions,
+    });
+  }
+
+  return {
+    title: "Choose Folders",
+    fields,
+    actions: {
+      layout: "",
+      buttons: [
+        {
+          id: "back",
+          variant: "se",
+          label: "Back",
+        },
+        {
+          id: "import",
+          variant: "pr",
+          label: "Import Transform",
+          validate: true,
+        },
+      ],
+    },
+  };
+};
+
+const createImportSourceDefaultValues = () => ({
+  url: "",
+});
+
+const resolveImportFolderValue = (folderId) => {
+  return typeof folderId === "string" && folderId.length > 0
+    ? folderId
+    : undefined;
+};
+
+const createImportDestinationDefaultValues = ({
+  transformFolderId,
+  imageFolderId,
+} = {}) => ({
+  transformFolderId: resolveImportFolderValue(transformFolderId),
+  imageFolderId: resolveImportFolderValue(imageFolderId),
+});
+
+const createImportDestinationFormForState = (state) =>
+  createTransformImportDestinationForm({
+    transformFolderOptions: createImportFolderOptions(state.data),
+    imageFolderOptions: createImportFolderOptions(state.imagesData),
+    includeImages: state.importDialogIncludeImages,
+  });
+
 const createDialogDefaultValues = (item) => ({
   name: item?.name ?? "",
   description: item?.description ?? "",
@@ -360,6 +471,10 @@ const {
     return {
       ...baseViewData,
       isDialogOpen: state.isDialogOpen,
+      isImportDialogOpen: state.isImportDialogOpen,
+      importForm: state.importForm,
+      importDialogDefaultValues: state.importDialogDefaultValues,
+      importDialogKey: `${state.isImportDialogOpen}-${state.importDialogStep}`,
       isPreviewOnlyDialog: state.dialogMode === "preview",
       transformForm: state.transformForm,
       dialogDefaultValues: state.dialogDefaultValues,
@@ -388,6 +503,15 @@ const {
 export const createInitialState = () => ({
   ...createCatalogInitialState(),
   isDialogOpen: false,
+  isImportDialogOpen: false,
+  importDialogStep: IMPORT_DIALOG_SOURCE_STEP,
+  importDialogTargetGroupId: undefined,
+  importDialogImageFolderId: undefined,
+  importDialogIncludeImages: false,
+  importDialogPendingInput: undefined,
+  importDialogSourceValues: createImportSourceDefaultValues(),
+  importForm: createTransformImportSourceForm(),
+  importDialogDefaultValues: createImportSourceDefaultValues(),
   dialogMode: "form",
   targetGroupId: undefined,
   editMode: false,
@@ -533,6 +657,72 @@ export const closeTransformFormDialog = ({ state }, _payload = {}) => {
   state.transformForm = createTransformForm({
     projectResolution: state.projectResolution,
   });
+};
+
+export const openImportDialog = ({ state }, { targetGroupId } = {}) => {
+  state.isImportDialogOpen = true;
+  state.importDialogStep = IMPORT_DIALOG_SOURCE_STEP;
+  state.importDialogTargetGroupId =
+    targetGroupId === IMPORT_FOLDER_ROOT_VALUE ? undefined : targetGroupId;
+  state.importDialogImageFolderId = undefined;
+  state.importDialogIncludeImages = false;
+  state.importDialogPendingInput = undefined;
+  state.importDialogSourceValues = createImportSourceDefaultValues();
+  state.importDialogDefaultValues = createImportSourceDefaultValues();
+  state.importForm = createTransformImportSourceForm();
+};
+
+export const openImportDestinationStep = (
+  { state },
+  { importInput, sourceValues, includeImages = false } = {},
+) => {
+  state.importDialogStep = IMPORT_DIALOG_DESTINATION_STEP;
+  state.importDialogPendingInput = importInput;
+  state.importDialogSourceValues =
+    sourceValues ?? createImportSourceDefaultValues();
+  state.importDialogIncludeImages = includeImages;
+  state.importDialogDefaultValues = createImportDestinationDefaultValues({
+    transformFolderId: state.importDialogTargetGroupId,
+    imageFolderId: state.importDialogImageFolderId,
+  });
+  state.importForm = createImportDestinationFormForState(state);
+};
+
+export const openImportSourceStep = ({ state }, _payload = {}) => {
+  state.importDialogStep = IMPORT_DIALOG_SOURCE_STEP;
+  state.importDialogPendingInput = undefined;
+  state.importDialogIncludeImages = false;
+  state.importDialogDefaultValues = state.importDialogSourceValues;
+  state.importForm = createTransformImportSourceForm();
+};
+
+export const closeImportDialog = ({ state }, _payload = {}) => {
+  state.isImportDialogOpen = false;
+  state.importDialogStep = IMPORT_DIALOG_SOURCE_STEP;
+  state.importDialogTargetGroupId = undefined;
+  state.importDialogImageFolderId = undefined;
+  state.importDialogIncludeImages = false;
+  state.importDialogPendingInput = undefined;
+  state.importDialogSourceValues = createImportSourceDefaultValues();
+  state.importDialogDefaultValues = createImportSourceDefaultValues();
+  state.importForm = createTransformImportSourceForm();
+};
+
+export const setImportDestinationValues = ({ state }, { values } = {}) => {
+  state.importDialogTargetGroupId = values?.transformFolderId;
+  state.importDialogImageFolderId = values?.imageFolderId;
+};
+
+export const selectImportDialogTargetGroupId = ({ state }) => {
+  return state.importDialogTargetGroupId;
+};
+
+export const selectImportDialogImageFolderId = ({ state }) => {
+  return state.importDialogImageFolderId;
+};
+
+export const selectImportDialogPendingInput = ({ state }) => {
+  return state.importDialogPendingInput;
 };
 
 export const selectTargetGroupId = ({ state }) => {

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -19,6 +19,8 @@ refs:
         handler: handleTransformItemDoubleClick
       add-click:
         handler: handleAddTransformClick
+      import-click:
+        handler: handleImportTransformClick
       search-input:
         handler: handleSearchInput
       tag-filter-change:
@@ -63,6 +65,14 @@ refs:
         handler: handleTransformFormChange
       add-option-click:
         handler: handleTransformFormAddOptionClick
+  importDialog:
+    eventListeners:
+      close:
+        handler: handleImportDialogClose
+  importForm:
+    eventListeners:
+      form-action:
+        handler: handleImportFormActionClick
   transformPreviewImageButton*:
     eventListeners:
       click:
@@ -150,9 +160,9 @@ template:
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
                   - $if showMobileTopTabs:
                       - 'rtgl-view d=v w=f h=f style="min-width: 0; min-height: 0;"':
-                          - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} show-menu-button show-search=false search-in-filter-popover show-tag-filter :mobileLayout=${mobileLayout} :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :emptyMessage=${emptyMessage} :addText=${addText} :itemContextMenuItems=${centerItemContextMenuItems}': null
+                          - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} show-menu-button show-search=false search-in-filter-popover show-tag-filter :mobileLayout=${mobileLayout} :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :emptyMessage=${emptyMessage} :addText=${addText} canImport importText="Import" :itemContextMenuItems=${centerItemContextMenuItems}': null
                     $else:
-                      - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} show-zoom-controls zoom-control-mode=columns default-items-per-row=6 items-per-row-config-key="groupTransformsView.itemsPerRow" search-in-filter-popover :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} show-tag-filter :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :emptyMessage=${emptyMessage} :addText=${addText} :itemContextMenuItems=${centerItemContextMenuItems}': null
+                      - 'rvn-catalog-resources-view#groupview w=f h=f :navTitle=${title} show-zoom-controls zoom-control-mode=columns default-items-per-row=6 items-per-row-config-key="groupTransformsView.itemsPerRow" search-in-filter-popover :groups=${catalogGroups} :selectedItemId=${selectedItemId} :selectedFolderId=${selectedFolderId} :searchQuery=${searchQuery} show-tag-filter :tagFilterOptions=${tagFilterOptions} :selectedTagFilterValues=${selectedTagFilterValues} :tagFilterPlaceholder=${tagFilterPlaceholder} :emptyMessage=${emptyMessage} :addText=${addText} canImport importText="Import" :itemContextMenuItems=${centerItemContextMenuItems}': null
           - $if showDetailPanel:
               - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
                   - rtgl-view wh=f slot="content":
@@ -196,6 +206,8 @@ template:
                       - rtgl-tag-select#detailTagSelect slot="transform-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
   - rtgl-dialog#folderNameDialog ?open=${isFolderNameDialogOpen} s=sm:
       - rtgl-form#folderNameForm key=${folderNameDialogItemId} slot=content :defaultValues=${folderNameDialogDefaultValues} :form=${folderNameForm} w=f: null
+  - rtgl-dialog#importDialog ?open=${isImportDialogOpen} s=md:
+      - rtgl-form#importForm key=${importDialogKey} slot=content :defaultValues=${importDialogDefaultValues} :form=${importForm} w=f: null
   - rtgl-dialog#transformDialog ?open=${isDialogOpen} s=lg:
       - rtgl-view slot="content" d=h lg-d=v ah=c g=lg w=f:
           - $if isDialogOpen:

--- a/tests/animations/animations.handlers.test.js
+++ b/tests/animations/animations.handlers.test.js
@@ -1,10 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleAnimationItemClick,
   handleFileExplorerSelectionChanged,
+  handleImportAnimationClick,
+  handleImportFormActionClick,
 } from "../../src/pages/animations/animations.handlers.js";
 
+const originalFetch = globalThis.fetch;
+
 describe("animations.handlers", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   it("selects an animation from the catalog without logging", () => {
     const deps = {
       store: {
@@ -331,5 +339,414 @@ describe("animations.handlers", () => {
     });
 
     vi.unstubAllGlobals();
+  });
+
+  it("opens animation import as a global page action", () => {
+    const render = vi.fn();
+    const store = {
+      openImportDialog: vi.fn(),
+    };
+
+    handleImportAnimationClick({ render, store });
+
+    expect(store.openImportDialog).toHaveBeenCalledWith();
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("shows an alert when the import URL is invalid", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    globalThis.fetch = vi.fn();
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        render: vi.fn(),
+        store: {},
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values: {
+              url: "/public/import-transform-sample.json",
+            },
+          },
+        },
+      },
+    );
+
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message: "Enter a valid http(s) URL.",
+      title: "Error",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows an alert when animation image dependencies are missing", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      openImportDestinationStep: vi.fn(),
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: vi.fn(() => "application/json"),
+      },
+      json: vi.fn(async () => ({
+        schema: "routevn.import-pack.v1",
+        repository: {
+          animations: {
+            items: {
+              "animation.mask": {
+                id: "animation.mask",
+                type: "animation",
+                name: "Mask Animation",
+                animation: {
+                  type: "transition",
+                  mask: {
+                    kind: "single",
+                    imageId: "image.missing",
+                  },
+                },
+              },
+            },
+            tree: [{ id: "animation.mask" }],
+          },
+          images: {
+            items: {},
+          },
+        },
+      })),
+    }));
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values: {
+              url: "https://example.com/import-animation-mask-sample.json",
+            },
+          },
+        },
+      },
+    );
+
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message: 'Image dependency "image.missing" is missing from the package.',
+      title: "Error",
+    });
+    expect(store.openImportDestinationStep).not.toHaveBeenCalled();
+  });
+
+  it("continues to folder selection after parsing a valid animation package", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      openImportDestinationStep: vi.fn(),
+    };
+    const importInput = {
+      schema: "routevn.import-pack.v1",
+      repository: {
+        animations: {
+          items: {
+            "animation.mask": {
+              id: "animation.mask",
+              type: "animation",
+              name: "Mask Animation",
+              animation: {
+                type: "transition",
+                mask: {
+                  kind: "single",
+                  imageId: "image.mask",
+                  channel: "alpha",
+                },
+              },
+            },
+          },
+          tree: [{ id: "animation.mask" }],
+        },
+        images: {
+          items: {
+            "image.mask": {
+              id: "image.mask",
+              type: "image",
+              name: "Mask",
+              fileId: "file.mask",
+            },
+          },
+        },
+      },
+      files: {
+        "file.mask": {
+          url: "https://example.com/mask.png",
+          mimeType: "image/png",
+        },
+      },
+    };
+    const values = {
+      url: "http://localhost:3001/public/import-transform-sample.json",
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: vi.fn(async () => importInput),
+    }));
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values,
+          },
+        },
+      },
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:3001/public/import-transform-sample.json",
+      {
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+    expect(store.openImportDestinationStep).toHaveBeenCalledWith({
+      importInput,
+      sourceValues: values,
+      includeImages: true,
+    });
+  });
+
+  it("imports animations and rewrites mask image dependencies", async () => {
+    const importedAnimations = [];
+    const importInput = {
+      schema: "routevn.import-pack.v1",
+      repository: {
+        animations: {
+          items: {
+            "animation.shake": {
+              id: "animation.shake",
+              type: "animation",
+              name: "Shake",
+              animation: {
+                type: "update",
+                tween: {
+                  x: {
+                    keyframes: [
+                      {
+                        duration: 100,
+                        value: 12,
+                        easing: "linear",
+                        relative: true,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+            "animation.mask": {
+              id: "animation.mask",
+              type: "animation",
+              name: "Mask Animation",
+              animation: {
+                type: "transition",
+                mask: {
+                  kind: "single",
+                  imageId: "image.mask",
+                  channel: "alpha",
+                },
+              },
+            },
+          },
+          tree: [{ id: "animation.shake" }, { id: "animation.mask" }],
+        },
+        images: {
+          items: {
+            "image.mask": {
+              id: "image.mask",
+              type: "image",
+              name: "Mask",
+              fileId: "file.mask",
+            },
+          },
+        },
+      },
+      files: {
+        "file.mask": {
+          url: "https://example.com/mask.png",
+          name: "mask.png",
+          mimeType: "image/png",
+        },
+      },
+    };
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const render = vi.fn();
+    const store = {
+      closeImportDialog: vi.fn(),
+      selectImportDialogPendingInput: vi.fn(() => importInput),
+      selectImportDialogTargetGroupId: vi.fn(() => undefined),
+      selectImportDialogImageFolderId: vi.fn(() => undefined),
+      setImportDestinationValues: vi.fn(),
+      setSearchQuery: vi.fn(),
+      setActiveTagIds: vi.fn(),
+      setAnimationPreviewVisible: vi.fn(),
+      setItems: vi.fn(),
+      setSelectedFolderId: vi.fn(),
+      setSelectedItemId: vi.fn(),
+      setTagsData: vi.fn(),
+      setProjectResolution: vi.fn(),
+      setImagesData: vi.fn(),
+      selectSelectedItemId: vi.fn(() => importedAnimations[0]?.animationId),
+      selectAnimationItemById: vi.fn(({ itemId } = {}) => {
+        return importedAnimations.find(
+          (animation) => animation.animationId === itemId,
+        )?.data;
+      }),
+      clearPreviewRuntime: vi.fn(),
+    };
+    const projectService = {
+      importImageFile: vi.fn(async () => ({
+        imageId: "project-image-mask",
+      })),
+      createAnimation: vi.fn(async (input) => {
+        importedAnimations.push(input);
+        return input.animationId;
+      }),
+      getRepositoryState: vi.fn(() => ({
+        animations: {
+          items: Object.fromEntries(
+            importedAnimations.map((animation) => [
+              animation.animationId,
+              {
+                id: animation.animationId,
+                ...animation.data,
+              },
+            ]),
+          ),
+          tree: importedAnimations.map((animation) => ({
+            id: animation.animationId,
+          })),
+        },
+        images: {
+          items: {},
+          tree: [],
+        },
+        project: {},
+        tags: {},
+      })),
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      blob: vi.fn(async () => new Blob(["mask"], { type: "image/png" })),
+    }));
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService,
+        refs: {
+          fileExplorer: {
+            selectItem: vi.fn(),
+          },
+        },
+        render,
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "import",
+            valid: true,
+            values: {
+              animationFolderId: "folder-animation",
+              imageFolderId: "folder-image",
+            },
+          },
+        },
+      },
+    );
+
+    expect(projectService.importImageFile).toHaveBeenCalledWith({
+      file: expect.objectContaining({
+        name: "mask.png",
+      }),
+      imageId: expect.any(String),
+      parentId: "folder-image",
+    });
+    expect(projectService.createAnimation).toHaveBeenCalledTimes(2);
+    expect(
+      projectService.createAnimation.mock.calls[0][0].data,
+    ).not.toHaveProperty("_level");
+    expect(
+      projectService.createAnimation.mock.calls[0][0].data,
+    ).not.toHaveProperty("fullLabel");
+    expect(
+      projectService.createAnimation.mock.calls[0][0].data,
+    ).not.toHaveProperty("hasChildren");
+    expect(
+      projectService.createAnimation.mock.calls[1][0].data,
+    ).not.toHaveProperty("_level");
+    expect(
+      projectService.createAnimation.mock.calls[1][0].data,
+    ).not.toHaveProperty("fullLabel");
+    expect(
+      projectService.createAnimation.mock.calls[1][0].data,
+    ).not.toHaveProperty("hasChildren");
+    expect(projectService.createAnimation).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: "Shake",
+        }),
+        parentId: "folder-animation",
+      }),
+    );
+    expect(projectService.createAnimation).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          animation: expect.objectContaining({
+            mask: expect.objectContaining({
+              imageId: "project-image-mask",
+            }),
+          }),
+        }),
+        parentId: "folder-animation",
+      }),
+    );
+    expect(store.closeImportDialog).toHaveBeenCalled();
+    expect(store.setSearchQuery).toHaveBeenCalledWith({ value: "" });
+    expect(store.setActiveTagIds).toHaveBeenCalledWith({ tagIds: [] });
+    expect(appService.showToast).toHaveBeenCalledWith({
+      message: "Animations imported.",
+    });
   });
 });

--- a/tests/animations/animations.store.test.js
+++ b/tests/animations/animations.store.test.js
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  openImportDestinationStep,
+  openImportDialog,
   selectViewData,
   setAnimationPreviewVisible,
+  setImagesData,
   setItems,
   setSelectedItemId,
 } from "../../src/pages/animations/animations.store.js";
@@ -50,5 +53,90 @@ describe("animations.store", () => {
     );
 
     expect(selectViewData({ state }).animationPreviewOpacity).toBe(1);
+  });
+
+  it("configures the import form for URL packages", () => {
+    const state = createInitialState();
+    openImportDialog({ state });
+
+    const viewData = selectViewData({ state });
+    const form = viewData.importForm;
+    const urlField = form.fields.find((field) => field.name === "url");
+    const continueButton = form.actions.buttons.find(
+      (button) => button.id === "continue",
+    );
+
+    expect(urlField).toMatchObject({
+      required: {
+        message: "Import URL is required.",
+      },
+    });
+    expect(viewData.importDialogDefaultValues).toEqual({
+      url: "",
+    });
+    expect(continueButton).toMatchObject({
+      label: "Continue",
+      validate: true,
+    });
+  });
+
+  it("configures destination folder selectors for animation and image dependencies", () => {
+    const state = createInitialState();
+    setItems(
+      { state },
+      {
+        data: {
+          items: {
+            "folder-animation": {
+              id: "folder-animation",
+              type: "folder",
+              name: "Animation Folder",
+            },
+          },
+          tree: [{ id: "folder-animation" }],
+        },
+      },
+    );
+    setImagesData(
+      { state },
+      {
+        imagesData: {
+          items: {
+            "folder-image": {
+              id: "folder-image",
+              type: "folder",
+              name: "Image Folder",
+            },
+          },
+          tree: [{ id: "folder-image" }],
+        },
+      },
+    );
+
+    openImportDestinationStep(
+      { state },
+      {
+        importInput: {},
+        sourceValues: {
+          url: "http://localhost:3001/public/import-transform-sample.json",
+        },
+        includeImages: true,
+      },
+    );
+
+    const form = selectViewData({ state }).importForm;
+    const animationFolderField = form.fields.find(
+      (field) => field.name === "animationFolderId",
+    );
+    const imageFolderField = form.fields.find(
+      (field) => field.name === "imageFolderId",
+    );
+
+    expect(animationFolderField.options).toEqual([
+      { value: "folder-animation", label: "Animation Folder" },
+    ]);
+    expect(imageFolderField.options).toEqual([
+      { value: "folder-image", label: "Image Folder" },
+    ]);
   });
 });

--- a/tests/catalogResourcesView/catalogResourcesView.store.test.js
+++ b/tests/catalogResourcesView/catalogResourcesView.store.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  toggleGroupCollapse,
+} from "../../src/components/catalogResourcesView/catalogResourcesView.store.js";
+
+describe("catalogResourcesView.store", () => {
+  it("keeps the selected item visible inside a collapsed group", () => {
+    const state = createInitialState();
+    toggleGroupCollapse(
+      { state },
+      {
+        groupId: "folder-1",
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        selectedItemId: "animation-1",
+        groups: [
+          {
+            id: "folder-1",
+            name: "Folder",
+            fullLabel: "Folder",
+            children: [
+              {
+                id: "animation-1",
+                name: "Imported Animation",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(viewData.groups[0].isCollapsed).toBe(false);
+    expect(viewData.groups[0].children).toEqual([
+      expect.objectContaining({
+        id: "animation-1",
+        name: "Imported Animation",
+      }),
+    ]);
+  });
+});

--- a/tests/internal/importPackages.test.js
+++ b/tests/internal/importPackages.test.js
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchImportPackageJson,
+  validateImportFileDescriptor,
+  validateImportPackageObject,
+} from "../../src/internal/importPackages.js";
+
+const originalFetch = globalThis.fetch;
+
+describe("importPackages", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("rejects import URLs that do not return JSON content", async () => {
+    const json = vi.fn();
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: vi.fn(() => "text/html"),
+      },
+      json,
+    }));
+
+    await expect(
+      fetchImportPackageJson({
+        url: "https://example.com/package.json",
+      }),
+    ).rejects.toThrow("Import URL must return JSON.");
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("rejects import URLs whose body is not valid JSON", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: vi.fn(() => "application/json"),
+      },
+      json: vi.fn(async () => {
+        throw new SyntaxError("Unexpected token");
+      }),
+    }));
+
+    await expect(
+      fetchImportPackageJson({
+        url: "https://example.com/package.json",
+      }),
+    ).rejects.toThrow("Import URL did not return valid JSON.");
+  });
+
+  it("validates package envelope shape and schema", () => {
+    expect(() => validateImportPackageObject([])).toThrow(
+      "Import package must be a JSON object.",
+    );
+    expect(() =>
+      validateImportPackageObject({
+        schema: "routevn.import-pack.v999",
+      }),
+    ).toThrow("Unsupported import package schema.");
+    expect(() =>
+      validateImportPackageObject({
+        schema: "routevn.import-pack.v1",
+      }),
+    ).toThrow("Import package repository is missing.");
+  });
+
+  it("validates file dependency descriptors", () => {
+    const importInput = {
+      repository: {
+        files: {
+          items: {
+            "file.mask": {
+              source: {
+                url: "https://example.com/mask.png",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      validateImportFileDescriptor({
+        importInput,
+        fileId: "file.mask",
+        label: 'Image dependency "Mask"',
+      }),
+    ).toEqual({
+      source: {
+        url: "https://example.com/mask.png",
+      },
+    });
+    expect(() =>
+      validateImportFileDescriptor({
+        importInput: {
+          files: {
+            "file.mask": {
+              url: "/mask.png",
+            },
+          },
+        },
+        fileId: "file.mask",
+        label: 'Image dependency "Mask"',
+      }),
+    ).toThrow('Image dependency "Mask" has an invalid file URL.');
+  });
+});

--- a/tests/transforms/transforms.handlers.test.js
+++ b/tests/transforms/transforms.handlers.test.js
@@ -1,11 +1,700 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  handleImportFormActionClick,
+  handleImportTransformClick,
   handleTransformPreviewImageContextMenu,
   handleTransformPreviewImageMenuItemClick,
   handleTransformPreviewImageSelected,
 } from "../../src/pages/transforms/transforms.handlers.js";
 
+const originalFetch = globalThis.fetch;
+
 describe("transforms.handlers", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("opens transform import as a global page action", () => {
+    const render = vi.fn();
+    const store = {
+      openImportDialog: vi.fn(),
+    };
+
+    handleImportTransformClick({ render, store });
+
+    expect(store.openImportDialog).toHaveBeenCalledWith();
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("imports one transform into the selected destination folder", async () => {
+    let createdTransform;
+    const importInput = {
+      type: "transform",
+      name: "Imported Center",
+      x: 960,
+      y: 540,
+      scaleX: 1.2,
+      scaleY: 1.3,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      rotation: 15,
+    };
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const render = vi.fn();
+    const store = {
+      closeImportDialog: vi.fn(),
+      selectImportDialogPendingInput: vi.fn(() => importInput),
+      selectImportDialogTargetGroupId: vi.fn(() => undefined),
+      selectImportDialogImageFolderId: vi.fn(() => undefined),
+      setImportDestinationValues: vi.fn(),
+      setSearchQuery: vi.fn(),
+      setActiveTagIds: vi.fn(),
+      setImagesData: vi.fn(),
+      setItems: vi.fn(),
+      setProjectResolution: vi.fn(),
+      setSelectedFolderId: vi.fn(),
+      setSelectedItemId: vi.fn(),
+      setTagsData: vi.fn(),
+    };
+    const projectService = {
+      createTransform: vi.fn(async (input) => {
+        createdTransform = input;
+        return input.transformId;
+      }),
+      importImageFile: vi.fn(),
+      getRepositoryState: vi.fn(() => ({
+        images: { items: {}, tree: [] },
+        project: {},
+        tags: {},
+        transforms: {
+          items: {
+            [createdTransform.transformId]: {
+              id: createdTransform.transformId,
+              ...createdTransform.data,
+            },
+          },
+          tree: [{ id: createdTransform.transformId }],
+        },
+      })),
+    };
+    const refs = {
+      fileExplorer: {
+        selectItem: vi.fn(),
+      },
+    };
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService,
+        refs,
+        render,
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "import",
+            valid: true,
+            values: {
+              transformFolderId: "folder-1",
+            },
+          },
+        },
+      },
+    );
+
+    expect(store.setImportDestinationValues).toHaveBeenCalledWith({
+      values: {
+        transformFolderId: "folder-1",
+      },
+    });
+    expect(projectService.createTransform).toHaveBeenCalledWith({
+      transformId: expect.any(String),
+      data: {
+        type: "transform",
+        name: "Imported Center",
+        description: "",
+        x: 960,
+        y: 540,
+        scaleX: 1.2,
+        scaleY: 1.3,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        rotation: 15,
+      },
+      parentId: "folder-1",
+      position: "last",
+    });
+    expect(store.closeImportDialog).toHaveBeenCalled();
+    expect(appService.showToast).toHaveBeenCalledWith({
+      message: "Transform imported.",
+    });
+    expect(store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: createdTransform.transformId,
+    });
+    expect(refs.fileExplorer.selectItem).toHaveBeenCalledWith({
+      itemId: createdTransform.transformId,
+    });
+  });
+
+  it("shows an alert when the form reports validation errors", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const projectService = {
+      createTransform: vi.fn(),
+    };
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService,
+        render: vi.fn(),
+        store: {},
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: false,
+            values: {},
+          },
+        },
+      },
+    );
+
+    expect(projectService.createTransform).not.toHaveBeenCalled();
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message: "Import URL is required.",
+      title: "Error",
+    });
+    expect(appService.showToast).not.toHaveBeenCalled();
+  });
+
+  it("shows an alert when the import URL is invalid", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    globalThis.fetch = vi.fn();
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        refs: {},
+        render: vi.fn(),
+        store: {},
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values: {
+              url: "/public/import-transform-sample.json",
+            },
+          },
+        },
+      },
+    );
+
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message: "Enter a valid http(s) URL.",
+      title: "Error",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows an alert when the import URL content is not JSON", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      openImportDestinationStep: vi.fn(),
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: vi.fn(() => "text/html"),
+      },
+      json: vi.fn(),
+    }));
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        refs: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values: {
+              url: "https://example.com/import-transform-sample.json",
+            },
+          },
+        },
+      },
+    );
+
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message: "Import URL must return JSON.",
+      title: "Error",
+    });
+    expect(store.openImportDestinationStep).not.toHaveBeenCalled();
+  });
+
+  it("shows an alert when transform image dependencies have invalid file URLs", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      openImportDestinationStep: vi.fn(),
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: vi.fn(() => "application/json"),
+      },
+      json: vi.fn(async () => ({
+        schema: "routevn.import-pack.v1",
+        primary: {
+          resourceType: "transforms",
+          id: "transform.primary",
+        },
+        repository: {
+          transforms: {
+            items: {
+              "transform.primary": {
+                id: "transform.primary",
+                type: "transform",
+                name: "Primary Transform",
+                preview: {
+                  target: {
+                    imageId: "image.primary",
+                  },
+                },
+              },
+            },
+          },
+          images: {
+            items: {
+              "image.primary": {
+                id: "image.primary",
+                type: "image",
+                name: "Primary Image",
+                fileId: "file.primary",
+              },
+            },
+          },
+        },
+        files: {
+          "file.primary": {
+            url: "/image.png",
+          },
+        },
+      })),
+    }));
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        refs: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values: {
+              url: "https://example.com/import-transform-sample.json",
+            },
+          },
+        },
+      },
+    );
+
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message: 'Image dependency "Primary Image" has an invalid file URL.',
+      title: "Error",
+    });
+    expect(store.openImportDestinationStep).not.toHaveBeenCalled();
+  });
+
+  it("continues to folder selection after parsing a valid package", async () => {
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      openImportDestinationStep: vi.fn(),
+    };
+    const importInput = {
+      schema: "routevn.import-pack.v1",
+      primary: {
+        resourceType: "transforms",
+        id: "transform.primary",
+      },
+      repository: {
+        transforms: {
+          items: {
+            "transform.primary": {
+              id: "transform.primary",
+              type: "transform",
+              name: "Primary Transform",
+            },
+          },
+        },
+        images: {
+          items: {
+            "image.primary": {
+              id: "image.primary",
+              type: "image",
+              name: "Primary Image",
+              fileId: "file.primary",
+            },
+          },
+        },
+      },
+      files: {
+        "file.primary": {
+          url: "https://example.com/image.png",
+          mimeType: "image/png",
+        },
+      },
+    };
+    const values = {
+      url: "http://localhost:3001/public/import-transform-sample.json",
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: vi.fn(async () => importInput),
+    }));
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService: {},
+        refs: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "continue",
+            valid: true,
+            values,
+          },
+        },
+      },
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:3001/public/import-transform-sample.json",
+      {
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+    expect(store.openImportDestinationStep).toHaveBeenCalledWith({
+      importInput,
+      sourceValues: values,
+      includeImages: false,
+    });
+  });
+
+  it("imports the primary transform from a package", async () => {
+    let createdTransform;
+    const importInput = {
+      schema: "routevn.import-pack.v1",
+      primary: {
+        resourceType: "transforms",
+        id: "transform.primary",
+      },
+      repository: {
+        transforms: {
+          items: {
+            "transform.other": {
+              id: "transform.other",
+              type: "transform",
+              name: "Other Transform",
+            },
+            "transform.primary": {
+              id: "transform.primary",
+              type: "transform",
+              name: "Primary Transform",
+              x: 320,
+              y: 180,
+            },
+          },
+        },
+        images: {
+          items: {
+            "image.unused": {
+              id: "image.unused",
+              type: "image",
+              name: "Unused Image",
+              fileId: "file.unused",
+            },
+          },
+        },
+      },
+      files: {
+        "file.unused": {
+          url: "/unused.png",
+        },
+      },
+    };
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      closeImportDialog: vi.fn(),
+      selectImportDialogPendingInput: vi.fn(() => importInput),
+      selectImportDialogTargetGroupId: vi.fn(() => undefined),
+      selectImportDialogImageFolderId: vi.fn(() => undefined),
+      setImportDestinationValues: vi.fn(),
+      setSearchQuery: vi.fn(),
+      setActiveTagIds: vi.fn(),
+      setImagesData: vi.fn(),
+      setItems: vi.fn(),
+      setProjectResolution: vi.fn(),
+      setSelectedFolderId: vi.fn(),
+      setSelectedItemId: vi.fn(),
+      setTagsData: vi.fn(),
+    };
+    const projectService = {
+      createTransform: vi.fn(async (input) => {
+        createdTransform = input;
+        return input.transformId;
+      }),
+      importImageFile: vi.fn(),
+      getRepositoryState: vi.fn(() => ({
+        images: { items: {}, tree: [] },
+        project: {},
+        tags: {},
+        transforms: {
+          items: {
+            [createdTransform.transformId]: {
+              id: createdTransform.transformId,
+              ...createdTransform.data,
+            },
+          },
+          tree: [{ id: createdTransform.transformId }],
+        },
+      })),
+    };
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService,
+        refs: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "import",
+            valid: true,
+            values: {
+              transformFolderId: "_root",
+            },
+          },
+        },
+      },
+    );
+
+    expect(projectService.createTransform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: "Primary Transform",
+          x: 320,
+          y: 180,
+        }),
+        parentId: undefined,
+      }),
+    );
+    expect(projectService.importImageFile).not.toHaveBeenCalled();
+    expect(store.closeImportDialog).toHaveBeenCalled();
+    expect(store.setSearchQuery).toHaveBeenCalledWith({ value: "" });
+    expect(store.setActiveTagIds).toHaveBeenCalledWith({ tagIds: [] });
+  });
+
+  it("imports only preview-referenced transform image dependencies", async () => {
+    let createdTransform;
+    const importInput = {
+      schema: "routevn.import-pack.v1",
+      primary: {
+        resourceType: "transforms",
+        id: "transform.primary",
+      },
+      repository: {
+        transforms: {
+          items: {
+            "transform.primary": {
+              id: "transform.primary",
+              type: "transform",
+              name: "Primary Transform",
+              preview: {
+                target: {
+                  imageId: "image.primary",
+                  slot: "target",
+                },
+              },
+            },
+          },
+        },
+        images: {
+          items: {
+            "image.primary": {
+              id: "image.primary",
+              type: "image",
+              name: "Primary Image",
+              fileId: "file.primary",
+            },
+            "image.unused": {
+              id: "image.unused",
+              type: "image",
+              name: "Unused Image",
+              fileId: "file.unused",
+            },
+          },
+        },
+      },
+      files: {
+        "file.primary": {
+          url: "https://example.com/primary.png",
+          mimeType: "image/png",
+        },
+        "file.unused": {
+          url: "/unused.png",
+        },
+      },
+    };
+    const appService = {
+      showAlert: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const store = {
+      closeImportDialog: vi.fn(),
+      selectImportDialogPendingInput: vi.fn(() => importInput),
+      selectImportDialogTargetGroupId: vi.fn(() => undefined),
+      selectImportDialogImageFolderId: vi.fn(() => undefined),
+      setImportDestinationValues: vi.fn(),
+      setSearchQuery: vi.fn(),
+      setActiveTagIds: vi.fn(),
+      setImagesData: vi.fn(),
+      setItems: vi.fn(),
+      setProjectResolution: vi.fn(),
+      setSelectedFolderId: vi.fn(),
+      setSelectedItemId: vi.fn(),
+      setTagsData: vi.fn(),
+    };
+    const projectService = {
+      createTransform: vi.fn(async (input) => {
+        createdTransform = input;
+        return input.transformId;
+      }),
+      importImageFile: vi.fn(async () => ({
+        imageId: "image.imported",
+      })),
+      getRepositoryState: vi.fn(() => ({
+        images: { items: {}, tree: [] },
+        project: {},
+        tags: {},
+        transforms: {
+          items: {
+            [createdTransform.transformId]: {
+              id: createdTransform.transformId,
+              ...createdTransform.data,
+            },
+          },
+          tree: [{ id: createdTransform.transformId }],
+        },
+      })),
+    };
+    globalThis.fetch = vi.fn(async (url) => {
+      if (url === "https://example.com/primary.png") {
+        return {
+          ok: true,
+          blob: vi.fn(async () => new Blob(["primary"], { type: "image/png" })),
+        };
+      }
+
+      return {
+        ok: false,
+        blob: vi.fn(),
+      };
+    });
+
+    await handleImportFormActionClick(
+      {
+        appService,
+        projectService,
+        refs: {},
+        render: vi.fn(),
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            actionId: "import",
+            valid: true,
+            values: {
+              imageFolderId: "images-folder",
+              transformFolderId: "transforms-folder",
+            },
+          },
+        },
+      },
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://example.com/primary.png",
+    );
+    expect(projectService.importImageFile).toHaveBeenCalledTimes(1);
+    expect(projectService.importImageFile).toHaveBeenCalledWith({
+      file: expect.any(Blob),
+      imageId: expect.any(String),
+      parentId: "images-folder",
+    });
+    expect(projectService.createTransform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          preview: {
+            target: {
+              imageId: "image.imported",
+              slot: "target",
+            },
+          },
+        }),
+        parentId: "transforms-folder",
+      }),
+    );
+    expect(appService.showAlert).not.toHaveBeenCalled();
+  });
+
   it("opens the preview image context menu from the target slot", () => {
     const preventDefault = vi.fn();
     const stopPropagation = vi.fn();

--- a/tests/transforms/transforms.store.test.js
+++ b/tests/transforms/transforms.store.test.js
@@ -8,6 +8,8 @@ import {
   closePreviewImageMenu,
   openPreviewImageSelectorDialog,
   openPreviewImageMenu,
+  openImportDialog,
+  openImportDestinationStep,
   openTransformFormDialog,
   openTransformPreviewDialog,
   selectDialogPreviewData,
@@ -206,6 +208,101 @@ describe("transforms.store", () => {
       fullImagePreviewVisible: true,
       fullImagePreviewImageId: "image-bg",
       fullImagePreviewFileId: "thumb-bg",
+    });
+  });
+
+  it("configures the import form for URL packages", () => {
+    const state = createInitialState();
+    openImportDialog(
+      { state },
+      {
+        targetGroupId: "folder-1",
+      },
+    );
+
+    const viewData = selectViewData({ state });
+    const form = viewData.importForm;
+    const urlField = form.fields.find((field) => field.name === "url");
+    const sourceField = form.fields.find(
+      (field) => field.name === "sourceType",
+    );
+    const jsonField = form.fields.find((field) => field.name === "json");
+    const continueButton = form.actions.buttons.find(
+      (button) => button.id === "continue",
+    );
+
+    expect(sourceField).toBeUndefined();
+    expect(jsonField).toBeUndefined();
+    expect(urlField).toMatchObject({
+      required: {
+        message: "Import URL is required.",
+      },
+    });
+    expect(viewData.importDialogDefaultValues).toEqual({
+      url: "",
+    });
+    expect(continueButton).toMatchObject({
+      label: "Continue",
+      validate: true,
+    });
+  });
+
+  it("configures destination folder selectors for transform and image dependencies", () => {
+    const state = createInitialState();
+    state.data = {
+      items: {
+        "folder-transform": {
+          id: "folder-transform",
+          type: "folder",
+          name: "Transform Folder",
+        },
+      },
+      tree: [{ id: "folder-transform" }],
+    };
+    setImagesData(
+      { state },
+      {
+        imagesData: {
+          items: {
+            "folder-image": {
+              id: "folder-image",
+              type: "folder",
+              name: "Image Folder",
+            },
+          },
+          tree: [{ id: "folder-image" }],
+        },
+      },
+    );
+
+    openImportDestinationStep(
+      { state },
+      {
+        importInput: {},
+        includeImages: true,
+      },
+    );
+
+    const form = selectViewData({ state }).importForm;
+    const transformFolderField = form.fields.find(
+      (field) => field.name === "transformFolderId",
+    );
+    const imageFolderField = form.fields.find(
+      (field) => field.name === "imageFolderId",
+    );
+    const importButton = form.actions.buttons.find(
+      (button) => button.id === "import",
+    );
+
+    expect(transformFolderField.options).toEqual([
+      { value: "folder-transform", label: "Transform Folder" },
+    ]);
+    expect(imageFolderField.options).toEqual([
+      { value: "folder-image", label: "Image Folder" },
+    ]);
+    expect(importButton).toMatchObject({
+      label: "Import Transform",
+      validate: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- add URL-based import dialogs for transforms and animations
- add shared import package URL/content/dependency validation
- add catalog import action support and keep selected imported items visible
- document the import package format and asset-store flow

## Testing
- bun prettier --check docs/import-packages.md src/internal/importPackages.js src/components/catalogResourcesView/catalogResourcesView.handlers.js src/components/catalogResourcesView/catalogResourcesView.schema.yaml src/components/catalogResourcesView/catalogResourcesView.store.js src/components/catalogResourcesView/catalogResourcesView.view.yaml src/pages/animations/animations.handlers.js src/pages/animations/animations.store.js src/pages/animations/animations.view.yaml src/pages/transforms/transforms.handlers.js src/pages/transforms/transforms.store.js src/pages/transforms/transforms.view.yaml tests/animations/animations.handlers.test.js tests/animations/animations.store.test.js tests/catalogResourcesView/catalogResourcesView.store.test.js tests/internal/importPackages.test.js tests/transforms/transforms.handlers.test.js tests/transforms/transforms.store.test.js
- bunx oxlint src/internal/importPackages.js src/components/catalogResourcesView/catalogResourcesView.handlers.js src/components/catalogResourcesView/catalogResourcesView.store.js src/pages/animations/animations.handlers.js src/pages/animations/animations.store.js src/pages/transforms/transforms.handlers.js src/pages/transforms/transforms.store.js tests/animations/animations.handlers.test.js tests/animations/animations.store.test.js tests/catalogResourcesView/catalogResourcesView.store.test.js tests/internal/importPackages.test.js tests/transforms/transforms.handlers.test.js tests/transforms/transforms.store.test.js
- bunx vitest run tests/internal/importPackages.test.js tests/animations/animations.handlers.test.js tests/animations/animations.store.test.js tests/transforms/transforms.handlers.test.js tests/transforms/transforms.store.test.js tests/catalogResourcesView/catalogResourcesView.store.test.js

Excluded from this PR: static/public/import-animation-mask-sample.json, static/public/import-animation-shake-sample.json, static/public/import-transform-sample.json.