### PR TITLE
Bump Tauri version to 1.5.2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
Summary:
- Bump `src-tauri/tauri.conf.json` from `1.5.1` to `1.5.2`.

Validation:
- bun prettier --check src-tauri/tauri.conf.json
- push hook: oxlint && bun prettier --check src

Not run:
- bun run build:web