### PR TITLE
Fix custom transform preview flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rettangoli/fe": "1.1.3",
         "@rettangoli/ui": "1.7.6",
         "@rettangoli/vt": "1.0.5",
-        "@routevn/creator-model": "1.7.1",
+        "@routevn/creator-model": "1.7.2",
         "@tauri-apps/api": "2.11.0",
         "@tauri-apps/plugin-dialog": "2.4.2",
         "@tauri-apps/plugin-fs": "2.5.1",
@@ -311,7 +311,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@routevn/creator-model": ["@routevn/creator-model@1.7.1", "", {}, "sha512-uxpGkFixcEZDOeDJUll7nsevgqYFjm92uLs5zUykD5CdcES5XrwQOJjy9uBVTE6EAfE/+8INUSJluipjIyb3ZA=="],
+    "@routevn/creator-model": ["@routevn/creator-model@1.7.2", "", {}, "sha512-oyPFAWyJm3MQSn48SsghK+qNERvKC6J2J3jAZSsGPvCSv7b1rdB/csE/1BeEKimmmqO3iW0xUnSDLvlQXym/Qg=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "jszip": "3.10.1",
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
-        "route-engine-js": "1.22.0",
+        "route-engine-js": "1.23.0",
         "route-graphics": "1.20.1",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
@@ -729,7 +729,7 @@
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
-    "route-engine-js": ["route-engine-js@1.22.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-rIxlqmgax2tE1CiFUgNTloqoqy7V8R+Fn0f2yCI4FE2/QB0lKT0CIk2hJNlEdlRi3yHXbRQWNeQkWW6gstkj1w=="],
+    "route-engine-js": ["route-engine-js@1.23.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-0UVMFGBZcyJrB1OUVXiY1bBSseolDyijCMDwAHOpg+l9OeoTA0tOu+w9w34+ulI/VNoCSCDhncFhNysCqXtr3Q=="],
 
     "route-graphics": ["route-graphics@1.20.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-auJzJ9dXHvCgbxqfPjMNc3qQCxippqEps6NnAR2UY3jzG9fuBH3gTAbD76WchoRR0ctrNqAi0r4oOJHW4k+uJw=="],
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -83,6 +83,18 @@ for routine validation of ordinary code or view edits. Prefer targeted tests,
 format checks, lint checks, and the active watch output. Reserve `build:web` for
 explicit user requests, release/VT output, or a specific build-only failure.
 
+### Debugging Discipline
+
+Do not claim a UI bug is fixed from code inspection alone. For user-visible
+runtime behavior, reproduce the issue in the running app or with an equivalent
+browser/VT validation before presenting a fix as complete.
+
+Avoid blind hypothesis stacking. Diagnostic logs are useful only when they are
+placed at concrete boundaries, used to prove where data changes, and followed by
+direct validation of the affected workflow. If a first hypothesis is disproven,
+stop changing code and gather the next missing observation before making another
+behavioral change.
+
 Common commands:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jszip": "3.10.1",
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
-    "route-engine-js": "1.22.0",
+    "route-engine-js": "1.23.0",
     "route-graphics": "1.20.1",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rettangoli/fe": "1.1.3",
     "@rettangoli/ui": "1.7.6",
     "@rettangoli/vt": "1.0.5",
-    "@routevn/creator-model": "1.7.1",
+    "@routevn/creator-model": "1.7.2",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-dialog": "2.4.2",
     "@tauri-apps/plugin-fs": "2.5.1",

--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -271,6 +271,16 @@ export const handleCustomTransformDoneButtonClick = (deps, payload) => {
   );
 };
 
+export const handleCancelCustomTransformEditor = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { store, render } = deps;
+
+  store.closeCustomTransformEditor?.();
+  render?.();
+};
+
 export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
   const canvasHost = refs?.backgroundTransformPreviewCanvasHost;
   return (
@@ -340,14 +350,33 @@ export const handleBeforeMount = (deps) => {
     });
   }
 
-  if (hasBackgroundInlineTransform(props.background)) {
+  if (transformId) {
+    store.setCustomTransformEnabled({
+      enabled: false,
+    });
+    store.setCustomTransform({
+      transform: undefined,
+    });
+    store.setSelectedTransform({
+      transformId,
+    });
+  } else if (hasBackgroundInlineTransform(props.background)) {
+    store.setSelectedTransform({
+      transformId: undefined,
+    });
     store.setCustomTransformEnabled({
       enabled: true,
     });
     store.setCustomTransform({
       transform: props.background,
     });
-  } else if (transformId) {
+  } else {
+    store.setCustomTransformEnabled({
+      enabled: false,
+    });
+    store.setCustomTransform({
+      transform: undefined,
+    });
     store.setSelectedTransform({
       transformId,
     });
@@ -520,7 +549,11 @@ export const handleFormInputChange = (deps, payload) => {
       enabled: fieldValue,
     });
 
-    if (!customTransformWasEnabled && customTransformEnabled) {
+    if (!customTransformEnabled) {
+      store.setCustomTransform?.({
+        transform: undefined,
+      });
+    } else if (!customTransformWasEnabled) {
       const selectedTransform = store.selectSelectedTransformResource?.();
       if (selectedTransform) {
         store.setCustomTransform?.({
@@ -535,6 +568,12 @@ export const handleFormInputChange = (deps, payload) => {
   }
 
   if (name === "transformId") {
+    store.setCustomTransformEnabled?.({
+      enabled: false,
+    });
+    store.setCustomTransform?.({
+      transform: undefined,
+    });
     store.setSelectedTransform({
       transformId: fieldValue,
     });

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -554,7 +554,7 @@ const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
     canvasAspectRatio: editor.canvasAspectRatio ?? "16 / 9",
     previewMaxWidth:
       editor.previewMaxWidth ??
-      "min(calc(100vw - 48px), calc((100vh - 170px) * 1.7777777778))",
+      "min(100vw, calc((100vh - 122px) * 1.7777777778))",
     metrics,
   };
 };
@@ -572,18 +572,6 @@ const createCustomTransformDetails = ({ state }) => {
     {
       label: "Scale",
       value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
-    },
-    {
-      label: "Rotation",
-      value: formatBackgroundTransformEditorMetric(transform.rotation),
-    },
-    {
-      label: "Anchor",
-      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
-    },
-    {
-      label: "Origin",
-      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
     },
   ];
 };

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -115,7 +115,7 @@ template:
               - rtgl-view h=48 bwb=xs w=f d=h av=c ph=md g=md:
                   - rtgl-text s=sm w=1fg: Transform
                   - rtgl-button#backgroundTransformEditorDoneButton v=pr: Done
-              - 'rtgl-view w=f h=1fg p=lg ah=c av=c style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=f h=1fg ah=c av=c style="min-width: 0; min-height: 0;"':
                   - 'rtgl-view h=f style="width: ${backgroundTransformEditor.previewMaxWidth}; max-width: 100%; min-width: 0; min-height: 0;"':
                       - rvn-scene-editor-preview-canvas#backgroundTransformPreviewCanvasHost canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}": null
               - rtgl-view w=f bwt=xs d=h av=c ph=md pv=sm g=lg bgc=bg wrap:
@@ -131,9 +131,6 @@ template:
                   - rtgl-view d=h av=c g=xs:
                       - rtgl-text s=xs c=mu-fg: scaleY
                       - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleY}
-                  - rtgl-view d=h av=c g=xs:
-                      - rtgl-text s=xs c=mu-fg: rotation
-                      - rtgl-text s=sm: ${backgroundTransformEditor.metrics.rotation}
       - $if mode == 'gallery':
           - rtgl-view d=h w=f av=c g=md:
               - rtgl-tabs#tabs selected-tab=${tab} :items=${tabs}: null

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -422,6 +422,16 @@ export const handleCustomTransformDoneButtonClick = (deps, payload) => {
   );
 };
 
+export const handleCancelCustomTransformEditor = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { store, render } = deps;
+
+  store.closeCustomTransformEditor?.();
+  render?.();
+};
+
 export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
   const canvasHost = refs?.backgroundTransformPreviewCanvasHost;
   return (

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -301,18 +301,6 @@ const createCustomTransformDetails = (character = {}) => {
       label: "Scale",
       value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
     },
-    {
-      label: "Rotation",
-      value: formatBackgroundTransformEditorMetric(transform.rotation),
-    },
-    {
-      label: "Anchor",
-      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
-    },
-    {
-      label: "Origin",
-      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
-    },
   ];
 };
 
