### PR TITLE
Cap layout editor canvas height

### DIFF
--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -22,6 +22,25 @@ const arePreviewDataEqual = (left, right) => {
   return JSON.stringify(left ?? {}) === JSON.stringify(right ?? {});
 };
 
+const selectCanvasAspectRatioWidthMultiplier = ({ state }) => {
+  const projectResolution = requireProjectResolution(
+    state.projectResolution ?? DEFAULT_PROJECT_RESOLUTION,
+    "Project resolution",
+  );
+  const width = Number(projectResolution.width);
+  const height = Number(projectResolution.height);
+  const ratio = width / height;
+
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : 16 / 9;
+};
+
+const selectLayoutEditorCanvasMaxWidth = ({ state }) => {
+  const widthMultiplier = selectCanvasAspectRatioWidthMultiplier({ state });
+  const maxWidthVh = Number((widthMultiplier * 50).toFixed(4));
+
+  return `min(100%, ${maxWidthVh}vh)`;
+};
+
 export const createInitialState = () => {
   return {
     lastUpdateDate: undefined,
@@ -459,6 +478,7 @@ export const selectViewData = ({ state, constants }) => {
     contextMenuItems,
     emptyContextMenuItems,
     layoutState,
+    layoutEditorCanvasMaxWidth: selectLayoutEditorCanvasMaxWidth({ state }),
     previewData: state.previewData,
     initialPreviewData: state.initialPreviewData,
     isPreviewMounted: state.isPreviewMounted,

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -52,7 +52,9 @@ template:
                   - rtgl-text: ${layout.name}
               - rtgl-button#saveButton ml=sm: Save Preview
           - 'rtgl-view d=v h=1fg w=f style="min-height: 0;"':
-              - rvn-layout-editor-canvas#layoutEditorCanvas :resolution=${projectResolution} :layoutState=${layoutState} selectedItemId=${selectedItemId} :previewData=${previewData} :disableMoveDrag=${selectedItemIsInsideDirectedContainer}: null
+              - 'rtgl-view w=f style="min-width: 0;"':
+                  - 'div style="position: relative; width: ${layoutEditorCanvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto;"':
+                      - 'rvn-layout-editor-canvas#layoutEditorCanvas style="display: block; width: 100%;" :resolution=${projectResolution} :layoutState=${layoutState} selectedItemId=${selectedItemId} :previewData=${previewData} :disableMoveDrag=${selectedItemIsInsideDirectedContainer}': null
               - 'rtgl-view h=1fg w=f sv style="min-height: 0;"':
                   - $if isPreviewMounted:
                       - rvn-layout-editor-preview#layoutEditorPreview :layoutState=${layoutState} :initialPreviewData=${initialPreviewData} :charactersData=${charactersData}: null


### PR DESCRIPTION
Summary: Cap the layout editor canvas to half the viewport height using the project aspect ratio, and center it above the preview settings panel. Validation: prettier on edited files; oxlint on layoutEditor.store.js; rtgl fe check; push hook oxlint and prettier passed.