### PR TITLE
Fix scene preview Enter handling and replay compatibility

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -50,6 +50,9 @@
           "url": "https://routevn.com/creator/*"
         },
         {
+          "url": "https://routevn.com/en/creator/docs/*"
+        },
+        {
           "url": "https://x.com/routevn"
         },
         {

--- a/src/components/projectCreateDialog/projectCreateDialog.store.js
+++ b/src/components/projectCreateDialog/projectCreateDialog.store.js
@@ -59,8 +59,7 @@ const form = {
       name: "resolution",
       type: "select",
       label: "Resolution",
-      description:
-        "Only 1920x1080 is supported for now, more options coming soon.",
+      description: "Choose the project resolution.",
       required: true,
       clearable: false,
       options: PROJECT_RESOLUTION_OPTIONS,

--- a/src/components/projectCreateDialog/projectCreateDialog.store.js
+++ b/src/components/projectCreateDialog/projectCreateDialog.store.js
@@ -1,8 +1,15 @@
 import {
   createProjectResolutionFormValues,
   CUSTOM_PROJECT_RESOLUTION_PRESET,
+  DEFAULT_PROJECT_RESOLUTION_PRESET,
   PROJECT_RESOLUTION_OPTIONS,
 } from "../../internal/projectResolution.js";
+
+const CREATE_PROJECT_RESOLUTION_OPTIONS = PROJECT_RESOLUTION_OPTIONS.filter(
+  ({ value }) =>
+    value === DEFAULT_PROJECT_RESOLUTION_PRESET ||
+    value === CUSTOM_PROJECT_RESOLUTION_PRESET,
+);
 
 const createCreateProjectDefaultValues = (values = {}) => {
   const preset =
@@ -62,7 +69,7 @@ const form = {
       description: "Choose the project resolution.",
       required: true,
       clearable: false,
-      options: PROJECT_RESOLUTION_OPTIONS,
+      options: CREATE_PROJECT_RESOLUTION_OPTIONS,
     },
     {
       $when: "values.resolution == 'custom'",

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -19,6 +19,9 @@ import {
   withPreviewEntryPoint,
 } from "./support/vnPreviewProjectData.js";
 
+const FORWARDED_PREVIEW_KEY_EVENT = "__rvnForwardedPreviewKeyEvent";
+const PREVIEW_FORWARDED_KEYS = new Set(["Enter"]);
+
 const focusPreviewSurface = (refs) => {
   const previewSurface = refs?.previewSurface;
   if (!previewSurface?.focus) {
@@ -39,10 +42,77 @@ const focusPreviewSurface = (refs) => {
   });
 };
 
-const suppressPreviewEscapeEvent = (event) => {
+const suppressPreviewKeyboardEvent = (event) => {
   event.preventDefault?.();
   event.stopPropagation?.();
   event.stopImmediatePropagation?.();
+};
+
+const isPreviewSurfaceEventTarget = (previewSurface, target) => {
+  if (!previewSurface || !target) {
+    return false;
+  }
+
+  if (target === previewSurface) {
+    return true;
+  }
+
+  return typeof previewSurface.contains === "function"
+    ? previewSurface.contains(target)
+    : false;
+};
+
+const shouldForwardPreviewKeyEvent = (event, refs) => {
+  const previewSurface = refs?.previewSurface;
+  if (
+    event?.[FORWARDED_PREVIEW_KEY_EVENT] === true ||
+    event?.defaultPrevented ||
+    !PREVIEW_FORWARDED_KEYS.has(event?.key) ||
+    !previewSurface ||
+    typeof previewSurface.dispatchEvent !== "function" ||
+    typeof KeyboardEvent !== "function"
+  ) {
+    return false;
+  }
+
+  return !isPreviewSurfaceEventTarget(previewSurface, event.target);
+};
+
+const createForwardedPreviewKeyEvent = (event) => {
+  if (typeof KeyboardEvent !== "function") {
+    return undefined;
+  }
+
+  const forwardedEvent = new KeyboardEvent(event.type, {
+    altKey: event.altKey === true,
+    bubbles: true,
+    cancelable: true,
+    code: event.code,
+    composed: true,
+    ctrlKey: event.ctrlKey === true,
+    key: event.key,
+    keyCode: event.keyCode,
+    metaKey: event.metaKey === true,
+    repeat: event.repeat === true,
+    shiftKey: event.shiftKey === true,
+    which: event.which,
+  });
+  Object.defineProperty(forwardedEvent, FORWARDED_PREVIEW_KEY_EVENT, {
+    value: true,
+  });
+  return forwardedEvent;
+};
+
+const forwardPreviewKeyEvent = (event, refs) => {
+  const previewSurface = refs?.previewSurface;
+  const forwardedEvent = createForwardedPreviewKeyEvent(event);
+  if (!previewSurface || !forwardedEvent) {
+    return false;
+  }
+
+  focusPreviewSurface(refs);
+  previewSurface.dispatchEvent(forwardedEvent);
+  return true;
 };
 
 const waitForBrowserPaint = async () => {
@@ -431,17 +501,31 @@ const createBeforeHandleActionsHook = (
 };
 
 export const handleBeforeMount = (deps) => {
-  const { dispatchEvent, store, graphicsService } = deps;
+  const { dispatchEvent, store, graphicsService, refs } = deps;
   function handleKeyDown(event) {
     if (event.key !== "Escape") {
+      if (shouldForwardPreviewKeyEvent(event, refs)) {
+        suppressPreviewKeyboardEvent(event);
+        forwardPreviewKeyEvent(event, refs);
+      }
       return;
     }
 
-    suppressPreviewEscapeEvent(event);
+    suppressPreviewKeyboardEvent(event);
     dispatchEvent(new CustomEvent("close"));
   }
 
+  function handleKeyUp(event) {
+    if (!shouldForwardPreviewKeyEvent(event, refs)) {
+      return;
+    }
+
+    suppressPreviewKeyboardEvent(event);
+    forwardPreviewKeyEvent(event, refs);
+  }
+
   window.addEventListener("keydown", handleKeyDown, true);
+  window.addEventListener("keyup", handleKeyUp, true);
 
   return () => {
     store.setAssetLoading({ isLoading: false });
@@ -449,6 +533,7 @@ export const handleBeforeMount = (deps) => {
     resetAssetLoadCache(store);
     void graphicsService.destroy?.();
     window.removeEventListener("keydown", handleKeyDown, true);
+    window.removeEventListener("keyup", handleKeyUp, true);
   };
 };
 

--- a/src/components/vnPreview/vnPreview.handlers.js
+++ b/src/components/vnPreview/vnPreview.handlers.js
@@ -21,6 +21,7 @@ import {
 
 const FORWARDED_PREVIEW_KEY_EVENT = "__rvnForwardedPreviewKeyEvent";
 const PREVIEW_FORWARDED_KEYS = new Set(["Enter"]);
+const PREVIEW_LEGACY_KEY_CODE_BY_KEY = new Map([["Enter", 13]]);
 
 const focusPreviewSurface = (refs) => {
   const previewSurface = refs?.previewSurface;
@@ -78,29 +79,107 @@ const shouldForwardPreviewKeyEvent = (event, refs) => {
   return !isPreviewSurfaceEventTarget(previewSurface, event.target);
 };
 
+const toPositiveInteger = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0
+    ? Math.round(numericValue)
+    : undefined;
+};
+
+const resolveForwardedPreviewLegacyKeyCode = (event) => {
+  return (
+    toPositiveInteger(event?.keyCode) ??
+    toPositiveInteger(event?.which) ??
+    toPositiveInteger(event?.charCode) ??
+    PREVIEW_LEGACY_KEY_CODE_BY_KEY.get(event?.key) ??
+    0
+  );
+};
+
+const defineForwardedPreviewEventProperty = (event, key, value) => {
+  try {
+    Object.defineProperty(event, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+    });
+    return event[key] === value;
+  } catch {
+    return false;
+  }
+};
+
+const applyForwardedPreviewKeyEventProperties = (forwardedEvent, event) => {
+  const legacyKeyCode = resolveForwardedPreviewLegacyKeyCode(event);
+  const properties = {
+    [FORWARDED_PREVIEW_KEY_EVENT]: true,
+    altKey: event.altKey === true,
+    charCode: legacyKeyCode,
+    code: event.code,
+    ctrlKey: event.ctrlKey === true,
+    key: event.key,
+    keyCode: legacyKeyCode,
+    metaKey: event.metaKey === true,
+    repeat: event.repeat === true,
+    shiftKey: event.shiftKey === true,
+    which: legacyKeyCode,
+  };
+  let didSetLegacyProperties = true;
+
+  Object.entries(properties).forEach(([key, value]) => {
+    const didSet = defineForwardedPreviewEventProperty(
+      forwardedEvent,
+      key,
+      value,
+    );
+    if (
+      (key === "charCode" || key === "keyCode" || key === "which") &&
+      !didSet
+    ) {
+      didSetLegacyProperties = false;
+    }
+  });
+
+  return didSetLegacyProperties;
+};
+
 const createForwardedPreviewKeyEvent = (event) => {
   if (typeof KeyboardEvent !== "function") {
     return undefined;
   }
 
+  const legacyKeyCode = resolveForwardedPreviewLegacyKeyCode(event);
   const forwardedEvent = new KeyboardEvent(event.type, {
     altKey: event.altKey === true,
     bubbles: true,
     cancelable: true,
+    charCode: legacyKeyCode,
     code: event.code,
     composed: true,
     ctrlKey: event.ctrlKey === true,
     key: event.key,
-    keyCode: event.keyCode,
+    keyCode: legacyKeyCode,
     metaKey: event.metaKey === true,
     repeat: event.repeat === true,
     shiftKey: event.shiftKey === true,
-    which: event.which,
+    which: legacyKeyCode,
   });
-  Object.defineProperty(forwardedEvent, FORWARDED_PREVIEW_KEY_EVENT, {
-    value: true,
+  if (applyForwardedPreviewKeyEventProperties(forwardedEvent, event)) {
+    return forwardedEvent;
+  }
+
+  if (typeof Event !== "function") {
+    return undefined;
+  }
+
+  const fallbackEvent = new Event(event.type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
   });
-  return forwardedEvent;
+  return applyForwardedPreviewKeyEventProperties(fallbackEvent, event)
+    ? fallbackEvent
+    : undefined;
 };
 
 const forwardPreviewKeyEvent = (event, refs) => {
@@ -504,9 +583,11 @@ export const handleBeforeMount = (deps) => {
   const { dispatchEvent, store, graphicsService, refs } = deps;
   function handleKeyDown(event) {
     if (event.key !== "Escape") {
-      if (shouldForwardPreviewKeyEvent(event, refs)) {
+      if (
+        shouldForwardPreviewKeyEvent(event, refs) &&
+        forwardPreviewKeyEvent(event, refs)
+      ) {
         suppressPreviewKeyboardEvent(event);
-        forwardPreviewKeyEvent(event, refs);
       }
       return;
     }
@@ -520,8 +601,9 @@ export const handleBeforeMount = (deps) => {
       return;
     }
 
-    suppressPreviewKeyboardEvent(event);
-    forwardPreviewKeyEvent(event, refs);
+    if (forwardPreviewKeyEvent(event, refs)) {
+      suppressPreviewKeyboardEvent(event);
+    }
   }
 
   window.addEventListener("keydown", handleKeyDown, true);

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -55,7 +55,7 @@ export const createAppShellService = ({
   subject,
   globalUI,
   filePicker,
-  openUrl,
+  openUrl: openExternalUrl,
   appVersion,
   platform,
   updater,
@@ -103,7 +103,17 @@ export const createAppShellService = ({
       router.back();
     },
 
-    openUrl,
+    async openUrl(url) {
+      try {
+        await openExternalUrl(url);
+      } catch {
+        globalUI.showToast({
+          title: "Error",
+          message: "Failed to open link.",
+          status: "error",
+        });
+      }
+    },
 
     showDialog(options) {
       return globalUI.showConfirm(options);

--- a/src/deps/services/shared/projectRepositoryViews/sceneStateView.js
+++ b/src/deps/services/shared/projectRepositoryViews/sceneStateView.js
@@ -31,6 +31,9 @@ const getSceneProjectionDebugDetails = (event) => {
   const payloadLineIds = Array.isArray(payload.lineIds)
     ? payload.lineIds.filter((id) => typeof id === "string" && id.length > 0)
     : [];
+  const payloadSectionIds = Array.isArray(payload.sectionIds)
+    ? payload.sectionIds.filter((id) => typeof id === "string" && id.length > 0)
+    : [];
   const payloadLinesLineIds = Array.isArray(payload.lines)
     ? payload.lines
         .map((line) => line?.lineId)
@@ -45,13 +48,14 @@ const getSceneProjectionDebugDetails = (event) => {
       ? payload.sectionId
       : typeof payload.toSectionId === "string"
         ? payload.toSectionId
-        : undefined;
+        : payloadSectionIds[0];
 
   return {
     command,
     payload,
     lineId,
     sectionId,
+    sectionIds: payloadSectionIds,
   };
 };
 
@@ -265,6 +269,11 @@ const isMissingSectionReplayError = (error) =>
     "payload.sectionId must reference an existing section",
   );
 
+const isMissingSectionIdsReplayError = (error) =>
+  String(error?.message || "").includes(
+    "payload.sectionIds must reference existing sections",
+  );
+
 const isMissingLineReplayError = (error) => {
   const message = String(error?.message || "");
   return (
@@ -288,12 +297,22 @@ const shouldSkipObsoleteSceneReplayEvent = ({
   repositoryState,
   error,
 }) => {
-  const { command, lineId, sectionId } = getSceneProjectionDebugDetails(event);
+  const { command, lineId, sectionId, sectionIds } =
+    getSceneProjectionDebugDetails(event);
   if (command?.type?.startsWith("section.")) {
     if (isDuplicateSectionReplayError(error)) {
       return !command?.type?.endsWith(".create")
         ? false
         : Boolean(findSectionLocationInState(repositoryState, sectionId));
+    }
+
+    if (isMissingSectionIdsReplayError(error)) {
+      return (
+        sectionIds.length > 0 &&
+        sectionIds.every(
+          (id) => !findSectionLocationInState(repositoryState, id),
+        )
+      );
     }
 
     if (isMissingSectionReplayError(error)) {

--- a/src/internal/projectResolution.js
+++ b/src/internal/projectResolution.js
@@ -12,6 +12,12 @@ export const PROJECT_RESOLUTION_PRESETS = Object.freeze([
     width: 1920,
     height: 1080,
   },
+  {
+    value: "1080x1920",
+    label: "1080x1920",
+    width: 1080,
+    height: 1920,
+  },
   // {
   //   value: "1280x720",
   //   label: "1280x720",

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -1513,6 +1513,13 @@ const selectCanvasAspectRatioWidthMultiplier = ({ state }) => {
   return Number.isFinite(ratio) && ratio > 0 ? ratio : 16 / 9;
 };
 
+const selectPreviewCanvasMaxWidth = ({ state }) => {
+  const widthMultiplier = selectCanvasAspectRatioWidthMultiplier({ state });
+  const maxWidthVh = Number((widthMultiplier * 50).toFixed(4));
+
+  return `min(100%, ${maxWidthVh}vh)`;
+};
+
 const selectSystemActionsDialogPanelWidth = ({ state }) => {
   return state.backgroundTransformEditor.isOpen === true
     ? "calc(100vw - 64px)"
@@ -1579,6 +1586,7 @@ export const selectViewData = ({ state }) => {
       previewSectionId: state.previewSectionId,
       previewLineId: state.previewLineId,
       canvasAspectRatio: selectCanvasAspectRatio({ state }),
+      previewCanvasMaxWidth: selectPreviewCanvasMaxWidth({ state }),
       systemActionsDialogPanelWidth: selectSystemActionsDialogPanelWidth({
         state,
       }),
@@ -1874,6 +1882,7 @@ export const selectViewData = ({ state }) => {
     previewSectionId: state.previewSectionId,
     previewLineId: state.previewLineId,
     canvasAspectRatio: selectCanvasAspectRatio({ state }),
+    previewCanvasMaxWidth: selectPreviewCanvasMaxWidth({ state }),
     systemActionsDialogPanelWidth: selectSystemActionsDialogPanelWidth({
       state,
     }),

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -173,8 +173,8 @@ template:
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - $if backgroundTransformEditor.isOpen == false:
                       - 'rtgl-view w=f style="min-width: 0;"':
-                          - 'rtgl-view pos=rel w=f':
-                              - rvn-scene-editor-preview-canvas#previewCanvasHost canvas-aspect-ratio="${canvasAspectRatio}": null
+                          - 'div style="position: relative; width: ${previewCanvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto;"':
+                              - 'rvn-scene-editor-preview-canvas#previewCanvasHost style="display: block; width: 100%;" canvas-aspect-ratio="${canvasAspectRatio}"': null
                               - $if isSceneAssetLoading:
                                   - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
                                       - rtgl-text s=h3: Loading assets...

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -997,6 +997,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.dismissedMentionTrigger = undefined;
     this.dismissedMentionTriggerScope = undefined;
     this.pendingTypedSlashMentionTrigger = undefined;
+    this.pendingHandledPasteBeforeInput = false;
 
     this.editor = createEditor({
       namespace: "routevn-lexical-scene-document-editor",
@@ -1136,8 +1137,16 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       ),
       this.editor.registerCommand(
         PASTE_COMMAND,
-        () => {
-          return false;
+        (event) => {
+          event?.preventDefault?.();
+          event?.stopPropagation?.();
+          event?.stopImmediatePropagation?.();
+          this.handlePasteEvent(event);
+          this.pendingHandledPasteBeforeInput = true;
+          requestAnimationFrame(() => {
+            this.pendingHandledPasteBeforeInput = false;
+          });
+          return true;
         },
         COMMAND_PRIORITY_HIGH,
       ),
@@ -4256,6 +4265,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   handleNativeBeforeInput(event) {
     this.hideSelectionPopover();
+    const inputType = String(event.inputType ?? "");
 
     if (this.state?.mode === "block") {
       this.clearPendingTextInputFallback();
@@ -4272,12 +4282,37 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     this.clearSelectedReferenceNodeKey();
 
-    const inputType = String(event.inputType ?? "");
     if (inputType === "historyUndo" || inputType === "historyRedo") {
       this.clearPendingTextInputFallback();
       event.preventDefault();
       event.stopPropagation?.();
       event.stopImmediatePropagation?.();
+      return;
+    }
+
+    if (
+      inputType === "insertFromPaste" ||
+      inputType === "insertFromPasteAsQuotation"
+    ) {
+      this.clearPendingTextInputFallback();
+      event.preventDefault();
+      event.stopPropagation?.();
+      event.stopImmediatePropagation?.();
+
+      if (this.pendingHandledPasteBeforeInput) {
+        this.pendingHandledPasteBeforeInput = false;
+        return;
+      }
+
+      const pastedText =
+        event.dataTransfer?.getData?.("text/plain") ?? event.data ?? "";
+      if (pastedText) {
+        this.handlePasteEvent({
+          clipboardData: {
+            getData: (type) => (type === "text/plain" ? pastedText : ""),
+          },
+        });
+      }
       return;
     }
 

--- a/tests/appService/appShellService.test.js
+++ b/tests/appService/appShellService.test.js
@@ -95,4 +95,21 @@ describe("appShellService", () => {
       throttleMs: 250,
     });
   });
+
+  it("shows a toast when opening an external URL fails", async () => {
+    const deps = createDeps();
+    deps.openUrl.mockRejectedValue(new Error("blocked"));
+    const service = createAppShellService(deps);
+
+    await service.openUrl("https://routevn.com/en/creator/docs/test");
+
+    expect(deps.openUrl).toHaveBeenCalledWith(
+      "https://routevn.com/en/creator/docs/test",
+    );
+    expect(deps.globalUI.showToast).toHaveBeenCalledWith({
+      title: "Error",
+      message: "Failed to open link.",
+      status: "error",
+    });
+  });
 });

--- a/tests/internal/projectResolution.test.js
+++ b/tests/internal/projectResolution.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProjectResolutionFormValues,
+  PROJECT_RESOLUTION_OPTIONS,
+  resolveProjectResolution,
+} from "../../src/internal/projectResolution.js";
+
+describe("project resolution presets", () => {
+  it("includes a portrait 1080p option", () => {
+    expect(PROJECT_RESOLUTION_OPTIONS).toContainEqual({
+      value: "1080x1920",
+      label: "1080x1920",
+    });
+  });
+
+  it("resolves the portrait preset dimensions", () => {
+    expect(createProjectResolutionFormValues("1080x1920")).toEqual({
+      resolution: "1080x1920",
+      resolutionWidth: 1080,
+      resolutionHeight: 1920,
+    });
+    expect(resolveProjectResolution({ preset: "1080x1920" })).toEqual({
+      width: 1080,
+      height: 1920,
+    });
+  });
+});

--- a/tests/project/sceneProjectionCompatibility.test.js
+++ b/tests/project/sceneProjectionCompatibility.test.js
@@ -722,6 +722,54 @@ describe("scene projection compatibility", () => {
     ).toBeUndefined();
   });
 
+  it("skips obsolete plural section delete replay events", async () => {
+    const initialState = createRepositoryState();
+    delete initialState.scenes.items[sceneId].sections.items[targetSectionId];
+    initialState.scenes.items[sceneId].sections.tree = [{ id: sectionId }];
+
+    const projectCreateEvent = createProjectCreateRepositoryEvent({
+      projectId,
+      state: initialState,
+    });
+    const sectionDeleteEvent = createCommandEvent({
+      id: "section-delete-missing",
+      partition: mainScenePartitionFor(sceneId),
+      type: COMMAND_TYPES.SECTION_DELETE,
+      payload: {
+        sectionIds: [targetSectionId],
+      },
+      clientTs: 1,
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const projection = await loadSceneProjectionState({
+        store: createCheckpointStore(),
+        mainState: createMainProjectionState(initialState),
+        events: [projectCreateEvent, sectionDeleteEvent],
+        createInitialState: () => structuredClone(initialProjectData),
+        reduceEventToState,
+        reduceEventsToState,
+        sceneId,
+      });
+
+      expect(
+        projection.scenes.items[sceneId].sections.items[targetSectionId],
+      ).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[sceneProjection] skipped obsolete replay event",
+        expect.objectContaining({
+          sceneId,
+          eventId: "section-delete-missing",
+          partition: mainScenePartitionFor(sceneId),
+          error: "payload.sectionIds must reference existing sections",
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("skips obsolete section and line lifecycle events while preserving newer scene lines", async () => {
     const initialState = createRepositoryState();
     const deletedSectionId = "section-deleted";

--- a/tests/projectCreateDialog/projectCreateDialog.store.test.js
+++ b/tests/projectCreateDialog/projectCreateDialog.store.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/components/projectCreateDialog/projectCreateDialog.store.js";
+
+describe("projectCreateDialog.store", () => {
+  it("does not expose portrait resolution in the create project form", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({ state });
+    const resolutionField = viewData.form.fields.find(
+      (field) => field.name === "resolution",
+    );
+
+    expect(resolutionField.options).toContainEqual({
+      value: "1920x1080",
+      label: "1920x1080",
+    });
+    expect(resolutionField.options).not.toContainEqual({
+      value: "1080x1920",
+      label: "1080x1920",
+    });
+  });
+});

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -61,6 +61,29 @@ describe("sceneEditorLexical.store", () => {
     });
   });
 
+  it("limits preview canvas width for portrait projects", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repository: {
+          project: {
+            resolution: {
+              width: 1080,
+              height: 1920,
+            },
+          },
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.canvasAspectRatio).toBe("1080 / 1920");
+    expect(viewData.previewCanvasMaxWidth).toBe("min(100%, 28.125vh)");
+  });
+
   it("includes conditional branch section targets in the section graph", () => {
     const state = createInitialState();
 

--- a/tests/vnPreview/vnPreview.handlers.test.js
+++ b/tests/vnPreview/vnPreview.handlers.test.js
@@ -218,14 +218,14 @@ describe("vnPreview.handlers", () => {
     );
   });
 
-  it("lets preview gameplay keys pass through and closes only on Escape", async () => {
+  it("forwards preview Enter from outside the preview and closes only on Escape", async () => {
     const { handleBeforeMount } = await import(
       "../../src/components/vnPreview/vnPreview.handlers.js"
     );
 
     const listeners = {};
     const removeEventListener = vi.fn();
-    const addEventListener = vi.fn((eventName, listener) => {
+    const addEventListener = vi.fn((eventName, listener, _options) => {
       listeners[eventName] = listener;
     });
     vi.stubGlobal("window", {
@@ -240,9 +240,33 @@ describe("vnPreview.handlers", () => {
         }
       },
     );
+    vi.stubGlobal(
+      "KeyboardEvent",
+      class KeyboardEvent {
+        constructor(type, init = {}) {
+          this.type = type;
+          Object.assign(this, init);
+        }
+      },
+    );
+
+    const editorTarget = {
+      name: "editor",
+    };
+    const previewChild = {
+      name: "preview",
+    };
+    const previewSurface = {
+      contains: vi.fn((target) => target === previewChild),
+      dispatchEvent: vi.fn(),
+      focus: vi.fn(),
+    };
 
     const deps = {
       dispatchEvent: vi.fn(),
+      refs: {
+        previewSurface,
+      },
       graphicsService: {
         destroy: vi.fn(),
       },
@@ -256,17 +280,71 @@ describe("vnPreview.handlers", () => {
     const cleanup = handleBeforeMount(deps);
 
     const enterEvent = {
+      type: "keydown",
       key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+      target: editorTarget,
       preventDefault: vi.fn(),
       stopPropagation: vi.fn(),
       stopImmediatePropagation: vi.fn(),
     };
     listeners.keydown(enterEvent);
 
-    expect(enterEvent.preventDefault).not.toHaveBeenCalled();
-    expect(enterEvent.stopPropagation).not.toHaveBeenCalled();
-    expect(enterEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(enterEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(enterEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(enterEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(previewSurface.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(previewSurface.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "keydown",
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        which: 13,
+      }),
+    );
     expect(deps.dispatchEvent).not.toHaveBeenCalled();
+
+    const previewEnterEvent = {
+      type: "keydown",
+      key: "Enter",
+      target: previewChild,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+    listeners.keydown(previewEnterEvent);
+
+    expect(previewEnterEvent.preventDefault).not.toHaveBeenCalled();
+    expect(previewEnterEvent.stopPropagation).not.toHaveBeenCalled();
+    expect(previewEnterEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(previewSurface.dispatchEvent).toHaveBeenCalledTimes(1);
+
+    const enterKeyUpEvent = {
+      type: "keyup",
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+      target: editorTarget,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    };
+    listeners.keyup(enterKeyUpEvent);
+
+    expect(enterKeyUpEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(enterKeyUpEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(enterKeyUpEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(previewSurface.dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(previewSurface.dispatchEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "keyup",
+        key: "Enter",
+      }),
+    );
 
     const escapeEvent = {
       key: "Escape",
@@ -292,13 +370,23 @@ describe("vnPreview.handlers", () => {
       expect.any(Function),
       true,
     );
+    expect(addEventListener).toHaveBeenCalledWith(
+      "keyup",
+      expect.any(Function),
+      true,
+    );
     expect(deps.graphicsService.destroy).toHaveBeenCalledTimes(1);
     expect(removeEventListener).toHaveBeenCalledWith(
       "keydown",
       expect.any(Function),
       true,
     );
-    expect(addEventListener).toHaveBeenCalledTimes(1);
-    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "keyup",
+      expect.any(Function),
+      true,
+    );
+    expect(addEventListener).toHaveBeenCalledTimes(2);
+    expect(removeEventListener).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/vnPreview/vnPreview.handlers.test.js
+++ b/tests/vnPreview/vnPreview.handlers.test.js
@@ -241,11 +241,40 @@ describe("vnPreview.handlers", () => {
       },
     );
     vi.stubGlobal(
+      "Event",
+      class Event {
+        constructor(type, init = {}) {
+          this.type = type;
+          Object.assign(this, init);
+        }
+      },
+    );
+    vi.stubGlobal(
       "KeyboardEvent",
       class KeyboardEvent {
         constructor(type, init = {}) {
           this.type = type;
-          Object.assign(this, init);
+          this.altKey = init.altKey;
+          this.bubbles = init.bubbles;
+          this.cancelable = init.cancelable;
+          this.code = init.code;
+          this.composed = init.composed;
+          this.ctrlKey = init.ctrlKey;
+          this.key = init.key;
+          this.metaKey = init.metaKey;
+          this.repeat = init.repeat;
+          this.shiftKey = init.shiftKey;
+          Object.defineProperties(this, {
+            charCode: {
+              value: 0,
+            },
+            keyCode: {
+              value: 0,
+            },
+            which: {
+              value: 0,
+            },
+          });
         }
       },
     );
@@ -301,6 +330,7 @@ describe("vnPreview.handlers", () => {
         type: "keydown",
         key: "Enter",
         code: "Enter",
+        charCode: 13,
         keyCode: 13,
         which: 13,
       }),
@@ -326,6 +356,7 @@ describe("vnPreview.handlers", () => {
       type: "keyup",
       key: "Enter",
       code: "Enter",
+      charCode: 13,
       keyCode: 13,
       which: 13,
       target: editorTarget,
@@ -343,6 +374,9 @@ describe("vnPreview.handlers", () => {
       expect.objectContaining({
         type: "keyup",
         key: "Enter",
+        charCode: 13,
+        keyCode: 13,
+        which: 13,
       }),
     );
 


### PR DESCRIPTION
Summary:
- Forward full-screen preview Enter keydown/keyup events from editor focus to the preview surface so Lexical does not insert a newline.
- Preserve forwarded Enter legacy key fields (`keyCode`, `which`, `charCode`) for WebKit/Tauri-style hotkey handling.
- Treat obsolete plural section delete replay events as warnings when the referenced sections are already gone.
- Keep 1080x1920 project resolution resolvable for existing/imported projects, but hide it from the create-project form.
- Adjust the scene preview canvas width for portrait projects.
- Show a stable toast if opening an external link fails, and allow the RouteVN docs URL in Tauri capabilities.
- Intercept Lexical paste paths without debug console logging so paste handling stays controlled.

Validation:
- bunx vitest run tests/project/sceneProjectionCompatibility.test.js tests/vnPreview/vnPreview.handlers.test.js tests/project/layout.keyboard.test.js
- bunx vitest run tests/internal/projectResolution.test.js tests/appService/appShellService.test.js tests/sceneEditor/sceneEditor.store.test.js tests/sceneEditor/lexicalLineEditing.test.js
- bunx vitest run tests/projectCreateDialog/projectCreateDialog.store.test.js tests/internal/projectResolution.test.js
- bunx vitest run tests/vnPreview/vnPreview.handlers.test.js tests/project/layout.keyboard.test.js
- bun run lint

Not run:
- bun run build:web