@@ -404,7 +392,7 @@ const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
     canvasAspectRatio: editor.canvasAspectRatio ?? "16 / 9",
     previewMaxWidth:
       editor.previewMaxWidth ??
-      "min(calc(100vw - 48px), calc((100vh - 170px) * 1.7777777778))",
+      "min(100vw, calc((100vh - 122px) * 1.7777777778))",
     metrics,
   };
 };

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -244,7 +244,7 @@ template:
           - rtgl-view h=48 bwb=xs w=f d=h av=c ph=md g=md:
               - rtgl-text s=sm w=1fg: Transform
               - rtgl-button#backgroundTransformEditorDoneButton v=pr: Done
-          - 'rtgl-view w=f h=1fg p=lg ah=c av=c style="min-width: 0; min-height: 0;"':
+          - 'rtgl-view w=f h=1fg ah=c av=c style="min-width: 0; min-height: 0;"':
               - 'rtgl-view h=f style="width: ${backgroundTransformEditor.previewMaxWidth}; max-width: 100%; min-width: 0; min-height: 0;"':
                   - rvn-scene-editor-preview-canvas#backgroundTransformPreviewCanvasHost canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}": null
           - rtgl-view w=f bwt=xs d=h av=c ph=md pv=sm g=lg bgc=bg wrap:
@@ -260,9 +260,6 @@ template:
               - rtgl-view d=h av=c g=xs:
                   - rtgl-text s=xs c=mu-fg: scaleY
                   - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleY}
-              - rtgl-view d=h av=c g=xs:
-                  - rtgl-text s=xs c=mu-fg: rotation
-                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.rotation}
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null

--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -335,6 +335,16 @@ export const handleCustomTransformDoneButtonClick = (deps, payload) => {
   );
 };
 
+export const handleCancelCustomTransformEditor = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { store, render } = deps;
+
+  store.closeCustomTransformEditor?.();
+  render?.();
+};
+
 export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
   const canvasHost = refs?.backgroundTransformPreviewCanvasHost;
   return (

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -556,18 +556,6 @@ const createCustomTransformDetails = (visual = {}) => {
       label: "Scale",
       value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
     },
-    {
-      label: "Rotation",
-      value: formatBackgroundTransformEditorMetric(transform.rotation),
-    },
-    {
-      label: "Anchor",
-      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
-    },
-    {
-      label: "Origin",
-      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
-    },
   ];
 };
 
@@ -609,7 +597,7 @@ const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
     canvasAspectRatio: editor.canvasAspectRatio ?? "16 / 9",
     previewMaxWidth:
       editor.previewMaxWidth ??
-      "min(calc(100vw - 48px), calc((100vh - 170px) * 1.7777777778))",
+      "min(100vw, calc((100vh - 122px) * 1.7777777778))",
     metrics,
   };
 };

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -250,7 +250,7 @@ template:
           - rtgl-view h=48 bwb=xs w=f d=h av=c ph=md g=md:
               - rtgl-text s=sm w=1fg: Transform
               - rtgl-button#backgroundTransformEditorDoneButton v=pr: Done
-          - 'rtgl-view w=f h=1fg p=lg ah=c av=c style="min-width: 0; min-height: 0;"':
+          - 'rtgl-view w=f h=1fg ah=c av=c style="min-width: 0; min-height: 0;"':
               - 'rtgl-view h=f style="width: ${backgroundTransformEditor.previewMaxWidth}; max-width: 100%; min-width: 0; min-height: 0;"':
                   - rvn-scene-editor-preview-canvas#backgroundTransformPreviewCanvasHost canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}": null
           - rtgl-view w=f bwt=xs d=h av=c ph=md pv=sm g=lg bgc=bg wrap:
@@ -266,9 +266,6 @@ template:
               - rtgl-view d=h av=c g=xs:
                   - rtgl-text s=xs c=mu-fg: scaleY
                   - rtgl-text s=sm: ${backgroundTransformEditor.metrics.scaleY}
-              - rtgl-view d=h av=c g=xs:
-                  - rtgl-text s=xs c=mu-fg: rotation
-                  - rtgl-text s=sm: ${backgroundTransformEditor.metrics.rotation}
   - $when: fullImagePreviewVisible
     rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:
       - rtgl-view w=f h=f pos=fix edge=f bgc=bg: null

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -160,6 +160,32 @@ export const handleActionTransformEditorDone = (deps, payload) => {
   );
 };
 
