### PR TITLE
Use wrapper radius for thumbnail cards

### DIFF
--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -118,16 +118,16 @@ template:
                                           - $if item.cardKind == 'color':
                                               - 'rtgl-view d=v w=f br=md style="overflow: hidden;"':
                                                   - $if item.useFullWidthCatalogPreview:
-                                                      - 'rtgl-view w=f br=sm style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden; background-color: ${item.swatchHex};"': null
+                                                      - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden; background-color: ${item.swatchHex};"': null
                                                     $else:
-                                                      - 'rtgl-view w=f h=120 br=sm style="background-color: ${item.swatchHex};"': null
+                                                      - 'rtgl-view w=f h=120 style="background-color: ${item.swatchHex};"': null
                                                   - rtgl-view w=f p=md:
                                                       - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
                                             $elif item.cardKind == 'layout':
                                               - $if item.cardVariant == 'thumbnail':
                                                   - 'rtgl-view w=${item.layoutPreviewWidth} br=md style="overflow: hidden; max-width: 100%;"':
                                                       - $if item.useFullWidthCatalogPreview:
-                                                          - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                          - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                               - $if item.previewFileId:
                                                                   - rvn-file-image fileId=${item.previewFileId} w=f h=f: null
                                                                 $else:
@@ -163,7 +163,7 @@ template:
                                             $elif item.cardKind == 'transform':
                                               - 'rtgl-view w=f br=md style="overflow: hidden;"':
                                                   - $if item.useFullWidthCatalogPreview:
-                                                      - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                      - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                           - $if item.thumbnailFileId:
                                                               - rvn-file-image fileId=${item.thumbnailFileId} w=f h=f: null
                                                             $else:

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -151,24 +151,24 @@ template:
                                                   - 'rtgl-view br=md w=${item.imageCardWidth} pos=rel overflow=hidden style="${item.imageCardStyle}"':
                                                       - $if showImageCardPreview:
                                                           - $if item.useFullWidthImageCard:
-                                                              - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${item.previewAspectRatio}; overflow: hidden; border-radius: 8px;"':
+                                                              - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                                   - $if item.isProcessing:
-                                                                      - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                      - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                           - rtgl-text s=sm c=mu-fg: Processing...
                                                                     $elif lazyImageCards && item.shouldLazyLoadPreview:
-                                                                      - rvn-file-image br=md w=f h=f fileId=${item.previewFileId} lazy: null
+                                                                      - rvn-file-image w=f h=f fileId=${item.previewFileId} lazy: null
                                                                     $else:
-                                                                      - rvn-file-image br=md w=f h=f fileId=${item.previewFileId}: null
+                                                                      - rvn-file-image w=f h=f fileId=${item.previewFileId}: null
                                                             $else:
-                                                              - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; height: ${imageHeight}px; overflow: hidden; border-radius: 8px;"':
+                                                              - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; height: ${imageHeight}px; overflow: hidden;"':
                                                                   - $if item.isProcessing:
-                                                                      - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                      - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                           - rtgl-text s=sm c=mu-fg: Processing...
                                                                     $else:
                                                                       - $if lazyImageCards && item.shouldLazyLoadPreview:
-                                                                          - rvn-file-image br=md w=f h=f fileId=${item.previewFileId} lazy: null
+                                                                          - rvn-file-image w=f h=f fileId=${item.previewFileId} lazy: null
                                                                         $else:
-                                                                          - rvn-file-image br=md w=f h=f fileId=${item.previewFileId}: null
+                                                                          - rvn-file-image w=f h=f fileId=${item.previewFileId}: null
                                                       - $if item.showPreviewIcon:
                                                           - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
                                                               - rtgl-svg svg=zoomIn wh=22 c=white: null
@@ -177,22 +177,22 @@ template:
                                                 $elif item.cardKind == 'video':
                                                   - 'rtgl-view br=md pos=rel w=${item.mediaCardWidth} overflow=hidden style="${item.mediaCardStyle}"':
                                                       - $if item.useFullWidthMediaPreview:
