### PR TITLE
fix: keep character spritesheet previews animating

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -31,6 +31,7 @@ const ANIMATION_PLAYBACK_CONTINUITY_OPTIONS = [
 ];
 
 const DEFAULT_BACKGROUND_OPACITY = 1;
+const BACKGROUND_RESOURCE_CARD_ASPECT_RATIO = "16 / 9";
 const DEFAULT_BACKGROUND_BLUR = {
   x: 6,
   y: 9,
@@ -522,7 +523,9 @@ const selectResourceById = ({ state }, { resourceId, resourceType } = {}) => {
   return {
     resourceId,
     resourceType,
-    fileId: item.thumbnailFileId || item.fileId,
+    fileId: item.thumbnailFileId ?? item.fileId,
+    previewAspectRatio: BACKGROUND_RESOURCE_CARD_ASPECT_RATIO,
+    resourceCardStyle: "max-width: 100%; box-sizing: border-box;",
     name: item.name,
     itemBorderColor: "bo",
     itemHoverBorderColor: "ac",
@@ -605,6 +608,12 @@ export const selectViewData = ({ state, props = {} }) => {
           const isSelected = child.id === state.tempSelectedResourceId;
           const itemBorderColor = isSelected ? "pr" : "bo";
           const itemHoverBorderColor = isSelected ? "pr" : "ac";
+          const selectedResourceInsetStyle = isSelected
+            ? " box-shadow: inset 0 0 0 1px var(--color-pr);"
+            : "";
+          const resourceCardStyle =
+            "max-width: 100%; box-sizing: border-box;" +
+            selectedResourceInsetStyle;
           const layoutTypeLabels = {
             general: "General",
             "save-load": "Save / Load",
@@ -619,6 +628,9 @@ export const selectViewData = ({ state, props = {} }) => {
             ...child,
             itemBorderColor,
             itemHoverBorderColor,
+            previewFileId: child.thumbnailFileId ?? child.fileId,
+            previewAspectRatio: BACKGROUND_RESOURCE_CARD_ASPECT_RATIO,
+            resourceCardStyle,
             typeInfo: layoutTypeLabels[child.layoutType] ?? child.layoutType,
             layoutTypeDisplay: child.layoutType
               ? layoutTypeLabels[child.layoutType] || child.layoutType

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -62,6 +62,13 @@ refs:
     eventListeners:
       click:
         action: hideFullImagePreview
+styles:
+  ".backgroundResourceThumbnailTransparencyGrid":
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 6px, 6px -6px, -6px 0"
+    background-repeat: repeat
+    background-size: 12px 12px
 template:
   - 'rtgl-view w=f h=f p=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - rtgl-view d=h g=md: null
@@ -71,35 +78,39 @@ template:
               - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues}:
                   - $if selectedResource:
                       - $if selectedResource.resourceType == 'image':
-                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
-                              - rtgl-view p=md g=md br=md:
-                                  - rvn-file-image w=200 h=120 fileId=${selectedResource.fileId}: null
-                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=md:
+                              - 'rtgl-view br=md w=200 pos=rel overflow=hidden style="${selectedResource.resourceCardStyle}"':
+                                  - 'div.backgroundResourceThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${selectedResource.previewAspectRatio}; overflow: hidden;"':
+                                      - rvn-file-image w=f h=f fileId=${selectedResource.fileId}: null
+                                  - rtgl-view w=f p=md:
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectedResource.name}
                         $elif selectedResource.resourceType == 'layout':
-                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
-                              - 'rtgl-view w=225 br=md style="overflow: hidden;"':
-                                  - $if selectedResource.item.thumbnailFileId:
-                                      - rvn-file-image fileId=${selectedResource.item.thumbnailFileId} w=225 h=120: null
-                                    $else:
-                                      - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
-                                          - rtgl-text s=sm c=mu-fg: No thumbnail
-                                  - rtgl-view d=v w=f g=xs ph=md pt=sm pb=md:
-                                      - rtgl-text s=sm ellipsis w=193: ${selectedResource.name}
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=md:
+                              - 'rtgl-view w=225 br=md overflow=hidden style="${selectedResource.resourceCardStyle}"':
+                                  - 'rtgl-view w=f style="aspect-ratio: ${selectedResource.previewAspectRatio}; overflow: hidden;"':
+                                      - $if selectedResource.fileId:
+                                          - rvn-file-image fileId=${selectedResource.fileId} w=f h=f: null
+                                        $else:
+                                          - rtgl-view w=f h=f av=c ah=c bgc=mu-fg:
+                                              - rtgl-text s=sm c=mu-fg: No thumbnail
+                                  - rtgl-view d=v w=f g=xs p=md:
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectedResource.name}
                                       - $if selectedResource.typeInfo:
-                                          - rtgl-text s=xs c=mu-fg ellipsis w=193: ${selectedResource.typeInfo}
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectedResource.typeInfo}
                         $elif selectedResource.resourceType == 'video':
-                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=sm:
-                              - rtgl-view p=md g=md br=md:
-                                  - rtgl-view pos=rel:
-                                      - rvn-file-image w=200 h=120 fileId=${selectedResource.item.thumbnailFileId}: null
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=md:
+                              - 'rtgl-view br=md pos=rel w=200 overflow=hidden style="${selectedResource.resourceCardStyle}"':
+                                  - 'rtgl-view w=f pos=rel style="aspect-ratio: ${selectedResource.previewAspectRatio}; overflow: hidden;"':
+                                      - rvn-file-image w=f h=f fileId=${selectedResource.fileId}: null
                                       - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
                                           - rtgl-icon icon=play s=xl c=fg: null
-                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${selectedResource.name}
+                                  - rtgl-view w=f p=md:
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectedResource.name}
                         $else:
-                          - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
+                          - 'rtgl-view#backgroundImage w=355 bw=xs bc=bo h-bc=ac br=md bgc=mu av=c ah=c cur=pointer slot=background style="aspect-ratio: 16 / 9;"':
                               - rtgl-text s=md c=mu-fg: Select Background
                     $else:
-                      - rtgl-view#backgroundImage w=355 h=200 bgc=mu av=c ah=c cur=pointer slot=background:
+                      - 'rtgl-view#backgroundImage w=355 bw=xs bc=bo h-bc=ac br=md bgc=mu av=c ah=c cur=pointer slot=background style="aspect-ratio: 16 / 9;"':
                           - rtgl-text s=md c=mu-fg: Select Background
                   - rtgl-view slot=custom-transform d=h av=c w=f g=md:
                       - rtgl-view d=h av=c w=1fg g=sm wrap:
@@ -150,17 +161,18 @@ template:
                                   - rtgl-text: ${group.fullLabel}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
-                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
-                                          - 'rtgl-view w=225 br=md style="overflow: hidden;"':
-                                              - $if item.thumbnailFileId:
-                                                  - rvn-file-image fileId=${item.thumbnailFileId} w=225 h=120: null
-                                                $else:
-                                                  - rtgl-view w=225 h=120 av=c ah=c bgc=mu-fg:
-                                                      - rtgl-text s=sm c=mu-fg: No thumbnail
-                                              - rtgl-view d=v w=f g=xs ph=md pt=sm pb=md:
-                                                  - rtgl-text s=sm ellipsis w=193: ${item.name}
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                          - 'rtgl-view w=225 br=md overflow=hidden style="${item.resourceCardStyle}"':
+                                              - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                  - $if item.previewFileId:
+                                                      - rvn-file-image fileId=${item.previewFileId} w=f h=f: null
+                                                    $else:
+                                                      - rtgl-view w=f h=f av=c ah=c bgc=mu-fg:
+                                                          - rtgl-text s=sm c=mu-fg: No thumbnail
+                                              - rtgl-view d=v w=f g=xs p=md:
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
                                                   - $if item.typeInfo:
-                                                      - rtgl-text s=xs c=mu-fg ellipsis w=193: ${item.typeInfo}
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.typeInfo}
                     $elif tab == 'video':
                       - $for group, i in groups:
                           - rtgl-view g=md:
@@ -169,10 +181,14 @@ template:
                                   - rtgl-text: ${group.fullLabel}
                               - rtgl-view d=h w=f wrap g=lg:
                                   - $for item, j in group.children:
-                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
-                                          - rtgl-view p=md g=md br=md:
-                                              - rvn-file-image w=200 h=120 fileId=${item.thumbnailFileId}: null
-                                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                          - 'rtgl-view br=md pos=rel w=200 overflow=hidden style="${item.resourceCardStyle}"':
+                                              - 'rtgl-view w=f pos=rel style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                  - rvn-file-image w=f h=f fileId=${item.previewFileId}: null
+                                                  - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
+                                                      - rtgl-icon icon=play s=xl c=fg: null
+                                              - rtgl-view w=f p=md:
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
 

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -123,6 +123,19 @@ refs:
     eventListeners:
       click:
         handler: handleCharacterItemClick
+styles:
+  ".commandLineCharacterThumbnailTransparencyGrid":
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 6px, 6px -6px, -6px 0"
+    background-repeat: repeat
+    background-size: 12px 12px
+  ".commandLineCharacterFullPreviewTransparencyGrid":
+    background-color: "#eef2f7"
+    background-image: 'linear-gradient(45deg, #94a3b8 25%, transparent 25%), linear-gradient(-45deg, #94a3b8 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #94a3b8 75%), linear-gradient(-45deg, transparent 75%, #94a3b8 75%)'
+    background-position: "0 0, 0 12px, 12px -12px, -12px 0"
+    background-repeat: repeat
+    background-size: 24px 24px
 template:
   - 'rtgl-view w=f h=f p=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - $if mode == 'current':
@@ -137,7 +150,8 @@ template:
                                   - 'rtgl-view#characterSpriteBox${i} data-index=${character.characterIndex} cur=pointer bw=xs bc=bo h-bc=ac br=sm style="align-self: flex-start; flex: 0 0 auto;"':
                                       - rtgl-view p=md g=md br=md:
                                           - $if character.hasSpritePreview:
-                                              - rvn-stacked-file-images :layers=${character.spritePreviewLayers} w=200 h=120 br=sm lazy: null
+                                              - 'div.commandLineCharacterThumbnailTransparencyGrid style="display: block; width: 200px; height: 120px; overflow: hidden; border-radius: 4px;"':
+                                                  - rvn-stacked-file-images :layers=${character.spritePreviewLayers} w=f h=f br=sm spritesheetBr=none spritesheetCheckerCellSize=6 showSpritesheetCheckerboard=false lazy: null
                                             $else:
                                               - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
                                                   - rtgl-text s=sm c=mu-fg: No Sprite
@@ -208,7 +222,8 @@ template:
                                   - rtgl-view#characterItem${i}x${j} data-character-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
                                       - rtgl-view p=md g=md br=md:
                                           - $if item.fileId:
-                                              - rvn-file-image fileId=${item.fileId} w=200 h=120: null
+                                              - 'div.commandLineCharacterThumbnailTransparencyGrid style="display: block; width: 200px; height: 120px; overflow: hidden; border-radius: 4px;"':
+                                                  - rvn-file-image fileId=${item.fileId} w=f h=f br=sm: null
                                             $else:
                                               - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
                                                   - rtgl-text s=sm c=mu-fg: No Avatar
@@ -235,9 +250,10 @@ template:
                                   - rtgl-view#spriteItem${i}x${j} data-sprite-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
                                       - rtgl-view p=md g=md br=md:
                                           - $if item.previewKind == 'spritesheet':
-                                              - 'rvn-spritesheet-preview key=${item.previewKey} fileId=${item.previewFileId} :atlas=${item.previewAtlas} :animation=${item.previewAnimation} w=200 h=120 emptyLabel="No preview"': null
+                                              - 'rvn-spritesheet-preview key=${item.previewKey} previewKey=${item.previewKey} fileId=${item.previewFileId} :atlas=${item.previewAtlas} :animation=${item.previewAnimation} w=200 h=120 br=sm checkerCellSize=6 showCheckerboard=true emptyLabel="No preview"': null
                                             $else:
-                                              - rvn-file-image fileId=${item.previewFileId} w=200 h=120: null
+                                              - 'div.commandLineCharacterThumbnailTransparencyGrid style="display: block; width: 200px; height: 120px; overflow: hidden; border-radius: 4px;"':
+                                                  - rvn-file-image fileId=${item.previewFileId} w=f h=f br=sm: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: Select
@@ -247,9 +263,10 @@ template:
           - $if fullImagePreviewFileId:
               - rtgl-view pos=fix edge=f ah=c av=c z=3001:
                   - $if fullImagePreviewKind == 'spritesheet':
-                      - 'rvn-spritesheet-preview key=${fullImagePreviewKey} fileId=${fullImagePreviewFileId} :atlas=${fullImagePreviewAtlas} :animation=${fullImagePreviewAnimation} w=80% h=80% emptyLabel="No preview"': null
+                      - 'rvn-spritesheet-preview key=${fullImagePreviewKey} previewKey=${fullImagePreviewKey} fileId=${fullImagePreviewFileId} :atlas=${fullImagePreviewAtlas} :animation=${fullImagePreviewAnimation} w=80% h=80% checkerCellSize=12 showCheckerboard=true emptyLabel="No preview"': null
                     $else:
