### PR TITLE
Improve transparency previews and section delete guard

### DIFF
--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -96,10 +96,11 @@ refs:
         handler: handlePreviewActionClick
 styles:
   ".mediaImageThumbnailTransparencyGrid":
-    background-color: "#f4f4f4"
-    background-image: 'url("data:image/svg+xml,%3Csvg xmlns=''http://www.w3.org/2000/svg'' width=''16'' height=''16'' viewBox=''0 0 16 16''%3E%3Cpath fill=''%23d0d0d0'' d=''M0 0h8v8H0zM8 8h8v8H8z''/%3E%3Cpath fill=''%23f4f4f4'' d=''M8 0h8v8H8zM0 8h8v8H0z''/%3E%3C/svg%3E")'
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 6px, 6px -6px, -6px 0"
     background-repeat: repeat
-    background-size: 16px 16px
+    background-size: 12px 12px
 template:
   - 'rtgl-view w=f h=f g=sm style="min-width: 0; min-height: 0;"':
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':

--- a/src/components/spritesheetPreview/spritesheetPreview.handlers.js
+++ b/src/components/spritesheetPreview/spritesheetPreview.handlers.js
@@ -2,8 +2,32 @@ import { isVisualTestMode } from "../../internal/visualTestMode.js";
 import { resolveSpritesheetAnimationFps } from "../../internal/spritesheets.js";
 
 const PREVIEW_PADDING_PX = 16;
+const TRANSPARENCY_GRID_CELL_SIZE_PX = 12;
+const TRANSPARENCY_GRID_LIGHT_COLOR = "#eef2f7";
+const TRANSPARENCY_GRID_DARK_COLOR = "#94a3b8";
 
 const isPaused = (value) => value === true || value === "true";
