### PR TITLE
Fix scene editor lexical selection navigation

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -111,6 +111,13 @@ Do not add unit tests for temporary diagnostic/debug logs. If debug logs are
 needed to inspect a local issue, keep tests focused on the underlying behavior
 instead of asserting log payloads.
 
+For rich-text editor selection bugs, separate the logical content offset from
+the DOM/Lexical selection position. Validate both the serialized content and
+the rendered caret boundary, especially around atomic chips and invisible
+caret anchors such as zero-length text nodes. Temporary selection logs should
+be removed once the behavior is protected by regression coverage or equivalent
+browser validation.
+
 Run one Puty scenario directly:
 
 ```bash

--- a/src/components/commandLineInput/commandLineInput.handlers.js
+++ b/src/components/commandLineInput/commandLineInput.handlers.js
@@ -36,7 +36,7 @@ const dispatchTemporaryPresentationStateChange = (deps) => {
     return;
   }
 
-  const form = store.selectFormData();
+  const form = store.selectFormDataWithEditingDraft();
   dispatchEvent(
     new CustomEvent("temporary-presentation-state-change", {
       detail: {
@@ -62,8 +62,6 @@ export const handleAfterMount = async (deps) => {
   await projectService.ensureRepository();
   const repositoryState = projectService.getRepositoryState();
   store.setRepositoryData({
-    scenes: repositoryState.scenes,
-    animations: repositoryState.animations,
     variables: repositoryState.variables,
   });
   store.hydrateForm({
@@ -78,26 +76,15 @@ export const handleFormChange = (deps, payload) => {
   const { props, render, store } = deps;
   const { name, value } = payload._event.detail;
 
-  if (name === "resourceId") {
-    store.setSelectedResourceId({
-      resourceId: value,
-      layouts: getLayouts({ props }),
-      layoutsData: getLayoutsData({ props }),
-    });
-  } else {
-    store.updateSettingsForm({ field: name, value });
-    if (name === "submitActionType" && value === "nextLine") {
-      store.updateSettingsForm({ field: "submitSceneId", value: "" });
-      store.updateSettingsForm({ field: "submitSectionId", value: "" });
-      store.updateSettingsForm({
-        field: "submitTransitionAnimationId",
-        value: "",
-      });
-    } else if (name === "submitSceneId") {
-      store.updateSettingsForm({ field: "submitSectionId", value: "" });
-    }
+  if (name !== "resourceId") {
+    return;
   }
 
+  store.setSelectedResourceId({
+    resourceId: value,
+    layouts: getLayouts({ props }),
+    layoutsData: getLayoutsData({ props }),
+  });
   render();
   dispatchTemporaryPresentationStateChange(deps);
 };
@@ -121,12 +108,65 @@ export const handleFieldConfigChange = (deps, payload) => {
   dispatchTemporaryPresentationStateChange(deps);
 };
 
+export const handleFieldRowClick = (deps, payload) => {
+  const { render, store } = deps;
+  const field = payload._event.currentTarget.dataset?.field;
+
+  if (!field) {
+    return;
+  }
+
+  store.startEditingField({ field });
+  render();
+};
+
+export const handleFieldEditChange = (deps, payload) => {
+  const { render, store } = deps;
+  const name = payload._event.currentTarget.dataset?.name;
+
+  if (!name) {
+    return;
+  }
+
+  store.updateEditFieldConfig({
+    name,
+    value: getEventValue(payload),
+  });
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleCancelFieldEditClick = (deps, payload = {}) => {
+  payload._event?.stopPropagation?.();
+  const { render, store } = deps;
+
+  store.cancelEditingField();
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleSaveFieldEditClick = (deps, payload = {}) => {
+  payload._event?.stopPropagation?.();
+  const { appService, render, store } = deps;
+
+  if (!store.selectCanSaveEditField()) {
+    appService.showAlert({
+      message: "Choose a string variable for this input field.",
+      title: "Warning",
+    });
+    return;
+  }
+
+  store.saveEditingField();
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
 export const handleSubmitClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { appService, dispatchEvent, store } = deps;
   const resourceId = store.selectSelectedResourceId();
   const fieldRows = store.selectFieldRows();
-  const settingsForm = store.selectSettingsForm();
 
   if (!resourceId) {
     appService.showAlert({
@@ -152,17 +192,6 @@ export const handleSubmitClick = (deps, payload) => {
     return;
   }
 
-  if (
-    settingsForm.submitActionType === "sectionTransition" &&
-    (!settingsForm.submitSceneId || !settingsForm.submitSectionId)
-  ) {
-    appService.showAlert({
-      message: "Please select a scene and section for the submit action.",
-      title: "Warning",
-    });
-    return;
-  }
-
   dispatchEvent(
     new CustomEvent("submit", {
       detail: {
@@ -173,7 +202,7 @@ export const handleSubmitClick = (deps, payload) => {
 };
 
 export const handleBreadcumbClick = (deps, payload) => {
-  const { dispatchEvent } = deps;
+  const { dispatchEvent, render, store } = deps;
 
   if (payload._event.detail.id === "actions") {
     dispatchEvent(
@@ -181,5 +210,9 @@ export const handleBreadcumbClick = (deps, payload) => {
         detail: {},
       }),
     );
+  } else if (payload._event.detail.id === "input") {
+    store.cancelEditingField();
+    render();
+    dispatchTemporaryPresentationStateChange(deps);
   }
 };

--- a/src/components/commandLineInput/commandLineInput.store.js
+++ b/src/components/commandLineInput/commandLineInput.store.js
@@ -1,10 +1,9 @@
-import { getTransitionAnimationOptions } from "../../internal/animationOptions.js";
 import { generateId } from "../../internal/id.js";
 import { getLayoutInputFieldItems } from "../../internal/project/layout.js";
 import { getVariableOptions } from "../../internal/project/projection.js";
-import { toFlatItems } from "../../internal/project/tree.js";
 
 const INPUT_FIELDS_SLOT = "input-fields";
+const DEFAULT_FIELD_MAX_LENGTH = 32;
 const EMPTY_COLLECTION = {
   items: {},
   tree: [],
@@ -12,10 +11,6 @@ const EMPTY_COLLECTION = {
 const BOOLEAN_OPTIONS = [
   { value: true, label: "Yes" },
   { value: false, label: "No" },
-];
-const SUBMIT_ACTION_TYPE_OPTIONS = [
-  { value: "nextLine", label: "Continue" },
-  { value: "sectionTransition", label: "Move to Section" },
 ];
 const FORM_TEMPLATE = {
   title: "Input",
@@ -33,46 +28,8 @@ const FORM_TEMPLATE = {
       slot: INPUT_FIELDS_SLOT,
       label: "Fields",
     },
-    {
-      name: "submitActionType",
-      type: "segmented-control",
-      label: "Submit Action",
-      required: true,
-      options: SUBMIT_ACTION_TYPE_OPTIONS,
-    },
-    {
-      $when: `values.submitActionType == 'sectionTransition'`,
-      name: "submitSceneId",
-      type: "select",
-      label: "Scene",
-      options: "${scenes}",
-    },
-    {
-      $when: `values.submitActionType == 'sectionTransition'`,
-      name: "submitSectionId",
-      type: "select",
-      label: "Section",
-      options: "${sections}",
-    },
-    {
-      $when: `values.submitActionType == 'sectionTransition'`,
-      name: "submitTransitionAnimationId",
-      type: "select",
-      label: "Screen",
-      required: false,
-      clearable: true,
-      placeholder: "Animation",
-      options: "${transitionAnimationOptions}",
-    },
   ],
 };
-
-const createDefaultSettingsForm = () => ({
-  submitActionType: "nextLine",
-  submitSceneId: "",
-  submitSectionId: "",
-  submitTransitionAnimationId: "",
-});
 
 const createFormId = () => generateId();
 
@@ -95,10 +52,12 @@ export const resolveSelectedResourceId = ({
   layouts = [],
   resourceId,
 } = {}) => {
-  const resourceOptions = getInputLayoutOptions(layouts);
+  if (!resourceId) {
+    return "";
+  }
 
+  const resourceOptions = getInputLayoutOptions(layouts);
   if (
-    resourceId &&
     resourceOptions.some(
       (resourceOption) => resourceOption.value === resourceId,
     )
@@ -106,7 +65,7 @@ export const resolveSelectedResourceId = ({
     return resourceId;
   }
 
-  return resourceOptions[0]?.value ?? "";
+  return "";
 };
 
 const getInputFieldItemsForResource = ({
@@ -161,9 +120,55 @@ const createFieldConfig = ({ item, existingField } = {}) => ({
   placeholder: existingField?.placeholder ?? item.placeholder ?? "",
   multiline: existingField?.multiline ?? item.multiline ?? false,
   maxLength: normalizeMaxLengthValue(
-    existingField?.maxLength ?? item.maxLength,
+    existingField?.maxLength ?? item.maxLength ?? DEFAULT_FIELD_MAX_LENGTH,
   ),
 });
+
+const createEmptyFieldConfig = () => ({
+  field: "",
+  label: "",
+  variableId: "",
+  required: false,
+  trim: true,
+  placeholder: "",
+  multiline: false,
+  maxLength: DEFAULT_FIELD_MAX_LENGTH,
+});
+
+const copyFieldConfig = (fieldConfig = {}) => ({
+  field: fieldConfig.field ?? "",
+  label: fieldConfig.label ?? fieldConfig.field ?? "",
+  variableId: fieldConfig.variableId ?? "",
+  required: fieldConfig.required === true,
+  trim: fieldConfig.trim !== false,
+  placeholder: fieldConfig.placeholder ?? "",
+  multiline: fieldConfig.multiline === true,
+  maxLength: normalizeMaxLengthValue(fieldConfig.maxLength),
+});
+
+const resetFieldEditor = (state) => {
+  state.mode = "list";
+  state.editingField = "";
+  state.editFieldForm = createEmptyFieldConfig();
+};
+
+const setFieldConfigValue = (fieldConfig, name, value) => {
+  if (!fieldConfig || !name) {
+    return;
+  }
+
+  if (name === "required" || name === "trim" || name === "multiline") {
+    fieldConfig[name] = value === true || value === "true";
+    return;
+  }
+
+  if (name === "maxLength") {
+    fieldConfig[name] = value ?? "";
+    return;
+  }
+
+  fieldConfig[name] = value ?? "";
+};
 
 const createFieldConfigs = ({ inputFieldItems = [], existingFields = {} }) => {
   const sourceItems =
@@ -196,21 +201,6 @@ const applyFieldConfigs = (state, fieldConfigs) => {
   state.fieldOrder = fieldConfigs.fieldOrder;
 };
 
-const createSettingsFormFromSubmitActions = (submitActions = {}) => {
-  const settingsForm = createDefaultSettingsForm();
-  const sectionTransition = submitActions.sectionTransition;
-
-  if (sectionTransition) {
-    settingsForm.submitActionType = "sectionTransition";
-    settingsForm.submitSceneId = sectionTransition.sceneId ?? "";
-    settingsForm.submitSectionId = sectionTransition.sectionId ?? "";
-    settingsForm.submitTransitionAnimationId =
-      sectionTransition.screen?.animations?.resourceId ?? "";
-  }
-
-  return settingsForm;
-};
-
 const createFormExtras = (form = {}) => {
   if (!form || typeof form !== "object" || Array.isArray(form)) {
     return {};
@@ -227,26 +217,7 @@ const createFormExtras = (form = {}) => {
   return structuredClone(extras);
 };
 
-export const buildSubmitActions = (settingsForm = {}) => {
-  if (settingsForm.submitActionType === "sectionTransition") {
-    const sectionTransition = {
-      sceneId: settingsForm.submitSceneId,
-      sectionId: settingsForm.submitSectionId,
-    };
-
-    if (settingsForm.submitTransitionAnimationId) {
-      sectionTransition.screen = {
-        animations: {
-          resourceId: settingsForm.submitTransitionAnimationId,
-        },
-      };
-    }
-
-    return {
-      sectionTransition,
-    };
-  }
-
+export const buildSubmitActions = () => {
   return {
     nextLine: {},
   };
@@ -281,7 +252,6 @@ const createFormFieldsObject = (fieldRows = []) => {
 export const createFormData = ({
   resourceId,
   fieldRows,
-  settingsForm,
   formExtras = {},
 } = {}) => {
   if (!resourceId) {
@@ -297,29 +267,24 @@ export const createFormData = ({
     ...formData,
     resourceId,
     fields: createFormFieldsObject(fieldRows),
-    submitActions: buildSubmitActions(settingsForm),
+    submitActions: buildSubmitActions(),
   };
 };
 
 export const createInitialState = () => ({
+  mode: "list",
   selectedResourceId: "",
   fields: {},
   fieldOrder: [],
-  settingsForm: createDefaultSettingsForm(),
+  editingField: "",
+  editFieldForm: createEmptyFieldConfig(),
   formExtras: {
     id: createFormId(),
   },
-  scenes: EMPTY_COLLECTION,
-  animations: EMPTY_COLLECTION,
   variables: EMPTY_COLLECTION,
 });
 
-export const setRepositoryData = (
-  { state },
-  { scenes, animations, variables } = {},
-) => {
-  state.scenes = scenes ?? EMPTY_COLLECTION;
-  state.animations = animations ?? EMPTY_COLLECTION;
+export const setRepositoryData = ({ state }, { variables } = {}) => {
   state.variables = variables ?? EMPTY_COLLECTION;
 };
 
@@ -341,12 +306,12 @@ export const hydrateForm = ({ state }, { form, layouts, layoutsData } = {}) => {
   const previousFormId = state.formExtras?.id;
 
   state.selectedResourceId = resourceId;
-  state.settingsForm = createSettingsFormFromSubmitActions(form?.submitActions);
   state.formExtras = createFormExtras(form);
   if (!state.formExtras.id) {
     state.formExtras.id = previousFormId ?? createFormId();
   }
   applyFieldConfigs(state, fieldConfigs);
+  resetFieldEditor(state);
 };
 
 export const setSelectedResourceId = (
@@ -365,10 +330,7 @@ export const setSelectedResourceId = (
   });
 
   applyFieldConfigs(state, fieldConfigs);
-};
-
-export const updateSettingsForm = ({ state }, { field, value } = {}) => {
-  state.settingsForm[field] = value;
+  resetFieldEditor(state);
 };
 
 export const updateFieldConfig = ({ state }, { field, name, value } = {}) => {
@@ -376,32 +338,95 @@ export const updateFieldConfig = ({ state }, { field, name, value } = {}) => {
     return;
   }
 
-  if (name === "required" || name === "trim" || name === "multiline") {
-    state.fields[field][name] = value === true || value === "true";
+  setFieldConfigValue(state.fields[field], name, value);
+};
+
+export const startEditingField = ({ state }, { field } = {}) => {
+  if (!field || !state.fields[field]) {
+    resetFieldEditor(state);
     return;
   }
 
-  if (name === "maxLength") {
-    state.fields[field][name] = value ?? "";
+  state.mode = "editField";
+  state.editingField = field;
+  state.editFieldForm = copyFieldConfig(state.fields[field]);
+};
+
+export const updateEditFieldConfig = ({ state }, { name, value } = {}) => {
+  if (state.mode !== "editField" || !state.editingField) {
     return;
   }
 
-  state.fields[field][name] = value ?? "";
+  setFieldConfigValue(state.editFieldForm, name, value);
+};
+
+export const saveEditingField = ({ state }, _payload = {}) => {
+  const field = state.editingField;
+  const fieldConfig = state.fields[field];
+
+  if (!field || !fieldConfig) {
+    resetFieldEditor(state);
+    return;
+  }
+
+  fieldConfig.variableId = state.editFieldForm.variableId ?? "";
+  fieldConfig.required = state.editFieldForm.required === true;
+  fieldConfig.trim = state.editFieldForm.trim === true;
+  fieldConfig.placeholder = state.editFieldForm.placeholder ?? "";
+  fieldConfig.multiline = state.editFieldForm.multiline === true;
+  fieldConfig.maxLength = normalizeMaxLengthValue(
+    state.editFieldForm.maxLength,
+  );
+  resetFieldEditor(state);
+};
+
+export const cancelEditingField = ({ state }, _payload = {}) => {
+  resetFieldEditor(state);
 };
 
 export const selectSelectedResourceId = ({ state }) =>
   state.selectedResourceId ?? "";
 
+export const selectMode = ({ state }) => state.mode ?? "list";
+
+export const selectEditFieldForm = ({ state }) =>
+  state.editFieldForm ?? createEmptyFieldConfig();
+
+export const selectCanSaveEditField = ({ state }) => {
+  return (
+    state.mode === "editField" &&
+    !!state.editingField &&
+    !!state.fields[state.editingField] &&
+    !!state.editFieldForm?.variableId
+  );
+};
+
 export const selectFieldRows = ({ state }) =>
   state.fieldOrder.map((field) => state.fields[field]).filter(Boolean);
 
-export const selectSettingsForm = ({ state }) => state.settingsForm;
+export const selectFieldRowsWithEditingDraft = ({ state }) => {
+  const fieldRows = selectFieldRows({ state });
+
+  if (state.mode !== "editField" || !state.editingField) {
+    return fieldRows;
+  }
+
+  return fieldRows.map((fieldRow) =>
+    fieldRow.field === state.editingField ? state.editFieldForm : fieldRow,
+  );
+};
 
 export const selectFormData = ({ state }) =>
   createFormData({
     resourceId: state.selectedResourceId,
     fieldRows: selectFieldRows({ state }),
-    settingsForm: state.settingsForm,
+    formExtras: state.formExtras,
+  });
+
+export const selectFormDataWithEditingDraft = ({ state }) =>
+  createFormData({
+    resourceId: state.selectedResourceId,
+    fieldRows: selectFieldRowsWithEditingDraft({ state }),
     formExtras: state.formExtras,
   });
 
@@ -415,13 +440,75 @@ export const selectCanSubmit = ({ state }) => {
     return false;
   }
 
-  if (state.settingsForm.submitActionType === "sectionTransition") {
-    return (
-      !!state.settingsForm.submitSceneId && !!state.settingsForm.submitSectionId
-    );
+  return true;
+};
+
+const getFieldRowSummary = (row, variableLabel) => {
+  const summary = [
+    variableLabel,
+    row.required ? "Required" : "Optional",
+    row.trim ? "Trim" : "Keep whitespace",
+    row.multiline ? "Multiline" : "Single line",
+  ];
+
+  if (row.placeholder) {
+    summary.push(`Placeholder: ${row.placeholder}`);
   }
 
-  return true;
+  if (row.maxLength !== "" && row.maxLength !== undefined) {
+    summary.push(`Max: ${row.maxLength}`);
+  }
+
+  return summary.join(" - ");
+};
+
+const createFieldDisplayRows = (fieldRows = [], variableOptions = []) => {
+  const variableLabels = new Map(
+    variableOptions.map((option) => [option.value, option.label]),
+  );
+
+  return fieldRows.map((row) => {
+    const variableLabel =
+      variableLabels.get(row.variableId) ?? "No variable mapped";
+
+    return {
+      ...row,
+      variableLabel,
+      summary: getFieldRowSummary(row, variableLabel),
+    };
+  });
+};
+
+const createFieldVariableOptions = (variablesData = EMPTY_COLLECTION) => {
+  return getVariableOptions(variablesData, {
+    type: "string",
+  }).map((option) => {
+    const variableType = (
+      variablesData.items?.[option.value]?.variableType || "string"
+    ).toLowerCase();
+
+    return {
+      ...option,
+      suffixText: variableType,
+    };
+  });
+};
+
+const createBreadcrumb = (state) => {
+  const breadcrumb = [{ id: "actions", label: "Actions", click: true }];
+
+  if (state.mode === "editField") {
+    breadcrumb.push({ id: "input", label: "Input", click: true });
+    breadcrumb.push({
+      label: state.editFieldForm?.label
+        ? `Edit ${state.editFieldForm.label}`
+        : "Edit Field",
+    });
+    return breadcrumb;
+  }
+
+  breadcrumb.push({ label: "Input" });
+  return breadcrumb;
 };
 
 export const selectViewData = ({ state, props }) => {
@@ -431,53 +518,32 @@ export const selectViewData = ({ state, props }) => {
     layouts,
     resourceId: state.selectedResourceId,
   });
-  const allScenes = toFlatItems(state.scenes).filter(
-    (item) => item.type === "scene",
+  const fieldVariableOptions = createFieldVariableOptions(state.variables);
+  const fieldRows = createFieldDisplayRows(
+    selectFieldRows({ state }),
+    fieldVariableOptions,
   );
-  const scenes = allScenes.map((item) => ({
-    label: item.name,
-    value: item.id,
-  }));
-  const selectedScene = allScenes.find(
-    (scene) => scene.id === state.settingsForm.submitSceneId,
-  );
-  const sections = selectedScene
-    ? toFlatItems(selectedScene.sections).map((item) => ({
-        label: item.name,
-        value: item.id,
-      }))
-    : [];
-  const fieldRows = selectFieldRows({ state });
+  const editFieldForm = selectEditFieldForm({ state });
 
   return {
-    breadcrumb: [
-      { id: "actions", label: "Actions", click: true },
-      { label: "Input" },
-    ],
+    mode: selectMode({ state }),
+    breadcrumb: createBreadcrumb(state),
     form: FORM_TEMPLATE,
-    formKey: `${selectedResourceId}|${state.fieldOrder.join("|")}|${state.settingsForm.submitActionType}|${state.settingsForm.submitSceneId}`,
+    formKey: `${selectedResourceId}|${state.fieldOrder.join("|")}`,
     defaultValues: {
       resourceId: selectedResourceId,
-      ...state.settingsForm,
     },
     context: {
       layoutOptions,
-      scenes,
-      sections,
-      transitionAnimationOptions: getTransitionAnimationOptions(
-        state.animations,
-        state.settingsForm.submitTransitionAnimationId,
-      ),
     },
     inputFieldsSlot: INPUT_FIELDS_SLOT,
     selectedResourceId,
     fieldRows,
     hasFields: fieldRows.length > 0,
-    fieldVariableOptions: getVariableOptions(state.variables, {
-      type: "string",
-      showType: true,
-    }),
+    editFieldForm,
+    fieldVariableOptions,
     booleanOptions: BOOLEAN_OPTIONS,
+    canSaveEditField: selectCanSaveEditField({ state }),
     submitDisabled: !selectCanSubmit({ state }),
   };
 };

--- a/src/components/commandLineInput/commandLineInput.view.yaml
+++ b/src/components/commandLineInput/commandLineInput.view.yaml
@@ -9,51 +9,79 @@ refs:
         handler: handleFormChange
       form-change:
         handler: handleFormChange
-  fieldConfig*:
+  fieldRow*:
+    eventListeners:
+      click:
+        handler: handleFieldRowClick
+  fieldEdit*:
     eventListeners:
       value-change:
-        handler: handleFieldConfigChange
+        handler: handleFieldEditChange
       value-input:
-        handler: handleFieldConfigChange
+        handler: handleFieldEditChange
+  cancelFieldEditButton:
+    eventListeners:
+      click:
+        handler: handleCancelFieldEditClick
+  saveFieldEditButton:
+    eventListeners:
+      click:
+        handler: handleSaveFieldEditClick
   submitButton:
     eventListeners:
       click:
         handler: handleSubmitClick
 template:
   - rtgl-view w=f h=f p=lg:
-      - rtgl-view d=h g=md:
-          - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-      - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f:
-              - rtgl-view slot=${inputFieldsSlot} g=md w=f:
-                  - $if hasFields:
-                      - $for fieldRow, index in fieldRows:
-                          - rtgl-view d=v g=md p=md bgc=mu br=md w=f:
-                              - rtgl-view d=h av=c w=f g=sm:
-                                  - rtgl-text s=sm w=1fg: ${fieldRow.label}
-                                  - rtgl-text s=xs c=mu-fg: ${fieldRow.field}
-                              - rtgl-view d=v g=sm w=f:
-                                  - rtgl-text s=sm c=mu-fg: Variable
-                                  - rtgl-select#fieldConfigVariable${index} data-field="${fieldRow.field}" data-name=variableId w=f :selectedValue=${fieldRow.variableId} :options=${fieldVariableOptions} placeholder="Choose a string variable...": null
-                              - rtgl-view d=h g=md w=f wrap:
-                                  - rtgl-view d=v g=xs w=150:
-                                      - rtgl-text s=sm c=mu-fg: Required
-                                      - rtgl-segmented-control#fieldConfigRequired${index} data-field="${fieldRow.field}" data-name=required w=f no-clear :selectedValue=${fieldRow.required} :options=${booleanOptions}: null
-                                  - rtgl-view d=v g=xs w=150:
-                                      - rtgl-text s=sm c=mu-fg: Trim
-                                      - rtgl-segmented-control#fieldConfigTrim${index} data-field="${fieldRow.field}" data-name=trim w=f no-clear :selectedValue=${fieldRow.trim} :options=${booleanOptions}: null
-                                  - rtgl-view d=v g=xs w=150:
-                                      - rtgl-text s=sm c=mu-fg: Multiline
-                                      - rtgl-segmented-control#fieldConfigMultiline${index} data-field="${fieldRow.field}" data-name=multiline w=f no-clear :selectedValue=${fieldRow.multiline} :options=${booleanOptions}: null
-                              - rtgl-view d=h g=md w=f wrap:
-                                  - rtgl-view d=v g=xs w=1fg:
-                                      - rtgl-text s=sm c=mu-fg: Placeholder
-                                      - rtgl-input#fieldConfigPlaceholder${index} data-field="${fieldRow.field}" data-name=placeholder w=f value=${fieldRow.placeholder}: null
-                                  - rtgl-view d=v g=xs w=150:
-                                      - rtgl-text s=sm c=mu-fg: Max Length
-                                      - rtgl-input#fieldConfigMaxLength${index} data-field="${fieldRow.field}" data-name=maxLength type=number min=0 step=1 w=f value=${fieldRow.maxLength}: null
-                    $else:
-                      - rtgl-view p=md bgc=mu br=md w=f:
-                          - rtgl-text s=sm c=mu-fg: No input fields found.
-      - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
-          - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit
+      - $if mode == "list":
+          - 'rtgl-view wh=f style="min-height: 0;"':
+              - rtgl-view d=h g=md:
+                  - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
+              - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f:
+                      - rtgl-view slot=${inputFieldsSlot} g=md w=f:
+                          - $if hasFields:
+                              - $for fieldRow, index in fieldRows:
+                                  - rtgl-view#fieldRow${index} data-field="${fieldRow.field}" d=h av=c w=f g=md p=sm bgc=mu br=sm cur=pointer:
+                                      - rtgl-view d=v g=xs w=1fg:
+                                          - rtgl-view d=h av=c w=f g=sm:
+                                              - rtgl-text s=sm w=1fg: ${fieldRow.label}
+                                              - rtgl-text s=xs c=mu-fg: ${fieldRow.field}
+                                          - rtgl-text s=xs c=mu-fg: ${fieldRow.summary}
+                            $else:
+                              - rtgl-view p=md bgc=mu br=md w=f:
+                                  - rtgl-text s=sm c=mu-fg: No input fields found.
+              - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
+                  - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit
+        $elif mode == "editField":
+          - 'rtgl-view wh=f style="min-height: 0;"':
+              - rtgl-view d=h g=md:
+                  - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
+              - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
+                  - rtgl-view d=v g=lg w=f:
+                      - rtgl-view d=v g=xs w=f:
+                          - rtgl-text s=sm: ${editFieldForm.label}
+                          - rtgl-text s=xs c=mu-fg: ${editFieldForm.field}
+                      - rtgl-view d=v g=sm w=f:
+                          - rtgl-text s=sm c=mu-fg: Variable
+                          - rtgl-select#fieldEditVariable data-name=variableId w=f no-clear :selectedValue=${editFieldForm.variableId} :options=${fieldVariableOptions} placeholder="Choose a string variable...": null
+                      - rtgl-view d=h g=md w=f wrap:
+                          - rtgl-view d=v g=xs w=150:
+                              - rtgl-text s=sm c=mu-fg: Required
+                              - rtgl-segmented-control#fieldEditRequired data-name=required w=f no-clear :selectedValue=${editFieldForm.required} :options=${booleanOptions}: null
+                          - rtgl-view d=v g=xs w=150:
+                              - rtgl-text s=sm c=mu-fg: Trim
+                              - rtgl-segmented-control#fieldEditTrim data-name=trim w=f no-clear :selectedValue=${editFieldForm.trim} :options=${booleanOptions}: null
+                          - rtgl-view d=v g=xs w=150:
+                              - rtgl-text s=sm c=mu-fg: Multiline
+                              - rtgl-segmented-control#fieldEditMultiline data-name=multiline w=f no-clear :selectedValue=${editFieldForm.multiline} :options=${booleanOptions}: null
+                      - rtgl-view d=h g=md w=f wrap:
+                          - rtgl-view d=v g=xs w=1fg:
+                              - rtgl-text s=sm c=mu-fg: Placeholder
+                              - rtgl-input#fieldEditPlaceholder data-name=placeholder w=f value=${editFieldForm.placeholder}: null
+                          - rtgl-view d=v g=xs w=150:
+                              - rtgl-text s=sm c=mu-fg: Max Length
+                              - rtgl-input#fieldEditMaxLength data-name=maxLength type=number min=0 step=1 w=f value=${editFieldForm.maxLength}: null
+              - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
+                  - rtgl-button#cancelFieldEditButton v=ol: Cancel
+                  - rtgl-button#saveFieldEditButton ?disabled=${!canSaveEditField}: Save Field

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js
@@ -4,7 +4,7 @@ const createDefaultValuesFromProps = (props = {}) => {
   const source = props.defaultValues ?? {};
 
   return {
-    name: source.name ?? "Sprite",
+    name: source.name ?? "Image",
   };
 };
 

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
@@ -14,6 +14,8 @@ propsSchema:
         properties: null
     selectedLineId:
       type: string
+    selectionActive:
+      type: boolean
     showLineNumbers:
       type: boolean
     textStyles:

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.store.js
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.store.js
@@ -4,6 +4,7 @@ export const selectViewData = ({ props }) => ({
   lines: props.lines || [],
   lineDecorations: props.lineDecorations || [],
   selectedLineId: props.selectedLineId,
+  selectionActive: props.selectionActive ?? true,
   showLineNumbers: props.showLineNumbers ?? true,
   textStyles: props.textStyles || [],
   mentionTargets: props.mentionTargets || [],

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
@@ -26,4 +26,4 @@ refs:
       furigana-dialog-request:
         handler: handleFuriganaDialogRequest
 template:
-  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectionActive=${selectionActive} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -5,6 +5,7 @@ import {
 } from "../../internal/runtimeActions.js";
 import { buildCharacterSpritePreviewFileIds } from "../../internal/characterSpritePreview.js";
 import { normalizeLineActions } from "../../internal/project/engineActions.js";
+import { getLayoutInputFieldItems } from "../../internal/project/layout.js";
 
 export const createInitialState = () => ({
   mode: "actions",
@@ -344,6 +345,27 @@ const truncatePreviewText = (value = "", maxLength = 36) => {
 
 const isPlainObject = (value) => {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+};
+
+const toPreviewLabel = (value, fallback = "") => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (isPlainObject(value)) {
+    const candidate =
+      value.label ?? value.name ?? value.field ?? value.id ?? value.value;
+
+    return candidate === undefined
+      ? fallback
+      : toPreviewLabel(candidate, fallback);
+  }
+
+  return fallback;
 };
 
 const resolveDialogueActionForPreview = ({
@@ -794,29 +816,46 @@ export const selectActionsData = ({ props, state }) => {
   if (actions.form) {
     actionsObject.form = actions.form;
     const variableItems = repositoryStateData.variables?.items || {};
+    const layout = layoutsItems[actions.form.resourceId];
+    const inputFieldItems = getLayoutInputFieldItems({
+      layout,
+      layoutId: actions.form.resourceId,
+      layoutsData: layoutsHierarchy,
+    });
+    const inputFieldsById = new Map(
+      inputFieldItems.map((field) => [field.field, field]),
+    );
     const fields =
       actions.form.fields &&
       typeof actions.form.fields === "object" &&
       !Array.isArray(actions.form.fields)
         ? actions.form.fields
         : {};
-    const fieldItems = Object.entries(fields).map(([fieldId, field]) => {
+    const fieldItems = Object.entries(fields).map(([fieldId, field], index) => {
       const variableId = field?.variableId;
       const variable = variableItems[variableId];
+      const inputField = inputFieldsById.get(fieldId) ?? inputFieldItems[index];
+      const fieldLabel = toPreviewLabel(
+        inputField?.label ?? inputField?.field ?? fieldId,
+        fieldId,
+      );
+      const variableName = toPreviewLabel(
+        variable?.name ?? variableId,
+        "No variable",
+      );
 
       return {
         field: fieldId,
+        fieldLabel,
         variableId,
-        variableName: variable?.name ?? variableId ?? "No variable",
+        variableName,
+        summary: `${fieldLabel}: ${variableName}`,
       };
     });
 
     preview.form = {
-      layout: layoutsItems[actions.form.resourceId],
-      layoutName:
-        layoutsItems[actions.form.resourceId]?.name ??
-        actions.form.resourceId ??
-        "No layout",
+      layout,
+      layoutName: layout?.name ?? actions.form.resourceId ?? "No layout",
       fields: fieldItems,
       fieldCount: fieldItems.length,
       submitActionCount: countActions(actions.form.submitActions),

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -141,12 +141,12 @@ template:
               - $if preview.form:
                   - rtgl-view#actionItemInput data-mode=input g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md w=f cur=pointer pv=md:
                       - rtgl-svg svg=input wh=24: null
-                      - rtgl-view d=v g=sm:
-                          - rtgl-text s=sm: ${preview.form.layoutName}
-                          - rtgl-view d=h g=sm wrap:
+                      - 'rtgl-view d=v g=sm w=1fg style="min-width: 0;"':
+                          - rtgl-text s=sm w=f: ${preview.form.layoutName}
+                          - rtgl-view d=h g=sm wrap w=f:
                               - $for field in preview.form.fields:
                                   - rtgl-view bw=xs bc=bo br=sm ph=md pv=sm:
-                                      - rtgl-text s=sm: '${field.field}: ${field.variableName}'
+                                      - rtgl-text s=sm: ${field.summary}
               - $if preview.nextLine:
                   - rtgl-view#actionItemNextLine data-mode=nextLine g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg="settings" wh=24: null

--- a/src/deps/clients/router.js
+++ b/src/deps/clients/router.js
@@ -16,11 +16,16 @@ const normalizeThrottleMs = (value) => {
   return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
 };
 
+const getCurrentPathWithSearch = () => {
+  return `${window.location.pathname}${window.location.search}`;
+};
+
 export default class WebRouter {
   // _routes;
   routerType = "web";
   pendingPayload = undefined;
   pendingPayloadPath = undefined;
+  pendingPayloadSourcePath = undefined;
   pendingPayloadTimerId = undefined;
   lastPayloadReplaceAt = 0;
 
@@ -31,7 +36,7 @@ export default class WebRouter {
   getPayload = () => {
     if (
       this.pendingPayload &&
-      this.pendingPayloadPath === window.location.pathname
+      this.pendingPayloadSourcePath === getCurrentPathWithSearch()
     ) {
       return { ...this.pendingPayload };
     }
@@ -50,12 +55,13 @@ export default class WebRouter {
     }
     this.pendingPayload = undefined;
     this.pendingPayloadPath = undefined;
+    this.pendingPayloadSourcePath = undefined;
     this.pendingPayloadTimerId = undefined;
   };
 
   replacePayload = (payload, path = window.location.pathname) => {
     const finalPath = createPathWithPayload(path, payload);
-    const currentPath = `${window.location.pathname}${window.location.search}`;
+    const currentPath = getCurrentPathWithSearch();
     if (finalPath === currentPath) {
       return;
     }
@@ -67,14 +73,16 @@ export default class WebRouter {
   flushPendingPayload = () => {
     const payload = this.pendingPayload;
     const path = this.pendingPayloadPath;
+    const sourcePath = this.pendingPayloadSourcePath;
     if (this.pendingPayloadTimerId !== undefined) {
       clearTimeout(this.pendingPayloadTimerId);
     }
     this.pendingPayload = undefined;
     this.pendingPayloadPath = undefined;
+    this.pendingPayloadSourcePath = undefined;
     this.pendingPayloadTimerId = undefined;
 
-    if (payload && path === window.location.pathname) {
+    if (payload && sourcePath === getCurrentPathWithSearch()) {
       this.replacePayload(payload, path);
     }
   };
@@ -100,6 +108,7 @@ export default class WebRouter {
     const elapsedMs = Date.now() - this.lastPayloadReplaceAt;
     this.pendingPayload = { ...payload };
     this.pendingPayloadPath = window.location.pathname;
+    this.pendingPayloadSourcePath = getCurrentPathWithSearch();
     if (elapsedMs >= throttleMs) {
       this.flushPendingPayload();
       return;

--- a/src/deps/clients/router.js
+++ b/src/deps/clients/router.js
@@ -1,12 +1,41 @@
+const createPayloadQuery = (payload) => {
+  const queryParams = new URLSearchParams();
+  Object.entries(payload).forEach(([key, value]) => {
+    queryParams.set(key, value);
+  });
+  return queryParams.toString();
+};
+
+const createPathWithPayload = (path, payload) => {
+  const query = payload ? createPayloadQuery(payload) : "";
+  return query ? `${path}?${query}` : path;
+};
+
+const normalizeThrottleMs = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
+};
+
 export default class WebRouter {
   // _routes;
   routerType = "web";
+  pendingPayload = undefined;
+  pendingPayloadPath = undefined;
+  pendingPayloadTimerId = undefined;
+  lastPayloadReplaceAt = 0;
 
   getPathName = () => {
     return window.location.pathname;
   };
 
   getPayload = () => {
+    if (
+      this.pendingPayload &&
+      this.pendingPayloadPath === window.location.pathname
+    ) {
+      return { ...this.pendingPayload };
+    }
+
     const searchParams = new URLSearchParams(window.location.search);
     const payload = {};
     for (const [key, value] of searchParams.entries()) {
@@ -15,48 +44,84 @@ export default class WebRouter {
     return payload;
   };
 
-  setPayload = (payload) => {
-    // update query params without reloading the page
-    const newQueryParams = new URLSearchParams();
-    Object.entries(payload).forEach(([key, value]) => {
-      newQueryParams.set(key, value);
-    });
-    if (newQueryParams.toString()) {
-      window.history.replaceState(
-        {},
-        "",
-        `${window.location.pathname}?${newQueryParams.toString()}`,
-      );
-    } else {
-      window.history.replaceState({}, "", window.location.pathname);
+  clearPendingPayload = () => {
+    if (this.pendingPayloadTimerId !== undefined) {
+      clearTimeout(this.pendingPayloadTimerId);
+    }
+    this.pendingPayload = undefined;
+    this.pendingPayloadPath = undefined;
+    this.pendingPayloadTimerId = undefined;
+  };
+
+  replacePayload = (payload, path = window.location.pathname) => {
+    const finalPath = createPathWithPayload(path, payload);
+    const currentPath = `${window.location.pathname}${window.location.search}`;
+    if (finalPath === currentPath) {
+      return;
+    }
+
+    window.history.replaceState({}, "", finalPath);
+    this.lastPayloadReplaceAt = Date.now();
+  };
+
+  flushPendingPayload = () => {
+    const payload = this.pendingPayload;
+    const path = this.pendingPayloadPath;
+    if (this.pendingPayloadTimerId !== undefined) {
+      clearTimeout(this.pendingPayloadTimerId);
+    }
+    this.pendingPayload = undefined;
+    this.pendingPayloadPath = undefined;
+    this.pendingPayloadTimerId = undefined;
+
+    if (payload && path === window.location.pathname) {
+      this.replacePayload(payload, path);
     }
   };
 
-  redirect = (path, payload) => {
-    let finalPath = path;
-    if (payload) {
-      let qs = "";
-      if (payload) {
-        qs = `?${new URLSearchParams(payload).toString()}`;
-      }
-      finalPath = `${path}${qs}`;
+  schedulePendingPayload = (delayMs) => {
+    if (this.pendingPayloadTimerId !== undefined) {
+      return;
     }
+
+    this.pendingPayloadTimerId = setTimeout(() => {
+      this.flushPendingPayload();
+    }, delayMs);
+  };
+
+  setPayload = (payload, options = {}) => {
+    const throttleMs = normalizeThrottleMs(options.throttleMs);
+    if (throttleMs === 0) {
+      this.clearPendingPayload();
+      this.replacePayload(payload);
+      return;
+    }
+
+    const elapsedMs = Date.now() - this.lastPayloadReplaceAt;
+    this.pendingPayload = { ...payload };
+    this.pendingPayloadPath = window.location.pathname;
+    if (elapsedMs >= throttleMs) {
+      this.flushPendingPayload();
+      return;
+    }
+
+    this.schedulePendingPayload(throttleMs - elapsedMs);
+  };
+
+  redirect = (path, payload) => {
+    this.clearPendingPayload();
+    const finalPath = createPathWithPayload(path, payload);
     window.history.pushState({}, "", finalPath);
   };
 
   replace = (path, payload) => {
-    let finalPath = path;
-    if (payload) {
-      let qs = "";
-      if (payload) {
-        qs = `?${new URLSearchParams(payload).toString()}`;
-      }
-      finalPath = `${path}${qs}`;
-    }
+    this.clearPendingPayload();
+    const finalPath = createPathWithPayload(path, payload);
     window.history.replaceState({}, "", finalPath);
   };
 
   back = () => {
+    this.clearPendingPayload();
     window.history.back();
   };
 

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -95,8 +95,8 @@ export const createAppShellService = ({
       return getCurrentProjectId();
     },
 
-    setPayload(payload) {
-      router.setPayload(payload);
+    setPayload(payload, options) {
+      router.setPayload(payload, options);
     },
 
     back() {

--- a/src/internal/layoutEditorElementRegistry.js
+++ b/src/internal/layoutEditorElementRegistry.js
@@ -104,14 +104,12 @@ const CREATE_TEMPLATES = {
   }),
   "form-submit-button": () => ({
     type: "container",
-    name: "Submit Button",
+    name: "Input Submit Container",
     ...BASE_TRANSFORM,
     direction: ABSOLUTE_DIRECTION,
     gapX: 0,
     gapY: 0,
     formRole: "submit",
-    width: 160,
-    height: 52,
   }),
   slider: () => ({
     type: "slider",

--- a/src/internal/ui/fileExplorer.js
+++ b/src/internal/ui/fileExplorer.js
@@ -808,7 +808,7 @@ export const createLayoutElementsFileExplorerHandlers = ({
             name: "New Folder",
           },
           parentId: null,
-          position: "last",
+          position: "first",
         });
       } else if (action === "new-child-folder") {
         if (!itemId) {
@@ -824,7 +824,7 @@ export const createLayoutElementsFileExplorerHandlers = ({
             name: "New Folder",
           },
           parentId: itemId,
-          position: "last",
+          position: "first",
         });
       } else if (
         action &&
@@ -850,7 +850,7 @@ export const createLayoutElementsFileExplorerHandlers = ({
           elementId: nextElementId,
           data: nextElementData,
           parentId: itemId || null,
-          position: "last",
+          position: "first",
         });
         if (createResult?.valid === false) {
           appService.showAlert({

--- a/src/pages/layoutEditor/layoutEditor.constants.yaml
+++ b/src/pages/layoutEditor/layoutEditor.constants.yaml
@@ -4,7 +4,7 @@ contextMenuItems:
   - label: Container
     type: item
     createType: container
-  - label: Sprite
+  - label: Image
     type: item
     createType: sprite
   - label: Spritesheet Animation
@@ -24,7 +24,7 @@ contextMenuItems:
     type: item
     createType: input
   - "$when": 'layoutType == "input"'
-    label: Submit Button
+    label: Input Submit Container
     type: item
     createType: form-submit-button
   - label: Fragment
@@ -83,7 +83,7 @@ contextMenuItems:
     type: item
     createType: container-save-load-slot
   - "$when": 'layoutType == "save-load"'
-    label: Sprite (Save Image)
+    label: Image (Save Image)
     type: item
     createType: sprite-save-load-slot-image
   - "$when": 'layoutType == "save-load"'
@@ -110,7 +110,7 @@ emptyContextMenuItems:
   - label: Container
     type: item
     createType: container
-  - label: Sprite
+  - label: Image
     type: item
     createType: sprite
   - label: Spritesheet Animation
@@ -130,7 +130,7 @@ emptyContextMenuItems:
     type: item
     createType: input
   - "$when": 'layoutType == "input"'
-    label: Submit Button
+    label: Input Submit Container
     type: item
     createType: form-submit-button
   - label: Fragment
@@ -149,7 +149,7 @@ emptyContextMenuItems:
     type: item
     createType: container-save-load-slot
   - "$when": 'layoutType == "save-load"'
-    label: Sprite (Save Image)
+    label: Image (Save Image)
     type: item
     createType: sprite-save-load-slot-image
   - "$when": 'layoutType == "save-load"'

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -649,12 +649,12 @@ const showSliderCreateDialog = async (appService, sliderAction = {}) => {
 const showSpriteCreateDialog = async (appService, spriteAction = {}) => {
   return appService.showComponentDialog({
     component: SPRITE_CREATE_DIALOG_COMPONENT,
-    title: "Create Sprite",
-    description: "Choose the sprite image before inserting it into the layout",
+    title: "Create Image",
+    description: "Choose the image before inserting it into the layout",
     size: "md",
     props: {
       defaultValues: {
-        name: spriteAction.name ?? "Sprite",
+        name: spriteAction.name ?? "Image",
       },
     },
     actions: {
@@ -668,7 +668,7 @@ const showSpriteCreateDialog = async (appService, spriteAction = {}) => {
         },
         {
           id: "create",
-          label: "Create Sprite",
+          label: "Create Image",
           variant: "pr",
           role: "confirm",
           validate: true,
@@ -724,7 +724,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       elementId: slotContainerId,
       data: slotContainer,
       parentId,
-      position: "last",
+      position: "first",
     });
 
     if (createContainerResult?.valid === false) {
@@ -851,7 +851,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
         fragmentLayoutId,
       },
       parentId,
-      position: "last",
+      position: "first",
     });
 
     if (createResult?.valid === false) {
@@ -973,7 +973,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       elementId: nextElementId,
       data: nextElementData,
       parentId,
-      position: "last",
+      position: "first",
     });
 
     if (createResult?.valid === false) {
@@ -1087,7 +1087,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       elementId: nextElementId,
       data: nextElementData,
       parentId,
-      position: "last",
+      position: "first",
     });
 
     if (createResult?.valid === false) {
@@ -1125,7 +1125,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       );
     } catch {
       appService.showAlert({
-        message: "Failed to open sprite dialog.",
+        message: "Failed to open image dialog.",
         title: "Error",
       });
       return;
@@ -1139,7 +1139,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     const name = values.name?.trim();
     if (!name) {
       appService.showAlert({
-        message: "Sprite name is required.",
+        message: "Image name is required.",
         title: "Warning",
       });
       return;
@@ -1199,15 +1199,12 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
       elementId: nextElementId,
       data: nextElementData,
       parentId,
-      position: "last",
+      position: "first",
     });
 
     if (createResult?.valid === false) {
       appService.showAlert({
-        message: getResultErrorMessage(
-          createResult,
-          "Failed to create sprite.",
-        ),
+        message: getResultErrorMessage(createResult, "Failed to create image."),
         title: "Error",
       });
       return;
@@ -1307,7 +1304,7 @@ const handleFileExplorerActionUnsafe = async (deps, payload) => {
     elementId: nextElementId,
     data: nextElementData,
     parentId,
-    position: "last",
+    position: "first",
   });
 
   if (createResult?.valid === false) {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -46,6 +46,7 @@ const BACKGROUND_TRANSFORM_RESIZE_TARGET_PREFIX = "selected-border-resize-";
 const MIN_BACKGROUND_TRANSFORM_SCALE = 0.01;
 const BACKGROUND_TRANSFORM_KEYBOARD_NUDGE = 1;
 const BACKGROUND_TRANSFORM_KEYBOARD_LARGE_NUDGE = 10;
+const SCENE_EDITOR_SELECTION_URL_SYNC_THROTTLE_MS = 250;
 
 const toPlainObject = (value) => {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -232,7 +233,10 @@ const findPreviousSectionLastLineTarget = (
   return undefined;
 };
 
-const selectEditorTarget = (deps, { sectionId, lineId } = {}) => {
+const selectEditorTarget = (
+  deps,
+  { sectionId, lineId, payloadThrottleMs } = {},
+) => {
   const { appService, store } = deps;
   const nextSectionId = sectionId || findSectionIdForLine(store, lineId);
 
@@ -260,7 +264,11 @@ const selectEditorTarget = (deps, { sectionId, lineId } = {}) => {
       delete nextPayload.lineId;
     }
 
-    appService.setPayload(nextPayload);
+    if (payloadThrottleMs > 0) {
+      appService.setPayload(nextPayload, { throttleMs: payloadThrottleMs });
+    } else {
+      appService.setPayload(nextPayload);
+    }
   }
 
   return nextSectionId;
@@ -1868,11 +1876,14 @@ export const handleSelectedLineChanged = (deps, payload) => {
   const sectionId =
     getSectionIdFromPayload(payload) || findSectionIdForLine(store, lineId);
   const previousLineId = store.selectSelectedLineId();
+  const previousSectionId = store.selectSelectedSectionId?.();
   const isSameSelection =
-    lineId === previousLineId &&
-    sectionId === store.selectSelectedSectionId?.();
+    lineId === previousLineId && sectionId === previousSectionId;
   let adjacentSectionTarget;
-  if (isSameSelection && detail.mode === "block") {
+  const canCrossSectionFromCurrentMode =
+    detail.mode === "block" ||
+    (detail.mode === "text-editor" && detail.isBoundaryNavigation === true);
+  if (isSameSelection && canCrossSectionFromCurrentMode) {
     if (detail.navigationDirection === "down") {
       adjacentSectionTarget = findNextSectionFirstLineTarget(store, {
         sectionId,
@@ -1891,18 +1902,41 @@ export const handleSelectedLineChanged = (deps, payload) => {
   }
 
   const target = adjacentSectionTarget || { sectionId, lineId };
-  selectEditorTarget(deps, target);
+  selectEditorTarget(deps, {
+    sectionId: target.sectionId,
+    lineId: target.lineId,
+    payloadThrottleMs: SCENE_EDITOR_SELECTION_URL_SYNC_THROTTLE_MS,
+  });
 
   render();
 
   if (adjacentSectionTarget) {
     requestAnimationFrame(() => {
+      const currentSectionId = store.selectSelectedSectionId?.();
+      const currentLineId = store.selectSelectedLineId?.();
+      if (
+        currentSectionId !== adjacentSectionTarget.sectionId ||
+        currentLineId !== adjacentSectionTarget.lineId
+      ) {
+        return;
+      }
+
       scrollLinesEditorLineIntoView(
         refs,
         adjacentSectionTarget.lineId,
         adjacentSectionTarget.sectionId,
       );
-      focusLinesEditorContainer(refs, adjacentSectionTarget.sectionId);
+      if (detail.mode === "text-editor") {
+        focusLinesEditorLine(refs, {
+          sectionId: adjacentSectionTarget.sectionId,
+          lineId: adjacentSectionTarget.lineId,
+          cursorPosition: detail.cursorPosition,
+          goalColumn: detail.cursorPosition,
+          direction: detail.navigationDirection,
+        });
+      } else {
+        focusLinesEditorContainer(refs, adjacentSectionTarget.sectionId);
+      }
     });
   }
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -25,6 +25,8 @@ import {
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
 
+const INACTIVE_SECTION_EDITOR_SELECTED_LINE_ID = "";
+
 const appendMissingIds = (orderedIds, allIds) => {
   const seen = new Set();
   const result = [];
@@ -1685,10 +1687,11 @@ export const selectViewData = ({ state }) => {
       index,
       name: section.name || `Section ${index + 1}`,
       isSelected: section.id === state.selectedSectionId,
+      selectionActive: section.id === state.selectedSectionId,
       selectedLineId:
         section.id === state.selectedSectionId
-          ? state.selectedLineId
-          : undefined,
+          ? (state.selectedLineId ?? INACTIVE_SECTION_EDITOR_SELECTED_LINE_ID)
+          : INACTIVE_SECTION_EDITOR_SELECTED_LINE_ID,
       editorKey: `document-${section.id}-${state.sceneSettings.showLineNumbers ? "line-numbers-show" : "line-numbers-hide"}`,
       documentEditorLines: sectionLines,
       documentLineDecorations: buildSceneDocumentLineDecorations({

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -164,7 +164,7 @@ template:
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
                                       - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
                                       - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm: ...
-                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
                           - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null
           - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -163,7 +163,7 @@ template:
                               - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
                                       - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
-                                      - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm: ...
+                                      - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm pre=ellipsis: null
                                   - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
                           - rtgl-view h=30vh: null
           - rtgl-view w=1 h=f bgc=mu: null

--- a/src/primitives/lexicalRichTextShared.js
+++ b/src/primitives/lexicalRichTextShared.js
@@ -482,7 +482,7 @@ const getTextLengthOfNode = (node) => {
   }
 
   if ($isTextNode(node)) {
-    return node.getTextContentSize?.() ?? node.getTextContent().length;
+    return normalizeDialogueText(node.getTextContent()).length;
   }
 
   if ($isElementNode(node)) {

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -40,6 +40,7 @@ import {
   getContentLength,
   getLineDialogueContent,
   getPlainTextFromContent,
+  mergeAdjacentContentItems,
   normalizeSingleLineText,
   setLineDialogueContent,
   splitContentRange,
@@ -57,7 +58,6 @@ import {
   createNodesFromContent as createLexicalNodesFromContent,
   filterMentionSuggestions,
   getFuriganaFromNode,
-  getMentionMenuPosition,
   getSelectionRange,
   getSelectionOffsets,
   getTextStyleIdFromNode,
@@ -79,7 +79,7 @@ import {
   setSelectionFromRange,
 } from "./lexicalSceneDocumentSelection.js";
 import {
-  getAdjacentReferenceNodeForCollapsedSelection,
+  getAdjacentReferenceNodeInfoForCollapsedSelection,
   getReferenceElementFromContextEvent,
   getReferenceRichTextStateFromNode,
   getReferenceSelectionInfo,
@@ -98,8 +98,104 @@ const MIN_EDITOR_TEXT_WIDTH = 160;
 const BLOCK_ROW_BACKGROUND = "var(--muted)";
 const DELETE_SHORTCUT_TIMEOUT_MS = 1200;
 const TEXT_INPUT_FALLBACK_MAX_AGE_MS = 1000;
+const TEXT_INPUT_FALLBACK_DUPLICATE_MAX_AGE_MS = 250;
+const TYPED_SLASH_MENTION_TRIGGER_WINDOW_MS = 1000;
 const PROGRAMMATIC_FOCUS_BLUR_SUPPRESS_MS = 750;
 const VERTICAL_NAVIGATION_SELECTION_SYNC_FRAMES = 4;
+
+const isSectionEditorSelectedLineIdBindingFallback = (value) => {
+  return /^sectionEditorItems\[\d+\]\.selectedLineId$/.test(
+    String(value ?? ""),
+  );
+};
+
+const isSlashText = (value) => {
+  return String(value ?? "") === "/";
+};
+
+const isArrowKeyEvent = (event) => {
+  const key = String(event?.key ?? "");
+  return (
+    key === "ArrowLeft" ||
+    key === "ArrowRight" ||
+    key === "ArrowUp" ||
+    key === "ArrowDown"
+  );
+};
+
+const areNativeLineSelectionContextsEqual = (first, second) => {
+  if (!first || !second) {
+    return first === second;
+  }
+
+  return (
+    first.lineId === second.lineId &&
+    first.start === second.start &&
+    first.end === second.end
+  );
+};
+
+const doesContentEndWithReference = (content = []) => {
+  const items = mergeAdjacentContentItems(content);
+  return items.at(-1)?.reference !== undefined;
+};
+
+const areRenderedMentionMenuItemsEqual = (
+  currentItems = [],
+  nextItems = [],
+) => {
+  if (currentItems.length !== nextItems.length) {
+    return false;
+  }
+
+  return currentItems.every((currentItem, index) => {
+    const nextItem = nextItems[index];
+    return (
+      currentItem?.id === nextItem?.id &&
+      currentItem?.type === nextItem?.type &&
+      currentItem?.label === nextItem?.label &&
+      currentItem?.suffixText === nextItem?.suffixText
+    );
+  });
+};
+
+const getMentionTriggerFromTextNode = (
+  anchorNode,
+  anchorOffset,
+  { source = "lexical" } = {},
+) => {
+  if (!$isTextNode(anchorNode) || $isMentionNode(anchorNode)) {
+    return undefined;
+  }
+
+  const text = anchorNode.getTextContent();
+  const offset = Math.max(
+    0,
+    Math.min(
+      Number(anchorOffset) || 0,
+      anchorNode.getTextContentSize?.() ?? text.length,
+    ),
+  );
+  const beforeCaret = text.slice(0, offset);
+  const match = beforeCaret.match(/(?:^|\s)\/([a-z0-9._-]*)$/i);
+  if (!match) {
+    return undefined;
+  }
+
+  const query = match[1] ?? "";
+  const startOffset = beforeCaret.lastIndexOf(`/${query}`);
+  if (startOffset === -1) {
+    return undefined;
+  }
+
+  return {
+    nodeKey: anchorNode.getKey(),
+    startOffset,
+    endOffset: offset,
+    query,
+    source,
+  };
+};
 
 const normalizeMentionTarget = (target = {}) => {
   const label = String(target.label ?? "")
@@ -211,6 +307,12 @@ const STYLES = `
 
   .editor[data-rvn-reference-selection-active="true"] {
     caret-color: transparent;
+  }
+
+  .editor[data-rvn-reference-selection-active="true"]::selection,
+  .editor[data-rvn-reference-selection-active="true"] *::selection {
+    background: transparent;
+    color: inherit;
   }
 
   .editor:focus {
@@ -825,6 +927,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       lineDecorations: [],
       textStyles: [],
       selectedLineId: undefined,
+      selectionActive: true,
       showLineNumbers: true,
       mode: "block",
       plainText: "",
@@ -864,16 +967,23 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.pendingParagraphSplitBeforeInput = false;
     this.pendingTextInputFallback = undefined;
     this.pendingTextInputFallbackTimerId = undefined;
+    this.lastCommittedTextInputFallback = undefined;
     this.pendingFocusTarget = undefined;
     this.pendingHandledBackspaceKeyDown = undefined;
     this.programmaticFocusRestoreUntil = 0;
     this.lastProgrammaticFocusTarget = undefined;
+    this.focusRestoreSequenceId = 0;
     this.isPointerDownInsideEditor = false;
     this.pointerDownInsideEditorTimerId = undefined;
     this.pendingPointerFallbackSelection = undefined;
     this.pendingBlockContextMenuSelectedLineId = undefined;
     this.pendingDefaultContextMenuLineId = undefined;
     this.verticalNavigationSelectionSyncId = 0;
+    this.pendingVerticalNavigationSelectionSync = undefined;
+    this.mentionMenuFocusRestoreTimerId = undefined;
+    this.dismissedMentionTrigger = undefined;
+    this.dismissedMentionTriggerScope = undefined;
+    this.pendingTypedSlashMentionTrigger = undefined;
 
     this.editor = createEditor({
       namespace: "routevn-lexical-scene-document-editor",
@@ -946,6 +1056,8 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.refs.mentionMenu.place = "bs";
     this.refs.mentionMenu.w = "260";
     this.refs.mentionMenu.h = "240";
+    this.refs.mentionMenu.render?.();
+    this.syncMentionMenuPopover();
     this.editor.setRootElement(this.refs.editor);
 
     this.unregister = mergeRegister(
@@ -1003,6 +1115,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           event?.preventDefault?.();
           this.closeMentionMenu({
             shouldRender: true,
+            dismissCurrentTrigger: true,
           });
           return true;
         },
@@ -1187,7 +1300,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.clearDeleteShortcutState();
     this.clearPendingTextInputFallback();
     this.clearPendingHandledBackspaceKeyDown();
+    this.clearMentionMenuFocusRestore();
     this.pendingFocusTarget = undefined;
+    this.pendingVerticalNavigationSelectionSync = undefined;
+    this.verticalNavigationSelectionSyncId += 1;
     this.clearPointerDownInsideEditor();
 
     if (this.didPatchActiveElement) {
@@ -1271,7 +1387,15 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   set selectedLineId(value) {
     const nextSelectedLineId =
-      typeof value === "string" && value.length > 0 ? value : undefined;
+      typeof value === "string" &&
+      value.length > 0 &&
+      !isSectionEditorSelectedLineIdBindingFallback(value)
+        ? value
+        : undefined;
+    const previousSelectedLineId = this.state.selectedLineId;
+    if (previousSelectedLineId !== nextSelectedLineId) {
+      this.invalidatePendingFocusRestore();
+    }
     this.state.selectedLineId = nextSelectedLineId;
 
     if (!nextSelectedLineId) {
@@ -1297,6 +1421,37 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   get selectedLineId() {
     return this.state.selectedLineId;
+  }
+
+  set selectionActive(value) {
+    const nextSelectionActive = value !== false && value !== "false";
+    if (this.state.selectionActive === nextSelectionActive) {
+      return;
+    }
+
+    this.state.selectionActive = nextSelectionActive;
+    if (!nextSelectionActive) {
+      this.isEditorFocused = false;
+      this.lastProgrammaticFocusTarget = undefined;
+      this.pendingFocusTarget = undefined;
+      this.programmaticFocusRestoreUntil = 0;
+      this.pendingSelectionSnapshot = undefined;
+      this.invalidatePendingFocusRestore();
+      this.applyModeState("block");
+      this.clearRenderedSelectionState();
+      this.hideSelectionPopover();
+      this.closeMentionMenu();
+    }
+
+    if (!this.isConnected || !this.refs.editor) {
+      return;
+    }
+
+    this.scheduleRender();
+  }
+
+  get selectionActive() {
+    return this.state.selectionActive !== false;
   }
 
   set showLineNumbers(value) {
@@ -1354,11 +1509,11 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     const targetPosition =
       typeof cursorPosition === "number"
         ? cursorPosition < 0
-          ? (lineElement.textContent?.length ?? 0)
+          ? this.getLineVisibleTextLength(lineElement)
           : cursorPosition
-        : (lineElement.textContent?.length ?? 0);
+        : this.getLineVisibleTextLength(lineElement);
 
-    const { range } = createCollapsedRangeAtPosition(
+    const { range, actualPosition } = createCollapsedRangeAtPosition(
       lineElement,
       targetPosition,
     );
@@ -1371,8 +1526,8 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
         applySelectionToLineNode(lineNode, {
           lineId,
-          start: targetPosition,
-          end: targetPosition,
+          start: actualPosition,
+          end: actualPosition,
         });
       },
       { discrete: true },
@@ -1417,25 +1572,69 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   restoreLineSelectionAfterLexicalFocus(payload = {}) {
-    if (typeof this.editor?.focus !== "function") {
+    const focusRestoreSequenceId = this.advanceFocusRestoreSequence();
+    this.markProgrammaticFocusRestore(payload);
+    const restoreSelection = () => {
+      if (!this.isConnected) {
+        return;
+      }
+
+      if (this.focusRestoreSequenceId !== focusRestoreSequenceId) {
+        return;
+      }
+
+      if (
+        this.state &&
+        (this.state.selectedLineId !== payload.lineId ||
+          this.state.mode !== "text-editor" ||
+          this.isEditorFocused !== true)
+      ) {
+        return;
+      }
+
+      const nativeSelection = this.getNativeLineSelectionContext();
+      if (this.shouldSkipAsyncLineSelectionRestore(payload, nativeSelection)) {
+        return;
+      }
+
+      this.markProgrammaticFocusRestore(payload);
+      if (!this.isEditorActiveElement()) {
+        this.focus({ preventScroll: true });
+      }
+      this.restoreLineSelection(payload);
+    };
+
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(restoreSelection);
       return;
     }
 
-    this.markProgrammaticFocusRestore(payload);
-    this.editor.focus(
-      () => {
-        if (!this.isConnected) {
-          return;
-        }
+    queueMicrotask(restoreSelection);
+  }
 
-        this.markProgrammaticFocusRestore(payload);
-        if (!this.isEditorActiveElement()) {
-          this.focus({ preventScroll: true });
-        }
-        this.restoreLineSelection(payload);
-      },
-      { defaultSelection: "rootEnd" },
-    );
+  shouldSkipAsyncLineSelectionRestore(payload = {}, nativeSelection) {
+    if (payload.forceRestore === true) {
+      return false;
+    }
+
+    if (!nativeSelection?.lineId) {
+      return false;
+    }
+
+    if (nativeSelection.lineId !== payload.lineId) {
+      return true;
+    }
+
+    if (
+      nativeSelection.start !== nativeSelection.end ||
+      typeof nativeSelection.start !== "number" ||
+      typeof payload.cursorPosition !== "number" ||
+      payload.cursorPosition < 0
+    ) {
+      return false;
+    }
+
+    return nativeSelection.start !== payload.cursorPosition;
   }
 
   focusContainer() {
@@ -1872,13 +2071,16 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
-    if (this.state.mentionMenu.isOpen && this.hasActiveMentionTrigger()) {
+    if (this.state.mentionMenu?.isOpen) {
       const relatedTarget = event?.relatedTarget;
       if (this.isMentionMenuFocusTarget(relatedTarget)) {
-        this.keepMentionMenuNonModal({ restoreFocus: true });
+        this.refs.mentionMenu.open = true;
+        this.syncMentionMenuPopover();
         return;
       }
+    }
 
+    if (this.state.mentionMenu?.isOpen && this.hasActiveMentionTrigger()) {
       setTimeout(() => {
         if (!this.isConnected || !this.state.mentionMenu.isOpen) {
           return;
@@ -1889,7 +2091,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         }
 
         if (this.isMentionMenuFocusTarget(document.activeElement)) {
-          this.keepMentionMenuNonModal({ restoreFocus: true });
+          this.syncMentionMenuPopover();
           return;
         }
 
@@ -1922,7 +2124,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     this.isEditorFocused = false;
     this.hideSelectionPopover();
-    this.closeMentionMenu();
+    this.closeMentionMenu({
+      dismissCurrentTrigger: this.state.mentionMenu?.isOpen === true,
+    });
     this.pendingSelectionSnapshot = undefined;
     this.enterBlockMode({
       focusSurface: false,
@@ -1939,7 +2143,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   getActiveElement() {
     const root = this.refs?.editor?.getRootNode?.();
-    return root?.activeElement || document.activeElement;
+    return (
+      root?.activeElement ||
+      (typeof document === "undefined" ? undefined : document.activeElement)
+    );
   }
 
   isEditorActiveElement() {
@@ -1995,6 +2202,15 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   isWithinProgrammaticFocusRestoreWindow() {
     return this.getNow() <= this.programmaticFocusRestoreUntil;
+  }
+
+  advanceFocusRestoreSequence() {
+    this.focusRestoreSequenceId = (this.focusRestoreSequenceId ?? 0) + 1;
+    return this.focusRestoreSequenceId;
+  }
+
+  invalidatePendingFocusRestore() {
+    return this.advanceFocusRestoreSequence();
   }
 
   restoreLastProgrammaticFocusTarget() {
@@ -2058,13 +2274,20 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     this.scheduleNativeSelectionLineSyncAfterVerticalNavigation(event);
+    if (this.state?.mentionMenu?.isOpen && isArrowKeyEvent(event)) {
+      this.closeMentionMenu({ dismissCurrentTrigger: true });
+    }
     this.updatePendingTextInputFallback(event);
 
     if (this.handleReferenceArrowNavigation(event)) {
       return;
     }
 
-    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+    if (
+      event.key !== "ArrowLeft" &&
+      event.key !== "ArrowRight" &&
+      event.key !== "Backspace"
+    ) {
       this.clearSelectedReferenceNodeKey();
     }
 
@@ -2090,9 +2313,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       !event.metaKey &&
       !event.altKey
     ) {
-      if (event.defaultPrevented) {
-        return;
-      }
+      this.invalidatePendingFocusRestore();
 
       const nativeSelection = this.getNativeLineSelectionContext();
       const nativeLineRangeSelection = nativeSelection?.lineId
@@ -2102,13 +2323,29 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         return;
       }
 
+      if (event.defaultPrevented) {
+        const didHandleDefaultPreventedReference =
+          nativeSelection?.lineId || this.selectedReferenceNodeKey
+            ? this.handleBackspaceReferenceDelete({
+                lineId: nativeSelection?.lineId,
+                start: nativeSelection?.start,
+                end: nativeSelection?.end,
+              })
+            : false;
+        if (didHandleDefaultPreventedReference) {
+          event.stopPropagation();
+          event.stopImmediatePropagation?.();
+          this.markHandledBackspaceKeyDown(event);
+        }
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation?.();
       const didHandle = this.handleBackspaceDelete({
         nativeSelection,
         nativeLineRangeSelection,
-        source: "keydown",
       });
       if (didHandle) {
         this.markHandledBackspaceKeyDown(event);
@@ -2121,37 +2358,85 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   scheduleNativeSelectionLineSyncAfterVerticalNavigation(event) {
+    const navigationDirection =
+      event.key === "ArrowUp"
+        ? "up"
+        : event.key === "ArrowDown"
+          ? "down"
+          : undefined;
     if (
       this.state?.mode !== "text-editor" ||
       event.isComposing ||
       event.ctrlKey ||
       event.metaKey ||
       event.altKey ||
-      (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+      !navigationDirection ||
       typeof requestAnimationFrame !== "function"
     ) {
       return;
     }
 
-    const syncNativeSelectionLine = (framesRemaining) => {
-      const syncId = (this.verticalNavigationSelectionSyncId ?? 0) + 1;
-      this.verticalNavigationSelectionSyncId = syncId;
+    const initialNativeSelection = this.getNativeLineSelectionContext();
+    const pendingSync = this.pendingVerticalNavigationSelectionSync;
+    if (
+      pendingSync?.direction === navigationDirection &&
+      pendingSync.selectedLineId === this.state.selectedLineId &&
+      areNativeLineSelectionContextsEqual(
+        pendingSync.initialNativeSelection,
+        initialNativeSelection,
+      )
+    ) {
+      return;
+    }
 
+    const syncId = (this.verticalNavigationSelectionSyncId ?? 0) + 1;
+    this.verticalNavigationSelectionSyncId = syncId;
+    this.pendingVerticalNavigationSelectionSync = {
+      syncId,
+      direction: navigationDirection,
+      selectedLineId: this.state.selectedLineId,
+      initialNativeSelection,
+    };
+    const clearPendingSync = () => {
+      if (this.pendingVerticalNavigationSelectionSync?.syncId === syncId) {
+        this.pendingVerticalNavigationSelectionSync = undefined;
+      }
+    };
+    const syncNativeSelectionLine = (framesRemaining) => {
       requestAnimationFrame(() => {
         if (this.verticalNavigationSelectionSyncId !== syncId) {
           return;
         }
 
         if (!this.isConnected || this.state?.mode !== "text-editor") {
+          clearPendingSync();
           return;
         }
 
         const nativeSelection = this.getNativeLineSelectionContext();
         const lineId = nativeSelection?.lineId;
         if (!lineId || lineId === this.state.selectedLineId) {
+          const didMoveWithinCurrentLine =
+            lineId &&
+            initialNativeSelection?.lineId === lineId &&
+            (nativeSelection.start !== initialNativeSelection.start ||
+              nativeSelection.end !== initialNativeSelection.end);
+          if (didMoveWithinCurrentLine) {
+            clearPendingSync();
+            return;
+          }
+
           if (framesRemaining > 1) {
             syncNativeSelectionLine(framesRemaining - 1);
+            return;
           }
+
+          this.dispatchTextModeVerticalBoundaryNavigation({
+            lineId,
+            nativeSelection,
+            direction: navigationDirection,
+          });
+          clearPendingSync();
           return;
         }
 
@@ -2162,10 +2447,66 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           isCollapsed: nativeSelection.start === nativeSelection.end,
           mode: "text-editor",
         });
+        clearPendingSync();
       });
     };
 
     syncNativeSelectionLine(VERTICAL_NAVIGATION_SELECTION_SYNC_FRAMES);
+  }
+
+  dispatchTextModeVerticalBoundaryNavigation({
+    lineId,
+    nativeSelection,
+    direction,
+  } = {}) {
+    if (!this.isTextModeVerticalNavigationBoundary(lineId, direction)) {
+      return false;
+    }
+
+    this.dispatchSelectedLineChanged(lineId, {
+      cursorPosition: nativeSelection?.start,
+      isCollapsed: nativeSelection?.start === nativeSelection?.end,
+      mode: "text-editor",
+      navigationDirection: direction,
+      isBoundaryNavigation: true,
+    });
+    return true;
+  }
+
+  isTextModeVerticalNavigationBoundary(lineId, direction) {
+    return this.getTextModeVerticalNavigationBoundaryInfo(lineId, direction)
+      .isBoundary;
+  }
+
+  getTextModeVerticalNavigationBoundaryInfo(lineId, direction) {
+    if (!lineId || (direction !== "up" && direction !== "down")) {
+      return {
+        isBoundary: false,
+        lineIndex: -1,
+        lineCount: 0,
+      };
+    }
+
+    const lines = Array.isArray(this.state?.lines) ? this.state.lines : [];
+    const lineIndex = lines.findIndex((line) => line?.id === lineId);
+    if (lineIndex < 0) {
+      return {
+        isBoundary: false,
+        lineIndex,
+        lineCount: lines.length,
+        firstLineId: lines[0]?.id,
+        lastLineId: lines.at(-1)?.id,
+      };
+    }
+
+    return {
+      isBoundary:
+        direction === "up" ? lineIndex === 0 : lineIndex === lines.length - 1,
+      lineIndex,
+      lineCount: lines.length,
+      firstLineId: lines[0]?.id,
+      lastLineId: lines.at(-1)?.id,
+    };
   }
 
   handleWindowKeyDownCapture(event) {
@@ -2312,10 +2653,12 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   updatePendingTextInputFallback(event) {
     const text = getPrintableKeyText(event);
     this.clearPendingTextInputFallback();
+    this.lastCommittedTextInputFallback = undefined;
     this.pendingTextInputFallback = text
       ? {
           text,
           timeStamp: getEventTimestamp(event),
+          nativeSelection: this.getNativeLineSelectionContext(),
         }
       : undefined;
 
@@ -2340,8 +2683,48 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         return;
       }
 
-      this.insertPlainText(fallback.text);
+      if (fallback.nativeSelection) {
+        if (isSlashText(fallback.text)) {
+          this.armMentionMenuOpenFromTypedSlash({
+            source: "keydown-fallback",
+          });
+        }
+        this.insertPlainText(fallback.text, {
+          nativeSelection: fallback.nativeSelection,
+        });
+      } else {
+        if (isSlashText(fallback.text)) {
+          this.armMentionMenuOpenFromTypedSlash({
+            source: "keydown-fallback",
+          });
+        }
+        this.insertPlainText(fallback.text);
+      }
+      this.lastCommittedTextInputFallback = fallback;
     }, 0);
+  }
+
+  shouldSkipCommittedTextInputFallback(event) {
+    const fallback = this.lastCommittedTextInputFallback;
+    if (this.pendingTextInputFallback?.text || !fallback?.text) {
+      return false;
+    }
+
+    const eventTimestamp = getEventTimestamp(event);
+    if (eventTimestamp !== undefined && fallback.timeStamp !== undefined) {
+      const elapsed = eventTimestamp - fallback.timeStamp;
+      if (elapsed < 0 || elapsed > TEXT_INPUT_FALLBACK_DUPLICATE_MAX_AGE_MS) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    if (typeof event?.data === "string" && event.data.length > 0) {
+      return event.data === fallback.text;
+    }
+
+    return true;
   }
 
   consumePendingTextInputFallback(event) {
@@ -2362,6 +2745,29 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     return fallback.text;
+  }
+
+  getPendingTextInputFallbackNativeSelection(event, inputText) {
+    const fallback = this.pendingTextInputFallback;
+    if (!fallback?.nativeSelection || !fallback.text) {
+      return undefined;
+    }
+
+    if (inputText && inputText !== fallback.text) {
+      return undefined;
+    }
+
+    const eventTimestamp = getEventTimestamp(event);
+    if (
+      eventTimestamp !== undefined &&
+      fallback.timeStamp !== undefined &&
+      (eventTimestamp < fallback.timeStamp ||
+        eventTimestamp - fallback.timeStamp > TEXT_INPUT_FALLBACK_MAX_AGE_MS)
+    ) {
+      return undefined;
+    }
+
+    return fallback.nativeSelection;
   }
 
   resolveBeforeInputText(event, { allowKeyFallback = true } = {}) {
@@ -3022,6 +3428,162 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     });
   }
 
+  getReferenceElementFromNativeRange(nativeRange, direction) {
+    if (
+      !nativeRange?.collapsed ||
+      typeof Node === "undefined" ||
+      typeof Element === "undefined"
+    ) {
+      return undefined;
+    }
+
+    const getMentionElement = (node) => {
+      const element =
+        node?.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+      if (!(element instanceof Element)) {
+        return undefined;
+      }
+
+      const mentionElement = element.closest?.(".mention-chip");
+      if (mentionElement && this.refs?.editor?.contains?.(mentionElement)) {
+        return mentionElement;
+      }
+
+      return undefined;
+    };
+
+    const directMentionElement = getMentionElement(nativeRange.startContainer);
+    if (directMentionElement) {
+      return directMentionElement;
+    }
+
+    let candidateNode;
+    if (nativeRange.startContainer.nodeType === Node.TEXT_NODE) {
+      const textLength = nativeRange.startContainer.textContent?.length ?? 0;
+      if (direction > 0 && nativeRange.startOffset < textLength) {
+        return undefined;
+      }
+      if (direction < 0 && nativeRange.startOffset > 0) {
+        return undefined;
+      }
+
+      candidateNode =
+        direction > 0
+          ? nativeRange.startContainer.nextSibling
+          : nativeRange.startContainer.previousSibling;
+    } else {
+      candidateNode =
+        direction > 0
+          ? nativeRange.startContainer.childNodes?.[nativeRange.startOffset]
+          : nativeRange.startContainer.childNodes?.[
+              nativeRange.startOffset - 1
+            ];
+    }
+
+    return getMentionElement(candidateNode);
+  }
+
+  getNativeReferenceArrowFallbackInfo(
+    nativeSelection,
+    direction,
+    { nativeRange } = {},
+  ) {
+    if (
+      !nativeSelection?.lineId ||
+      nativeSelection.start !== nativeSelection.end ||
+      typeof nativeSelection.start !== "number"
+    ) {
+      return undefined;
+    }
+
+    const lineKey = this.lineKeyById.get(nativeSelection.lineId);
+    const lineNode = lineKey ? $getNodeByKey(lineKey) : undefined;
+    if (!lineNode) {
+      return undefined;
+    }
+
+    const content = this.serializeLineContent(lineNode);
+    const lineLength = getContentLength(content);
+    const offset = Math.max(0, Math.min(nativeSelection.start, lineLength));
+    const mentionNodes = this.getMentionNodesInLine(lineNode);
+    const domReferenceNodeKey = this.getReferenceElementFromNativeRange(
+      nativeRange,
+      direction,
+    )?.dataset?.rvnReferenceKey;
+    let consumed = 0;
+    let referenceIndex = 0;
+
+    for (const item of ensureContentArray(content)) {
+      const itemLength = getPlainTextFromContent([item]).length;
+      const itemStart = consumed;
+      const itemEnd = consumed + itemLength;
+      consumed = itemEnd;
+
+      if (!item?.reference) {
+        continue;
+      }
+
+      const mentionNode = mentionNodes[referenceIndex];
+      referenceIndex += 1;
+      if (!$isMentionNode(mentionNode)) {
+        continue;
+      }
+
+      const matchesDomReference = mentionNode.getKey() === domReferenceNodeKey;
+      const isFinalReference = itemEnd === lineLength;
+      const isInsideReference = offset > itemStart && offset < itemEnd;
+      const isAfterReference =
+        direction < 0 && (offset === itemEnd || matchesDomReference);
+      const isBeforeReference =
+        direction > 0 &&
+        (offset === itemStart || isInsideReference || matchesDomReference);
+      if (!isAfterReference && !isBeforeReference) {
+        continue;
+      }
+
+      return {
+        node: mentionNode,
+        lineId: nativeSelection.lineId,
+        offset,
+        itemStart,
+        itemEnd,
+        lineLength,
+        isFinalReference,
+        matchesDomReference,
+        isInsideReference,
+        shouldMoveAcross:
+          isFinalReference &&
+          ((direction < 0 && offset === lineLength) ||
+            (direction > 0 &&
+              (offset === itemStart ||
+                isInsideReference ||
+                matchesDomReference))),
+      };
+    }
+
+    return undefined;
+  }
+
+  isFinalVisibleReferenceNode(node) {
+    if (!$isMentionNode(node)) {
+      return false;
+    }
+
+    const lineNode = node.getParent();
+    if (!lineNode) {
+      return false;
+    }
+
+    const content = this.serializeLineContent(lineNode);
+    const contentItems = mergeAdjacentContentItems(content);
+    if (!contentItems.at(-1)?.reference) {
+      return false;
+    }
+
+    const mentionNodes = this.getMentionNodesInLine(lineNode);
+    return mentionNodes.at(-1)?.getKey() === node.getKey();
+  }
+
   selectReferenceNodeAsElement(node) {
     this.selectedReferenceNodeKey = node.getKey();
     selectReferenceNodeAsElement(node);
@@ -3042,6 +3604,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return false;
     }
 
+    const nativeRange =
+      this.refs?.editor &&
+      typeof window !== "undefined" &&
+      typeof ShadowRoot !== "undefined"
+        ? getSelectionRange(this.refs.editor)
+        : undefined;
+    const nativeSelection = this.getNativeLineSelectionContext(nativeRange);
+
     let didHandle = false;
     let nextSelectedReferenceNodeKey = this.selectedReferenceNodeKey;
     this.editor.update(
@@ -3049,12 +3619,39 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         const selectedReferenceNode = this.selectedReferenceNodeKey
           ? $getNodeByKey(this.selectedReferenceNodeKey)
           : undefined;
+        const handleNativeFallback = () => {
+          const nativeFallbackInfo = this.getNativeReferenceArrowFallbackInfo(
+            nativeSelection,
+            direction,
+            {
+              nativeRange,
+            },
+          );
+          if (!nativeFallbackInfo?.node) {
+            return false;
+          }
+
+          if (nativeFallbackInfo.shouldMoveAcross) {
+            placeCaretAroundReferenceNode(nativeFallbackInfo.node, direction);
+            nextSelectedReferenceNodeKey = undefined;
+            didHandle = true;
+            return true;
+          }
+
+          this.selectReferenceNodeAsElement(nativeFallbackInfo.node);
+          nextSelectedReferenceNodeKey = nativeFallbackInfo.node.getKey();
+          didHandle = true;
+          return true;
+        };
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           if ($isMentionNode(selectedReferenceNode)) {
             placeCaretAroundReferenceNode(selectedReferenceNode, direction);
             nextSelectedReferenceNodeKey = undefined;
             didHandle = true;
+          }
+          if (didHandle || handleNativeFallback()) {
+            return;
           }
           return;
         }
@@ -3091,11 +3688,34 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           return;
         }
 
-        const adjacentReference = getAdjacentReferenceNodeForCollapsedSelection(
-          selection,
-          direction,
-        );
+        const adjacentReferenceInfo =
+          getAdjacentReferenceNodeInfoForCollapsedSelection(
+            selection,
+            direction,
+          );
+        const adjacentReference = adjacentReferenceInfo?.node;
         if (!adjacentReference) {
+          if (handleNativeFallback()) {
+            return;
+          }
+
+          return;
+        }
+
+        if (adjacentReferenceInfo.skippedZeroLengthText && direction < 0) {
+          placeCaretAroundReferenceNode(adjacentReference, direction);
+          nextSelectedReferenceNodeKey = undefined;
+          didHandle = true;
+          return;
+        }
+
+        if (
+          direction > 0 &&
+          this.isFinalVisibleReferenceNode(adjacentReference)
+        ) {
+          placeCaretAroundReferenceNode(adjacentReference, direction);
+          nextSelectedReferenceNodeKey = undefined;
+          didHandle = true;
           return;
         }
 
@@ -3395,6 +4015,53 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.updateReferenceSelectionMarkers();
   }
 
+  getReferenceElementByNodeKey(nodeKey) {
+    if (!nodeKey || !this.refs?.editor) {
+      return undefined;
+    }
+
+    for (const element of this.refs.editor.querySelectorAll(
+      "[data-rvn-reference-key]",
+    )) {
+      if (element.dataset.rvnReferenceKey === nodeKey) {
+        return element;
+      }
+    }
+
+    return undefined;
+  }
+
+  collapseNativeSelectionAfterReference(nodeKey) {
+    const element = this.getReferenceElementByNodeKey(nodeKey);
+    const parentNode = element?.parentNode;
+    if (!parentNode || typeof document === "undefined") {
+      return false;
+    }
+
+    const childIndex = Array.from(parentNode.childNodes).indexOf(element);
+    if (childIndex === -1) {
+      return false;
+    }
+
+    const selectionOffset = Math.min(
+      childIndex + 1,
+      parentNode.childNodes.length,
+    );
+    const currentRange = getSelectionRange(this.refs.editor);
+    if (
+      currentRange?.collapsed &&
+      currentRange.startContainer === parentNode &&
+      currentRange.startOffset === selectionOffset
+    ) {
+      return true;
+    }
+
+    const range = document.createRange();
+    range.setStart(parentNode, selectionOffset);
+    range.collapse(true);
+    return setSelectionFromRange(this.refs.editor, range);
+  }
+
   updateReferenceSelectionMarkers() {
     if (!this.refs.editor) {
       return;
@@ -3420,6 +4087,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       } else {
         delete element.dataset.rvnReferenceSelected;
       }
+    }
+
+    if (selectedKey) {
+      this.collapseNativeSelectionAfterReference(selectedKey);
     }
   }
 
@@ -3614,6 +4285,16 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     if (inputType === "insertText" || inputType === "insertReplacementText") {
+      const fallbackNativeSelection =
+        this.getPendingTextInputFallbackNativeSelection(event, event?.data);
+      if (this.shouldSkipCommittedTextInputFallback(event)) {
+        this.lastCommittedTextInputFallback = undefined;
+        event.preventDefault();
+        event.stopPropagation?.();
+        event.stopImmediatePropagation?.();
+        return;
+      }
+
       const inputText = this.resolveBeforeInputText(event, {
         allowKeyFallback: inputType === "insertText",
       });
@@ -3621,27 +4302,41 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         return;
       }
 
+      this.lastCommittedTextInputFallback = undefined;
       event.preventDefault();
       event.stopPropagation?.();
       event.stopImmediatePropagation?.();
-      this.insertPlainText(inputText);
+      const nativeSelection =
+        this.getInputLineSelectionContext(event) ?? fallbackNativeSelection;
+      if (isSlashText(inputText)) {
+        this.armMentionMenuOpenFromTypedSlash({
+          source: "beforeinput",
+        });
+      }
+      if (nativeSelection) {
+        this.insertPlainText(inputText, { nativeSelection });
+      } else {
+        this.insertPlainText(inputText);
+      }
       return;
     }
 
     if (inputType === "deleteContentBackward") {
+      this.invalidatePendingFocusRestore();
       this.clearPendingTextInputFallback();
       event.preventDefault();
       event.stopPropagation?.();
       event.stopImmediatePropagation?.();
 
-      if (this.consumeHandledBackspaceKeyDown(event)) {
+      const didConsumeHandledKeyDown =
+        this.consumeHandledBackspaceKeyDown(event);
+      if (didConsumeHandledKeyDown) {
         return;
       }
 
-      const nativeSelection = this.getNativeLineSelectionContext();
+      const nativeSelection = this.getInputLineSelectionContext(event);
       const didHandle = this.handleBackspaceDelete({
         nativeSelection,
-        source: "beforeinput",
       });
       if (!didHandle) {
         this.deleteCharacterBackward({ nativeSelection });
@@ -3720,13 +4415,12 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
-    if (this.hasActiveMentionTrigger()) {
-      this.refs.mentionMenu.open = true;
-      this.scheduleRender();
-      return;
-    }
+    const activeTriggerState = this.getActiveMentionTriggerState();
+    const triggerState = activeTriggerState ?? { ...this.state.mentionMenu };
 
+    this.dismissMentionTrigger(triggerState);
     this.closeMentionMenu();
+    this.restoreMentionTriggerSelection(triggerState);
   }
 
   applyTextStyleIdToSelection(textStyleId) {
@@ -4437,12 +5131,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         lines.push(this.createPersistableLine(lineMeta, childNode));
       }
 
+      let lexicalSelectedLineId;
       if ($isRangeSelection(selection)) {
         const selectedLineNode = this.getLineNodeFromSelection(selection);
-        selectedLineId =
-          this.lineMetaByKey.get(selectedLineNode?.getKey())?.id ??
-          selectedLineId;
+        lexicalSelectedLineId = this.lineMetaByKey.get(
+          selectedLineNode?.getKey(),
+        )?.id;
       }
+      selectedLineId = lexicalSelectedLineId ?? selectedLineId;
 
       const activeFormats = {
         bold: $isRangeSelection(selection)
@@ -4459,40 +5155,25 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           $getSelectionStyleValueForProperty(selection, "color", "") ===
             ACCENT_FILL,
       };
+      const lexicalMentionTrigger = $isRangeSelection(selection)
+        ? getMentionTriggerFromTextNode(
+            selection.anchor.getNode(),
+            selection.anchor.offset,
+            { source: "lexical" },
+          )
+        : undefined;
+      const mentionTrigger = lexicalMentionTrigger
+        ? {
+            ...lexicalMentionTrigger,
+            lineId: selectedLineId,
+          }
+        : undefined;
 
       return {
         lines,
         selectedLineId,
         activeFormats,
-        mentionTrigger: $isRangeSelection(selection)
-          ? (() => {
-              const anchorNode = selection.anchor.getNode();
-              if (!$isTextNode(anchorNode) || $isMentionNode(anchorNode)) {
-                return undefined;
-              }
-
-              const anchorOffset = selection.anchor.offset;
-              const text = anchorNode.getTextContent();
-              const beforeCaret = text.slice(0, anchorOffset);
-              const match = beforeCaret.match(/(?:^|\s)\/([a-z0-9._-]*)$/i);
-              if (!match) {
-                return undefined;
-              }
-
-              const query = match[1] ?? "";
-              const startOffset = beforeCaret.lastIndexOf(`/${query}`);
-              if (startOffset === -1) {
-                return undefined;
-              }
-
-              return {
-                nodeKey: anchorNode.getKey(),
-                startOffset,
-                endOffset: anchorOffset,
-                query,
-              };
-            })()
-          : undefined,
+        mentionTrigger,
       };
     });
   }
@@ -4548,6 +5229,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     const nodes = this.createNodesFromContent(content);
     if (nodes.length > 0) {
       lineNode.append(...nodes);
+      if (doesContentEndWithReference(content)) {
+        lineNode.append($createTextNode(EDITOR_CARET_TEXT));
+      }
       return;
     }
 
@@ -5102,17 +5786,18 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     });
   }
 
-  insertPlainText(text) {
+  insertPlainText(text, { nativeSelection } = {}) {
     const nextText = String(text ?? "").replace(/\r\n?/g, "\n");
-    const nativeSelection = this.getNativeLineSelectionContext();
+    const resolvedNativeSelection =
+      nativeSelection ?? this.getNativeLineSelectionContext();
 
     this.editor.update(
       () => {
-        if (nativeSelection?.lineId) {
-          const lineKey = this.lineKeyById.get(nativeSelection.lineId);
+        if (resolvedNativeSelection?.lineId) {
+          const lineKey = this.lineKeyById.get(resolvedNativeSelection.lineId);
           const lineNode = lineKey ? $getNodeByKey(lineKey) : undefined;
           if (lineNode) {
-            applySelectionToLineNode(lineNode, nativeSelection);
+            applySelectionToLineNode(lineNode, resolvedNativeSelection);
           }
         }
 
@@ -5121,7 +5806,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           return;
         }
 
-        if (nativeSelection?.lineId) {
+        if (resolvedNativeSelection?.lineId) {
           selection = $getSelection();
           if (!$isRangeSelection(selection)) {
             return;
@@ -5209,6 +5894,266 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     );
   }
 
+  getLineNodeFromNode(node) {
+    const root = $getRoot();
+    let lineNode = node;
+
+    while (lineNode?.getParent?.() && lineNode.getParent() !== root) {
+      lineNode = lineNode.getParent();
+    }
+
+    if (!lineNode || lineNode === root || lineNode.getParent?.() !== root) {
+      return undefined;
+    }
+
+    return lineNode;
+  }
+
+  getMentionNodesInLine(lineNode) {
+    const mentionNodes = [];
+
+    const visitNode = (node) => {
+      if ($isMentionNode(node)) {
+        mentionNodes.push(node);
+        return;
+      }
+
+      if (!$isElementNode(node)) {
+        return;
+      }
+
+      for (const childNode of node.getChildren()) {
+        visitNode(childNode);
+      }
+    };
+
+    if (lineNode) {
+      visitNode(lineNode);
+    }
+
+    return mentionNodes;
+  }
+
+  getReferenceNodeFromSerializedContentRange(lineNode, start, end = start) {
+    if (!lineNode) {
+      return undefined;
+    }
+
+    const content = this.serializeLineContent(lineNode);
+    const lineLength = getContentLength(content);
+    const rangeStart = Math.min(Math.max(0, Number(start) || 0), lineLength);
+    const rangeEnd = Math.min(
+      Math.max(rangeStart, Number(end) || 0),
+      lineLength,
+    );
+    const isCollapsed = rangeStart === rangeEnd;
+    const mentionNodes = this.getMentionNodesInLine(lineNode);
+    let consumed = 0;
+    let referenceIndex = 0;
+
+    for (const item of ensureContentArray(content)) {
+      const itemLength = getPlainTextFromContent([item]).length;
+      const itemStart = consumed;
+      const itemEnd = consumed + itemLength;
+      consumed = itemEnd;
+
+      if (!item?.reference) {
+        continue;
+      }
+
+      const mentionNode = mentionNodes[referenceIndex];
+      referenceIndex += 1;
+      const isInsideReference =
+        isCollapsed && rangeStart > itemStart && rangeStart <= itemEnd;
+      const intersectsReference =
+        !isCollapsed && rangeStart < itemEnd && rangeEnd > itemStart;
+      if (isInsideReference || intersectsReference) {
+        return mentionNode;
+      }
+    }
+
+    return undefined;
+  }
+
+  getReferenceNodeBeforeLineOffset(lineNode, offset) {
+    return this.getReferenceNodeFromSerializedContentRange(
+      lineNode,
+      offset,
+      offset,
+    );
+  }
+
+  getReferenceNodeIntersectingLineRange(lineNode, start, end = start) {
+    return this.getReferenceNodeFromSerializedContentRange(
+      lineNode,
+      start,
+      end,
+    );
+  }
+
+  removeReferenceNodeFromBackspace(
+    node,
+    fallbackLineId,
+    fallbackCursorPosition,
+  ) {
+    const lineNode = this.getLineNodeFromNode(node);
+    const lineMeta = lineNode
+      ? this.lineMetaByKey.get(lineNode.getKey())
+      : undefined;
+    const lineId = lineMeta?.id ?? fallbackLineId;
+    const offsetResult =
+      lineNode && node?.getKey
+        ? getLexicalOffsetBeforeNode(lineNode, node.getKey())
+        : undefined;
+    const cursorPosition = offsetResult?.found
+      ? offsetResult.offset
+      : Math.max(0, Number(fallbackCursorPosition) || 0);
+    const parentNode = node.getParent();
+    const referenceIndex = node.getIndexWithinParent();
+
+    this.pendingChangeReason = "text";
+    node.remove();
+    if ($isElementNode(parentNode)) {
+      const caretIndex = Math.min(referenceIndex, parentNode.getChildrenSize());
+      parentNode.select(caretIndex, caretIndex);
+    }
+
+    if (this.state && lineId) {
+      this.state.selectedLineId = lineId;
+    }
+    this.selectedReferenceNodeKey = undefined;
+    this.pendingFocusTarget = lineId
+      ? {
+          lineId,
+          cursorPosition,
+        }
+      : undefined;
+
+    return {
+      lineId,
+      cursorPosition,
+    };
+  }
+
+  handleBackspaceReferenceDelete({ lineId, start, end } = {}) {
+    let didHandle = false;
+    let focusTarget;
+
+    this.editor.update(
+      () => {
+        const selection = $getSelection();
+        const referenceSelection = getReferenceSelectionInfo(selection);
+        const selectedReferenceCandidate = this.selectedReferenceNodeKey
+          ? $getNodeByKey(this.selectedReferenceNodeKey)
+          : undefined;
+        let selectedReferenceNode = $isMentionNode(selectedReferenceCandidate)
+          ? selectedReferenceCandidate
+          : undefined;
+        if (selectedReferenceNode) {
+          const selectedReferenceLineNode = this.getLineNodeFromNode(
+            selectedReferenceNode,
+          );
+          const selectedReferenceLineId = selectedReferenceLineNode
+            ? this.lineMetaByKey.get(selectedReferenceLineNode.getKey())?.id
+            : undefined;
+          if (
+            lineId &&
+            selectedReferenceLineId &&
+            selectedReferenceLineId !== lineId
+          ) {
+            selectedReferenceNode = undefined;
+            this.selectedReferenceNodeKey = undefined;
+          }
+        }
+
+        const wholeSelectedReferenceNode =
+          referenceSelection?.isWhole === true
+            ? referenceSelection.node
+            : undefined;
+        const referenceNodeToRemove =
+          selectedReferenceNode ?? wholeSelectedReferenceNode;
+
+        if ($isMentionNode(referenceNodeToRemove)) {
+          const referenceLineNode = this.getLineNodeFromNode(
+            referenceNodeToRemove,
+          );
+          const referenceLineId = referenceLineNode
+            ? this.lineMetaByKey.get(referenceLineNode.getKey())?.id
+            : undefined;
+          if (lineId && referenceLineId && referenceLineId !== lineId) {
+            return;
+          }
+
+          focusTarget = this.removeReferenceNodeFromBackspace(
+            referenceNodeToRemove,
+            lineId,
+            start,
+          );
+          didHandle = true;
+          return;
+        }
+
+        if (referenceSelection?.node) {
+          this.selectReferenceNodeAsElement(referenceSelection.node);
+          didHandle = true;
+          return;
+        }
+
+        if (!lineId || (start === end && start <= 0)) {
+          return;
+        }
+
+        const lineKey = this.lineKeyById.get(lineId);
+        const lineNode = lineKey ? $getNodeByKey(lineKey) : undefined;
+        const referenceNode =
+          this.getReferenceNodeIntersectingLineRange(lineNode, start, end) ??
+          (start === end
+            ? this.getReferenceNodeBeforeLineOffset(lineNode, start)
+            : undefined);
+        if (!$isMentionNode(referenceNode)) {
+          return;
+        }
+
+        this.selectReferenceNodeAsElement(referenceNode);
+        didHandle = true;
+      },
+      { discrete: true },
+    );
+
+    if (!didHandle) {
+      return false;
+    }
+
+    if (this.state && lineId) {
+      this.state.selectedLineId = lineId;
+    }
+    this.updateReferenceSelectionMarkers();
+    if (typeof requestAnimationFrame === "function") {
+      this.scheduleRender();
+      if (focusTarget?.lineId) {
+        this.scheduleFocusTargetRestore(focusTarget);
+      }
+    }
+
+    return true;
+  }
+
+  getLineContentLength(lineId) {
+    if (!lineId || typeof this.editor?.getEditorState !== "function") {
+      return undefined;
+    }
+
+    return this.editor.getEditorState().read(() => {
+      const lineKey = this.lineKeyById.get(lineId);
+      const lineNode = lineKey ? $getNodeByKey(lineKey) : undefined;
+      if (!lineNode) {
+        return undefined;
+      }
+
+      return getContentLength(this.serializeLineContent(lineNode));
+    });
+  }
+
   handleBackspaceDelete({
     nativeSelection = this.getNativeLineSelectionContext(),
     nativeLineRangeSelection,
@@ -5221,10 +6166,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     if (!nativeSelection?.lineId) {
       if (resolvedLineRangeSelection?.isMultiLine) {
-        const didDelete = this.deleteNativeLineRangeSelection(
-          resolvedLineRangeSelection,
-        );
-        return didDelete;
+        return this.deleteNativeLineRangeSelection(resolvedLineRangeSelection);
       }
 
       return false;
@@ -5240,25 +6182,53 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return false;
     }
 
-    const start = Math.min(selectionStart, selectionEnd);
-    const end = Math.max(selectionStart, selectionEnd);
+    const lineContentLength = this.getLineContentLength(nativeSelection.lineId);
+    const normalizedSelectionStart =
+      typeof lineContentLength === "number"
+        ? Math.min(Math.max(0, selectionStart), lineContentLength)
+        : selectionStart;
+    const normalizedSelectionEnd =
+      typeof lineContentLength === "number"
+        ? Math.min(Math.max(0, selectionEnd), lineContentLength)
+        : selectionEnd;
+    const start = Math.min(normalizedSelectionStart, normalizedSelectionEnd);
+    const end = Math.max(normalizedSelectionStart, normalizedSelectionEnd);
+
+    if (
+      this.handleBackspaceReferenceDelete({
+        lineId: nativeSelection.lineId,
+        start,
+        end,
+      })
+    ) {
+      return true;
+    }
 
     if (start !== end) {
-      const didDelete = this.deleteNativeLineContentRange({
+      return this.deleteNativeLineContentRange({
         lineId: nativeSelection.lineId,
         start,
         end,
       });
-      return didDelete;
     }
 
     if (start > 0) {
-      const didDelete = this.deleteNativeLineContentRange({
+      const deleteStart = start - 1;
+      if (
+        this.handleBackspaceReferenceDelete({
+          lineId: nativeSelection.lineId,
+          start: deleteStart,
+          end: start,
+        })
+      ) {
+        return true;
+      }
+
+      return this.deleteNativeLineContentRange({
         lineId: nativeSelection.lineId,
-        start: start - 1,
+        start: deleteStart,
         end: start,
       });
-      return didDelete;
     }
 
     const context = this.getLineSelectionContextFromLineSelection({
@@ -5329,10 +6299,17 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       lineId: focusTarget.lineId,
       cursorPosition: focusTarget.cursorPosition,
     };
+    const focusRestoreSequenceId = this.advanceFocusRestoreSequence();
 
     requestAnimationFrame(() => {
+      if (this.focusRestoreSequenceId !== focusRestoreSequenceId) {
+        return;
+      }
+
       if (this.isEditorActiveElement() && this.state.mode === "text-editor") {
         this.restoreTextEditorFocusState();
+        this.markProgrammaticFocusRestore(lineFocusTarget);
+        this.restoreLineSelection(lineFocusTarget);
         return;
       }
 
@@ -5513,7 +6490,15 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     );
   }
 
-  closeMentionMenu({ shouldRender = false } = {}) {
+  closeMentionMenu({
+    shouldRender = false,
+    dismissCurrentTrigger = false,
+  } = {}) {
+    if (dismissCurrentTrigger) {
+      this.dismissCurrentMentionTrigger();
+    }
+    this.pendingTypedSlashMentionTrigger = undefined;
+    this.clearMentionMenuFocusRestore();
     this.state.mentionMenu = createClosedMentionMenuState();
 
     if (this.refs.mentionMenu) {
@@ -5543,6 +6528,259 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     return this.isMentionMenuFocusTarget(document.activeElement);
+  }
+
+  shouldPreserveMentionMenuUntilFirstRender(editorState) {
+    const menuState = this.state.mentionMenu;
+    if (
+      !menuState?.isOpen ||
+      this.refs.mentionMenu?.open === true ||
+      !this.isEditorFocused ||
+      !menuState.nodeKey
+    ) {
+      return false;
+    }
+
+    try {
+      return editorState.read(() => {
+        const node = $getNodeByKey(menuState.nodeKey);
+        const trigger = getMentionTriggerFromTextNode(
+          node,
+          menuState.endOffset,
+          { source: "pending-menu-render" },
+        );
+
+        return (
+          trigger?.nodeKey === menuState.nodeKey &&
+          trigger.startOffset === menuState.startOffset &&
+          trigger.endOffset === menuState.endOffset &&
+          trigger.query === menuState.query
+        );
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  getMentionTriggerSelectionSnapshot(triggerState = {}) {
+    if (!triggerState.nodeKey || !this.editor) {
+      return undefined;
+    }
+
+    return this.editor.getEditorState().read(() => {
+      const node = $getNodeByKey(triggerState.nodeKey);
+      if (!$isTextNode(node) || $isMentionNode(node)) {
+        return undefined;
+      }
+
+      const root = $getRoot();
+      let lineNode = node;
+      while (lineNode?.getParent?.() && lineNode.getParent() !== root) {
+        lineNode = lineNode.getParent();
+      }
+
+      if (!lineNode || lineNode === root || lineNode.getParent?.() !== root) {
+        return undefined;
+      }
+
+      const lineMeta = this.lineMetaByKey.get(lineNode.getKey());
+      if (!lineMeta) {
+        return undefined;
+      }
+
+      const result = getLexicalOffsetBeforeNode(lineNode, node.getKey());
+      if (!result.found) {
+        return undefined;
+      }
+
+      const nodeLength = getLexicalTextLength(node);
+      const localOffset = Math.max(
+        0,
+        Math.min(Number(triggerState.endOffset) || 0, nodeLength),
+      );
+      const offset = result.offset + localOffset;
+      return {
+        lineId: lineMeta.id,
+        start: offset,
+        end: offset,
+      };
+    });
+  }
+
+  restoreMentionTriggerSelection(triggerState = {}) {
+    const snapshot = this.getMentionTriggerSelectionSnapshot(triggerState);
+    if (snapshot?.lineId) {
+      const focusTarget = {
+        lineId: snapshot.lineId,
+        cursorPosition: snapshot.start,
+        forceRestore: true,
+      };
+      this.state.selectedLineId = snapshot.lineId;
+      this.isEditorFocused = true;
+      this.applyModeState("text-editor");
+      this.markProgrammaticFocusRestore(focusTarget);
+      this.focus({ preventScroll: true });
+      this.restoreLineSelection(snapshot);
+      this.restoreLineSelectionAfterLexicalFocus(focusTarget);
+      this.scheduleRender();
+      return true;
+    }
+
+    if (!triggerState.lineId) {
+      return false;
+    }
+
+    return this.focusLine({
+      lineId: triggerState.lineId,
+      cursorPosition: Number.isFinite(triggerState.endOffset)
+        ? triggerState.endOffset
+        : undefined,
+    });
+  }
+
+  getActiveMentionTriggerState() {
+    try {
+      const mentionTrigger = this.readEditorSnapshot().mentionTrigger;
+      return mentionTrigger
+        ? {
+            ...this.state.mentionMenu,
+            ...mentionTrigger,
+          }
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  getMentionTriggerSignature(trigger = {}) {
+    if (!trigger.nodeKey) {
+      return undefined;
+    }
+
+    const signature = {
+      nodeKey: trigger.nodeKey,
+      startOffset: trigger.startOffset,
+      endOffset: trigger.endOffset,
+      query: trigger.query ?? "",
+    };
+    if (trigger.lineId) {
+      signature.lineId = trigger.lineId;
+    }
+    return signature;
+  }
+
+  dismissMentionTrigger(trigger = {}) {
+    const signature = this.getMentionTriggerSignature(trigger);
+    if (signature) {
+      this.dismissedMentionTrigger = signature;
+      this.dismissedMentionTriggerScope = {
+        nodeKey: signature.nodeKey,
+        query: signature.query,
+        until: this.getNow() + PROGRAMMATIC_FOCUS_BLUR_SUPPRESS_MS,
+      };
+    }
+  }
+
+  dismissCurrentMentionTrigger() {
+    this.dismissMentionTrigger(this.state.mentionMenu);
+  }
+
+  armMentionMenuOpenFromTypedSlash({ source = "input" } = {}) {
+    this.pendingTypedSlashMentionTrigger = {
+      source,
+      until: this.getNow() + TYPED_SLASH_MENTION_TRIGGER_WINDOW_MS,
+    };
+    this.dismissedMentionTrigger = undefined;
+    this.dismissedMentionTriggerScope = undefined;
+  }
+
+  isSameMentionTriggerRoot(left = {}, right = {}) {
+    if (!left.nodeKey || !right.nodeKey) {
+      return false;
+    }
+
+    return (
+      left.nodeKey === right.nodeKey &&
+      left.lineId === right.lineId &&
+      left.startOffset === right.startOffset
+    );
+  }
+
+  isOpenMentionTriggerContinuation(trigger = {}) {
+    return (
+      this.state.mentionMenu?.isOpen === true &&
+      this.isSameMentionTriggerRoot(trigger, this.state.mentionMenu)
+    );
+  }
+
+  consumeTypedSlashMentionTriggerOpen(trigger = {}) {
+    const pendingTrigger = this.pendingTypedSlashMentionTrigger;
+    if (!pendingTrigger) {
+      return undefined;
+    }
+
+    if (this.getNow() > pendingTrigger.until) {
+      this.pendingTypedSlashMentionTrigger = undefined;
+      return undefined;
+    }
+
+    if (trigger.query !== "" || trigger.endOffset !== trigger.startOffset + 1) {
+      return undefined;
+    }
+
+    this.pendingTypedSlashMentionTrigger = undefined;
+    return pendingTrigger.source;
+  }
+
+  getMentionTriggerOpenReason(trigger = {}) {
+    if (this.isOpenMentionTriggerContinuation(trigger)) {
+      return "continuation";
+    }
+
+    const typedSlashSource = this.consumeTypedSlashMentionTriggerOpen(trigger);
+    if (typedSlashSource) {
+      return typedSlashSource;
+    }
+
+    return undefined;
+  }
+
+  isDismissedMentionTrigger(trigger = {}) {
+    const signature = this.getMentionTriggerSignature(trigger);
+    const dismissed = this.dismissedMentionTrigger;
+    const isExactDismissed = Boolean(
+      signature &&
+        dismissed &&
+        signature.nodeKey === dismissed.nodeKey &&
+        signature.lineId === dismissed.lineId &&
+        signature.startOffset === dismissed.startOffset &&
+        signature.endOffset === dismissed.endOffset &&
+        signature.query === dismissed.query,
+    );
+    if (isExactDismissed) {
+      return true;
+    }
+
+    const scope = this.dismissedMentionTriggerScope;
+    if (!signature || !scope) {
+      return false;
+    }
+
+    if (this.getNow() > scope.until) {
+      this.dismissedMentionTriggerScope = undefined;
+      return false;
+    }
+
+    return (
+      signature.nodeKey === scope.nodeKey && signature.query === scope.query
+    );
+  }
+
+  clearMentionMenuFocusRestore() {
+    if (this.mentionMenuFocusRestoreTimerId !== undefined) {
+      clearTimeout(this.mentionMenuFocusRestoreTimerId);
+      this.mentionMenuFocusRestoreTimerId = undefined;
+    }
   }
 
   isMentionMenuFocusTarget(element) {
@@ -5576,26 +6814,49 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     );
   }
 
-  keepMentionMenuNonModal({ restoreFocus = false } = {}) {
-    const popover =
-      this.refs.mentionMenu?.shadowRoot?.querySelector?.("rtgl-popover");
-    popover?.setAttribute("no-overlay", "");
-    popover?.shadowRoot
-      ?.querySelector?.("dialog")
-      ?.setAttribute("tabindex", "-1");
+  getMentionMenuPopover() {
+    return this.refs.mentionMenu?.shadowRoot?.querySelector?.("rtgl-popover");
+  }
 
-    if (!restoreFocus) {
-      return;
+  getMentionMenuPositionForTrigger(trigger = {}) {
+    const surfaceRect = this.refs.surface.getBoundingClientRect();
+    const editorRect = this.refs.editor.getBoundingClientRect();
+    const maxLeft = Math.max(12, surfaceRect.width - 292);
+    const lineKey = trigger.lineId
+      ? this.lineKeyById.get(trigger.lineId)
+      : undefined;
+    const lineElement = lineKey
+      ? this.editor.getElementByKey(lineKey)
+      : undefined;
+    const triggerRange =
+      lineElement && Number.isFinite(trigger.endOffset)
+        ? createCollapsedRangeAtPosition(lineElement, trigger.endOffset).range
+        : undefined;
+    const triggerRect =
+      triggerRange?.getBoundingClientRect?.() ??
+      lineElement?.getBoundingClientRect?.() ??
+      editorRect;
+
+    return {
+      left:
+        surfaceRect.left +
+        Math.max(12, Math.min(maxLeft, triggerRect.left - surfaceRect.left)),
+      top:
+        surfaceRect.top +
+        Math.max(18, triggerRect.bottom - surfaceRect.top + 12),
+    };
+  }
+
+  syncMentionMenuPopover() {
+    const popover = this.getMentionMenuPopover();
+    if (popover?.hasAttribute("no-overlay")) {
+      popover.removeAttribute("no-overlay");
     }
 
-    setTimeout(() => {
-      if (!this.isConnected || !this.state.mentionMenu.isOpen) {
-        return;
-      }
-
-      this.keepMentionMenuNonModal();
-      this.focus({ preventScroll: true });
-    }, 0);
+    const dialog = popover?.shadowRoot?.querySelector?.("dialog");
+    if (dialog && dialog.getAttribute("tabindex") !== "-1") {
+      dialog.setAttribute("tabindex", "-1");
+    }
   }
 
   selectMentionByIndex(index) {
@@ -5686,34 +6947,68 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       .join("\n");
 
     if (snapshot.mentionTrigger) {
-      const items = filterMentionSuggestions(
-        snapshot.mentionTrigger.query,
-        this.state.mentionTargets,
+      const openReason = this.getMentionTriggerOpenReason(
+        snapshot.mentionTrigger,
       );
-      this.state.mentionMenu = {
-        isOpen: true,
-        query: snapshot.mentionTrigger.query,
-        items,
-        highlightedIndex: 0,
-        left: 12,
-        top: 18,
-        nodeKey: snapshot.mentionTrigger.nodeKey,
-        startOffset: snapshot.mentionTrigger.startOffset,
-        endOffset: snapshot.mentionTrigger.endOffset,
-      };
 
-      const position = getMentionMenuPosition(
-        this.refs.editor,
-        this.refs.surface,
-      );
-      const surfaceRect = this.refs.surface.getBoundingClientRect();
-      this.state.mentionMenu.left = surfaceRect.left + position.left;
-      this.state.mentionMenu.top = surfaceRect.top + position.top;
-    } else if (this.shouldPreserveMentionMenuAfterSelectionLoss()) {
-      this.refs.mentionMenu.open = true;
-      this.keepMentionMenuNonModal({ restoreFocus: true });
-    } else {
-      this.closeMentionMenu();
+      if (!openReason) {
+        if (
+          this.state.mentionMenu?.isOpen === true &&
+          !this.shouldPreserveMentionMenuAfterSelectionLoss()
+        ) {
+          this.closeMentionMenu({
+            dismissCurrentTrigger: true,
+          });
+        } else if (this.state.mentionMenu?.isOpen === true) {
+          this.refs.mentionMenu.open = true;
+          this.syncMentionMenuPopover();
+        } else {
+          this.closeMentionMenu();
+        }
+      } else if (
+        openReason !== "continuation" &&
+        this.isDismissedMentionTrigger(snapshot.mentionTrigger)
+      ) {
+        this.closeMentionMenu();
+      } else {
+        if (openReason !== "continuation") {
+          this.dismissedMentionTrigger = undefined;
+          this.dismissedMentionTriggerScope = undefined;
+        }
+        const items = filterMentionSuggestions(
+          snapshot.mentionTrigger.query,
+          this.state.mentionTargets,
+        );
+        this.state.mentionMenu = {
+          isOpen: true,
+          query: snapshot.mentionTrigger.query,
+          items,
+          highlightedIndex: 0,
+          left: 12,
+          top: 18,
+          nodeKey: snapshot.mentionTrigger.nodeKey,
+          lineId: snapshot.mentionTrigger.lineId,
+          startOffset: snapshot.mentionTrigger.startOffset,
+          endOffset: snapshot.mentionTrigger.endOffset,
+        };
+
+        const position = this.getMentionMenuPositionForTrigger(
+          snapshot.mentionTrigger,
+        );
+        this.state.mentionMenu.left = position.left;
+        this.state.mentionMenu.top = position.top;
+      }
+    }
+
+    if (!snapshot.mentionTrigger) {
+      if (this.shouldPreserveMentionMenuUntilFirstRender(editorState)) {
+        this.syncMentionMenuPopover();
+      } else if (this.shouldPreserveMentionMenuAfterSelectionLoss()) {
+        this.refs.mentionMenu.open = true;
+        this.syncMentionMenuPopover();
+      } else {
+        this.closeMentionMenu();
+      }
     }
 
     this.scheduleRender();
@@ -5848,6 +7143,26 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.updateReferenceSelectionMarkers();
   }
 
+  clearRenderedSelectionState() {
+    this.refs?.editor
+      ?.querySelectorAll?.('.editor-paragraph[data-selected="true"]')
+      ?.forEach((lineElement) => {
+        lineElement.dataset.selected = "false";
+      });
+
+    this.refs?.leftGutter
+      ?.querySelectorAll?.('.gutter-row[data-selected="true"]')
+      ?.forEach((row) => {
+        row.dataset.selected = "false";
+      });
+
+    this.refs?.rightGutter
+      ?.querySelectorAll?.('.gutter-row[data-selected="true"]')
+      ?.forEach((row) => {
+        row.dataset.selected = "false";
+      });
+  }
+
   renderGutters() {
     const lineDecorationsById = new Map();
 
@@ -5879,7 +7194,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       const lineRect = lineElement.getBoundingClientRect();
       const top = Math.max(0, lineRect.top - surfaceRect.top);
       const height = Math.max(24, lineRect.height);
-      const isSelected = line.id === this.state.selectedLineId;
+      const isSelected =
+        this.state.selectionActive !== false &&
+        line.id === this.state.selectedLineId;
       lineElement.dataset.selected = String(isSelected);
       lineElement.dataset.mode = this.state.mode;
       const leftRow = this.getOrCreateGutterRow(
@@ -6216,7 +7533,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       const prefixRange = document.createRange();
       prefixRange.selectNodeContents(lineElement);
       prefixRange.setEnd(range.startContainer, range.startOffset);
-      return prefixRange.toString().length;
+      return prefixRange.toString().replaceAll(EDITOR_CARET_TEXT, "").length;
     } catch {
       return undefined;
     }
@@ -6257,8 +7574,31 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     return undefined;
   }
 
-  getNativeLineSelectionContext() {
-    const range = getSelectionRange(this.refs?.editor);
+  createNativeSelectionRange(rangeLike) {
+    if (!rangeLike?.startContainer || !rangeLike?.endContainer) {
+      return undefined;
+    }
+
+    if (
+      !this.refs?.editor?.contains?.(rangeLike.startContainer) ||
+      !this.refs?.editor?.contains?.(rangeLike.endContainer)
+    ) {
+      return undefined;
+    }
+
+    const range = document.createRange();
+    try {
+      range.setStart(rangeLike.startContainer, rangeLike.startOffset);
+      range.setEnd(rangeLike.endContainer, rangeLike.endOffset);
+    } catch {
+      return undefined;
+    }
+
+    return range;
+  }
+
+  getLineSelectionContextFromRange(rangeLike) {
+    const range = this.createNativeSelectionRange(rangeLike);
     if (!range) {
       return undefined;
     }
@@ -6317,6 +7657,38 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       start: offset,
       end: offset,
     };
+  }
+
+  getNativeLineSelectionContext(rangeLike) {
+    if (
+      !rangeLike &&
+      (!this.refs?.editor ||
+        typeof window === "undefined" ||
+        typeof document === "undefined" ||
+        typeof ShadowRoot === "undefined")
+    ) {
+      return undefined;
+    }
+
+    return this.getLineSelectionContextFromRange(
+      rangeLike ?? getSelectionRange(this.refs?.editor),
+    );
+  }
+
+  getBeforeInputLineSelectionContext(event) {
+    const targetRange = event?.getTargetRanges?.()?.[0];
+    if (!targetRange) {
+      return undefined;
+    }
+
+    return this.getLineSelectionContextFromRange(targetRange);
+  }
+
+  getInputLineSelectionContext(event) {
+    return (
+      this.getBeforeInputLineSelectionContext(event) ??
+      this.getNativeLineSelectionContext()
+    );
   }
 
   getNativeLineRangeSelectionContext() {
@@ -6880,26 +8252,57 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
-    if (!menuState.isOpen || menuState.items.length === 0) {
+    const mentionItems = menuState.items ?? [];
+    if (!menuState.isOpen || mentionItems.length === 0) {
+      if (menu.open !== true && (menu.items?.length ?? 0) === 0) {
+        return;
+      }
       menu.items = [];
       menu.open = false;
       menu.render?.();
       return;
     }
 
-    menu.items = menuState.items.map((item) => ({
+    const nextItems = mentionItems.map((item) => ({
       id: `mention:${item.id}`,
       type: "item",
       label: item.label,
-      suffixText: item.variableType || "",
+      suffixText: item.variableType ?? "",
     }));
-    menu.x = String(menuState.left);
-    menu.y = String(menuState.top);
-    menu.place = "bs";
-    menu.w = "260";
-    menu.h = "240";
+    const nextX = String(menuState.left);
+    const nextY = String(menuState.top);
+    const nextPlace = "bs";
+    const nextWidth = "260";
+    const nextHeight = "240";
+    const hasPopover = Boolean(this.getMentionMenuPopover());
+    const needsRender =
+      menu.open !== true ||
+      menu.x !== nextX ||
+      menu.y !== nextY ||
+      menu.place !== nextPlace ||
+      menu.w !== nextWidth ||
+      menu.h !== nextHeight ||
+      !areRenderedMentionMenuItemsEqual(menu.items, nextItems) ||
+      !hasPopover;
+
+    if (!needsRender) {
+      this.syncMentionMenuPopover();
+      return;
+    }
+
+    menu.items = nextItems;
+    menu.x = nextX;
+    menu.y = nextY;
+    menu.place = nextPlace;
+    menu.w = nextWidth;
+    menu.h = nextHeight;
+    if (!hasPopover) {
+      menu.open = false;
+      menu.render?.();
+      this.syncMentionMenuPopover();
+    }
     menu.open = true;
     menu.render?.();
-    this.keepMentionMenuNonModal({ restoreFocus: true });
+    this.syncMentionMenuPopover();
   }
 }

--- a/src/primitives/lexicalSceneDocumentReferences.js
+++ b/src/primitives/lexicalSceneDocumentReferences.js
@@ -146,7 +146,15 @@ export const placeCaretAroundReferenceNode = (node, direction) => {
   }
 
   const referenceIndex = node.getIndexWithinParent();
-  const caretIndex = referenceIndex + (direction > 0 ? 1 : 0);
+  let caretIndex = referenceIndex + (direction > 0 ? 1 : 0);
+  const nextSibling = node.getNextSibling();
+  if (
+    direction > 0 &&
+    $isTextNode(nextSibling) &&
+    getLexicalTextLength(nextSibling) === 0
+  ) {
+    caretIndex += 1;
+  }
   parentNode.select(caretIndex, caretIndex);
 };
 
@@ -175,7 +183,7 @@ export const isCollapsedReferenceCaretMovingIntoNode = (
   );
 };
 
-export const getAdjacentReferenceNodeForCollapsedSelection = (
+export const getAdjacentReferenceNodeInfoForCollapsedSelection = (
   selection,
   direction,
 ) => {
@@ -186,6 +194,22 @@ export const getAdjacentReferenceNodeForCollapsedSelection = (
   const point = selection.anchor;
   const node = point.getNode();
   let candidate;
+  let skippedZeroLengthText = false;
+  const skipZeroLengthTextCandidate = (candidateNode) => {
+    let nextCandidate = candidateNode;
+    while (
+      $isTextNode(nextCandidate) &&
+      getLexicalTextLength(nextCandidate) === 0
+    ) {
+      skippedZeroLengthText = true;
+      nextCandidate =
+        direction < 0
+          ? nextCandidate.getPreviousSibling()
+          : nextCandidate.getNextSibling();
+    }
+
+    return nextCandidate;
+  };
 
   if ($isMentionNode(node)) {
     candidate = isCollapsedReferenceCaretMovingIntoNode(
@@ -197,7 +221,9 @@ export const getAdjacentReferenceNodeForCollapsedSelection = (
       : undefined;
   } else if (point.type === "text" && $isTextNode(node)) {
     const textLength = getLexicalTextLength(node);
-    if (direction < 0 && point.offset === 0) {
+    if (textLength === 0) {
+      candidate = skipZeroLengthTextCandidate(node);
+    } else if (direction < 0 && point.offset === 0) {
       candidate = node.getPreviousSibling();
     } else if (direction > 0 && point.offset >= textLength) {
       candidate = node.getNextSibling();
@@ -208,7 +234,23 @@ export const getAdjacentReferenceNodeForCollapsedSelection = (
       childIndex >= 0 && childIndex < node.getChildrenSize()
         ? node.getChildAtIndex(childIndex)
         : undefined;
+    candidate = skipZeroLengthTextCandidate(candidate);
   }
 
-  return $isMentionNode(candidate) ? candidate : undefined;
+  if (!$isMentionNode(candidate)) {
+    return undefined;
+  }
+
+  return {
+    node: candidate,
+    skippedZeroLengthText,
+  };
+};
+
+export const getAdjacentReferenceNodeForCollapsedSelection = (
+  selection,
+  direction,
+) => {
+  return getAdjacentReferenceNodeInfoForCollapsedSelection(selection, direction)
+    ?.node;
 };

--- a/src/primitives/lexicalSceneDocumentSelection.js
+++ b/src/primitives/lexicalSceneDocumentSelection.js
@@ -5,9 +5,42 @@ import {
   $isTextNode,
   $setSelection,
 } from "lexical";
+import { EDITOR_CARET_TEXT } from "../internal/ui/sceneEditorLexical/contentModel.js";
 
 const REFERENCE_CHIP_SELECTOR =
   '[data-rvn-mention="true"][data-rvn-reference-key]';
+const REFERENCE_NODE_TYPE = "rvn-mention";
+
+const isReferenceTextNode = (node) => {
+  return $isTextNode(node) && node.getType?.() === REFERENCE_NODE_TYPE;
+};
+
+const getLogicalText = (text) => {
+  return String(text ?? "").replaceAll(EDITOR_CARET_TEXT, "");
+};
+
+const getLogicalTextLength = (text) => {
+  return getLogicalText(text).length;
+};
+
+const getTextNodeOffsetFromLogicalOffset = (text, targetOffset) => {
+  const normalizedTargetOffset = Math.max(0, Number(targetOffset) || 0);
+  let logicalOffset = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === EDITOR_CARET_TEXT) {
+      continue;
+    }
+
+    if (logicalOffset >= normalizedTargetOffset) {
+      return index;
+    }
+
+    logicalOffset += 1;
+  }
+
+  return text.length;
+};
 
 export const walkTextUnits = (node, visitor) => {
   if (
@@ -15,6 +48,7 @@ export const walkTextUnits = (node, visitor) => {
     node.matches?.(REFERENCE_CHIP_SELECTOR)
   ) {
     return visitor({
+      type: "reference",
       length: node.textContent?.length ?? 0,
       setRangeAtOffset: (range, offset) => {
         const parent = node.parentNode;
@@ -27,17 +61,21 @@ export const walkTextUnits = (node, visitor) => {
   }
 
   if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent ?? "";
     return visitor({
-      length: node.textContent.length,
+      type: "text",
+      length: getLogicalTextLength(text),
       setRangeAtOffset: (range, offset) => {
-        range.setStart(node, offset);
-        range.setEnd(node, offset);
+        const textOffset = getTextNodeOffsetFromLogicalOffset(text, offset);
+        range.setStart(node, textOffset);
+        range.setEnd(node, textOffset);
       },
     });
   }
 
   if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === "BR") {
     return visitor({
+      type: "line-break",
       length: 1,
       setRangeAtOffset: (range, offset) => {
         const parent = node.parentNode;
@@ -58,29 +96,44 @@ export const walkTextUnits = (node, visitor) => {
   return false;
 };
 
+const collectTextUnits = (element) => {
+  const units = [];
+  walkTextUnits(element, (unit) => {
+    units.push(unit);
+    return false;
+  });
+  return units;
+};
+
 export const createCollapsedRangeAtPosition = (element, targetPosition) => {
   const range = document.createRange();
   const normalizedTargetPosition = Math.max(0, Number(targetPosition) || 0);
+  const units = collectTextUnits(element);
   let currentPosition = 0;
   let lastUnit;
   let actualPosition = 0;
   let foundNode = false;
 
-  walkTextUnits(element, (unit) => {
+  for (let index = 0; index < units.length; index += 1) {
+    const unit = units[index];
     const nodeLength = unit.length;
     lastUnit = unit;
+    const unitEnd = currentPosition + nodeLength;
 
-    if (currentPosition + nodeLength >= normalizedTargetPosition) {
+    if (
+      normalizedTargetPosition < unitEnd ||
+      (normalizedTargetPosition === unitEnd &&
+        (unit.type !== "reference" || units[index + 1]?.type !== "text"))
+    ) {
       const offset = normalizedTargetPosition - currentPosition;
       unit.setRangeAtOffset(range, offset);
       actualPosition = normalizedTargetPosition;
       foundNode = true;
-      return true;
+      break;
     }
 
-    currentPosition += nodeLength;
-    return false;
-  });
+    currentPosition = unitEnd;
+  }
 
   if (!foundNode && lastUnit) {
     lastUnit.setRangeAtOffset(range, lastUnit.length);
@@ -190,7 +243,7 @@ export const getLexicalTextLength = (node) => {
   }
 
   if ($isTextNode(node)) {
-    return node.getTextContentSize?.() ?? node.getTextContent().length;
+    return getLogicalTextLength(node.getTextContent());
   }
 
   if ($isElementNode(node)) {
@@ -244,11 +297,27 @@ export const resolvePointAtOffset = (node, offset) => {
     };
   }
 
+  if (isReferenceTextNode(node)) {
+    const parent = node.getParent();
+    if (!$isElementNode(parent)) {
+      return undefined;
+    }
+
+    return {
+      key: parent.getKey(),
+      offset: node.getIndexWithinParent() + (targetOffset > 0 ? 1 : 0),
+      type: "element",
+    };
+  }
+
   if ($isTextNode(node)) {
     const textLength = getLexicalTextLength(node);
     return {
       key: node.getKey(),
-      offset: Math.min(targetOffset, textLength),
+      offset: getTextNodeOffsetFromLogicalOffset(
+        node.getTextContent(),
+        Math.min(targetOffset, textLength),
+      ),
       type: "text",
     };
   }
@@ -260,7 +329,8 @@ export const resolvePointAtOffset = (node, offset) => {
   const children = node.getChildren();
   let remainingOffset = targetOffset;
 
-  for (const childNode of children) {
+  for (let index = 0; index < children.length; index += 1) {
+    const childNode = children[index];
     const childLength = getLexicalTextLength(childNode);
     if ($isLineBreakNode(childNode) && remainingOffset <= childLength) {
       return {
@@ -269,6 +339,15 @@ export const resolvePointAtOffset = (node, offset) => {
           childNode.getIndexWithinParent() + (remainingOffset > 0 ? 1 : 0),
         type: "element",
       };
+    }
+
+    if (
+      isReferenceTextNode(childNode) &&
+      remainingOffset === childLength &&
+      $isTextNode(children[index + 1]) &&
+      !isReferenceTextNode(children[index + 1])
+    ) {
+      return resolvePointAtOffset(children[index + 1], 0);
     }
 
     if (remainingOffset <= childLength) {

--- a/svg/ellipsis.svg
+++ b/svg/ellipsis.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="6" cy="12" r="1" fill="currentColor"/>
-  <circle cx="12" cy="12" r="1" fill="currentColor"/>
-  <circle cx="18" cy="12" r="1" fill="currentColor"/>
+  <circle cx="6" cy="12" r="1.6" fill="currentColor"/>
+  <circle cx="12" cy="12" r="1.6" fill="currentColor"/>
+  <circle cx="18" cy="12" r="1.6" fill="currentColor"/>
 </svg>

--- a/tests/appService/appShellService.test.js
+++ b/tests/appService/appShellService.test.js
@@ -79,4 +79,20 @@ describe("appShellService", () => {
     expect(result).toBe(true);
     expect(deps.globalUI.showConfirm).toHaveBeenCalledWith(options);
   });
+
+  it("forwards payload update options to the router", () => {
+    const deps = createDeps();
+    const service = createAppShellService(deps);
+    const payload = {
+      p: "project-1",
+      sectionId: "section-1",
+      lineId: "line-1",
+    };
+
+    service.setPayload(payload, { throttleMs: 250 });
+
+    expect(deps.router.setPayload).toHaveBeenCalledWith(payload, {
+      throttleMs: 250,
+    });
+  });
 });

--- a/tests/appService/router.test.js
+++ b/tests/appService/router.test.js
@@ -143,4 +143,33 @@ describe("web router payload updates", () => {
     expect(windowMock.location.pathname).toBe("/projects");
     expect(windowMock.location.search).toBe("?p=project-1");
   });
+
+  it("drops pending payload writes when the same path query changes outside the router", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-1" },
+      { throttleMs: 250 },
+    );
+    vi.setSystemTime(1050);
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-2" },
+      { throttleMs: 250 },
+    );
+
+    setLocationFromPath(
+      windowMock.location,
+      "/project/scene-editor?p=project-2",
+    );
+    vi.advanceTimersByTime(250);
+
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(windowMock.location.pathname).toBe("/project/scene-editor");
+    expect(windowMock.location.search).toBe("?p=project-2");
+  });
 });

--- a/tests/appService/router.test.js
+++ b/tests/appService/router.test.js
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WebRouter from "../../src/deps/clients/router.js";
+
+const setLocationFromPath = (location, path) => {
+  const [pathname, query = ""] = String(path).split("?");
+  location.pathname = pathname;
+  location.search = query ? `?${query}` : "";
+};
+
+const createWindowMock = () => {
+  const location = {
+    pathname: "/project/scene-editor",
+    search: "?p=project-1",
+  };
+
+  return {
+    location,
+    history: {
+      replaceState: vi.fn((_state, _title, path) => {
+        setLocationFromPath(location, path);
+      }),
+      pushState: vi.fn((_state, _title, path) => {
+        setLocationFromPath(location, path);
+      }),
+      back: vi.fn(),
+    },
+  };
+};
+
+describe("web router payload updates", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("does not replace history when the payload URL is unchanged", () => {
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+
+    router.setPayload({ p: "project-1" });
+
+    expect(windowMock.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it("coalesces throttled payload writes and exposes the pending payload", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-1" },
+      { throttleMs: 250 },
+    );
+
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(windowMock.location.search).toBe(
+      "?p=project-1&sectionId=section-1&lineId=line-1",
+    );
+
+    vi.setSystemTime(1050);
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-2" },
+      { throttleMs: 250 },
+    );
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-3" },
+      { throttleMs: 250 },
+    );
+
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(router.getPayload()).toMatchObject({
+      sectionId: "section-1",
+      lineId: "line-3",
+    });
+
+    vi.advanceTimersByTime(199);
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(2);
+    expect(windowMock.location.search).toBe(
+      "?p=project-1&sectionId=section-1&lineId=line-3",
+    );
+  });
+
+  it("clears pending payload writes before navigation", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-1" },
+      { throttleMs: 250 },
+    );
+    vi.setSystemTime(1050);
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-2" },
+      { throttleMs: 250 },
+    );
+
+    router.redirect("/projects", { p: "project-1" });
+    vi.advanceTimersByTime(250);
+
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(windowMock.history.pushState).toHaveBeenCalledWith(
+      {},
+      "",
+      "/projects?p=project-1",
+    );
+    expect(windowMock.location.pathname).toBe("/projects");
+    expect(windowMock.location.search).toBe("?p=project-1");
+  });
+
+  it("drops pending payload writes when the path changes outside the router", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-1" },
+      { throttleMs: 250 },
+    );
+    vi.setSystemTime(1050);
+    router.setPayload(
+      { p: "project-1", sectionId: "section-1", lineId: "line-2" },
+      { throttleMs: 250 },
+    );
+
+    setLocationFromPath(windowMock.location, "/projects?p=project-1");
+    vi.advanceTimersByTime(250);
+
+    expect(windowMock.history.replaceState).toHaveBeenCalledTimes(1);
+    expect(windowMock.location.pathname).toBe("/projects");
+    expect(windowMock.location.search).toBe("?p=project-1");
+  });
+});

--- a/tests/commandLineInput/commandLineInput.handlers.test.js
+++ b/tests/commandLineInput/commandLineInput.handlers.test.js
@@ -1,20 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleBeforeMount,
-  handleFieldConfigChange,
+  handleFieldEditChange,
+  handleFieldRowClick,
+  handleSaveFieldEditClick,
   handleSubmitClick,
 } from "../../src/components/commandLineInput/commandLineInput.handlers.js";
 import {
   createInitialState,
   hydrateForm,
+  saveEditingField,
+  selectCanSaveEditField,
   selectFieldRows,
   selectFormData,
+  selectFormDataWithEditingDraft,
   selectSelectedResourceId,
-  selectSettingsForm,
-  setRepositoryData,
-  setSelectedResourceId,
-  updateFieldConfig,
-  updateSettingsForm,
+  startEditingField,
+  updateEditFieldConfig,
 } from "../../src/components/commandLineInput/commandLineInput.store.js";
 
 const inputLayout = {
@@ -72,14 +74,15 @@ const props = {
 
 const createStoreApi = (state) => ({
   hydrateForm: (payload) => hydrateForm({ state }, payload),
+  saveEditingField: (payload) => saveEditingField({ state }, payload),
+  selectCanSaveEditField: () => selectCanSaveEditField({ state }),
   selectFieldRows: () => selectFieldRows({ state }),
   selectFormData: () => selectFormData({ state }),
+  selectFormDataWithEditingDraft: () =>
+    selectFormDataWithEditingDraft({ state }),
   selectSelectedResourceId: () => selectSelectedResourceId({ state }),
-  selectSettingsForm: () => selectSettingsForm({ state }),
-  setRepositoryData: (payload) => setRepositoryData({ state }, payload),
-  setSelectedResourceId: (payload) => setSelectedResourceId({ state }, payload),
-  updateFieldConfig: (payload) => updateFieldConfig({ state }, payload),
-  updateSettingsForm: (payload) => updateSettingsForm({ state }, payload),
+  startEditingField: (payload) => startEditingField({ state }, payload),
+  updateEditFieldConfig: (payload) => updateEditFieldConfig({ state }, payload),
 });
 
 describe("commandLineInput.handlers", () => {
@@ -94,7 +97,23 @@ describe("commandLineInput.handlers", () => {
       store,
     });
 
-    handleFieldConfigChange(
+    handleFieldRowClick(
+      {
+        render,
+        store,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              field: "name",
+            },
+          },
+        },
+      },
+    );
+
+    handleFieldEditChange(
       {
         dispatchEvent,
         render,
@@ -107,7 +126,6 @@ describe("commandLineInput.handlers", () => {
           },
           currentTarget: {
             dataset: {
-              field: "name",
               name: "placeholder",
             },
           },
@@ -115,7 +133,7 @@ describe("commandLineInput.handlers", () => {
       },
     );
 
-    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(2);
     expect(dispatchEvent).toHaveBeenCalledTimes(1);
     expect(dispatchEvent.mock.calls[0][0].type).toBe(
       "temporary-presentation-state-change",
@@ -131,12 +149,14 @@ describe("commandLineInput.handlers", () => {
               required: true,
               trim: true,
               placeholder: "Full name",
+              maxLength: 32,
             },
             code: {
               variableId: "playerCode",
               required: true,
               trim: true,
               placeholder: "",
+              maxLength: 32,
             },
           },
           submitActions: {
@@ -145,6 +165,23 @@ describe("commandLineInput.handlers", () => {
         },
       },
     });
+
+    expect(selectFormData({ state }).fields.name.placeholder).toBe("");
+
+    handleSaveFieldEditClick(
+      {
+        dispatchEvent,
+        render,
+        store,
+      },
+      {
+        _event: {
+          stopPropagation: vi.fn(),
+        },
+      },
+    );
+
+    expect(selectFormData({ state }).fields.name.placeholder).toBe("Full name");
   });
 
   it("submits the authored form payload", () => {
@@ -183,12 +220,14 @@ describe("commandLineInput.handlers", () => {
             required: true,
             trim: true,
             placeholder: "",
+            maxLength: 32,
           },
           code: {
             variableId: "playerCode",
             required: true,
             trim: true,
             placeholder: "",
+            maxLength: 32,
           },
         },
         submitActions: {
@@ -235,5 +274,63 @@ describe("commandLineInput.handlers", () => {
       message: "Map every input field to a string variable.",
       title: "Warning",
     });
+  });
+
+  it("requires a variable before saving a field edit", () => {
+    const state = createInitialState();
+    const store = createStoreApi(state);
+    const showAlert = vi.fn();
+    const dispatchEvent = vi.fn();
+    const render = vi.fn();
+
+    handleBeforeMount({
+      props: {
+        ...props,
+        form: {
+          resourceId: inputLayout.id,
+          fields: {},
+        },
+      },
+      store,
+    });
+
+    handleFieldRowClick(
+      {
+        render,
+        store,
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              field: "name",
+            },
+          },
+        },
+      },
+    );
+
+    handleSaveFieldEditClick(
+      {
+        appService: {
+          showAlert,
+        },
+        dispatchEvent,
+        render,
+        store,
+      },
+      {
+        _event: {
+          stopPropagation: vi.fn(),
+        },
+      },
+    );
+
+    expect(showAlert).toHaveBeenCalledWith({
+      message: "Choose a string variable for this input field.",
+      title: "Warning",
+    });
+    expect(dispatchEvent).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/commandLineInput/commandLineInput.store.test.js
+++ b/tests/commandLineInput/commandLineInput.store.test.js
@@ -2,9 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   hydrateForm,
+  saveEditingField,
+  selectCanSaveEditField,
   selectFormData,
+  selectFormDataWithEditingDraft,
+  selectMode,
   selectViewData,
   setRepositoryData,
+  startEditingField,
+  updateEditFieldConfig,
 } from "../../src/components/commandLineInput/commandLineInput.store.js";
 
 const inputLayout = {
@@ -67,6 +73,32 @@ const variables = {
 };
 
 describe("commandLineInput.store", () => {
+  it("leaves the input layout unselected for a new input action", () => {
+    const state = createInitialState();
+
+    hydrateForm(
+      { state },
+      {
+        layouts,
+        layoutsData,
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        layouts,
+      },
+    });
+
+    expect(viewData.selectedResourceId).toBe("");
+    expect(viewData.defaultValues.resourceId).toBe("");
+    expect(viewData.fieldRows).toEqual([]);
+    expect(viewData.hasFields).toBe(false);
+    expect(viewData.submitDisabled).toBe(true);
+    expect(selectFormData({ state })).toBeUndefined();
+  });
+
   it("hydrates one form field mapping for every input element", () => {
     const state = createInitialState();
 
@@ -118,12 +150,17 @@ describe("commandLineInput.store", () => {
       "name",
       "code",
     ]);
+    expect(viewData.fieldRows.map((field) => field.summary)).toEqual([
+      "Player Name - Required - Trim - Single line - Placeholder: Full name - Max: 32",
+      "Player Code - Optional - Keep whitespace - Single line - Placeholder: Code - Max: 8",
+    ]);
     expect(viewData.fieldRows[0]).toMatchObject({
       label: "Name",
       variableId: "playerName",
       required: true,
       trim: true,
       placeholder: "Full name",
+      maxLength: 32,
     });
     expect(viewData.fieldRows[1]).toMatchObject({
       label: "Code",
@@ -134,14 +171,21 @@ describe("commandLineInput.store", () => {
     });
     expect(viewData.fieldVariableOptions).toEqual([
       {
-        label: "Player Name (string)",
+        label: "Player Name",
         value: "playerName",
+        suffixText: "string",
       },
       {
-        label: "Player Code (string)",
+        label: "Player Code",
         value: "playerCode",
+        suffixText: "string",
       },
     ]);
+    expect(
+      viewData.fieldVariableOptions.some((option) =>
+        option.label.includes("("),
+      ),
+    ).toBe(false);
     expect(viewData.submitDisabled).toBe(false);
     expect(selectFormData({ state })).toEqual({
       id: expect.any(String),
@@ -152,6 +196,7 @@ describe("commandLineInput.store", () => {
           required: true,
           trim: true,
           placeholder: "Full name",
+          maxLength: 32,
         },
         code: {
           variableId: "playerCode",
@@ -167,56 +212,9 @@ describe("commandLineInput.store", () => {
     });
   });
 
-  it("prefills section transition submit actions with animation options", () => {
+  it("normalizes existing section transition submit actions to next line", () => {
     const state = createInitialState();
 
-    setRepositoryData(
-      { state },
-      {
-        variables,
-        scenes: {
-          items: {
-            "scene-1": {
-              id: "scene-1",
-              type: "scene",
-              name: "Opening",
-              sections: {
-                items: {
-                  "section-2": {
-                    id: "section-2",
-                    type: "section",
-                    name: "Profile Submitted",
-                  },
-                },
-                tree: [{ id: "section-2" }],
-              },
-            },
-          },
-          tree: [{ id: "scene-1" }],
-        },
-        animations: {
-          items: {
-            "screen-crossfade": {
-              id: "screen-crossfade",
-              type: "animation",
-              name: "Crossfade",
-              animation: {
-                type: "transition",
-              },
-            },
-            "pulse-update": {
-              id: "pulse-update",
-              type: "animation",
-              name: "Pulse",
-              animation: {
-                type: "update",
-              },
-            },
-          },
-          tree: [{ id: "screen-crossfade" }, { id: "pulse-update" }],
-        },
-      },
-    );
     hydrateForm(
       { state },
       {
@@ -255,27 +253,147 @@ describe("commandLineInput.store", () => {
     });
 
     expect(viewData.defaultValues).toMatchObject({
-      submitActionType: "sectionTransition",
-      submitSceneId: "scene-1",
-      submitSectionId: "section-2",
-      submitTransitionAnimationId: "screen-crossfade",
+      resourceId: inputLayout.id,
     });
-    expect(viewData.context.transitionAnimationOptions).toEqual([
-      {
-        value: "screen-crossfade",
-        label: "Crossfade",
-      },
-    ]);
     expect(selectFormData({ state }).submitActions).toEqual({
-      sectionTransition: {
-        sceneId: "scene-1",
-        sectionId: "section-2",
-        screen: {
-          animations: {
-            resourceId: "screen-crossfade",
+      nextLine: {},
+    });
+  });
+
+  it("edits field configuration as a draft before saving", () => {
+    const state = createInitialState();
+
+    hydrateForm(
+      { state },
+      {
+        layouts,
+        layoutsData,
+        form: {
+          resourceId: inputLayout.id,
+          fields: {
+            name: {
+              variableId: "playerName",
+            },
+            code: {
+              variableId: "playerCode",
+            },
+          },
+          submitActions: {
+            nextLine: {},
           },
         },
       },
+    );
+
+    startEditingField({ state }, { field: "name" });
+    updateEditFieldConfig(
+      { state },
+      { name: "placeholder", value: "Full name" },
+    );
+
+    expect(selectMode({ state })).toBe("editField");
+    expect(selectFormData({ state }).fields.name.placeholder).toBe("Name");
+    expect(
+      selectFormDataWithEditingDraft({ state }).fields.name.placeholder,
+    ).toBe("Full name");
+    expect(selectCanSaveEditField({ state })).toBe(true);
+
+    saveEditingField({ state });
+
+    expect(selectMode({ state })).toBe("list");
+    expect(selectFormData({ state }).fields.name.placeholder).toBe("Full name");
+  });
+
+  it("requires a variable before saving a field edit", () => {
+    const state = createInitialState();
+
+    setRepositoryData(
+      { state },
+      {
+        variables,
+      },
+    );
+    hydrateForm(
+      { state },
+      {
+        layouts,
+        layoutsData,
+        form: {
+          resourceId: inputLayout.id,
+          fields: {},
+          submitActions: {
+            nextLine: {},
+          },
+        },
+      },
+    );
+
+    startEditingField({ state }, { field: "name" });
+
+    let viewData = selectViewData({
+      state,
+      props: {
+        layouts,
+      },
+    });
+
+    expect(selectCanSaveEditField({ state })).toBe(false);
+    expect(viewData.canSaveEditField).toBe(false);
+
+    updateEditFieldConfig(
+      { state },
+      { name: "variableId", value: "playerName" },
+    );
+
+    viewData = selectViewData({
+      state,
+      props: {
+        layouts,
+      },
+    });
+
+    expect(selectCanSaveEditField({ state })).toBe(true);
+    expect(viewData.canSaveEditField).toBe(true);
+  });
+
+  it("starts editing from a proxied field config", () => {
+    const state = createInitialState();
+
+    hydrateForm(
+      { state },
+      {
+        layouts,
+        layoutsData,
+        form: {
+          resourceId: inputLayout.id,
+          fields: {
+            name: {
+              variableId: "playerName",
+              required: true,
+              trim: false,
+              placeholder: "Full name",
+            },
+          },
+          submitActions: {
+            nextLine: {},
+          },
+        },
+      },
+    );
+
+    state.fields.name = new Proxy(state.fields.name, {});
+
+    expect(() => {
+      startEditingField({ state }, { field: "name" });
+    }).not.toThrow();
+    expect(selectMode({ state })).toBe("editField");
+    expect(state.editFieldForm).toMatchObject({
+      field: "name",
+      label: "Name",
+      variableId: "playerName",
+      required: true,
+      trim: false,
+      placeholder: "Full name",
     });
   });
 });

--- a/tests/commandLineInput/commandLineInput.view.test.js
+++ b/tests/commandLineInput/commandLineInput.view.test.js
@@ -16,4 +16,17 @@ describe("commandLineInput view", () => {
     expect(view).not.toContain("$for field, index in fieldRows:");
     expect(view).not.toContain("data-field=${field.field}");
   });
+
+  it("does not show submit action choices", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineInput/commandLineInput.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).not.toContain("Submit Action");
+    expect(view).not.toContain("Move to Section");
+  });
 });

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleBackClick,
+  handleFileExplorerAction,
   handleLayoutEditorCanvasDragUpdate,
   handleLayoutEditorCanvasMetricsChange,
   handleSaveButtonClick,
@@ -279,6 +280,66 @@ describe("layoutEditor.handleSaveButtonClick", () => {
     });
     expect(deps.appService.showToast).toHaveBeenCalledWith({
       message: "Layout preview saved.",
+    });
+  });
+});
+
+describe("layoutEditor.handleFileExplorerAction", () => {
+  it("creates image elements at the top of the selected parent", async () => {
+    const createLayoutElement = vi.fn(async () => ({ valid: true }));
+    const deps = createLayoutEditorDeps();
+    deps.appService.showComponentDialog = vi.fn(async () => ({
+      actionId: "create",
+      values: {
+        name: "Hero Image",
+        imageId: "image-1",
+      },
+    }));
+    deps.projectService.createLayoutElement = createLayoutElement;
+    deps.store.selectProjectResolution = vi.fn(() => ({
+      width: 1920,
+      height: 1080,
+    }));
+    deps.store.selectImages = vi.fn(() => ({
+      items: {
+        "image-1": {
+          id: "image-1",
+          width: 320,
+          height: 160,
+        },
+      },
+      tree: [{ id: "image-1" }],
+    }));
+    deps.store.setSelectedItemId = vi.fn();
+    deps.store.setDetailPanelSelectedItemId = vi.fn();
+    deps.refs.fileExplorer = {
+      selectItem: vi.fn(),
+    };
+
+    await handleFileExplorerAction(deps, {
+      _event: {
+        detail: {
+          itemId: "parent-1",
+          item: {
+            value: {
+              action: "new-child-item",
+              type: "sprite",
+            },
+          },
+        },
+      },
+    });
+
+    expect(createLayoutElement).toHaveBeenCalledWith({
+      layoutId: "layout-1",
+      elementId: expect.any(String),
+      data: expect.objectContaining({
+        type: "sprite",
+        name: "Hero Image",
+        imageId: "image-1",
+      }),
+      parentId: "parent-1",
+      position: "first",
     });
   });
 });

--- a/tests/layoutEditor/layoutEditorViewData.test.js
+++ b/tests/layoutEditor/layoutEditorViewData.test.js
@@ -42,7 +42,7 @@ describe("layoutEditorViewData", () => {
   it("builds form submit button create actions as containers with a static form role", () => {
     const [submitItem] = toLayoutEditorContextMenuItems([
       {
-        label: "Submit Button",
+        label: "Input Submit Container",
         type: "item",
         createType: "form-submit-button",
       },
@@ -51,14 +51,14 @@ describe("layoutEditorViewData", () => {
     expect(submitItem.value).toMatchObject({
       action: "new-child-item",
       type: "container",
-      name: "Submit Button",
+      name: "Input Submit Container",
       direction: "absolute",
       gapX: 0,
       gapY: 0,
       formRole: "submit",
-      width: 160,
-      height: 52,
     });
+    expect(submitItem.value).not.toHaveProperty("width");
+    expect(submitItem.value).not.toHaveProperty("height");
   });
 
   it("builds choice single item container create actions", () => {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -2,10 +2,13 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getSelection,
+  $setSelection,
   createEditor,
 } from "lexical";
 import { JSDOM } from "jsdom";
 import { describe, expect, it, vi } from "vitest";
+import { EDITOR_CARET_TEXT } from "../../src/internal/ui/sceneEditorLexical/contentModel.js";
 
 const installDomGlobals = () => {
   const dom = new JSDOM("<!doctype html><html><body></body></html>");
@@ -41,6 +44,26 @@ const installDomGlobals = () => {
     }
 
     dom.window.close();
+  };
+};
+
+const installAnimationFrameQueue = () => {
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const callbacks = [];
+  globalThis.requestAnimationFrame = vi.fn((callback) => {
+    callbacks.push(callback);
+    return callbacks.length;
+  });
+
+  return {
+    callbacks,
+    restore() {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    },
   };
 };
 
@@ -81,6 +104,10 @@ describe("lexical scene document editor line editing", () => {
         configurable: true,
         value: true,
       });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
       editorElement.hideSelectionPopover = vi.fn();
       editorElement.scheduleRender = vi.fn();
       editorElement.dispatchSelectedLineChanged = vi.fn();
@@ -108,7 +135,7 @@ describe("lexical scene document editor line editing", () => {
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(event.stopPropagation).toHaveBeenCalledTimes(1);
       expect(editorElement.state.mode).toBe("text-editor");
-      expect(calls).toEqual(["focus", "restore", "restore"]);
+      expect(calls).toEqual(["focus", "restore", "restore", "restore"]);
       expect(editorElement.restoreLineSelection).toHaveBeenCalledWith({
         lineId: "line-1",
         cursorPosition: -1,
@@ -438,6 +465,11 @@ describe("lexical scene document editor line editing", () => {
 
   it("focuses before restoring selection in focusLine recovery", async () => {
     const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
 
     try {
       const { LexicalSceneDocumentEditorElement } = await import(
@@ -451,6 +483,10 @@ describe("lexical scene document editor line editing", () => {
       Object.defineProperty(editorElement, "dataset", {
         configurable: true,
         value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
       });
       editorElement.state = {
         mode: "block",
@@ -473,13 +509,122 @@ describe("lexical scene document editor line editing", () => {
       });
 
       expect(didFocus).toBe(true);
-      expect(calls).toEqual(["focus", "restore"]);
+      expect(calls).toEqual(["focus", "restore", "focus", "restore"]);
       expect(editorElement.state.mode).toBe("text-editor");
       expect(editorElement.state.selectedLineId).toBe("line-1");
       expect(editorElement.markProgrammaticFocusRestore).toHaveBeenCalledTimes(
-        2,
+        4,
       );
     } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("ignores stale async focus callbacks after a newer caret restore starts", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.focusRestoreSequenceId = 0;
+      editorElement.programmaticFocusRestoreUntil = 0;
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      editorElement.focus = vi.fn();
+      editorElement.restoreLineSelection = vi.fn(() => true);
+
+      editorElement.restoreLineSelectionAfterLexicalFocus({
+        lineId: "line-1",
+        cursorPosition: 99,
+      });
+      editorElement.restoreLineSelectionAfterLexicalFocus({
+        lineId: "line-1",
+        cursorPosition: 12,
+      });
+
+      animationFrameCallbacks[0]();
+      animationFrameCallbacks[1]();
+
+      expect(editorElement.restoreLineSelection).toHaveBeenCalledTimes(1);
+      expect(editorElement.restoreLineSelection).toHaveBeenCalledWith({
+        lineId: "line-1",
+        cursorPosition: 12,
+      });
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not overwrite a native caret that moved before async focus restore", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.focusRestoreSequenceId = 0;
+      editorElement.programmaticFocusRestoreUntil = 0;
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-1",
+        start: 12,
+        end: 12,
+      }));
+      editorElement.focus = vi.fn();
+      editorElement.restoreLineSelection = vi.fn(() => true);
+
+      editorElement.restoreLineSelectionAfterLexicalFocus({
+        lineId: "line-1",
+        cursorPosition: 99,
+      });
+
+      animationFrameCallbacks[0]();
+
+      expect(editorElement.restoreLineSelection).not.toHaveBeenCalled();
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
       restoreDomGlobals();
     }
   });
@@ -915,6 +1060,11 @@ describe("lexical scene document editor line editing", () => {
           end: 0,
         })
         .mockReturnValueOnce({
+          lineId: "line-2",
+          start: 0,
+          end: 0,
+        })
+        .mockReturnValueOnce({
           lineId: "line-1",
           start: 3,
           end: 3,
@@ -947,6 +1097,215 @@ describe("lexical scene document editor line editing", () => {
           mode: "text-editor",
         },
       );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("emits text-mode boundary navigation when ArrowDown cannot move past the last line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-2",
+        start: 6,
+        end: 6,
+      }));
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation({
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+      });
+
+      while (animationFrameCallbacks.length > 0) {
+        const callback = animationFrameCallbacks.shift();
+        callback();
+      }
+
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledOnce();
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-2",
+        {
+          cursorPosition: 6,
+          isCollapsed: true,
+          mode: "text-editor",
+          navigationDirection: "down",
+          isBoundaryNavigation: true,
+        },
+      );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("coalesces held ArrowDown repeats so boundary navigation can finish", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      editorElement.verticalNavigationSelectionSyncId = 0;
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-2",
+        start: 6,
+        end: 6,
+      }));
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      const event = {
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+      };
+
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation(
+        event,
+      );
+
+      for (let index = 0; index < 8; index += 1) {
+        editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation({
+          ...event,
+          repeat: true,
+        });
+        const callback = animationFrameCallbacks.shift();
+        if (callback) {
+          callback();
+        }
+        if (editorElement.dispatchSelectedLineChanged.mock.calls.length > 0) {
+          break;
+        }
+      }
+
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledOnce();
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-2",
+        {
+          cursorPosition: 6,
+          isCollapsed: true,
+          mode: "text-editor",
+          navigationDirection: "down",
+          isBoundaryNavigation: true,
+        },
+      );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not emit text-mode boundary navigation when ArrowDown moves within the last line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrameCallbacks = [];
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      editorElement.getNativeLineSelectionContext = vi
+        .fn()
+        .mockReturnValueOnce({
+          lineId: "line-2",
+          start: 6,
+          end: 6,
+        })
+        .mockReturnValueOnce({
+          lineId: "line-2",
+          start: 12,
+          end: 12,
+        });
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation({
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+      });
+
+      animationFrameCallbacks[0]();
+
+      expect(editorElement.dispatchSelectedLineChanged).not.toHaveBeenCalled();
     } finally {
       if (previousRequestAnimationFrame === undefined) {
         delete globalThis.requestAnimationFrame;
@@ -1855,6 +2214,1229 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("keeps slash mention popover modal before opening", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const menu = document.createElement("div");
+      const menuShadow = menu.attachShadow({ mode: "open" });
+      const popover = document.createElement("rtgl-popover");
+      const popoverShadow = popover.attachShadow({ mode: "open" });
+      const dialog = document.createElement("dialog");
+      const renderCalls = [];
+
+      popoverShadow.append(dialog);
+      menu.items = [];
+      menu.open = false;
+      menu.render = vi.fn(() => {
+        renderCalls.push({
+          open: menu.open,
+          noOverlay: popover.hasAttribute("no-overlay"),
+        });
+        if (!menuShadow.querySelector("rtgl-popover")) {
+          menuShadow.append(popover);
+        }
+      });
+
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.mentionMenuFocusRestoreTimerId = undefined;
+      editorElement.refs = { mentionMenu: menu };
+      editorElement.state = {
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [{ id: "character-1", label: "Alex" }],
+          left: 24,
+          top: 48,
+        },
+      };
+
+      editorElement.renderMentionMenu();
+
+      expect(renderCalls).toEqual([
+        { open: false, noOverlay: false },
+        { open: true, noOverlay: false },
+      ]);
+      expect(popover.hasAttribute("no-overlay")).toBe(false);
+      expect(dialog.getAttribute("tabindex")).toBe("-1");
+
+      editorElement.clearMentionMenuFocusRestore();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("removes stale no-overlay from the slash mention popover", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const popover = document.createElement("rtgl-popover");
+      const popoverShadow = popover.attachShadow({ mode: "open" });
+      const dialog = document.createElement("dialog");
+
+      popover.setAttribute("no-overlay", "");
+      popoverShadow.append(dialog);
+      editorElement.getMentionMenuPopover = vi.fn(() => popover);
+
+      editorElement.syncMentionMenuPopover();
+
+      expect(popover.hasAttribute("no-overlay")).toBe(false);
+      expect(dialog.getAttribute("tabindex")).toBe("-1");
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not re-render an already matching slash mention menu", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const popover = document.createElement("rtgl-popover");
+
+      editorElement.state = {
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [
+            {
+              id: "character-1",
+              label: "Alex",
+              variableType: "character",
+            },
+          ],
+          left: 193,
+          top: 193,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          open: true,
+          items: [
+            {
+              id: "mention:character-1",
+              type: "item",
+              label: "Alex",
+              suffixText: "character",
+            },
+          ],
+          x: "193",
+          y: "193",
+          place: "bs",
+          w: "260",
+          h: "240",
+          render: vi.fn(),
+        },
+      };
+      editorElement.getMentionMenuPopover = vi.fn(() => popover);
+      editorElement.syncMentionMenuPopover = vi.fn();
+
+      editorElement.renderMentionMenu();
+
+      expect(editorElement.refs.mentionMenu.render).not.toHaveBeenCalled();
+      expect(editorElement.syncMentionMenuPopover).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("closes and dismisses the current slash mention trigger from the close event", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          nodeKey: "node-1",
+          startOffset: 1,
+          endOffset: 2,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [{ id: "character-1", label: "Alex" }],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.mentionMenuFocusRestoreTimerId = undefined;
+      editorElement.hasActiveMentionTrigger = vi.fn(() => true);
+      editorElement.syncMentionMenuPopover = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.handleMentionMenuClose();
+
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: "node-1",
+        startOffset: 1,
+        endOffset: 2,
+        query: "",
+      });
+      expect(editorElement.scheduleRender).not.toHaveBeenCalled();
+      expect(editorElement.syncMentionMenuPopover).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("restores the slash mention trigger caret when the overlay closes the menu", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-slash-mention-overlay-close-selection-test",
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let firstLineKey;
+      let secondLineKey;
+      let triggerTextKey;
+
+      rootElement.tabIndex = 0;
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.refs = {
+        editor: rootElement,
+        surface: {
+          dataset: {},
+        },
+        mentionMenu: {
+          items: [{ id: "character-1", label: "Alex" }],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const firstLine = $createParagraphNode();
+          const secondLine = $createParagraphNode();
+          const firstText = $createTextNode("first");
+          const prefixText = $createTextNode("say ");
+          const triggerText = $createTextNode("/a");
+          const suffixText = $createTextNode(" later");
+
+          triggerText.setStyle("--rvn-test-trigger: 1;");
+          root.clear();
+          firstLine.append(firstText);
+          secondLine.append(prefixText, triggerText, suffixText);
+          root.append(firstLine, secondLine);
+          firstLineKey = firstLine.getKey();
+          secondLineKey = secondLine.getKey();
+          triggerTextKey = triggerText.getKey();
+          editorElement.lineMetaByKey.set(firstLineKey, {
+            id: "line-1",
+          });
+          editorElement.lineMetaByKey.set(secondLineKey, {
+            id: "line-2",
+          });
+          editorElement.lineKeyById.set("line-1", firstLineKey);
+          editorElement.lineKeyById.set("line-2", secondLineKey);
+          firstText.select(0, 0);
+        },
+        { discrete: true },
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines: [],
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: true,
+          query: "a",
+          items: [{ id: "character-1", label: "Alex" }],
+          highlightedIndex: 0,
+          nodeKey: triggerTextKey,
+          lineId: "line-2",
+          startOffset: 0,
+          endOffset: 2,
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.mentionMenuFocusRestoreTimerId = undefined;
+      editorElement.hasActiveMentionTrigger = vi.fn(() => false);
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.handleMentionMenuClose();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.state.selectedLineId).toBe("line-2");
+      expect(editorElement.getCurrentSelectionSnapshot()).toEqual({
+        lineId: "line-2",
+        start: 6,
+        end: 6,
+      });
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: triggerTextKey,
+        lineId: "line-2",
+        startOffset: 0,
+        endOffset: 2,
+        query: "a",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("prefers the live slash trigger over stale menu state when closing", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-slash-mention-live-close-selection-test",
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const textValue = "say / first /";
+      let lineKey;
+      let textKey;
+
+      rootElement.tabIndex = 0;
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.refs = {
+        editor: rootElement,
+        surface: {
+          dataset: {},
+        },
+        mentionMenu: {
+          items: [{ id: "character-1", label: "Alex" }],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const text = $createTextNode(textValue);
+
+          text.setStyle("--rvn-test-trigger: 1;");
+          root.clear();
+          line.append(text);
+          root.append(line);
+          lineKey = line.getKey();
+          textKey = text.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+          text.select(textValue.length, textValue.length);
+        },
+        { discrete: true },
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines: [],
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [{ id: "character-1", label: "Alex" }],
+          highlightedIndex: 0,
+          nodeKey: textKey,
+          lineId: "line-1",
+          startOffset: 4,
+          endOffset: 5,
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.mentionMenuFocusRestoreTimerId = undefined;
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.handleMentionMenuClose();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(editorElement.state.selectedLineId).toBe("line-1");
+      expect(editorElement.getCurrentSelectionSnapshot()).toEqual({
+        lineId: "line-1",
+        start: textValue.length,
+        end: textValue.length,
+      });
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: textKey,
+        lineId: "line-1",
+        startOffset: textValue.length - 1,
+        endOffset: textValue.length,
+        query: "",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("dismisses the current slash mention trigger when blur closes the menu", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-1",
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          nodeKey: "node-1",
+          startOffset: 1,
+          endOffset: 2,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [{ id: "character-1", label: "Alex" }],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorActiveElement = vi.fn(() => false);
+      editorElement.isWithinProgrammaticFocusRestoreWindow = vi.fn(() => false);
+      editorElement.shouldRestoreProgrammaticBodyBlur = vi.fn(() => false);
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.enterBlockMode = vi.fn();
+      editorElement.dispatchEvent = vi.fn();
+
+      editorElement.commitNativeBlur();
+
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: "node-1",
+        startOffset: 1,
+        endOffset: 2,
+        query: "",
+      });
+      expect(editorElement.enterBlockMode).toHaveBeenCalledWith({
+        focusSurface: false,
+        emitSelectionChange: false,
+        lineId: "line-1",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("dismisses the slash mention menu on arrow keys without blocking caret movement", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-1",
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          nodeKey: "node-1",
+          startOffset: 1,
+          endOffset: 2,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [{ id: "character-1", label: "Alex" }],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation =
+        vi.fn();
+      editorElement.updatePendingTextInputFallback = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+
+      const event = {
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeKeyDown(event);
+
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: "node-1",
+        startOffset: 1,
+        endOffset: 2,
+        query: "",
+      });
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+      expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+      expect(
+        editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation,
+      ).toHaveBeenCalledWith(event);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not reopen a dismissed slash mention menu for the same trigger", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.dismissedMentionTrigger = {
+        nodeKey: "node-1",
+        startOffset: 0,
+        endOffset: 1,
+        query: "",
+      };
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+        mentionTrigger: {
+          nodeKey: "node-1",
+          startOffset: 0,
+          endOffset: 1,
+          query: "",
+          source: "lexical",
+        },
+      }));
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: "node-1",
+        startOffset: 0,
+        endOffset: 1,
+        query: "",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not open the slash mention menu when the caret moves to an existing slash", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [],
+          open: false,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+        mentionTrigger: {
+          nodeKey: "node-1",
+          lineId: "line-1",
+          startOffset: 0,
+          endOffset: 1,
+          query: "",
+          source: "lexical",
+        },
+      }));
+      editorElement.getMentionMenuPositionForTrigger = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(
+        editorElement.getMentionMenuPositionForTrigger,
+      ).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("opens the slash mention menu when slash was just typed", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [],
+          open: false,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+        mentionTrigger: {
+          nodeKey: "node-1",
+          lineId: "line-1",
+          startOffset: 0,
+          endOffset: 1,
+          query: "",
+          source: "lexical",
+        },
+      }));
+      editorElement.getMentionMenuPositionForTrigger = vi.fn(() => ({
+        left: 24,
+        top: 48,
+      }));
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.armMentionMenuOpenFromTypedSlash({
+        source: "test",
+      });
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.mentionMenu).toMatchObject({
+        isOpen: true,
+        query: "",
+        items: [{ id: "character-1", label: "Alex" }],
+        nodeKey: "node-1",
+        lineId: "line-1",
+        startOffset: 0,
+        endOffset: 1,
+        left: 24,
+        top: 48,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps updating an open slash mention menu while typing the query", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/a" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [
+          { id: "character-1", label: "Alex" },
+          { id: "character-2", label: "Blake" },
+        ],
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [{ id: "character-1", label: "Alex" }],
+          nodeKey: "node-1",
+          lineId: "line-1",
+          startOffset: 0,
+          endOffset: 1,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+        mentionTrigger: {
+          nodeKey: "node-1",
+          lineId: "line-1",
+          startOffset: 0,
+          endOffset: 2,
+          query: "a",
+          source: "lexical",
+        },
+      }));
+      editorElement.getMentionMenuPositionForTrigger = vi.fn(() => ({
+        left: 24,
+        top: 48,
+      }));
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.mentionMenu).toMatchObject({
+        isOpen: true,
+        query: "a",
+        items: [{ id: "character-1", label: "Alex" }],
+        nodeKey: "node-1",
+        lineId: "line-1",
+        startOffset: 0,
+        endOffset: 2,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps a dismissed slash mention trigger through a transient no-trigger sync", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.dismissedMentionTrigger = {
+        nodeKey: "node-1",
+        startOffset: 0,
+        endOffset: 1,
+        query: "",
+      };
+      editorElement.readEditorSnapshot = vi
+        .fn()
+        .mockReturnValueOnce({
+          lines,
+          selectedLineId: "line-1",
+          activeFormats: {},
+          mentionTrigger: undefined,
+        })
+        .mockReturnValueOnce({
+          lines,
+          selectedLineId: "line-1",
+          activeFormats: {},
+          mentionTrigger: {
+            nodeKey: "node-1",
+            startOffset: 0,
+            endOffset: 1,
+            query: "",
+            source: "lexical",
+          },
+        });
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.dismissedMentionTrigger).toEqual({
+        nodeKey: "node-1",
+        startOffset: 0,
+        endOffset: 1,
+        query: "",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not reopen another slash trigger in the same text node during close restore", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "first / second /" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [{ id: "character-1", label: "Alex" }],
+          nodeKey: "node-1",
+          lineId: "line-1",
+          startOffset: 6,
+          endOffset: 7,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          items: [{ id: "character-1", label: "Alex" }],
+          open: true,
+          render: vi.fn(),
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+        mentionTrigger: {
+          nodeKey: "node-1",
+          lineId: "line-1",
+          startOffset: 15,
+          endOffset: 16,
+          query: "",
+          source: "lexical",
+        },
+      }));
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.closeMentionMenu({
+        dismissCurrentTrigger: true,
+      });
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.state.mentionMenu.isOpen).toBe(false);
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+      expect(editorElement.dismissedMentionTriggerScope).toMatchObject({
+        nodeKey: "node-1",
+        query: "",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("closes an open slash mention menu immediately when the trigger disappears", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [],
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [{ id: "character-1", label: "Alex" }],
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          open: false,
+        },
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+      }));
+      editorElement.shouldPreserveMentionMenuAfterSelectionLoss = vi.fn(
+        () => false,
+      );
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      editorElement.syncMentionMenuPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState({});
+
+      expect(editorElement.closeMentionMenu).toHaveBeenCalledTimes(1);
+      expect(editorElement.syncMentionMenuPopover).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps a newly opened slash mention menu through a stale no-trigger sync before render", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-slash-mention-pending-render-test",
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let textNodeKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          const text = $createTextNode("/");
+
+          paragraph.append(text);
+          root.append(paragraph);
+          textNodeKey = text.getKey();
+        },
+        { discrete: true },
+      );
+
+      const lines = [
+        {
+          id: "line-1",
+          actions: {
+            dialogue: {
+              content: [{ text: "/" }],
+            },
+          },
+        },
+      ];
+
+      editorElement.state = {
+        mode: "text-editor",
+        lines,
+        selectedLineId: "line-1",
+        mentionTargets: [{ id: "character-1", label: "Alex" }],
+        mentionMenu: {
+          isOpen: true,
+          query: "",
+          items: [{ id: "character-1", label: "Alex" }],
+          highlightedIndex: 0,
+          nodeKey: textNodeKey,
+          lineId: "line-1",
+          startOffset: 0,
+          endOffset: 1,
+        },
+      };
+      editorElement.refs = {
+        mentionMenu: {
+          open: false,
+          items: [],
+          render: vi.fn(),
+        },
+      };
+      editorElement.editor = editor;
+      editorElement.isEditorFocused = true;
+      editorElement.readEditorSnapshot = vi.fn(() => ({
+        lines,
+        selectedLineId: "line-1",
+        activeFormats: {},
+      }));
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.syncMentionMenuPopover = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      editorElement.syncFromEditorState(editor.getEditorState());
+
+      expect(editorElement.closeMentionMenu).not.toHaveBeenCalled();
+      expect(editorElement.syncMentionMenuPopover).toHaveBeenCalledTimes(1);
+      expect(editorElement.scheduleRender).toHaveBeenCalledTimes(1);
+      expect(editorElement.state.mentionMenu.isOpen).toBe(true);
+      expect(editorElement.refs.mentionMenu.open).toBe(false);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps the slash mention menu open when blur moves focus to the menu", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const menu = document.createElement("div");
+
+      editorElement.state = {
+        mode: "text-editor",
+        mentionMenu: {
+          isOpen: true,
+          items: [{ id: "character-1", label: "Alex" }],
+        },
+      };
+      editorElement.refs = {
+        editor: document.createElement("div"),
+        mentionMenu: menu,
+      };
+      editorElement.refs.mentionMenu.open = false;
+      editorElement.refs.mentionMenu.items = [];
+      editorElement.isEditorFocused = true;
+      editorElement.isEditorActiveElement = vi.fn(() => false);
+      editorElement.isWithinProgrammaticFocusRestoreWindow = vi.fn(() => false);
+      editorElement.shouldRestoreProgrammaticBodyBlur = vi.fn(() => false);
+      editorElement.selectionMenuIsOpen = false;
+      editorElement.furiganaDialogIsPending = false;
+      editorElement.hasActiveMentionTrigger = vi.fn(() => false);
+      editorElement.syncMentionMenuPopover = vi.fn();
+      editorElement.commitNativeBlur = vi.fn();
+
+      editorElement.handleNativeBlur({
+        relatedTarget: menu,
+      });
+
+      expect(editorElement.refs.mentionMenu.open).toBe(true);
+      expect(editorElement.syncMentionMenuPopover).toHaveBeenCalledTimes(1);
+      expect(editorElement.hasActiveMentionTrigger).not.toHaveBeenCalled();
+      expect(editorElement.commitNativeBlur).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("keeps native double-click word selection inside non-final line text", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -2238,6 +3820,191 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("does not run a stale async selection restore after the selected line prop is cleared", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const animationFrame = installAnimationFrameQueue();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const editorNode = document.createElement("div");
+
+      editorElement.refs = {
+        editor: editorNode,
+        surface: document.createElement("div"),
+      };
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-1",
+        lines: [{ id: "line-1" }],
+      };
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.focusRestoreSequenceId = 0;
+      editorElement.isEditorFocused = true;
+      editorElement.lastProgrammaticFocusTarget = {
+        lineId: "line-1",
+        cursorPosition: 2,
+      };
+      editorElement.programmaticFocusRestoreUntil = Number.POSITIVE_INFINITY;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.focus = vi.fn();
+      editorElement.restoreLineSelection = vi.fn(() => true);
+      editorElement.getNativeLineSelectionContext = vi.fn(() => undefined);
+
+      editorElement.restoreLineSelectionAfterLexicalFocus({
+        lineId: "line-1",
+        cursorPosition: 2,
+      });
+      editorElement.selectedLineId = undefined;
+      animationFrame.callbacks.shift()();
+
+      expect(editorElement.focus).not.toHaveBeenCalled();
+      expect(editorElement.restoreLineSelection).not.toHaveBeenCalled();
+      expect(editorElement.isEditorFocused).toBe(false);
+      expect(editorElement.state.mode).toBe("block");
+      expect(editorElement.lastProgrammaticFocusTarget).toBeUndefined();
+      expect(editorElement.programmaticFocusRestoreUntil).toBe(0);
+    } finally {
+      animationFrame.restore();
+      restoreDomGlobals();
+    }
+  });
+
+  it("treats section editor binding fallback strings as no selected line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.refs = {
+        editor: document.createElement("div"),
+        surface: document.createElement("div"),
+      };
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-1",
+        lines: [{ id: "line-1" }],
+      };
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.focusRestoreSequenceId = 0;
+      editorElement.isEditorFocused = true;
+      editorElement.lastProgrammaticFocusTarget = {
+        lineId: "line-1",
+        cursorPosition: 2,
+      };
+      editorElement.programmaticFocusRestoreUntil = Number.POSITIVE_INFINITY;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.selectedLineId = "sectionEditorItems[0].selectedLineId";
+
+      expect(editorElement.state.selectedLineId).toBeUndefined();
+      expect(editorElement.isEditorFocused).toBe(false);
+      expect(editorElement.state.mode).toBe("block");
+      expect(editorElement.lastProgrammaticFocusTarget).toBeUndefined();
+      expect(editorElement.programmaticFocusRestoreUntil).toBe(0);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("clears rendered selected styling when section selection becomes inactive", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const editorNode = document.createElement("div");
+      const selectedLine = document.createElement("p");
+      const leftGutter = document.createElement("div");
+      const rightGutter = document.createElement("div");
+      const leftRow = document.createElement("div");
+      const rightRow = document.createElement("div");
+
+      selectedLine.className = "editor-paragraph";
+      selectedLine.dataset.selected = "true";
+      leftRow.className = "gutter-row";
+      leftRow.dataset.selected = "true";
+      rightRow.className = "gutter-row";
+      rightRow.dataset.selected = "true";
+      editorNode.append(selectedLine);
+      leftGutter.append(leftRow);
+      rightGutter.append(rightRow);
+
+      editorElement.refs = {
+        editor: editorNode,
+        surface: document.createElement("div"),
+        leftGutter,
+        rightGutter,
+      };
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        selectionActive: true,
+        lines: [{ id: "line-1" }],
+      };
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.focusRestoreSequenceId = 0;
+      editorElement.isEditorFocused = true;
+      editorElement.lastProgrammaticFocusTarget = {
+        lineId: "line-1",
+        cursorPosition: 2,
+      };
+      editorElement.programmaticFocusRestoreUntil = Number.POSITIVE_INFINITY;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+
+      editorElement.selectionActive = false;
+
+      expect(editorElement.state.selectionActive).toBe(false);
+      expect(editorElement.isEditorFocused).toBe(false);
+      expect(selectedLine.dataset.selected).toBe("false");
+      expect(leftRow.dataset.selected).toBe("false");
+      expect(rightRow.dataset.selected).toBe("false");
+      expect(editorElement.scheduleRender).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("restores focus when programmatic text entry drops focus to body", async () => {
     const restoreDomGlobals = installDomGlobals();
     const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
@@ -2344,7 +4111,7 @@ describe("lexical scene document editor line editing", () => {
       expect(stopImmediatePropagation).toHaveBeenCalledTimes(1);
       expect(handleBackspaceDelete).toHaveBeenCalledWith({
         nativeSelection,
-        source: "keydown",
+        nativeLineRangeSelection: undefined,
       });
     } finally {
       restoreDomGlobals();
@@ -2487,6 +4254,115 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("suppresses delayed insertText beforeinput after printable fallback insertion", async () => {
+    vi.useFakeTimers();
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const preventDefault = vi.fn();
+      const stopPropagation = vi.fn();
+      const stopImmediatePropagation = vi.fn();
+
+      editorElement.state = {
+        mode: "text-editor",
+      };
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.insertPlainText = vi.fn();
+
+      editorElement.updatePendingTextInputFallback({
+        key: "/",
+        defaultPrevented: false,
+        isComposing: false,
+        ctrlKey: false,
+        metaKey: false,
+        timeStamp: 10,
+      });
+
+      vi.runOnlyPendingTimers();
+
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertText",
+        data: "/",
+        isComposing: false,
+        defaultPrevented: false,
+        timeStamp: 12,
+        preventDefault,
+        stopPropagation,
+        stopImmediatePropagation,
+      });
+
+      expect(editorElement.insertPlainText).toHaveBeenCalledTimes(1);
+      expect(editorElement.insertPlainText).toHaveBeenCalledWith("/");
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(stopPropagation).toHaveBeenCalledTimes(1);
+      expect(stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.lastCommittedTextInputFallback).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps different delayed insertText beforeinput after printable fallback insertion", async () => {
+    vi.useFakeTimers();
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const preventDefault = vi.fn();
+
+      editorElement.state = {
+        mode: "text-editor",
+      };
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.insertPlainText = vi.fn();
+
+      editorElement.updatePendingTextInputFallback({
+        key: "a",
+        defaultPrevented: false,
+        isComposing: false,
+        ctrlKey: false,
+        metaKey: false,
+        timeStamp: 10,
+      });
+
+      vi.runOnlyPendingTimers();
+
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertText",
+        data: "b",
+        isComposing: false,
+        defaultPrevented: false,
+        timeStamp: 12,
+        preventDefault,
+      });
+
+      expect(editorElement.insertPlainText).toHaveBeenNthCalledWith(1, "a");
+      expect(editorElement.insertPlainText).toHaveBeenNthCalledWith(2, "b");
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("leaves insertText beforeinput to native handling when no text data is available", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -2588,6 +4464,237 @@ describe("lexical scene document editor line editing", () => {
 
       expect(result).toBe("axb");
     } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("inserts slash from the beforeinput target range instead of a stale Lexical selection", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-native-selection-mention-trigger-test",
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let firstLineKey;
+      let secondLineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: {
+          isOpen: false,
+        },
+        mode: "text-editor",
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.pendingTextInputFallback = undefined;
+      editorElement.lastCommittedTextInputFallback = undefined;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const firstLine = $createParagraphNode();
+          const secondLine = $createParagraphNode();
+          const firstText = $createTextNode("first");
+          const secondText = $createTextNode("second");
+
+          firstLine.append(firstText);
+          secondLine.append(secondText);
+          root.append(firstLine, secondLine);
+          firstLineKey = firstLine.getKey();
+          secondLineKey = secondLine.getKey();
+          editorElement.lineMetaByKey.set(firstLineKey, {
+            id: "line-1",
+          });
+          editorElement.lineMetaByKey.set(secondLineKey, {
+            id: "line-2",
+          });
+          editorElement.lineKeyById.set("line-1", firstLineKey);
+          editorElement.lineKeyById.set("line-2", secondLineKey);
+          firstText.select(1, 1);
+        },
+        { discrete: true },
+      );
+
+      const secondLineElement = editor.getElementByKey(secondLineKey);
+      const secondTextNode = secondLineElement.firstChild.firstChild;
+      const range = document.createRange();
+      range.setStart(secondTextNode, 0);
+      range.collapse(true);
+
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertText",
+        data: "/",
+        isComposing: false,
+        defaultPrevented: false,
+        getTargetRanges: () => [range],
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      });
+
+      const snapshot = editorElement.readEditorSnapshot();
+      expect(snapshot.selectedLineId).toBe("line-2");
+      expect(snapshot.mentionTrigger).toMatchObject({
+        query: "",
+        startOffset: 0,
+        endOffset: 1,
+        source: "lexical",
+        lineId: "line-2",
+      });
+      expect(snapshot.lines[1].actions.dialogue.content[0].text).toBe(
+        "/second",
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("uses the keydown fallback selection when slash beforeinput has no target range", async () => {
+    vi.useFakeTimers();
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-keydown-selection-slash-trigger-test",
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let firstLineKey;
+      let secondLineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: {
+          isOpen: false,
+        },
+        mode: "text-editor",
+      };
+      editorElement.isEditorFocused = true;
+      editorElement.pendingTextInputFallback = undefined;
+      editorElement.lastCommittedTextInputFallback = undefined;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation =
+        vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const firstLine = $createParagraphNode();
+          const secondLine = $createParagraphNode();
+          const firstText = $createTextNode("first");
+          const secondText = $createTextNode("second");
+
+          firstLine.append(firstText);
+          secondLine.append(secondText);
+          root.append(firstLine, secondLine);
+          firstLineKey = firstLine.getKey();
+          secondLineKey = secondLine.getKey();
+          editorElement.lineMetaByKey.set(firstLineKey, {
+            id: "line-1",
+          });
+          editorElement.lineMetaByKey.set(secondLineKey, {
+            id: "line-2",
+          });
+          editorElement.lineKeyById.set("line-1", firstLineKey);
+          editorElement.lineKeyById.set("line-2", secondLineKey);
+          firstText.select(1, 1);
+        },
+        { discrete: true },
+      );
+
+      const secondLineElement = editor.getElementByKey(secondLineKey);
+      const secondTextNode = secondLineElement.firstChild.firstChild;
+      const range = document.createRange();
+      range.setStart(secondTextNode, 0);
+      range.collapse(true);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+
+      editorElement.handleNativeKeyDown({
+        key: "/",
+        code: "Slash",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        defaultPrevented: false,
+        timeStamp: 10,
+      });
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertText",
+        data: "/",
+        isComposing: false,
+        defaultPrevented: false,
+        timeStamp: 12,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      });
+
+      const snapshot = editorElement.readEditorSnapshot();
+      expect(snapshot.selectedLineId).toBe("line-2");
+      expect(snapshot.mentionTrigger).toMatchObject({
+        query: "",
+        startOffset: 0,
+        endOffset: 1,
+        source: "lexical",
+        lineId: "line-2",
+      });
+      expect(snapshot.lines[1].actions.dialogue.content[0].text).toBe(
+        "/second",
+      );
+    } finally {
+      vi.useRealTimers();
       restoreDomGlobals();
     }
   });
@@ -2779,7 +4886,10 @@ describe("lexical scene document editor line editing", () => {
         cursorPosition: 1,
       });
       expect(editorElement.focusLine).not.toHaveBeenCalled();
-      expect(editorElement.restoreLineSelection).not.toHaveBeenCalled();
+      expect(editorElement.restoreLineSelection).toHaveBeenCalledWith({
+        lineId: "line-1",
+        cursorPosition: 1,
+      });
     } finally {
       if (previousRequestAnimationFrame === undefined) {
         delete globalThis.requestAnimationFrame;
@@ -2790,6 +4900,1242 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("selects a reference chip on Backspace before removing it", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const { getReferenceSelectionInfo } = await import(
+        "../../src/primitives/lexicalSceneDocumentReferences.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-backspace-delete-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+      let mentionKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.pendingHandledBackspaceKeyDown = undefined;
+      editorElement.pendingTextInputFallback = undefined;
+      editorElement.pendingTextInputFallbackTimerId = undefined;
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.renderFrame = 0;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.scheduleRender = vi.fn();
+      editorElement.focusLine = vi.fn();
+      editorElement.restoreLineSelection = vi.fn();
+      editorElement.isEditorActiveElement = vi.fn(() => true);
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "playerName",
+            label: "Player",
+          });
+
+          line.append(
+            $createTextNode("Hi "),
+            mentionNode,
+            $createTextNode("!"),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          mentionKey = mentionNode.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "Hi " },
+                  { reference: { resourceId: "playerName" } },
+                  { text: "!" },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+        },
+        { discrete: true },
+      );
+
+      const lineElement = editor.getElementByKey(lineKey);
+      const afterReferenceTextNode = lineElement.childNodes[2];
+      const range = document.createRange();
+      range.setStart(afterReferenceTextNode, 0);
+      range.collapse(true);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+
+      editorElement.handleNativeKeyDown({
+        key: "Backspace",
+        code: "Backspace",
+        isComposing: false,
+        timeStamp: 10,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      });
+
+      const selectedResult = editor.getEditorState().read(() => {
+        const referenceSelection = getReferenceSelectionInfo($getSelection());
+        return {
+          text: $getRoot().getFirstChild().getTextContent(),
+          selectedReferenceKey: referenceSelection?.node.getKey(),
+          isWhole: referenceSelection?.isWhole,
+          isCollapsed: referenceSelection?.isCollapsed,
+        };
+      });
+
+      expect(selectedResult).toEqual({
+        text: "Hi Player!",
+        selectedReferenceKey: mentionKey,
+        isWhole: true,
+        isCollapsed: false,
+      });
+      expect(editorElement.selectedReferenceNodeKey).toBe(mentionKey);
+
+      editorElement.handleNativeKeyDown({
+        key: "Backspace",
+        code: "Backspace",
+        isComposing: false,
+        timeStamp: 20,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      });
+
+      const deletedResult = editor.getEditorState().read(() => {
+        return $getRoot().getFirstChild().getTextContent();
+      });
+
+      expect(deletedResult).toBe("Hi !");
+      expect(
+        editorElement.getLinesSnapshot()[0].actions.dialogue.content,
+      ).toEqual([{ text: "Hi !" }]);
+      expect(editorElement.selectedReferenceNodeKey).toBeUndefined();
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not leave native text selected when selecting a reference chip", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-native-selection-collapse-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let mentionKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "playerName",
+            label: "Player",
+          });
+
+          line.append(
+            $createTextNode("Hi "),
+            mentionNode,
+            $createTextNode("!"),
+          );
+          root.append(line);
+          mentionKey = mentionNode.getKey();
+        },
+        { discrete: true },
+      );
+
+      const mentionElement = rootElement.querySelector(".mention-chip");
+      const parentNode = mentionElement.parentNode;
+      const selection = window.getSelection();
+      const staleRange = document.createRange();
+      staleRange.selectNodeContents(parentNode);
+      selection.removeAllRanges();
+      selection.addRange(staleRange);
+
+      editorElement.selectReferenceByNodeKey(mentionKey);
+
+      const mentionOffset = Array.from(parentNode.childNodes).indexOf(
+        mentionElement,
+      );
+      expect(rootElement.dataset.rvnReferenceSelectionActive).toBe("true");
+      expect(mentionElement.dataset.rvnReferenceSelected).toBe("true");
+      expect(selection.isCollapsed).toBe(true);
+      expect(selection.anchorNode).toBe(parentNode);
+      expect(selection.anchorOffset).toBe(mentionOffset + 1);
+      expect(selection.toString()).toBe("");
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("normalizes a collapsed reference-chip selection before Backspace deletes", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const { EDITOR_CARET_TEXT } = await import(
+        "../../src/internal/ui/sceneEditorLexical/contentModel.js"
+      );
+      const { getReferenceSelectionInfo } = await import(
+        "../../src/primitives/lexicalSceneDocumentReferences.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-backspace-collapsed-selection-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+      let mentionKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.renderFrame = 0;
+      editorElement.scheduleRender = vi.fn();
+      editorElement.focusLine = vi.fn();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "playerName",
+            label: "Player",
+          });
+
+          line.append(
+            $createTextNode("Hi "),
+            mentionNode,
+            $createTextNode("!"),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          mentionKey = mentionNode.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "Hi " },
+                  { reference: { resourceId: "playerName" } },
+                  { text: "!" },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+          mentionNode.select(2, 2);
+        },
+        { discrete: true },
+      );
+
+      const didSelect = editorElement.handleBackspaceDelete({
+        nativeSelection: {
+          lineId: "line-1",
+          start: 5,
+          end: 5,
+        },
+        source: "keydown",
+      });
+
+      const selectedResult = editor.getEditorState().read(() => {
+        const referenceSelection = getReferenceSelectionInfo($getSelection());
+        return {
+          text: $getRoot()
+            .getFirstChild()
+            .getTextContent()
+            .replaceAll(EDITOR_CARET_TEXT, ""),
+          selectedReferenceKey: referenceSelection?.node.getKey(),
+          isWhole: referenceSelection?.isWhole,
+          isCollapsed: referenceSelection?.isCollapsed,
+        };
+      });
+
+      expect(didSelect).toBe(true);
+      expect(selectedResult).toEqual({
+        text: "Hi Player!",
+        selectedReferenceKey: mentionKey,
+        isWhole: true,
+        isCollapsed: false,
+      });
+      expect(editorElement.selectedReferenceNodeKey).toBe(mentionKey);
+
+      const didDelete = editorElement.handleBackspaceDelete({
+        nativeSelection: {
+          lineId: "line-1",
+          start: 5,
+          end: 5,
+        },
+        source: "keydown",
+      });
+
+      expect(didDelete).toBe(true);
+      expect(
+        editorElement.getLinesSnapshot()[0].actions.dialogue.content,
+      ).toEqual([{ text: "Hi !" }]);
+      expect(editorElement.selectedReferenceNodeKey).toBeUndefined();
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("selects a reference chip when a native Backspace range intersects it", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const { getReferenceSelectionInfo } = await import(
+        "../../src/primitives/lexicalSceneDocumentReferences.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-backspace-native-range-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+      let mentionKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.renderFrame = 0;
+      editorElement.scheduleRender = vi.fn();
+      editorElement.focusLine = vi.fn();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "playerName",
+            label: "Player",
+          });
+
+          line.append(
+            $createTextNode("Hi "),
+            mentionNode,
+            $createTextNode("!"),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          mentionKey = mentionNode.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "Hi " },
+                  { reference: { resourceId: "playerName" } },
+                  { text: "!" },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+        },
+        { discrete: true },
+      );
+
+      const didHandle = editorElement.handleBackspaceDelete({
+        nativeSelection: {
+          lineId: "line-1",
+          start: 3,
+          end: 4,
+        },
+        source: "keydown",
+      });
+
+      const selectedResult = editor.getEditorState().read(() => {
+        const referenceSelection = getReferenceSelectionInfo($getSelection());
+        return {
+          text: $getRoot().getFirstChild().getTextContent(),
+          selectedReferenceKey: referenceSelection?.node.getKey(),
+          isWhole: referenceSelection?.isWhole,
+          isCollapsed: referenceSelection?.isCollapsed,
+        };
+      });
+
+      expect(didHandle).toBe(true);
+      expect(selectedResult).toEqual({
+        text: "Hi Player!",
+        selectedReferenceKey: mentionKey,
+        isWhole: true,
+        isCollapsed: false,
+      });
+      expect(
+        editorElement.getLinesSnapshot()[0].actions.dialogue.content,
+      ).toEqual([
+        { text: "Hi " },
+        { reference: { resourceId: "playerName" } },
+        { text: "!" },
+      ]);
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("selects a final reference chip when native Backspace offset includes the hidden boundary", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const { EDITOR_CARET_TEXT } = await import(
+        "../../src/internal/ui/sceneEditorLexical/contentModel.js"
+      );
+      const { getReferenceSelectionInfo } = await import(
+        "../../src/primitives/lexicalSceneDocumentReferences.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-backspace-hidden-boundary-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+      let mentionKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.renderFrame = 0;
+      editorElement.scheduleRender = vi.fn();
+      editorElement.focusLine = vi.fn();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "ageVariable",
+            label: "age2",
+          });
+
+          line.append(
+            $createTextNode("2  "),
+            mentionNode,
+            $createTextNode(EDITOR_CARET_TEXT),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          mentionKey = mentionNode.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "2  " },
+                  { reference: { resourceId: "ageVariable" } },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+          line.selectStart();
+        },
+        { discrete: true },
+      );
+
+      const didHandle = editorElement.handleBackspaceDelete({
+        nativeSelection: {
+          lineId: "line-1",
+          start: 8,
+          end: 8,
+        },
+        source: "keydown",
+      });
+
+      const selectedResult = editor.getEditorState().read(() => {
+        const referenceSelection = getReferenceSelectionInfo($getSelection());
+        return {
+          text: $getRoot()
+            .getFirstChild()
+            .getTextContent()
+            .replaceAll(EDITOR_CARET_TEXT, ""),
+          selectedReferenceKey: referenceSelection?.node.getKey(),
+          isWhole: referenceSelection?.isWhole,
+          isCollapsed: referenceSelection?.isCollapsed,
+        };
+      });
+
+      expect(didHandle).toBe(true);
+      expect(selectedResult).toEqual({
+        text: "2  age2",
+        selectedReferenceKey: mentionKey,
+        isWhole: true,
+        isCollapsed: false,
+      });
+      expect(
+        editorElement.getLinesSnapshot()[0].actions.dialogue.content,
+      ).toEqual([
+        { text: "2  " },
+        { reference: { resourceId: "ageVariable" } },
+      ]);
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
+  it("finds a final reference chip from native arrow selection offsets", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-native-arrow-fallback-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+      let mentionKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "ageVariable",
+            label: "age2",
+          });
+
+          line.append(
+            $createTextNode("2  "),
+            mentionNode,
+            $createTextNode(EDITOR_CARET_TEXT),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          mentionKey = mentionNode.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "2  " },
+                  { reference: { resourceId: "ageVariable" } },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+        },
+        { discrete: true },
+      );
+
+      const result = editor.getEditorState().read(() => {
+        const backwardFallbackInfo =
+          editorElement.getNativeReferenceArrowFallbackInfo(
+            {
+              lineId: "line-1",
+              start: 7,
+              end: 7,
+            },
+            -1,
+          );
+        const forwardFallbackInfo =
+          editorElement.getNativeReferenceArrowFallbackInfo(
+            {
+              lineId: "line-1",
+              start: 7,
+              end: 7,
+            },
+            1,
+          );
+        return {
+          backward: {
+            nodeKey: backwardFallbackInfo?.node.getKey(),
+            offset: backwardFallbackInfo?.offset,
+            itemStart: backwardFallbackInfo?.itemStart,
+            itemEnd: backwardFallbackInfo?.itemEnd,
+            lineLength: backwardFallbackInfo?.lineLength,
+            shouldMoveAcross: backwardFallbackInfo?.shouldMoveAcross,
+          },
+          forward: {
+            nodeKey: forwardFallbackInfo?.node.getKey(),
+            offset: forwardFallbackInfo?.offset,
+            itemStart: forwardFallbackInfo?.itemStart,
+            itemEnd: forwardFallbackInfo?.itemEnd,
+            lineLength: forwardFallbackInfo?.lineLength,
+            shouldMoveAcross: forwardFallbackInfo?.shouldMoveAcross,
+          },
+        };
+      });
+
+      expect(result.backward).toEqual({
+        nodeKey: mentionKey,
+        offset: 7,
+        itemStart: 3,
+        itemEnd: 7,
+        lineLength: 7,
+        shouldMoveAcross: true,
+      });
+      expect(result.forward).toEqual({
+        nodeKey: undefined,
+        offset: undefined,
+        itemStart: undefined,
+        itemEnd: undefined,
+        lineLength: undefined,
+        shouldMoveAcross: undefined,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("does not recatch ArrowRight after a final reference chip has already been crossed", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-final-arrow-right-end-fallback-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.updateReferenceSelectionMarkers = vi.fn();
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-1",
+        start: 7,
+        end: 7,
+      }));
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "ageVariable",
+            label: "age2",
+          });
+
+          line.append(
+            $createTextNode("2  "),
+            mentionNode,
+            $createTextNode(EDITOR_CARET_TEXT),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "2  " },
+                  { reference: { resourceId: "ageVariable" } },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+          $setSelection(null);
+        },
+        { discrete: true },
+      );
+
+      const event = {
+        key: "ArrowRight",
+        code: "ArrowRight",
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+      const didHandle = editorElement.handleReferenceArrowNavigation(event);
+      const selection = editor.getEditorState().read(() => {
+        const currentSelection = $getSelection();
+        return {
+          type: currentSelection?.getType?.(),
+        };
+      });
+
+      expect(didHandle).toBe(false);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+      expect(editorElement.selectedReferenceNodeKey).toBeUndefined();
+      expect(selection).toEqual({
+        type: undefined,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("moves right across a final reference chip in one keypress", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-final-arrow-right-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.updateReferenceSelectionMarkers = vi.fn();
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-1",
+        start: 3,
+        end: 3,
+      }));
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "ageVariable",
+            label: "age2",
+          });
+
+          line.append(
+            $createTextNode("2  "),
+            mentionNode,
+            $createTextNode(EDITOR_CARET_TEXT),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "2  " },
+                  { reference: { resourceId: "ageVariable" } },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+          line.select(1, 1);
+        },
+        { discrete: true },
+      );
+
+      const event = {
+        key: "ArrowRight",
+        code: "ArrowRight",
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+      const didHandle = editorElement.handleReferenceArrowNavigation(event);
+      const selection = editor.getEditorState().read(() => {
+        const currentSelection = $getSelection();
+        return {
+          anchorKey: currentSelection?.anchor?.key,
+          anchorOffset: currentSelection?.anchor?.offset,
+          anchorType: currentSelection?.anchor?.type,
+        };
+      });
+
+      expect(didHandle).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.selectedReferenceNodeKey).toBeUndefined();
+      expect(selection).toEqual({
+        anchorKey: lineKey,
+        anchorOffset: 3,
+        anchorType: "element",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("moves right out of a final reference when native selection is inside the chip", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-final-arrow-right-dom-fallback-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.updateReferenceSelectionMarkers = vi.fn();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "ageVariable",
+            label: "age2",
+          });
+
+          line.append(
+            $createTextNode("2  "),
+            mentionNode,
+            $createTextNode(EDITOR_CARET_TEXT),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "2  " },
+                  { reference: { resourceId: "ageVariable" } },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+          $setSelection(null);
+        },
+        { discrete: true },
+      );
+
+      const mentionElement = rootElement.querySelector(".mention-chip");
+      const range = document.createRange();
+      range.setStart(
+        mentionElement.firstChild,
+        mentionElement.firstChild.textContent.length,
+      );
+      range.collapse(true);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+
+      const event = {
+        key: "ArrowRight",
+        code: "ArrowRight",
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+      const didHandle = editorElement.handleReferenceArrowNavigation(event);
+      const selection = editor.getEditorState().read(() => {
+        const currentSelection = $getSelection();
+        return {
+          anchorKey: currentSelection?.anchor?.key,
+          anchorOffset: currentSelection?.anchor?.offset,
+          anchorType: currentSelection?.anchor?.type,
+        };
+      });
+
+      expect(didHandle).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.selectedReferenceNodeKey).toBeUndefined();
+      expect(selection).toEqual({
+        anchorKey: lineKey,
+        anchorOffset: 3,
+        anchorType: "element",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("uses native arrow fallback when Lexical selection is missing", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const { $createMentionNode, MentionNode } = await import(
+        "../../src/primitives/lexicalRichTextShared.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-reference-native-arrow-no-selection-test",
+        nodes: [MentionNode],
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: { isOpen: false },
+        mode: "text-editor",
+      };
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+      editorElement.selectedReferenceNodeKey = undefined;
+      editorElement.updateReferenceSelectionMarkers = vi.fn();
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-1",
+        start: 7,
+        end: 7,
+      }));
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+          const mentionNode = $createMentionNode({
+            resourceId: "ageVariable",
+            label: "age2",
+          });
+
+          line.append(
+            $createTextNode("2  "),
+            mentionNode,
+            $createTextNode(EDITOR_CARET_TEXT),
+          );
+          root.append(line);
+          lineKey = line.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+            actions: {
+              dialogue: {
+                content: [
+                  { text: "2  " },
+                  { reference: { resourceId: "ageVariable" } },
+                ],
+              },
+            },
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+        },
+        { discrete: true },
+      );
+
+      const event = {
+        key: "ArrowLeft",
+        code: "ArrowLeft",
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      };
+      const didHandle = editorElement.handleReferenceArrowNavigation(event);
+      const selection = editor.getEditorState().read(() => {
+        const currentSelection = $getSelection();
+        return {
+          anchorKey: currentSelection?.anchor?.key,
+          anchorOffset: currentSelection?.anchor?.offset,
+          anchorType: currentSelection?.anchor?.type,
+        };
+      });
+
+      expect(didHandle).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(selection).toEqual({
+        anchorKey: lineKey,
+        anchorOffset: 1,
+        anchorType: "element",
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
   it("deletes selected text from the native DOM range when Lexical selection is missing", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -2982,7 +6328,10 @@ describe("lexical scene document editor line editing", () => {
         skipPageRestore: true,
       });
       expect(editorElement.focusLine).not.toHaveBeenCalled();
-      expect(editorElement.restoreLineSelection).not.toHaveBeenCalled();
+      expect(editorElement.restoreLineSelection).toHaveBeenCalledWith({
+        lineId: "line-1",
+        cursorPosition: 2,
+      });
     } finally {
       if (previousRequestAnimationFrame === undefined) {
         delete globalThis.requestAnimationFrame;
@@ -3568,7 +6917,10 @@ describe("lexical scene document editor line editing", () => {
         text: ["previouscurrent"],
       });
       expect(editorElement.focusLine).not.toHaveBeenCalled();
-      expect(editorElement.restoreLineSelection).not.toHaveBeenCalled();
+      expect(editorElement.restoreLineSelection).toHaveBeenCalledWith({
+        lineId: "line-1",
+        cursorPosition: 8,
+      });
     } finally {
       if (previousRequestAnimationFrame === undefined) {
         delete globalThis.requestAnimationFrame;
@@ -3866,7 +7218,8 @@ describe("lexical scene document editor line editing", () => {
 
       const textBeforeTargets = editor
         .getEditorState()
-        .read(() => $getRoot().getTextContent());
+        .read(() => $getRoot().getTextContent())
+        .replaceAll(EDITOR_CARET_TEXT, "");
 
       editorElement.mentionTargets = [
         { id: "playerName", label: "Player Name", variableType: "string" },
@@ -3874,7 +7227,8 @@ describe("lexical scene document editor line editing", () => {
 
       const textAfterTargets = editor
         .getEditorState()
-        .read(() => $getRoot().getTextContent());
+        .read(() => $getRoot().getTextContent())
+        .replaceAll(EDITOR_CARET_TEXT, "");
 
       expect(textBeforeTargets).toBe("playerName");
       expect(textAfterTargets).toBe("Player Name");

--- a/tests/sceneEditor/lexicalSceneDocumentReferences.test.js
+++ b/tests/sceneEditor/lexicalSceneDocumentReferences.test.js
@@ -13,7 +13,9 @@ import {
   applyFuriganaToNode,
   applyTextStyleIdToNode,
 } from "../../src/primitives/lexicalRichTextShared.js";
+import { EDITOR_CARET_TEXT } from "../../src/internal/ui/sceneEditorLexical/contentModel.js";
 import {
+  getAdjacentReferenceNodeInfoForCollapsedSelection,
   getAdjacentReferenceNodeForCollapsedSelection,
   getReferenceRichTextStateFromNode,
   getReferenceSelectionInfo,
@@ -21,6 +23,7 @@ import {
   placeCaretAroundReferenceNode,
   selectReferenceNodeAsElement,
 } from "../../src/primitives/lexicalSceneDocumentReferences.js";
+import { applySelectionToLineNode } from "../../src/primitives/lexicalSceneDocumentSelection.js";
 
 const createReferenceEditor = () => {
   return createEditor({
@@ -125,6 +128,218 @@ describe("lexical scene document reference helpers", () => {
     });
   });
 
+  it("moves the caret after the hidden anchor for a final atomic reference", () => {
+    const editor = createReferenceEditor();
+    let result;
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const mentionNode = $createMentionNode({
+          resourceId: "age",
+          label: "Age",
+        });
+        const trailingAnchorNode = $createTextNode(EDITOR_CARET_TEXT);
+        paragraph.append(
+          $createTextNode("prefix "),
+          mentionNode,
+          trailingAnchorNode,
+        );
+        $getRoot().append(paragraph);
+
+        placeCaretAroundReferenceNode(mentionNode, 1);
+        const selection = $getSelection();
+        const point = $isRangeSelection(selection)
+          ? {
+              key: selection.anchor.key,
+              offset: selection.anchor.offset,
+            }
+          : undefined;
+
+        result = {
+          paragraphKey: paragraph.getKey(),
+          afterHiddenAnchorOffset:
+            trailingAnchorNode.getIndexWithinParent() + 1,
+          point,
+        };
+      },
+      { discrete: true },
+    );
+
+    expect(result.point).toEqual({
+      key: result.paragraphKey,
+      offset: result.afterHiddenAnchorOffset,
+    });
+  });
+
+  it("maps content offsets around references to atomic element positions", () => {
+    const editor = createReferenceEditor();
+    let result;
+
+    editor.update(
+      () => {
+        const { paragraph, mentionNode } = createReferenceLine();
+        const mentionIndex = mentionNode.getIndexWithinParent();
+        const afterReferenceTextNode = mentionNode.getNextSibling();
+
+        applySelectionToLineNode(paragraph, {
+          start: 7,
+          end: 7,
+        });
+        const beforeReferenceSelection = $getSelection();
+        const beforeReferencePoint = $isRangeSelection(beforeReferenceSelection)
+          ? {
+              key: beforeReferenceSelection.anchor.key,
+              offset: beforeReferenceSelection.anchor.offset,
+              type: beforeReferenceSelection.anchor.type,
+            }
+          : undefined;
+
+        applySelectionToLineNode(paragraph, {
+          start: 8,
+          end: 8,
+        });
+        const insideReferenceSelection = $getSelection();
+        const insideReferencePoint = $isRangeSelection(insideReferenceSelection)
+          ? {
+              key: insideReferenceSelection.anchor.key,
+              offset: insideReferenceSelection.anchor.offset,
+              type: insideReferenceSelection.anchor.type,
+            }
+          : undefined;
+
+        applySelectionToLineNode(paragraph, {
+          start: 18,
+          end: 18,
+        });
+        const afterReferenceSelection = $getSelection();
+        const afterReferencePoint = $isRangeSelection(afterReferenceSelection)
+          ? {
+              key: afterReferenceSelection.anchor.key,
+              offset: afterReferenceSelection.anchor.offset,
+              type: afterReferenceSelection.anchor.type,
+            }
+          : undefined;
+
+        const leadingReferenceParagraph = $createParagraphNode();
+        const leadingReferenceNode = $createMentionNode({
+          resourceId: "leading-reference",
+          label: "Age",
+        });
+        leadingReferenceParagraph.append(
+          leadingReferenceNode,
+          $createTextNode(" suffix"),
+        );
+        $getRoot().append(leadingReferenceParagraph);
+        const leadingMentionIndex = leadingReferenceNode.getIndexWithinParent();
+
+        applySelectionToLineNode(leadingReferenceParagraph, {
+          start: 0,
+          end: 0,
+        });
+        const beforeLeadingReferenceSelection = $getSelection();
+        const beforeLeadingReferencePoint = $isRangeSelection(
+          beforeLeadingReferenceSelection,
+        )
+          ? {
+              key: beforeLeadingReferenceSelection.anchor.key,
+              offset: beforeLeadingReferenceSelection.anchor.offset,
+              type: beforeLeadingReferenceSelection.anchor.type,
+            }
+          : undefined;
+
+        applySelectionToLineNode(leadingReferenceParagraph, {
+          start: 1,
+          end: 1,
+        });
+        const insideLeadingReferenceSelection = $getSelection();
+        const insideLeadingReferencePoint = $isRangeSelection(
+          insideLeadingReferenceSelection,
+        )
+          ? {
+              key: insideLeadingReferenceSelection.anchor.key,
+              offset: insideLeadingReferenceSelection.anchor.offset,
+              type: insideLeadingReferenceSelection.anchor.type,
+            }
+          : undefined;
+
+        const trailingReferenceParagraph = $createParagraphNode();
+        const trailingReferenceNode = $createMentionNode({
+          resourceId: "trailing-reference",
+          label: "Age",
+        });
+        const trailingAnchorNode = $createTextNode(EDITOR_CARET_TEXT);
+        trailingReferenceParagraph.append(
+          $createTextNode("prefix "),
+          trailingReferenceNode,
+          trailingAnchorNode,
+        );
+        $getRoot().append(trailingReferenceParagraph);
+
+        applySelectionToLineNode(trailingReferenceParagraph, {
+          start: 10,
+          end: 10,
+        });
+        const trailingReferenceEndSelection = $getSelection();
+        const trailingReferenceEndPoint = $isRangeSelection(
+          trailingReferenceEndSelection,
+        )
+          ? {
+              key: trailingReferenceEndSelection.anchor.key,
+              offset: trailingReferenceEndSelection.anchor.offset,
+              type: trailingReferenceEndSelection.anchor.type,
+            }
+          : undefined;
+
+        result = {
+          paragraphKey: paragraph.getKey(),
+          mentionIndex,
+          afterReferenceTextKey: afterReferenceTextNode?.getKey(),
+          beforeReferencePoint,
+          insideReferencePoint,
+          afterReferencePoint,
+          leadingReferenceParagraphKey: leadingReferenceParagraph.getKey(),
+          leadingMentionIndex,
+          beforeLeadingReferencePoint,
+          insideLeadingReferencePoint,
+          trailingAnchorKey: trailingAnchorNode.getKey(),
+          trailingReferenceEndPoint,
+        };
+      },
+      { discrete: true },
+    );
+
+    expect(result.beforeReferencePoint).toMatchObject({
+      offset: 7,
+      type: "text",
+    });
+    expect(result.insideReferencePoint).toEqual({
+      key: result.paragraphKey,
+      offset: result.mentionIndex + 1,
+      type: "element",
+    });
+    expect(result.afterReferencePoint).toEqual({
+      key: result.afterReferenceTextKey,
+      offset: 0,
+      type: "text",
+    });
+    expect(result.beforeLeadingReferencePoint).toEqual({
+      key: result.leadingReferenceParagraphKey,
+      offset: result.leadingMentionIndex,
+      type: "element",
+    });
+    expect(result.insideLeadingReferencePoint).toEqual({
+      key: result.leadingReferenceParagraphKey,
+      offset: result.leadingMentionIndex + 1,
+      type: "element",
+    });
+    expect(result.trailingReferenceEndPoint).toEqual({
+      key: result.trailingAnchorKey,
+      offset: EDITOR_CARET_TEXT.length,
+      type: "text",
+    });
+  });
+
   it("detects adjacent reference nodes from collapsed element selections", () => {
     const editor = createReferenceEditor();
     let result;
@@ -160,6 +375,60 @@ describe("lexical scene document reference helpers", () => {
 
     expect(result.nextReferenceKey).toBe(result.mentionKey);
     expect(result.previousReferenceKey).toBe(result.mentionKey);
+  });
+
+  it("detects a reference before a trailing hidden caret anchor", () => {
+    const editor = createReferenceEditor();
+    let result;
+
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const mentionNode = $createMentionNode({
+          resourceId: "age",
+          label: "Age",
+        });
+        const trailingAnchorNode = $createTextNode(EDITOR_CARET_TEXT);
+        const extraTrailingAnchorNode = $createTextNode(EDITOR_CARET_TEXT);
+        paragraph.append(
+          $createTextNode("prefix "),
+          mentionNode,
+          trailingAnchorNode,
+          extraTrailingAnchorNode,
+        );
+        $getRoot().append(paragraph);
+
+        trailingAnchorNode.select(
+          EDITOR_CARET_TEXT.length,
+          EDITOR_CARET_TEXT.length,
+        );
+        const adjacentReference = getAdjacentReferenceNodeForCollapsedSelection(
+          $getSelection(),
+          -1,
+        );
+        paragraph.select(4, 4);
+        const elementBoundaryAdjacentReference =
+          getAdjacentReferenceNodeForCollapsedSelection($getSelection(), -1);
+        const elementBoundaryAdjacentReferenceInfo =
+          getAdjacentReferenceNodeInfoForCollapsedSelection(
+            $getSelection(),
+            -1,
+          );
+        result = {
+          mentionKey: mentionNode.getKey(),
+          adjacentReferenceKey: adjacentReference?.getKey(),
+          elementBoundaryAdjacentReferenceKey:
+            elementBoundaryAdjacentReference?.getKey(),
+          skippedZeroLengthText:
+            elementBoundaryAdjacentReferenceInfo?.skippedZeroLengthText,
+        };
+      },
+      { discrete: true },
+    );
+
+    expect(result.adjacentReferenceKey).toBe(result.mentionKey);
+    expect(result.elementBoundaryAdjacentReferenceKey).toBe(result.mentionKey);
+    expect(result.skippedZeroLengthText).toBe(true);
   });
 
   it("reads reference snapshot and rich-text metadata from mention nodes", () => {

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -282,11 +282,13 @@ describe("sceneEditorLexical.store", () => {
 
     expect(viewData.sectionEditorItems).toHaveLength(2);
     expect(viewData.sectionEditorItems[0].selectedLineId).toBe("line-1");
+    expect(viewData.sectionEditorItems[0].selectionActive).toBe(true);
     expect(viewData.sectionEditorItems[0].documentEditorLines).toHaveLength(2);
     expect(viewData.sectionEditorItems[0].documentLineDecorations[0]).toEqual(
       expect.objectContaining({ id: "line-1", lineNumber: 1 }),
     );
-    expect(viewData.sectionEditorItems[1].selectedLineId).toBeUndefined();
+    expect(viewData.sectionEditorItems[1].selectedLineId).toBe("");
+    expect(viewData.sectionEditorItems[1].selectionActive).toBe(false);
     expect(viewData.sectionEditorItems[1].documentEditorLines).toHaveLength(1);
     expect(viewData.sectionEditorItems[1].documentLineDecorations[0]).toEqual(
       expect.objectContaining({ id: "line-3", lineNumber: 1 }),

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -16,6 +16,26 @@ import {
   handleSelectedLineChanged,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
+const installAnimationFrameQueue = () => {
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const callbacks = [];
+  globalThis.requestAnimationFrame = vi.fn((callback) => {
+    callbacks.push(callback);
+    return callbacks.length;
+  });
+
+  return {
+    callbacks,
+    restore() {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    },
+  };
+};
+
 describe("sceneEditorLexical.handlers transform editor resize", () => {
   it("keeps x and y fixed while scaling from the anchor", () => {
     const transform = {
@@ -1328,6 +1348,13 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       sectionId: "section-2",
       lineId: "line-3",
     });
+    expect(deps.appService.setPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionId: "section-2",
+        lineId: "line-3",
+      }),
+      { throttleMs: 250 },
+    );
     expect(deps.render).toHaveBeenCalledOnce();
     expect(deps.subject.dispatch).toHaveBeenCalledWith(
       "sceneEditor.renderCanvas",
@@ -1422,6 +1449,13 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
         sectionId: "section-2",
         lineId: "line-3",
       });
+      expect(deps.appService.setPayload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sectionId: "section-2",
+          lineId: "line-3",
+        }),
+        { throttleMs: 250 },
+      );
       expect(deps.render).toHaveBeenCalledOnce();
       expect(nextSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-3",
@@ -1530,6 +1564,13 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
         sectionId: "section-1",
         lineId: "line-2",
       });
+      expect(deps.appService.setPayload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sectionId: "section-1",
+          lineId: "line-2",
+        }),
+        { throttleMs: 250 },
+      );
       expect(deps.render).toHaveBeenCalledOnce();
       expect(previousSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-2",
@@ -1542,6 +1583,317 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
           syncPresentationState: true,
         }),
       );
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    }
+  });
+
+  it("moves text selection from the last line to the next section first line", () => {
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    try {
+      const state = {
+        selectedSectionId: "section-1",
+        selectedLineId: "line-2",
+        payload: {
+          sceneId: "scene-1",
+          sectionId: "section-1",
+          lineId: "line-2",
+        },
+      };
+      const nextSectionEditor = {
+        dataset: { sectionId: "section-2" },
+        focusLine: vi.fn(),
+        scrollLineIntoView: vi.fn(),
+      };
+      const store = {
+        selectSelectedSectionId: vi.fn(() => state.selectedSectionId),
+        setSelectedSectionId: vi.fn(({ selectedSectionId }) => {
+          state.selectedSectionId = selectedSectionId;
+        }),
+        selectSelectedLineId: vi.fn(() => state.selectedLineId),
+        setSelectedLineId: vi.fn(({ selectedLineId }) => {
+          state.selectedLineId = selectedLineId;
+        }),
+        selectScene: vi.fn(() => ({
+          sections: [
+            {
+              id: "section-1",
+              lines: [{ id: "line-1" }, { id: "line-2" }],
+            },
+            {
+              id: "section-2",
+              lines: [{ id: "line-3" }, { id: "line-4" }],
+            },
+          ],
+        })),
+      };
+      const deps = {
+        store,
+        refs: {
+          sectionEditor0: {
+            dataset: { sectionId: "section-1" },
+            focusLine: vi.fn(),
+            scrollLineIntoView: vi.fn(),
+          },
+          sectionEditor1: nextSectionEditor,
+        },
+        render: vi.fn(),
+        subject: {
+          dispatch: vi.fn(),
+        },
+        appService: {
+          getPayload: vi.fn(() => state.payload),
+          setPayload: vi.fn((payload) => {
+            state.payload = payload;
+          }),
+        },
+      };
+
+      handleSelectedLineChanged(deps, {
+        _event: {
+          currentTarget: {
+            dataset: {
+              sectionId: "section-1",
+            },
+          },
+          detail: {
+            lineId: "line-2",
+            mode: "text-editor",
+            cursorPosition: 6,
+            navigationDirection: "down",
+            isBoundaryNavigation: true,
+          },
+        },
+      });
+
+      expect(state.selectedSectionId).toBe("section-2");
+      expect(state.selectedLineId).toBe("line-3");
+      expect(state.payload).toMatchObject({
+        sectionId: "section-2",
+        lineId: "line-3",
+      });
+      expect(nextSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-3",
+      });
+      expect(nextSectionEditor.focusLine).toHaveBeenCalledWith({
+        sectionId: "section-2",
+        lineId: "line-3",
+        cursorPosition: 6,
+        goalColumn: 6,
+        direction: "down",
+      });
+      expect(deps.render).toHaveBeenCalledOnce();
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+    }
+  });
+
+  it("does not focus a stale text boundary target after selection changes before the frame", () => {
+    const animationFrame = installAnimationFrameQueue();
+
+    try {
+      const state = {
+        selectedSectionId: "section-1",
+        selectedLineId: "line-2",
+        payload: {
+          sceneId: "scene-1",
+          sectionId: "section-1",
+          lineId: "line-2",
+        },
+      };
+      const nextSectionEditor = {
+        dataset: { sectionId: "section-2" },
+        focusLine: vi.fn(),
+        scrollLineIntoView: vi.fn(),
+      };
+      const store = {
+        selectSelectedSectionId: vi.fn(() => state.selectedSectionId),
+        setSelectedSectionId: vi.fn(({ selectedSectionId }) => {
+          state.selectedSectionId = selectedSectionId;
+        }),
+        selectSelectedLineId: vi.fn(() => state.selectedLineId),
+        setSelectedLineId: vi.fn(({ selectedLineId }) => {
+          state.selectedLineId = selectedLineId;
+        }),
+        selectScene: vi.fn(() => ({
+          sections: [
+            {
+              id: "section-1",
+              lines: [{ id: "line-1" }, { id: "line-2" }],
+            },
+            {
+              id: "section-2",
+              lines: [{ id: "line-3" }, { id: "line-4" }],
+            },
+          ],
+        })),
+      };
+      const deps = {
+        store,
+        refs: {
+          sectionEditor0: {
+            dataset: { sectionId: "section-1" },
+            focusLine: vi.fn(),
+            scrollLineIntoView: vi.fn(),
+          },
+          sectionEditor1: nextSectionEditor,
+        },
+        render: vi.fn(),
+        subject: {
+          dispatch: vi.fn(),
+        },
+        appService: {
+          getPayload: vi.fn(() => state.payload),
+          setPayload: vi.fn((payload) => {
+            state.payload = payload;
+          }),
+        },
+      };
+
+      handleSelectedLineChanged(deps, {
+        _event: {
+          currentTarget: {
+            dataset: {
+              sectionId: "section-1",
+            },
+          },
+          detail: {
+            lineId: "line-2",
+            mode: "text-editor",
+            cursorPosition: 6,
+            navigationDirection: "down",
+            isBoundaryNavigation: true,
+          },
+        },
+      });
+
+      expect(state.selectedSectionId).toBe("section-2");
+      expect(state.selectedLineId).toBe("line-3");
+
+      state.selectedSectionId = "section-1";
+      state.selectedLineId = "line-1";
+      animationFrame.callbacks.shift()();
+
+      expect(nextSectionEditor.scrollLineIntoView).not.toHaveBeenCalled();
+      expect(nextSectionEditor.focusLine).not.toHaveBeenCalled();
+    } finally {
+      animationFrame.restore();
+    }
+  });
+
+  it("moves text selection from the first line to the previous section last line", () => {
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    try {
+      const state = {
+        selectedSectionId: "section-2",
+        selectedLineId: "line-3",
+        payload: {
+          sceneId: "scene-1",
+          sectionId: "section-2",
+          lineId: "line-3",
+        },
+      };
+      const previousSectionEditor = {
+        dataset: { sectionId: "section-1" },
+        focusLine: vi.fn(),
+        scrollLineIntoView: vi.fn(),
+      };
+      const store = {
+        selectSelectedSectionId: vi.fn(() => state.selectedSectionId),
+        setSelectedSectionId: vi.fn(({ selectedSectionId }) => {
+          state.selectedSectionId = selectedSectionId;
+        }),
+        selectSelectedLineId: vi.fn(() => state.selectedLineId),
+        setSelectedLineId: vi.fn(({ selectedLineId }) => {
+          state.selectedLineId = selectedLineId;
+        }),
+        selectScene: vi.fn(() => ({
+          sections: [
+            {
+              id: "section-1",
+              lines: [{ id: "line-1" }, { id: "line-2" }],
+            },
+            {
+              id: "section-2",
+              lines: [{ id: "line-3" }, { id: "line-4" }],
+            },
+          ],
+        })),
+      };
+      const deps = {
+        store,
+        refs: {
+          sectionEditor0: previousSectionEditor,
+          sectionEditor1: {
+            dataset: { sectionId: "section-2" },
+            focusLine: vi.fn(),
+            scrollLineIntoView: vi.fn(),
+          },
+        },
+        render: vi.fn(),
+        subject: {
+          dispatch: vi.fn(),
+        },
+        appService: {
+          getPayload: vi.fn(() => state.payload),
+          setPayload: vi.fn((payload) => {
+            state.payload = payload;
+          }),
+        },
+      };
+
+      handleSelectedLineChanged(deps, {
+        _event: {
+          currentTarget: {
+            dataset: {
+              sectionId: "section-2",
+            },
+          },
+          detail: {
+            lineId: "line-3",
+            mode: "text-editor",
+            cursorPosition: 4,
+            navigationDirection: "up",
+            isBoundaryNavigation: true,
+          },
+        },
+      });
+
+      expect(state.selectedSectionId).toBe("section-1");
+      expect(state.selectedLineId).toBe("line-2");
+      expect(state.payload).toMatchObject({
+        sectionId: "section-1",
+        lineId: "line-2",
+      });
+      expect(previousSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-2",
+      });
+      expect(previousSectionEditor.focusLine).toHaveBeenCalledWith({
+        sectionId: "section-1",
+        lineId: "line-2",
+        cursorPosition: 4,
+        goalColumn: 4,
+        direction: "up",
+      });
+      expect(deps.render).toHaveBeenCalledOnce();
     } finally {
       if (previousRequestAnimationFrame === undefined) {
         delete globalThis.requestAnimationFrame;

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -299,8 +299,10 @@ describe("systemActions.store", () => {
       fields: [
         {
           field: "name",
+          fieldLabel: "name",
           variableId: "playerName",
           variableName: "Player Name",
+          summary: "name: Player Name",
         },
       ],
       fieldCount: 1,
@@ -313,6 +315,97 @@ describe("systemActions.store", () => {
         layoutType: "input",
         elements: inputElements,
       },
+    ]);
+  });
+
+  it("uses input layout field labels in the input action preview", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          layouts: {
+            items: {
+              "profile-form-layout": {
+                id: "profile-form-layout",
+                type: "layout",
+                name: "Profile Form",
+                layoutType: "input",
+                elements: {
+                  items: {
+                    nameInput: {
+                      id: "nameInput",
+                      type: "input",
+                      field: "name",
+                      name: "Name",
+                    },
+                    ageInput: {
+                      id: "ageInput",
+                      type: "input",
+                      field: "age",
+                      name: "Age",
+                    },
+                  },
+                  tree: [{ id: "nameInput" }, { id: "ageInput" }],
+                },
+              },
+            },
+            tree: [{ id: "profile-form-layout" }],
+          },
+          variables: {
+            items: {
+              playerName: {
+                id: "playerName",
+                type: "variable",
+                name: "fe",
+                variableType: "string",
+              },
+              playerAge: {
+                id: "playerAge",
+                type: "variable",
+                name: "age2",
+                variableType: "string",
+              },
+            },
+            tree: [{ id: "playerName" }, { id: "playerAge" }],
+          },
+        },
+      },
+    );
+
+    const { preview } = selectActionsData({
+      state,
+      props: {
+        actions: {
+          form: {
+            resourceId: "profile-form-layout",
+            fields: {
+              name: {
+                variableId: "playerName",
+              },
+              age: {
+                variableId: "playerAge",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(preview.form.fields).toEqual([
+      expect.objectContaining({
+        field: "name",
+        fieldLabel: "Name",
+        variableName: "fe",
+        summary: "Name: fe",
+      }),
+      expect.objectContaining({
+        field: "age",
+        fieldLabel: "Age",
+        variableName: "age2",
+        summary: "Age: age2",
+      }),
     ]);
   });
 


### PR DESCRIPTION
## Summary
- stabilize scene editor Lexical selection/caret navigation across sections, including held-arrow boundary navigation
- ensure only the active global section renders selected-line state
- keep reference chip selection scoped to the chip without native text highlight
- add throttled router payload updates for frequent selection URL syncs
- simplify input action configuration into draft field editing and next-line submit behavior
- update input action previews and layout editor image/create-at-top UX
- remove temporary navigation debug logging

## Tests
- bun run lint
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js
- bunx vitest run tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/lexicalSceneDocumentReferences.test.js tests/sceneEditor/sceneEditor.store.test.js
- bunx vitest run tests/appService/appShellService.test.js tests/appService/router.test.js tests/commandLineInput/commandLineInput.handlers.test.js tests/commandLineInput/commandLineInput.store.test.js tests/commandLineInput/commandLineInput.view.test.js tests/systemActions/systemActions.store.test.js tests/layoutEditor/layoutEditor.handlers.test.js tests/layoutEditor/layoutEditorViewData.test.js