-                      - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null
+                      - 'div.commandLineCharacterFullPreviewTransparencyGrid style="display: block; width: 80%; height: 80%; overflow: hidden; border-radius: 6px; box-shadow: 0 0 0 1px var(--accent);"':
+                          - rvn-file-image fileId=${fullImagePreviewFileId} w=f h=f br=md: null
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
   - $if backgroundTransformEditor.isOpen:
       - 'rtgl-view pos=abs edge=f z=20 bgc=bg d=v style="pointer-events: auto; min-width: 0; min-height: 0;"':

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -152,7 +152,7 @@ template:
                                   - rtgl-view#spriteItem${i}x${j} data-sprite-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm:
                                       - rtgl-view p=md g=md br=md:
                                           - $if item.previewKind == 'spritesheet':
-                                              - 'rvn-spritesheet-preview key=${item.previewKey} fileId=${item.previewFileId} :atlas=${item.previewAtlas} :animation=${item.previewAnimation} w=200 h=120 emptyLabel="No preview"': null
+                                              - 'rvn-spritesheet-preview key=${item.previewKey} previewKey=${item.previewKey} fileId=${item.previewFileId} :atlas=${item.previewAtlas} :animation=${item.previewAnimation} w=200 h=120 emptyLabel="No preview"': null
                                             $else:
                                               - rvn-file-image fileId=${item.previewFileId} w=200 h=120: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
@@ -164,6 +164,6 @@ template:
           - $if fullImagePreviewFileId:
               - rtgl-view pos=fix edge=f ah=c av=c z=3001:
                   - $if fullImagePreviewKind == 'spritesheet':
-                      - 'rvn-spritesheet-preview key=${fullImagePreviewKey} fileId=${fullImagePreviewFileId} :atlas=${fullImagePreviewAtlas} :animation=${fullImagePreviewAnimation} w=80% h=80% emptyLabel="No preview"': null
+                      - 'rvn-spritesheet-preview key=${fullImagePreviewKey} previewKey=${fullImagePreviewKey} fileId=${fullImagePreviewFileId} :atlas=${fullImagePreviewAtlas} :animation=${fullImagePreviewAnimation} w=80% h=80% emptyLabel="No preview"': null
                     $else:
                       - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null

--- a/src/components/imageSelector/imageSelector.store.js
+++ b/src/components/imageSelector/imageSelector.store.js
@@ -54,6 +54,7 @@ export const selectViewData = ({ state, props = {} }) => {
             itemBorderColor,
             itemHoverBorderColor,
             imageCardStyle,
+            previewAspectRatio: "16 / 9",
           };
         });
 

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -24,7 +24,7 @@ template:
               - $for item, j in group.children:
                   - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md cur=pointer key=${item.id}:
                       - 'rtgl-view br=md w=200 pos=rel overflow=hidden style="${item.imageCardStyle}"':
-                          - 'div.imageSelectorThumbnailTransparencyGrid style="display: block; width: 100%; height: 120px; overflow: hidden;"':
+                          - 'div.imageSelectorThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                               - rvn-file-image w=f h=f imageId=${item.id} source="thumbnail": null
                           - rtgl-view w=f p=md:
                               - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -296,14 +296,14 @@ template:
                               - rtgl-view w=1fg: null
                               - $if barItem.kind == 'spritesheet' && barItem.resourceId:
                                   - rtgl-view w=56 h=32 overflow=hidden br=sm:
-                                      - 'rvn-spritesheet-preview key=${barItem.spritesheetPreviewKey} fileId=${barItem.spritesheetFileId} :atlas=${barItem.spritesheetAtlas} :animation=${barItem.spritesheetAnimation} w=f h=f emptyLabel="No preview"': null
+                                      - 'rvn-spritesheet-preview key=${barItem.spritesheetPreviewKey} previewKey=${barItem.spritesheetPreviewKey} fileId=${barItem.spritesheetFileId} :atlas=${barItem.spritesheetAtlas} :animation=${barItem.spritesheetAnimation} w=f h=f emptyLabel="No preview"': null
                                 $elif barItem.imageId:
                                   - rvn-file-image imageId=${barItem.imageId} source="thumbnail" h=32: null
                                 $else:
                                   - rtgl-view d=h av=c ah=c h=32 ph=sm bgc=mu br=sm:
                                       - rtgl-text s=xs c=mu: Not set
                     $elif item.type == 'spritesheet-preview':
-                      - 'rvn-spritesheet-preview key=${item.previewKey} fileId=${item.fileId} :atlas=${item.atlas} :animation=${item.animation} h=180 emptyLabel="Select a spritesheet animation"': null
+                      - 'rvn-spritesheet-preview key=${item.previewKey} previewKey=${item.previewKey} fileId=${item.fileId} :atlas=${item.atlas} :animation=${item.animation} h=180 emptyLabel="Select a spritesheet animation"': null
                     $elif item.type == 'popover-input':
                       - rtgl-view#groupItem${i}x${j} data-name=${item.name} d=h pv=sm ph=md bgc=mu br=md av=c g=md cur=pointer bw=xs bc=bg h-bc=ac h=32 w=1fg:
                           - rtgl-text s=sm: ${item.value}
@@ -386,7 +386,7 @@ template:
                       - rtgl-view#textRevealIndicatorImageField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
                           - $if textRevealIndicatorDialog.kind == 'spritesheet' && textRevealIndicatorDialog.resourceId:
                               - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
-                                  - 'rvn-spritesheet-preview key=${textRevealIndicatorDialogPreviewKey} fileId=${textRevealIndicatorDialogSpritesheetFileId} :atlas=${textRevealIndicatorDialogSpritesheetAtlas} :animation=${textRevealIndicatorDialogSpritesheetAnimation} w=f h=f emptyLabel="No preview"': null
+                                  - 'rvn-spritesheet-preview key=${textRevealIndicatorDialogPreviewKey} previewKey=${textRevealIndicatorDialogPreviewKey} fileId=${textRevealIndicatorDialogSpritesheetFileId} :atlas=${textRevealIndicatorDialogSpritesheetAtlas} :animation=${textRevealIndicatorDialogSpritesheetAnimation} w=f h=f emptyLabel="No preview"': null
                             $elif textRevealIndicatorDialog.imageId:
                               - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                                   - rvn-file-image imageId=${textRevealIndicatorDialog.imageId} source="thumbnail" w=f h=f: null

