### PR TITLE
fix: keep character sprite group order stable

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -27,7 +27,10 @@ import {
   CHARACTER_TAG_SCOPE_KEY,
   SPRITE_GROUPS_CREATE_MESSAGE,
 } from "./characters.store.js";
-import { validateSpriteGroupsForSave } from "./support/spriteGroups.js";
+import {
+  reverseSpriteGroups,
+  validateSpriteGroupsForSave,
+} from "./support/spriteGroups.js";
 import {
   buildSpriteGroupInUseMessage,
   findSpriteGroupUsage,
@@ -444,7 +447,7 @@ export const handleCharacterCreated = async (deps, payload) => {
   }
 
   if (Array.isArray(spriteGroups) && spriteGroups.length > 0) {
-    characterData.spriteGroups = spriteGroups;
+    characterData.spriteGroups = reverseSpriteGroups(spriteGroups);
   }
 
   const createAttempt = await runResourcePageMutation({
@@ -947,7 +950,7 @@ export const handleSpriteGroupDropdownMenuItemClick = (deps, payload) => {
     store.moveSpriteGroup({
       target,
       index,
-      offset: 1,
+      offset: -1,
     });
   }
 
@@ -955,7 +958,7 @@ export const handleSpriteGroupDropdownMenuItemClick = (deps, payload) => {
     store.moveSpriteGroup({
       target,
       index,
-      offset: -1,
+      offset: 1,
     });
   }
 
@@ -1020,7 +1023,7 @@ export const handleEditFormAction = async (deps, payload) => {
       description: formData.description,
       shortcut: formData.shortcut || "",
       tagIds: Array.isArray(formData.tagIds) ? formData.tagIds : [],
-      spriteGroups: spriteGroupValidation.spriteGroups,
+      spriteGroups: reverseSpriteGroups(spriteGroupValidation.spriteGroups),
     };
 
     // Include avatar file ID if it was changed

--- a/src/pages/characters/characters.store.js
+++ b/src/pages/characters/characters.store.js
@@ -18,6 +18,7 @@ import {
   buildSpriteGroupViewData,
   createEmptySpriteGroup,
   normalizeSpriteGroupsForDraft,
+  reverseSpriteGroups,
 } from "./support/spriteGroups.js";
 import { getVariableOptions } from "../../internal/project/projection.js";
 
@@ -303,13 +304,16 @@ const normalizeDraftSpriteGroups = ({
     }),
   });
 
+const normalizeSavedSpriteGroupsForDraft = (payload = {}) =>
+  reverseSpriteGroups(normalizeDraftSpriteGroups(payload));
+
 const getSpriteGroupDraftKey = (target) =>
   target === "edit" ? "editSpriteGroups" : "dialogSpriteGroups";
 
 const buildSpriteGroupDropdownItems = ({ index, total } = {}) => {
   const items = [];
 
-  if (index < total - 1) {
+  if (index > 0) {
     items.push({
       label: "Move Up",
       type: "item",
@@ -317,7 +321,7 @@ const buildSpriteGroupDropdownItems = ({ index, total } = {}) => {
     });
   }
 
-  if (index > 0) {
+  if (index < total - 1) {
     items.push({
       label: "Move Down",
       type: "item",
@@ -785,7 +789,7 @@ export const openEditDialog = ({ state }, { itemId, spriteGroups } = {}) => {
   const editItem = flatItems.find((item) => item.id === itemId);
   state.editAvatarFileId = editItem?.fileId || null;
   state.editAvatarUploadResult = null;
-  state.editSpriteGroups = normalizeDraftSpriteGroups({
+  state.editSpriteGroups = normalizeSavedSpriteGroupsForDraft({
     state,
     target: "edit",
     itemId,
@@ -1062,7 +1066,6 @@ export const selectViewData = ({ state }) => {
     dialogSpriteGroups: buildDraftSpriteGroupViewData({
       spriteGroups: state.dialogSpriteGroups,
       tagsById: {},
-      displayTopFirst: true,
     }),
     dialogForm: createCharacterDialogForm({
       tagOptions: tagFilterOptions,
@@ -1089,7 +1092,6 @@ export const selectViewData = ({ state }) => {
     editSpriteGroups: buildDraftSpriteGroupViewData({
       spriteGroups: state.editSpriteGroups,
       tagsById: editSpriteTagsCollection.items ?? {},
-      displayTopFirst: true,
     }),
   };
 };

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -233,7 +233,7 @@ template:
                           - rtgl-button.spriteGroupAddButton data-target=edit s=sm v=gh pre=plus: Add Group
                       - $if editSpriteGroups.length > 0:
                           - $for spriteGroup, i in editSpriteGroups:
-                              - rtgl-view.spriteGroupCard data-target=edit data-index=${spriteGroup.sourceIndex} d=v w=f g=xs p=md bw=xs bc=bo h-bc=ac br=md cur=pointer:
+                              - rtgl-view.spriteGroupCard data-target=edit data-index=${i} d=v w=f g=xs p=md bw=xs bc=bo h-bc=ac br=md cur=pointer:
                                   - rtgl-text s=sm: ${spriteGroup.name}
                                   - $if spriteGroup.tagSummary:
                                       - rtgl-text s=xs c=mu-fg: ${spriteGroup.tagSummary}

--- a/src/pages/characters/support/spriteGroups.js
+++ b/src/pages/characters/support/spriteGroups.js
@@ -66,6 +66,9 @@ export const normalizeSpriteGroupsForDraft = ({
     }));
 };
 
+export const reverseSpriteGroups = (spriteGroups = []) =>
+  Array.isArray(spriteGroups) ? spriteGroups.slice().reverse() : [];
+
 export const validateSpriteGroupsForSave = ({
   spriteGroups,
   validTagIds,

--- a/tests/characters/characters.handlers.test.js
+++ b/tests/characters/characters.handlers.test.js
@@ -147,6 +147,98 @@ describe("characters name variable", () => {
     expect(deps.store.closeEditDialog).toHaveBeenCalledTimes(1);
   });
 
+  it("saves top-first edit sprite groups in render order", async () => {
+    const deps = {
+      appService: {
+        showAlert: vi.fn(),
+      },
+      store: {
+        getState: vi.fn(() => ({
+          editItemId: "character-hero",
+          editAvatarFileId: undefined,
+          editAvatarUploadResult: undefined,
+          editSpriteGroups: [
+            {
+              id: "group-face",
+              name: "Face",
+              tags: ["sprite-tag-face"],
+            },
+            {
+              id: "group-body",
+              name: "Body",
+              tags: ["sprite-tag-body"],
+            },
+          ],
+          spriteTagsByCharacterId: {
+            "character-hero": {
+              items: {
+                "sprite-tag-face": {
+                  id: "sprite-tag-face",
+                  type: "tag",
+                  name: "Face",
+                },
+                "sprite-tag-body": {
+                  id: "sprite-tag-body",
+                  type: "tag",
+                  name: "Body",
+                },
+              },
+              tree: [{ id: "sprite-tag-face" }, { id: "sprite-tag-body" }],
+            },
+          },
+        })),
+        setTagsData: vi.fn(),
+        setSpriteTagsByCharacterId: vi.fn(),
+        setItems: vi.fn(),
+        closeEditDialog: vi.fn(),
+      },
+      projectService: {
+        updateCharacter: vi.fn(() => Promise.resolve({ valid: true })),
+        getRepositoryState: vi.fn(() => ({
+          tags: {},
+          characters: { items: {}, tree: [] },
+          variables: { items: {}, tree: [] },
+        })),
+      },
+      refs: {},
+      render: vi.fn(),
+    };
+
+    await handleEditFormAction(deps, {
+      _event: {
+        detail: {
+          actionId: "submit",
+          values: {
+            name: "Hero",
+            nameVariableId: "",
+            description: "",
+            shortcut: "",
+            tagIds: [],
+          },
+        },
+      },
+    });
+
+    expect(deps.projectService.updateCharacter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          spriteGroups: [
+            {
+              id: "group-body",
+              name: "Body",
+              tags: ["sprite-tag-body"],
+            },
+            {
+              id: "group-face",
+              name: "Face",
+              tags: ["sprite-tag-face"],
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
   it("sends an empty name variable to clear the character override", async () => {
     const deps = {
       appService: {
@@ -635,7 +727,7 @@ describe("characters sprite group removal guard", () => {
         getState: vi.fn(() => ({
           spriteGroupDropdownMenu: {
             target: "edit",
-            index: 0,
+            index: 1,
           },
         })),
         hideSpriteGroupDropdownMenu: vi.fn(),
@@ -656,8 +748,8 @@ describe("characters sprite group removal guard", () => {
 
     expect(deps.store.moveSpriteGroup).toHaveBeenCalledWith({
       target: "edit",
-      index: 0,
-      offset: 1,
+      index: 1,
+      offset: -1,
     });
   });
 

--- a/tests/characters/characters.store.test.js
+++ b/tests/characters/characters.store.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  openEditDialog,
   openSpriteGroupDialog,
   selectViewData,
   showSpriteGroupDropdownMenu,
@@ -50,19 +51,18 @@ describe("characters store sprite group tags", () => {
       tree: [{ id: "character-hero" }],
     };
     state.selectedItemId = "character-hero";
-    state.editItemId = "character-hero";
-    state.editSpriteGroups = [
+    openEditDialog(
+      { state },
       {
-        id: "group-body",
-        name: "Body",
-        tags: ["sprite-tag-body"],
+        itemId: "character-hero",
+        spriteGroups: state.charactersData.items["character-hero"].spriteGroups,
       },
-      {
-        id: "group-face",
-        name: "Face",
-        tags: ["sprite-tag-face"],
-      },
-    ];
+    );
+
+    expect(state.editSpriteGroups.map((group) => group.id)).toEqual([
+      "group-face",
+      "group-body",
+    ]);
 
     const viewData = selectViewData({ state });
 
@@ -70,27 +70,16 @@ describe("characters store sprite group tags", () => {
       "group-face",
       "group-body",
     ]);
-    expect(
-      viewData.editSpriteGroups.map((group) => ({
-        id: group.id,
-        sourceIndex: group.sourceIndex,
-      })),
-    ).toEqual([
-      {
-        id: "group-face",
-        sourceIndex: 1,
-      },
-      {
-        id: "group-body",
-        sourceIndex: 0,
-      },
+    expect(viewData.editSpriteGroups.map((group) => group.id)).toEqual([
+      "group-face",
+      "group-body",
     ]);
 
     showSpriteGroupDropdownMenu(
       { state },
       {
         target: "edit",
-        index: 1,
+        index: 0,
       },
     );
     expect(state.spriteGroupDropdownMenu.items).toEqual([
@@ -110,7 +99,7 @@ describe("characters store sprite group tags", () => {
       { state },
       {
         target: "edit",
-        index: 0,
+        index: 1,
       },
     );
     expect(state.spriteGroupDropdownMenu.items).toEqual([


### PR DESCRIPTION
## Summary
- keep character sprite group edit drafts in the same top-first order users see
- convert top-first drafts back to render order when saving character data
- bump Tauri app version to 1.6.4

## Testing
- bunx vitest run tests/characters/characters.store.test.js tests/characters/characters.handlers.test.js
- bun run lint
- bun prettier --check src-tauri/tauri.conf.json tests/characters/characters.store.test.js tests/characters/characters.handlers.test.js