### PR TITLE
Fix resource tag selection and voice audio defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
         "route-engine-js": "1.26.1",
-        "route-graphics": "1.23.4",
+        "route-graphics": "1.23.5",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
         "snabbdom-to-html": "7.1.0",
@@ -732,7 +732,7 @@
 
     "route-engine-js": ["route-engine-js@1.26.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-azxqZKV8jxh+6WBm8tiLuW2hCNTjzKsS/a3EBJ5yuzToC+fIVyXz0KaQaGbXFBZu4Ha778d5dQlpwR2ZsZaUuA=="],
 
-    "route-graphics": ["route-graphics@1.23.4", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-yjwPGegVAjt+xPFPnwfoPl3SqoIiExHt9RCC2KCs/V+b1sXM4mYaPUb4YazM296AGCViS9QXH4jIBMrIYMAOig=="],
+    "route-graphics": ["route-graphics@1.23.5", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-M5FxInUKqTj0/1GuvNoLw/iBjNGf7WPeE2ynrs21cvx9p8oaCgZLpC8H3C4hu5Gy+CD2hJcYlEZFJum7cbmKww=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
     "route-engine-js": "1.26.1",
-    "route-graphics": "1.23.4",
+    "route-graphics": "1.23.5",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",
     "snabbdom-to-html": "7.1.0",

--- a/src/components/commandLineVoice/commandLineVoice.handlers.js
+++ b/src/components/commandLineVoice/commandLineVoice.handlers.js
@@ -118,10 +118,6 @@ export const handleAudioWaveformClick = async (deps, payload) => {
   store.setVoiceAudio({
     resourceId: voiceId,
   });
-  store.openAudioPlayer({
-    fileId: uploadResult.fileId,
-    fileName: uploadResult.displayName,
-  });
   render();
 };
 

--- a/src/components/commandLineVoice/commandLineVoice.store.js
+++ b/src/components/commandLineVoice/commandLineVoice.store.js
@@ -1,4 +1,4 @@
-const DEFAULT_AUDIO_VOLUME = 75;
+const DEFAULT_AUDIO_VOLUME = 100;
 
 const normalizeVolume = (volume) => {
   const parsedVolume = Number(volume);
@@ -13,7 +13,7 @@ const normalizeVolume = (volume) => {
 const normalizeVoice = (voice = {}) => ({
   resourceId: voice?.resourceId,
   loop: voice?.loop ?? false,
-  volume: normalizeVolume(voice?.volume),
+  volume: normalizeVolume(voice?.volume) ?? DEFAULT_AUDIO_VOLUME,
   startDelayMs: voice?.startDelayMs,
 });
 

--- a/src/components/commandLineVoice/commandLineVoice.store.js
+++ b/src/components/commandLineVoice/commandLineVoice.store.js
@@ -44,10 +44,12 @@ export const setVoiceAudio = ({ state }, { resourceId } = {}) => {
   const nextVoice = normalizeVoice(state.voice);
   nextVoice.resourceId = resourceId;
   state.voice = nextVoice;
+  closeAudioPlayer({ state });
 };
 
 export const clearVoiceAudio = ({ state }, _payload = {}) => {
   state.voice.resourceId = undefined;
+  closeAudioPlayer({ state });
 };
 
 export const setLoop = ({ state }, { loop } = {}) => {

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -265,6 +265,7 @@ export const selectViewData = ({ state, props }) => {
   const hasActiveSearch = searchQuery.trim().length > 0;
   const hasActiveFilter =
     hasActiveTagFilter || (searchInFilterPopover && hasActiveSearch);
+  const hasSelectedItem = Boolean(props.selectedItemId);
   const tagFilterPopoverViewData = buildTagFilterPopoverViewData({
     state,
     props,
@@ -364,7 +365,9 @@ export const selectViewData = ({ state, props }) => {
             ? "pr"
             : !isInteractive
               ? defaultBorderColor
-              : "ac",
+              : hasSelectedItem
+                ? defaultBorderColor
+                : "ac",
           showPreviewIcon: Boolean(
             isInteractive && item.canPreview && item.id === state.hoveredItemId,
           ),

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -151,25 +151,25 @@ template:
                                               - $if item.cardKind == 'image':
                                                   - 'rtgl-view br=md w=${item.imageCardWidth} pos=rel overflow=hidden style="${item.imageCardStyle}"':
                                                       - $if showImageCardPreview:
-                                                          - $if item.useFullWidthImageCard:
+                                                          - $if item.isProcessing:
+                                                              - $if item.useFullWidthImageCard:
+                                                                  - 'rtgl-view w=f bw=xs bc=bo bgc=mu av=c ah=c style="aspect-ratio: ${item.previewAspectRatio};"':
+                                                                      - rtgl-text s=sm c=fg: Processing...
+                                                                $else:
+                                                                  - rtgl-view w=f h=${imageHeight} bw=xs bc=bo bgc=mu av=c ah=c:
+                                                                      - rtgl-text s=sm c=fg: Processing...
+                                                            $elif item.useFullWidthImageCard:
                                                               - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
-                                                                  - $if item.isProcessing:
-                                                                      - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
-                                                                          - rtgl-text s=sm c=mu-fg: Processing...
-                                                                    $elif lazyImageCards && item.shouldLazyLoadPreview:
+                                                                  - $if lazyImageCards && item.shouldLazyLoadPreview:
                                                                       - rvn-file-image w=f h=f fileId=${item.previewFileId} lazy: null
                                                                     $else:
                                                                       - rvn-file-image w=f h=f fileId=${item.previewFileId}: null
                                                             $else:
                                                               - 'div.mediaImageThumbnailTransparencyGrid style="display: block; width: 100%; height: ${imageHeight}px; overflow: hidden;"':
-                                                                  - $if item.isProcessing:
-                                                                      - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
-                                                                          - rtgl-text s=sm c=mu-fg: Processing...
+                                                                  - $if lazyImageCards && item.shouldLazyLoadPreview:
+                                                                      - rvn-file-image w=f h=f fileId=${item.previewFileId} lazy: null
                                                                     $else:
-                                                                      - $if lazyImageCards && item.shouldLazyLoadPreview:
-                                                                          - rvn-file-image w=f h=f fileId=${item.previewFileId} lazy: null
-                                                                        $else:
-                                                                          - rvn-file-image w=f h=f fileId=${item.previewFileId}: null
+                                                                      - rvn-file-image w=f h=f fileId=${item.previewFileId}: null
                                                       - $if item.showPreviewIcon:
                                                           - 'rtgl-view#previewActionRef${gIndex}x${itemIndex} data-item-id=${item.id} br=f w=32 h=32 pos=abs z=2 ah=c av=c cur=pointer style="top: 6px; right: 6px; background-color: #000;"':
                                                               - rtgl-svg svg=zoomIn wh=22 c=white: null

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -35,7 +35,7 @@ const dispatchTemporaryPresentationStateChange = (
   );
 };
 
-const syncRepositoryState = async (deps) => {
+const syncRepositoryState = (deps) => {
   const { store, projectService } = deps;
   store.setRepositoryState({
     repositoryState: projectService.getRepositoryState(),
@@ -75,6 +75,7 @@ export const handleBeforeMount = (deps) => {
 export const handleOnUpdate = (deps, changes) => {
   const { render, store } = deps;
   const { newProps } = changes;
+  syncRepositoryState(deps);
   store.updateActions(normalizeActionsObject(newProps.actions));
 
   if (
@@ -310,10 +311,14 @@ export const handleHelpFloatingButtonClick = (deps, payload) => {
 export const handleVoicePreviewClick = (deps, payload) => {
   payload?._event?.preventDefault?.();
   payload?._event?.stopPropagation?.();
-  const { store, render } = deps;
+  const { appService, store, render } = deps;
   const voicePreview = store.selectVoicePreview();
 
   if (!voicePreview?.fileId) {
+    appService.showAlert({
+      message: "Voice preview audio is unavailable.",
+      title: "Warning",
+    });
     return;
   }
 

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -307,6 +307,30 @@ export const handleHelpFloatingButtonClick = (deps, payload) => {
   appService.openUrl(getRoutevnCreatorSystemActionDocsUrl(mode));
 };
 
+export const handleVoicePreviewClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  const { store, render } = deps;
+  const voicePreview = store.selectVoicePreview();
+
+  if (!voicePreview?.fileId) {
+    return;
+  }
+
+  store.openAudioPlayer({
+    fileId: voicePreview.fileId,
+    fileName: voicePreview.name,
+  });
+  render();
+};
+
+export const handleAudioPlayerClose = (deps, payload) => {
+  payload?._event?.stopPropagation?.();
+  const { store, render } = deps;
+  store.closeAudioPlayer();
+  render();
+};
+
 const isBooleanPropEnabled = (value) => {
   return value === true || value === "true";
 };

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -515,6 +515,7 @@ export const selectActionsData = ({ props, state }) => {
   const videos = repositoryStateData.videos?.items || {};
   const sounds = repositoryStateData.sounds?.items || {};
   const voices = repositoryStateData.voices?.items || {};
+  const files = repositoryStateData.files?.items || {};
   const animations = repositoryStateData.animations?.items || {};
   const colors = repositoryStateData.colors?.items || {};
   const scenes = repositoryStateData.scenes || {};
@@ -593,7 +594,14 @@ export const selectActionsData = ({ props, state }) => {
   if (voiceAction?.resourceId) {
     actionsObject.voice = voiceAction;
     preview.voice = voices[voiceAction.resourceId] ??
-      sounds[voiceAction.resourceId] ?? {
+      sounds[voiceAction.resourceId] ??
+      (files[voiceAction.resourceId]
+        ? {
+            id: voiceAction.resourceId,
+            name: files[voiceAction.resourceId].name ?? voiceAction.resourceId,
+            fileId: voiceAction.resourceId,
+          }
+        : undefined) ?? {
         id: voiceAction.resourceId,
         name: voiceAction.resourceId,
       };

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -29,6 +29,11 @@ export const createInitialState = () => ({
     ],
   },
   repositoryState: {}, // Add this - default to empty object
+  playingSound: {
+    title: "",
+    fileId: undefined,
+  },
+  showAudioPlayer: false,
 });
 
 export const setUiConfig = ({ state }, { uiConfig } = {}) => {
@@ -226,6 +231,8 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     displayActions,
     actions: actionsObject,
     preview,
+    playingSound: state.playingSound,
+    showAudioPlayer: state.showAudioPlayer,
     repositoryState,
     selectedLineId: props.selectedLineId,
     layouts: choiceLayouts, // Default to choice layouts for backward compatibility
@@ -281,13 +288,28 @@ export const selectAction = ({ state }) => {
   return state.actions || {};
 };
 
+export const selectVoicePreview = ({ state, props }) => {
+  const actionProps = { ...props };
+  actionProps.actions = selectAction({ state });
+  return selectActionsData({
+    props: actionProps,
+    state,
+  }).preview.voice;
+};
+
 export const selectMode = ({ state }) => {
   return state.mode;
 };
 
 export const updateActions = ({ state }, payload = {}) => {
+  const previousVoiceResourceId = state.actions?.voice?.resourceId;
   const nextPayload = payload || {};
+  const nextVoiceResourceId = nextPayload.voice?.resourceId;
   state.actions = { ...nextPayload };
+
+  if (previousVoiceResourceId !== nextVoiceResourceId) {
+    closeAudioPlayer({ state });
+  }
 };
 
 export const showActionsDialog = ({ state }, _payload = {}) => {
@@ -317,6 +339,20 @@ export const setSuppressDialogClose = (
 
 export const selectSuppressDialogClose = ({ state }) => {
   return state.suppressDialogClose === true;
+};
+
+export const openAudioPlayer = ({ state }, { fileId, fileName } = {}) => {
+  state.playingSound.fileId = fileId;
+  state.playingSound.title = fileName;
+  state.showAudioPlayer = true;
+};
+
+export const closeAudioPlayer = ({ state }, _payload = {}) => {
+  state.showAudioPlayer = false;
+  state.playingSound = {
+    title: "",
+    fileId: undefined,
+  };
 };
 
 const resolveDialogueModeLabel = (dialogue, layoutsItems) => {

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -29,6 +29,14 @@ refs:
     eventListeners:
       click:
         handler: handleHelpFloatingButtonClick
+  voicePreviewButton:
+    eventListeners:
+      click:
+        handler: handleVoicePreviewClick
+  rvnAudioPlayer:
+    eventListeners:
+      audio-player-close:
+        handler: handleAudioPlayerClose
   actionsDialog:
     eventListeners:
       close-request:
@@ -89,7 +97,9 @@ template:
               - $if preview.voice:
                   - rtgl-view#actionItemVoice data-mode=voice g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=microphone wh=24: null
-                      - rtgl-text s=sm: ${preview.voice.name}
+                      - rtgl-text s=sm w=1fg ellipsis=true: ${preview.voice.name}
+                      - $if preview.voice.fileId:
+                          - rtgl-button#voicePreviewButton sq v=gh pre=play: null
               - $if preview.sfx:
                   - rtgl-view#actionItemSfx data-mode=sfx g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=audio wh=24: null
@@ -224,6 +234,9 @@ template:
                       - rtgl-view d=v:
                           - rtgl-text s=sm: 'Conditional: ${preview.conditional.summary}'
                           - rtgl-text s=xs c=mu-fg: ${preview.conditional.actionsSummary}
+              - $if showAudioPlayer:
+                  - rtgl-view h=72 w=f:
+                      - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null
           - rtgl-button#addActionButton v=ol w=f: +
           - $if showEmbeddedClose:
               - rtgl-view d=h av=c ah=e w=f g=lg:

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -98,8 +98,7 @@ template:
                   - rtgl-view#actionItemVoice data-mode=voice g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=microphone wh=24: null
                       - rtgl-text s=sm w=1fg ellipsis=true: ${preview.voice.name}
-                      - $if preview.voice.fileId:
-                          - rtgl-button#voicePreviewButton sq v=gh pre=play: null
+                      - 'rtgl-button#voicePreviewButton sq v=ol pre=play title="Preview voice" aria-label="Preview voice"': null
               - $if preview.sfx:
                   - rtgl-view#actionItemSfx data-mode=sfx g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer:
                       - rtgl-svg svg=audio wh=24: null

--- a/src/internal/ui/resourcePages/catalog/createCatalogPageHandlers.js
+++ b/src/internal/ui/resourcePages/catalog/createCatalogPageHandlers.js
@@ -261,8 +261,10 @@ export const createCatalogPageHandlers = ({
     ? createResourcePageTagHandlers({
         resolveScopeKey: resolveTagScopeKey,
         updateItemTagIds: tagging.updateItemTagIds,
-        refreshAfterItemTagUpdate: ({ deps, itemId }) =>
-          refreshData(deps, { selectedItemId: itemId }),
+        refreshAfterItemTagUpdate: ({ deps, itemId, itemStillSelected }) =>
+          refreshData(deps, {
+            selectedItemId: itemStillSelected ? itemId : undefined,
+          }),
         appendCreatedTagByMode: tagging.appendCreatedTagByMode,
         getSelectedItemId: tagging.getSelectedItemId,
         getSelectedItemTagIds: tagging.getSelectedItemTagIds,

--- a/src/internal/ui/resourcePages/media/createMediaPageHandlers.js
+++ b/src/internal/ui/resourcePages/media/createMediaPageHandlers.js
@@ -385,8 +385,10 @@ export const createMediaPageHandlers = ({
     ? createResourcePageTagHandlers({
         resolveScopeKey: resolveTagScopeKey,
         updateItemTagIds: tagging.updateItemTagIds,
-        refreshAfterItemTagUpdate: ({ deps, itemId }) =>
-          refreshData(deps, { selectedItemId: itemId }),
+        refreshAfterItemTagUpdate: ({ deps, itemId, itemStillSelected }) =>
+          refreshData(deps, {
+            selectedItemId: itemStillSelected ? itemId : undefined,
+          }),
         appendCreatedTagByMode: tagging.appendCreatedTagByMode,
         getSelectedItemId: tagging.getSelectedItemId,
         getSelectedItemTagIds: tagging.getSelectedItemTagIds,

--- a/src/internal/ui/resourcePages/tags.js
+++ b/src/internal/ui/resourcePages/tags.js
@@ -401,6 +401,10 @@ export const createResourcePageTagHandlers = ({
       });
       render();
       runAfterNextFrame(() => {
+        if (resolvedItemId !== getSelectedItemId({ deps })) {
+          return;
+        }
+
         store.openCreateTagDialog({
           mode,
           itemId: resolvedItemId,
@@ -509,11 +513,16 @@ export const createResourcePageTagHandlers = ({
       return;
     }
 
-    store.commitDetailTagIds({ tagIds });
+    const itemStillSelected = itemId === getSelectedItemId({ deps });
+    if (itemStillSelected) {
+      store.commitDetailTagIds({ tagIds });
+    }
+
     if (typeof refreshAfterItemTagUpdate === "function") {
       await refreshAfterItemTagUpdate({
         deps,
         itemId,
+        itemStillSelected,
         tagIds,
       });
       return;
@@ -611,7 +620,7 @@ export const createResourcePageTagHandlers = ({
       });
     }
 
-    if (mode === "item" && itemId) {
+    if (mode === "item" && itemId && itemId === getSelectedItemId({ deps })) {
       store.setDetailTagIds({
         tagIds: buildUniqueTagIds(draftTagIds, [tagId]),
       });

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -240,6 +240,14 @@ const buildInputPreview = (lineActions) => {
   return !!lineActions?.form;
 };
 
+const buildVoicePreview = (lineActions, changes) => {
+  return (
+    !!changes.voice ||
+    !!lineActions?.voice?.resourceId ||
+    lineActions?.voice?.clear === true
+  );
+};
+
 const buildDialogueSpeakerPreview = (characterId, characterLookups) => {
   if (!characterId) {
     return undefined;
@@ -328,6 +336,8 @@ const buildSceneDocumentLineViewModels = ({
       hasConditional: buildConditionalPreview(lineActions),
       hasUpdateVariable: buildUpdateVariablePreview(lineActions),
       hasInput: buildInputPreview(lineActions),
+      hasVoice: buildVoicePreview(lineActions, changes),
+      voiceChangeType: changes.voice?.changeType,
       hasSfx: !!changes.sfx,
       sfxChangeType: changes.sfx?.changeType,
       hasSetNextLineConfig:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -253,7 +253,7 @@ template:
                                                       - rvn-file-image fileId=${selectedPreviewFileId} w=f h=f: null
                                           - $if selectedItemType == 'spritesheet':
                                               - 'rvn-spritesheet-preview slot="spritesheet-preview" key=${detailPreviewKey} fileId=${detailPreviewFileId} :atlas=${detailPreviewAtlas} :animation=${detailPreviewAnimation} :paused=${detailPreviewPaused} h=220 emptyLabel="No preview available"': null
-                                          - rtgl-tag-select#detailTagSelect slot="sprite-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
+                                          - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="sprite-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
                                           - 'rtgl-view slot="sprite-groups" d=v w=f g=sm':
                                               - $if selectedItemSpriteGroups.length > 0:
                                                   - $for spriteGroup, i in selectedItemSpriteGroups:
@@ -295,7 +295,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
-                      - rtgl-tag-select#detailTagSelect slot="sprite-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
+                      - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="sprite-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} w=f:

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -213,7 +213,7 @@ template:
                                           - $if selectedPreviewFileId:
                                               - 'div#detailImage.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
                                                   - rvn-file-image fileId=${selectedPreviewFileId} w=f h=f: null
-                                          - rtgl-tag-select#detailTagSelect slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
+                                          - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
                             $else:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: No selection
@@ -233,7 +233,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
-                      - rtgl-tag-select#detailTagSelect slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
+                      - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="Add tag": null
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content g=md:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} w=f:

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -1101,8 +1101,10 @@ const {
         tagIds,
       },
     }),
-  refreshAfterItemTagUpdate: ({ deps, itemId }) =>
-    refreshParticleData(deps, { selectedItemId: itemId }),
+  refreshAfterItemTagUpdate: ({ deps, itemId, itemStillSelected }) =>
+    refreshParticleData(deps, {
+      selectedItemId: itemStillSelected ? itemId : undefined,
+    }),
   getSelectedItemTagIds: ({ deps }) =>
     deps.store.selectSelectedParticle()?.tagIds ?? [],
   appendCreatedTagByMode: ({ deps, mode, tagId }) => {

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -65,6 +65,7 @@ export const handleAfterMount = async (deps) => {
   const platform = appService.getPlatform();
   const showCloudProjects = store.selectShowCloudProjects();
   store.setPlatform({ platform: platform });
+  store.setAppVersion({ version: appService.getAppVersion() });
   const authUser = getPersistedAuthenticatedUser(appService);
   const cloudSession = getAuthenticatedSession(appService);
   store.setAuthUser({ user: authUser });

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -16,6 +16,7 @@ export const createInitialState = () => ({
   projects: [],
   cloudProjects: [],
   platform: "tauri",
+  appVersion: "",
 
   profileMenu: {
     isOpen: false,
@@ -130,6 +131,10 @@ export const addCloudProject = ({ state }, { project } = {}) => {
 
 export const setPlatform = ({ state }, { platform } = {}) => {
   state.platform = platform;
+};
+
+export const setAppVersion = ({ state }, { version } = {}) => {
+  state.appVersion = version ?? "";
 };
 
 export const setAuthUser = ({ state }, { user } = {}) => {

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -188,6 +188,8 @@ template:
                                                   - rtgl-text s=xs c=mu-fg: Members
                                                   - rtgl-text s=xs c=mu-fg: ${project.memberCount}
                                   - rtgl-view h="33vh": null
+                          - rtgl-view w=f ah=c pb=lg:
+                              - rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}
   - rtgl-dialog#deleteProjectDialog ?open=${deleteDialog.isOpen} s=sm:
       - rtgl-view slot=content g=lg p=lg:
           - rtgl-view d=v g=md:

--- a/src/pages/spritesheets/spritesheets.handlers.js
+++ b/src/pages/spritesheets/spritesheets.handlers.js
@@ -990,8 +990,10 @@ const {
         tagIds,
       },
     }),
-  refreshAfterItemTagUpdate: ({ deps, itemId }) =>
-    refreshSpritesheetData(deps, { selectedItemId: itemId }),
+  refreshAfterItemTagUpdate: ({ deps, itemId, itemStillSelected }) =>
+    refreshSpritesheetData(deps, {
+      selectedItemId: itemStillSelected ? itemId : undefined,
+    }),
   appendCreatedTagByMode: ({ deps, mode, tagId }) => {
     if (mode !== "form") {
       return;

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -125,8 +125,10 @@ const {
         tagIds,
       },
     }),
-  refreshAfterItemTagUpdate: ({ deps, itemId }) =>
-    refreshTextStylesData(deps, { selectedItemId: itemId }),
+  refreshAfterItemTagUpdate: ({ deps, itemId, itemStillSelected }) =>
+    refreshTextStylesData(deps, {
+      selectedItemId: itemStillSelected ? itemId : undefined,
+    }),
   appendCreatedTagByMode: ({ deps, mode, tagId }) => {
     if (mode !== "form") {
       return;

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -7406,6 +7406,8 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       hasControl: Boolean(lineDecoration.hasControl),
       controlChangeType: lineDecoration.controlChangeType,
       bgm: lineDecoration.bgm,
+      hasVoice: Boolean(lineDecoration.hasVoice),
+      voiceChangeType: lineDecoration.voiceChangeType,
       hasSfx: Boolean(lineDecoration.hasSfx),
       sfxChangeType: lineDecoration.sfxChangeType,
       hasChoices: Boolean(lineDecoration.hasChoices),
@@ -8169,6 +8171,15 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
         this.createIconPreview({
           icon: "music",
           isDelete: lineDecoration.bgm.changeType === "delete",
+        }),
+      );
+    }
+
+    if (lineDecoration.hasVoice) {
+      container.append(
+        this.createIconPreview({
+          icon: "microphone",
+          isDelete: lineDecoration.voiceChangeType === "delete",
         }),
       );
     }

--- a/tests/commandLineVoice/commandLineVoice.handlers.test.js
+++ b/tests/commandLineVoice/commandLineVoice.handlers.test.js
@@ -110,10 +110,7 @@ describe("commandLineVoice.handlers", () => {
     expect(selectVoicePayload({ state })).toEqual({
       resourceId: createdVoiceId,
       loop: false,
-    });
-    expect(state.playingSound).toEqual({
-      title: "Alice Line",
-      fileId: "file-voice-1",
+      volume: 100,
     });
     expect(render).toHaveBeenCalledTimes(1);
     expect(appService.showAlert).not.toHaveBeenCalled();
@@ -147,6 +144,7 @@ describe("commandLineVoice.handlers", () => {
       voice: {
         resourceId: "voice-1",
         loop: false,
+        volume: 100,
       },
     });
   });

--- a/tests/commandLineVoice/commandLineVoice.handlers.test.js
+++ b/tests/commandLineVoice/commandLineVoice.handlers.test.js
@@ -8,6 +8,7 @@ import {
   openAudioPlayer,
   selectSelectedResource,
   selectVoicePayload,
+  selectViewData,
   setRepositoryState,
   setVoiceAudio,
 } from "../../src/components/commandLineVoice/commandLineVoice.store.js";
@@ -114,6 +115,89 @@ describe("commandLineVoice.handlers", () => {
     });
     expect(render).toHaveBeenCalledTimes(1);
     expect(appService.showAlert).not.toHaveBeenCalled();
+  });
+
+  it("closes a stale preview player after uploading replacement voice audio", async () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const uploadResult = {
+      fileId: "file-voice-2",
+      displayName: "Alice Line 2",
+      fileRecords: [{ fileId: "file-voice-2" }],
+    };
+    const file = {
+      name: "alice-line-2.ogg",
+      uploadSucessful: true,
+      uploadSuccessful: true,
+      uploadResult,
+    };
+    let createdVoiceId;
+    const projectService = {
+      ensureRepository: vi.fn(async () => {}),
+      getState: vi.fn(() => ({
+        voices: {
+          items: createdVoiceId
+            ? {
+                [createdVoiceId]: {
+                  id: createdVoiceId,
+                  type: "voice",
+                  name: "Alice Line 2",
+                  sceneId: "scene-1",
+                  fileId: "file-voice-2",
+                },
+              }
+            : {},
+          tree: createdVoiceId ? [{ id: createdVoiceId }] : [],
+        },
+      })),
+      createVoice: vi.fn(async ({ voiceId }) => {
+        createdVoiceId = voiceId;
+        return voiceId;
+      }),
+    };
+    const appService = {
+      pickFiles: vi.fn(async () => file),
+      showAlert: vi.fn(),
+    };
+
+    setVoiceAudio({ state }, { resourceId: "voice-1" });
+    openAudioPlayer(
+      { state },
+      {
+        fileId: "file-voice-1",
+        fileName: "Alice Line 1",
+      },
+    );
+
+    await handleAudioWaveformClick(
+      {
+        appService,
+        projectService,
+        props: {
+          currentSceneId: "scene-1",
+        },
+        store: createStoreDeps(state),
+        render,
+      },
+      {
+        _event: {
+          stopPropagation: vi.fn(),
+        },
+      },
+    );
+
+    expect(selectVoicePayload({ state })).toEqual({
+      resourceId: createdVoiceId,
+      loop: false,
+      volume: 100,
+    });
+    expect(selectViewData({ state })).toMatchObject({
+      showAudioPlayer: false,
+      playingSound: {
+        fileId: undefined,
+        title: "",
+      },
+    });
   });
 
   it("submits the selected voice payload", () => {

--- a/tests/commandLineVoice/commandLineVoice.store.test.js
+++ b/tests/commandLineVoice/commandLineVoice.store.test.js
@@ -9,7 +9,7 @@ import {
 } from "../../src/components/commandLineVoice/commandLineVoice.store.js";
 
 describe("commandLineVoice.store", () => {
-  it("keeps voice volume optional until the user changes it", () => {
+  it("defaults missing voice volume to 100 and allows changes", () => {
     const state = createInitialState();
 
     setRepositoryState(
@@ -38,10 +38,11 @@ describe("commandLineVoice.store", () => {
       },
     );
 
-    expect(selectViewData({ state }).voice.volume).toBe(75);
+    expect(selectViewData({ state }).voice.volume).toBe(100);
     expect(selectVoicePayload({ state })).toEqual({
       resourceId: "voice-1",
       loop: false,
+      volume: 100,
     });
 
     setVolume({ state }, { volume: 80 });

--- a/tests/images/images.handlers.test.js
+++ b/tests/images/images.handlers.test.js
@@ -165,7 +165,7 @@ describe("images handlers", () => {
     });
   });
 
-  it("creates and assigns a new tag from the detail-panel flow", async () => {
+  it("creates a new tag from the detail-panel flow and keeps the draft open", async () => {
     const deps = {
       appService: {
         showAlert: vi.fn(),
@@ -426,6 +426,88 @@ describe("images handlers", () => {
     });
     expect(deps.store.commitDetailTagIds).toHaveBeenCalledWith({
       tagIds: ["tag-1", "tag-2"],
+    });
+  });
+
+  it("does not reselect the previous item when a detail tag update finishes after selection changes", async () => {
+    let selectedItemId = "image-1";
+    const deps = {
+      appService: {
+        showAlert: vi.fn(),
+      },
+      projectService: {
+        updateImage: vi.fn(async () => {
+          selectedItemId = "image-2";
+          return { valid: true };
+        }),
+        getRepositoryState: vi.fn(() => ({
+          files: { items: {}, tree: [] },
+          images: {
+            tree: [],
+            items: {
+              "image-1": {
+                id: "image-1",
+                type: "image",
+                name: "Hero",
+                tagIds: ["tag-1", "tag-2"],
+              },
+              "image-2": {
+                id: "image-2",
+                type: "image",
+                name: "Villain",
+                tagIds: [],
+              },
+            },
+          },
+          tags: {
+            images: {
+              tree: [{ id: "tag-1" }, { id: "tag-2" }],
+              items: {
+                "tag-1": { id: "tag-1", type: "tag", name: "Old" },
+                "tag-2": { id: "tag-2", type: "tag", name: "New" },
+              },
+            },
+          },
+        })),
+        subscribeProjectState: vi.fn(() => () => {}),
+      },
+      store: {
+        selectSelectedItemId: vi.fn(() => selectedItemId),
+        commitDetailTagIds: vi.fn(),
+        setTagsData: vi.fn(),
+        setItems: vi.fn(),
+        setProjectResolution: vi.fn(),
+        setSelectedItemId: vi.fn(),
+        setSelectedFolderId: vi.fn(),
+      },
+      refs: {
+        fileExplorer: {
+          selectItem: vi.fn(),
+        },
+      },
+      render: vi.fn(),
+    };
+
+    await handleDetailTagValueChange(deps, {
+      _event: {
+        detail: {
+          value: ["tag-1", "tag-2"],
+        },
+      },
+    });
+
+    expect(deps.projectService.updateImage).toHaveBeenCalledWith({
+      imageId: "image-1",
+      data: {
+        tagIds: ["tag-1", "tag-2"],
+      },
+    });
+    expect(deps.store.commitDetailTagIds).not.toHaveBeenCalled();
+    expect(deps.store.setSelectedItemId).not.toHaveBeenCalledWith({
+      itemId: "image-1",
+    });
+    expect(deps.refs.fileExplorer.selectItem).not.toHaveBeenCalledWith({
+      itemId: "image-1",
     });
   });
 

--- a/tests/mediaResourcesView/mediaResourcesView.store.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.store.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/components/mediaResourcesView/mediaResourcesView.store.js";
+
+describe("mediaResourcesView.store", () => {
+  it("does not show a strong hover border on non-selected cards while another card is selected", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({
+      state,
+      props: {
+        selectedItemId: "sprite-1",
+        groups: [
+          {
+            id: "folder-1",
+            children: [
+              { id: "sprite-1", cardKind: "image" },
+              { id: "sprite-2", cardKind: "image" },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(viewData.groups[0].children[0]).toEqual(
+      expect.objectContaining({
+        itemBorderColor: "pr",
+        itemHoverBorderColor: "pr",
+      }),
+    );
+    expect(viewData.groups[0].children[1]).toEqual(
+      expect.objectContaining({
+        itemBorderColor: "bo",
+        itemHoverBorderColor: "bo",
+      }),
+    );
+  });
+
+  it("keeps the hover border for interactive cards when nothing is selected", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({
+      state,
+      props: {
+        groups: [
+          {
+            id: "folder-1",
+            children: [{ id: "sprite-1", cardKind: "image" }],
+          },
+        ],
+      },
+    });
+
+    expect(viewData.groups[0].children[0]).toEqual(
+      expect.objectContaining({
+        itemBorderColor: "bo",
+        itemHoverBorderColor: "ac",
+      }),
+    );
+  });
+});

--- a/tests/sceneEditor/lexicalLinePreview.test.js
+++ b/tests/sceneEditor/lexicalLinePreview.test.js
@@ -149,6 +149,46 @@ describe("lexical scene document editor line previews", () => {
     }
   });
 
+  it("renders voice action markers in right-gutter preview items", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const previewHost = {
+        createIconPreview({ icon }) {
+          const item = document.createElement("div");
+          item.className = "preview-item";
+          const iconElement = document.createElement("rtgl-svg");
+          iconElement.setAttribute("svg", icon);
+          item.append(iconElement);
+          return item;
+        },
+      };
+
+      const signature = JSON.parse(
+        LexicalSceneDocumentEditorElement.prototype.buildRightGutterSignature({
+          hasVoice: true,
+        }),
+      );
+      const previewItems =
+        LexicalSceneDocumentEditorElement.prototype.createPreviewItems.call(
+          previewHost,
+          { hasVoice: true },
+        );
+
+      expect(signature.hasVoice).toBe(true);
+      expect(
+        Array.from(previewItems.querySelectorAll("rtgl-svg")).map((icon) =>
+          icon.getAttribute("svg"),
+        ),
+      ).toEqual(["microphone"]);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("renders deleted dialogue previews as dialogue icons with a centered x mark", async () => {
     const restoreDomGlobals = installDomGlobals();
 

--- a/tests/sceneEditor/lineViewModels.test.js
+++ b/tests/sceneEditor/lineViewModels.test.js
@@ -444,6 +444,34 @@ describe("sceneEditor.lineDecorations", () => {
     expect(viewModels[1].hasInput).toBe(false);
   });
 
+  it("marks voice actions for inline action previews", () => {
+    const lines = [
+      {
+        id: "line-1",
+        actions: {
+          voice: {
+            resourceId: "voice-line-1",
+          },
+        },
+      },
+      {
+        id: "line-2",
+        actions: {},
+      },
+    ];
+
+    const viewModels = buildSceneDocumentLineDecorations({
+      lines,
+      repositoryState: createRepositoryState(),
+      sectionLineChanges: {
+        lines: [],
+      },
+    });
+
+    expect(viewModels[0].hasVoice).toBe(true);
+    expect(viewModels[1].hasVoice).toBe(false);
+  });
+
   it("marks screen actions for inline action previews without duplicating section transitions", () => {
     const lines = [
       {

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  closeAudioPlayer,
   createInitialState,
+  openAudioPlayer,
+  selectVoicePreview,
   selectAction,
+  setRepositoryState,
   updateActions,
 } from "../../src/components/systemActions/systemActions.store.js";
 import {
@@ -10,9 +14,11 @@ import {
   handleBackgroundTransformCustomize,
   handleBackgroundTransformEditorDone,
   handleGetBackgroundTransformPreviewCanvasRoot,
+  handleAudioPlayerClose,
   handleEmbeddedCloseClick,
   handleCommandLineSubmit,
   handleTemporaryPresentationStateChange,
+  handleVoicePreviewClick,
   handleSetBackgroundCustomTransform,
   handleSetActionCustomTransform,
   open,
@@ -802,5 +808,86 @@ describe("systemActions.handlers", () => {
       }),
     ).toBe(canvasRoot);
     expect(getCanvasRoot).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens and closes the inline voice preview player", () => {
+    const state = createInitialState();
+    const props = {
+      actions: {
+        voice: {
+          resourceId: "voice-line-1",
+        },
+      },
+    };
+    const render = vi.fn();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    updateActions({ state }, props.actions);
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          voices: {
+            items: {
+              "voice-line-1": {
+                id: "voice-line-1",
+                type: "voice",
+                name: "Aki Line 1",
+                fileId: "file-voice-line-1",
+              },
+            },
+            tree: [{ id: "voice-line-1" }],
+          },
+        },
+      },
+    );
+
+    handleVoicePreviewClick(
+      {
+        store: {
+          selectVoicePreview: () => selectVoicePreview({ state, props }),
+          openAudioPlayer: (payload) => openAudioPlayer({ state }, payload),
+        },
+        render,
+      },
+      {
+        _event: {
+          preventDefault,
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(state.showAudioPlayer).toBe(true);
+    expect(state.playingSound).toEqual({
+      fileId: "file-voice-line-1",
+      title: "Aki Line 1",
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+
+    handleAudioPlayerClose(
+      {
+        store: {
+          closeAudioPlayer: () => closeAudioPlayer({ state }),
+        },
+        render,
+      },
+      {
+        _event: {
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(stopPropagation).toHaveBeenCalledTimes(2);
+    expect(state.showAudioPlayer).toBe(false);
+    expect(state.playingSound).toEqual({
+      fileId: undefined,
+      title: "",
+    });
+    expect(render).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -16,6 +16,7 @@ import {
   handleGetBackgroundTransformPreviewCanvasRoot,
   handleAudioPlayerClose,
   handleEmbeddedCloseClick,
+  handleOnUpdate,
   handleCommandLineSubmit,
   handleTemporaryPresentationStateChange,
   handleVoicePreviewClick,
@@ -889,5 +890,89 @@ describe("systemActions.handlers", () => {
       title: "",
     });
     expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns when a voice action has no previewable audio file", () => {
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const showAlert = vi.fn();
+    const render = vi.fn();
+
+    handleVoicePreviewClick(
+      {
+        appService: {
+          showAlert,
+        },
+        store: {
+          selectVoicePreview: () => ({
+            id: "voice-line-1",
+            name: "Aki Line 1",
+          }),
+          openAudioPlayer: vi.fn(),
+        },
+        render,
+      },
+      {
+        _event: {
+          preventDefault,
+          stopPropagation,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(showAlert).toHaveBeenCalledWith({
+      message: "Voice preview audio is unavailable.",
+      title: "Warning",
+    });
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it("refreshes repository resources when system action props update", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+
+    handleOnUpdate(
+      {
+        projectService: {
+          getRepositoryState: () => ({
+            voices: {
+              items: {
+                "voice-line-1": {
+                  id: "voice-line-1",
+                  type: "voice",
+                  name: "Aki Line 1",
+                  fileId: "file-voice-line-1",
+                },
+              },
+              tree: [{ id: "voice-line-1" }],
+            },
+          }),
+        },
+        store: {
+          setRepositoryState: (payload) =>
+            setRepositoryState({ state }, payload),
+          updateActions: (payload) => updateActions({ state }, payload),
+        },
+        render,
+      },
+      {
+        newProps: {
+          actions: {
+            voice: {
+              resourceId: "voice-line-1",
+            },
+          },
+        },
+      },
+    );
+
+    expect(selectVoicePreview({ state, props: {} })).toMatchObject({
+      id: "voice-line-1",
+      name: "Aki Line 1",
+      fileId: "file-voice-line-1",
+    });
+    expect(render).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  closeAudioPlayer,
   createInitialState,
+  openAudioPlayer,
   selectActionsData,
   selectViewData,
   setRepositoryState,
@@ -254,6 +256,73 @@ describe("systemActions.store", () => {
     expect(preview.voice).toMatchObject({
       id: "voice-line-1",
       name: "Aki Line 1",
+    });
+  });
+
+  it("exposes inline voice preview player state", () => {
+    const state = createInitialState();
+
+    openAudioPlayer(
+      { state },
+      {
+        fileId: "file-voice-line-1",
+        fileName: "Aki Line 1",
+      },
+    );
+
+    expect(selectViewData({ state, props: {} })).toMatchObject({
+      showAudioPlayer: true,
+      playingSound: {
+        fileId: "file-voice-line-1",
+        title: "Aki Line 1",
+      },
+    });
+
+    closeAudioPlayer({ state });
+
+    expect(selectViewData({ state, props: {} })).toMatchObject({
+      showAudioPlayer: false,
+      playingSound: {
+        fileId: undefined,
+        title: "",
+      },
+    });
+  });
+
+  it("closes the inline voice preview player when the voice action changes", () => {
+    const state = createInitialState();
+
+    updateActions(
+      { state },
+      {
+        voice: {
+          resourceId: "voice-line-1",
+        },
+      },
+    );
+    openAudioPlayer(
+      { state },
+      {
+        fileId: "file-voice-line-1",
+        fileName: "Aki Line 1",
+      },
+    );
+
+    updateActions(
+      { state },
+      {
+        background: {
+          resourceId: "bg-classroom",
+        },
+      },
+    );
+
+    expect(selectViewData({ state, props: {} })).toMatchObject({
+      showAudioPlayer: false,
+      playingSound: {
+        fileId: undefined,
+        title: "",
+      },
     });
   });
 

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -259,6 +259,48 @@ describe("systemActions.store", () => {
     });
   });
 
+  it("previews legacy voice actions that reference a file id directly", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          files: {
+            items: {
+              "file-voice-line-1": {
+                id: "file-voice-line-1",
+                name: "Aki Line 1.ogg",
+                mimeType: "audio/ogg",
+              },
+            },
+            tree: [{ id: "file-voice-line-1" }],
+          },
+        },
+      },
+    );
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actions: {
+          voice: {
+            resourceId: "file-voice-line-1",
+          },
+        },
+      },
+    });
+
+    expect(actions.voice).toEqual({
+      resourceId: "file-voice-line-1",
+    });
+    expect(preview.voice).toMatchObject({
+      id: "file-voice-line-1",
+      name: "Aki Line 1.ogg",
+      fileId: "file-voice-line-1",
+    });
+  });
+
   it("exposes inline voice preview player state", () => {
     const state = createInitialState();
 

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -32,6 +32,10 @@ describe("systemActions view", () => {
     );
     expect(systemActionsView).toContain("rtgl-view#actionItemVoice");
     expect(systemActionsView).toContain("rtgl-svg svg=microphone wh=24");
+    expect(systemActionsView).toContain("rtgl-button#voicePreviewButton");
+    expect(systemActionsView).toContain(
+      "rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}",
+    );
     expect(systemActionsView).toContain("rtgl-svg svg=screen wh=24");
     expect(conditionalView).toContain(
       "rvn-system-actions#branchActionsEditor :showSelected=${true} :actions=${branchActions} actionType=system :hiddenModes=${hiddenModes} :allowedModes=${branchActionAllowedModes}",

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -32,7 +32,10 @@ describe("systemActions view", () => {
     );
     expect(systemActionsView).toContain("rtgl-view#actionItemVoice");
     expect(systemActionsView).toContain("rtgl-svg svg=microphone wh=24");
-    expect(systemActionsView).toContain("rtgl-button#voicePreviewButton");
+    expect(systemActionsView).toContain(
+      'rtgl-button#voicePreviewButton sq v=ol pre=play title="Preview voice" aria-label="Preview voice"',
+    );
+    expect(systemActionsView).not.toContain("$if preview.voice.fileId");
     expect(systemActionsView).toContain(
       "rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}",
     );


### PR DESCRIPTION
## Summary
- stabilize detail tag create/update flows so delayed popover/dialog renders do not affect a newly selected item
- key image and character sprite detail tag selectors by selected item, and keep hover styling from looking like a second selection
- improve processing placeholders on media cards so text remains visible
- include command line voice fix: avoid auto-opening the uploaded audio player, default missing voice volume to 100, and reset stale preview playback when selected voice audio changes
- add right-panel voice preview playback in the scene text editor, keep the play control visible, resync voice resource data after uploads, and show voice actions as microphone markers in the text editor gutter
- bump route-graphics to 1.23.5
- show the RouteVN Creator app version at the bottom of the projects page

## Testing
- bun run lint
- bunx vitest run tests/commandLineVoice/commandLineVoice.store.test.js tests/commandLineVoice/commandLineVoice.handlers.test.js
- bunx vitest run tests/sceneEditor/lineViewModels.test.js tests/sceneEditor/lexicalLinePreview.test.js
- bunx vitest run tests/systemActions/systemActions.store.test.js tests/systemActions/systemActions.handlers.test.js tests/systemActions/systemActions.view.test.js tests/commandLineVoice/commandLineVoice.store.test.js tests/commandLineVoice/commandLineVoice.handlers.test.js
- bunx vitest run tests/images/images.handlers.test.js tests/mediaResourcesView/mediaResourcesView.store.test.js tests/characterSprites/characterSprites.store.test.js
- bun run build:web