### PR TITLE
Fix web project bootstrap history

### DIFF
--- a/src/deps/clients/web/webRepositoryAdapter.js
+++ b/src/deps/clients/web/webRepositoryAdapter.js
@@ -9,7 +9,7 @@ import {
   loadCommittedEventsFromClientStore,
   loadDraftEventsFromClientStore,
   normalizeRepositoryHistoryStats,
-  toBootstrappedDraftEvent,
+  toBootstrappedCommittedEvent,
 } from "../../services/shared/collab/clientStoreHistory.js";
 import {
   createMainProjectionState,
@@ -179,7 +179,14 @@ export const initializeProject = async ({
     state: templateData,
     clientTs: initialClientTs,
   });
-  await rawClientStore.insertDraft(toBootstrappedDraftEvent(initialEvent, 0));
+  if (typeof rawClientStore.applyCommittedBatch !== "function") {
+    throw new Error(
+      "rawClientStore.applyCommittedBatch is required for web project initialization",
+    );
+  }
+  await rawClientStore.applyCommittedBatch({
+    events: [toBootstrappedCommittedEvent(initialEvent, 0)],
+  });
   await adapter.saveMaterializedViewCheckpoint({
     viewName: MAIN_VIEW_NAME,
     partition: MAIN_PARTITION,

--- a/src/deps/services/shared/collab/clientStoreHistory.js
+++ b/src/deps/services/shared/collab/clientStoreHistory.js
@@ -176,6 +176,42 @@ const logInvalidLocalDraftDuringProjectLoad = ({
   });
 };
 
+const logMissingProjectBootstrapEvent = ({
+  projectId,
+  events = [],
+  committed = [],
+  drafts = [],
+} = {}) => {
+  if (events.some((event) => event?.type === "project.create")) {
+    return;
+  }
+
+  console.error("Project repository history is missing project.create", {
+    projectId,
+    committedCount: committed.length,
+    draftCount: drafts.length,
+    loadedEventCount: events.length,
+    firstCommittedType: committed[0]?.type,
+    firstDraftType: drafts[0]?.type,
+    firstLoadedType: events[0]?.type,
+  });
+};
+
+const finalizeLoadedRepositoryEvents = ({
+  projectId,
+  events = [],
+  committed = [],
+  drafts = [],
+} = {}) => {
+  logMissingProjectBootstrapEvent({
+    projectId,
+    events,
+    committed,
+    drafts,
+  });
+  return events;
+};
+
 const discardInvalidLocalDraftDuringProjectLoad = async ({
   store,
   failedDraft,
@@ -297,7 +333,12 @@ export const loadRepositoryEventsFromClientStore = async ({
 
   if (drafts.length === 0) {
     reportProgress({ force: true });
-    return events;
+    return finalizeLoadedRepositoryEvents({
+      projectId,
+      events,
+      committed,
+      drafts,
+    });
   }
 
   const draftEvents = drafts.map((draft) => {
@@ -318,7 +359,12 @@ export const loadRepositoryEventsFromClientStore = async ({
 
     if (draftEvents.length === 1) {
       reportProgress({ force: true });
-      return events;
+      return finalizeLoadedRepositoryEvents({
+        projectId,
+        events,
+        committed,
+        drafts,
+      });
     }
 
     let repositoryState = structuredClone(
@@ -383,7 +429,12 @@ export const loadRepositoryEventsFromClientStore = async ({
     }
 
     reportProgress({ force: true });
-    return events;
+    return finalizeLoadedRepositoryEvents({
+      projectId,
+      events,
+      committed,
+      drafts,
+    });
   }
 
   emitRepositoryEventLoadProgress(onProgress, {
@@ -456,7 +507,12 @@ export const loadRepositoryEventsFromClientStore = async ({
   }
 
   reportProgress({ force: true });
-  return events;
+  return finalizeLoadedRepositoryEvents({
+    projectId,
+    events,
+    committed,
+    drafts,
+  });
 };
 
 export const toBootstrappedCommittedEvent = (repositoryEvent, index) => ({

--- a/src/deps/services/shared/projectRepositoryService.js
+++ b/src/deps/services/shared/projectRepositoryService.js
@@ -28,6 +28,20 @@ const discardReusableMainCheckpoint = async (store) => {
   });
 };
 
+const summarizeCheckpointValue = (value = {}) => {
+  const counts = {};
+  for (const [key, entry] of Object.entries(value || {})) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+    if (!entry.items || typeof entry.items !== "object") {
+      continue;
+    }
+    counts[key] = Object.keys(entry.items).length;
+  }
+  return counts;
+};
+
 export const createProjectRepositoryService = ({
   router,
   db,
@@ -309,6 +323,16 @@ export const createProjectRepositoryService = ({
           currentHistoryStats,
         )
       ) {
+        console.warn("Discarding stale project repository checkpoint", {
+          cacheKey,
+          checkpointRevision: Math.max(
+            0,
+            Math.floor(Number(checkpoint.lastCommittedId) || 0),
+          ),
+          checkpointHistoryStats,
+          currentHistoryStats,
+          checkpointValueCounts: summarizeCheckpointValue(checkpoint.value),
+        });
         await discardReusableMainCheckpoint(store);
         return undefined;
       }
@@ -322,6 +346,16 @@ export const createProjectRepositoryService = ({
       );
 
       if (checkpointRevision !== currentHistoryLength) {
+        console.warn(
+          "Discarding project repository checkpoint without matching history length",
+          {
+            cacheKey,
+            checkpointRevision,
+            currentHistoryStats,
+            currentHistoryLength,
+            checkpointValueCounts: summarizeCheckpointValue(checkpoint.value),
+          },
+        );
         await discardReusableMainCheckpoint(store);
         return undefined;
       }

--- a/tests/support/projectInitializationContract.js
+++ b/tests/support/projectInitializationContract.js
@@ -8,24 +8,32 @@ export const expectInitializedProjectStorageContract = ({
   expectedProjectInfo,
   draftEvents = [],
   committedEvents = [],
+  bootstrapEventLocation = "draft",
   checkpoint,
   storedCreatorVersion,
   storedProjectInfo,
   expectedHistoryStats,
 }) => {
-  expect(committedEvents).toEqual([]);
+  const bootstrapEventExpectation = expect.objectContaining({
+    projectId,
+    type: "project.create",
+    payload: {
+      state: structuredClone(templateState),
+    },
+  });
 
-  expect(draftEvents).toEqual([
-    expect.objectContaining({
-      projectId,
-      type: "project.create",
-      payload: {
-        state: structuredClone(templateState),
-      },
-    }),
-  ]);
-  expect(Number(draftEvents[0]?.clientTs)).toBeGreaterThan(0);
-  expect(Number(draftEvents[0]?.createdAt)).toBeGreaterThan(0);
+  if (bootstrapEventLocation === "committed") {
+    expect(draftEvents).toEqual([]);
+    expect(committedEvents).toEqual([bootstrapEventExpectation]);
+    expect(Number(committedEvents[0]?.committedId)).toBe(1);
+    expect(Number(committedEvents[0]?.clientTs)).toBeGreaterThan(0);
+    expect(Number(committedEvents[0]?.serverTs)).toBeGreaterThan(0);
+  } else {
+    expect(committedEvents).toEqual([]);
+    expect(draftEvents).toEqual([bootstrapEventExpectation]);
+    expect(Number(draftEvents[0]?.clientTs)).toBeGreaterThan(0);
+    expect(Number(draftEvents[0]?.createdAt)).toBeGreaterThan(0);
+  }
 
   expect(checkpoint).toEqual(
     expect.objectContaining({

--- a/tests/web/webRepositoryAdapter.test.js
+++ b/tests/web/webRepositoryAdapter.test.js
@@ -25,6 +25,7 @@ vi.mock("../../src/internal/projectResolution.js", () => ({
 
 import {
   createProjectCreateRepositoryEvent,
+  createProjectRepository,
   initialProjectData,
 } from "../../src/deps/services/shared/projectRepository.js";
 import { loadRepositoryEventsFromClientStore } from "../../src/deps/services/shared/collab/clientStoreHistory.js";
@@ -259,7 +260,9 @@ const createRawClientStoreStub = ({
     },
     async applyCommittedBatch({ events, nextCursor }) {
       state.committed = (events || []).map((event) => structuredClone(event));
-      state.cursor = Number(nextCursor) || 0;
+      if (nextCursor !== undefined) {
+        state.cursor = Number(nextCursor) || 0;
+      }
     },
     async applySubmitResult({ result }) {
       state.submitResults.push(structuredClone(result));
@@ -340,7 +343,7 @@ describe("webRepositoryAdapter", () => {
     db.close();
   });
 
-  it("initializes project history by seeding bootstrap state into local drafts for offline projects", async () => {
+  it("initializes project history by seeding bootstrap state into committed history for offline projects", async () => {
     const projectId = "web-init-project";
     const rawClientStore = createRawClientStoreStub();
 
@@ -365,13 +368,14 @@ describe("webRepositoryAdapter", () => {
       rawClientStore,
     });
 
-    expect(rawClientStore.getState().committed).toEqual([]);
-    expect(rawClientStore.getState().drafts).toEqual([
+    expect(rawClientStore.getState().committed).toEqual([
       expect.objectContaining({
         projectId,
         type: "project.create",
       }),
     ]);
+    expect(rawClientStore.getState().drafts).toEqual([]);
+    expect(rawClientStore.getState().cursor).toBe(0);
 
     const adapter = await createInsiemeWebStoreAdapter(projectId, {
       rawClientStore,
@@ -389,10 +393,10 @@ describe("webRepositoryAdapter", () => {
     ]);
     const historyStats = await adapter.getRepositoryHistoryStats();
     expect(historyStats).toEqual({
-      committedCount: 0,
-      latestCommittedId: 0,
-      draftCount: 1,
-      latestDraftClock: 1,
+      committedCount: 1,
+      latestCommittedId: 1,
+      draftCount: 0,
+      latestDraftClock: 0,
     });
     const checkpoint = await adapter.loadMaterializedViewCheckpoint({
       viewName: "project_repository_main_state",
@@ -414,6 +418,7 @@ describe("webRepositoryAdapter", () => {
       },
       draftEvents: rawClientStore.getState().drafts,
       committedEvents: rawClientStore.getState().committed,
+      bootstrapEventLocation: "committed",
       checkpoint,
       storedCreatorVersion,
       storedProjectInfo,
@@ -425,6 +430,96 @@ describe("webRepositoryAdapter", () => {
         key: "creatorVersion",
       }),
     ).resolves.toBe(21);
+  });
+
+  it("can replay an initialized project from history after checkpoint loss and later local edits", async () => {
+    const projectId = "web-replay-after-checkpoint-loss";
+    const folderId = "variables-folder-1";
+    const variableId = "variable-1";
+    const rawClientStore = createRawClientStoreStub();
+    const templateState = structuredClone(initialProjectData);
+    templateState.variables = {
+      items: {
+        [folderId]: {
+          id: folderId,
+          type: "folder",
+          name: "Default",
+        },
+      },
+      tree: [{ id: folderId }],
+    };
+
+    mocked.getTemplateFiles.mockResolvedValue([]);
+    mocked.loadTemplate.mockResolvedValue(templateState);
+    mocked.resolveProjectResolutionForWrite.mockReturnValue(
+      structuredClone(templateState.project.resolution),
+    );
+    mocked.scaleTemplateProjectStateForResolution.mockImplementation(
+      (templateData) => templateData,
+    );
+
+    await initializeProject({
+      projectId,
+      template: "blank",
+      projectInfo: {
+        id: projectId,
+        name: "Browser Project",
+      },
+      projectResolution: templateState.project.resolution,
+      creatorVersion: 21,
+      rawClientStore,
+    });
+
+    await rawClientStore.insertDraft({
+      id: "draft-variable-create",
+      partition: "m",
+      projectId,
+      type: "variable.create",
+      schemaVersion: COMMAND_EVENT_MODEL.schemaVersion,
+      payload: {
+        variableId,
+        data: {
+          type: "variable",
+          name: "Score",
+          scope: "context",
+          variableType: "number",
+          default: 0,
+          value: 0,
+        },
+        parentId: folderId,
+        index: 0,
+      },
+      clientTs: 2,
+      createdAt: 2,
+    });
+
+    const adapter = await createInsiemeWebStoreAdapter(projectId, {
+      rawClientStore,
+    });
+    await adapter.clearMaterializedViewCheckpoints();
+    const historyStats = await adapter.getRepositoryHistoryStats();
+
+    const repository = await createProjectRepository({
+      projectId,
+      store: adapter,
+      initialRevision:
+        Number(historyStats.committedCount) + Number(historyStats.draftCount),
+      historyStats,
+      loadEvents: () =>
+        loadRepositoryEventsFromClientStore({
+          store: adapter,
+          projectId,
+        }),
+    });
+
+    expect(repository.getState().variables.items[folderId]).toMatchObject({
+      type: "folder",
+      name: "Default",
+    });
+    expect(repository.getState().variables.items[variableId]).toMatchObject({
+      type: "variable",
+      name: "Score",
+    });
   });
 
   it("rejects and discards invalid local drafts during project load", async () => {


### PR DESCRIPTION
## Summary
- Seed new web projects with the bootstrap project.create event in committed local history instead of local drafts.
- Keep the web sync cursor untouched for that local bootstrap event.
- Add critical diagnostics for missing bootstrap history and discarded checkpoints.
- Add regression coverage for replay after checkpoint loss with later local edits.

## Tests
- bunx vitest run tests/web/webRepositoryAdapter.test.js
- bunx vitest run tests/tauri/projectServiceAdapters.test.js tests/projectRepositoryService/projectRepositoryService.mainCheckpoint.test.js tests/web/webRepositoryAdapter.test.js
- git diff --check
- push hook: oxlint && bun prettier --check src