### PR TITLE
fix: preserve visual custom transforms and layer ordering

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -58,6 +58,9 @@ const beginAddCharacterSelection = (store) => {
   });
 };
 
+const getTopSpriteSelectionGroupId = (spriteSelectionGroups = []) =>
+  spriteSelectionGroups[spriteSelectionGroups.length - 1]?.id;
+
 const buildTempSelectedSpriteIdsByGroup = ({
   character,
   spriteSelectionGroups,
@@ -112,7 +115,7 @@ const beginExistingCharacterSpriteSelection = (store, index) => {
     }),
   });
   store.setSelectedSpriteGroupId({
-    spriteGroupId: spriteSelectionGroups[0]?.id,
+    spriteGroupId: getTopSpriteSelectionGroupId(spriteSelectionGroups),
   });
   store.setSearchQuery({ value: "" });
   store.setMode({
@@ -133,7 +136,7 @@ const beginExistingCharacterSpriteSelectionAtGroup = (
     (spriteSelectionGroup) => spriteSelectionGroup.id === spriteGroupId,
   )
     ? spriteGroupId
-    : spriteSelectionGroups[0]?.id;
+    : getTopSpriteSelectionGroupId(spriteSelectionGroups);
 
   beginExistingCharacterSpriteSelection(store, index);
   store.setSelectedSpriteGroupId({
@@ -163,7 +166,7 @@ const beginNewCharacterSpriteSelection = (store, characterId) => {
     }),
   });
   store.setSelectedSpriteGroupId({
-    spriteGroupId: spriteSelectionGroups[0]?.id,
+    spriteGroupId: getTopSpriteSelectionGroupId(spriteSelectionGroups),
   });
   store.setSearchQuery({ value: "" });
   store.setMode({

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -124,7 +124,7 @@ const buildSpriteSelectionGroups = (character = {}) => {
   }));
 };
 
-const orderSpriteSelectionGroupsForTabs = (spriteSelectionGroups = []) =>
+const orderSpriteSelectionGroupsTopFirst = (spriteSelectionGroups = []) =>
   spriteSelectionGroups.slice().reverse();
 
 const findFirstSpriteIdForGroup = ({
@@ -227,22 +227,24 @@ const buildSpriteGroupBoxViewData = ({
       .map((item) => [item.id, item]),
   );
 
-  return (spriteSelectionGroups ?? []).map((spriteSelectionGroup) => {
-    const selectedSpriteId =
-      selectedSpriteIdsByGroup?.[spriteSelectionGroup.id];
-    const selectedSprite = selectedSpriteId
-      ? spriteItemsById[selectedSpriteId]
-      : undefined;
+  return orderSpriteSelectionGroupsTopFirst(spriteSelectionGroups).map(
+    (spriteSelectionGroup) => {
+      const selectedSpriteId =
+        selectedSpriteIdsByGroup?.[spriteSelectionGroup.id];
+      const selectedSprite = selectedSpriteId
+        ? spriteItemsById[selectedSpriteId]
+        : undefined;
 
-    return {
-      id: spriteSelectionGroup.id,
-      name: spriteSelectionGroup.name,
-      selectedSpriteId,
-      selectedSpriteName: selectedSprite?.name ?? "No sprite",
-      hasSelection: !!selectedSpriteId,
-      backgroundColor: selectedSpriteId ? "mu" : "bg",
-    };
-  });
+      return {
+        id: spriteSelectionGroup.id,
+        name: spriteSelectionGroup.name,
+        selectedSpriteId,
+        selectedSpriteName: selectedSprite?.name ?? "No sprite",
+        hasSelection: !!selectedSpriteId,
+        backgroundColor: selectedSpriteId ? "mu" : "bg",
+      };
+    },
+  );
 };
 
 const buildSpritePreviewItemViewData = (item = {}) => {
@@ -447,7 +449,7 @@ const resolveSelectedSpriteGroupId = ({
     return state.selectedSpriteGroupId;
   }
 
-  return orderSpriteSelectionGroupsForTabs(spriteSelectionGroups)[0]?.id;
+  return orderSpriteSelectionGroupsTopFirst(spriteSelectionGroups)[0]?.id;
 };
 
 const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
@@ -1219,7 +1221,7 @@ export const selectViewData = ({ state, props = {} }) => {
         state,
         index: state.selectedCharacterIndex,
       });
-    const spriteSelectionTabGroups = orderSpriteSelectionGroupsForTabs(
+    const spriteSelectionTabGroups = orderSpriteSelectionGroupsTopFirst(
       currentSpriteSelectionGroups,
     );
 

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -124,6 +124,9 @@ const buildSpriteSelectionGroups = (character = {}) => {
   }));
 };
 
