### PR TITLE
Bump Tauri app version to 1.5.1

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- Bump RouteVN Creator Tauri app version from 1.5.0 to 1.5.1

## Validation
- Parsed src-tauri/tauri.conf.json as JSON
- Push hook ran oxlint and Prettier

No build run.