-                                                          - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                          - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                               - $if item.isProcessing:
-                                                                  - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                  - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                       - rtgl-text s=sm c=mu-fg: Processing...
                                                                 $elif item.thumbnailFileId:
-                                                                  - rvn-file-image br=md w=f h=f fileId=${item.thumbnailFileId}: null
+                                                                  - rvn-file-image w=f h=f fileId=${item.thumbnailFileId}: null
                                                                 $else:
-                                                                  - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                  - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                       - rtgl-text s=xs c=mu-fg: No thumbnail
                                                         $elif item.isProcessing:
-                                                          - rtgl-view w=f h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=sm c=mu-fg: Processing...
                                                         $elif item.thumbnailFileId:
-                                                          - rvn-file-image br=md w=f h=${mediaHeight} fileId=${item.thumbnailFileId}: null
+                                                          - rvn-file-image w=f h=${mediaHeight} fileId=${item.thumbnailFileId}: null
                                                         $else:
-                                                          - rtgl-view w=f h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=xs c=mu-fg: No thumbnail
                                                       - $if item.showPreviewIcon:
                                                           - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
@@ -202,22 +202,22 @@ template:
                                                 $elif item.cardKind == 'sound':
                                                   - 'rtgl-view br=md pos=rel w=${item.mediaCardWidth} overflow=hidden style="${item.mediaCardStyle}"':
                                                       - $if item.useFullWidthMediaPreview:
-                                                          - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                          - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                               - $if item.isProcessing:
-                                                                  - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                  - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                       - rtgl-text s=sm c=mu-fg: Processing...
                                                                 $elif item.waveformDataFileId:
                                                                   - rvn-waveform-visualizer key=${item.waveformDataFileId}-${item.mediaCardWidth}x16x9 waveformDataFileId=${item.waveformDataFileId} w=f h=f: null
                                                                 $else:
-                                                                  - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                  - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                       - rtgl-text s=xs c=mu-fg: No waveform
                                                         $elif item.isProcessing:
-                                                          - rtgl-view w=f h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=sm c=mu-fg: Processing...
                                                         $elif item.waveformDataFileId:
                                                           - rvn-waveform-visualizer key=${item.waveformDataFileId}-${item.mediaCardWidth}x${mediaHeight} waveformDataFileId=${item.waveformDataFileId} w=f h=${mediaHeight}: null
                                                         $else:
-                                                          - rtgl-view w=f h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=xs c=mu-fg: No waveform
                                                       - $if item.showPreviewIcon:
                                                           - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
@@ -227,14 +227,14 @@ template:
                                                 $elif item.cardKind == 'font':
                                                   - 'rtgl-view w=${item.mediaCardWidth} d=v br=md overflow=hidden style="${item.mediaCardStyle}"':
                                                       - $if item.useFullWidthFontPreview:
-                                                          - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                          - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                               - $if item.isProcessing:
-                                                                  - rtgl-view w=f h=f br=md bw=xs bc=bo av=c ah=c:
+                                                                  - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                       - rtgl-text s=sm c=mu-fg: Processing...
                                                                 $else:
                                                                   - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=f height=f padding=8 av=c ah=c: null
                                                         $elif item.isProcessing:
-                                                          - rtgl-view w=f h=${mediaHeight} br=md bw=xs bc=bo av=c ah=c:
+                                                          - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=sm c=mu-fg: Processing...
                                                         $else:
                                                           - rvn-font-preview fontFamily=${item.fontFamily} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=60 width=${item.fontPreviewWidth} height=${mediaHeight} av=c ah=c: null

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -110,7 +110,7 @@ template:
                                       - rtgl-view#itemRef${gIndex}x${itemIndex} data-item-id=${item.id} w=${item.itemWidth} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md style="${item.itemContainerStyle}":
                                           - 'rtgl-view w=f br=md style="overflow: hidden;"':
                                               - $if item.useFullWidthPreview:
-                                                  - 'rtgl-view w=f br=md style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                  - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                       - rvn-font-preview fontFamily=${item.fontStyle} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=${item.fontSize} lineHeight=${item.lineHeight} color=${item.color} strokeColor=${item.strokeColor} strokeWidth=${item.strokeWidth} fontWeight=${item.fontWeight} width=f height=f padding=8 showBorder=false: null
                                                 $else:
                                                   - rvn-font-preview fontFamily=${item.fontStyle} previewText="${item.previewText}" fileId=${item.fontFileId} fontSize=${item.fontSize} lineHeight=${item.lineHeight} color=${item.color} strokeColor=${item.strokeColor} strokeWidth=${item.strokeWidth} fontWeight=${item.fontWeight} width=${item.previewWidth} height=96 padding=8 showBorder=false: null

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -335,7 +335,7 @@ template:
                                                   - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
                                                       - $if image.previewFileId:
                                                           - 'rtgl-view w=f br=md style="aspect-ratio: ${image.previewAspectRatio}; overflow: hidden;"':
-                                                              - rvn-file-image br=md w=f h=f fileId=${image.previewFileId}: null
+                                                              - rvn-file-image w=f h=f fileId=${image.previewFileId}: null
                                                         $else:
                                                               - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=xs c=mu-fg: No preview
@@ -363,7 +363,7 @@ template:
                                       - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
                                           - $if item.image.previewFileId:
                                               - 'rtgl-view w=f br=md style="aspect-ratio: ${item.image.previewAspectRatio}; overflow: hidden;"':
-                                                  - rvn-file-image br=md w=f h=f fileId=${item.image.previewFileId}: null
+                                                  - rvn-file-image w=f h=f fileId=${item.image.previewFileId}: null
                                             $else:
                                               - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
                                                   - rtgl-text s=xs c=mu-fg: No preview

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -212,7 +212,7 @@ template:
                                   - 'rtgl-view#dialogPreviewBackgroundImageButton cur=pointer bw=xs bc=${dialogPreviewBackgroundImage.itemBorderColor} h-bc=${dialogPreviewBackgroundImage.itemHoverBorderColor} br=md w=160 style="max-width: 100%; box-sizing: border-box;"':
                                       - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
                                           - 'rtgl-view w=f br=md style="aspect-ratio: ${dialogPreviewBackgroundImage.previewAspectRatio}; overflow: hidden;"':
-                                              - rvn-file-image br=md w=f h=f fileId=${dialogPreviewBackgroundImage.previewFileId}: null
+                                              - rvn-file-image w=f h=f fileId=${dialogPreviewBackgroundImage.previewFileId}: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=f: ${dialogPreviewBackgroundImage.name}
                                 $else:
                                   - 'rtgl-view#dialogPreviewBackgroundImageButton w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -176,7 +176,7 @@ template:
                                       - $if selectedItem:
                                           - 'rtgl-view slot="transform-preview" w=f bw=xs bc=bo br=md style="aspect-ratio: 16 / 9; overflow: hidden;"':
                                               - $if selectedItem.thumbnailFileId:
-                                                  - rvn-file-image fileId=${selectedItem.thumbnailFileId} w=f h=f br=md: null
+                                                  - rvn-file-image fileId=${selectedItem.thumbnailFileId} w=f h=f: null
                                                 $else:
                                                   - rtgl-view w=f h=f av=c ah=c bgc=bg:
                                                       - rtgl-view d=v av=c ah=c g=xs ph=sm:
@@ -239,7 +239,7 @@ template:
                                           - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
                                               - $if item.image.previewFileId:
                                                   - 'rtgl-view w=f br=md style="aspect-ratio: ${item.image.previewAspectRatio}; overflow: hidden;"':
-                                                      - rvn-file-image br=md w=f h=f fileId=${item.image.previewFileId}: null
+                                                      - rvn-file-image w=f h=f fileId=${item.image.previewFileId}: null
                                                 $else:
                                                   - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
                                                       - rtgl-text s=xs c=mu-fg: No preview


### PR DESCRIPTION
## Summary
- remove nested border radius from thumbnail preview frames/images where the outer card already clips with radius
- apply the wrapper-only radius pattern across media, catalog, text style, animation, transform, and particle thumbnail grids
- avoid adding new props for thumbnail border radius

## Validation
- bun run lint
- pre-push hook: bun run lint