### PR TITLE
Add canvas-scale preview modes

### DIFF
--- a/src/internal/layoutEditorElementRegistry.js
+++ b/src/internal/layoutEditorElementRegistry.js
@@ -65,7 +65,7 @@ const CREATE_TEMPLATES = {
   }),
   sprite: () => ({
     type: "sprite",
-    name: "Sprite",
+    name: "Image",
     ...BASE_TRANSFORM,
     aspectRatioLock: 1,
     width: 0,
@@ -316,7 +316,7 @@ const CREATE_TEMPLATES = {
     scaleLayoutElementItemForProjectResolution(
       {
         type: "sprite-ref-save-load-slot-image",
-        name: "Sprite (Save Image)",
+        name: "Image (Save Image)",
         ...BASE_TRANSFORM,
         aspectRatioLock: 320 / 180,
         width: 320,

--- a/src/internal/ui/resourcePages/tags.js
+++ b/src/internal/ui/resourcePages/tags.js
@@ -44,11 +44,13 @@ export const createTagField = ({
   label = "Tags",
   placeholder = "Select tags",
   addOptionLabel = "Add tag",
+  options = [],
 } = {}) => ({
   name,
   type: "tag-select",
   label,
   placeholder,
+  options,
   addOption: {
     label: addOptionLabel,
   },

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -76,8 +76,7 @@ const {
   handleKeyboardScopeClick: handleFileExplorerKeyboardScopeClick,
   handleKeyboardScopeKeyDown: handleBaseFileExplorerKeyboardScopeKeyDown,
 } = createFileExplorerKeyboardScopeHandlers({
-  isNavigationBlocked: ({ deps }) =>
-    deps.store.getState().fullImagePreviewVisible,
+  isNavigationBlocked: ({ deps }) => deps.store.selectFullImagePreviewVisible(),
   onEnterKey: ({ deps, selectedItemId }) => {
     openSpritePreviewById({ deps, itemId: selectedItemId, syncExplorer: true });
   },
@@ -132,6 +131,9 @@ const syncCharacterSpritesData = ({ deps, repositoryState } = {}) => {
   store.setCharacterName({ characterName: character.name });
   store.setTagsData({ tagsData });
   store.setItems({ spritesData });
+  store.setProjectResolution({
+    projectResolution: state?.project?.resolution,
+  });
 
   if (store.selectSelectedItemId() && !store.selectSelectedItem()) {
     store.setSelectedItemId({ itemId: undefined });
@@ -629,11 +631,31 @@ export const handlePreviewNextClick = (deps, payload) => {
   navigateSpritePreview(deps, { direction: "next" });
 };
 
+export const handlePreviewFitModeClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const { store, render } = deps;
+  store.setFullImagePreviewDisplayMode({ displayMode: "fit" });
+  render();
+  focusPreviewOverlay(deps);
+};
+
+export const handlePreviewCanvasModeClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const { store, render } = deps;
+  store.setFullImagePreviewDisplayMode({ displayMode: "canvas" });
+  render();
+  focusPreviewOverlay(deps);
+};
+
 export const handlePreviewOverlayKeyDown = (deps, payload) => {
   const { store } = deps;
   const event = payload._event;
 
-  if (!store.getState().fullImagePreviewVisible) {
+  if (!store.selectFullImagePreviewVisible()) {
     return;
   }
 
@@ -645,6 +667,15 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
     event.preventDefault();
     event.stopPropagation();
     closeSpritePreview(deps);
+    return;
+  }
+
+  if (event.key === "Tab") {
+    event.preventDefault();
+    event.stopPropagation();
+    store.toggleFullImagePreviewDisplayMode();
+    deps.render();
+    focusPreviewOverlay(deps);
     return;
   }
 
@@ -662,7 +693,7 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
 export const handleFileExplorerKeyboardScopeKeyDown = (deps, payload) => {
   const event = payload?._event;
   if (
-    deps.store.getState().fullImagePreviewVisible &&
+    deps.store.selectFullImagePreviewVisible() &&
     isResourceZoomShortcutKeyEvent(event)
   ) {
     event.preventDefault();

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -225,11 +225,11 @@ const navigateSpritePreview = (deps, { direction, distance, clamp } = {}) => {
 };
 
 const resolvePreviewNavigationDirection = (event) => {
-  if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+  if (event.key === "ArrowDown") {
     return { direction: "next" };
   }
 
-  if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+  if (event.key === "ArrowUp") {
     return { direction: "previous" };
   }
 
@@ -251,12 +251,37 @@ const resolvePreviewNavigationDirection = (event) => {
   }
 
   const key = String(event.key ?? "").toLowerCase();
-  if (key === "j" || key === "l") {
+  if (key === "j") {
     return { direction: "next" };
   }
 
-  if (key === "k" || key === "h") {
+  if (key === "k") {
     return { direction: "previous" };
+  }
+
+  return undefined;
+};
+
+const resolvePreviewDisplayMode = (event) => {
+  if (event.altKey || event.ctrlKey || event.metaKey) {
+    return undefined;
+  }
+
+  if (event.key === "ArrowLeft") {
+    return "canvas";
+  }
+
+  if (event.key === "ArrowRight") {
+    return "fit";
+  }
+
+  const key = String(event.key ?? "").toLowerCase();
+  if (key === "h") {
+    return "canvas";
+  }
+
+  if (key === "l") {
+    return "fit";
   }
 
   return undefined;
@@ -670,10 +695,11 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
     return;
   }
 
-  if (event.key === "Tab") {
+  const displayMode = resolvePreviewDisplayMode(event);
+  if (displayMode) {
     event.preventDefault();
     event.stopPropagation();
-    store.toggleFullImagePreviewDisplayMode();
+    store.setFullImagePreviewDisplayMode({ displayMode });
     deps.render();
     focusPreviewOverlay(deps);
     return;

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -7,6 +7,11 @@ import {
   matchesTagFilter,
 } from "../../internal/resourceTags.js";
 import {
+  DEFAULT_PROJECT_RESOLUTION,
+  formatProjectResolutionAspectRatio,
+  requireProjectResolution,
+} from "../../internal/projectResolution.js";
+import {
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD,
   shouldStartCollapsedFileExplorer,
 } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
@@ -37,12 +42,65 @@ const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
 const IMAGE_CARD_MAX_WIDTH = 400;
 const IMAGE_CARD_HEIGHT = 225;
-const PREVIEW_FRAME_STYLE = [
-  "width: 92vw",
-  "height: 92vh",
-  "max-width: 92vw",
-  "max-height: 92vh",
-].join("; ");
+const FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT = "fit";
+const FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS = "canvas";
+
+const createPreviewFrameStyle = (projectResolution) => {
+  const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
+
+  return [
+    `width: min(92vw, calc(92vh * (${aspectRatio})))`,
+    `aspect-ratio: ${aspectRatio}`,
+    "max-width: 92vw",
+    "max-height: 92vh",
+  ].join("; ");
+};
+
+const resolvePositiveNumber = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0
+    ? numericValue
+    : undefined;
+};
+
+const createPreviewImageWrapperStyle = ({
+  image,
+  displayMode,
+  projectResolution,
+} = {}) => {
+  if (displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS) {
+    return "position: absolute; inset: 0;";
+  }
+
+  const imageWidth = resolvePositiveNumber(image?.width);
+  const imageHeight = resolvePositiveNumber(image?.height);
+  if (!imageWidth || !imageHeight) {
+    return "position: absolute; inset: 0;";
+  }
+
+  const widthPercent = (imageWidth / projectResolution.width) * 100;
+  const heightPercent = (imageHeight / projectResolution.height) * 100;
+
+  return [
+    "position: absolute",
+    "left: 50%",
+    "top: 50%",
+    `width: ${widthPercent}%`,
+    `height: ${heightPercent}%`,
+    "transform: translate(-50%, -50%)",
+  ].join("; ");
+};
+
+const createPreviewModeButtonViewData = ({ displayMode, mode } = {}) => {
+  const selected = displayMode === mode;
+
+  return {
+    backgroundColor: selected ? "ac" : "bg",
+    borderColor: selected ? "ac" : "bo",
+    iconColor: selected ? "white" : "mu-fg",
+    selected,
+  };
+};
 
 const folderContextMenuItems = [
   { label: "New Folder", type: "item", value: "new-child-folder" },
@@ -267,6 +325,8 @@ export const createInitialState = () => ({
   ...createMobileResourcePageState(),
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
+  fullImagePreviewDisplayMode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  projectResolution: DEFAULT_PROJECT_RESOLUTION,
   isEditDialogOpen: false,
   editItemId: undefined,
   editDefaultValues: {
@@ -362,6 +422,13 @@ export const setCharacterName = ({ state }, { characterName } = {}) => {
   state.characterName = characterName;
 };
 
+export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
+  state.projectResolution = requireProjectResolution(
+    projectResolution ?? DEFAULT_PROJECT_RESOLUTION,
+    "Project resolution",
+  );
+};
+
 export const clearCharacterSpritesView = ({ state }) => {
   state.characterName = undefined;
   state.spritesData = EMPTY_TREE;
@@ -375,6 +442,8 @@ export const clearCharacterSpritesView = ({ state }) => {
   state.selectedFolderId = undefined;
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
+  state.fullImagePreviewDisplayMode = FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+  state.projectResolution = DEFAULT_PROJECT_RESOLUTION;
   state.isEditDialogOpen = false;
   state.editItemId = undefined;
   state.editDefaultValues = {
@@ -576,6 +645,10 @@ export const showFullImagePreview = ({ state }, { itemId } = {}) => {
   const item = state.spritesData.items?.[itemId];
 
   if (item?.type === "image" && item.fileId) {
+    if (!state.fullImagePreviewVisible) {
+      state.fullImagePreviewDisplayMode =
+        FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+    }
     state.fullImagePreviewVisible = true;
     state.fullImagePreviewFileId = item.fileId;
   }
@@ -584,6 +657,30 @@ export const showFullImagePreview = ({ state }, { itemId } = {}) => {
 export const hideFullImagePreview = ({ state }, _payload = {}) => {
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
+};
+
+export const setFullImagePreviewDisplayMode = (
+  { state },
+  { displayMode } = {},
+) => {
+  if (
+    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT &&
+    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
+  ) {
+    return;
+  }
+
+  state.fullImagePreviewDisplayMode = displayMode;
+};
+
+export const selectFullImagePreviewVisible = ({ state }) =>
+  state.fullImagePreviewVisible;
+
+export const toggleFullImagePreviewDisplayMode = ({ state }) => {
+  state.fullImagePreviewDisplayMode =
+    state.fullImagePreviewDisplayMode === FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
+      ? FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT
+      : FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
 };
 
 export const selectViewData = ({ state }) => {
@@ -642,6 +739,12 @@ export const selectViewData = ({ state }) => {
     .filter((group) => group.shouldDisplay);
 
   const selectedItem = state.spritesData.items?.[state.selectedItemId];
+  const previewImage =
+    selectedItem?.type === "image" ? selectedItem : undefined;
+  const projectResolution = requireProjectResolution(
+    state.projectResolution,
+    "Project resolution",
+  );
   const selectedFolder = state.spritesData.items?.[state.selectedFolderId];
   const selectedDetailId =
     selectedItem?.type === "image" ? selectedItem.id : selectedFolder?.id;
@@ -704,7 +807,21 @@ export const selectViewData = ({ state }) => {
     maxWidth: IMAGE_CARD_MAX_WIDTH,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewFileId: state.fullImagePreviewFileId,
-    fullImagePreviewFrameStyle: PREVIEW_FRAME_STYLE,
+    fullImagePreviewFrameStyle: createPreviewFrameStyle(projectResolution),
+    fullImagePreviewImageWrapperStyle: createPreviewImageWrapperStyle({
+      image: previewImage,
+      displayMode: state.fullImagePreviewDisplayMode,
+      projectResolution,
+    }),
+    fullImagePreviewDisplayMode: state.fullImagePreviewDisplayMode,
+    fullImagePreviewFitModeButton: createPreviewModeButtonViewData({
+      displayMode: state.fullImagePreviewDisplayMode,
+      mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+    }),
+    fullImagePreviewCanvasModeButton: createPreviewModeButtonViewData({
+      displayMode: state.fullImagePreviewDisplayMode,
+      mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+    }),
     fullImagePreviewPreviousVisible: Boolean(previousItemId),
     fullImagePreviewNextVisible: Boolean(nextItemId),
     folderContextMenuItems,

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -181,7 +181,7 @@ const buildFolderDetailFields = (folder) => {
 
 const getPreviewFileId = (item) => item?.thumbnailFileId ?? item?.fileId;
 
-const createEditForm = () => ({
+const createEditForm = ({ tagOptions } = {}) => ({
   title: "Edit Sprite",
   fields: [
     {
@@ -196,7 +196,9 @@ const createEditForm = () => ({
       label: "Description",
       required: false,
     },
-    createTagField(),
+    createTagField({
+      options: tagOptions ?? [],
+    }),
     {
       type: "slot",
       slot: "image-slot",
@@ -767,6 +769,11 @@ export const selectViewData = ({ state }) => {
         direction: "next",
       })
     : undefined;
+  const tagViewData = buildTagViewData({
+    state,
+    selectedItem,
+    createTagFormDefinition: createTagForm(),
+  });
 
   return {
     flatItems,
@@ -778,11 +785,7 @@ export const selectViewData = ({ state }) => {
     selectedDetailId,
     selectedDetailName,
     selectedItemName: selectedDetailName,
-    ...buildTagViewData({
-      state,
-      selectedItem,
-      createTagFormDefinition: createTagForm(),
-    }),
+    ...tagViewData,
     detailFields,
     ...buildMobileResourcePageViewData({
       state,
@@ -823,7 +826,9 @@ export const selectViewData = ({ state }) => {
     centerItemContextMenuItems,
     title: state.characterName,
     isEditDialogOpen: state.isEditDialogOpen,
-    editForm: createEditForm(),
+    editForm: createEditForm({
+      tagOptions: tagViewData.tagFilterOptions,
+    }),
     editDefaultValues: state.editDefaultValues,
     editPreviewFileId: state.editPreviewFileId,
     isFolderNameDialogOpen: state.isFolderNameDialogOpen,

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -676,13 +676,6 @@ export const setFullImagePreviewDisplayMode = (
 export const selectFullImagePreviewVisible = ({ state }) =>
   state.fullImagePreviewVisible;
 
-export const toggleFullImagePreviewDisplayMode = ({ state }) => {
-  state.fullImagePreviewDisplayMode =
-    state.fullImagePreviewDisplayMode === FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
-      ? FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT
-      : FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
-};
-
 export const selectViewData = ({ state }) => {
   const flatItems = applyFolderRequiredRootDragOptions(
     toFlatItems(state.spritesData),

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -80,6 +80,18 @@ refs:
         handler: handlePreviewNextClick
         preventDefault: true
         stopPropagation: true
+  previewFitModeButton:
+    eventListeners:
+      click:
+        handler: handlePreviewFitModeClick
+        preventDefault: true
+        stopPropagation: true
+  previewCanvasModeButton:
+    eventListeners:
+      click:
+        handler: handlePreviewCanvasModeClick
+        preventDefault: true
+        stopPropagation: true
   editDialog:
     eventListeners:
       close:
@@ -151,8 +163,15 @@ styles:
   ".imagePreviewEdgeNext":
     right: "0"
     background: linear-gradient(to left, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0))
+  ".imagePreviewTransparencyGrid":
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 12px, 12px -12px, -12px 0"
+    background-repeat: repeat
+    background-size: 24px 24px
   ".imagePreviewFrame":
     position: relative
+    box-shadow: 0 0 0 1px var(--border)
     overflow: hidden
     cursor: default
 template:
@@ -218,12 +237,17 @@ template:
   - rtgl-dialog#createTagDialog ?open=${isCreateTagDialogOpen} s=sm:
       - rtgl-form#createTagForm key=${isCreateTagDialogOpen} slot=content :defaultValues=${createTagDefaultValues} :form=${createTagForm} w=f: null
   - $when: fullImagePreviewVisible
-    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none;"':
-      - 'rtgl-view w=f h=f pos=fix edge=f style="background-color: rgba(0, 0, 0, 0.9);"': null
+    'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
+          - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 24px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
+              - 'rtgl-view#previewCanvasModeButton role=button aria-label="Show sprite at canvas scale" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="Show sprite at canvas scale" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewCanvasModeButton.borderColor} bgc=${fullImagePreviewCanvasModeButton.backgroundColor} cur=pointer':
+                  - rtgl-svg svg=canvas-scale wh=18 c=${fullImagePreviewCanvasModeButton.iconColor}: null
+              - 'rtgl-view#previewFitModeButton role=button aria-label="Fit sprite to preview" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="Fit sprite to preview" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewFitModeButton.borderColor} bgc=${fullImagePreviewFitModeButton.backgroundColor} cur=pointer':
+                  - rtgl-svg svg=fit-to-frame wh=18 c=${fullImagePreviewFitModeButton.iconColor}: null
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
-              - 'div#previewImageFrame.imagePreviewFrame style="${fullImagePreviewFrameStyle}"':
-                  - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
+              - 'div#previewImageFrame.imagePreviewFrame.imagePreviewTransparencyGrid style="${fullImagePreviewFrameStyle}"':
+                  - 'div style="${fullImagePreviewImageWrapperStyle}"':
+                      - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
                   - $if fullImagePreviewPreviousVisible:
                       - div#previewPrevious.imagePreviewEdge.imagePreviewEdgePrevious role=button aria-label="Previous sprite": null
                   - $if fullImagePreviewNextVisible:

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -100,6 +100,9 @@ const syncImagePageData = ({ store, repositoryState } = {}) => {
       itemType: "image",
     }),
   });
+  store.setProjectResolution({
+    projectResolution: repositoryState?.project?.resolution,
+  });
 };
 
 const {
@@ -242,8 +245,7 @@ const {
   focusKeyboardScope: focusGroupView,
   handleKeyboardScopeKeyDown: handleBaseFileExplorerKeyboardScopeKeyDown,
 } = createFileExplorerKeyboardScopeHandlers({
-  isNavigationBlocked: ({ deps }) =>
-    deps.store.getState().fullImagePreviewVisible,
+  isNavigationBlocked: ({ deps }) => deps.store.selectFullImagePreviewVisible(),
   onEnterKey: ({ deps, selectedItemId }) => {
     openImagePreviewById({ deps, itemId: selectedItemId, syncExplorer: true });
   },
@@ -263,7 +265,7 @@ const focusPreviewOverlay = ({ refs } = {}) => {
 const handleZoomShortcutKeyDown = (deps, payload) => {
   const event = payload?._event;
   if (
-    deps.store.getState().fullImagePreviewVisible &&
+    deps.store.selectFullImagePreviewVisible() &&
     isResourceZoomShortcutKeyEvent(event)
   ) {
     event.preventDefault();
@@ -628,11 +630,31 @@ export const handlePreviewNextClick = (deps, payload) => {
   navigateImagePreview(deps, { direction: "next" });
 };
 
+export const handlePreviewFitModeClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const { store, render } = deps;
+  store.setFullImagePreviewDisplayMode({ displayMode: "fit" });
+  render();
+  focusPreviewOverlay(deps);
+};
+
+export const handlePreviewCanvasModeClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const { store, render } = deps;
+  store.setFullImagePreviewDisplayMode({ displayMode: "canvas" });
+  render();
+  focusPreviewOverlay(deps);
+};
+
 export const handlePreviewOverlayKeyDown = (deps, payload) => {
   const { store } = deps;
   const event = payload._event;
 
-  if (!store.getState().fullImagePreviewVisible) {
+  if (!store.selectFullImagePreviewVisible()) {
     return;
   }
 
@@ -644,6 +666,15 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
     event.preventDefault();
     event.stopPropagation();
     closeImagePreview(deps);
+    return;
+  }
+
+  if (event.key === "Tab") {
+    event.preventDefault();
+    event.stopPropagation();
+    store.toggleFullImagePreviewDisplayMode();
+    deps.render();
+    focusPreviewOverlay(deps);
     return;
   }
 

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -357,11 +357,11 @@ const navigateImagePreview = (deps, { direction, distance, clamp } = {}) => {
 };
 
 const resolvePreviewNavigationDirection = (event) => {
-  if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+  if (event.key === "ArrowDown") {
     return { direction: "next" };
   }
 
-  if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+  if (event.key === "ArrowUp") {
     return { direction: "previous" };
   }
 
@@ -383,12 +383,37 @@ const resolvePreviewNavigationDirection = (event) => {
   }
 
   const key = String(event.key ?? "").toLowerCase();
-  if (key === "j" || key === "l") {
+  if (key === "j") {
     return { direction: "next" };
   }
 
-  if (key === "k" || key === "h") {
+  if (key === "k") {
     return { direction: "previous" };
+  }
+
+  return undefined;
+};
+
+const resolvePreviewDisplayMode = (event) => {
+  if (event.altKey || event.ctrlKey || event.metaKey) {
+    return undefined;
+  }
+
+  if (event.key === "ArrowLeft") {
+    return "canvas";
+  }
+
+  if (event.key === "ArrowRight") {
+    return "fit";
+  }
+
+  const key = String(event.key ?? "").toLowerCase();
+  if (key === "h") {
+    return "canvas";
+  }
+
+  if (key === "l") {
+    return "fit";
   }
 
   return undefined;
@@ -669,10 +694,11 @@ export const handlePreviewOverlayKeyDown = (deps, payload) => {
     return;
   }
 
-  if (event.key === "Tab") {
+  const displayMode = resolvePreviewDisplayMode(event);
+  if (displayMode) {
     event.preventDefault();
     event.stopPropagation();
-    store.toggleFullImagePreviewDisplayMode();
+    store.setFullImagePreviewDisplayMode({ displayMode });
     deps.render();
     focusPreviewOverlay(deps);
     return;

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -428,13 +428,6 @@ export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
 export const selectFullImagePreviewVisible = ({ state }) =>
   state.fullImagePreviewVisible;
 
-export const toggleFullImagePreviewDisplayMode = ({ state }) => {
-  state.fullImagePreviewDisplayMode =
-    state.fullImagePreviewDisplayMode === FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
-      ? FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT
-      : FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
-};
-
 export const selectViewData = (context) => {
   const viewData = selectMediaViewData(context);
   const flatItems = applyFolderRequiredRootDragOptions(viewData.flatItems);

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -4,6 +4,11 @@ import { createMediaPageStore } from "../../internal/ui/resourcePages/media/crea
 import { createTagField } from "../../internal/ui/resourcePages/tags.js";
 import { matchesTagAwareSearch } from "../../internal/resourceTags.js";
 import {
+  DEFAULT_PROJECT_RESOLUTION,
+  formatProjectResolutionAspectRatio,
+  requireProjectResolution,
+} from "../../internal/projectResolution.js";
+import {
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD,
   shouldStartCollapsedFileExplorer,
 } from "../../internal/ui/resourcePages/media/mediaPageShared.js";
@@ -12,6 +17,8 @@ const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
 const IMAGE_CARD_MAX_WIDTH = 400;
 const IMAGE_CARD_HEIGHT = 225;
+const FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT = "fit";
+const FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS = "canvas";
 export const IMAGE_TAG_SCOPE_KEY = "images";
 
 const resolveImageAspectRatio = (item) => {
@@ -25,12 +32,62 @@ const resolveImageAspectRatio = (item) => {
   return `${Math.max(1, Math.round(width))} / ${Math.max(1, Math.round(height))}`;
 };
 
-const PREVIEW_FRAME_STYLE = [
-  "width: min(92vw, calc(92vh * 16 / 9))",
-  "aspect-ratio: 16 / 9",
-  "max-width: 92vw",
-  "max-height: 92vh",
-].join("; ");
+const createPreviewFrameStyle = (projectResolution) => {
+  const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
+
+  return [
+    `width: min(92vw, calc(92vh * (${aspectRatio})))`,
+    `aspect-ratio: ${aspectRatio}`,
+    "max-width: 92vw",
+    "max-height: 92vh",
+  ].join("; ");
+};
+
+const resolvePositiveNumber = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0
+    ? numericValue
+    : undefined;
+};
+
+const createPreviewImageWrapperStyle = ({
+  image,
+  displayMode,
+  projectResolution,
+} = {}) => {
+  if (displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS) {
+    return "position: absolute; inset: 0;";
+  }
+
+  const imageWidth = resolvePositiveNumber(image?.width);
+  const imageHeight = resolvePositiveNumber(image?.height);
+  if (!imageWidth || !imageHeight) {
+    return "position: absolute; inset: 0;";
+  }
+
+  const widthPercent = (imageWidth / projectResolution.width) * 100;
+  const heightPercent = (imageHeight / projectResolution.height) * 100;
+
+  return [
+    "position: absolute",
+    "left: 50%",
+    "top: 50%",
+    `width: ${widthPercent}%`,
+    `height: ${heightPercent}%`,
+    "transform: translate(-50%, -50%)",
+  ].join("; ");
+};
+
+const createPreviewModeButtonViewData = ({ displayMode, mode } = {}) => {
+  const selected = displayMode === mode;
+
+  return {
+    backgroundColor: selected ? "ac" : "bg",
+    borderColor: selected ? "ac" : "bo",
+    iconColor: selected ? "white" : "mu-fg",
+    selected,
+  };
+};
 
 const buildDetailFields = (item) => {
   if (!item) {
@@ -181,10 +238,10 @@ const {
   closeFolderNameDialog,
   setEditUpload,
   setUiConfig,
+  selectItemById,
   openMobileFileExplorer,
   closeMobileFileExplorer,
   selectSelectedItem,
-  selectItemById,
   selectSelectedItemId,
   selectFolderById,
   selectSelectedFolderId,
@@ -219,6 +276,11 @@ const {
   hiddenMobileDetailSlots: ["image-file-id"],
   extendViewData: ({ state, baseViewData }) => {
     const selectedItemId = state.selectedItemId;
+    const previewImage = state.data?.items?.[selectedItemId];
+    const projectResolution = requireProjectResolution(
+      state.projectResolution,
+      "Project resolution",
+    );
     const visibleImageIds = selectVisibleImageIds({
       mediaGroups: baseViewData.mediaGroups,
       items: state.data?.items,
@@ -241,7 +303,26 @@ const {
 
     viewData.fullImagePreviewVisible = state.fullImagePreviewVisible;
     viewData.fullImagePreviewFileId = state.fullImagePreviewFileId;
-    viewData.fullImagePreviewFrameStyle = PREVIEW_FRAME_STYLE;
+    viewData.fullImagePreviewFrameStyle =
+      createPreviewFrameStyle(projectResolution);
+    viewData.fullImagePreviewImageWrapperStyle = createPreviewImageWrapperStyle(
+      {
+        image: previewImage,
+        displayMode: state.fullImagePreviewDisplayMode,
+        projectResolution,
+      },
+    );
+    viewData.fullImagePreviewDisplayMode = state.fullImagePreviewDisplayMode;
+    viewData.fullImagePreviewFitModeButton = createPreviewModeButtonViewData({
+      displayMode: state.fullImagePreviewDisplayMode,
+      mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+    });
+    viewData.fullImagePreviewCanvasModeButton = createPreviewModeButtonViewData(
+      {
+        displayMode: state.fullImagePreviewDisplayMode,
+        mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+      },
+    );
     viewData.fullImagePreviewPreviousVisible = Boolean(previousItemId);
     viewData.fullImagePreviewNextVisible = Boolean(nextItemId);
 
@@ -253,6 +334,8 @@ export const createInitialState = () => ({
   ...createMediaInitialState(),
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
+  fullImagePreviewDisplayMode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  projectResolution: DEFAULT_PROJECT_RESOLUTION,
 });
 
 export {
@@ -309,6 +392,9 @@ export const showFullImagePreview = ({ state }, { itemId } = {}) => {
     return;
   }
 
+  if (!state.fullImagePreviewVisible) {
+    state.fullImagePreviewDisplayMode = FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+  }
   state.fullImagePreviewVisible = true;
   state.fullImagePreviewFileId = item.fileId;
 };
@@ -316,6 +402,37 @@ export const showFullImagePreview = ({ state }, { itemId } = {}) => {
 export const hideFullImagePreview = ({ state }, _payload = {}) => {
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
+};
+
+export const setFullImagePreviewDisplayMode = (
+  { state },
+  { displayMode } = {},
+) => {
+  if (
+    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT &&
+    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
+  ) {
+    return;
+  }
+
+  state.fullImagePreviewDisplayMode = displayMode;
+};
+
+export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
+  state.projectResolution = requireProjectResolution(
+    projectResolution ?? DEFAULT_PROJECT_RESOLUTION,
+    "Project resolution",
+  );
+};
+
+export const selectFullImagePreviewVisible = ({ state }) =>
+  state.fullImagePreviewVisible;
+
+export const toggleFullImagePreviewDisplayMode = ({ state }) => {
+  state.fullImagePreviewDisplayMode =
+    state.fullImagePreviewDisplayMode === FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
+      ? FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT
+      : FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
 };
 
 export const selectViewData = (context) => {

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -82,6 +82,18 @@ refs:
         handler: handlePreviewNextClick
         preventDefault: true
         stopPropagation: true
+  previewFitModeButton:
+    eventListeners:
+      click:
+        handler: handlePreviewFitModeClick
+        preventDefault: true
+        stopPropagation: true
+  previewCanvasModeButton:
+    eventListeners:
+      click:
+        handler: handlePreviewCanvasModeClick
+        preventDefault: true
+        stopPropagation: true
   editDialog:
     eventListeners:
       close:
@@ -161,6 +173,7 @@ styles:
     background-size: 24px 24px
   ".imagePreviewFrame":
     position: relative
+    box-shadow: 0 0 0 1px var(--border)
     overflow: hidden
     cursor: default
 template:
@@ -229,9 +242,15 @@ template:
   - $when: fullImagePreviewVisible
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
+          - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 24px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
+              - 'rtgl-view#previewCanvasModeButton role=button aria-label="Show image at canvas scale" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="Show image at canvas scale" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewCanvasModeButton.borderColor} bgc=${fullImagePreviewCanvasModeButton.backgroundColor} cur=pointer':
+                  - rtgl-svg svg=canvas-scale wh=18 c=${fullImagePreviewCanvasModeButton.iconColor}: null
+              - 'rtgl-view#previewFitModeButton role=button aria-label="Fit image to preview" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="Fit image to preview" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewFitModeButton.borderColor} bgc=${fullImagePreviewFitModeButton.backgroundColor} cur=pointer':
+                  - rtgl-svg svg=fit-to-frame wh=18 c=${fullImagePreviewFitModeButton.iconColor}: null
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
               - 'div#previewImageFrame.imagePreviewFrame.imagePreviewTransparencyGrid style="${fullImagePreviewFrameStyle}"':
-                  - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
+                  - 'div style="${fullImagePreviewImageWrapperStyle}"':
+                      - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f: null
                   - $if fullImagePreviewPreviousVisible:
                       - div#previewPrevious.imagePreviewEdge.imagePreviewEdgePrevious role=button aria-label="Previous image": null
                   - $if fullImagePreviewNextVisible:

--- a/svg/canvas-scale.svg
+++ b/svg/canvas-scale.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect
+    x="3"
+    y="6.5"
+    width="18"
+    height="11"
+    rx="1.5"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+  <rect x="10" y="10" width="4" height="4" rx="0.75" fill="currentColor" />
+</svg>

--- a/svg/fit-to-frame.svg
+++ b/svg/fit-to-frame.svg
@@ -1,0 +1,19 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect
+    x="3"
+    y="6.5"
+    width="18"
+    height="11"
+    rx="1.5"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M8.5 10.5L6 8M6 8H8.75M6 8V10.75M15.5 13.5L18 16M18 16H15.25M18 16V13.25"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/tests/characterSprites/characterSprites.handlers.test.js
+++ b/tests/characterSprites/characterSprites.handlers.test.js
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  handlePreviewCanvasModeClick,
+  handlePreviewFitModeClick,
   handlePreviewNextClick,
   handlePreviewOverlayKeyDown,
   handlePreviewPreviousClick,
@@ -12,9 +14,7 @@ const createPreviewDeps = ({
   previewVisible = true,
 } = {}) => {
   const store = {
-    getState: vi.fn(() => ({
-      fullImagePreviewVisible: previewVisible,
-    })),
+    selectFullImagePreviewVisible: vi.fn(() => previewVisible),
     selectSelectedItemId: vi.fn(() => selectedItemId),
     selectAdjacentSpriteItemId: vi.fn(({ direction }) => {
       return direction === "next" ? "sprite-2" : "sprite-0";
@@ -26,6 +26,8 @@ const createPreviewDeps = ({
     })),
     setSelectedItemId: vi.fn(),
     showFullImagePreview: vi.fn(),
+    setFullImagePreviewDisplayMode: vi.fn(),
+    toggleFullImagePreviewDisplayMode: vi.fn(),
   };
 
   return {
@@ -142,6 +144,62 @@ describe("characterSprites preview handlers", () => {
     expect(deps.store.selectAdjacentSpriteItemId).toHaveBeenCalledTimes(3);
     expect(inputEvent.preventDefault).not.toHaveBeenCalled();
     expect(inputEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("switches full sprite preview display modes from the overlay controls", () => {
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+    const deps = createPreviewDeps();
+    const canvasEvent = createEvent("click");
+    const fitEvent = createEvent("click");
+
+    handlePreviewCanvasModeClick(deps, {
+      _event: canvasEvent,
+    });
+    handlePreviewFitModeClick(deps, {
+      _event: fitEvent,
+    });
+
+    expect(deps.store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(
+      1,
+      {
+        displayMode: "canvas",
+      },
+    );
+    expect(deps.store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(
+      2,
+      {
+        displayMode: "fit",
+      },
+    );
+    expect(canvasEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(canvasEvent.stopPropagation).toHaveBeenCalledOnce();
+    expect(fitEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(fitEvent.stopPropagation).toHaveBeenCalledOnce();
+    expect(deps.render).toHaveBeenCalledTimes(2);
+    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses tab to toggle the full sprite preview display mode", () => {
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+    const deps = createPreviewDeps();
+    const event = createEvent("Tab");
+
+    handlePreviewOverlayKeyDown(deps, {
+      _event: event,
+    });
+
+    expect(deps.store.toggleFullImagePreviewDisplayMode).toHaveBeenCalledOnce();
+    expect(deps.render).toHaveBeenCalledOnce();
+    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledOnce();
+    expect(deps.store.selectAdjacentSpriteItemId).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
   });
 
   it("does not navigate when the preview is hidden", () => {

--- a/tests/characterSprites/characterSprites.handlers.test.js
+++ b/tests/characterSprites/characterSprites.handlers.test.js
@@ -27,7 +27,6 @@ const createPreviewDeps = ({
     setSelectedItemId: vi.fn(),
     showFullImagePreview: vi.fn(),
     setFullImagePreviewDisplayMode: vi.fn(),
-    toggleFullImagePreviewDisplayMode: vi.fn(),
   };
 
   return {
@@ -98,7 +97,7 @@ describe("characterSprites preview handlers", () => {
     expect(previousEvent.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
-  it("supports image-preview keyboard parity and ignores text entry targets", () => {
+  it("uses vertical keys to navigate preview items and ignores text entry targets", () => {
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
       return 1;
@@ -106,10 +105,10 @@ describe("characterSprites preview handlers", () => {
     const deps = createPreviewDeps();
 
     handlePreviewOverlayKeyDown(deps, {
-      _event: createEvent("ArrowRight"),
+      _event: createEvent("ArrowDown"),
     });
     handlePreviewOverlayKeyDown(deps, {
-      _event: createEvent("ArrowLeft"),
+      _event: createEvent("ArrowUp"),
     });
     handlePreviewOverlayKeyDown(deps, {
       _event: createEvent("d", {
@@ -182,11 +181,56 @@ describe("characterSprites preview handlers", () => {
     expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(2);
   });
 
-  it("uses tab to toggle the full sprite preview display mode", () => {
+  it("uses horizontal keys to switch full sprite preview display modes", () => {
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
       return 1;
     });
+    const deps = createPreviewDeps();
+
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("ArrowLeft"),
+    });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("ArrowRight"),
+    });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("h"),
+    });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("l"),
+    });
+
+    expect(deps.store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(
+      1,
+      {
+        displayMode: "canvas",
+      },
+    );
+    expect(deps.store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(
+      2,
+      {
+        displayMode: "fit",
+      },
+    );
+    expect(deps.store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(
+      3,
+      {
+        displayMode: "canvas",
+      },
+    );
+    expect(deps.store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(
+      4,
+      {
+        displayMode: "fit",
+      },
+    );
+    expect(deps.render).toHaveBeenCalledTimes(4);
+    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(4);
+    expect(deps.store.selectAdjacentSpriteItemId).not.toHaveBeenCalled();
+  });
+
+  it("does not use tab as a full sprite preview shortcut", () => {
     const deps = createPreviewDeps();
     const event = createEvent("Tab");
 
@@ -194,12 +238,12 @@ describe("characterSprites preview handlers", () => {
       _event: event,
     });
 
-    expect(deps.store.toggleFullImagePreviewDisplayMode).toHaveBeenCalledOnce();
-    expect(deps.render).toHaveBeenCalledOnce();
-    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledOnce();
+    expect(deps.store.setFullImagePreviewDisplayMode).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.refs.previewOverlay.focus).not.toHaveBeenCalled();
     expect(deps.store.selectAdjacentSpriteItemId).not.toHaveBeenCalled();
-    expect(event.preventDefault).toHaveBeenCalledOnce();
-    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
   });
 
   it("does not navigate when the preview is hidden", () => {
@@ -214,6 +258,7 @@ describe("characterSprites preview handlers", () => {
 
     expect(deps.store.selectSelectedItemId).not.toHaveBeenCalled();
     expect(deps.store.selectAdjacentSpriteItemId).not.toHaveBeenCalled();
+    expect(deps.store.setFullImagePreviewDisplayMode).not.toHaveBeenCalled();
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(event.stopPropagation).not.toHaveBeenCalled();
   });

--- a/tests/characterSprites/characterSprites.store.test.js
+++ b/tests/characterSprites/characterSprites.store.test.js
@@ -6,10 +6,10 @@ import {
   setActiveTagIds,
   selectAdjacentSpriteItemId,
   selectViewData,
+  setFullImagePreviewDisplayMode,
   setProjectResolution,
   setSelectedItemId,
   showFullImagePreview,
-  toggleFullImagePreviewDisplayMode,
 } from "../../src/pages/characterSprites/characterSprites.store.js";
 
 describe("characterSprites store", () => {
@@ -240,7 +240,7 @@ describe("characterSprites store", () => {
     expect(viewData.fullImagePreviewNextVisible).toBe(true);
   });
 
-  it("uses project resolution for full sprite preview sizing and toggles mode", () => {
+  it("uses project resolution for full sprite preview sizing and sets mode", () => {
     const state = createInitialState();
     state.characterName = "Hero";
     state.spritesData = {
@@ -300,7 +300,12 @@ describe("characterSprites store", () => {
       "height: 5%",
     );
 
-    toggleFullImagePreviewDisplayMode({ state });
+    setFullImagePreviewDisplayMode(
+      { state },
+      {
+        displayMode: "fit",
+      },
+    );
 
     const fitViewData = selectViewData({ state });
     expect(state.fullImagePreviewDisplayMode).toBe("fit");
@@ -310,7 +315,12 @@ describe("characterSprites store", () => {
     expect(fitViewData.fullImagePreviewCanvasModeButton.selected).toBe(false);
     expect(fitViewData.fullImagePreviewFitModeButton.selected).toBe(true);
 
-    toggleFullImagePreviewDisplayMode({ state });
+    setFullImagePreviewDisplayMode(
+      { state },
+      {
+        displayMode: "canvas",
+      },
+    );
     expect(state.fullImagePreviewDisplayMode).toBe("canvas");
   });
 

--- a/tests/characterSprites/characterSprites.store.test.js
+++ b/tests/characterSprites/characterSprites.store.test.js
@@ -164,6 +164,33 @@ describe("characterSprites store", () => {
     ).toEqual(["sprite-2"]);
   });
 
+  it("provides tag labels to the edit form tag selector", () => {
+    const state = createInitialState();
+    state.tagsData = {
+      tree: [{ id: "tag-idle" }],
+      items: {
+        "tag-idle": {
+          id: "tag-idle",
+          type: "tag",
+          name: "Idle",
+        },
+      },
+    };
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.editForm.fields[2]).toMatchObject({
+      name: "tagIds",
+      type: "tag-select",
+      options: [
+        {
+          label: "Idle",
+          value: "tag-idle",
+        },
+      ],
+    });
+  });
+
   it("uses the original file and exposes adjacent controls for the full preview overlay", () => {
     const state = createInitialState();
     state.characterName = "Hero";

--- a/tests/characterSprites/characterSprites.store.test.js
+++ b/tests/characterSprites/characterSprites.store.test.js
@@ -6,8 +6,10 @@ import {
   setActiveTagIds,
   selectAdjacentSpriteItemId,
   selectViewData,
+  setProjectResolution,
   setSelectedItemId,
   showFullImagePreview,
+  toggleFullImagePreviewDisplayMode,
 } from "../../src/pages/characterSprites/characterSprites.store.js";
 
 describe("characterSprites store", () => {
@@ -194,6 +196,8 @@ describe("characterSprites store", () => {
           name: "Hero Smile",
           fileId: "original-file",
           thumbnailFileId: "thumbnail-file",
+          width: 48,
+          height: 48,
         },
         "sprite-3": {
           id: "sprite-3",
@@ -220,9 +224,94 @@ describe("characterSprites store", () => {
     const viewData = selectViewData({ state });
     expect(state.fullImagePreviewVisible).toBe(true);
     expect(state.fullImagePreviewFileId).toBe("original-file");
-    expect(viewData.fullImagePreviewFrameStyle).toContain("width: 92vw");
+    expect(viewData.fullImagePreviewFrameStyle).toContain(
+      "aspect-ratio: 1920 / 1080",
+    );
+    expect(viewData.fullImagePreviewFrameStyle).toContain(
+      "width: min(92vw, calc(92vh * (1920 / 1080)))",
+    );
+    expect(viewData.fullImagePreviewImageWrapperStyle).toContain("width: 2.5%");
+    expect(viewData.fullImagePreviewImageWrapperStyle).toContain(
+      "height: 4.444444444444445%",
+    );
+    expect(viewData.fullImagePreviewCanvasModeButton.selected).toBe(true);
+    expect(viewData.fullImagePreviewFitModeButton.selected).toBe(false);
     expect(viewData.fullImagePreviewPreviousVisible).toBe(true);
     expect(viewData.fullImagePreviewNextVisible).toBe(true);
+  });
+
+  it("uses project resolution for full sprite preview sizing and toggles mode", () => {
+    const state = createInitialState();
+    state.characterName = "Hero";
+    state.spritesData = {
+      tree: [
+        {
+          id: "folder-1",
+          children: [{ id: "sprite-1" }],
+        },
+      ],
+      items: {
+        "folder-1": {
+          id: "folder-1",
+          type: "folder",
+          name: "Main",
+        },
+        "sprite-1": {
+          id: "sprite-1",
+          type: "image",
+          name: "Hero Icon",
+          fileId: "sprite-file",
+          width: 54,
+          height: 96,
+        },
+      },
+    };
+
+    setProjectResolution(
+      { state },
+      {
+        projectResolution: {
+          width: 1080,
+          height: 1920,
+        },
+      },
+    );
+    setSelectedItemId(
+      { state },
+      {
+        itemId: "sprite-1",
+      },
+    );
+    showFullImagePreview(
+      { state },
+      {
+        itemId: "sprite-1",
+      },
+    );
+
+    const canvasViewData = selectViewData({ state });
+    expect(canvasViewData.fullImagePreviewFrameStyle).toContain(
+      "aspect-ratio: 1080 / 1920",
+    );
+    expect(canvasViewData.fullImagePreviewImageWrapperStyle).toContain(
+      "width: 5%",
+    );
+    expect(canvasViewData.fullImagePreviewImageWrapperStyle).toContain(
+      "height: 5%",
+    );
+
+    toggleFullImagePreviewDisplayMode({ state });
+
+    const fitViewData = selectViewData({ state });
+    expect(state.fullImagePreviewDisplayMode).toBe("fit");
+    expect(fitViewData.fullImagePreviewImageWrapperStyle).toBe(
+      "position: absolute; inset: 0;",
+    );
+    expect(fitViewData.fullImagePreviewCanvasModeButton.selected).toBe(false);
+    expect(fitViewData.fullImagePreviewFitModeButton.selected).toBe(true);
+
+    toggleFullImagePreviewDisplayMode({ state });
+    expect(state.fullImagePreviewDisplayMode).toBe("canvas");
   });
 
   it("jumps adjacent sprite selection by distance and clamps to visible bounds", () => {

--- a/tests/images/images.handlers.test.js
+++ b/tests/images/images.handlers.test.js
@@ -21,6 +21,8 @@ import {
   handleCreateTagDialogClose,
   handleDetailTagAddOptionClick,
   handleDetailTagValueChange,
+  handlePreviewCanvasModeClick,
+  handlePreviewFitModeClick,
   handlePreviewOverlayKeyDown,
   handleItemDelete,
   handleUploadClick,
@@ -116,6 +118,7 @@ describe("images handlers", () => {
         updatePendingUpload: vi.fn(),
         setTagsData: vi.fn(),
         setItems: vi.fn(),
+        setProjectResolution: vi.fn(),
         setSelectedItemId: vi.fn(),
         setSelectedFolderId: vi.fn(),
       },
@@ -220,6 +223,7 @@ describe("images handlers", () => {
         closeCreateTagDialog: vi.fn(),
         setTagsData: vi.fn(),
         setItems: vi.fn(),
+        setProjectResolution: vi.fn(),
         setDetailTagIds: vi.fn(),
         setDetailTagPopoverOpen: vi.fn(),
         selectSelectedItemId: vi.fn(() => "image-1"),
@@ -394,6 +398,7 @@ describe("images handlers", () => {
         commitDetailTagIds: vi.fn(),
         setTagsData: vi.fn(),
         setItems: vi.fn(),
+        setProjectResolution: vi.fn(),
         setSelectedItemId: vi.fn(),
         setSelectedFolderId: vi.fn(),
       },
@@ -437,9 +442,7 @@ describe("images handlers", () => {
       ...overrides,
     });
     const store = {
-      getState: vi.fn(() => ({
-        fullImagePreviewVisible: true,
-      })),
+      selectFullImagePreviewVisible: vi.fn(() => true),
       selectSelectedItemId: vi.fn(() => "image-1"),
       selectAdjacentImageItemId: vi.fn(({ direction }) => {
         return direction === "next" ? "image-2" : "image-0";
@@ -506,6 +509,93 @@ describe("images handlers", () => {
     expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(2);
   });
 
+  it("switches full image preview display modes from the overlay controls", () => {
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    const createClickEvent = () => ({
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    });
+    const store = {
+      setFullImagePreviewDisplayMode: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      refs: {
+        previewOverlay: {
+          focus: vi.fn(),
+        },
+      },
+    };
+
+    const canvasEvent = createClickEvent();
+    handlePreviewCanvasModeClick(deps, {
+      _event: canvasEvent,
+    });
+
+    expect(store.setFullImagePreviewDisplayMode).toHaveBeenCalledWith({
+      displayMode: "canvas",
+    });
+    expect(canvasEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(canvasEvent.stopPropagation).toHaveBeenCalledOnce();
+
+    const fitEvent = createClickEvent();
+    handlePreviewFitModeClick(deps, {
+      _event: fitEvent,
+    });
+
+    expect(store.setFullImagePreviewDisplayMode).toHaveBeenCalledWith({
+      displayMode: "fit",
+    });
+    expect(fitEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(fitEvent.stopPropagation).toHaveBeenCalledOnce();
+    expect(deps.render).toHaveBeenCalledTimes(2);
+    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses tab to toggle the full image preview display mode", () => {
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      callback();
+      return 1;
+    });
+
+    const event = {
+      key: "Tab",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+    const store = {
+      selectFullImagePreviewVisible: vi.fn(() => true),
+      toggleFullImagePreviewDisplayMode: vi.fn(),
+      selectSelectedItemId: vi.fn(),
+      selectAdjacentImageItemId: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      refs: {
+        previewOverlay: {
+          focus: vi.fn(),
+        },
+      },
+    };
+
+    handlePreviewOverlayKeyDown(deps, {
+      _event: event,
+    });
+
+    expect(store.toggleFullImagePreviewDisplayMode).toHaveBeenCalledOnce();
+    expect(deps.render).toHaveBeenCalledOnce();
+    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledOnce();
+    expect(store.selectAdjacentImageItemId).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+  });
+
   it("uses h, j, k, and l to navigate preview items without handling text entry", () => {
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
@@ -522,9 +612,7 @@ describe("images handlers", () => {
       ...overrides,
     });
     const store = {
-      getState: vi.fn(() => ({
-        fullImagePreviewVisible: true,
-      })),
+      selectFullImagePreviewVisible: vi.fn(() => true),
       selectSelectedItemId: vi.fn(() => "image-1"),
       selectAdjacentImageItemId: vi.fn(({ direction }) => {
         return direction === "next" ? "image-2" : "image-0";
@@ -612,9 +700,7 @@ describe("images handlers", () => {
       ...overrides,
     });
     const store = {
-      getState: vi.fn(() => ({
-        fullImagePreviewVisible: true,
-      })),
+      selectFullImagePreviewVisible: vi.fn(() => true),
       selectSelectedItemId: vi.fn(() => "image-11"),
       selectAdjacentImageItemId: vi.fn(({ direction }) => {
         return direction === "next" ? "image-21" : "image-1";
@@ -701,9 +787,7 @@ describe("images handlers", () => {
     };
     const deps = {
       store: {
-        getState: vi.fn(() => ({
-          fullImagePreviewVisible: false,
-        })),
+        selectFullImagePreviewVisible: vi.fn(() => false),
         selectSelectedItemId: vi.fn(),
         selectAdjacentImageItemId: vi.fn(),
       },

--- a/tests/images/images.handlers.test.js
+++ b/tests/images/images.handlers.test.js
@@ -429,7 +429,7 @@ describe("images handlers", () => {
     });
   });
 
-  it("uses left and right arrows to navigate preview items only while preview is visible", () => {
+  it("uses left and right arrows to switch preview display modes", () => {
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
       return 1;
@@ -443,17 +443,8 @@ describe("images handlers", () => {
     });
     const store = {
       selectFullImagePreviewVisible: vi.fn(() => true),
-      selectSelectedItemId: vi.fn(() => "image-1"),
-      selectAdjacentImageItemId: vi.fn(({ direction }) => {
-        return direction === "next" ? "image-2" : "image-0";
-      }),
-      selectImageItemById: vi.fn(({ itemId }) => ({
-        id: itemId,
-        type: "image",
-        fileId: `${itemId}-file`,
-      })),
-      setSelectedItemId: vi.fn(),
-      showFullImagePreview: vi.fn(),
+      setFullImagePreviewDisplayMode: vi.fn(),
+      selectAdjacentImageItemId: vi.fn(),
     };
     const deps = {
       store,
@@ -476,16 +467,10 @@ describe("images handlers", () => {
       _event: rightEvent,
     });
 
-    expect(store.selectAdjacentImageItemId).toHaveBeenCalledWith({
-      itemId: "image-1",
-      direction: "next",
+    expect(store.setFullImagePreviewDisplayMode).toHaveBeenCalledWith({
+      displayMode: "fit",
     });
-    expect(store.setSelectedItemId).toHaveBeenCalledWith({
-      itemId: "image-2",
-    });
-    expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
-      itemId: "image-2",
-    });
+    expect(store.selectAdjacentImageItemId).not.toHaveBeenCalled();
     expect(rightEvent.preventDefault).toHaveBeenCalledTimes(1);
     expect(rightEvent.stopPropagation).toHaveBeenCalledTimes(1);
 
@@ -494,18 +479,12 @@ describe("images handlers", () => {
       _event: leftEvent,
     });
 
-    expect(store.selectAdjacentImageItemId).toHaveBeenCalledWith({
-      itemId: "image-1",
-      direction: "previous",
-    });
-    expect(store.setSelectedItemId).toHaveBeenCalledWith({
-      itemId: "image-0",
-    });
-    expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
-      itemId: "image-0",
+    expect(store.setFullImagePreviewDisplayMode).toHaveBeenCalledWith({
+      displayMode: "canvas",
     });
     expect(leftEvent.preventDefault).toHaveBeenCalledTimes(1);
     expect(leftEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(2);
     expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(2);
   });
 
@@ -557,7 +536,7 @@ describe("images handlers", () => {
     expect(deps.refs.previewOverlay.focus).toHaveBeenCalledTimes(2);
   });
 
-  it("uses tab to toggle the full image preview display mode", () => {
+  it("does not use tab as a full image preview shortcut", () => {
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
       return 1;
@@ -570,7 +549,7 @@ describe("images handlers", () => {
     };
     const store = {
       selectFullImagePreviewVisible: vi.fn(() => true),
-      toggleFullImagePreviewDisplayMode: vi.fn(),
+      setFullImagePreviewDisplayMode: vi.fn(),
       selectSelectedItemId: vi.fn(),
       selectAdjacentImageItemId: vi.fn(),
     };
@@ -588,15 +567,15 @@ describe("images handlers", () => {
       _event: event,
     });
 
-    expect(store.toggleFullImagePreviewDisplayMode).toHaveBeenCalledOnce();
-    expect(deps.render).toHaveBeenCalledOnce();
-    expect(deps.refs.previewOverlay.focus).toHaveBeenCalledOnce();
+    expect(store.setFullImagePreviewDisplayMode).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.refs.previewOverlay.focus).not.toHaveBeenCalled();
     expect(store.selectAdjacentImageItemId).not.toHaveBeenCalled();
-    expect(event.preventDefault).toHaveBeenCalledOnce();
-    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
   });
 
-  it("uses h, j, k, and l to navigate preview items without handling text entry", () => {
+  it("uses j and k to navigate, and h and l to switch display modes", () => {
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
       return 1;
@@ -624,6 +603,7 @@ describe("images handlers", () => {
       })),
       setSelectedItemId: vi.fn(),
       showFullImagePreview: vi.fn(),
+      setFullImagePreviewDisplayMode: vi.fn(),
     };
     const deps = {
       store,
@@ -641,13 +621,13 @@ describe("images handlers", () => {
       },
     };
 
-    for (const key of ["j", "l"]) {
+    for (const key of ["j"]) {
       handlePreviewOverlayKeyDown(deps, {
         _event: createEvent(key),
       });
     }
 
-    for (const key of ["k", "h"]) {
+    for (const key of ["k"]) {
       handlePreviewOverlayKeyDown(deps, {
         _event: createEvent(key),
       });
@@ -659,16 +639,23 @@ describe("images handlers", () => {
     });
     expect(store.selectAdjacentImageItemId).toHaveBeenNthCalledWith(2, {
       itemId: "image-1",
-      direction: "next",
-    });
-    expect(store.selectAdjacentImageItemId).toHaveBeenNthCalledWith(3, {
-      itemId: "image-1",
       direction: "previous",
     });
-    expect(store.selectAdjacentImageItemId).toHaveBeenNthCalledWith(4, {
-      itemId: "image-1",
-      direction: "previous",
+
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("h"),
     });
+    handlePreviewOverlayKeyDown(deps, {
+      _event: createEvent("l"),
+    });
+
+    expect(store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(1, {
+      displayMode: "canvas",
+    });
+    expect(store.setFullImagePreviewDisplayMode).toHaveBeenNthCalledWith(2, {
+      displayMode: "fit",
+    });
+    expect(store.selectAdjacentImageItemId).toHaveBeenCalledTimes(2);
 
     const inputEvent = createEvent("j", {
       target: {
@@ -679,7 +666,7 @@ describe("images handlers", () => {
       _event: inputEvent,
     });
 
-    expect(store.selectAdjacentImageItemId).toHaveBeenCalledTimes(4);
+    expect(store.selectAdjacentImageItemId).toHaveBeenCalledTimes(2);
     expect(inputEvent.preventDefault).not.toHaveBeenCalled();
     expect(inputEvent.stopPropagation).not.toHaveBeenCalled();
   });
@@ -779,7 +766,7 @@ describe("images handlers", () => {
     expect(inputEvent.preventDefault).not.toHaveBeenCalled();
   });
 
-  it("ignores left and right preview navigation when preview is not visible", () => {
+  it("ignores preview display mode shortcuts when preview is not visible", () => {
     const event = {
       key: "ArrowRight",
       preventDefault: vi.fn(),
@@ -788,6 +775,7 @@ describe("images handlers", () => {
     const deps = {
       store: {
         selectFullImagePreviewVisible: vi.fn(() => false),
+        setFullImagePreviewDisplayMode: vi.fn(),
         selectSelectedItemId: vi.fn(),
         selectAdjacentImageItemId: vi.fn(),
       },
@@ -801,6 +789,7 @@ describe("images handlers", () => {
 
     expect(deps.store.selectSelectedItemId).not.toHaveBeenCalled();
     expect(deps.store.selectAdjacentImageItemId).not.toHaveBeenCalled();
+    expect(deps.store.setFullImagePreviewDisplayMode).not.toHaveBeenCalled();
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(event.stopPropagation).not.toHaveBeenCalled();
   });

--- a/tests/images/images.store.test.js
+++ b/tests/images/images.store.test.js
@@ -6,9 +6,11 @@ import {
   selectViewData,
   setDetailTagIds,
   setItems,
+  setProjectResolution,
   setSelectedItemId,
   setTagsData,
   showFullImagePreview,
+  toggleFullImagePreviewDisplayMode,
 } from "../../src/pages/images/images.store.js";
 
 const createContext = () => ({
@@ -149,15 +151,68 @@ describe("images store preview navigation", () => {
     expect(context.state.fullImagePreviewFileId).toBe("original-file");
   });
 
-  it("uses a 16:9 frame for the full preview overlay", () => {
+  it("can show the full preview image at project canvas scale", () => {
+    const context = createContext();
+
+    setProjectResolution(context, {
+      projectResolution: {
+        width: 1920,
+        height: 1080,
+      },
+    });
+    setItems(context, {
+      data: {
+        tree: [{ id: "image-1" }],
+        items: {
+          "image-1": {
+            id: "image-1",
+            type: "image",
+            name: "Small Icon",
+            fileId: "icon-file",
+            width: 48,
+            height: 48,
+          },
+        },
+      },
+    });
+    setSelectedItemId(context, {
+      itemId: "image-1",
+    });
+    showFullImagePreview(context, {
+      itemId: "image-1",
+    });
+
+    const viewData = selectViewData(context);
+
+    expect(viewData.fullImagePreviewImageWrapperStyle).toContain("width: 2.5%");
+    expect(viewData.fullImagePreviewImageWrapperStyle).toContain(
+      "height: 4.444444444444445%",
+    );
+    expect(viewData.fullImagePreviewCanvasModeButton.selected).toBe(true);
+    expect(viewData.fullImagePreviewFitModeButton.selected).toBe(false);
+  });
+
+  it("toggles the full preview display mode", () => {
+    const context = createContext();
+
+    expect(context.state.fullImagePreviewDisplayMode).toBe("canvas");
+
+    toggleFullImagePreviewDisplayMode(context);
+    expect(context.state.fullImagePreviewDisplayMode).toBe("fit");
+
+    toggleFullImagePreviewDisplayMode(context);
+    expect(context.state.fullImagePreviewDisplayMode).toBe("canvas");
+  });
+
+  it("uses the project resolution frame for the full preview overlay", () => {
     const context = createContext();
     const viewData = selectViewData(context);
 
     expect(viewData.fullImagePreviewFrameStyle).toContain(
-      "aspect-ratio: 16 / 9",
+      "aspect-ratio: 1920 / 1080",
     );
     expect(viewData.fullImagePreviewFrameStyle).toContain(
-      "width: min(92vw, calc(92vh * 16 / 9))",
+      "width: min(92vw, calc(92vh * (1920 / 1080)))",
     );
   });
 

--- a/tests/images/images.store.test.js
+++ b/tests/images/images.store.test.js
@@ -4,13 +4,13 @@ import {
   createInitialState,
   selectAdjacentImageItemId,
   selectViewData,
+  setFullImagePreviewDisplayMode,
   setDetailTagIds,
   setItems,
   setProjectResolution,
   setSelectedItemId,
   setTagsData,
   showFullImagePreview,
-  toggleFullImagePreviewDisplayMode,
 } from "../../src/pages/images/images.store.js";
 
 const createContext = () => ({
@@ -192,15 +192,24 @@ describe("images store preview navigation", () => {
     expect(viewData.fullImagePreviewFitModeButton.selected).toBe(false);
   });
 
-  it("toggles the full preview display mode", () => {
+  it("sets the full preview display mode", () => {
     const context = createContext();
 
     expect(context.state.fullImagePreviewDisplayMode).toBe("canvas");
 
-    toggleFullImagePreviewDisplayMode(context);
+    setFullImagePreviewDisplayMode(context, {
+      displayMode: "fit",
+    });
     expect(context.state.fullImagePreviewDisplayMode).toBe("fit");
 
-    toggleFullImagePreviewDisplayMode(context);
+    setFullImagePreviewDisplayMode(context, {
+      displayMode: "canvas",
+    });
+    expect(context.state.fullImagePreviewDisplayMode).toBe("canvas");
+
+    setFullImagePreviewDisplayMode(context, {
+      displayMode: "unknown",
+    });
     expect(context.state.fullImagePreviewDisplayMode).toBe("canvas");
   });
 

--- a/tests/layoutEditor/layoutEditorViewData.test.js
+++ b/tests/layoutEditor/layoutEditorViewData.test.js
@@ -39,6 +39,22 @@ describe("layoutEditorViewData", () => {
     });
   });
 
+  it("builds image create actions with the image default name", () => {
+    const [imageItem] = toLayoutEditorContextMenuItems([
+      {
+        label: "Image",
+        type: "item",
+        createType: "sprite",
+      },
+    ]);
+
+    expect(imageItem.value).toMatchObject({
+      action: "new-child-item",
+      type: "sprite",
+      name: "Image",
+    });
+  });
+
   it("builds form submit button create actions as containers with a static form role", () => {
     const [submitItem] = toLayoutEditorContextMenuItems([
       {
@@ -93,7 +109,7 @@ describe("layoutEditorViewData", () => {
         createType: "container",
       },
       {
-        label: "Sprite",
+        label: "Image",
         type: "item",
         createType: "sprite",
       },


### PR DESCRIPTION
Summary: Add canvas-scale and fit-to-frame modes to image and character sprite full-screen previews. Default previews to project canvas scale, support toolbar and Tab switching, and add matching custom SVG icons. Tests: bun prettier --check on touched JS/YAML files; bun prettier --check --parser html on the new SVG files; bunx vitest run tests/images/images.store.test.js tests/images/images.handlers.test.js tests/characterSprites/characterSprites.store.test.js tests/characterSprites/characterSprites.handlers.test.js.