### PR TITLE
Fix variable dialog keys and image previews

### DIFF
--- a/src/components/groupVariablesView/groupVariablesView.handlers.js
+++ b/src/components/groupVariablesView/groupVariablesView.handlers.js
@@ -147,6 +147,18 @@ const setVariableFormValues = ({ refs, render, store }, values = {}) => {
   render();
 };
 
+const shouldSyncVariableFormValues = ({
+  formValues = {},
+  nextValues = {},
+} = {}) => {
+  const syncFieldNames = ["variableType", "isEnum", "default"];
+  return syncFieldNames.some(
+    (fieldName) =>
+      Object.prototype.hasOwnProperty.call(formValues, fieldName) &&
+      formValues[fieldName] !== nextValues[fieldName],
+  );
+};
+
 const getFormFieldNameFromEvent = (event) => {
   const directFieldName = event?.target?.dataset?.fieldName;
   if (directFieldName) {
@@ -289,21 +301,27 @@ export const handleVariableItemClick = (deps, payload) => {
 };
 
 export const handleDialogFormChange = (deps, payload) => {
-  const { store, render } = deps;
+  const { refs, store, render } = deps;
   const prevValues = store.selectDefaultValues();
   const newValues = payload._event.detail.values;
-  const storeState = store.getState
-    ? store.getState()
-    : store._state || store.state;
-  const isEditMode = storeState?.dialogMode === "edit";
-
-  store.updateFormValues({
-    ...resolveVariableFormValues({
-      prevValues,
-      newValues,
-      isEditMode,
-    }),
+  const isEditMode = store.selectIsEditMode();
+  const nextValues = resolveVariableFormValues({
+    prevValues,
+    newValues,
+    isEditMode,
   });
+
+  store.updateFormValues(nextValues);
+  if (
+    shouldSyncVariableFormValues({
+      formValues: newValues,
+      nextValues,
+    })
+  ) {
+    refs.variableForm?.setValues?.({
+      values: nextValues,
+    });
+  }
   render();
 };
 

--- a/src/components/groupVariablesView/groupVariablesView.store.js
+++ b/src/components/groupVariablesView/groupVariablesView.store.js
@@ -478,14 +478,7 @@ export const selectViewData = ({ state, props }) => {
       index,
     }),
   );
-  const dialogKey = [
-    state.dialogMode,
-    state.editingItemId || "new",
-    defaultValues.variableType,
-    defaultValues.isEnum ? "enum" : "plain",
-    normalizeVariableEnumValues(defaultValues.enumValues).join("|"),
-    String(defaultValues.default),
-  ].join("-");
+  const dialogKey = state.editingItemId ?? state.targetGroupId ?? "new";
 
   return {
     flatGroups,

--- a/src/components/groupVariablesView/groupVariablesView.store.js
+++ b/src/components/groupVariablesView/groupVariablesView.store.js
@@ -208,6 +208,10 @@ export const selectDefaultValues = ({ state }) => {
   return state.defaultValues;
 };
 
+export const selectIsEditMode = ({ state }) => {
+  return state.dialogMode === "edit";
+};
+
 export const toggleGroupCollapse = ({ state }, { groupId } = {}) => {
   const index = state.collapsedIds.indexOf(groupId);
   if (index > -1) {

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -94,6 +94,12 @@ refs:
     eventListeners:
       click:
         handler: handlePreviewActionClick
+styles:
+  ".mediaImageThumbnailTransparencyGrid":
+    background-color: "#f4f4f4"
+    background-image: 'url("data:image/svg+xml,%3Csvg xmlns=''http://www.w3.org/2000/svg'' width=''16'' height=''16'' viewBox=''0 0 16 16''%3E%3Cpath fill=''%23d0d0d0'' d=''M0 0h8v8H0zM8 8h8v8H8z''/%3E%3Cpath fill=''%23f4f4f4'' d=''M8 0h8v8H8zM0 8h8v8H0z''/%3E%3C/svg%3E")'
+    background-repeat: repeat
+    background-size: 16px 16px
 template:
   - 'rtgl-view w=f h=f g=sm style="min-width: 0; min-height: 0;"':
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
@@ -145,7 +151,7 @@ template:
                                                   - 'rtgl-view br=md w=${item.imageCardWidth} pos=rel overflow=hidden style="${item.imageCardStyle}"':
                                                       - $if showImageCardPreview:
                                                           - $if item.useFullWidthImageCard:
-                                                              - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                              - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${item.previewAspectRatio}; overflow: hidden; border-radius: 8px;"':
                                                                   - $if item.isProcessing:
                                                                       - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
                                                                           - rtgl-text s=sm c=mu-fg: Processing...
@@ -154,14 +160,15 @@ template:
                                                                     $else:
                                                                       - rvn-file-image br=md w=f h=f fileId=${item.previewFileId}: null
                                                             $else:
-                                                              - $if item.isProcessing:
-                                                                  - rtgl-view w=f h=${imageHeight} br=md bw=xs bc=bo av=c ah=c:
-                                                                      - rtgl-text s=sm c=mu-fg: Processing...
-                                                                $else:
-                                                                  - $if lazyImageCards && item.shouldLazyLoadPreview:
-                                                                      - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId} lazy: null
+                                                              - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; height: ${imageHeight}px; overflow: hidden; border-radius: 8px;"':
+                                                                  - $if item.isProcessing:
+                                                                      - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                          - rtgl-text s=sm c=mu-fg: Processing...
                                                                     $else:
-                                                                      - rvn-file-image br=md w=f h=${imageHeight} fileId=${item.previewFileId}: null
+                                                                      - $if lazyImageCards && item.shouldLazyLoadPreview:
+                                                                          - rvn-file-image br=md w=f h=f fileId=${item.previewFileId} lazy: null
+                                                                        $else:
+                                                                          - rvn-file-image br=md w=f h=f fileId=${item.previewFileId}: null
                                                       - $if item.showPreviewIcon:
                                                           - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
                                                               - rtgl-svg svg=zoomIn wh=22 c=white: null

--- a/src/internal/routevnUrls.js
+++ b/src/internal/routevnUrls.js
@@ -1,4 +1,4 @@
-const ROUTEVN_CREATOR_DOCS_BASE_URL = "https://routevn.com/creator/docs";
+const ROUTEVN_CREATOR_DOCS_BASE_URL = "https://routevn.com/en/creator/docs";
 
 export const ROUTEVN_CREATOR_DOCS_URL = `${ROUTEVN_CREATOR_DOCS_BASE_URL}/introduction/`;
 export const ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL = `${ROUTEVN_CREATOR_DOCS_BASE_URL}/page-index/`;
@@ -71,7 +71,8 @@ const creatorDocsPathBySystemActionMode = {
   setMenuPage: "/line-actions/controls/",
   setMenuEntryPoint: "/line-actions/controls/",
   updateVariable: "/line-actions/update-variable/",
-  conditional: "/line-actions/controls/",
+  input: "/line-actions/input/",
+  conditional: "/line-actions/conditional/",
 };
 
 const normalizeRoutePattern = (routePattern) => {

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -26,8 +26,8 @@ const resolveImageAspectRatio = (item) => {
 };
 
 const PREVIEW_FRAME_STYLE = [
-  "width: 92vw",
-  "height: 92vh",
+  "width: min(92vw, calc(92vh * 16 / 9))",
+  "aspect-ratio: 16 / 9",
   "max-width: 92vw",
   "max-height: 92vh",
 ].join("; ");
@@ -74,7 +74,7 @@ const buildMediaItem = (item) => ({
   id: item.id,
   name: item.name,
   cardKind: "image",
-  previewFileId: item.thumbnailFileId ?? item.fileId,
+  previewFileId: item.fileId ?? item.thumbnailFileId,
   previewAspectRatio: resolveImageAspectRatio(item),
   canPreview: false,
 });

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -153,6 +153,11 @@ styles:
   ".imagePreviewEdgeNext":
     right: "0"
     background: linear-gradient(to left, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
+  ".imagePreviewTransparencyGrid":
+    background-color: "#f4f4f4"
+    background-image: 'url("data:image/svg+xml,%3Csvg xmlns=''http://www.w3.org/2000/svg'' width=''32'' height=''32'' viewBox=''0 0 32 32''%3E%3Cpath fill=''%23d0d0d0'' d=''M0 0h16v16H0zM16 16h16v16H16z''/%3E%3Cpath fill=''%23f4f4f4'' d=''M16 0h16v16H16zM0 16h16v16H0z''/%3E%3C/svg%3E")'
+    background-repeat: repeat
+    background-size: 32px 32px
   ".imagePreviewFrame":
     position: relative
     overflow: hidden
@@ -221,11 +226,10 @@ template:
   - rtgl-dialog#createTagDialog ?open=${isCreateTagDialogOpen} s=sm:
       - rtgl-form#createTagForm key=${isCreateTagDialogOpen} slot=content :defaultValues=${createTagDefaultValues} :form=${createTagForm} w=f: null
   - $when: fullImagePreviewVisible
-    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none;"':
-      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: rgba(0, 0, 0, 0.9);"': null
+    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
-              - 'div#previewImageFrame.imagePreviewFrame style="${fullImagePreviewFrameStyle}"':
+              - 'div#previewImageFrame.imagePreviewFrame.imagePreviewTransparencyGrid style="${fullImagePreviewFrameStyle}"':
                   - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
                   - $if fullImagePreviewPreviousVisible:
                       - div#previewPrevious.imagePreviewEdge.imagePreviewEdgePrevious role=button aria-label="Previous image": null

--- a/tests/groupVariablesView/groupVariablesView.handlers.test.js
+++ b/tests/groupVariablesView/groupVariablesView.handlers.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { handleDialogFormChange } from "../../src/components/groupVariablesView/groupVariablesView.handlers.js";
+import {
+  createInitialState,
+  openAddDialog,
+  selectDefaultValues,
+  selectIsEditMode,
+  updateFormValues,
+} from "../../src/components/groupVariablesView/groupVariablesView.store.js";
+
+const createDeps = (state) => {
+  const setValuesCalls = [];
+  let renderCount = 0;
+
+  return {
+    deps: {
+      refs: {
+        variableForm: {
+          setValues: (payload) => {
+            setValuesCalls.push(payload);
+          },
+        },
+      },
+      store: {
+        selectDefaultValues: () => selectDefaultValues({ state }),
+        selectIsEditMode: () => selectIsEditMode({ state }),
+        updateFormValues: (payload) => updateFormValues({ state }, payload),
+      },
+      render: () => {
+        renderCount += 1;
+      },
+    },
+    getRenderCount: () => renderCount,
+    setValuesCalls,
+  };
+};
+
+describe("groupVariablesView.handlers", () => {
+  it("syncs normalized defaults back into the variable form", () => {
+    const state = createInitialState();
+    openAddDialog({ state }, { groupId: "group-1" });
+    updateFormValues(
+      { state },
+      {
+        variableType: "number",
+        default: 12,
+      },
+    );
+    const { deps, getRenderCount, setValuesCalls } = createDeps(state);
+
+    handleDialogFormChange(deps, {
+      _event: {
+        detail: {
+          values: {
+            name: "score",
+            scope: "context",
+            variableType: "string",
+            default: 12,
+          },
+        },
+      },
+    });
+
+    expect(selectDefaultValues({ state })).toMatchObject({
+      variableType: "string",
+      isEnum: false,
+      enumValues: [],
+      default: "",
+    });
+    expect(setValuesCalls).toEqual([
+      {
+        values: expect.objectContaining({
+          variableType: "string",
+          default: "",
+        }),
+      },
+    ]);
+    expect(getRenderCount()).toBe(1);
+  });
+});

--- a/tests/groupVariablesView/groupVariablesView.store.test.js
+++ b/tests/groupVariablesView/groupVariablesView.store.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  closeDialog,
+  openAddDialog,
+  openEditDialog,
+  selectViewData,
+} from "../../src/components/groupVariablesView/groupVariablesView.store.js";
+
+describe("groupVariablesView.store", () => {
+  it("uses the variable id as the edit form key", () => {
+    const state = createInitialState();
+
+    openEditDialog(
+      { state },
+      {
+        groupId: "group-1",
+        itemId: "variable-1",
+        defaultValues: {
+          name: "Label with spaces",
+          variableType: "string",
+          isEnum: true,
+          enumValues: ["enum value (one)"],
+          default: "()9f 0e faw faw fe awfaw efawe fawef awef",
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state, props: {} });
+
+    expect(viewData.dialogKey).toBe("variable-1");
+    expect(viewData.dialogKey).not.toContain("()9f");
+    expect(viewData.dialogKey).not.toContain("enum value");
+    expect(viewData.dialogKey).not.toContain("Label with spaces");
+  });
+
+  it("uses the target group id as the add form key", () => {
+    const state = createInitialState();
+
+    openAddDialog({ state }, { groupId: "group-1" });
+    const firstKey = selectViewData({ state, props: {} }).dialogKey;
+
+    closeDialog({ state });
+    const closedKey = selectViewData({ state, props: {} }).dialogKey;
+
+    openAddDialog({ state }, { groupId: "group-1" });
+    const secondKey = selectViewData({ state, props: {} }).dialogKey;
+
+    expect(firstKey).toBe("group-1");
+    expect(closedKey).toBe("new");
+    expect(secondKey).toBe("group-1");
+  });
+});

--- a/tests/images/images.store.test.js
+++ b/tests/images/images.store.test.js
@@ -3,6 +3,7 @@ import {
   commitDetailTagIds,
   createInitialState,
   selectAdjacentImageItemId,
+  selectViewData,
   setDetailTagIds,
   setItems,
   setSelectedItemId,
@@ -97,6 +98,31 @@ describe("images store detail tag draft", () => {
 });
 
 describe("images store preview navigation", () => {
+  it("uses the original image file for grid thumbnails so transparency can show", () => {
+    const context = createContext();
+
+    setItems(context, {
+      data: {
+        tree: [{ id: "image-1" }],
+        items: {
+          "image-1": {
+            id: "image-1",
+            type: "image",
+            name: "Transparent Image",
+            fileId: "original-file",
+            thumbnailFileId: "opaque-thumbnail-file",
+          },
+        },
+      },
+    });
+
+    const viewData = selectViewData(context);
+
+    expect(viewData.mediaGroups[0].children[0].previewFileId).toBe(
+      "original-file",
+    );
+  });
+
   it("uses the original file for the full preview overlay", () => {
     const context = createContext();
 
@@ -121,6 +147,18 @@ describe("images store preview navigation", () => {
 
     expect(context.state.fullImagePreviewVisible).toBe(true);
     expect(context.state.fullImagePreviewFileId).toBe("original-file");
+  });
+
+  it("uses a 16:9 frame for the full preview overlay", () => {
+    const context = createContext();
+    const viewData = selectViewData(context);
+
+    expect(viewData.fullImagePreviewFrameStyle).toContain(
+      "aspect-ratio: 16 / 9",
+    );
+    expect(viewData.fullImagePreviewFrameStyle).toContain(
+      "width: min(92vw, calc(92vh * 16 / 9))",
+    );
   });
 
   it("jumps adjacent image selection by distance and clamps to visible bounds", () => {

--- a/tests/internal/routevnUrls.test.js
+++ b/tests/internal/routevnUrls.test.js
@@ -9,55 +9,55 @@ import {
 describe("routevnUrls", () => {
   it("returns the verified docs page for a known resource route", () => {
     expect(getRoutevnCreatorDocsUrl("/project/images")).toBe(
-      "https://routevn.com/creator/docs/images/",
+      "https://routevn.com/en/creator/docs/images/",
     );
     expect(getRoutevnCreatorDocsUrl("/projects")).toBe(
-      "https://routevn.com/creator/docs/projects/",
+      "https://routevn.com/en/creator/docs/projects/",
     );
     expect(getRoutevnCreatorDocsUrl("/project/particles")).toBe(
-      "https://routevn.com/creator/docs/particles/",
+      "https://routevn.com/en/creator/docs/particles/",
     );
     expect(getRoutevnCreatorDocsUrl("/project/spritesheets")).toBe(
-      "https://routevn.com/creator/docs/spritesheets/",
+      "https://routevn.com/en/creator/docs/spritesheets/",
     );
     expect(getRoutevnCreatorDocsUrl("/project/variables")).toBe(
-      "https://routevn.com/creator/docs/variables/",
+      "https://routevn.com/en/creator/docs/variables/",
     );
   });
 
   it("maps non-slug route names to their docs page", () => {
     expect(getRoutevnCreatorDocsUrl("/project/scenes/")).toBe(
-      "https://routevn.com/creator/docs/scene-map/",
+      "https://routevn.com/en/creator/docs/scene-map/",
     );
     expect(getRoutevnCreatorDocsUrl("/project/releases")).toBe(
-      "https://routevn.com/creator/docs/versions/",
+      "https://routevn.com/en/creator/docs/versions/",
     );
     expect(getRoutevnCreatorDocsUrl("/project/releases/web-server")).toBe(
-      "https://routevn.com/creator/docs/web-server/",
+      "https://routevn.com/en/creator/docs/web-server/",
     );
   });
 
   it("maps editor sub-routes to the matching docs sections", () => {
     expect(getRoutevnCreatorDocsUrl("/project/character-sprites")).toBe(
-      "https://routevn.com/creator/docs/characters/#character-sprites",
+      "https://routevn.com/en/creator/docs/characters/#character-sprites",
     );
     expect(getRoutevnCreatorDocsUrl("/project/animation-editor")).toBe(
-      "https://routevn.com/creator/docs/animations/#animation-editor-page",
+      "https://routevn.com/en/creator/docs/animations/#animation-editor-page",
     );
     expect(getRoutevnCreatorDocsUrl("/project/layout-editor")).toBe(
-      "https://routevn.com/creator/docs/layouts/#layout-editor",
+      "https://routevn.com/en/creator/docs/layouts/#layout-editor",
     );
   });
 
   it("maps settings routes to the docs settings section", () => {
     expect(getRoutevnCreatorDocsUrl("/project/about")).toBe(
-      "https://routevn.com/creator/docs/page-index/#settings",
+      "https://routevn.com/en/creator/docs/page-index/#settings",
     );
     expect(getRoutevnCreatorDocsUrl("/project/appearance")).toBe(
-      "https://routevn.com/creator/docs/page-index/#settings",
+      "https://routevn.com/en/creator/docs/page-index/#settings",
     );
     expect(getRoutevnCreatorDocsUrl("/project/user")).toBe(
-      "https://routevn.com/creator/docs/page-index/#settings",
+      "https://routevn.com/en/creator/docs/page-index/#settings",
     );
   });
 
@@ -70,40 +70,43 @@ describe("routevnUrls", () => {
 
   it("returns the dedicated line-action docs page for known system action modes", () => {
     expect(getRoutevnCreatorSystemActionDocsUrl("background")).toBe(
-      "https://routevn.com/creator/docs/line-actions/background/",
+      "https://routevn.com/en/creator/docs/line-actions/background/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("screen")).toBe(
-      "https://routevn.com/creator/docs/line-actions/visual/",
+      "https://routevn.com/en/creator/docs/line-actions/visual/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("setNextLineConfig")).toBe(
-      "https://routevn.com/creator/docs/line-actions/next-line-config/",
+      "https://routevn.com/en/creator/docs/line-actions/next-line-config/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("updateVariable")).toBe(
-      "https://routevn.com/creator/docs/line-actions/update-variable/",
+      "https://routevn.com/en/creator/docs/line-actions/update-variable/",
+    );
+    expect(getRoutevnCreatorSystemActionDocsUrl("input")).toBe(
+      "https://routevn.com/en/creator/docs/line-actions/input/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("conditional")).toBe(
-      "https://routevn.com/creator/docs/line-actions/controls/",
+      "https://routevn.com/en/creator/docs/line-actions/conditional/",
     );
   });
 
   it("maps related system action modes to the closest documented guide", () => {
     expect(getRoutevnCreatorSystemActionDocsUrl("toggleDialogueUI")).toBe(
-      "https://routevn.com/creator/docs/line-actions/dialogue/",
+      "https://routevn.com/en/creator/docs/line-actions/dialogue/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("startSkipMode")).toBe(
-      "https://routevn.com/creator/docs/line-actions/toggle-skip-mode/",
+      "https://routevn.com/en/creator/docs/line-actions/toggle-skip-mode/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("stopSkipMode")).toBe(
-      "https://routevn.com/creator/docs/line-actions/toggle-skip-mode/",
+      "https://routevn.com/en/creator/docs/line-actions/toggle-skip-mode/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl("setSoundVolume")).toBe(
-      "https://routevn.com/creator/docs/line-actions/sfx/",
+      "https://routevn.com/en/creator/docs/line-actions/sfx/",
     );
   });
 
   it("maps generic system action modes and falls back for undocumented modes", () => {
     expect(getRoutevnCreatorSystemActionDocsUrl("actions")).toBe(
-      "https://routevn.com/creator/docs/scene-editor/",
+      "https://routevn.com/en/creator/docs/scene-editor/",
     );
     expect(getRoutevnCreatorSystemActionDocsUrl(undefined)).toBe(
       ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL,


### PR DESCRIPTION
Summary:
- Use ids for variable form keys so user-authored default values cannot break view parsing.
- Show image thumbnails and full previews on checker backgrounds for transparency.
- Use original image files for grid previews and constrain full preview to a 16:9 frame.

Tests:
- ./node_modules/.bin/vitest run tests/groupVariablesView/groupVariablesView.store.test.js tests/images/images.store.test.js
- bun run lint