+
+const drawTransparencyGrid = (context, width, height) => {
+  context.fillStyle = TRANSPARENCY_GRID_LIGHT_COLOR;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = TRANSPARENCY_GRID_DARK_COLOR;
+  for (let y = 0; y < height; y += TRANSPARENCY_GRID_CELL_SIZE_PX) {
+    const rowIndex = Math.floor(y / TRANSPARENCY_GRID_CELL_SIZE_PX);
+    for (let x = 0; x < width; x += TRANSPARENCY_GRID_CELL_SIZE_PX) {
+      const columnIndex = Math.floor(x / TRANSPARENCY_GRID_CELL_SIZE_PX);
+      if ((rowIndex + columnIndex) % 2 === 0) {
+        context.fillRect(
+          x,
+          y,
+          TRANSPARENCY_GRID_CELL_SIZE_PX,
+          TRANSPARENCY_GRID_CELL_SIZE_PX,
+        );
+      }
+    }
+  }
+};
 
 const clearCanvas = (canvas) => {
   if (
@@ -31,8 +55,7 @@ const clearCanvas = (canvas) => {
   }
 
   context.clearRect(0, 0, width, height);
-  context.fillStyle = "#000000";
-  context.fillRect(0, 0, width, height);
+  drawTransparencyGrid(context, width, height);
 };
 
 const revokeOwnedImageSrc = (store) => {

--- a/src/components/spritesheetPreview/spritesheetPreview.view.yaml
+++ b/src/components/spritesheetPreview/spritesheetPreview.view.yaml
@@ -9,8 +9,15 @@ refs:
         handler: handleSourceImageError
   canvas:
     selector: canvas
+styles:
+  ".spritesheetPreviewTransparencyGrid":
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 12px, 12px -12px, -12px 0"
+    background-repeat: repeat
+    background-size: 24px 24px
 template:
-  - 'rtgl-view w=${w} h=${h} pos=rel bgc=bg bc=bo bw=xs br=md of=hidden data-preview-status="${status}"':
+  - 'rtgl-view.spritesheetPreviewTransparencyGrid w=${w} h=${h} pos=rel bc=bo bw=xs br=md of=hidden data-preview-status="${status}"':
       - 'canvas#canvas style="width: 100%; height: 100%; display: block;"': null
       - $if imageSrc:
           - 'img#sourceImage src=${imageSrc} style="display: none;"': null

--- a/src/deps/services/shared/commandApi/story.js
+++ b/src/deps/services/shared/commandApi/story.js
@@ -41,6 +41,87 @@ export const createStoryCommandApi = (shared) => {
     return appendMissingIds(orderedFromTree, fallbackIds);
   };
 
+  const collectActionTargetSectionIds = (actions) => {
+    const sectionIds = new Set();
+
+    const scanActionValue = (value, key) => {
+      if (key === "when") {
+        return;
+      }
+
+      if (!value || typeof value !== "object") {
+        return;
+      }
+
+      if (
+        (key === "sectionTransition" || key === "resetStoryAtSection") &&
+        typeof value.sectionId === "string" &&
+        value.sectionId.length > 0
+      ) {
+        sectionIds.add(value.sectionId);
+      }
+
+      if (Array.isArray(value)) {
+        value.forEach((entry) => scanActionValue(entry));
+        return;
+      }
+
+      Object.entries(value).forEach(([entryKey, entryValue]) => {
+        scanActionValue(entryValue, entryKey);
+      });
+    };
+
+    scanActionValue(actions);
+
+    return [...sectionIds];
+  };
+
+  const findSectionReferenceUsage = (state, targetSectionIds = []) => {
+    const targetIds = new Set(
+      targetSectionIds.filter(
+        (sectionId) => typeof sectionId === "string" && sectionId.length > 0,
+      ),
+    );
+
+    if (targetIds.size === 0) {
+      return undefined;
+    }
+
+    const sceneItems = state?.scenes?.items || {};
+
+    for (const [sceneId, scene] of Object.entries(sceneItems)) {
+      const sectionItems = scene?.sections?.items || {};
+
+      for (const [sourceSectionId, section] of Object.entries(sectionItems)) {
+        if (targetIds.has(sourceSectionId)) {
+          continue;
+        }
+
+        const lineItems = section?.lines?.items || {};
+
+        for (const lineId of getOrderedLineIds(section)) {
+          const line = lineItems[lineId];
+          const referencedSectionId = collectActionTargetSectionIds(
+            line?.actions,
+          ).find((sectionId) => targetIds.has(sectionId));
+
+          if (referencedSectionId) {
+            return {
+              sceneId,
+              sceneName: scene?.name,
+              sectionId: sourceSectionId,
+              sectionName: section?.name,
+              lineId,
+              referencedSectionId,
+            };
+          }
+        }
+      }
+    }
+
+    return undefined;
+  };
+
   const findTreeNodeById = (nodes = [], nodeId) => {
     for (const node of nodes || []) {
       if (!node || typeof node !== "object") {
@@ -950,21 +1031,50 @@ export const createStoryCommandApi = (shared) => {
 
     async deleteSectionItem({ sceneId, sectionIds }) {
       const context = await shared.ensureCommandContext();
+      const allSceneIds = Object.entries(context.state?.scenes?.items || {})
+        .filter(([_id, scene]) => scene?.type !== "folder")
+        .map(([id]) => id);
+      const deleteContext =
+        allSceneIds.length > 0 &&
+        typeof context.repository?.getContextState === "function"
+          ? {
+              ...context,
+              state: await context.repository.getContextState({
+                sceneIds: allSceneIds,
+              }),
+            }
+          : context;
       const sceneIdsForPartitions = new Set();
+      const sectionReferenceUsage = findSectionReferenceUsage(
+        deleteContext.state,
+        sectionIds || [],
+      );
+
+      if (sectionReferenceUsage) {
+        return {
+          valid: false,
+          error: {
+            message:
+              "This section can't be deleted because another section references it.",
+            code: "section_referenced",
+            details: sectionReferenceUsage,
+          },
+        };
+      }
 
       if (typeof sceneId === "string" && sceneId.length > 0) {
         sceneIdsForPartitions.add(sceneId);
       }
 
       for (const id of sectionIds || []) {
-        const sectionLocation = findSectionLocation(context.state, id);
+        const sectionLocation = findSectionLocation(deleteContext.state, id);
         if (sectionLocation?.sceneId) {
           sceneIdsForPartitions.add(sectionLocation.sceneId);
         }
       }
 
       return shared.submitCommandWithContext({
-        context,
+        context: deleteContext,
         scope: "story",
         partition: getMainScenePartition(context, [...sceneIdsForPartitions]),
         type: COMMAND_TYPES.SECTION_DELETE,

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -154,10 +154,11 @@ styles:
     right: "0"
     background: linear-gradient(to left, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
   ".imagePreviewTransparencyGrid":
-    background-color: "#f4f4f4"
-    background-image: 'url("data:image/svg+xml,%3Csvg xmlns=''http://www.w3.org/2000/svg'' width=''32'' height=''32'' viewBox=''0 0 32 32''%3E%3Cpath fill=''%23d0d0d0'' d=''M0 0h16v16H0zM16 16h16v16H16z''/%3E%3Cpath fill=''%23f4f4f4'' d=''M16 0h16v16H16zM0 16h16v16H0z''/%3E%3C/svg%3E")'
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 12px, 12px -12px, -12px 0"
     background-repeat: repeat
-    background-size: 32px 32px
+    background-size: 24px 24px
   ".imagePreviewFrame":
     position: relative
     overflow: hidden

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -2539,14 +2539,21 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   }
 
   if (action === "delete-section") {
+    render();
     await flushSceneEditorDrafts(deps, { force: true });
     await runSceneEditorPersistence(
       deps,
       async () => {
-        await projectService.deleteSectionItem({
-          sceneId,
-          sectionIds: [sectionId],
-        });
+        assertSceneEditorCommandResult(
+          await projectService.deleteSectionItem({
+            sceneId,
+            sectionIds: [sectionId],
+          }),
+          {
+            appService,
+            fallbackMessage: "Failed to delete section",
+          },
+        );
       },
       {
         label: "delete-section",

--- a/tests/commandApi/storyCommandApi.test.js
+++ b/tests/commandApi/storyCommandApi.test.js
@@ -39,6 +39,105 @@ const createEmptyStoryState = () => ({
 });
 
 describe("story command api", () => {
+  it("rejects deleting a section referenced by another scene projection", async () => {
+    const contextState = {
+      scenes: {
+        items: {
+          "scene-1": {
+            id: "scene-1",
+            type: "scene",
+            name: "Scene 1",
+            sections: {
+              items: {
+                "section-1": {
+                  id: "section-1",
+                  name: "Intro",
+                  lines: {
+                    items: {},
+                    tree: [],
+                  },
+                },
+              },
+              tree: [{ id: "section-1" }],
+            },
+          },
+          "scene-2": {
+            id: "scene-2",
+            type: "scene",
+            name: "Scene 2",
+            sections: {
+              items: {
+                "section-2": {
+                  id: "section-2",
+                  name: "Branch",
+                  lines: {
+                    items: {},
+                    tree: [],
+                  },
+                },
+              },
+              tree: [{ id: "section-2" }],
+            },
+          },
+        },
+        tree: [{ id: "scene-1" }, { id: "scene-2" }],
+      },
+    };
+    const fullState = structuredClone(contextState);
+    fullState.scenes.items["scene-2"].sections.items["section-2"].lines = {
+      items: {
+        "line-1": {
+          id: "line-1",
+          actions: {
+            sectionTransition: {
+              sceneId: "scene-1",
+              sectionId: "section-1",
+            },
+          },
+        },
+      },
+      tree: [{ id: "line-1" }],
+    };
+    const context = {
+      projectId: "project-1",
+      state: contextState,
+      repository: {
+        getContextState: vi.fn(async () => fullState),
+      },
+    };
+    const shared = {
+      ensureCommandContext: vi.fn(async () => context),
+      submitCommandWithContext: vi.fn(async () => ({ valid: true })),
+    };
+    const api = createStoryCommandApi(shared);
+
+    const result = await api.deleteSectionItem({
+      sceneId: "scene-1",
+      sectionIds: ["section-1"],
+    });
+
+    expect(context.repository.getContextState).toHaveBeenCalledWith({
+      sceneIds: ["scene-1", "scene-2"],
+    });
+    expect(result).toEqual({
+      valid: false,
+      error: {
+        message:
+          "This section can't be deleted because another section references it.",
+        code: "section_referenced",
+        details: {
+          sceneId: "scene-2",
+          sceneName: "Scene 2",
+          sectionId: "section-2",
+          sectionName: "Branch",
+          lineId: "line-1",
+          referencedSectionId: "section-1",
+        },
+      },
+    });
+    expect(shared.submitCommandWithContext).not.toHaveBeenCalled();
+  });
+
   it("creates a scene with its initial section and line in one ordered batch", async () => {
     const context = {
       projectId: "project-1",

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -1943,6 +1943,73 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     }
   });
 
+  it("closes the section dropdown before showing a delete validation alert", async () => {
+    const store = {
+      selectDropdownMenu: vi.fn(() => ({
+        sectionId: "section-1",
+      })),
+      hideDropdownMenu: vi.fn(),
+      selectSceneId: vi.fn(() => "scene-1"),
+      selectSelectedSectionId: vi.fn(() => "section-1"),
+      selectDraftSaveTimerId: vi.fn(() => undefined),
+      selectDraftSectionBySectionId: vi.fn(() => ({
+        sceneId: "scene-1",
+        sectionId: "section-1",
+        dirty: false,
+        lines: [],
+      })),
+      selectPendingDraftSections: vi.fn(() => []),
+      setDraftSavePendingSinceAt: vi.fn(),
+    };
+    const render = vi.fn();
+    const showAlert = vi.fn();
+    const deps = {
+      store,
+      render,
+      refs: {},
+      projectService: {
+        deleteSectionItem: vi.fn(async () => ({
+          valid: false,
+          error: {
+            message:
+              "This section can't be deleted because another section references it.",
+          },
+        })),
+      },
+      subject: {
+        dispatch: vi.fn(),
+      },
+      appService: {
+        showAlert,
+      },
+    };
+
+    await expect(
+      handleDropdownMenuClickItem(deps, {
+        _event: {
+          detail: {
+            item: {
+              value: "delete-section",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      "This section can't be deleted because another section references it.",
+    );
+
+    expect(store.hideDropdownMenu).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalled();
+    expect(showAlert).toHaveBeenCalledWith({
+      message:
+        "This section can't be deleted because another section references it.",
+      title: "Error",
+    });
+    expect(render.mock.invocationCallOrder[0]).toBeLessThan(
+      showAlert.mock.invocationCallOrder[0],
+    );
+  });
+
   it("opens section create dialog with below placement from the section menu", async () => {
     const store = {
       selectDropdownMenu: vi.fn(() => ({


### PR DESCRIPTION
## Summary
- improve transparency checkerboards for image thumbnails and full-screen image previews
- draw a checkerboard directly into spritesheet preview canvases instead of filling them black
- reject section deletion when another section action references the target section, and close the scene editor menu before showing the validation alert

## Validation
- bun prettier --check src/components/mediaResourcesView/mediaResourcesView.view.yaml src/components/spritesheetPreview/spritesheetPreview.handlers.js src/components/spritesheetPreview/spritesheetPreview.view.yaml src/deps/services/shared/commandApi/story.js src/pages/images/images.view.yaml src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js tests/commandApi/storyCommandApi.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js
- bunx vitest run tests/commandApi/storyCommandApi.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js
- bun run lint
- pre-push hook: bun run lint