+const orderSpriteSelectionGroupsForTabs = (spriteSelectionGroups = []) =>
+  spriteSelectionGroups.slice().reverse();
+
 const findFirstSpriteIdForGroup = ({
   group,
   spritesCollection,
@@ -444,7 +447,7 @@ const resolveSelectedSpriteGroupId = ({
     return state.selectedSpriteGroupId;
   }
 
-  return spriteSelectionGroups?.[0]?.id;
+  return orderSpriteSelectionGroupsForTabs(spriteSelectionGroups)[0]?.id;
 };
 
 const createBackgroundTransformEditorViewData = ({ state, props = {} }) => {
@@ -1216,8 +1219,11 @@ export const selectViewData = ({ state, props = {} }) => {
         state,
         index: state.selectedCharacterIndex,
       });
+    const spriteSelectionTabGroups = orderSpriteSelectionGroupsForTabs(
+      currentSpriteSelectionGroups,
+    );
 
-    spriteSelectionTabs = currentSpriteSelectionGroups.map(
+    spriteSelectionTabs = spriteSelectionTabGroups.map(
       (spriteSelectionGroup) => ({
         id: spriteSelectionGroup.id,
         label: spriteSelectionGroup.name,

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -35,24 +35,24 @@ const tabs = RESOURCE_TYPES.map(({ type, label }) => ({
 const DEFAULT_VISUAL_LAYER = 50;
 const VISUAL_LAYER_OPTIONS = [
   {
-    value: 10,
-    label: "Behind Background",
-  },
-  {
-    value: 30,
-    label: "Behind Character",
-  },
-  {
-    value: DEFAULT_VISUAL_LAYER,
-    label: "Behind Dialogue",
+    value: 90,
+    label: "Foreground",
   },
   {
     value: 70,
     label: "Behind Choice",
   },
   {
-    value: 90,
-    label: "Foreground",
+    value: DEFAULT_VISUAL_LAYER,
+    label: "Behind Dialogue",
+  },
+  {
+    value: 30,
+    label: "Behind Character",
+  },
+  {
+    value: 10,
+    label: "Behind Background",
   },
 ];
 const VISUAL_LAYER_VALUES = VISUAL_LAYER_OPTIONS.map((option) => option.value);

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -226,11 +226,13 @@ const resolveActionTransformIndex = (items = [], { itemIndex, item } = {}) => {
 
 export const handleSetActionCustomTransform = (
   deps,
-  { targetType, itemIndex, item, transform } = {},
+  { targetType, itemIndex, item, transform, action: actionSnapshot } = {},
 ) => {
   const { refs, store } = deps;
   const actionKey = targetType === "character" ? "character" : "visual";
-  const action = toPlainObject(store.selectAction()?.[actionKey]);
+  const action = toPlainObject(
+    actionSnapshot ?? store.selectAction()?.[actionKey],
+  );
   const items = Array.isArray(action.items) ? [...action.items] : [];
   const resolvedIndex = resolveActionTransformIndex(items, { itemIndex, item });
   const sourceItem = item ?? items[resolvedIndex];

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -272,6 +272,7 @@ const syncCharacterSpritesData = ({ deps, repositoryState } = {}) => {
 
   store.setCharacterId({ characterId });
   store.setCharacterName({ characterName: character.name });
+  store.setCharacterSpriteGroups({ spriteGroups: character.spriteGroups });
   store.setTagsData({ tagsData });
   store.setItems({ spritesData });
   store.setProjectResolution({

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -112,6 +112,52 @@ const createPreviewModeButtonViewData = ({ displayMode, mode } = {}) => {
   };
 };
 
+const matchesSpriteGroupTags = ({ item, tagIds } = {}) => {
+  if (!Array.isArray(tagIds) || tagIds.length === 0) {
+    return true;
+  }
+
+  const itemTagIds = Array.isArray(item?.tagIds) ? item.tagIds : [];
+  return tagIds.some((tagId) => itemTagIds.includes(tagId));
+};
+
+const normalizeCharacterSpriteGroups = (spriteGroups) => {
+  return (spriteGroups ?? []).map((spriteGroup, index) => ({
+    id: spriteGroup?.id ?? "sprite-group-" + index,
+    name: spriteGroup?.name ?? "",
+    tags: Array.isArray(spriteGroup?.tags) ? [...spriteGroup.tags] : [],
+  }));
+};
+
+const buildSelectedItemSpriteGroups = ({
+  item,
+  spriteGroups,
+  tagsById,
+} = {}) => {
+  if (!item) {
+    return [];
+  }
+
+  return normalizeCharacterSpriteGroups(spriteGroups)
+    .map((spriteGroup, index) => {
+      if (!matchesSpriteGroupTags({ item, tagIds: spriteGroup.tags })) {
+        return undefined;
+      }
+
+      const tagNames = spriteGroup.tags.map(
+        (tagId) => tagsById?.[tagId]?.name ?? tagId,
+      );
+
+      return {
+        id: spriteGroup.id,
+        name: spriteGroup.name.trim() || "Group " + (index + 1),
+        tags: spriteGroup.tags,
+        tagSummary: tagNames.join(", "),
+      };
+    })
+    .filter(Boolean);
+};
+
 const folderContextMenuItems = [
   { label: "New Folder", type: "item", value: "new-child-folder" },
   { label: "Rename", type: "item", value: "rename-item" },
@@ -163,6 +209,11 @@ const buildImageDetailFields = (item) => {
       label: "Tags",
     },
     {
+      type: "slot",
+      slot: "sprite-groups",
+      label: "Sprite Groups",
+    },
+    {
       type: "text",
       label: "File Type",
       value: item.fileType ?? "",
@@ -201,6 +252,11 @@ const buildSpritesheetDetailFields = (item) => {
       type: "slot",
       slot: "sprite-tags",
       label: "Tags",
+    },
+    {
+      type: "slot",
+      slot: "sprite-groups",
+      label: "Sprite Groups",
     },
     {
       type: "text",
@@ -565,6 +621,7 @@ export const createInitialState = () => ({
   selectedFolderId: undefined,
   characterId: undefined,
   characterName: undefined,
+  characterSpriteGroups: [],
   searchQuery: "",
   ...createMobileResourcePageState(),
   fullImagePreviewVisible: false,
@@ -689,6 +746,10 @@ export const setCharacterName = ({ state }, { characterName } = {}) => {
   state.characterName = characterName;
 };
 
+export const setCharacterSpriteGroups = ({ state }, { spriteGroups } = {}) => {
+  state.characterSpriteGroups = normalizeCharacterSpriteGroups(spriteGroups);
+};
+
 export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
   state.projectResolution = requireProjectResolution(
     projectResolution ?? DEFAULT_PROJECT_RESOLUTION,
@@ -698,6 +759,7 @@ export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
 
 export const clearCharacterSpritesView = ({ state }) => {
   state.characterName = undefined;
+  state.characterSpriteGroups = [];
   state.spritesData = EMPTY_TREE;
   state.tagsData = createEmptyTagCollection();
   state.activeTagIds = [];
@@ -1290,6 +1352,11 @@ export const selectViewData = ({ state }) => {
     selectedItem,
     createTagFormDefinition: createTagForm(),
   });
+  const selectedItemSpriteGroups = buildSelectedItemSpriteGroups({
+    item: selectedItem,
+    spriteGroups: state.characterSpriteGroups,
+    tagsById: state.tagsData.items ?? {},
+  });
   const detailSelection = buildClipOptions(
     selectedItem?.type === "spritesheet" ? selectedItem.animations : {},
     state.detailSelectedClipName,
@@ -1359,6 +1426,7 @@ export const selectViewData = ({ state }) => {
     selectedDetailName,
     selectedItemName: selectedDetailName,
     ...tagViewData,
+    selectedItemSpriteGroups,
     detailFields,
     ...buildMobileResourcePageViewData({
       state,
@@ -1367,6 +1435,7 @@ export const selectViewData = ({ state }) => {
         "image-file-id",
         "spritesheet-preview",
         "spritesheet-animations",
+        "sprite-groups",
       ],
     }),
     selectedPreviewFileId:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -214,6 +214,14 @@ styles:
     box-shadow: 0 0 0 1px var(--border)
     overflow: hidden
     cursor: default
+  ".imageDetailPreviewFrame":
+    display: block
+    width: 100%
+    aspect-ratio: 16 / 9
+    box-shadow: 0 0 0 1px var(--border)
+    border-radius: 6px
+    overflow: hidden
+    cursor: pointer
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -241,10 +249,20 @@ template:
                                       - $if selectedItemId:
                                           - $if selectedItemType == 'image':
                                               - $if selectedPreviewFileId:
-                                                  - rvn-file-image#detailImage slot="image-file-id" fileId=${selectedPreviewFileId} w=f h=160 bw=xs bc=bo br=md cur=pointer: null
+                                                  - 'div#detailImage.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
+                                                      - rvn-file-image fileId=${selectedPreviewFileId} w=f h=f: null
                                           - $if selectedItemType == 'spritesheet':
                                               - 'rvn-spritesheet-preview slot="spritesheet-preview" key=${detailPreviewKey} fileId=${detailPreviewFileId} :atlas=${detailPreviewAtlas} :animation=${detailPreviewAnimation} :paused=${detailPreviewPaused} h=220 emptyLabel="No preview available"': null
                                           - rtgl-tag-select#detailTagSelect slot="sprite-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
+                                          - 'rtgl-view slot="sprite-groups" d=v w=f g=sm':
+                                              - $if selectedItemSpriteGroups.length > 0:
+                                                  - $for spriteGroup, i in selectedItemSpriteGroups:
+                                                      - rtgl-view d=v w=f g=xs p=md bw=xs bc=bo br=md:
+                                                          - rtgl-text s=sm: ${spriteGroup.name}
+                                                          - $if spriteGroup.tagSummary:
+                                                              - rtgl-text s=xs c=mu-fg: ${spriteGroup.tagSummary}
+                                                $else:
+                                                  - rtgl-text s=xs c=mu-fg: No sprite groups
                                           - $if selectedItemType == 'spritesheet':
                                               - 'rtgl-view slot="spritesheet-animations" d=v w=f g=sm':
                                                   - rtgl-text s=sm c=mu-fg: Animations

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -947,7 +947,7 @@ export const handleSpriteGroupDropdownMenuItemClick = (deps, payload) => {
     store.moveSpriteGroup({
       target,
       index,
-      offset: -1,
+      offset: 1,
     });
   }
 
@@ -955,7 +955,7 @@ export const handleSpriteGroupDropdownMenuItemClick = (deps, payload) => {
     store.moveSpriteGroup({
       target,
       index,
-      offset: 1,
+      offset: -1,
     });
   }
 

--- a/src/pages/characters/characters.store.js
+++ b/src/pages/characters/characters.store.js
@@ -309,7 +309,7 @@ const getSpriteGroupDraftKey = (target) =>
 const buildSpriteGroupDropdownItems = ({ index, total } = {}) => {
   const items = [];
 
-  if (index > 0) {
+  if (index < total - 1) {
     items.push({
       label: "Move Up",
       type: "item",
@@ -317,7 +317,7 @@ const buildSpriteGroupDropdownItems = ({ index, total } = {}) => {
     });
   }
 
-  if (index < total - 1) {
+  if (index > 0) {
     items.push({
       label: "Move Down",
       type: "item",
@@ -874,6 +874,7 @@ export const selectViewData = ({ state }) => {
   const selectedItemSpriteGroups = buildSpriteGroupViewData({
     spriteGroups: selectedItem?.spriteGroups,
     tagsById: selectedItemSpriteTagsCollection.items ?? {},
+    displayTopFirst: true,
   });
   const nameVariableOptions = createCharacterNameVariableOptions(
     state.variablesData,
@@ -1061,6 +1062,7 @@ export const selectViewData = ({ state }) => {
     dialogSpriteGroups: buildDraftSpriteGroupViewData({
       spriteGroups: state.dialogSpriteGroups,
       tagsById: {},
+      displayTopFirst: true,
     }),
     dialogForm: createCharacterDialogForm({
       tagOptions: tagFilterOptions,
@@ -1087,6 +1089,7 @@ export const selectViewData = ({ state }) => {
     editSpriteGroups: buildDraftSpriteGroupViewData({
       spriteGroups: state.editSpriteGroups,
       tagsById: editSpriteTagsCollection.items ?? {},
+      displayTopFirst: true,
     }),
   };
 };

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -233,7 +233,7 @@ template:
                           - rtgl-button.spriteGroupAddButton data-target=edit s=sm v=gh pre=plus: Add Group
                       - $if editSpriteGroups.length > 0:
                           - $for spriteGroup, i in editSpriteGroups:
-                              - rtgl-view.spriteGroupCard data-target=edit data-index=${i} d=v w=f g=xs p=md bw=xs bc=bo h-bc=ac br=md cur=pointer:
+                              - rtgl-view.spriteGroupCard data-target=edit data-index=${spriteGroup.sourceIndex} d=v w=f g=xs p=md bw=xs bc=bo h-bc=ac br=md cur=pointer:
                                   - rtgl-text s=sm: ${spriteGroup.name}
                                   - $if spriteGroup.tagSummary:
                                       - rtgl-text s=xs c=mu-fg: ${spriteGroup.tagSummary}

--- a/src/pages/characters/support/spriteGroups.js
+++ b/src/pages/characters/support/spriteGroups.js
@@ -113,8 +113,12 @@ export const validateSpriteGroupsForSave = ({
 const resolveSpriteGroupTagNames = ({ tagIds, tagsById } = {}) =>
   (tagIds ?? []).map((tagId) => tagsById?.[tagId]?.name ?? tagId);
 
-export const buildSpriteGroupViewData = ({ spriteGroups, tagsById } = {}) => {
-  return normalizeSpriteGroupsForDraft({
+export const buildSpriteGroupViewData = ({
+  spriteGroups,
+  tagsById,
+  displayTopFirst = false,
+} = {}) => {
+  const viewData = normalizeSpriteGroupsForDraft({
     spriteGroups,
   }).map((spriteGroup) => {
     const tagNames = resolveSpriteGroupTagNames({
@@ -130,13 +134,16 @@ export const buildSpriteGroupViewData = ({ spriteGroups, tagsById } = {}) => {
       tagSummary: tagNames.join(", "),
     };
   });
+
+  return displayTopFirst ? viewData.slice().reverse() : viewData;
 };
 
 export const buildDraftSpriteGroupViewData = ({
   spriteGroups,
   tagsById,
+  displayTopFirst = false,
 } = {}) => {
-  return normalizeSpriteGroupsForDraft({
+  const viewData = normalizeSpriteGroupsForDraft({
     spriteGroups,
   }).map((spriteGroup, index) => {
     const tagNames = resolveSpriteGroupTagNames({
@@ -150,7 +157,10 @@ export const buildDraftSpriteGroupViewData = ({
       tags: spriteGroup.tags,
       tagNames,
       tagSummary: tagNames.join(", "),
+      sourceIndex: index,
       label: `Group ${index + 1}`,
     };
   });
+
+  return displayTopFirst ? viewData.slice().reverse() : viewData;
 };

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1264,13 +1264,14 @@ const closeActionTransformEditor = (deps, payload) => {
   store.suppressNextActionsDialogClose?.();
   const editor = store.selectBackgroundTransformEditor?.();
   const actionKey = editor?.actionKey === "character" ? "character" : "visual";
+  const action = selectEditorActionSnapshot(store, editor);
   const nextItem = createActionItemWithInlineTransform(
     editor?.item,
     editor?.transform,
     { preserveTransformId: true },
   );
   const nextAction = replaceActionItem({
-    action: selectEditorActionSnapshot(store, editor),
+    action,
     itemIndex: editor?.itemIndex,
     item: nextItem,
   });
@@ -1280,6 +1281,7 @@ const closeActionTransformEditor = (deps, payload) => {
     itemIndex: editor?.itemIndex,
     item: editor?.item,
     transform: editor?.transform,
+    action,
   });
   store.closeBackgroundTransformEditor?.();
   render();

--- a/tests/characterSprites/characterSprites.store.test.js
+++ b/tests/characterSprites/characterSprites.store.test.js
@@ -5,6 +5,7 @@ import {
   removePendingUploads,
   openSpritesheetCreateDialog,
   setActiveTagIds,
+  setCharacterSpriteGroups,
   selectAdjacentSpriteItemId,
   selectViewData,
   setFullImagePreviewDisplayMode,
@@ -163,6 +164,105 @@ describe("characterSprites store", () => {
     expect(
       searchOnlyViewData.mediaGroups[0].children.map((child) => child.id),
     ).toEqual(["sprite-2"]);
+  });
+
+  it("shows matching sprite groups in character order", () => {
+    const state = createInitialState();
+    state.characterName = "Hero";
+    state.tagsData = {
+      tree: [{ id: "tag-expression" }, { id: "tag-idle" }, { id: "tag-body" }],
+      items: {
+        "tag-expression": {
+          id: "tag-expression",
+          type: "tag",
+          name: "Expression",
+        },
+        "tag-idle": {
+          id: "tag-idle",
+          type: "tag",
+          name: "Idle",
+        },
+        "tag-body": {
+          id: "tag-body",
+          type: "tag",
+          name: "Body",
+        },
+      },
+    };
+    state.spritesData = {
+      tree: [
+        {
+          id: "folder-1",
+          children: [{ id: "sprite-1" }],
+        },
+      ],
+      items: {
+        "folder-1": {
+          id: "folder-1",
+          type: "folder",
+          name: "Main",
+        },
+        "sprite-1": {
+          id: "sprite-1",
+          type: "image",
+          name: "Hero Idle",
+          fileId: "file-1",
+          tagIds: ["tag-expression", "tag-idle"],
+        },
+      },
+    };
+
+    setCharacterSpriteGroups(
+      { state },
+      {
+        spriteGroups: [
+          {
+            id: "expression",
+            name: "Expression",
+            tags: ["tag-expression"],
+          },
+          {
+            id: "idle",
+            name: "Idle",
+            tags: ["tag-idle"],
+          },
+          {
+            id: "body",
+            name: "Body",
+            tags: ["tag-body"],
+          },
+        ],
+      },
+    );
+    setSelectedItemId(
+      { state },
+      {
+        itemId: "sprite-1",
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.selectedItemSpriteGroups).toEqual([
+      {
+        id: "expression",
+        name: "Expression",
+        tags: ["tag-expression"],
+        tagSummary: "Expression",
+      },
+      {
+        id: "idle",
+        name: "Idle",
+        tags: ["tag-idle"],
+        tagSummary: "Idle",
+      },
+    ]);
+    expect(
+      viewData.detailFields.map((field) => field.slot).filter(Boolean),
+    ).toContain("sprite-groups");
+    expect(
+      viewData.mobileDetailFields.map((field) => field.slot).filter(Boolean),
+    ).not.toContain("sprite-groups");
   });
 
   it("provides tag labels to the edit form tag selector", () => {
@@ -388,7 +488,7 @@ describe("characterSprites store", () => {
       "aspect-ratio: 1920 / 1080",
     );
     expect(viewData.fullImagePreviewFrameStyle).toContain(
-      "width: min(92vw, calc(92vh * (1920 / 1080)))",
+      "width: min(88vw, calc((100vh - 120px) * (1920 / 1080)))",
     );
     expect(viewData.fullImagePreviewImageWrapperStyle).toContain("width: 2.5%");
     expect(viewData.fullImagePreviewImageWrapperStyle).toContain(

--- a/tests/characters/characters.handlers.test.js
+++ b/tests/characters/characters.handlers.test.js
@@ -623,6 +623,44 @@ describe("characters sprite group removal guard", () => {
     });
   });
 
+  it("moves sprite groups by visual top-first direction", () => {
+    const deps = {
+      appService: {
+        showAlert: vi.fn(),
+      },
+      projectService: {
+        getRepositoryState: vi.fn(),
+      },
+      store: {
+        getState: vi.fn(() => ({
+          spriteGroupDropdownMenu: {
+            target: "edit",
+            index: 0,
+          },
+        })),
+        hideSpriteGroupDropdownMenu: vi.fn(),
+        moveSpriteGroup: vi.fn(),
+      },
+      render: vi.fn(),
+    };
+
+    handleSpriteGroupDropdownMenuItemClick(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "move-up",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.moveSpriteGroup).toHaveBeenCalledWith({
+      target: "edit",
+      index: 0,
+      offset: 1,
+    });
+  });
+
   it("removes an edit sprite group when no story lines use it", () => {
     const deps = {
       appService: {

--- a/tests/characters/characters.store.test.js
+++ b/tests/characters/characters.store.test.js
@@ -3,9 +3,130 @@ import {
   createInitialState,
   openSpriteGroupDialog,
   selectViewData,
+  showSpriteGroupDropdownMenu,
 } from "../../src/pages/characters/characters.store.js";
 
 describe("characters store sprite group tags", () => {
+  it("orders sprite groups with the top rendered group first", () => {
+    const state = createInitialState();
+
+    state.spriteTagsByCharacterId = {
+      "character-hero": {
+        items: {
+          "sprite-tag-body": {
+            id: "sprite-tag-body",
+            type: "tag",
+            name: "Body",
+          },
+          "sprite-tag-face": {
+            id: "sprite-tag-face",
+            type: "tag",
+            name: "Face",
+          },
+        },
+        tree: [{ id: "sprite-tag-body" }, { id: "sprite-tag-face" }],
+      },
+    };
+    state.charactersData = {
+      items: {
+        "character-hero": {
+          id: "character-hero",
+          type: "character",
+          name: "Hero",
+          spriteGroups: [
+            {
+              id: "group-body",
+              name: "Body",
+              tags: ["sprite-tag-body"],
+            },
+            {
+              id: "group-face",
+              name: "Face",
+              tags: ["sprite-tag-face"],
+            },
+          ],
+        },
+      },
+      tree: [{ id: "character-hero" }],
+    };
+    state.selectedItemId = "character-hero";
+    state.editItemId = "character-hero";
+    state.editSpriteGroups = [
+      {
+        id: "group-body",
+        name: "Body",
+        tags: ["sprite-tag-body"],
+      },
+      {
+        id: "group-face",
+        name: "Face",
+        tags: ["sprite-tag-face"],
+      },
+    ];
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.selectedItemSpriteGroups.map((group) => group.id)).toEqual([
+      "group-face",
+      "group-body",
+    ]);
+    expect(
+      viewData.editSpriteGroups.map((group) => ({
+        id: group.id,
+        sourceIndex: group.sourceIndex,
+      })),
+    ).toEqual([
+      {
+        id: "group-face",
+        sourceIndex: 1,
+      },
+      {
+        id: "group-body",
+        sourceIndex: 0,
+      },
+    ]);
+
+    showSpriteGroupDropdownMenu(
+      { state },
+      {
+        target: "edit",
+        index: 1,
+      },
+    );
+    expect(state.spriteGroupDropdownMenu.items).toEqual([
+      {
+        label: "Move Down",
+        type: "item",
+        value: "move-down",
+      },
+      {
+        label: "Remove",
+        type: "item",
+        value: "remove",
+      },
+    ]);
+
+    showSpriteGroupDropdownMenu(
+      { state },
+      {
+        target: "edit",
+        index: 0,
+      },
+    );
+    expect(state.spriteGroupDropdownMenu.items).toEqual([
+      {
+        label: "Move Up",
+        type: "item",
+        value: "move-up",
+      },
+      {
+        label: "Remove",
+        type: "item",
+        value: "remove",
+      },
+    ]);
+  });
+
   it("uses character sprite tags for sprite group labels and options", () => {
     const state = createInitialState();
 

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -1141,11 +1141,11 @@ describe("commandLineCharacters.handlers", () => {
       },
     );
 
-    expect(selectSelectedSpriteGroupId({ state })).toBe("body");
+    expect(selectSelectedSpriteGroupId({ state })).toBe("face");
     expect(selectTempSelectedSpriteIds({ state })).toEqual({
       body: "sprite-body",
     });
-    expect(selectTempSelectedSpriteId({ state })).toBe("sprite-body");
+    expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
 
     handleSpriteGroupTabClick(
       {
@@ -1155,14 +1155,14 @@ describe("commandLineCharacters.handlers", () => {
       {
         _event: {
           detail: {
-            id: "face",
+            id: "body",
           },
         },
       },
     );
 
-    expect(selectSelectedSpriteGroupId({ state })).toBe("face");
-    expect(selectTempSelectedSpriteId({ state })).toBeUndefined();
+    expect(selectSelectedSpriteGroupId({ state })).toBe("body");
+    expect(selectTempSelectedSpriteId({ state })).toBe("sprite-body");
   });
 
   it("emits temporary presentation state while picking character sprites", () => {

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -227,16 +227,16 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     );
     expect(viewData.defaultValues.characters[0].spriteGroupBoxes).toEqual([
       {
-        id: "body",
-        name: "Body",
+        id: "face",
+        name: "Face",
         selectedSpriteId: undefined,
         selectedSpriteName: "No sprite",
         hasSelection: false,
         backgroundColor: "bg",
       },
       {
-        id: "face",
-        name: "Face",
+        id: "body",
+        name: "Body",
         selectedSpriteId: undefined,
         selectedSpriteName: "No sprite",
         hasSelection: false,

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -196,6 +196,25 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     ]);
   });
 
+  it("orders sprite group tabs with the top preview layer first", () => {
+    const state = createSpriteSelectState();
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.spriteSelectionTabs).toEqual([
+      {
+        id: "face",
+        label: "Face",
+      },
+      {
+        id: "body",
+        label: "Body",
+      },
+    ]);
+    expect(viewData.selectedSpriteGroupId).toBe("face");
+    expect(viewData.selectedSpriteGroupName).toBe("Face");
+  });
+
   it("exposes current-mode sprite group boxes for multipart characters", () => {
     const state = createSpriteSelectState();
 

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -172,24 +172,24 @@ describe("commandLineVisual.store animation controls", () => {
     });
     expect(viewData.defaultValues.layerOptions).toEqual([
       {
-        value: 10,
-        label: "Behind Background",
-      },
-      {
-        value: 30,
-        label: "Behind Character",
-      },
-      {
-        value: 50,
-        label: "Behind Dialogue",
+        value: 90,
+        label: "Foreground",
       },
       {
         value: 70,
         label: "Behind Choice",
       },
       {
-        value: 90,
-        label: "Foreground",
+        value: 50,
+        label: "Behind Dialogue",
+      },
+      {
+        value: 30,
+        label: "Behind Character",
+      },
+      {
+        value: 10,
+        label: "Behind Background",
       },
     ]);
     expect(viewData.defaultValues.animationOptions).toEqual([
@@ -436,24 +436,24 @@ describe("commandLineVisual.store animation controls", () => {
         label: "Layer",
         options: [
           {
-            value: 10,
-            label: "Behind Background",
-          },
-          {
-            value: 30,
-            label: "Behind Character",
-          },
-          {
-            value: 50,
-            label: "Behind Dialogue",
+            value: 90,
+            label: "Foreground",
           },
           {
             value: 70,
             label: "Behind Choice",
           },
           {
-            value: 90,
-            label: "Foreground",
+            value: 50,
+            label: "Behind Dialogue",
+          },
+          {
+            value: 30,
+            label: "Behind Character",
+          },
+          {
+            value: 10,
+            label: "Behind Background",
           },
         ],
         clearable: false,

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -859,6 +859,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
           x: 1400,
           y: 800,
         },
+        action: editorVisualAction,
       });
       expect(open).toHaveBeenCalledWith({
         mode: "visual",

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -14,6 +14,7 @@ import {
   handleCommandLineSubmit,
   handleTemporaryPresentationStateChange,
   handleSetBackgroundCustomTransform,
+  handleSetActionCustomTransform,
   open,
 } from "../../src/components/systemActions/systemActions.handlers.js";
 
@@ -332,6 +333,91 @@ describe("systemActions.handlers", () => {
     });
   });
 
+  it("uses the transform editor action snapshot when applying a visual custom transform", () => {
+    const state = createInitialState();
+    const dispatchedEvents = [];
+    const setChildCustomTransform = vi.fn();
+    const transform = {
+      x: 320,
+      y: 180,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      scaleX: 1.4,
+      scaleY: 1.4,
+      rotation: 12,
+      originX: 100,
+      originY: 80,
+    };
+    const staleAction = {
+      items: [
+        {
+          id: "visual-1",
+          resourceId: "image-1",
+          transformId: "center",
+        },
+      ],
+    };
+    const editorAction = {
+      items: [
+        {
+          id: "visual-1",
+          resourceId: "image-1",
+          transformId: "center",
+        },
+        {
+          id: "visual-2",
+          resourceId: "image-2",
+          transformId: "center",
+        },
+      ],
+    };
+
+    updateActions(
+      { state },
+      {
+        visual: staleAction,
+      },
+    );
+
+    handleSetActionCustomTransform(
+      {
+        refs: {
+          commandLineVisual: {
+            transformedHandlers: {
+              handleSetCustomTransform: setChildCustomTransform,
+            },
+          },
+        },
+        store: {
+          selectAction: () => selectAction({ state }),
+        },
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        targetType: "visual",
+        itemIndex: 1,
+        item: editorAction.items[1],
+        transform,
+        action: editorAction,
+      },
+    );
+
+    expect(setChildCustomTransform).toHaveBeenCalledWith({
+      index: 1,
+      transform,
+    });
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].detail.presentationState.visual.items).toEqual([
+      editorAction.items[0],
+      {
+        ...editorAction.items[1],
+        ...transform,
+      },
+    ]);
+  });
+
   it("emits close from embedded system action editors", () => {
     const dispatchedEvents = [];
     let stopPropagationCalled = false;
@@ -554,9 +640,7 @@ describe("systemActions.handlers", () => {
       suppressDialogClose: true,
     });
     expect(dispatchedEvents).toHaveLength(1);
-    expect(dispatchedEvents[0].type).toBe(
-      "background-transform-editor-cancel",
-    );
+    expect(dispatchedEvents[0].type).toBe("background-transform-editor-cancel");
   });
 
   it("clears temporary presentation state when the actions dialog closes", () => {


### PR DESCRIPTION
## Summary
- order visual layer options and visual layer groups with the foreground/top layer first
- order character sprite group tabs and current-mode sprite group boxes so the visually top sprite layer is first
- order the Characters page sprite group detail/edit lists top-first while preserving source indices for edit/remove/move actions
- preserve the full visual action snapshot when applying a custom transform so other visuals are not dropped
- show matching character sprite groups in the character sprite detail panel and keep the sprite group slot off mobile detail fields
- improve image detail preview framing for character sprites
- bump Tauri app version to 1.6.3

## Testing
- bun run lint
- bunx vitest run tests/commandLineVisual/commandLineVisual.store.test.js tests/commandLineCharacters/commandLineCharacters.store.test.js tests/commandLineCharacters/commandLineCharacters.handlers.test.js tests/systemActions/systemActions.handlers.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/commandLineVisual/commandLineVisual.handlers.test.js
- bunx vitest run tests/characterSprites/characterSprites.store.test.js
- bunx vitest run tests/characters/characters.store.test.js tests/characters/characters.handlers.test.js