--- a/src/components/layoutEditorPreview/layoutEditorPreview.view.yaml
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.view.yaml
@@ -98,7 +98,7 @@ template:
   - $if previewBackgroundOnlyForm:
       - rtgl-form key=${previewBackgroundOnlyFormKey} w=f :form=${previewBackgroundOnlyForm}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -107,7 +107,7 @@ template:
   - $if showDialogueForm:
       - rtgl-form#dialogueForm key=${dialogueFormKey} w=f :form=${dialogueForm} :defaultValues=${dialogueDefaultValues} :context=${dialogueContext}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -116,7 +116,7 @@ template:
   - $if showNvlForm:
       - rtgl-form#nvlForm key=${nvlFormKey} w=f :form=${nvlForm} :defaultValues=${nvlDefaultValues} :context=${nvlContext}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -130,7 +130,7 @@ template:
   - $if showChoiceForm:
       - rtgl-form#choiceForm key=${choiceFormKey} w=f :form=${choiceForm} :defaultValues=${choiceDefaultValues} :context=${choicesContext}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -139,7 +139,7 @@ template:
   - $if showHistoryForm:
       - rtgl-form#historyForm key=${historyFormKey} w=f :form=${historyForm} :defaultValues=${historyDefaultValues} :context=${historyContext}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -148,7 +148,7 @@ template:
   - $if showInputFieldsForm:
       - rtgl-form#inputFieldsForm key=${inputFieldsFormKey} w=f :form=${inputFieldsForm} :defaultValues=${inputFieldsDefaultValues}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -157,7 +157,7 @@ template:
   - $if showPreviewVariablesForm:
       - rtgl-form#previewVariablesForm key=${previewVariablesFormKey} w=f :form=${previewVariablesForm} :defaultValues=${previewVariablesDefaultValues}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null
@@ -166,7 +166,7 @@ template:
   - $if showSaveLoadForm:
       - rtgl-form#saveLoadForm key=${saveLoadFormKey} w=f :form=${saveLoadForm} :defaultValues=${saveLoadDefaultValues} :context=${saveLoadContext}:
           - rtgl-view slot=${previewBackgroundSlot} g=xs:
-              - rtgl-view#previewBackgroundField w=220 h=160 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden:
+              - 'rtgl-view#previewBackgroundField w=220 bw=xs bc=bo br=md cur=pointer av=c ah=c overflow=hidden style="aspect-ratio: 16 / 9;"':
                   - $if previewBackgroundImageId:
                       - 'div.layoutEditorImageFieldTransparencyGrid style="display: block; width: 100%; height: 100%; overflow: hidden;"':
                           - rvn-file-image imageId=${previewBackgroundImageId} source="thumbnail" w=f h=f: null

--- a/src/components/spritesheetPreview/spritesheetPreview.handlers.js
+++ b/src/components/spritesheetPreview/spritesheetPreview.handlers.js
@@ -284,6 +284,64 @@ const startAnimation = (deps) => {
   store.setAnimationFrameId({ animationFrameId });
 };
 
+const getSourceImageSrc = (sourceImage) => {
+  return (
+    sourceImage?.getAttribute?.("src") ??
+    sourceImage?.currentSrc ??
+    sourceImage?.src ??
+    ""
+  );
+};
+
+const isCurrentSourceImageLoaded = ({ refs, store } = {}) => {
+  const sourceImage = refs?.sourceImage;
+  if (
+    typeof HTMLImageElement === "undefined" ||
+    !(sourceImage instanceof HTMLImageElement) ||
+    !sourceImage.complete ||
+    sourceImage.naturalWidth <= 0
+  ) {
+    return false;
+  }
+
+  const imageSrc = store.selectImageSrc();
+  return imageSrc.length > 0 && getSourceImageSrc(sourceImage) === imageSrc;
+};
+
+const renderReadySourceImage = (deps) => {
+  const { props, render, store } = deps;
+  stopAnimation(store);
+  store.setStatus({ status: "ready" });
+  drawFrame(deps);
+  if (!isPaused(props.paused)) {
+    startAnimation(deps);
+  }
+  render();
+};
+
+const syncReadySourceImage = (deps) => {
+  const { store } = deps;
+  if (store.selectStatus() !== "loading") {
+    return;
+  }
+
+  if (isCurrentSourceImageLoaded(deps)) {
+    renderReadySourceImage(deps);
+  }
+};
+
+const renderImageSourceChange = (deps) => {
+  const { render } = deps;
+  render();
+  syncReadySourceImage(deps);
+
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(() => {
+      syncReadySourceImage(deps);
+    });
+  }
+};
+
 const loadImageSource = async (deps) => {
   const { projectService, props, refs, render, store } = deps;
 
@@ -301,7 +359,7 @@ const loadImageSource = async (deps) => {
       imageSrc: props.src,
       ownsImageSrc: false,
     });
-    render();
+    renderImageSourceChange(deps);
     return;
   }
 
@@ -320,7 +378,7 @@ const loadImageSource = async (deps) => {
       imageSrc: url ?? "",
       ownsImageSrc: true,
     });
