### PR TITLE
Fix Windows scene assets and scene editor entry scroll

### DIFF
--- a/src-tauri/src/project_media_server.rs
+++ b/src-tauri/src/project_media_server.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
 use std::{fs, path::PathBuf};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::{
     fs::File,
     io::{Read, Seek, SeekFrom, Write},
@@ -11,10 +11,10 @@ use std::{
 };
 
 use tauri::State;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use url::Url;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 const MEDIA_MIME_BY_EXTENSION: &[(&str, &str)] = &[
     (".apng", "image/apng"),
     (".png", "image/png"),
@@ -78,10 +78,10 @@ pub fn get_project_media_server_origin(
 }
 
 fn start_project_media_server() -> Option<String> {
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     return None;
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
         let listener = TcpListener::bind(("127.0.0.1", 0)).ok()?;
         let address = listener.local_addr().ok()?;
@@ -99,7 +99,7 @@ fn start_project_media_server() -> Option<String> {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
     let request = read_request_head(&mut stream)?;
     let mut lines = request.split("\r\n");
@@ -231,7 +231,7 @@ fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn read_request_head(stream: &mut TcpStream) -> std::io::Result<String> {
     let mut buffer = [0_u8; 4096];
     let mut request = Vec::new();
@@ -251,7 +251,7 @@ fn read_request_head(stream: &mut TcpStream) -> std::io::Result<String> {
     Ok(String::from_utf8_lossy(&request).into_owned())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn parse_byte_range(header: Option<&str>, file_size: u64) -> Result<Option<(u64, u64)>, ()> {
     let Some(header) = header else {
         return Ok(None);
@@ -287,7 +287,7 @@ fn parse_byte_range(header: Option<&str>, file_size: u64) -> Result<Option<(u64,
     Ok(Some((start, end.min(file_size - 1))))
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
 fn resolve_allowed_project_file_path(path: &str) -> Option<PathBuf> {
     let canonical_path = fs::canonicalize(path).ok()?;
     if !canonical_path.is_file() {
@@ -308,7 +308,7 @@ fn resolve_allowed_project_file_path(path: &str) -> Option<PathBuf> {
         .then_some(canonical_path)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn get_media_mime_from_request_path(path: &str) -> Option<&'static str> {
     let normalized_path = path.to_ascii_lowercase();
 
@@ -317,7 +317,7 @@ fn get_media_mime_from_request_path(path: &str) -> Option<&'static str> {
         .find_map(|(extension, mime)| normalized_path.ends_with(extension).then_some(*mime))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn write_headers(
     stream: &mut TcpStream,
     status_code: u16,
@@ -348,7 +348,7 @@ fn write_headers(
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn write_simple_response(
     stream: &mut TcpStream,
     status_code: u16,

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -1008,6 +1008,19 @@ const getSceneSectionIds = (scene) => {
   return sectionIds;
 };
 
+export const resolveSceneEditorEntrySelection = (scene, { sectionId } = {}) => {
+  const sections = Array.isArray(scene?.sections) ? scene.sections : [];
+  const selectedSection =
+    sections.find((section) => section.id === sectionId) ||
+    sections.find((section) => section.id === scene?.initialSectionId) ||
+    sections[0];
+
+  return {
+    sectionId: selectedSection?.id,
+    lineId: selectedSection?.lines?.[0]?.id,
+  };
+};
+
 export const updateSceneEditorSectionChanges = async (deps) => {
   const { store, graphicsService } = deps;
   const selectedSectionId = store.selectSelectedSectionId();
@@ -1051,11 +1064,7 @@ export const initializeSceneEditorPage = async (deps) => {
   } = deps;
   await projectService.ensureRepository();
 
-  const {
-    s,
-    sectionId: payloadSectionId,
-    lineId: payloadLineId,
-  } = appService.getPayload();
+  const { s, sectionId: payloadSectionId } = appService.getPayload();
   const sceneId = s;
 
   await projectService.setActiveSceneId(sceneId);
@@ -1066,19 +1075,13 @@ export const initializeSceneEditorPage = async (deps) => {
 
   const scene = store.selectScene();
   if (scene?.sections?.length > 0) {
-    const selectedSection =
-      scene.sections.find((section) => section.id === payloadSectionId) ||
-      scene.sections[0];
-    store.setSelectedSectionId({ selectedSectionId: selectedSection.id });
-
-    if (selectedSection.lines?.length > 0) {
-      const selectedLine =
-        selectedSection.lines.find((line) => line.id === payloadLineId) ||
-        selectedSection.lines[0];
-      store.setSelectedLineId({ selectedLineId: selectedLine.id });
-    } else {
-      store.setSelectedLineId({ selectedLineId: undefined });
-    }
+    const entrySelection = resolveSceneEditorEntrySelection(scene, {
+      sectionId: payloadSectionId,
+    });
+    store.setSelectedSectionId({
+      selectedSectionId: entrySelection.sectionId,
+    });
+    store.setSelectedLineId({ selectedLineId: entrySelection.lineId });
   }
 
   resetAssetLoadCache("initialize scene editor");

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -454,36 +454,48 @@ const scrollLinesEditorLineIntoView = (
   linesEditorRef.scrollLineIntoView({ lineId, ...options });
 };
 
-const scheduleFrame = (callback) => {
-  if (typeof requestAnimationFrame === "function") {
-    requestAnimationFrame(callback);
-    return;
-  }
-
-  globalThis.setTimeout?.(callback, 0);
+const getSceneEditorSectionsScrollContainer = (refs) => {
+  return (
+    refs?.sceneEditorSectionsScroll ||
+    getRefElements(refs).find(
+      (element) => element?.id === "sceneEditorSectionsScroll",
+    ) ||
+    refs?.sceneEditorLeftEditor?.querySelector?.("#sceneEditorSectionsScroll")
+  );
 };
 
-const scrollEntrySelectionIntoView = (deps, payload = {}) => {
+const resetSceneEditorSectionsScroll = (refs) => {
+  const scrollContainer = getSceneEditorSectionsScrollContainer(refs);
+  if (!scrollContainer) {
+    return;
+  }
+
+  const previousScrollBehavior = scrollContainer.style?.scrollBehavior;
+  if (scrollContainer.style) {
+    scrollContainer.style.scrollBehavior = "auto";
+  }
+  scrollContainer.scrollTop = 0;
+  scrollContainer.scrollTo?.({
+    top: 0,
+    left: scrollContainer.scrollLeft ?? 0,
+    behavior: "auto",
+  });
+  if (scrollContainer.style) {
+    scrollContainer.style.scrollBehavior = previousScrollBehavior;
+  }
+};
+
+export const scrollEntrySelectionIntoView = (deps) => {
   const { refs, store } = deps;
-  if (!payload.sectionId && !payload.lineId) {
-    return;
-  }
-
   const selectedSectionId = store.selectSelectedSectionId?.();
-  const selectedLineId = store.selectSelectedLineId?.();
-
-  if (payload.lineId && selectedLineId) {
-    scheduleFrame(() => {
-      scrollLinesEditorLineIntoView(refs, selectedLineId, selectedSectionId, {
-        block: "start",
-      });
-    });
+  const scene = store.selectScene?.();
+  const firstSectionId = scene?.sections?.[0]?.id;
+  if (!selectedSectionId || selectedSectionId === firstSectionId) {
+    resetSceneEditorSectionsScroll(refs);
     return;
   }
 
-  if (selectedSectionId) {
-    scrollSceneEditorSectionTabIntoView(deps, selectedSectionId);
-  }
+  scrollSceneEditorSectionTabIntoView(deps, selectedSectionId);
 };
 
 const focusLinesEditorContainer = (refs, sectionId) => {
@@ -1449,14 +1461,13 @@ export const handleBeforeMount = (deps) => {
 
 export const handleAfterMount = async (deps) => {
   try {
-    const entryPayload = deps.appService?.getPayload?.() || {};
     await initializeSceneEditorPage({
       ...deps,
       syncProjectState: syncStoreProjectState,
     });
     reconcileCurrentEditorSession(deps);
     deps.render();
-    scrollEntrySelectionIntoView(deps, entryPayload);
+    scrollEntrySelectionIntoView(deps);
   } catch (error) {
     if (!isMissingProjectResolutionError(error)) {
       throw error;

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -158,7 +158,7 @@ template:
                           - rtgl-text: ${sectionsGraph}
                 $else:
                   - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
-                      - 'rtgl-view w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px;"':
+                      - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px;"':
                           - $for section, sectionIndex in sectionEditorItems:
                               - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1222,7 +1222,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         return;
       }
 
-      this.focusContainer();
+      this.focusContainer({ scrollLine: false });
     });
   }
 
@@ -1671,12 +1671,13 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     return nativeSelection.start !== payload.cursorPosition;
   }
 
-  focusContainer() {
+  focusContainer({ scrollLine = true } = {}) {
     const selectedLineId = this.state.selectedLineId || this.state.lines[0]?.id;
     this.enterBlockMode({
       focusSurface: true,
       lineId: selectedLineId,
       emitSelectionChange: false,
+      scrollLine,
     });
   }
 
@@ -1749,6 +1750,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     focusSurface = true,
     lineId = this.state.selectedLineId || this.state.lines[0]?.id,
     emitSelectionChange = false,
+    scrollLine = true,
   } = {}) {
     this.clearPendingTextInputFallback();
     this.lastProgrammaticFocusTarget = undefined;
@@ -1757,7 +1759,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     if (lineId) {
       this.state.selectedLineId = lineId;
-      this.scrollLineIntoView({ lineId });
+      if (scrollLine) {
+        this.scrollLineIntoView({ lineId });
+      }
     }
 
     this.setMode("block");
@@ -2166,6 +2170,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       focusSurface: false,
       emitSelectionChange: false,
       lineId: this.state.selectedLineId,
+      // Blur can fire while section editors mount. Sync block state without
+      // scrolling, so scene entry stays pinned to the target section start.
+      scrollLine: false,
     });
     this.dispatchEvent(
       new CustomEvent("editor-blur", {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -731,6 +731,65 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("can prepare block focus without scrolling the selected line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const editorNode = document.createElement("div");
+      const surfaceNode = document.createElement("div");
+
+      editorElement.refs = {
+        editor: editorNode,
+        surface: surfaceNode,
+      };
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      Object.defineProperty(editorElement, "dataset", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(editorElement, "isConnected", {
+        configurable: true,
+        value: true,
+      });
+      editorElement.clearPendingTextInputFallback = vi.fn();
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.scrollLineIntoView = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.focus = vi.fn();
+
+      editorElement.focusContainer({ scrollLine: false });
+
+      expect(editorElement.state.mode).toBe("block");
+      expect(editorElement.state.selectedLineId).toBe("line-2");
+      expect(editorElement.scrollLineIntoView).not.toHaveBeenCalled();
+      expect(editorElement.focus).toHaveBeenCalledWith({
+        preventScroll: true,
+      });
+    } finally {
+      if (previousRequestAnimationFrame === undefined) {
+        delete globalThis.requestAnimationFrame;
+      } else {
+        globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      }
+      restoreDomGlobals();
+    }
+  });
+
   it("emits block navigation direction when moving down at the last line", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -2695,6 +2754,7 @@ describe("lexical scene document editor line editing", () => {
         focusSurface: false,
         emitSelectionChange: false,
         lineId: "line-1",
+        scrollLine: false,
       });
     } finally {
       restoreDomGlobals();

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -4,6 +4,7 @@ import {
   createSceneEditorRenderQueue,
   renderSceneEditorCanvas,
   renderSceneEditorState,
+  resolveSceneEditorEntrySelection,
   updateSceneEditorSectionChanges,
 } from "../../src/internal/ui/sceneEditor/runtime.js";
 
@@ -132,6 +133,68 @@ const createGraphicsService = () => {
 };
 
 describe("renderSceneEditorState", () => {
+  it("resolves scene entry from the target section and ignores stale line payload", () => {
+    const scene = {
+      initialSectionId: "section-2",
+      sections: [
+        {
+          id: "section-1",
+          lines: [{ id: "line-1" }, { id: "line-stale" }],
+        },
+        {
+          id: "section-2",
+          lines: [{ id: "line-2a" }, { id: "line-2b" }],
+        },
+      ],
+    };
+
+    expect(
+      resolveSceneEditorEntrySelection(scene, {
+        sectionId: "section-1",
+        lineId: "line-stale",
+      }),
+    ).toEqual({
+      sectionId: "section-1",
+      lineId: "line-1",
+    });
+  });
+
+  it("resolves scene entry from initial section or falls back to first section", () => {
+    expect(
+      resolveSceneEditorEntrySelection({
+        initialSectionId: "section-2",
+        sections: [
+          {
+            id: "section-1",
+            lines: [{ id: "line-1" }],
+          },
+          {
+            id: "section-2",
+            lines: [{ id: "line-2" }],
+          },
+        ],
+      }),
+    ).toEqual({
+      sectionId: "section-2",
+      lineId: "line-2",
+    });
+
+    expect(
+      resolveSceneEditorEntrySelection({
+        initialSectionId: "missing-section",
+        sections: [
+          {
+            id: "section-1",
+            lines: [{ id: "line-1" }],
+          },
+        ],
+      }),
+    ).toEqual({
+      sectionId: "section-1",
+      lineId: "line-1",
+    });
+  });
+
   it("requests per-line presentationState from section line changes", async () => {
     const changes = { lines: [] };
     const engineSelectSectionLineChanges = vi.fn(() => changes);

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -14,6 +14,7 @@ import {
   handleNewLine,
   handleSectionMoveSceneFormActionClick,
   handleSelectedLineChanged,
+  scrollEntrySelectionIntoView,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
 const installAnimationFrameQueue = () => {
@@ -37,6 +38,45 @@ const installAnimationFrameQueue = () => {
 };
 
 describe("sceneEditorLexical.handlers transform editor resize", () => {
+  it("resets stale section scroll when entering the first section", () => {
+    const scrollContainer = {
+      id: "sceneEditorSectionsScroll",
+      scrollTop: 420,
+      scrollLeft: 0,
+      style: {
+        scrollBehavior: "smooth",
+      },
+      scrollTo: vi.fn(({ top }) => {
+        scrollContainer.scrollTop = top;
+      }),
+    };
+    const deps = {
+      refs: {
+        sceneEditorSectionsScroll: scrollContainer,
+      },
+      store: {
+        selectSelectedSectionId: vi.fn(() => "section-1"),
+        selectScene: vi.fn(() => ({
+          sections: [
+            {
+              id: "section-1",
+            },
+          ],
+        })),
+      },
+    };
+
+    scrollEntrySelectionIntoView(deps);
+
+    expect(scrollContainer.scrollTop).toBe(0);
+    expect(scrollContainer.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
+    expect(scrollContainer.style.scrollBehavior).toBe("smooth");
+  });
+
   it("keeps x and y fixed while scaling from the anchor", () => {
     const transform = {
       x: 100,


### PR DESCRIPTION
## Summary
- start the bounded project media localhost server on Windows as well as macOS
- route Pixi scene asset fetches through the same 127.0.0.1 media path instead of the Windows custom-protocol fallback
- keep non-macOS/non-Windows platforms on the existing fallback
- resolve scene editor entry to the target or initial section, then select that section's first line instead of a stale payload line
- keep scene editor entry pinned to the section start by resetting first-section scroll and preventing mount/blur block sync from scrolling selected lines

## Scene editor scroll root cause
The scene editor runtime was selecting the correct initial section and first line. The jump happened later while document editors mounted: blur handling re-entered block mode with the default line-scroll behavior, so scrollLineIntoView ran during initialization. With multiple section editors mounting, those blur-driven scrolls could pull the viewport down into a long first section. Blur and mount block sync now run without line scrolling; deliberate user navigation still scrolls normally.

## Validation
- bunx vitest run tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/runtime.test.js tests/sceneEditor/lexicalLineEditing.test.js
- bun run lint
- push hook: bun run lint
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo test --manifest-path src-tauri/Cargo.toml project_media_server::tests
- bunx vitest run tests/graphicsService/graphicsService.test.js