### PR TITLE
chore: bump Tauri version to 1.5.0

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
Summary:
- Update the Tauri app version from 1.4.2 to 1.5.0.

Tests:
- bun run lint