### PR TITLE
fix: keep full-screen preview controls clear

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -59,10 +59,10 @@ const createPreviewFrameStyle = (projectResolution) => {
   const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
 
   return [
-    `width: min(92vw, calc(92vh * (${aspectRatio})))`,
+    `width: min(88vw, calc((100vh - 120px) * (${aspectRatio})))`,
     `aspect-ratio: ${aspectRatio}`,
-    "max-width: 92vw",
-    "max-height: 92vh",
+    "max-width: 88vw",
+    "max-height: calc(100vh - 120px)",
   ].join("; ");
 };
 

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -347,7 +347,7 @@ template:
   - $when: fullImagePreviewVisible
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
-          - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 24px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
+          - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 8px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
               - 'rtgl-view#previewCanvasModeButton role=button aria-label="Show sprite at canvas scale" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="Show sprite at canvas scale" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewCanvasModeButton.borderColor} bgc=${fullImagePreviewCanvasModeButton.backgroundColor} cur=pointer':
                   - rtgl-svg svg=canvas-scale wh=18 c=${fullImagePreviewCanvasModeButton.iconColor}: null
               - 'rtgl-view#previewFitModeButton role=button aria-label="Fit sprite to preview" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="Fit sprite to preview" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewFitModeButton.borderColor} bgc=${fullImagePreviewFitModeButton.backgroundColor} cur=pointer':

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -36,10 +36,10 @@ const createPreviewFrameStyle = (projectResolution) => {
   const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
 
   return [
-    `width: min(92vw, calc(92vh * (${aspectRatio})))`,
+    `width: min(88vw, calc((100vh - 120px) * (${aspectRatio})))`,
     `aspect-ratio: ${aspectRatio}`,
-    "max-width: 92vw",
-    "max-height: 92vh",
+    "max-width: 88vw",
+    "max-height: calc(100vh - 120px)",
   ].join("; ");
 };
 

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -242,7 +242,7 @@ template:
   - $when: fullImagePreviewVisible
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
-          - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 24px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
+          - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 8px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
               - 'rtgl-view#previewCanvasModeButton role=button aria-label="Show image at canvas scale" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="Show image at canvas scale" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewCanvasModeButton.borderColor} bgc=${fullImagePreviewCanvasModeButton.backgroundColor} cur=pointer':
                   - rtgl-svg svg=canvas-scale wh=18 c=${fullImagePreviewCanvasModeButton.iconColor}: null
               - 'rtgl-view#previewFitModeButton role=button aria-label="Fit image to preview" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="Fit image to preview" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewFitModeButton.borderColor} bgc=${fullImagePreviewFitModeButton.backgroundColor} cur=pointer':


### PR DESCRIPTION
## Summary
- reduce Images and Character Sprites full-screen preview frame max size to leave room for the top controls
- move the canvas/fit control strip closer to the top of the overlay
- bump the Tauri app version to 1.6.1

## Testing
- bun prettier --check src/pages/images/images.store.js src/pages/images/images.view.yaml src/pages/characterSprites/characterSprites.store.js src/pages/characterSprites/characterSprites.view.yaml src-tauri/tauri.conf.json
- git diff --check -- touched files
- pre-push hook: oxlint && bun prettier --check src
- bun run build:web
- custom Playwright check at 1440x560 for Images overlay: controls bottom 50px, frame top 60px, 10px gap

## Notes
- Targeted VT screenshot run was attempted for project/images.yaml and project/character-sprites.yaml, but existing spec flow timeouts stopped it later in the scenarios: hidden #searchInput on Images and missing VT file picker input on Character Sprites.