### PR TITLE
Normalize macOS updater artifact name

### DIFF
--- a/scripts/tauri-build-mac.sh
+++ b/scripts/tauri-build-mac.sh
@@ -6,6 +6,36 @@ has_notarization_credentials() {
   [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]
 }
 
+read_tauri_config_value() {
+  bun --print "JSON.parse(await Bun.file('src-tauri/tauri.conf.json').text()).${1}"
+}
+
+normalize_macos_updater_artifact_name() {
+  local artifact_dir="${1}"
+  local app_name="${2}"
+  local app_version="${3}"
+  local source_path="${artifact_dir}/${app_name}.app.tar.gz"
+  local target_path="${artifact_dir}/${app_name}_${app_version}.app.tar.gz"
+  local source_sig_path="${source_path}.sig"
+  local target_sig_path="${target_path}.sig"
+
+  if [ -f "${source_path}" ]; then
+    mv -f "${source_path}" "${target_path}"
+    echo "Final app updater archive: ${target_path}"
+  elif [ -f "${target_path}" ]; then
+    echo "Final app updater archive: ${target_path}"
+  else
+    echo "Warning: no app updater archive found in ${artifact_dir}."
+  fi
+
+  if [ -f "${source_sig_path}" ]; then
+    mv -f "${source_sig_path}" "${target_sig_path}"
+    echo "Final app updater signature: ${target_sig_path}"
+  elif [ -f "${target_sig_path}" ]; then
+    echo "Final app updater signature: ${target_sig_path}"
+  fi
+}
+
 if [ -f ".env" ]; then
   set -a
   # shellcheck disable=SC1091
@@ -17,6 +47,9 @@ if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
   echo "Error: APPLE_SIGNING_IDENTITY is not set. Add it to .env."
   exit 1
 fi
+
+APP_NAME=$(read_tauri_config_value "productName")
+APP_VERSION=$(read_tauri_config_value "version")
 
 echo "Building macOS bundle with signing identity: ${APPLE_SIGNING_IDENTITY}"
 
@@ -35,7 +68,10 @@ fi
 bun run build:tauri
 tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles app,dmg
 
+MACOS_BUNDLE_DIR="src-tauri/target/universal-apple-darwin/release/bundle/macos"
 DMG_DIR="src-tauri/target/universal-apple-darwin/release/bundle/dmg"
+normalize_macos_updater_artifact_name "${MACOS_BUNDLE_DIR}" "${APP_NAME}" "${APP_VERSION}"
+
 DMG_PATH=$(find "${DMG_DIR}" -maxdepth 1 -type f -name "*.dmg" -print | sort | tail -n 1)
 
 if [ -z "${DMG_PATH}" ]; then


### PR DESCRIPTION
## Summary
- read the Tauri app name and version from src-tauri/tauri.conf.json during macOS builds
- rename generated macOS updater archives and signatures to include the app version
- keep existing DMG notarization flow unchanged

## Validation
- bun run lint
- bash -n scripts/tauri-build-mac.sh
- git diff --check
- bun --print config lookup for productName/version