### PR TITLE
fix: use route engine 1.26.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "jszip": "3.10.1",
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
-        "route-engine-js": "1.26.0",
+        "route-engine-js": "1.26.1",
         "route-graphics": "1.23.4",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
@@ -730,7 +730,7 @@
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
-    "route-engine-js": ["route-engine-js@1.26.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-4/JtuKCuQld+cy/ZIna6Oo4Ep9REKAb/uWTghANYCdY/kiShYhaT1jH8o4JeUIa5ObZx+oG44ragVprCyq6MUA=="],
+    "route-engine-js": ["route-engine-js@1.26.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-azxqZKV8jxh+6WBm8tiLuW2hCNTjzKsS/a3EBJ5yuzToC+fIVyXz0KaQaGbXFBZu4Ha778d5dQlpwR2ZsZaUuA=="],
 
     "route-graphics": ["route-graphics@1.23.4", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-yjwPGegVAjt+xPFPnwfoPl3SqoIiExHt9RCC2KCs/V+b1sXM4mYaPUb4YazM296AGCViS9QXH4jIBMrIYMAOig=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jszip": "3.10.1",
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
-    "route-engine-js": "1.26.0",
+    "route-engine-js": "1.26.1",
     "route-graphics": "1.23.4",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- update `route-engine-js` from 1.26.0 to 1.26.1
- refresh `bun.lock` for the published engine package
- bump Tauri app version from 1.6.4 to 1.6.5

## Testing
- node package/version check for `route-engine-js`
- node ESM import check for `route-engine-js`
- bun run build:web
- pre-push hook: oxlint && bun prettier --check src