+const closeEmbeddedTransformEditors = (refs = {}) => {
+  refs?.commandLineBackground?.transformedHandlers?.handleCancelCustomTransformEditor?.();
+  refs?.commandLineCharacters?.transformedHandlers?.handleCancelCustomTransformEditor?.();
+  refs?.commandLineVisual?.transformedHandlers?.handleCancelCustomTransformEditor?.();
+};
+
+export const handleActionsDialogCloseRequest = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const { props, refs, store } = deps;
+  if (props?.backgroundTransformEditor?.isOpen !== true) {
+    return;
+  }
+
+  store?.setSuppressDialogClose?.({ suppressDialogClose: true });
+  closeEmbeddedTransformEditors(refs);
+  deps.dispatchEvent(
+    new CustomEvent("background-transform-editor-cancel", {
+      detail: {},
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
 export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
   return (
     refs?.commandLineBackground?.transformedHandlers?.handleGetBackgroundTransformPreviewCanvasRoot?.() ||
@@ -285,10 +311,9 @@ const isBooleanPropEnabled = (value) => {
 
 export const handleActionsDialogClose = (deps, payload) => {
   const { props, store, render, dispatchEvent } = deps;
-  if (
-    isBooleanPropEnabled(props?.suppressDialogClose) ||
-    store.selectSuppressDialogClose?.() === true
-  ) {
+  const suppressByProps = isBooleanPropEnabled(props?.suppressDialogClose);
+  const suppressByStore = store.selectSuppressDialogClose?.() === true;
+  if (suppressByProps || suppressByStore) {
     payload?._event?.preventDefault?.();
     payload?._event?.stopPropagation?.();
     return;

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -31,6 +31,8 @@ refs:
         handler: handleHelpFloatingButtonClick
   actionsDialog:
     eventListeners:
+      close-request:
+        handler: handleActionsDialogCloseRequest
       close:
         handler: handleActionsDialogClose
   actionItem*:

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.handlers.js
@@ -2,6 +2,12 @@ const dispatchClose = ({ dispatchEvent }) => {
   dispatchEvent(new CustomEvent("close", { detail: {}, bubbles: true }));
 };
 
+const dispatchCloseRequest = ({ dispatchEvent }) => {
+  dispatchEvent(
+    new CustomEvent("close-request", { detail: {}, bubbles: true }),
+  );
+};
+
 const isCloseSuppressed = ({ props = {}, store } = {}) => {
   return (
     props.suppressClose === true ||
@@ -15,6 +21,7 @@ export const handleSurfaceClose = (deps, payload = {}) => {
   payload._event?.preventDefault?.();
 
   if (isCloseSuppressed(deps)) {
+    dispatchCloseRequest(deps);
     return;
   }
 
@@ -44,6 +51,7 @@ export const handleDocumentKeyDown = (deps, payload = {}) => {
   event.stopPropagation?.();
 
   if (isCloseSuppressed(deps)) {
+    dispatchCloseRequest(deps);
     return;
   }
 

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.schema.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.schema.yaml
@@ -20,3 +20,5 @@ propsSchema:
 events:
   close:
     type: object
+  close-request:
+    type: object

--- a/src/deps/services/projectService.js
+++ b/src/deps/services/projectService.js
@@ -20,7 +20,7 @@ export const createProjectService = ({
         ? console.error.bind(console)
         : level === "warn"
           ? console.warn.bind(console)
-          : console.log.bind(console);
+          : console.debug.bind(console);
     fn(`[routevn.collab.tauri] ${message}`, meta);
   };
 

--- a/src/deps/services/shared/debugLog.js
+++ b/src/deps/services/shared/debugLog.js
@@ -50,7 +50,7 @@ const emitDebugLog = (scope, event, data = {}) => {
       ? Number(getDebugNow().toFixed(2))
       : Date.now();
 
-  console.log(`[rvn.debug.${scope}]`, {
+  console.debug(`[rvn.debug.${scope}]`, {
     seq: debugSequence,
     event,
     ts: timestamp,

--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -21,7 +21,7 @@ export const createProjectService = ({
         ? console.error.bind(console)
         : level === "warn"
           ? console.warn.bind(console)
-          : console.log.bind(console);
+          : console.debug.bind(console);
     fn(`[routevn.collab.web] ${message}`, meta);
   };
 

--- a/src/deps/subject.js
+++ b/src/deps/subject.js
@@ -8,7 +8,7 @@ import { Subject } from "rxjs";
  * const subject = new CustomSubject();
  *
  * const subscription = subject.subscribe(({ action, payload }) => {
- *   console.log(action, payload);
+ *   // Handle action and payload.
  * });
  *
  * subject.dispatch("action", { payload: "payload" });

--- a/src/internal/project/engineActions.js
+++ b/src/internal/project/engineActions.js
@@ -1,5 +1,16 @@
 const BLUR_KERNEL_SIZE_OPTIONS = [5, 7, 9, 11, 13, 15];
 const DEFAULT_BLUR_KERNEL_SIZE = 9;
+const BACKGROUND_INLINE_TRANSFORM_FIELDS = [
+  "x",
+  "y",
+  "anchorX",
+  "anchorY",
+  "scaleX",
+  "scaleY",
+  "rotation",
+  "originX",
+  "originY",
+];
 
 const normalizeBlurKernelSize = (value) => {
   const parsedValue = Number(value);
@@ -35,6 +46,18 @@ const normalizeActionWithBlur = (action = {}) => {
   }
 
   return normalizedAction;
+};
+
+const normalizeBackgroundAction = (background = {}) => {
+  const normalizedBackground = normalizeActionWithBlur(background);
+
+  if (typeof normalizedBackground.transformId === "string") {
+    for (const field of BACKGROUND_INLINE_TRANSFORM_FIELDS) {
+      delete normalizedBackground[field];
+    }
+  }
+
+  return normalizedBackground;
 };
 
 const normalizeActionItemsWithBlur = (action = {}) => {
@@ -108,7 +131,7 @@ export const normalizeEngineActions = (value) => {
     typeof normalizedValue.background === "object" &&
     !Array.isArray(normalizedValue.background)
   ) {
-    normalizedValue.background = normalizeActionWithBlur(
+    normalizedValue.background = normalizeBackgroundAction(
       normalizedValue.background,
     );
   }

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -137,19 +137,24 @@ const getBackgroundTransformEditorCanvasRoot = (refs) => {
   return getCanvasRootFromHost(refs?.backgroundTransformPreviewCanvasHost);
 };
 
-const getCurrentCanvasRoot = (refs) => {
-  const transformEditorCanvasRoot =
-    getBackgroundTransformEditorCanvasRoot(refs);
-  if (transformEditorCanvasRoot?.isConnected) {
-    return transformEditorCanvasRoot;
+const getCurrentCanvasRoot = (
+  refs,
+  { preferTransformEditorCanvas = false } = {},
+) => {
+  if (preferTransformEditorCanvas) {
+    const transformEditorCanvasRoot =
+      getBackgroundTransformEditorCanvasRoot(refs);
+    if (transformEditorCanvasRoot?.isConnected) {
+      return transformEditorCanvasRoot;
+    }
   }
 
   return getCanvasRootFromHost(refs?.previewCanvasHost);
 };
 
-const waitForMountedCanvasRoot = async (refs, maxFrames = 10) => {
+const waitForMountedCanvasRoot = async (refs, maxFrames = 10, options = {}) => {
   for (let attempt = 0; attempt < maxFrames; attempt += 1) {
-    const canvasRoot = getCurrentCanvasRoot(refs);
+    const canvasRoot = getCurrentCanvasRoot(refs, options);
     if (canvasRoot?.isConnected) {
       return canvasRoot;
     }
@@ -157,13 +162,16 @@ const waitForMountedCanvasRoot = async (refs, maxFrames = 10) => {
     await waitForNextFrame();
   }
 
-  return getCurrentCanvasRoot(refs);
+  return getCurrentCanvasRoot(refs, options);
 };
 
 const attachGraphicsCanvasToMountedRoot = async (deps, maxFrames = 10) => {
+  const preferTransformEditorCanvas =
+    deps?.store?.selectIsBackgroundTransformEditorOpen?.() === true;
   const mountedCanvasRoot = await waitForMountedCanvasRoot(
     deps?.refs,
     maxFrames,
+    { preferTransformEditorCanvas },
   );
   if (!mountedCanvasRoot?.isConnected) {
     return mountedCanvasRoot;
@@ -1189,7 +1197,11 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
     return;
   }
 
-  const mountedCanvasRoot = getCurrentCanvasRoot(deps.refs);
+  const backgroundTransformEditorOpen =
+    store.selectIsBackgroundTransformEditorOpen?.() === true;
+  const mountedCanvasRoot = getCurrentCanvasRoot(deps.refs, {
+    preferTransformEditorCanvas: backgroundTransformEditorOpen,
+  });
   if (!mountedCanvasRoot?.isConnected) {
     return;
   }

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -88,40 +88,12 @@ const {
   },
 });
 
-const logSelectedControlItem = ({ store }, { itemId } = {}) => {
-  if (!itemId) {
-    return;
-  }
-
-  const item = store.selectControlItemById({ itemId });
-  if (!item) {
-    return;
-  }
-
-  console.log("Selected control item", item);
-};
-
-const getSelectedItemIdFromEvent = (payload) => {
-  return payload._event.detail.itemId;
-};
-
 export const handleFileExplorerSelectionChanged = (deps, payload) => {
   handleCatalogFileExplorerSelectionChanged(deps, payload);
-
-  if (payload._event.detail.isFolder) {
-    return;
-  }
-
-  logSelectedControlItem(deps, {
-    itemId: getSelectedItemIdFromEvent(payload),
-  });
 };
 
 export const handleControlItemClick = (deps, payload) => {
   handleCatalogControlItemClick(deps, payload);
-  logSelectedControlItem(deps, {
-    itemId: getSelectedItemIdFromEvent(payload),
-  });
 };
 
 export {

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -34,18 +34,6 @@ const navigateToLayoutEditor = ({ appService, layoutId } = {}) => {
 
 const normalizeBooleanField = (value) => value === true || value === "true";
 
-const printSelectedLayoutData = (store, { itemId } = {}) => {
-  const layoutData = store.selectLayoutItemById({ itemId });
-  if (!layoutData || layoutData.type !== "layout") {
-    return;
-  }
-
-  console.log("[layouts] selected layout data", {
-    selectedItemId: itemId,
-    layoutData,
-  });
-};
-
 const openLayoutEditorWithItem = ({ deps, itemId } = {}) => {
   if (!itemId) {
     return;
@@ -198,23 +186,10 @@ export {
 
 export const handleFileExplorerSelectionChanged = (deps, payload) => {
   handleCatalogFileExplorerSelectionChanged(deps, payload);
-
-  const { itemId, isFolder } = payload._event.detail;
-  if (isFolder || !itemId) {
-    return;
-  }
-
-  printSelectedLayoutData(deps.store, { itemId });
 };
 
 export const handleLayoutItemClick = (deps, payload) => {
   handleCatalogLayoutItemClick(deps, payload);
-  const { itemId } = payload._event.detail;
-  if (!itemId) {
-    return;
-  }
-
-  printSelectedLayoutData(deps.store, { itemId });
 };
 
 export const handleFileExplorerDoubleClick = (deps, payload) => {

--- a/src/pages/resources/resources.store.js
+++ b/src/pages/resources/resources.store.js
@@ -70,8 +70,6 @@ export const createInitialState = () => ({
 });
 
 export const selectResourceRoute = ({ state }, id) => {
-  // console.log('payload', payload)
-  // const { resourceId, projectId } = payload;
   const resources = state.assets
     .concat(state.animatedAssets)
     .concat(state.ui)

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1,4 +1,4 @@
-import { filter, tap } from "rxjs";
+import { filter, fromEvent, tap } from "rxjs";
 import { createProjectStateStream } from "../../deps/services/shared/projectStateStream.js";
 import { generateId } from "../../internal/id.js";
 import {
@@ -33,6 +33,7 @@ import {
   createSceneEditorSectionWithName,
   isSectionsOverviewOpen,
   reconcileSceneEditorSelection,
+  scrollSceneEditorSectionTabIntoView,
   selectSceneEditorSection,
 } from "../../internal/ui/sceneEditor/sectionOperations.js";
 const DEAD_END_TOOLTIP_CONTENT =
@@ -43,6 +44,8 @@ const SHOW_LINE_NUMBERS_CONFIG_KEY = "sceneEditor.showLineNumbers";
 const IS_MUTED_CONFIG_KEY = "sceneEditor.isMuted";
 const BACKGROUND_TRANSFORM_RESIZE_TARGET_PREFIX = "selected-border-resize-";
 const MIN_BACKGROUND_TRANSFORM_SCALE = 0.01;
+const BACKGROUND_TRANSFORM_KEYBOARD_NUDGE = 1;
+const BACKGROUND_TRANSFORM_KEYBOARD_LARGE_NUDGE = 10;
 
 const toPlainObject = (value) => {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -424,13 +427,50 @@ const focusLinesEditorLine = (refs, payload = {}) => {
   linesEditorRef.focusLine(payload);
 };
 
-const scrollLinesEditorLineIntoView = (refs, lineId, sectionId) => {
+const scrollLinesEditorLineIntoView = (
+  refs,
+  lineId,
+  sectionId,
+  options = {},
+) => {
   const linesEditorRef = getLinesEditorRef(refs, { lineId, sectionId });
   if (!linesEditorRef || !lineId) {
     return;
   }
 
-  linesEditorRef.scrollLineIntoView({ lineId });
+  linesEditorRef.scrollLineIntoView({ lineId, ...options });
+};
+
+const scheduleFrame = (callback) => {
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(callback);
+    return;
+  }
+
+  globalThis.setTimeout?.(callback, 0);
+};
+
+const scrollEntrySelectionIntoView = (deps, payload = {}) => {
+  const { refs, store } = deps;
+  if (!payload.sectionId && !payload.lineId) {
+    return;
+  }
+
+  const selectedSectionId = store.selectSelectedSectionId?.();
+  const selectedLineId = store.selectSelectedLineId?.();
+
+  if (payload.lineId && selectedLineId) {
+    scheduleFrame(() => {
+      scrollLinesEditorLineIntoView(refs, selectedLineId, selectedSectionId, {
+        block: "start",
+      });
+    });
+    return;
+  }
+
+  if (selectedSectionId) {
+    scrollSceneEditorSectionTabIntoView(deps, selectedSectionId);
+  }
 };
 
 const focusLinesEditorContainer = (refs, sectionId) => {
@@ -746,6 +786,13 @@ const replaceActionItem = ({ action, itemIndex, item } = {}) => {
   };
 };
 
+const selectEditorActionSnapshot = (store, editor = {}) => {
+  const actionKey = editor?.actionKey === "character" ? "character" : "visual";
+  return toPlainObject(
+    editor?.action ?? store.selectSelectedLine?.()?.actions?.[actionKey],
+  );
+};
+
 const reopenActionTransformCommandLine = ({
   refs,
   store,
@@ -780,11 +827,12 @@ const selectInitialBackgroundTransformEditorTransform = (
   const transformId =
     background.transformId ?? selectedLine?.actions?.background?.transformId;
   const transform = selectTransformResourceById(store, transformId);
+  const inlineBackground = transformId ? {} : toPlainObject(background);
 
   return normalizeBackgroundTransformEditorTransform({
     ...getDefaultBackgroundTransform(store, background),
     ...toPlainObject(transform),
-    ...toPlainObject(background),
+    ...inlineBackground,
   });
 };
 
@@ -942,6 +990,96 @@ const applyBackgroundTransformDragChange = ({
   });
 };
 
+const isBackgroundTransformKeyboardMoveKey = (key) => {
+  return (
+    key === "ArrowUp" ||
+    key === "ArrowDown" ||
+    key === "ArrowLeft" ||
+    key === "ArrowRight"
+  );
+};
+
+export const applyBackgroundTransformKeyboardPositionChange = ({
+  transform,
+  key,
+  unit = BACKGROUND_TRANSFORM_KEYBOARD_NUDGE,
+} = {}) => {
+  if (!isBackgroundTransformKeyboardMoveKey(key)) {
+    return transform;
+  }
+
+  const normalizedTransform =
+    normalizeBackgroundTransformEditorTransform(transform);
+  const moveUnit = Number.isFinite(Number(unit))
+    ? Number(unit)
+    : BACKGROUND_TRANSFORM_KEYBOARD_NUDGE;
+
+  if (key === "ArrowUp") {
+    return normalizeBackgroundTransformEditorTransform({
+      ...normalizedTransform,
+      y: normalizedTransform.y - moveUnit,
+    });
+  }
+
+  if (key === "ArrowDown") {
+    return normalizeBackgroundTransformEditorTransform({
+      ...normalizedTransform,
+      y: normalizedTransform.y + moveUnit,
+    });
+  }
+
+  if (key === "ArrowLeft") {
+    return normalizeBackgroundTransformEditorTransform({
+      ...normalizedTransform,
+      x: normalizedTransform.x - moveUnit,
+    });
+  }
+
+  return normalizeBackgroundTransformEditorTransform({
+    ...normalizedTransform,
+    x: normalizedTransform.x + moveUnit,
+  });
+};
+
+export const handleBackgroundTransformEditorKeyDown = (deps, event) => {
+  const { render, store } = deps;
+  if (!store.selectIsBackgroundTransformEditorOpen?.()) {
+    return false;
+  }
+
+  if (
+    event?.defaultPrevented ||
+    event?.isComposing ||
+    event?.ctrlKey ||
+    event?.metaKey ||
+    event?.altKey ||
+    !isBackgroundTransformKeyboardMoveKey(event?.key)
+  ) {
+    return false;
+  }
+
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  event.stopImmediatePropagation?.();
+
+  const editor = store.selectBackgroundTransformEditor?.();
+  const updatedTransform = applyBackgroundTransformKeyboardPositionChange({
+    transform: editor?.transform,
+    key: event.key,
+    unit: event.shiftKey
+      ? BACKGROUND_TRANSFORM_KEYBOARD_LARGE_NUDGE
+      : BACKGROUND_TRANSFORM_KEYBOARD_NUDGE,
+  });
+
+  store.clearBackgroundTransformEditorDragStartPosition?.();
+  store.setBackgroundTransformEditorTransform?.({
+    transform: updatedTransform,
+  });
+  render();
+  requestBackgroundTransformEditorCanvasRender(deps.subject);
+  return true;
+};
+
 const handleBackgroundTransformBorderDragStart = (deps, payload = {}) => {
   if (!deps.store.selectIsBackgroundTransformEditorOpen?.()) {
     return;
@@ -1031,6 +1169,9 @@ const handleBackgroundTransformBorderDragEnd = (deps) => {
 const mountBackgroundTransformEditorSubscriptions = (deps) => {
   const { subject } = deps;
   const streams = [
+    fromEvent(window, "keydown", { capture: true }).pipe(
+      tap((event) => handleBackgroundTransformEditorKeyDown(deps, event)),
+    ),
     subject.pipe(
       filter(({ action }) => action === "border-drag-start"),
       tap(({ payload }) =>
@@ -1088,6 +1229,11 @@ const closeActionTransformEditor = (deps, payload) => {
     editor?.transform,
     { preserveTransformId: true },
   );
+  const nextAction = replaceActionItem({
+    action: selectEditorActionSnapshot(store, editor),
+    itemIndex: editor?.itemIndex,
+    item: nextItem,
+  });
 
   refs?.systemActions?.transformedHandlers?.handleSetActionCustomTransform?.({
     targetType: editor?.targetType,
@@ -1101,8 +1247,7 @@ const closeActionTransformEditor = (deps, payload) => {
     refs,
     store,
     actionKey,
-    itemIndex: editor?.itemIndex,
-    item: nextItem,
+    action: nextAction,
   });
   requestBackgroundTransformEditorCanvasRender(subject);
   globalThis.setTimeout?.(() => {
@@ -1127,6 +1272,11 @@ export const handleBackgroundTransformEditorCloseClick = (deps, payload) => {
     editor?.background,
     editor?.transform,
   );
+  store.setTemporaryPresentationState?.({
+    presentationState: {
+      background: nextBackground,
+    },
+  });
   refs?.systemActions?.transformedHandlers?.handleSetBackgroundCustomTransform?.(
     {
       background: editor?.background,
@@ -1149,6 +1299,54 @@ export const handleBackgroundTransformEditorCloseClick = (deps, payload) => {
 
 export const handleBackgroundTransformEditorDone = (deps, payload) => {
   handleBackgroundTransformEditorCloseClick(deps, payload);
+};
+
+export const handleBackgroundTransformEditorCancel = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  payload?._event?.stopImmediatePropagation?.();
+  const { refs, render, store, subject } = deps;
+  const editor = store.selectBackgroundTransformEditor?.();
+
+  store.suppressNextActionsDialogClose?.();
+  store.closeBackgroundTransformEditor?.();
+
+  if (!editor?.targetType || editor.targetType === "background") {
+    const background = toPlainObject(editor?.background);
+    store.setTemporaryPresentationState?.({
+      presentationState: {
+        background,
+      },
+    });
+    render();
+    reopenBackgroundCommandLine({ refs, store, background });
+    requestTemporaryPresentationCanvasRender(subject);
+    globalThis.setTimeout?.(() => {
+      store.clearSuppressNextActionsDialogClose?.();
+      render();
+    }, 50);
+    return;
+  }
+
+  const actionKey = editor?.actionKey === "character" ? "character" : "visual";
+  const action = selectEditorActionSnapshot(store, editor);
+  store.setTemporaryPresentationState?.({
+    presentationState: {
+      [actionKey]: action,
+    },
+  });
+  render();
+  reopenActionTransformCommandLine({
+    refs,
+    store,
+    actionKey,
+    action,
+  });
+  requestTemporaryPresentationCanvasRender(subject);
+  globalThis.setTimeout?.(() => {
+    store.clearSuppressNextActionsDialogClose?.();
+    render();
+  }, 50);
 };
 
 export const handleActionTransformCustomize = (deps, payload) => {
@@ -1179,6 +1377,7 @@ export const handleActionTransformCustomize = (deps, payload) => {
   store.openBackgroundTransformEditor?.({
     targetType,
     actionKey,
+    action,
     itemIndex,
     item,
     targetId,
@@ -1233,12 +1432,14 @@ export const handleBeforeMount = (deps) => {
 
 export const handleAfterMount = async (deps) => {
   try {
+    const entryPayload = deps.appService?.getPayload?.() || {};
     await initializeSceneEditorPage({
       ...deps,
       syncProjectState: syncStoreProjectState,
     });
     reconcileCurrentEditorSession(deps);
     deps.render();
+    scrollEntrySelectionIntoView(deps, entryPayload);
   } catch (error) {
     if (!isMissingProjectResolutionError(error)) {
       throw error;
@@ -2144,12 +2345,14 @@ export const handleSectionTabRightClick = (deps, payload) => {
 
 export const handleActionsDialogClose = (deps) => {
   const { render, store, subject } = deps;
-  if (store.selectSuppressNextActionsDialogClose?.()) {
+  const suppressNext = store.selectSuppressNextActionsDialogClose?.() === true;
+  const editorOpen = store.selectIsBackgroundTransformEditorOpen?.() === true;
+  if (suppressNext) {
     store.clearSuppressNextActionsDialogClose?.();
     return;
   }
 
-  if (store.selectIsBackgroundTransformEditorOpen?.()) {
+  if (editorOpen) {
     return;
   }
 
@@ -2166,10 +2369,11 @@ export const handleActionsDialogClose = (deps) => {
 export const handleTemporaryPresentationStateChange = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { store, subject } = deps;
+  const presentationState = normalizeTemporaryPresentationState(
+    payload?._event?.detail,
+  );
   store.setTemporaryPresentationState?.({
-    presentationState: normalizeTemporaryPresentationState(
-      payload?._event?.detail,
-    ),
+    presentationState,
   });
   requestTemporaryPresentationCanvasRender(subject);
 };

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -624,6 +624,7 @@ export const createInitialState = () => ({
     background: {},
     targetType: "background",
     actionKey: "background",
+    action: undefined,
     itemIndex: undefined,
     item: undefined,
     targetId: undefined,
@@ -772,6 +773,7 @@ export const openBackgroundTransformEditor = (
     transform,
     targetType = "background",
     actionKey = "background",
+    action,
     itemIndex,
     item,
     targetId,
@@ -781,6 +783,9 @@ export const openBackgroundTransformEditor = (
   state.backgroundTransformEditor.background = toPlainObject(background);
   state.backgroundTransformEditor.targetType = targetType;
   state.backgroundTransformEditor.actionKey = actionKey;
+  state.backgroundTransformEditor.action = action
+    ? toPlainObject(action)
+    : undefined;
   state.backgroundTransformEditor.itemIndex = itemIndex;
   state.backgroundTransformEditor.item = item ? toPlainObject(item) : undefined;
   state.backgroundTransformEditor.targetId = targetId;
@@ -1142,11 +1147,15 @@ export const selectSelectedLineId = ({ state }) => {
 };
 
 export const setSelectedLineId = ({ state }, { selectedLineId } = {}) => {
+  const selectionChanged = state.selectedLineId !== selectedLineId;
   const syncedPresentationState = getSectionLinePresentationState(
     state,
     selectedLineId,
   );
   state.selectedLineId = selectedLineId;
+  if (selectionChanged) {
+    state.temporaryPresentationState = {};
+  }
   if (!selectedLineId) {
     state.presentationState = {};
     return;
@@ -1493,7 +1502,7 @@ const selectBackgroundTransformEditorViewData = ({ state }) => {
   return {
     isOpen: editor.isOpen === true,
     transform,
-    previewMaxWidth: `min(calc(100vw - 48px), calc((100vh - 170px) * ${widthMultiplier}))`,
+    previewMaxWidth: `min(100vw, calc((100vh - 122px) * ${widthMultiplier}))`,
     canvasAspectRatio: selectCanvasAspectRatio({ state }),
     suppressNextActionsDialogClose:
       editor.suppressNextActionsDialogClose === true,

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -103,6 +103,8 @@ refs:
         handler: handleBackgroundTransformCustomize
       background-transform-editor-done:
         handler: handleBackgroundTransformEditorDone
+      background-transform-editor-cancel:
+        handler: handleBackgroundTransformEditorCancel
       action-transform-customize:
         handler: handleActionTransformCustomize
       action-transform-editor-done:
@@ -156,10 +158,10 @@ template:
                           - rtgl-text: ${sectionsGraph}
                 $else:
                   - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
-                      - 'rtgl-view w=f ph=sm pv=md sv h=1fg style="min-width: 0; scroll-behavior: smooth;"':
+                      - 'rtgl-view w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px;"':
                           - $for section, sectionIndex in sectionEditorItems:
                               - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
-                                  - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: -16px; z-index: 5; min-width: 0;"':
+                                  - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
                                       - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
                                       - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm: ...
                                   - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -442,11 +442,6 @@ export const selectViewData = ({ state }) => {
     },
   };
 
-  // console.log({
-  //   selectedItemId: state.selectedItemId,
-  //   defaultValues: defaultValues,
-  // });
-
   return {
     flatItems,
     flatGroups,

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleCancelCustomTransformEditor,
   handleBeforeMount,
   handleCustomTransformButtonClick,
   handleCustomTransformDoneButtonClick,
@@ -238,6 +239,49 @@ describe("commandLineBackground.handlers", () => {
       originX: 64,
       originY: 128,
     });
+  });
+
+  it("clears stale custom transform mode when hydrating a predefined transform", () => {
+    const state = createInitialState();
+
+    setCustomTransformEnabled(
+      { state },
+      {
+        enabled: true,
+      },
+    );
+    setCustomTransform(
+      { state },
+      {
+        transform: {
+          x: 1400,
+          y: 800,
+        },
+      },
+    );
+
+    handleBeforeMount({
+      store: createStoreApi(state),
+      props: {
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+          x: 1400,
+          y: 800,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 1.2,
+          scaleY: 1.2,
+          rotation: 0,
+          originX: 960,
+          originY: 540,
+        },
+      },
+    });
+
+    expect(selectCustomTransformEnabled({ state })).toBe(false);
+    expect(selectCustomTransform({ state })).toBeUndefined();
+    expect(selectSelectedTransform({ state })).toBe("bg-center");
   });
 
   it("submits transformId when selected and omits it when cleared", () => {
@@ -1041,6 +1085,37 @@ describe("commandLineBackground.handlers", () => {
     );
     expect(dispatchEvent.mock.calls[0][0].bubbles).toBe(true);
     expect(dispatchEvent.mock.calls[0][0].composed).toBe(true);
+  });
+
+  it("cancels the local transform editor without saving", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+
+    openCustomTransformEditor({ state });
+
+    handleCancelCustomTransformEditor(
+      {
+        store: createStoreApi(state),
+        render,
+        dispatchEvent,
+      },
+      {
+        _event: event,
+      },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(selectCustomTransformEditorOpen({ state })).toBe(false);
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).not.toHaveBeenCalled();
   });
 
   it("exposes the nested background transform preview canvas root", () => {

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -349,9 +349,6 @@ describe("commandLineBackground.store", () => {
     expect(viewData.customTransformDetails).toEqual([
       { label: "Position", value: "100, 120" },
       { label: "Scale", value: "1.2 x 1.2" },
-      { label: "Rotation", value: "0" },
-      { label: "Anchor", value: "0.5, 0.5" },
-      { label: "Origin", value: "320, 180" },
     ]);
   });
 

--- a/tests/project/engineActions.test.js
+++ b/tests/project/engineActions.test.js
@@ -71,6 +71,31 @@ describe("normalizeLineActions", () => {
     });
   });
 
+  it("removes stale inline background transform fields when a transformId is selected", () => {
+    expect(
+      normalizeLineActions({
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+          x: 1400,
+          y: 800,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 1.2,
+          scaleY: 1.2,
+          rotation: 0,
+          originX: 960,
+          originY: 540,
+        },
+      }),
+    ).toEqual({
+      background: {
+        resourceId: "bg-school",
+        transformId: "bg-center",
+      },
+    });
+  });
+
   it("normalizes screen blur kernel size to a supported route-graphics value", () => {
     expect(
       normalizeLineActions({

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -484,6 +484,94 @@ describe("renderSceneEditorState", () => {
     );
   });
 
+  it("paints the main preview canvas after the background transform editor closes", async () => {
+    const projectData = createProjectData();
+    projectData.resources.images["bg-school"] = {
+      id: "bg-school",
+      fileId: "bg-school.png",
+      width: 3840,
+      height: 2160,
+    };
+    projectData.story.scenes["scene-1"].sections[
+      "section-1"
+    ].lines[1].actions.background = {
+      resourceId: "bg-school",
+      x: 2051,
+      y: 1300,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      scaleX: 1,
+      scaleY: 1,
+      rotation: 0,
+      originX: 0,
+      originY: 0,
+    };
+    const graphicsService = createGraphicsService();
+    graphicsService.attachCanvas = vi.fn(async () => {});
+    graphicsService.loadAssets = vi.fn(async () => {});
+    const mainCanvasRoot = {
+      isConnected: true,
+      id: "main-preview",
+    };
+    const transformEditorCanvasRoot = {
+      isConnected: true,
+      id: "transform-editor-preview",
+    };
+    const store = {
+      selectIsScenePageLoading: () => false,
+      selectPreviewScene: () => ({
+        previewVisible: false,
+      }),
+      selectSceneId: () => "scene-1",
+      selectSelectedSectionId: () => "section-1",
+      selectSelectedLineId: () => "line-2",
+      selectProjectData: () => projectData,
+      selectTemporaryPresentationState: () => ({}),
+      selectIsBackgroundTransformEditorOpen: () => false,
+      selectScene: () => ({
+        sections: [{ id: "section-1" }],
+      }),
+      selectIsMuted: () => false,
+      setPresentationState: ({ presentationState }) => {
+        store.presentationState = presentationState;
+      },
+      setSectionLineChanges: vi.fn(),
+    };
+
+    await renderSceneEditorCanvas(
+      {
+        store,
+        render: vi.fn(),
+        graphicsService,
+        projectService: {
+          getFileContent: vi.fn(async (fileId) => ({
+            url: fileId,
+          })),
+        },
+        refs: {
+          previewCanvasHost: {
+            getCanvasRoot: () => mainCanvasRoot,
+          },
+          systemActions: {
+            transformedHandlers: {
+              handleGetBackgroundTransformPreviewCanvasRoot: () =>
+                transformEditorCanvasRoot,
+            },
+          },
+        },
+      },
+      {
+        skipRender: true,
+        skipAnimations: true,
+      },
+    );
+
+    expect(graphicsService.attachCanvas).toHaveBeenCalledWith(mainCanvasRoot);
+    expect(graphicsService.attachCanvas).not.toHaveBeenCalledWith(
+      transformEditorCanvasRoot,
+    );
+  });
+
   it("syncs the graphics engine audio mute state from scene editor settings", async () => {
     const projectData = createProjectData();
     const graphicsService = createGraphicsService();

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyBackgroundTransformKeyboardPositionChange,
   applyBackgroundTransformResizeChange,
   handleActionsDialogClose,
+  handleActionTransformCustomize,
+  handleBackgroundTransformCustomize,
+  handleBackgroundTransformEditorCancel,
   handleBackgroundTransformEditorCloseClick,
+  handleBackgroundTransformEditorKeyDown,
   handleCommandLineSubmit,
   handleDropdownMenuClickItem,
   handleEditorBlur,
@@ -50,9 +55,202 @@ describe("sceneEditorLexical.handlers transform editor resize", () => {
       scaleY: 3,
     });
   });
+
+  it("nudges transform position with arrow keys", () => {
+    const transform = {
+      x: 100,
+      y: 120,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      scaleX: 1,
+      scaleY: 1,
+      rotation: 0,
+      originX: 960,
+      originY: 540,
+    };
+
+    expect(
+      applyBackgroundTransformKeyboardPositionChange({
+        transform,
+        key: "ArrowUp",
+      }),
+    ).toMatchObject({
+      x: 100,
+      y: 119,
+    });
+    expect(
+      applyBackgroundTransformKeyboardPositionChange({
+        transform,
+        key: "ArrowRight",
+        unit: 10,
+      }),
+    ).toMatchObject({
+      x: 110,
+      y: 120,
+    });
+  });
+
+  it("captures arrow keys while the transform editor is open", () => {
+    const event = {
+      key: "ArrowDown",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+    const setBackgroundTransformEditorTransform = vi.fn();
+    const deps = {
+      store: {
+        selectIsBackgroundTransformEditorOpen: vi.fn(() => true),
+        selectBackgroundTransformEditor: vi.fn(() => ({
+          transform: {
+            x: 100,
+            y: 120,
+            anchorX: 0.5,
+            anchorY: 0.5,
+            scaleX: 1,
+            scaleY: 1,
+            rotation: 0,
+            originX: 960,
+            originY: 540,
+          },
+        })),
+        clearBackgroundTransformEditorDragStartPosition: vi.fn(),
+        setBackgroundTransformEditorTransform,
+      },
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    const didHandle = handleBackgroundTransformEditorKeyDown(deps, event);
+
+    expect(didHandle).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(setBackgroundTransformEditorTransform).toHaveBeenCalledWith({
+      transform: expect.objectContaining({
+        x: 100,
+        y: 121,
+      }),
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.subject.dispatch).toHaveBeenCalledWith(
+      "sceneEditor.renderCanvas",
+      {
+        skipRender: true,
+        skipAnimations: true,
+        skipAudio: true,
+      },
+    );
+  });
 });
 
 describe("sceneEditorLexical.handlers actions dialog", () => {
+  it("opens the background transform editor from the predefined transform when stale inline fields are present", () => {
+    const openBackgroundTransformEditor = vi.fn();
+    const open = vi.fn();
+
+    handleBackgroundTransformCustomize(
+      {
+        store: {
+          selectRepositoryState: vi.fn(() => ({
+            project: {
+              resolution: {
+                width: 1920,
+                height: 1080,
+              },
+            },
+            images: {
+              items: {
+                "bg-school": {
+                  id: "bg-school",
+                  width: 1920,
+                  height: 1080,
+                },
+              },
+            },
+            transforms: {
+              items: {
+                "bg-center": {
+                  id: "bg-center",
+                  type: "transform",
+                  x: 100,
+                  y: 120,
+                  anchorX: 0.5,
+                  anchorY: 0.5,
+                  scaleX: 1,
+                  scaleY: 1,
+                  rotation: 0,
+                },
+              },
+            },
+          })),
+          selectSelectedLine: vi.fn(() => ({
+            actions: {},
+          })),
+          setTemporaryPresentationState: vi.fn(),
+          openBackgroundTransformEditor,
+        },
+        refs: {
+          systemActions: {
+            transformedHandlers: {
+              open,
+            },
+          },
+        },
+        render: vi.fn(),
+        subject: {
+          dispatch: vi.fn(),
+        },
+      },
+      {
+        _event: {
+          stopPropagation: vi.fn(),
+          detail: {
+            background: {
+              resourceId: "bg-school",
+              transformId: "bg-center",
+              x: 1400,
+              y: 800,
+              anchorX: 0.5,
+              anchorY: 0.5,
+              scaleX: 1.2,
+              scaleY: 1.2,
+              rotation: 0,
+            },
+          },
+        },
+      },
+    );
+
+    expect(openBackgroundTransformEditor).toHaveBeenCalledWith({
+      background: {
+        resourceId: "bg-school",
+        transformId: "bg-center",
+        x: 1400,
+        y: 800,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: 1.2,
+        scaleY: 1.2,
+        rotation: 0,
+      },
+      transform: expect.objectContaining({
+        x: 100,
+        y: 120,
+        scaleX: 1,
+        scaleY: 1,
+      }),
+    });
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "background",
+      }),
+    );
+  });
+
   it("closes only the background transform editor when Done is clicked", () => {
     const handleSetBackgroundCustomTransform = vi.fn();
     const open = vi.fn();
@@ -94,6 +292,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
             },
           },
         })),
+        setTemporaryPresentationState: vi.fn(),
         closeBackgroundTransformEditor: vi.fn(),
         suppressNextActionsDialogClose: vi.fn(),
         clearSuppressNextActionsDialogClose: vi.fn(),
@@ -126,6 +325,22 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     expect(handleSetBackgroundCustomTransform).toHaveBeenCalledWith({
       background: editor.background,
       transform: editor.transform,
+    });
+    expect(deps.store.setTemporaryPresentationState).toHaveBeenCalledWith({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+          x: 100,
+          y: 120,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          scaleX: 1,
+          scaleY: 1,
+          rotation: 0,
+          originX: 0,
+          originY: 0,
+        },
+      },
     });
     expect(open).toHaveBeenCalledWith({
       mode: "background",
@@ -203,6 +418,438 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     expect(store.clearActionTargetLineId).not.toHaveBeenCalled();
     expect(deps.render).not.toHaveBeenCalled();
     expect(deps.subject.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("cancels the background transform editor back to the background command line", () => {
+    const callOrder = [];
+    const open = vi.fn(() => {
+      callOrder.push("open");
+    });
+    let suppressNextClose = false;
+    const setTimeoutCalls = [];
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((callback, delay) => {
+        setTimeoutCalls.push({ callback, delay });
+        return 1;
+      });
+    const store = {
+      selectSelectedLine: vi.fn(() => ({
+        actions: {
+          dialogue: {
+            content: "line text",
+          },
+        },
+      })),
+      selectBackgroundTransformEditor: vi.fn(() => ({
+        targetType: "background",
+        background: {
+          resourceId: "bg-school",
+          transformId: "bg-center",
+        },
+        transform: {
+          x: 1400,
+          y: 800,
+        },
+      })),
+      closeBackgroundTransformEditor: vi.fn(),
+      suppressNextActionsDialogClose: vi.fn(() => {
+        suppressNextClose = true;
+      }),
+      selectSuppressNextActionsDialogClose: vi.fn(() => suppressNextClose),
+      clearSuppressNextActionsDialogClose: vi.fn(() => {
+        suppressNextClose = false;
+      }),
+      selectActionTargetLineId: vi.fn(),
+      clearActionTargetLineId: vi.fn(),
+      clearTemporaryPresentationState: vi.fn(),
+      setTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      refs: {
+        systemActions: {
+          transformedHandlers: {
+            open,
+          },
+        },
+      },
+      render: vi.fn(() => {
+        callOrder.push("render");
+      }),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+
+    try {
+      handleBackgroundTransformEditorCancel(deps, {
+        _event: event,
+      });
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(store.suppressNextActionsDialogClose).toHaveBeenCalledTimes(1);
+      expect(store.closeBackgroundTransformEditor).toHaveBeenCalledTimes(1);
+      expect(store.clearSuppressNextActionsDialogClose).not.toHaveBeenCalled();
+      expect(store.clearTemporaryPresentationState).not.toHaveBeenCalled();
+      expect(store.setTemporaryPresentationState).toHaveBeenCalledWith({
+        presentationState: {
+          background: {
+            resourceId: "bg-school",
+            transformId: "bg-center",
+          },
+        },
+      });
+      expect(open).toHaveBeenCalledWith({
+        mode: "background",
+        actions: {
+          dialogue: {
+            content: "line text",
+          },
+          background: {
+            resourceId: "bg-school",
+            transformId: "bg-center",
+          },
+        },
+      });
+      expect(deps.render).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(["render", "open"]);
+      expect(deps.subject.dispatch).toHaveBeenCalledWith(
+        "sceneEditor.renderCanvas",
+        {
+          skipRender: true,
+          skipAnimations: true,
+        },
+      );
+      expect(setTimeoutCalls).toHaveLength(1);
+      expect(setTimeoutCalls[0].delay).toBe(50);
+
+      handleActionsDialogClose(deps);
+
+      expect(store.clearSuppressNextActionsDialogClose).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(store.clearTemporaryPresentationState).not.toHaveBeenCalled();
+      expect(deps.render).toHaveBeenCalledTimes(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("cancels an action transform editor back to the owning command line", () => {
+    const callOrder = [];
+    const open = vi.fn(() => {
+      callOrder.push("open");
+    });
+    let suppressNextClose = false;
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(() => 1);
+    const selectedLineVisualAction = {
+      items: [
+        {
+          id: "stale-visual",
+          resourceId: "old-image",
+          transformId: "old-preset",
+        },
+      ],
+    };
+    const editorVisualAction = {
+      items: [
+        {
+          id: "visual-1",
+          resourceId: "image-1",
+          transformId: "preset",
+        },
+        {
+          id: "visual-2",
+          resourceId: "image-2",
+          transformId: "preset",
+        },
+      ],
+    };
+    const store = {
+      selectSelectedLine: vi.fn(() => ({
+        actions: {
+          visual: selectedLineVisualAction,
+        },
+      })),
+      selectBackgroundTransformEditor: vi.fn(() => ({
+        targetType: "visual",
+        actionKey: "visual",
+        action: editorVisualAction,
+        itemIndex: 0,
+        item: editorVisualAction.items[0],
+        transform: {
+          x: 1400,
+          y: 800,
+        },
+      })),
+      closeBackgroundTransformEditor: vi.fn(),
+      suppressNextActionsDialogClose: vi.fn(() => {
+        suppressNextClose = true;
+      }),
+      selectSuppressNextActionsDialogClose: vi.fn(() => suppressNextClose),
+      clearSuppressNextActionsDialogClose: vi.fn(() => {
+        suppressNextClose = false;
+      }),
+      setTemporaryPresentationState: vi.fn(),
+    };
+    const deps = {
+      store,
+      refs: {
+        systemActions: {
+          transformedHandlers: {
+            open,
+          },
+        },
+      },
+      render: vi.fn(() => {
+        callOrder.push("render");
+      }),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    try {
+      handleBackgroundTransformEditorCancel(deps);
+
+      expect(store.suppressNextActionsDialogClose).toHaveBeenCalledTimes(1);
+      expect(store.closeBackgroundTransformEditor).toHaveBeenCalledTimes(1);
+      expect(store.setTemporaryPresentationState).toHaveBeenCalledWith({
+        presentationState: {
+          visual: editorVisualAction,
+        },
+      });
+      expect(open).toHaveBeenCalledWith({
+        mode: "visual",
+        actions: {
+          visual: editorVisualAction,
+        },
+      });
+      expect(deps.subject.dispatch).toHaveBeenCalledWith(
+        "sceneEditor.renderCanvas",
+        {
+          skipRender: true,
+          skipAnimations: true,
+        },
+      );
+      expect(deps.render).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(["render", "open"]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("saves an action transform back into the owning command line snapshot", () => {
+    const handleSetActionCustomTransform = vi.fn();
+    const open = vi.fn();
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((callback) => {
+        callback();
+        return 1;
+      });
+    const editorVisualAction = {
+      items: [
+        {
+          id: "visual-1",
+          resourceId: "image-1",
+          transformId: "preset",
+        },
+        {
+          id: "visual-2",
+          resourceId: "image-2",
+          transformId: "preset",
+        },
+      ],
+    };
+    const store = {
+      selectSelectedLine: vi.fn(() => ({
+        actions: {
+          visual: {
+            items: [
+              {
+                id: "stale-visual",
+                resourceId: "old-image",
+                transformId: "old-preset",
+              },
+            ],
+          },
+        },
+      })),
+      selectBackgroundTransformEditor: vi.fn(() => ({
+        targetType: "visual",
+        actionKey: "visual",
+        action: editorVisualAction,
+        itemIndex: 0,
+        item: editorVisualAction.items[0],
+        transform: {
+          x: 1400,
+          y: 800,
+        },
+      })),
+      closeBackgroundTransformEditor: vi.fn(),
+      suppressNextActionsDialogClose: vi.fn(),
+      clearSuppressNextActionsDialogClose: vi.fn(),
+    };
+    const deps = {
+      store,
+      refs: {
+        systemActions: {
+          transformedHandlers: {
+            handleSetActionCustomTransform,
+            open,
+          },
+        },
+      },
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    try {
+      handleBackgroundTransformEditorCloseClick(deps, {
+        _event: {
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+          stopImmediatePropagation: vi.fn(),
+        },
+      });
+
+      expect(handleSetActionCustomTransform).toHaveBeenCalledWith({
+        targetType: "visual",
+        itemIndex: 0,
+        item: editorVisualAction.items[0],
+        transform: {
+          x: 1400,
+          y: 800,
+        },
+      });
+      expect(open).toHaveBeenCalledWith({
+        mode: "visual",
+        actions: {
+          visual: {
+            items: [
+              {
+                id: "visual-1",
+                resourceId: "image-1",
+                transformId: "preset",
+                x: 1400,
+                y: 800,
+                anchorX: 0.5,
+                anchorY: 0.5,
+                scaleX: 1,
+                scaleY: 1,
+                rotation: 0,
+                originX: 0,
+                originY: 0,
+              },
+              editorVisualAction.items[1],
+            ],
+          },
+        },
+      });
+      expect(deps.store.closeBackgroundTransformEditor).toHaveBeenCalledTimes(
+        1,
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("stores the full action snapshot when opening an action transform editor", () => {
+    const action = {
+      items: [
+        {
+          id: "visual-1",
+          resourceId: "image-1",
+          transformId: "preset",
+        },
+      ],
+    };
+    const openBackgroundTransformEditor = vi.fn();
+    const open = vi.fn();
+    const store = {
+      setTemporaryPresentationState: vi.fn(),
+      openBackgroundTransformEditor,
+      selectRepositoryState: vi.fn(() => ({
+        project: {
+          resolution: {
+            width: 1920,
+            height: 1080,
+          },
+        },
+        images: {
+          items: {
+            "image-1": {
+              id: "image-1",
+              width: 1920,
+              height: 1080,
+            },
+          },
+        },
+      })),
+      selectSelectedLine: vi.fn(() => ({
+        actions: {
+          visual: {
+            items: [],
+          },
+        },
+      })),
+    };
+    const deps = {
+      store,
+      refs: {
+        systemActions: {
+          transformedHandlers: {
+            open,
+          },
+        },
+      },
+      render: vi.fn(),
+      subject: {
+        dispatch: vi.fn(),
+      },
+    };
+
+    handleActionTransformCustomize(deps, {
+      _event: {
+        stopPropagation: vi.fn(),
+        detail: {
+          targetType: "visual",
+          actionKey: "visual",
+          itemIndex: 0,
+          item: action.items[0],
+          action,
+        },
+      },
+    });
+
+    expect(openBackgroundTransformEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetType: "visual",
+        actionKey: "visual",
+        action,
+        itemIndex: 0,
+        item: action.items[0],
+      }),
+    );
+    expect(open).toHaveBeenCalledWith({
+      mode: "visual",
+      actions: {
+        visual: action,
+      },
+    });
   });
 
   it("clears temporary presentation state and refreshes the canvas when the actions dialog closes", () => {

--- a/tests/sceneEditor/selectionPresentationState.test.js
+++ b/tests/sceneEditor/selectionPresentationState.test.js
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   selectEffectivePresentationState,
+  selectTemporaryPresentationState,
   setPresentationState,
   setSectionLineChanges,
   setSelectedLineId,
+  setTemporaryPresentationState,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.store.js";
 
 const stalePresentationState = {
@@ -97,6 +99,71 @@ describe("scene editor selected line presentation state", () => {
         ui: {
           resourceId: "dialogue-next",
         },
+      },
+    });
+  });
+
+  it("clears temporary presentation state when selecting a different line", () => {
+    const state = createInitialState();
+
+    setSelectedLineId({ state }, { selectedLineId: "line-previous" });
+    setPresentationState(
+      { state },
+      {
+        presentationState: {
+          background: {
+            resourceId: "background-committed",
+            transformId: "preset-center",
+          },
+        },
+      },
+    );
+    setTemporaryPresentationState(
+      { state },
+      {
+        presentationState: {
+          background: {
+            resourceId: "background-previous",
+            x: 1400,
+            y: 800,
+          },
+        },
+      },
+    );
+
+    setSelectedLineId({ state }, { selectedLineId: "line-next" });
+
+    expect(selectTemporaryPresentationState({ state })).toEqual({});
+    expect(selectEffectivePresentationState({ state })).toEqual({
+      background: {
+        resourceId: "background-committed",
+        transformId: "preset-center",
+      },
+    });
+  });
+
+  it("keeps temporary presentation state when reselecting the same line", () => {
+    const state = createInitialState();
+
+    setSelectedLineId({ state }, { selectedLineId: "line-next" });
+    setTemporaryPresentationState(
+      { state },
+      {
+        presentationState: {
+          background: {
+            resourceId: "background-next",
+            x: 1400,
+          },
+        },
+      },
+    );
+
+    setSelectedLineId({ state }, { selectedLineId: "line-next" });
+
+    expect(selectTemporaryPresentationState({ state })).toEqual({
+      background: {
+        resourceId: "background-next",
+        x: 1400,
       },
     });
   });

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -6,6 +6,7 @@ import {
 } from "../../src/components/systemActions/systemActions.store.js";
 import {
   handleActionsDialogClose,
+  handleActionsDialogCloseRequest,
   handleBackgroundTransformCustomize,
   handleBackgroundTransformEditorDone,
   handleGetBackgroundTransformPreviewCanvasRoot,
@@ -494,6 +495,68 @@ describe("systemActions.handlers", () => {
     expect(dispatchedEvents).toHaveLength(0);
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("turns suppressed dialog close requests into transform editor cancel", () => {
+    const dispatchedEvents = [];
+    const handleCancelBackground = vi.fn();
+    const handleCancelCharacters = vi.fn();
+    const handleCancelVisual = vi.fn();
+    const setSuppressDialogClose = vi.fn();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    handleActionsDialogCloseRequest(
+      {
+        props: {
+          backgroundTransformEditor: {
+            isOpen: true,
+          },
+        },
+        refs: {
+          commandLineBackground: {
+            transformedHandlers: {
+              handleCancelCustomTransformEditor: handleCancelBackground,
+            },
+          },
+          commandLineCharacters: {
+            transformedHandlers: {
+              handleCancelCustomTransformEditor: handleCancelCharacters,
+            },
+          },
+          commandLineVisual: {
+            transformedHandlers: {
+              handleCancelCustomTransformEditor: handleCancelVisual,
+            },
+          },
+        },
+        store: {
+          setSuppressDialogClose,
+        },
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        _event: {
+          preventDefault,
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(handleCancelBackground).toHaveBeenCalledTimes(1);
+    expect(handleCancelCharacters).toHaveBeenCalledTimes(1);
+    expect(handleCancelVisual).toHaveBeenCalledTimes(1);
+    expect(setSuppressDialogClose).toHaveBeenCalledWith({
+      suppressDialogClose: true,
+    });
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe(
+      "background-transform-editor-cancel",
+    );
   });
 
   it("clears temporary presentation state when the actions dialog closes", () => {

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js
@@ -32,7 +32,7 @@ describe("systemActionsDialogSurface.handlers", () => {
     expect(dispatchedEvents[0].type).toBe("close");
   });
 
-  it("does not emit close while close is suppressed", () => {
+  it("emits a close request while close is suppressed", () => {
     const dispatchedEvents = [];
     let stopPropagationCalled = false;
     let preventDefaultCalled = false;
@@ -58,7 +58,8 @@ describe("systemActionsDialogSurface.handlers", () => {
 
     expect(stopPropagationCalled).toBe(true);
     expect(preventDefaultCalled).toBe(true);
-    expect(dispatchedEvents).toHaveLength(0);
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("close-request");
   });
 
   it("closes on Escape only while open", () => {
@@ -124,6 +125,7 @@ describe("systemActionsDialogSurface.handlers", () => {
       },
     );
 
-    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents).toHaveLength(2);
+    expect(dispatchedEvents[1].type).toBe("close-request");
   });
 });


### PR DESCRIPTION
## Summary
- fix custom background transform preview persistence and predefined transform fallback behavior
- keep the command-line editor open when canceling the embedded custom transform preview
- add arrow-key movement support in transform preview mode and simplify the transform display chips
- update route-engine-js to 1.23.0 and @routevn/creator-model to 1.7.2
- remove temporary debug logging and unrelated console logs

## Tests
- bun install
- bun run lint
- bunx vitest run tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/systemActions/systemActions.handlers.test.js tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js tests/commandLineBackground/commandLineBackground.handlers.test.js tests/commandLineBackground/commandLineBackground.store.test.js tests/commandLineVisual/commandLineVisual.store.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js tests/project/engineActions.test.js tests/sceneEditor/runtime.test.js tests/sceneEditor/selectionPresentationState.test.js