### PR TITLE
Fix Lexical double-click word selection

### DIFF
--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -3043,7 +3043,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       lineElement,
     );
     const visibleTextLength = this.getLineVisibleTextLength(lineElement);
-    if (pointerOffset !== -1 && pointerOffset < visibleTextLength) {
+    const isResolvedBoundaryClick =
+      typeof pointerOffset === "number" &&
+      pointerOffset >= 0 &&
+      pointerOffset >= visibleTextLength;
+    const isUnresolvedTrailingBoundaryClick =
+      pointerOffset === -1 &&
+      this.isPointerInTrailingLineBoundary(event, lineElement);
+    if (!isResolvedBoundaryClick && !isUnresolvedTrailingBoundaryClick) {
       return false;
     }
 
@@ -7622,6 +7629,46 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     }
 
     return -1;
+  }
+
+  isPointerInTrailingLineBoundary(event, lineElement) {
+    const clientX = Number(event?.clientX);
+    const clientY = Number(event?.clientY);
+    if (
+      !lineElement ||
+      !Number.isFinite(clientX) ||
+      !Number.isFinite(clientY)
+    ) {
+      return false;
+    }
+
+    const range = document.createRange();
+    try {
+      range.selectNodeContents(lineElement);
+    } catch {
+      return false;
+    }
+
+    const rects = Array.from(range.getClientRects?.() ?? []).filter((rect) => {
+      return rect.width > 0 || rect.height > 0;
+    });
+    const trailingRect = rects.at(-1);
+    if (!trailingRect) {
+      return false;
+    }
+
+    const lineRect = lineElement.getBoundingClientRect?.();
+    if (!lineRect) {
+      return false;
+    }
+
+    const verticalTolerance = 2;
+    return (
+      clientY >= trailingRect.top - verticalTolerance &&
+      clientY <= trailingRect.bottom + verticalTolerance &&
+      clientX >= trailingRect.right &&
+      clientX <= lineRect.right
+    );
   }
 
   getLineVisibleTextLength(lineElement) {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1588,6 +1588,65 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("selects the trailing word when unresolved pointer geometry is in trailing line space", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+      lineElement.textContent = "hello world\u200b";
+
+      editorElement.state = {
+        selectedLineId: "line-0",
+      };
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-1");
+      editorElement.getEditorLineOrder = vi.fn(() => [
+        { lineId: "line-1" },
+        { lineId: "line-2" },
+      ]);
+      editorElement.getLineOffsetFromPointerEvent = vi.fn(() => -1);
+      editorElement.isPointerInTrailingLineBoundary = vi.fn(() => true);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.setMode = vi.fn();
+      editorElement.focusLine = vi.fn();
+      editorElement.selectLineTextRange = vi.fn(() => true);
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      const event = {
+        detail: 2,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      const didSuppress =
+        editorElement.suppressNativeLineBoundaryDoubleClick(event);
+
+      expect(didSuppress).toBe(true);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(
+        editorElement.isPointerInTrailingLineBoundary,
+      ).toHaveBeenCalledWith(event, lineElement);
+      expect(editorElement.selectLineTextRange).toHaveBeenCalledWith({
+        lineId: "line-1",
+        lineElement,
+        start: 6,
+        end: 11,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("selects the full line on third click at a non-final line boundary", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -3529,6 +3588,50 @@ describe("lexical scene document editor line editing", () => {
 
       expect(didSuppress).toBe(false);
       expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(editorElement.focusLine).not.toHaveBeenCalled();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps native double-click word selection when pointer offset cannot be resolved inside text", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+      lineElement.textContent = "hello world\u200b";
+
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-1");
+      editorElement.getEditorLineOrder = vi.fn(() => [
+        { lineId: "line-1" },
+        { lineId: "line-2" },
+      ]);
+      editorElement.getLineOffsetFromPointerEvent = vi.fn(() => -1);
+      editorElement.isPointerInTrailingLineBoundary = vi.fn(() => false);
+      editorElement.selectLineTextRange = vi.fn();
+      editorElement.focusLine = vi.fn();
+
+      const event = {
+        detail: 2,
+        preventDefault: vi.fn(),
+      };
+
+      const didSuppress =
+        editorElement.suppressNativeLineBoundaryDoubleClick(event);
+
+      expect(didSuppress).toBe(false);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(
+        editorElement.isPointerInTrailingLineBoundary,
+      ).toHaveBeenCalledWith(event, lineElement);
+      expect(editorElement.selectLineTextRange).not.toHaveBeenCalled();
       expect(editorElement.focusLine).not.toHaveBeenCalled();
     } finally {
       restoreDomGlobals();


### PR DESCRIPTION
Summary:
- Preserve native double-click word selection when pointer offset resolution fails inside text.
- Keep the trailing-boundary workaround only for resolved line-end clicks or confirmed trailing empty space.
- Add regression coverage for unresolved pointer offsets and trailing boundary selection.

Tests:
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js
- bun prettier --check src/primitives/lexicalSceneDocumentEditor.js tests/sceneEditor/lexicalLineEditing.test.js
- push hook: oxlint && bun prettier --check src