-    render();
+    renderImageSourceChange(deps);
   } catch {
     store.setStatus({ status: "error" });
     render();
@@ -335,6 +393,8 @@ const didSourceChange = (oldProps = {}, newProps = {}) => {
 
 const didFrameRenderingChange = (oldProps = {}, newProps = {}) => {
   return (
+    oldProps?.previewKey !== newProps?.previewKey ||
+    oldProps?.key !== newProps?.key ||
     oldProps?.atlas !== newProps?.atlas ||
     oldProps?.animation !== newProps?.animation
   );
@@ -392,13 +452,7 @@ export const handleOnUpdate = async (deps, payload = {}) => {
 };
 
 export const handleSourceImageLoad = (deps) => {
-  const { props, render, store } = deps;
-  store.setStatus({ status: "ready" });
-  drawFrame(deps);
-  if (!isPaused(props.paused)) {
-    startAnimation(deps);
-  }
-  render();
+  renderReadySourceImage(deps);
 };
 
 export const handleSourceImageError = (deps) => {

--- a/src/components/spritesheetSelector/spritesheetSelector.view.yaml
+++ b/src/components/spritesheetSelector/spritesheetSelector.view.yaml
@@ -18,7 +18,7 @@ template:
                   - $for item, j in group.children:
                       - rtgl-view#spritesheetItemRef${i}x${j} data-selection-value=${item.selectionValue} data-resource-id=${item.resourceId} data-animation-name=${item.animationName} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md cur=pointer key=${item.selectionValue}:
                           - 'rtgl-view br=md w=200 pos=rel overflow=hidden style="${item.cardStyle}"':
-                              - 'rvn-spritesheet-preview key=${item.previewKey} fileId=${item.fileId} :atlas=${item.atlas} :animation=${item.animation} w=f h=120 emptyLabel="No preview"': null
+                              - 'rvn-spritesheet-preview key=${item.previewKey} previewKey=${item.previewKey} fileId=${item.fileId} :atlas=${item.atlas} :animation=${item.animation} w=f h=120 emptyLabel="No preview"': null
                               - rtgl-view w=f p=md:
                                   - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
         $else:

--- a/src/components/stackedFileImages/stackedFileImages.view.yaml
+++ b/src/components/stackedFileImages/stackedFileImages.view.yaml
@@ -1,8 +1,8 @@
 template:
   - 'rtgl-view pos=rel w=${w} h=${h} br=${br} style="${containerStyle}"':
       - $for layer, i in fileLayers:
-          - rtgl-view pos=abs edge=f:
+          - rtgl-view pos=abs edge=f key=${layer.key}:
               - $if layer.kind == 'spritesheet':
-                  - 'rvn-spritesheet-preview key=${layer.key} fileId=${layer.fileId} :atlas=${layer.atlas} :animation=${layer.animation} :showCheckerboard=${showSpritesheetCheckerboard} w=f h=f br=${spritesheetBr} checkerCellSize=${spritesheetCheckerCellSize} emptyLabel="No preview"': null
+                  - 'rvn-spritesheet-preview key=${layer.key} previewKey=${layer.key} fileId=${layer.fileId} :atlas=${layer.atlas} :animation=${layer.animation} :showCheckerboard=${showSpritesheetCheckerboard} w=f h=f br=${spritesheetBr} checkerCellSize=${spritesheetCheckerCellSize} emptyLabel="No preview"': null
                 $else:
                   - rvn-file-image fileId=${layer.fileId} w=f h=f br=${imageBr} ?lazy=${lazy} key=${layer.key}: null

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -1840,9 +1840,13 @@ export const createGraphicsService = async ({
       if (!engine || !routeGraphics) {
         return;
       }
-      const { skipAudio = false, skipAnimations = false } = options;
+      const {
+        preserveAnimationPlayback = false,
+        skipAudio = false,
+        skipAnimations = false,
+      } = options;
       routeGraphics.setAnimationPlaybackMode?.(
-        skipAnimations ? "manual" : "auto",
+        skipAnimations && !preserveAnimationPlayback ? "manual" : "auto",
       );
       const effectiveSkipAudio = skipAudio || isEngineAudioMuted;
       let renderState = engine.selectRenderState();

--- a/src/internal/runtime/graphicsEngineRuntime.js
+++ b/src/internal/runtime/graphicsEngineRuntime.js
@@ -6,6 +6,102 @@ const THUMBNAIL_MAX_HEIGHT = 225;
 const THUMBNAIL_FORMAT = "image/jpeg";
 const THUMBNAIL_QUALITY = 0.75;
 
+const findDisplayObjectByLabel = (parent, label) => {
+  if (!parent || !Array.isArray(parent.children)) {
+    return undefined;
+  }
+
+  return parent.children.find((child) => child?.label === label);
+};
+
+const destroyDisplayObject = (displayObject) => {
+  if (!displayObject || displayObject.destroyed) {
+    return;
+  }
+
+  displayObject.stop?.();
+  displayObject.removeFromParent?.();
+  displayObject.destroy?.({ children: true });
+};
+
+const replacePluginDisplay = async (plugin, params = {}) => {
+  const { parent, prevElement, nextElement, signal } = params;
+
+  if (signal?.aborted || parent?.destroyed) {
+    return;
+  }
+
+  destroyDisplayObject(findDisplayObjectByLabel(parent, prevElement?.id));
+
+  if (signal?.aborted || parent?.destroyed || !nextElement) {
+    return;
+  }
+
+  return await plugin.add?.({
+    ...params,
+    element: nextElement,
+  });
+};
+
+const isMissingPlayMethodError = (error) => {
+  return (
+    error instanceof TypeError &&
+    /play is not a function/.test(error.message ?? "")
+  );
+};
+
+export const createSafeSpritesheetAnimationPlugin = (plugin) => {
+  if (!plugin) {
+    return undefined;
+  }
+
+  return {
+    ...plugin,
+    update: async (params = {}) => {
+      const displayObject = findDisplayObjectByLabel(
+        params.parent,
+        params.prevElement?.id,
+      );
+
+      if (displayObject && typeof displayObject.play !== "function") {
+        return await replacePluginDisplay(plugin, params);
+      }
+
+      try {
+        return await plugin.update?.(params);
+      } catch (error) {
+        if (!isMissingPlayMethodError(error)) {
+          throw error;
+        }
+
+        return await replacePluginDisplay(plugin, params);
+      }
+    },
+  };
+};
+
+export const createSafeSpritePlugin = (plugin) => {
+  if (!plugin) {
+    return undefined;
+  }
+
+  return {
+    ...plugin,
+    update: async (params = {}) => {
+      const displayObject = findDisplayObjectByLabel(
+        params.parent,
+        params.prevElement?.id,
+      );
+
+      if (displayObject && typeof displayObject.play === "function") {
+        return await replacePluginDisplay(plugin, params);
+      }
+
+      return await plugin.update?.(params);
+    },
+  };
+};
+
 export const loadGraphicsEnginePlugins = async () => {
   const routeGraphicsModule = await import("route-graphics");
   const spritesheetAnimationPlugin = Object.prototype.hasOwnProperty.call(
@@ -38,13 +134,13 @@ export const loadGraphicsEnginePlugins = async () => {
       textPlugin,
       inputPlugin,
       rectPlugin,
-      spritePlugin,
+      createSafeSpritePlugin(spritePlugin),
       sliderPlugin,
       containerPlugin,
       textRevealingPlugin,
       videoPlugin,
       particlesPlugin,
-      spritesheetAnimationPlugin,
+      createSafeSpritesheetAnimationPlugin(spritesheetAnimationPlugin),
     ].filter(Boolean),
     animations: [tweenPlugin].filter(Boolean),
     audio: [soundPlugin].filter(Boolean),

--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -815,7 +815,11 @@ const prepareTemporaryPresentationProjectData = async (
 
 export const renderSceneEditorState = async (deps, payload = {}) => {
   const { store, graphicsService } = deps;
-  const { skipAnimations = true, skipCanvasPaint = false } = payload;
+  const {
+    preserveAnimationPlayback = false,
+    skipAnimations = true,
+    skipCanvasPaint = false,
+  } = payload;
   const perfEnabled = isDebugEnabled(SCENE_EDITOR_PERF_SCOPE);
   const renderStartedAt = perfEnabled ? getDebugNow() : 0;
   const sceneId = store.selectSceneId();
@@ -954,6 +958,7 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
       graphicsService.render(backgroundTransformCanvasState.renderState);
     } else {
       graphicsService.engineRenderCurrentState({
+        preserveAnimationPlayback,
         skipAudio: isMuted,
         skipAnimations,
       });

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -176,6 +176,14 @@ styles:
     box-shadow: 0 0 0 1px var(--border)
     overflow: hidden
     cursor: default
+  ".imageDetailPreviewFrame":
+    display: block
+    width: 100%
+    aspect-ratio: 16 / 9
+    box-shadow: 0 0 0 1px var(--border)
+    border-radius: 6px
+    overflow: hidden
+    cursor: pointer
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -203,7 +211,8 @@ template:
                                   - rvn-detail-view#detailView key=${selectedDetailId} w=f h=1fg :fields=${detailFields}:
                                       - $if selectedItemId:
                                           - $if selectedPreviewFileId:
-                                              - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} w=f h=160 bw=xs bc=bo br=md cur=pointer: null
+                                              - 'div#detailImage.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
+                                                  - rvn-file-image fileId=${selectedPreviewFileId} w=f h=f: null
                                           - rtgl-tag-select#detailTagSelect slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
                             $else:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -63,16 +63,28 @@ const normalizeTemporaryPresentationState = (detail = {}) => {
   return toPlainObject(detail.presentationState);
 };
 
-const requestTemporaryPresentationCanvasRender = (subject) => {
-  subject?.dispatch?.("sceneEditor.renderCanvas", {
+const requestTemporaryPresentationCanvasRender = (
+  subject,
+  { preserveAnimationPlayback = false, skipAnimations = false } = {},
+) => {
+  const renderPayload = {
     skipRender: true,
-    skipAnimations: true,
-  });
+    skipAnimations,
+  };
+
+  if (preserveAnimationPlayback) {
+    renderPayload.preserveAnimationPlayback = true;
+  }
+
+  subject?.dispatch?.("sceneEditor.renderCanvas", renderPayload);
 };
 
 const clearTemporaryPresentationPreview = ({ store, subject }) => {
   store.clearTemporaryPresentationState?.();
-  requestTemporaryPresentationCanvasRender(subject);
+  requestTemporaryPresentationCanvasRender(subject, {
+    preserveAnimationPlayback: true,
+    skipAnimations: true,
+  });
 };
 
 const flattenRefs = (value) => {
@@ -548,13 +560,16 @@ const dispatchLineNavigationRender = (
     return;
   }
 
+  const skipAnimations = !shouldAnimateLineNavigation(store, {
+    previousLineId,
+    nextLineId,
+  });
+
   subject.dispatch("sceneEditor.renderCanvas", {
     skipRender,
     syncPresentationState: true,
-    skipAnimations: !shouldAnimateLineNavigation(store, {
-      previousLineId,
-      nextLineId,
-    }),
+    skipAnimations,
+    preserveAnimationPlayback: skipAnimations,
   });
 };
 
@@ -1345,7 +1360,7 @@ export const handleBackgroundTransformEditorCancel = (deps, payload) => {
     });
     render();
     reopenBackgroundCommandLine({ refs, store, background });
-    requestTemporaryPresentationCanvasRender(subject);
+    requestTemporaryPresentationCanvasRender(subject, { skipAnimations: true });
     globalThis.setTimeout?.(() => {
       store.clearSuppressNextActionsDialogClose?.();
       render();
@@ -1367,7 +1382,7 @@ export const handleBackgroundTransformEditorCancel = (deps, payload) => {
     actionKey,
     action,
   });
-  requestTemporaryPresentationCanvasRender(subject);
+  requestTemporaryPresentationCanvasRender(subject, { skipAnimations: true });
   globalThis.setTimeout?.(() => {
     store.clearSuppressNextActionsDialogClose?.();
     render();

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -1171,4 +1171,46 @@ describe("graphicsService", () => {
       }),
     );
   });
+
+  it("can preserve playback mode while skipping render-state animations", async () => {
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+
+    service.initRouteEngine({
+      screen: { width: 1920, height: 1080 },
+      story: { scenes: {} },
+      resources: {},
+    });
+    routeGraphicsInstance.render.mockClear();
+
+    service.engineRenderCurrentState({
+      preserveAnimationPlayback: true,
+      skipAnimations: true,
+    });
+
+    expect(routeGraphicsInstance.setAnimationPlaybackMode).toHaveBeenCalledWith(
+      "auto",
+    );
+    expect(routeGraphicsInstance.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        animations: [],
+      }),
+    );
+  });
 });

--- a/tests/internal/runtimeActionPreparation.test.js
+++ b/tests/internal/runtimeActionPreparation.test.js
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   captureCanvasImage,
   captureCanvasThumbnailImage,
+  createSafeSpritePlugin,
+  createSafeSpritesheetAnimationPlugin,
   preloadRuntimeSaveSlotImages,
   prepareRuntimeInteractionExecution,
   prepareRuntimeInteractionActions,
@@ -36,6 +38,164 @@ class FakeImage {
     });
   }
 }
+
+describe("createSafeSpritePlugin", () => {
+  it("replaces a stale animated display object before sprite update", async () => {
+    const staleDisplay = {
+      label: "sprite-1",
+      play: vi.fn(),
+      stop: vi.fn(),
+      removeFromParent: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const parent = {
+      children: [staleDisplay],
+    };
+    const nextElement = {
+      id: "sprite-1",
+    };
+    const plugin = {
+      type: "sprite",
+      add: vi.fn(async () => "added"),
+      update: vi.fn(async () => "updated"),
+    };
+
+    const wrappedPlugin = createSafeSpritePlugin(plugin);
+    const result = await wrappedPlugin.update({
+      parent,
+      prevElement: { id: "sprite-1" },
+      nextElement,
+      zIndex: 2,
+    });
+
+    expect(result).toBe("added");
+    expect(plugin.update).not.toHaveBeenCalled();
+    expect(staleDisplay.stop).toHaveBeenCalledTimes(1);
+    expect(staleDisplay.removeFromParent).toHaveBeenCalledTimes(1);
+    expect(staleDisplay.destroy).toHaveBeenCalledWith({ children: true });
+    expect(plugin.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        element: nextElement,
+        parent,
+        zIndex: 2,
+      }),
+    );
+  });
+
+  it("delegates sprite updates for normal display objects", async () => {
+    const display = {
+      label: "sprite-1",
+      removeFromParent: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const parent = {
+      children: [display],
+    };
+    const plugin = {
+      type: "sprite",
+      add: vi.fn(async () => "added"),
+      update: vi.fn(async () => "updated"),
+    };
+
+    const wrappedPlugin = createSafeSpritePlugin(plugin);
+    const result = await wrappedPlugin.update({
+      parent,
+      prevElement: { id: "sprite-1" },
+      nextElement: { id: "sprite-1" },
+    });
+
+    expect(result).toBe("updated");
+    expect(plugin.update).toHaveBeenCalledTimes(1);
+    expect(plugin.add).not.toHaveBeenCalled();
+    expect(display.removeFromParent).not.toHaveBeenCalled();
+    expect(display.destroy).not.toHaveBeenCalled();
+  });
+});
+
+describe("createSafeSpritesheetAnimationPlugin", () => {
+  it("replaces a stale non-animated display object before spritesheet update", async () => {
+    const staleDisplay = {
+      label: "sprite-1",
+      stop: vi.fn(),
+      removeFromParent: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const parent = {
+      children: [staleDisplay],
+    };
+    const nextElement = {
+      id: "sprite-1",
+    };
+    const plugin = {
+      type: "spritesheet-animation",
+      add: vi.fn(async () => "added"),
+      update: vi.fn(async () => "updated"),
+    };
+
+    const wrappedPlugin = createSafeSpritesheetAnimationPlugin(plugin);
+    const result = await wrappedPlugin.update({
+      parent,
+      prevElement: { id: "sprite-1" },
+      nextElement,
+      zIndex: 2,
+    });
+
+    expect(result).toBe("added");
+    expect(plugin.update).not.toHaveBeenCalled();
+    expect(staleDisplay.stop).toHaveBeenCalledTimes(1);
+    expect(staleDisplay.removeFromParent).toHaveBeenCalledTimes(1);
+    expect(staleDisplay.destroy).toHaveBeenCalledWith({ children: true });
+    expect(plugin.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        element: nextElement,
+        parent,
+        zIndex: 2,
+      }),
+    );
+  });
+
+  it("falls back to replacement when RouteGraphics throws a missing play method error", async () => {
+    const display = {
+      label: "sprite-1",
+      play: vi.fn(),
+      stop: vi.fn(),
+      removeFromParent: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const parent = {
+      children: [display],
+    };
+    const nextElement = {
+      id: "sprite-1",
+    };
+    const plugin = {
+      type: "spritesheet-animation",
+      add: vi.fn(async () => "added"),
+      update: vi.fn(async () => {
+        throw new TypeError("c.play is not a function");
+      }),
+    };
+
+    const wrappedPlugin = createSafeSpritesheetAnimationPlugin(plugin);
+    const result = await wrappedPlugin.update({
+      parent,
+      prevElement: { id: "sprite-1" },
+      nextElement,
+    });
+
+    expect(result).toBe("added");
+    expect(plugin.update).toHaveBeenCalledTimes(1);
+    expect(display.stop).toHaveBeenCalledTimes(1);
+    expect(display.removeFromParent).toHaveBeenCalledTimes(1);
+    expect(display.destroy).toHaveBeenCalledWith({ children: true });
+    expect(plugin.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        element: nextElement,
+        parent,
+      }),
+    );
+  });
+});
 
 describe("captureCanvasThumbnailImage", () => {
   afterEach(() => {

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -477,12 +477,52 @@ describe("renderSceneEditorState", () => {
     );
 
     expect(engineRenderCurrentState).toHaveBeenNthCalledWith(1, {
+      preserveAnimationPlayback: false,
       skipAudio: false,
       skipAnimations: true,
     });
     expect(engineRenderCurrentState).toHaveBeenNthCalledWith(2, {
+      preserveAnimationPlayback: false,
       skipAudio: false,
       skipAnimations: false,
+    });
+  });
+
+  it("can skip render-state animations while preserving playback", async () => {
+    const projectData = createProjectData();
+    const graphicsService = createGraphicsService();
+    const engineRenderCurrentState = vi.fn();
+    graphicsService.engineRenderCurrentState = engineRenderCurrentState;
+    const store = {
+      selectSceneId: () => "scene-1",
+      selectSelectedSectionId: () => "section-1",
+      selectSelectedLineId: () => "line-2",
+      selectProjectData: () => projectData,
+      selectPreviewRuntimeGlobal: () => ({
+        dialogueTextSpeed: 100,
+      }),
+      selectIsMuted: () => false,
+      setPresentationState: ({ presentationState }) => {
+        store.presentationState = presentationState;
+      },
+      presentationState: undefined,
+    };
+
+    await renderSceneEditorState(
+      {
+        store,
+        graphicsService,
+      },
+      {
+        preserveAnimationPlayback: true,
+        skipAnimations: true,
+      },
+    );
+
+    expect(engineRenderCurrentState).toHaveBeenCalledWith({
+      preserveAnimationPlayback: true,
+      skipAudio: false,
+      skipAnimations: true,
     });
   });
 

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -14,6 +14,7 @@ import {
   handleNewLine,
   handleSectionMoveSceneFormActionClick,
   handleSelectedLineChanged,
+  handleTemporaryPresentationStateChange,
   scrollEntrySelectionIntoView,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 
@@ -36,6 +37,70 @@ const installAnimationFrameQueue = () => {
     },
   };
 };
+
+describe("sceneEditorLexical.handlers temporary presentation preview", () => {
+  it("renders temporary action previews with animations enabled", () => {
+    const stopPropagation = vi.fn();
+    const store = {
+      setTemporaryPresentationState: vi.fn(),
+    };
+    const subject = {
+      dispatch: vi.fn(),
+    };
+
+    handleTemporaryPresentationStateChange(
+      {
+        store,
+        subject,
+      },
+      {
+        _event: {
+          stopPropagation,
+          detail: {
+            presentationState: {
+              character: {
+                items: [
+                  {
+                    id: "character-hero",
+                    sprites: [
+                      {
+                        id: "face",
+                        resourceId: "sprite-blink",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(store.setTemporaryPresentationState).toHaveBeenCalledWith({
+      presentationState: {
+        character: {
+          items: [
+            {
+              id: "character-hero",
+              sprites: [
+                {
+                  id: "face",
+                  resourceId: "sprite-blink",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(subject.dispatch).toHaveBeenCalledWith("sceneEditor.renderCanvas", {
+      skipRender: true,
+      skipAnimations: false,
+    });
+  });
+});
 
 describe("sceneEditorLexical.handlers transform editor resize", () => {
   it("resets stale section scroll when entering the first section", () => {
@@ -938,6 +1003,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     expect(deps.subject.dispatch).toHaveBeenCalledWith(
       "sceneEditor.renderCanvas",
       {
+        preserveAnimationPlayback: true,
         skipRender: true,
         skipAnimations: true,
       },
@@ -988,6 +1054,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     expect(deps.subject.dispatch).toHaveBeenCalledWith(
       "sceneEditor.renderCanvas",
       {
+        preserveAnimationPlayback: true,
         skipRender: true,
         skipAnimations: true,
       },
@@ -1619,6 +1686,8 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       expect(deps.subject.dispatch).toHaveBeenCalledWith(
         "sceneEditor.renderCanvas",
         expect.objectContaining({
+          preserveAnimationPlayback: true,
+          skipAnimations: true,
           skipRender: true,
           syncPresentationState: true,
         }),

--- a/tests/spritesheetPreview/spritesheetPreview.handlers.test.js
+++ b/tests/spritesheetPreview/spritesheetPreview.handlers.test.js
@@ -97,6 +97,93 @@ describe("spritesheetPreview.handlers", () => {
     expect(render).toHaveBeenCalledTimes(1);
   });
 
+  it("renders an already-loaded source image after src is added", async () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const drawImage = vi.fn();
+    const context = {
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      drawImage,
+    };
+    const originalCanvasElement = globalThis.HTMLCanvasElement;
+    const originalImageElement = globalThis.HTMLImageElement;
+
+    class FakeCanvas {
+      constructor() {
+        this.width = 0;
+        this.height = 0;
+        this.clientWidth = 64;
+        this.clientHeight = 64;
+      }
+
+      getBoundingClientRect() {
+        return {
+          width: 64,
+          height: 64,
+        };
+      }
+
+      getContext(type) {
+        return type === "2d" ? context : undefined;
+      }
+    }
+
+    class FakeImage {
+      constructor() {
+        this.complete = true;
+        this.naturalWidth = 64;
+        this.naturalHeight = 64;
+        this.src = "blob:test-spritesheet";
+      }
+
+      getAttribute(name) {
+        return name === "src" ? this.src : undefined;
+      }
+    }
+
+    const canvas = new FakeCanvas();
+    const sourceImage = new FakeImage();
+
+    globalThis.HTMLCanvasElement = FakeCanvas;
+    globalThis.HTMLImageElement = FakeImage;
+
+    try {
+      await handleOnUpdate(
+        {
+          projectService: {},
+          props: {},
+          refs: {
+            canvas,
+            sourceImage,
+          },
+          render,
+          store: createStoreApi(state),
+        },
+        {
+          oldProps: {},
+          newProps: {
+            paused: true,
+            src: "blob:test-spritesheet",
+          },
+        },
+      );
+    } finally {
+      globalThis.HTMLCanvasElement = originalCanvasElement;
+      globalThis.HTMLImageElement = originalImageElement;
+    }
+
+    expect(selectStatus({ state })).toBe("ready");
+    expect(drawImage).toHaveBeenCalledWith(
+      sourceImage,
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number),
+    );
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
   it("returns to empty when preview source is cleared", async () => {
     const state = createInitialState();
     const render = vi.fn();
@@ -132,6 +219,58 @@ describe("spritesheetPreview.handlers", () => {
 
     expect(selectStatus({ state })).toBe("empty");
     expect(selectImageSrc({ state })).toBe("");
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts animation when the preview key changes", async () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const requestAnimationFrameSpy = vi.fn(() => 101);
+    const cancelAnimationFrameSpy = vi.fn();
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+    setStatus(
+      { state },
+      {
+        status: "ready",
+      },
+    );
+    state.animationFrameId = 42;
+    globalThis.requestAnimationFrame = requestAnimationFrameSpy;
+    globalThis.cancelAnimationFrame = cancelAnimationFrameSpy;
+
+    try {
+      await handleOnUpdate(
+        {
+          projectService: {},
+          refs: {},
+          render,
+          store: createStoreApi(state),
+        },
+        {
+          oldProps: {
+            previewKey: "spritesheet:idle:file-a:idle:0,1:12",
+            animation: {
+              frames: [0, 1],
+            },
+          },
+          newProps: {
+            previewKey: "spritesheet:blink:file-a:idle:0,1:12",
+            animation: {
+              frames: [0, 1],
+            },
+          },
+        },
+      );
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(42);
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+    expect(state.animationFrameId).toBe(101);
     expect(render).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- add checkerboard-backed character/background/image previews and fixed preview aspect ratios
- pass stable preview keys through spritesheet preview surfaces so sprite group selections restart correctly
- keep scene editor sprite animations running during temporary preview, line navigation, and close/reset renders
- replace stale route-graphics sprite/spritesheet display objects when switching between static sprites and animated spritesheets
- bump Tauri app version to 1.6.2

## Testing
- bun prettier --check src/components/commandLineBackground/commandLineBackground.store.js src/components/commandLineBackground/commandLineBackground.view.yaml src/components/commandLineCharacters/commandLineCharacters.view.yaml src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml src/components/imageSelector/imageSelector.store.js src/components/imageSelector/imageSelector.view.yaml src/components/layoutEditPanel/layoutEditPanel.view.yaml src/components/layoutEditorPreview/layoutEditorPreview.view.yaml src/components/spritesheetPreview/spritesheetPreview.handlers.js src/components/spritesheetSelector/spritesheetSelector.view.yaml src/components/stackedFileImages/stackedFileImages.view.yaml src/deps/services/graphicsService.js src/internal/runtime/graphicsEngineRuntime.js src/internal/ui/sceneEditor/runtime.js src/pages/images/images.view.yaml src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js tests/graphicsService/graphicsService.test.js tests/internal/runtimeActionPreparation.test.js tests/sceneEditor/runtime.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/spritesheetPreview/spritesheetPreview.handlers.test.js
- bunx vitest run tests/graphicsService/graphicsService.test.js tests/internal/runtimeActionPreparation.test.js tests/sceneEditor/runtime.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/spritesheetPreview/spritesheetPreview.handlers.test.js tests/commandLineCharacters/commandLineCharacters.handlers.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js tests/commandLineBackground/commandLineBackground.handlers.test.js tests/commandLineBackground/commandLineBackground.store.test.js
- push hook: oxlint
- push hook: bun prettier --check src