### PR TITLE
Improve mobile scene editor touch UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@tauri-apps/plugin-updater": "2.10.1",
         "file-type": "21.3.4",
         "immer": "10.2.0",
-        "insieme": "2.1.0",
+        "insieme": "2.1.1",
         "jempl": "1.0.0",
         "js-yaml": "4.1.1",
         "jsdom": "26.1.0",
@@ -572,7 +572,7 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
-    "insieme": ["insieme@2.1.0", "", { "dependencies": { "immer": "^11.1.4" } }, "sha512-LTBw2R5Dc4eyqgkDLsFr2TQ4qCIJGivoHxun3j+kiI78HRCW8q/M5fnfLTWqh8+JOoP986ie7+WrBiYsyWlSHg=="],
+    "insieme": ["insieme@2.1.1", "", { "dependencies": { "immer": "^11.1.4", "nanoid": "^5.1.5" } }, "sha512-IVlLWYopJIm3U62LKVBeCKT7enyVDjUYGEG769+90elhJ/OQpq4TSvR5CnFb5ACzGFBCKDO5Iq7T8K4aHVHPFw=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tauri-apps/plugin-updater": "2.10.1",
     "file-type": "21.3.4",
     "immer": "10.2.0",
-    "insieme": "2.1.0",
+    "insieme": "2.1.1",
     "jempl": "1.0.0",
     "js-yaml": "4.1.1",
     "jsdom": "26.1.0",

--- a/src/components/catalogResourcesView/catalogResourcesView.schema.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.schema.yaml
@@ -76,6 +76,9 @@ propsSchema:
     mobileLayout:
       type: boolean
       description: Whether cards should use the touch/mobile full-width layout
+    scrollBottomPadding:
+      type: string
+      description: Extra bottom padding inside the scroll container
     itemContextMenuItems:
       type: array
       description: Context menu items for catalog cards

--- a/src/components/catalogResourcesView/catalogResourcesView.store.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.store.js
@@ -7,6 +7,7 @@ import {
   selectTagFilterPopoverDraftTagIds,
   toggleTagFilterPopoverTagId,
 } from "../../internal/ui/tagFilterPopover.js";
+import { resolveResourceScrollBottomPadding } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const DEFAULT_ITEMS_PER_ROW = 6;
 const MIN_ITEMS_PER_ROW = 1;
@@ -145,11 +146,17 @@ export const selectViewData = ({ state, props }) => {
     ? clampItemsPerRow(fixedItemsPerRow)
     : undefined;
   const itemsPerRow = mobileLayout ? 1 : clampItemsPerRow(state.itemsPerRow);
-  const cardGridColumns = useColumnZoomControl
-    ? `${itemsPerRow}`
-    : hasFixedItemsPerRow
-      ? `${fixedColumnCount}`
-      : buildAutoFillGridColumns(DEFAULT_CARD_WIDTH);
+  const cardGridColumns = mobileLayout
+    ? "1"
+    : useColumnZoomControl
+      ? `${itemsPerRow}`
+      : hasFixedItemsPerRow
+        ? `${fixedColumnCount}`
+        : buildAutoFillGridColumns(DEFAULT_CARD_WIDTH);
+  const scrollBottomPadding = resolveResourceScrollBottomPadding({
+    mobileLayout,
+    scrollBottomPadding: props.scrollBottomPadding,
+  });
   const hasActiveTagFilter = (props.selectedTagFilterValues?.length ?? 0) > 0;
   const searchQuery = props.searchQuery ?? "";
   const searchInFilterPopover = parseBooleanProp(props.searchInFilterPopover);
@@ -250,6 +257,7 @@ export const selectViewData = ({ state, props }) => {
     importText: props.importText ?? "Import",
     canImport: parseBooleanProp(props.canImport),
     mobileLayout,
+    scrollBottomPadding,
     dropdownMenu: state.dropdownMenu,
   };
 };

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -95,7 +95,7 @@ template:
                       - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
               - $if canImport:
                   - rtgl-button#importBtn s=sm pre=upload v=se: ${importText}
-      - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
+      - 'rtgl-view h=1fg w=f sv style="min-width: 0; padding-bottom: ${scrollBottomPadding}; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
                   - rtgl-view w=f ph=md pos=rel:
@@ -197,7 +197,7 @@ template:
                                                     $else:
                                                       - rvn-keyframe-timeline w=f ?showRuler=true :properties=${item.updateProperties}: null
                                             $else:
-                                              - rtgl-view w=225 h=152 d=v ah=c av=c br=md p=md g=sm:
+                                              - rtgl-view w=${item.catalogTextWidth} h=152 d=v ah=c av=c br=md p=md g=sm:
                                                   - rtgl-text s=md ellipsis w=f: ${item.name}
                                                   - $if item.subtitle:
                                                       - rtgl-text s=sm c=mu-fg ellipsis w=f: ${item.subtitle}

--- a/src/components/charactersResourcesView/charactersResourcesView.schema.yaml
+++ b/src/components/charactersResourcesView/charactersResourcesView.schema.yaml
@@ -47,6 +47,9 @@ propsSchema:
     mobileLayout:
       type: boolean
       description: Whether cards should use the touch/mobile full-width layout
+    scrollBottomPadding:
+      type: string
+      description: Extra bottom padding inside the scroll container
     addText:
       type: string
       description: Text to display in add affordances

--- a/src/components/charactersResourcesView/charactersResourcesView.store.js
+++ b/src/components/charactersResourcesView/charactersResourcesView.store.js
@@ -7,6 +7,7 @@ import {
   selectTagFilterPopoverDraftTagIds,
   toggleTagFilterPopoverTagId,
 } from "../../internal/ui/tagFilterPopover.js";
+import { resolveResourceScrollBottomPadding } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 export const createInitialState = () => ({
   collapsedIds: [],
@@ -88,6 +89,10 @@ export const selectViewData = ({ state, props }) => {
   const hasActiveSearch = searchQuery.trim().length > 0;
   const hasActiveFilter =
     hasActiveTagFilter || (searchInFilterPopover && hasActiveSearch);
+  const scrollBottomPadding = resolveResourceScrollBottomPadding({
+    mobileLayout,
+    scrollBottomPadding: props.scrollBottomPadding,
+  });
   const tagFilterPopoverViewData = buildTagFilterPopoverViewData({
     state,
     props,
@@ -145,6 +150,7 @@ export const selectViewData = ({ state, props }) => {
           : `No characters found matching "${searchQuery}"`),
     addText: props.addText ?? "Add Character",
     mobileLayout,
+    scrollBottomPadding,
     dropdownMenu: state.dropdownMenu,
   };
 };

--- a/src/components/charactersResourcesView/charactersResourcesView.view.yaml
+++ b/src/components/charactersResourcesView/charactersResourcesView.view.yaml
@@ -68,7 +68,7 @@ template:
               - $if showTagFilter:
                   - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
                       - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
-      - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
+      - 'rtgl-view h=1fg w=f sv style="min-width: 0; padding-bottom: ${scrollBottomPadding}; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
                   - rtgl-view w=f ph=md pos=rel:

--- a/src/components/groupVariablesView/groupVariablesView.schema.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.schema.yaml
@@ -38,6 +38,9 @@ propsSchema:
     mobileLayout:
       type: boolean
       description: Whether to use the mobile layout
+    scrollBottomPadding:
+      type: string
+      description: Extra bottom padding inside the scroll container
     readonly:
       type: boolean
       description: Whether the view should disable add/edit/delete affordances

--- a/src/components/groupVariablesView/groupVariablesView.store.js
+++ b/src/components/groupVariablesView/groupVariablesView.store.js
@@ -17,6 +17,7 @@ import {
   selectTagFilterPopoverDraftTagIds,
   toggleTagFilterPopoverTagId,
 } from "../../internal/ui/tagFilterPopover.js";
+import { resolveResourceScrollBottomPadding } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const DEFAULT_FORM_VALUES = {
   name: "",
@@ -373,6 +374,10 @@ export const selectViewData = ({ state, props }) => {
     props,
   });
   const mobileLayout = parseBooleanProp(props.mobileLayout);
+  const scrollBottomPadding = resolveResourceScrollBottomPadding({
+    mobileLayout,
+    scrollBottomPadding: props.scrollBottomPadding,
+  });
 
   // Helper function to check if an item matches the search query
   const matchesSearch = (item) => {
@@ -505,6 +510,7 @@ export const selectViewData = ({ state, props }) => {
     showFilterPopoverSearch: searchInFilterPopover,
     showMenuButton: parseBooleanProp(props.showMenuButton),
     mobileLayout,
+    scrollBottomPadding,
     hasActiveTagFilter,
     tagFilterButtonBackgroundColor: hasActiveFilter ? "ac" : "bg",
     tagFilterButtonBorderColor: hasActiveFilter ? "ac" : "bo",

--- a/src/components/groupVariablesView/groupVariablesView.view.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.view.yaml
@@ -105,7 +105,7 @@ template:
           - $if showTagFilter:
               - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
                   - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
-      - 'rtgl-view h=1fg w=f sv style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view h=1fg w=f sv style="min-width: 0; min-height: 0; padding-bottom: ${scrollBottomPadding}; box-sizing: border-box;"':
           - $if flatGroups.length > 0:
               - $for group, i in flatGroups:
                   - rtgl-view w=f ph=md pos=rel:

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -7,6 +7,7 @@ import {
   selectTagFilterPopoverDraftTagIds,
   toggleTagFilterPopoverTagId,
 } from "../../internal/ui/tagFilterPopover.js";
+import { resolveResourceScrollBottomPadding } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const DEFAULT_PROGRESSIVE_INITIAL_ITEM_COUNT = 8;
 const DEFAULT_EAGER_IMAGE_CARD_COUNT = 8;
@@ -254,7 +255,10 @@ export const selectViewData = ({ state, props }) => {
         : buildAutoFillGridColumns(
             hasImageCards(sourceGroups) ? maxWidth : mediaWidth,
           );
-  const scrollBottomPadding = props.scrollBottomPadding ?? "0px";
+  const scrollBottomPadding = resolveResourceScrollBottomPadding({
+    mobileLayout,
+    scrollBottomPadding: props.scrollBottomPadding,
+  });
   const hasActiveTagFilter = (props.selectedTagFilterValues?.length ?? 0) > 0;
   const searchQuery = props.searchQuery ?? "";
   const searchInFilterPopover = parseBooleanProp(props.searchInFilterPopover);

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -242,8 +242,8 @@ template:
                                                       - rtgl-view w=f p=md:
                                                           - rtgl-text s=xs c=mu-fg ellipsis w=${item.mediaTextWidth}: ${item.name}
                                                 $else:
-                                                  - rtgl-view p=md g=md w=${mediaWidth} d=v br=md:
-                                                      - rtgl-text s=xs c=mu-fg ellipsis w=${mediaWidth}: ${item.name}
+                                                  - rtgl-view p=md g=md w=${item.mediaCardWidth} d=v br=md:
+                                                      - rtgl-text s=xs c=mu-fg ellipsis w=${item.mediaTextWidth}: ${item.name}
                                     $else:
                                       - $if canUpload:
                                           - 'rtgl-view#uploadBtnEmptyRef${gIndex} data-group-id=${group.id} w=f h=150 bw=xs br=md ah=c av=c g=md cur=pointer style="grid-column: 1 / -1;"':

--- a/src/components/mobileKeyboardToolbar/mobileKeyboardToolbar.handlers.js
+++ b/src/components/mobileKeyboardToolbar/mobileKeyboardToolbar.handlers.js
@@ -1,4 +1,10 @@
 const KEYBOARD_VISIBLE_INSET_PX = 100;
+const ARROW_REPEAT_DELAY_MS = 280;
+const ARROW_REPEAT_INTERVAL_MS = 70;
+const ARROW_REPEAT_SUPPRESSION_ATTRIBUTE =
+  "data-rvn-mobile-keyboard-arrow-repeat";
+const ARROW_REPEAT_SUPPRESSION_STYLE_ID =
+  "rvn-mobile-keyboard-arrow-repeat-style";
 
 const getDeepActiveElement = () => {
   let activeElement = document.activeElement;
@@ -38,13 +44,57 @@ const getSelectionForElement = (element) => {
   return window.getSelection?.();
 };
 
-const moveSelectionByLine = (element, direction) => {
+const ARROW_KEY_BY_DIRECTION = {
+  left: "ArrowLeft",
+  up: "ArrowUp",
+  down: "ArrowDown",
+  right: "ArrowRight",
+};
+
+const DIRECTION_BY_ACTION_ID = {
+  "arrow-left": "left",
+  "arrow-up": "up",
+  "arrow-down": "down",
+  "arrow-right": "right",
+};
+
+const moveSelection = (element, direction) => {
   const selection = getSelectionForElement(element);
   if (typeof selection?.modify !== "function") {
     return;
   }
 
-  selection.modify("move", direction === "up" ? "backward" : "forward", "line");
+  const moveDirection =
+    direction === "left" || direction === "up" ? "backward" : "forward";
+  const granularity =
+    direction === "up" || direction === "down" ? "line" : "character";
+
+  selection.modify("move", moveDirection, granularity);
+};
+
+const getEditableOwner = (element) => {
+  const root = element?.getRootNode?.();
+  return typeof ShadowRoot !== "undefined" && root instanceof ShadowRoot
+    ? root.host
+    : undefined;
+};
+
+const revealEditableSelection = (direction) => {
+  const owner = getEditableOwner(getDeepActiveElement());
+  owner?.revealCurrentSelection?.({ behavior: "auto", direction });
+};
+
+const scheduleRevealEditableSelection = (direction) => {
+  if (typeof requestAnimationFrame !== "function") {
+    revealEditableSelection(direction);
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      revealEditableSelection(direction);
+    });
+  });
 };
 
 const dispatchArrowKey = (direction) => {
@@ -53,7 +103,11 @@ const dispatchArrowKey = (direction) => {
     return;
   }
 
-  const key = direction === "up" ? "ArrowUp" : "ArrowDown";
+  const key = ARROW_KEY_BY_DIRECTION[direction];
+  if (!key) {
+    return;
+  }
+
   const event = new KeyboardEvent("keydown", {
     key,
     code: key,
@@ -64,14 +118,80 @@ const dispatchArrowKey = (direction) => {
 
   activeElement.dispatchEvent(event);
   if (!event.defaultPrevented) {
-    moveSelectionByLine(activeElement, direction);
+    moveSelection(activeElement, direction);
   }
+  scheduleRevealEditableSelection(direction);
+};
+
+const blurActiveEditableElement = () => {
+  const activeElement = getDeepActiveElement();
+  if (!isEditableElement(activeElement)) {
+    return;
+  }
+
+  activeElement.blur?.();
+};
+
+const getVirtualKeyboard = () => {
+  return navigator.virtualKeyboard;
+};
+
+const enableVirtualKeyboardOverlay = () => {
+  const virtualKeyboard = getVirtualKeyboard();
+  if (!virtualKeyboard || !("overlaysContent" in virtualKeyboard)) {
+    return undefined;
+  }
+
+  const previousOverlaysContent = virtualKeyboard.overlaysContent;
+  virtualKeyboard.overlaysContent = true;
+
+  return () => {
+    virtualKeyboard.overlaysContent = previousOverlaysContent;
+  };
+};
+
+const getVirtualKeyboardRect = () => {
+  const rect = getVirtualKeyboard()?.boundingRect;
+  if (!rect) {
+    return undefined;
+  }
+
+  const height = Number(rect.height) || 0;
+  if (height <= 0) {
+    return undefined;
+  }
+
+  const top = Number(rect.y ?? rect.top);
+  if (!Number.isFinite(top)) {
+    return undefined;
+  }
+
+  return {
+    height,
+    top: Math.max(0, Math.round(top)),
+  };
 };
 
 const getViewportMetrics = (largestViewportHeight) => {
   const viewport = window.visualViewport;
   const layoutHeight =
     window.innerHeight || document.documentElement?.clientHeight || 0;
+  const virtualKeyboardRect = getVirtualKeyboardRect();
+
+  if (virtualKeyboardRect) {
+    const keyboardInset = Math.min(virtualKeyboardRect.height, layoutHeight);
+    const visualHeight = Math.max(0, layoutHeight - keyboardInset);
+
+    return {
+      keyboardInset,
+      visualOffsetTop: 0,
+      pageTop: 0,
+      bottom: keyboardInset,
+      visualHeight,
+      layoutHeight,
+    };
+  }
+
   const visualHeight = viewport?.height ?? layoutHeight;
   const visualOffsetTop = viewport?.offsetTop ?? 0;
   const overlayKeyboardInset = Math.max(
@@ -86,6 +206,8 @@ const getViewportMetrics = (largestViewportHeight) => {
 
   return {
     keyboardInset,
+    visualOffsetTop,
+    pageTop: 0,
     bottom: overlayKeyboardInset > 0 ? overlayKeyboardInset : 0,
     visualHeight,
     layoutHeight,
@@ -105,11 +227,93 @@ const dispatchKeyboardStateChange = (dispatchEvent, keyboardState) => {
   );
 };
 
-export const handleBeforeMount = ({ store, render, dispatchEvent }) => {
+const ensureArrowRepeatSuppressionStyle = () => {
+  if (document.getElementById(ARROW_REPEAT_SUPPRESSION_STYLE_ID)) {
+    return;
+  }
+
+  const styleElement = document.createElement("style");
+  styleElement.id = ARROW_REPEAT_SUPPRESSION_STYLE_ID;
+  styleElement.textContent = `
+html[${ARROW_REPEAT_SUPPRESSION_ATTRIBUTE}="true"],
+html[${ARROW_REPEAT_SUPPRESSION_ATTRIBUTE}="true"] * {
+  -webkit-touch-callout: none !important;
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+`;
+  document.head.append(styleElement);
+};
+
+const enableArrowRepeatNativeCalloutSuppression = () => {
+  document.documentElement?.setAttribute(
+    ARROW_REPEAT_SUPPRESSION_ATTRIBUTE,
+    "true",
+  );
+};
+
+const disableArrowRepeatNativeCalloutSuppression = () => {
+  document.documentElement?.removeAttribute(ARROW_REPEAT_SUPPRESSION_ATTRIBUTE);
+};
+
+const isArrowRepeatNativeCalloutSuppressed = () => {
+  return (
+    document.documentElement?.getAttribute(
+      ARROW_REPEAT_SUPPRESSION_ATTRIBUTE,
+    ) === "true"
+  );
+};
+
+const stopArrowRepeat = (store) => {
+  const repeatState = store.selectArrowRepeatState?.();
+  if (!repeatState) {
+    disableArrowRepeatNativeCalloutSuppression();
+    return;
+  }
+
+  clearTimeout(repeatState.delayTimerId);
+  clearInterval(repeatState.intervalTimerId);
+  store.clearArrowRepeatState?.();
+  disableArrowRepeatNativeCalloutSuppression();
+};
+
+const startArrowRepeat = (store, direction, pointerId) => {
+  stopArrowRepeat(store);
+  enableArrowRepeatNativeCalloutSuppression();
+  dispatchArrowKey(direction);
+
+  const delayTimerId = setTimeout(() => {
+    const repeatState = store.selectArrowRepeatState?.();
+    if (
+      repeatState?.direction !== direction ||
+      repeatState?.pointerId !== pointerId
+    ) {
+      return;
+    }
+
+    dispatchArrowKey(direction);
+    const intervalTimerId = setInterval(() => {
+      dispatchArrowKey(direction);
+    }, ARROW_REPEAT_INTERVAL_MS);
+    store.setArrowRepeatIntervalId?.({ intervalTimerId });
+  }, ARROW_REPEAT_DELAY_MS);
+
+  store.setArrowRepeatState?.({
+    direction,
+    pointerId,
+    delayTimerId,
+  });
+};
+
+export const handleBeforeMount = (deps) => {
+  const { store, render, dispatchEvent } = deps;
+
   if (typeof window === "undefined" || typeof document === "undefined") {
     return undefined;
   }
 
+  ensureArrowRepeatSuppressionStyle();
+  const cleanupVirtualKeyboardOverlay = enableVirtualKeyboardOverlay();
   let largestViewportHeight =
     window.visualViewport?.height ??
     window.innerHeight ??
@@ -132,11 +336,21 @@ export const handleBeforeMount = ({ store, render, dispatchEvent }) => {
         hasEditableFocus() &&
         metrics.keyboardInset >= KEYBOARD_VISIBLE_INSET_PX,
       bottom: metrics.bottom,
+      keyboardInset: metrics.keyboardInset,
+      visualOffsetTop: metrics.visualOffsetTop,
+      pageTop: metrics.pageTop,
+      visualHeight: metrics.visualHeight,
+      layoutHeight: metrics.layoutHeight,
     };
     const currentState = store.selectKeyboardState();
     if (
       currentState.isVisible === nextState.isVisible &&
-      currentState.bottom === Math.round(nextState.bottom)
+      currentState.bottom === Math.round(nextState.bottom) &&
+      currentState.keyboardInset === Math.round(nextState.keyboardInset) &&
+      currentState.visualOffsetTop === Math.round(nextState.visualOffsetTop) &&
+      currentState.pageTop === Math.round(nextState.pageTop) &&
+      currentState.visualHeight === Math.round(nextState.visualHeight) &&
+      currentState.layoutHeight === Math.round(nextState.layoutHeight)
     ) {
       return;
     }
@@ -157,32 +371,132 @@ export const handleBeforeMount = ({ store, render, dispatchEvent }) => {
     clearTimeout(focusTimerId);
     focusTimerId = setTimeout(scheduleSync, 60);
   };
+  const stopArrowRepeatOnPointerEnd = () => {
+    stopArrowRepeat(store);
+  };
+  const suppressNativeCalloutEvent = (event) => {
+    if (!isArrowRepeatNativeCalloutSuppressed()) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+  };
 
   const viewport = window.visualViewport;
+  const virtualKeyboard = getVirtualKeyboard();
   viewport?.addEventListener("resize", scheduleSync);
   viewport?.addEventListener("scroll", scheduleSync);
+  virtualKeyboard?.addEventListener?.("geometrychange", scheduleSync);
   window.addEventListener("resize", scheduleSync);
+  window.addEventListener("scroll", scheduleSync, true);
   window.addEventListener("orientationchange", scheduleSync);
   window.addEventListener("focusin", scheduleFocusSync);
   window.addEventListener("focusout", scheduleFocusSync);
+  window.addEventListener("pointerup", stopArrowRepeatOnPointerEnd, true);
+  window.addEventListener("pointercancel", stopArrowRepeatOnPointerEnd, true);
+  window.addEventListener("blur", stopArrowRepeatOnPointerEnd);
+  document.addEventListener("contextmenu", suppressNativeCalloutEvent, true);
+  document.addEventListener("selectstart", suppressNativeCalloutEvent, true);
   scheduleSync();
 
   return () => {
     viewport?.removeEventListener("resize", scheduleSync);
     viewport?.removeEventListener("scroll", scheduleSync);
+    virtualKeyboard?.removeEventListener?.("geometrychange", scheduleSync);
     window.removeEventListener("resize", scheduleSync);
+    window.removeEventListener("scroll", scheduleSync, true);
     window.removeEventListener("orientationchange", scheduleSync);
     window.removeEventListener("focusin", scheduleFocusSync);
     window.removeEventListener("focusout", scheduleFocusSync);
+    window.removeEventListener("pointerup", stopArrowRepeatOnPointerEnd, true);
+    window.removeEventListener(
+      "pointercancel",
+      stopArrowRepeatOnPointerEnd,
+      true,
+    );
+    window.removeEventListener("blur", stopArrowRepeatOnPointerEnd);
+    document.removeEventListener(
+      "contextmenu",
+      suppressNativeCalloutEvent,
+      true,
+    );
+    document.removeEventListener(
+      "selectstart",
+      suppressNativeCalloutEvent,
+      true,
+    );
     clearTimeout(focusTimerId);
     if (animationFrameId !== undefined) {
       cancelAnimationFrame(animationFrameId);
     }
+    stopArrowRepeat(store);
+    document.getElementById(ARROW_REPEAT_SUPPRESSION_STYLE_ID)?.remove();
+    cleanupVirtualKeyboardOverlay?.();
   };
 };
 
-export const handleToolbarItemPointerDown = (_deps, payload) => {
+export const handleToolbarItemPointerDown = ({ store }, payload) => {
+  const event = payload._event;
+  const actionId = event.currentTarget.dataset.actionId;
+  const direction = DIRECTION_BY_ACTION_ID[actionId];
+
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (!direction) {
+    stopArrowRepeat(store);
+    return;
+  }
+
+  event.currentTarget.setPointerCapture?.(event.pointerId);
+  startArrowRepeat(store, direction, event.pointerId);
+};
+
+const stopToolbarPointerAction = ({ store }, payload) => {
+  const event = payload._event;
+  event.preventDefault();
+  event.stopPropagation();
+  event.currentTarget.releasePointerCapture?.(event.pointerId);
+  stopArrowRepeat(store);
+};
+
+export const handleToolbarItemPointerUp = stopToolbarPointerAction;
+
+export const handleToolbarItemPointerCancel = stopToolbarPointerAction;
+
+export const handleToolbarItemLostPointerCapture = ({ store }) => {
+  stopArrowRepeat(store);
+};
+
+const suppressArrowTouchDefault = (payload) => {
+  const event = payload._event;
+  const actionId = event.currentTarget.dataset.actionId;
+  const direction = DIRECTION_BY_ACTION_ID[actionId];
+  if (!direction) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+};
+
+export const handleToolbarItemTouchStart = (_deps, payload) => {
+  suppressArrowTouchDefault(payload);
+};
+
+export const handleToolbarItemTouchEnd = (_deps, payload) => {
+  suppressArrowTouchDefault(payload);
+};
+
+export const handleToolbarItemTouchCancel = (_deps, payload) => {
+  suppressArrowTouchDefault(payload);
+};
+
+export const handleToolbarItemContextMenu = (deps, payload) => {
   payload._event.preventDefault();
+  payload._event.stopPropagation();
+  stopArrowRepeat(deps.store);
 };
 
 export const handleToolbarItemClick = ({ dispatchEvent }, payload) => {
@@ -190,16 +504,12 @@ export const handleToolbarItemClick = ({ dispatchEvent }, payload) => {
   payload._event.preventDefault();
   payload._event.stopPropagation();
 
-  if (actionId === "arrow-up") {
-    dispatchArrowKey("up");
+  const direction = DIRECTION_BY_ACTION_ID[actionId];
+  if (direction) {
     return;
   }
 
-  if (actionId === "arrow-down") {
-    dispatchArrowKey("down");
-    return;
-  }
-
+  blurActiveEditableElement();
   dispatchEvent(
     new CustomEvent("action-click", {
       detail: {

--- a/src/components/mobileKeyboardToolbar/mobileKeyboardToolbar.store.js
+++ b/src/components/mobileKeyboardToolbar/mobileKeyboardToolbar.store.js
@@ -1,42 +1,167 @@
 const toolbarItems = [
   {
+    id: "arrow-left",
+    icon: "chevronDown",
+    iconStyle: "transform: rotate(90deg);",
+    width: "42",
+    title: "Left",
+  },
+  {
     id: "arrow-up",
     icon: "chevronDown",
     iconStyle: "transform: rotate(180deg);",
+    width: "42",
+    title: "Up",
   },
   {
     id: "arrow-down",
     icon: "chevronDown",
     iconStyle: "",
+    width: "42",
+    title: "Down",
   },
   {
-    id: "add-actions",
+    id: "arrow-right",
+    icon: "chevronDown",
+    iconStyle: "transform: rotate(-90deg);",
+    width: "42",
+    title: "Right",
+  },
+  {
+    id: "actions",
     icon: "plus",
     iconStyle: "",
+    width: "40",
+    title: "Actions",
+  },
+  {
+    id: "preview",
+    icon: "play",
+    iconStyle: "",
+    width: "40",
+    title: "Preview",
+  },
+  {
+    id: "sections-overview",
+    icon: "hamburger",
+    iconStyle: "",
+    width: "40",
+    title: "Sections",
+  },
+  {
+    id: "scene-settings",
+    icon: "settings",
+    iconStyle: "",
+    width: "40",
+    title: "Settings",
   },
 ];
+
+const TOOLBAR_HEIGHT_PX = 48;
 
 export const createInitialState = () => ({
   isVisible: false,
   bottom: 0,
+  keyboardInset: 0,
+  visualOffsetTop: 0,
+  pageTop: 0,
+  visualHeight: 0,
+  layoutHeight: 0,
+  arrowRepeat: {
+    direction: undefined,
+    pointerId: undefined,
+    delayTimerId: undefined,
+    intervalTimerId: undefined,
+  },
 });
 
-export const setKeyboardState = ({ state }, { isVisible, bottom } = {}) => {
+export const setKeyboardState = (
+  { state },
+  {
+    isVisible,
+    bottom,
+    keyboardInset,
+    visualOffsetTop,
+    pageTop,
+    visualHeight,
+    layoutHeight,
+  } = {},
+) => {
   state.isVisible = isVisible === true;
   state.bottom = Number.isFinite(bottom) ? Math.max(0, Math.round(bottom)) : 0;
+  state.keyboardInset = Number.isFinite(keyboardInset)
+    ? Math.max(0, Math.round(keyboardInset))
+    : 0;
+  state.visualOffsetTop = Number.isFinite(visualOffsetTop)
+    ? Math.max(0, Math.round(visualOffsetTop))
+    : 0;
+  state.pageTop = Number.isFinite(pageTop)
+    ? Math.max(0, Math.round(pageTop))
+    : 0;
+  state.visualHeight = Number.isFinite(visualHeight)
+    ? Math.max(0, Math.round(visualHeight))
+    : 0;
+  state.layoutHeight = Number.isFinite(layoutHeight)
+    ? Math.max(0, Math.round(layoutHeight))
+    : 0;
 };
 
 export const selectKeyboardState = ({ state }) => {
   return {
     isVisible: state.isVisible,
     bottom: state.bottom,
+    keyboardInset: state.keyboardInset,
+    visualOffsetTop: state.visualOffsetTop,
+    pageTop: state.pageTop,
+    visualHeight: state.visualHeight,
+    layoutHeight: state.layoutHeight,
+  };
+};
+
+export const setArrowRepeatState = (
+  { state },
+  { direction, pointerId, delayTimerId } = {},
+) => {
+  state.arrowRepeat.direction = direction;
+  state.arrowRepeat.pointerId = pointerId;
+  state.arrowRepeat.delayTimerId = delayTimerId;
+  state.arrowRepeat.intervalTimerId = undefined;
+};
+
+export const setArrowRepeatIntervalId = (
+  { state },
+  { intervalTimerId } = {},
+) => {
+  state.arrowRepeat.intervalTimerId = intervalTimerId;
+};
+
+export const clearArrowRepeatState = ({ state }) => {
+  state.arrowRepeat.direction = undefined;
+  state.arrowRepeat.pointerId = undefined;
+  state.arrowRepeat.delayTimerId = undefined;
+  state.arrowRepeat.intervalTimerId = undefined;
+};
+
+export const selectArrowRepeatState = ({ state }) => {
+  return {
+    direction: state.arrowRepeat.direction,
+    pointerId: state.arrowRepeat.pointerId,
+    delayTimerId: state.arrowRepeat.delayTimerId,
+    intervalTimerId: state.arrowRepeat.intervalTimerId,
   };
 };
 
 export const selectViewData = ({ state }) => {
+  const visualViewportBottom =
+    Number(state.visualOffsetTop) + Number(state.visualHeight);
+  const toolbarTop = Number.isFinite(visualViewportBottom)
+    ? Math.max(0, Math.round(visualViewportBottom - TOOLBAR_HEIGHT_PX))
+    : 0;
+
   return {
     isVisible: state.isVisible,
     bottomStyle: `${state.bottom}px`,
+    toolbarTopStyle: `${toolbarTop}px`,
     toolbarItems,
   };
 };

--- a/src/components/mobileKeyboardToolbar/mobileKeyboardToolbar.view.yaml
+++ b/src/components/mobileKeyboardToolbar/mobileKeyboardToolbar.view.yaml
@@ -3,13 +3,27 @@ refs:
     eventListeners:
       pointerdown:
         handler: handleToolbarItemPointerDown
+      pointerup:
+        handler: handleToolbarItemPointerUp
+      pointercancel:
+        handler: handleToolbarItemPointerCancel
+      lostpointercapture:
+        handler: handleToolbarItemLostPointerCapture
+      touchstart:
+        handler: handleToolbarItemTouchStart
+      touchend:
+        handler: handleToolbarItemTouchEnd
+      touchcancel:
+        handler: handleToolbarItemTouchCancel
+      contextmenu:
+        handler: handleToolbarItemContextMenu
       click:
         handler: handleToolbarItemClick
 template:
   - $if isVisible:
-      - 'rtgl-view pos=fix w=100vw h=48 bgc=bg bw=xs bc=bo style="left: 0; bottom: ${bottomStyle}; z-index: 1450; box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.12);"':
-          - rtgl-view w=f h=f d=h av=c ah=c g=lg:
+      - 'rtgl-view pos=fix w=100vw h=48 bgc=bg bw=xs bc=bo style="left: 0; top: ${toolbarTopStyle}; z-index: 1450; box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.12); touch-action: none; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none;"':
+          - rtgl-view w=f h=f d=h av=c ah=c g=xs:
               - $for item, i in toolbarItems:
-                  - rtgl-view#toolbarItem${i} data-action-id=${item.id} w=42 h=42 br=md av=c ah=c bgc=mu h-bgc=ac cur=pointer:
+                  - 'rtgl-view#toolbarItem${i} data-action-id=${item.id} title="${item.title}" role=button w=${item.width} h=42 br=md av=c ah=c bgc=mu h-bgc=ac cur=pointer style="touch-action: none; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none;"':
                       - 'rtgl-view style="${item.iconStyle}"':
                           - rtgl-svg svg=${item.icon} wh=20 c=mu-fg: null

--- a/src/components/mobileSidebar/mobileSidebar.store.js
+++ b/src/components/mobileSidebar/mobileSidebar.store.js
@@ -82,12 +82,6 @@ const releaseItems = [
     path: "/project/releases/versions",
     icon: "rocket",
   },
-  {
-    id: "web-server",
-    label: "Web Server",
-    path: "/project/releases/web-server",
-    icon: "website",
-  },
 ];
 
 const settingsItems = [

--- a/src/components/textStyleResourcesView/textStyleResourcesView.schema.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.schema.yaml
@@ -61,6 +61,9 @@ propsSchema:
     mobileLayout:
       type: boolean
       description: Whether cards should use the touch/mobile full-width layout
+    scrollBottomPadding:
+      type: string
+      description: Extra bottom padding inside the scroll container
     addText:
       type: string
       description: Text to display in add affordances

--- a/src/components/textStyleResourcesView/textStyleResourcesView.store.js
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.store.js
@@ -7,6 +7,7 @@ import {
   selectTagFilterPopoverDraftTagIds,
   toggleTagFilterPopoverTagId,
 } from "../../internal/ui/tagFilterPopover.js";
+import { resolveResourceScrollBottomPadding } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const DEFAULT_ITEMS_PER_ROW = 6;
 const MIN_ITEMS_PER_ROW = 1;
@@ -139,9 +140,15 @@ export const selectViewData = ({ state, props }) => {
   const mobileLayout = parseBooleanProp(props.mobileLayout);
   const useColumnZoomControl = !mobileLayout && isColumnZoomControlMode(props);
   const itemsPerRow = mobileLayout ? 1 : clampItemsPerRow(state.itemsPerRow);
-  const cardGridColumns = useColumnZoomControl
-    ? `${itemsPerRow}`
-    : buildAutoFillGridColumns(DEFAULT_CARD_WIDTH);
+  const cardGridColumns = mobileLayout
+    ? "1"
+    : useColumnZoomControl
+      ? `${itemsPerRow}`
+      : buildAutoFillGridColumns(DEFAULT_CARD_WIDTH);
+  const scrollBottomPadding = resolveResourceScrollBottomPadding({
+    mobileLayout,
+    scrollBottomPadding: props.scrollBottomPadding,
+  });
   const hasActiveTagFilter = (props.selectedTagFilterValues?.length ?? 0) > 0;
   const searchQuery = props.searchQuery ?? "";
   const searchInFilterPopover = parseBooleanProp(props.searchInFilterPopover);
@@ -224,5 +231,6 @@ export const selectViewData = ({ state, props }) => {
     addText: props.addText ?? "Add Text Style",
     dropdownMenu: state.dropdownMenu,
     mobileLayout,
+    scrollBottomPadding,
   };
 };

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -89,7 +89,7 @@ template:
               - $if showTagFilter:
                   - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
                       - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
-      - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
+      - 'rtgl-view h=1fg w=f sv style="min-width: 0; padding-bottom: ${scrollBottomPadding}; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
                   - rtgl-view w=f ph=md pos=rel:

--- a/src/internal/ui/resourcePages/mobileResourcePage.js
+++ b/src/internal/ui/resourcePages/mobileResourcePage.js
@@ -1,6 +1,19 @@
 export const isTouchUiConfig = (uiConfig) =>
   uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
 
+export const MOBILE_RESOURCE_SCROLL_BOTTOM_PADDING =
+  "calc(96px + env(safe-area-inset-bottom))";
+
+export const resolveResourceScrollBottomPadding = ({
+  mobileLayout,
+  scrollBottomPadding,
+} = {}) => {
+  return (
+    scrollBottomPadding ??
+    (mobileLayout ? MOBILE_RESOURCE_SCROLL_BOTTOM_PADDING : "0px")
+  );
+};
+
 export const createMobileResourcePageState = () => ({
   isTouchMode: false,
   isMobileFileExplorerOpen: false,

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -14,6 +14,7 @@ const MOBILE_TAB_BAR_HEIGHT_PX = 64;
 const HELP_BUTTON_BOTTOM_OFFSET_PX = 24;
 
 const routesWithoutNavbar = ["/projects", "/authenticate"];
+const routesWithoutMobileTabBar = ["/project/scene-editor"];
 
 const mobileTabBarItems = [
   { id: "assets", icon: "image", label: "Assets" },
@@ -36,7 +37,17 @@ export const selectShowSidebar = ({ state }) => {
 };
 
 export const selectShowMobileTabBar = ({ state }) => {
-  return selectShowAppNavigation({ state }) && state.isTouchMode;
+  const currentRoutePattern = selectCurrentRoutePattern({ state });
+  const normalizedPattern = currentRoutePattern?.replace(/\/$/, "");
+  const normalizedRoutesWithoutMobileTabBar = routesWithoutMobileTabBar.map(
+    (route) => route.replace(/\/$/, ""),
+  );
+
+  return (
+    selectShowAppNavigation({ state }) &&
+    state.isTouchMode &&
+    !normalizedRoutesWithoutMobileTabBar.includes(normalizedPattern)
+  );
 };
 
 export const selectCurrentRoutePattern = ({ state }) => {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -1440,8 +1440,9 @@ export const handleActionTransformEditorDone = (deps, payload) => {
 };
 
 export const handleBeforeMount = (deps) => {
-  const { projectService, appService, store } = deps;
+  const { projectService, appService, store, uiConfig } = deps;
   store.setScenePageLoading({ isLoading: true });
+  store.setUiConfig({ uiConfig });
   const showLineNumbers =
     appService.getUserConfig(SHOW_LINE_NUMBERS_CONFIG_KEY) ?? true;
   const isMuted = appService.getUserConfig(IS_MUTED_CONFIG_KEY) ?? false;
@@ -2078,6 +2079,39 @@ export const handleAddActionsButtonClick = (deps) => {
   refs.systemActions?.transformedHandlers?.open?.({
     mode: "actions",
   });
+  render();
+};
+
+export const handleMobileKeyboardToolbarActionClick = (deps, payload) => {
+  const actionId = payload?._event?.detail?.actionId;
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  if (actionId === "actions" || actionId === "add-actions") {
+    handleAddActionsButtonClick(deps);
+    return;
+  }
+
+  if (actionId === "preview") {
+    handlePreviewClick(deps, payload);
+    return;
+  }
+
+  if (actionId === "sections-overview") {
+    handleSectionsOverviewClick(deps, payload);
+    return;
+  }
+
+  if (actionId === "scene-settings") {
+    handleSceneSettingsClick(deps);
+  }
+};
+
+export const handleMobileKeyboardStateChange = (deps, payload) => {
+  const { store, render } = deps;
+  const detail = payload?._event?.detail || {};
+
+  store.setMobileKeyboardState(detail);
   render();
 };
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -35,6 +35,9 @@ const SCENE_EDITOR_FONT_SIZE_OPTIONS = [
   { value: "xl", label: "Extra Large" },
 ];
 const DEFAULT_SCENE_EDITOR_FONT_SIZE = "md";
+const MOBILE_KEYBOARD_TOOLBAR_HEIGHT_PX = 48;
+const MOBILE_PREVIEW_VERTICAL_PADDING_PX = 16;
+const MOBILE_PREVIEW_MIN_HEIGHT_PX = 72;
 
 const normalizeSceneEditorFontSize = (fontSize) =>
   SCENE_EDITOR_FONT_SIZE_OPTIONS.some((option) => option.value === fontSize)
@@ -563,6 +566,16 @@ const buildProjectDataSourceState = (state) => {
 };
 
 export const createInitialState = () => ({
+  isTouchMode: false,
+  mobileKeyboardState: {
+    isVisible: false,
+    bottom: 0,
+    keyboardInset: 0,
+    visualOffsetTop: 0,
+    pageTop: 0,
+    visualHeight: 0,
+    layoutHeight: 0,
+  },
   sceneId: undefined,
   selectedLineId: undefined,
   sectionsGraphView: false,
@@ -665,6 +678,44 @@ export const createInitialState = () => ({
 
 export const setSceneId = ({ state }, { sceneId } = {}) => {
   state.sceneId = sceneId;
+};
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode =
+    uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
+};
+
+export const setMobileKeyboardState = (
+  { state },
+  {
+    isVisible,
+    bottom,
+    keyboardInset,
+    visualOffsetTop,
+    pageTop,
+    visualHeight,
+    layoutHeight,
+  } = {},
+) => {
+  state.mobileKeyboardState.isVisible = isVisible === true;
+  state.mobileKeyboardState.bottom = Number.isFinite(bottom)
+    ? Math.max(0, Math.round(bottom))
+    : 0;
+  state.mobileKeyboardState.keyboardInset = Number.isFinite(keyboardInset)
+    ? Math.max(0, Math.round(keyboardInset))
+    : 0;
+  state.mobileKeyboardState.visualOffsetTop = Number.isFinite(visualOffsetTop)
+    ? Math.max(0, Math.round(visualOffsetTop))
+    : 0;
+  state.mobileKeyboardState.pageTop = Number.isFinite(pageTop)
+    ? Math.max(0, Math.round(pageTop))
+    : 0;
+  state.mobileKeyboardState.visualHeight = Number.isFinite(visualHeight)
+    ? Math.max(0, Math.round(visualHeight))
+    : 0;
+  state.mobileKeyboardState.layoutHeight = Number.isFinite(layoutHeight)
+    ? Math.max(0, Math.round(layoutHeight))
+    : 0;
 };
 
 export const setRepositoryState = ({ state }, { repository } = {}) => {
@@ -1520,6 +1571,49 @@ const selectPreviewCanvasMaxWidth = ({ state }) => {
   return `min(100%, ${maxWidthVh}vh)`;
 };
 
+const selectMobilePreviewCanvasMaxWidth = ({ state }) => {
+  const defaultMaxWidth = selectPreviewCanvasMaxWidth({ state });
+  if (!state.isTouchMode || !state.mobileKeyboardState?.isVisible) {
+    return defaultMaxWidth;
+  }
+
+  const visualHeight = Number(state.mobileKeyboardState.visualHeight);
+  if (!Number.isFinite(visualHeight) || visualHeight <= 0) {
+    return defaultMaxWidth;
+  }
+
+  const widthMultiplier = selectCanvasAspectRatioWidthMultiplier({ state });
+  const reservedHeight =
+    MOBILE_KEYBOARD_TOOLBAR_HEIGHT_PX + MOBILE_PREVIEW_VERTICAL_PADDING_PX;
+  const availableCanvasHeight = Math.max(
+    MOBILE_PREVIEW_MIN_HEIGHT_PX,
+    visualHeight - reservedHeight,
+  );
+  const maxWidthPx = Number(
+    (availableCanvasHeight * widthMultiplier).toFixed(4),
+  );
+
+  return `min(100%, ${maxWidthPx}px)`;
+};
+
+const selectMobileEditorBottomSpacerHeight = ({ state }) => {
+  if (!state.isTouchMode || !state.mobileKeyboardState?.isVisible) {
+    return "30vh";
+  }
+
+  const keyboardInset = Math.max(
+    0,
+    Number(state.mobileKeyboardState.keyboardInset) || 0,
+  );
+  const visualHeight = Math.max(
+    0,
+    Number(state.mobileKeyboardState.visualHeight) || 0,
+  );
+  const scrollRoom = Math.max(260, Math.round(visualHeight * 0.9));
+
+  return `${keyboardInset + MOBILE_KEYBOARD_TOOLBAR_HEIGHT_PX + scrollRoom}px`;
+};
+
 const selectSystemActionsDialogPanelWidth = ({ state }) => {
   return state.backgroundTransformEditor.isOpen === true
     ? "calc(100vw - 64px)"
@@ -1587,6 +1681,10 @@ export const selectViewData = ({ state }) => {
       previewLineId: state.previewLineId,
       canvasAspectRatio: selectCanvasAspectRatio({ state }),
       previewCanvasMaxWidth: selectPreviewCanvasMaxWidth({ state }),
+      mobilePreviewCanvasMaxWidth: selectMobilePreviewCanvasMaxWidth({ state }),
+      mobileEditorBottomSpacerHeight: selectMobileEditorBottomSpacerHeight({
+        state,
+      }),
       systemActionsDialogPanelWidth: selectSystemActionsDialogPanelWidth({
         state,
       }),
@@ -1605,6 +1703,7 @@ export const selectViewData = ({ state }) => {
       backgroundTransformEditor: selectBackgroundTransformEditorViewData({
         state,
       }),
+      isTouchMode: state.isTouchMode,
     };
   }
 
@@ -1883,6 +1982,10 @@ export const selectViewData = ({ state }) => {
     previewLineId: state.previewLineId,
     canvasAspectRatio: selectCanvasAspectRatio({ state }),
     previewCanvasMaxWidth: selectPreviewCanvasMaxWidth({ state }),
+    mobilePreviewCanvasMaxWidth: selectMobilePreviewCanvasMaxWidth({ state }),
+    mobileEditorBottomSpacerHeight: selectMobileEditorBottomSpacerHeight({
+      state,
+    }),
     systemActionsDialogPanelWidth: selectSystemActionsDialogPanelWidth({
       state,
     }),
@@ -1902,6 +2005,7 @@ export const selectViewData = ({ state }) => {
     backgroundTransformEditor: selectBackgroundTransformEditorViewData({
       state,
     }),
+    isTouchMode: state.isTouchMode,
   };
 };
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -140,50 +140,82 @@ refs:
       current-line-changed:
         handler: handlePreviewCurrentLineChanged
   previewCanvasHost: {}
+  mobileKeyboardToolbar:
+    eventListeners:
+      action-click:
+        handler: handleMobileKeyboardToolbarActionClick
+      keyboard-state-change:
+        handler: handleMobileKeyboardStateChange
 template:
   - 'rtgl-view pos=rel w=f h=f style="min-width: 0; min-height: 0;"':
-      - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
-          - 'rtgl-view w="calc((100vw - 64px) / 2)" d=v h=f style="min-width: 0; min-height: 0;"':
-              - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h:
-                  - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
-                  - rtgl-view w=1fg d=h av=c:
-                      - rtgl-text w=1fg ellipsis=true: ${scene.name}
-                      - rtgl-button#sectionsOverview sq pre=hamburger v="gh" ml=sm: null
-                      - rtgl-button#sceneSettingsButton sq pre=settings v="gh": null
+      - $if isTouchMode:
+          - 'rtgl-view pos=fix edge=f d=v bgc=bg style="z-index: 1100; min-width: 0; min-height: 0; overflow: hidden; overscroll-behavior: none;"':
+              - 'rtgl-view w=f bwb=xs style="min-width: 0; flex-shrink: 0;"':
+                  - $if backgroundTransformEditor.isOpen == false:
+                      - 'rtgl-view w=f p=sm style="min-width: 0;"':
+                          - 'div style="position: relative; width: ${mobilePreviewCanvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto;"':
+                              - 'rvn-scene-editor-preview-canvas#previewCanvasHost style="display: block; width: 100%;" canvas-aspect-ratio="${canvasAspectRatio}"': null
+                              - $if isSceneAssetLoading:
+                                  - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
+                                      - rtgl-text s=h3: Loading assets...
               - $if sectionsGraphView:
-                  - rtgl-view w=f h=1fg:
-                      - rtgl-view d=h w=f:
-                          - rtgl-view w=1fg: null
-                      - rtgl-view:
-                          - rtgl-text: ${sectionsGraph}
+                  - rtgl-view w=f h=1fg sv:
+                      - rtgl-text: ${sectionsGraph}
                 $else:
                   - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
-                      - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px;"':
+                      - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px; overscroll-behavior: contain;"':
                           - $for section, sectionIndex in sectionEditorItems:
                               - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
                                       - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
                                       - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm pre=ellipsis: null
                                   - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :fontSize=${sceneSettings.fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
-                          - rtgl-view h=30vh: null
-          - rtgl-view w=1 h=f bgc=mu: null
-          - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':
-              - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h jc=e g=sm:
-                  - rtgl-button#previewButton: Preview
-              - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
-                  - $if backgroundTransformEditor.isOpen == false:
-                      - 'rtgl-view w=f style="min-width: 0;"':
-                          - 'div style="position: relative; width: ${previewCanvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto;"':
-                              - 'rvn-scene-editor-preview-canvas#previewCanvasHost style="display: block; width: 100%;" canvas-aspect-ratio="${canvasAspectRatio}"': null
-                              - $if isSceneAssetLoading:
-                                  - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
-                                      - rtgl-text s=h3: Loading assets...
-                  - rtgl-view w=f h=1 bgc=mu: null
-                  - rtgl-view w=f m=md:
-                      - rtgl-view d=h av=c:
-                          - rtgl-text s=sm c=mu-fg: State
-                      - rtgl-view g=md w=f pv=md:
-                          - 'rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor} dialog-variant=scene-editor-left dialog-panel-width="${systemActionsDialogPanelWidth}" :suppressDialogClose=${backgroundTransformEditor.suppressActionsDialogClose}': null
+                          - rtgl-view h=${mobileEditorBottomSpacerHeight}: null
+              - rvn-mobile-keyboard-toolbar#mobileKeyboardToolbar: null
+              - 'rvn-system-actions#systemActions :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor} :suppressDialogClose=${backgroundTransformEditor.suppressActionsDialogClose}': null
+        $else:
+          - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w="calc((100vw - 64px) / 2)" d=v h=f style="min-width: 0; min-height: 0;"':
+                  - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h:
+                      - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
+                      - rtgl-view w=1fg d=h av=c:
+                          - rtgl-text w=1fg ellipsis=true: ${scene.name}
+                          - rtgl-button#sectionsOverview sq pre=hamburger v="gh" ml=sm: null
+                          - rtgl-button#sceneSettingsButton sq pre=settings v="gh": null
+                  - $if sectionsGraphView:
+                      - rtgl-view w=f h=1fg:
+                          - rtgl-view d=h w=f:
+                              - rtgl-view w=1fg: null
+                          - rtgl-view:
+                              - rtgl-text: ${sectionsGraph}
+                    $else:
+                      - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
+                          - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px;"':
+                              - $for section, sectionIndex in sectionEditorItems:
+                                  - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
+                                      - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
+                                          - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
+                                          - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm pre=ellipsis: null
+                                      - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :fontSize=${sceneSettings.fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+                              - rtgl-view h=30vh: null
+              - rtgl-view w=1 h=f bgc=mu: null
+              - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':
+                  - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h jc=e g=sm:
+                      - rtgl-button#previewButton: Preview
+                  - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
+                      - $if backgroundTransformEditor.isOpen == false:
+                          - 'rtgl-view w=f style="min-width: 0;"':
+                              - 'div style="position: relative; width: ${previewCanvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto;"':
+                                  - 'rvn-scene-editor-preview-canvas#previewCanvasHost style="display: block; width: 100%;" canvas-aspect-ratio="${canvasAspectRatio}"': null
+                                  - $if isSceneAssetLoading:
+                                      - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.7 av=c ah=c:
+                                          - rtgl-text s=h3: Loading assets...
+                      - rtgl-view w=f h=1 bgc=mu: null
+                      - rtgl-view w=f m=md:
+                          - rtgl-view d=h av=c:
+                              - rtgl-text s=sm c=mu-fg: State
+                          - rtgl-view g=md w=f pv=md:
+                              - 'rvn-system-actions#systemActions :showSelected=${true} :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor} dialog-variant=scene-editor-left dialog-panel-width="${systemActionsDialogPanelWidth}" :suppressDialogClose=${backgroundTransformEditor.suppressActionsDialogClose}': null
       - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
       - rtgl-popover#popover ?open=${popover.isOpen} x=${popover.position.x} y=${popover.position.y}:
           - rtgl-form#form slot=content :form=${form}: null

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -146,6 +146,208 @@ const areNativeLineSelectionContextsEqual = (first, second) => {
   );
 };
 
+const MOBILE_KEYBOARD_TOOLBAR_HEIGHT_PX = 48;
+
+const getViewportObscuredBottomInset = () => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return 0;
+  }
+
+  const layoutHeight =
+    window.innerHeight || document.documentElement?.clientHeight || 0;
+  const virtualKeyboardRect =
+    typeof navigator !== "undefined"
+      ? navigator.virtualKeyboard?.boundingRect
+      : undefined;
+  const virtualKeyboardHeight = Number(virtualKeyboardRect?.height) || 0;
+  if (virtualKeyboardHeight > 0) {
+    return Math.min(virtualKeyboardHeight, layoutHeight);
+  }
+
+  const viewport = window.visualViewport;
+  if (!viewport) {
+    return 0;
+  }
+
+  const viewportBottom = Number(viewport.offsetTop) + Number(viewport.height);
+  return Number.isFinite(viewportBottom)
+    ? Math.max(0, layoutHeight - viewportBottom)
+    : 0;
+};
+
+const getParentElementAcrossShadowRoot = (element) => {
+  if (element?.parentElement) {
+    return element.parentElement;
+  }
+
+  const root = element?.getRootNode?.();
+  if (typeof ShadowRoot !== "undefined" && root instanceof ShadowRoot) {
+    return root.host;
+  }
+
+  return undefined;
+};
+
+const isScrollableElement = (element) => {
+  if (
+    !element ||
+    element === document.body ||
+    element === document.documentElement
+  ) {
+    return false;
+  }
+
+  const overflowY = window.getComputedStyle(element).overflowY;
+  const canScrollY =
+    overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
+
+  return canScrollY && element.scrollHeight > element.clientHeight + 1;
+};
+
+const getNearestScrollableElement = (element) => {
+  let current = getParentElementAcrossShadowRoot(element);
+
+  while (current) {
+    if (isScrollableElement(current)) {
+      return current;
+    }
+
+    current = getParentElementAcrossShadowRoot(current);
+  }
+
+  return undefined;
+};
+
+const getScrollMarginValue = (element, property) => {
+  const value = Number.parseFloat(window.getComputedStyle(element)[property]);
+  return Number.isFinite(value) ? value : 0;
+};
+
+const scrollElementIntoNearestScrollableView = (
+  element,
+  { behavior = "auto", block = "nearest" } = {},
+) => {
+  if (!element || typeof window === "undefined") {
+    return;
+  }
+
+  const scrollContainer = getNearestScrollableElement(element);
+  if (!scrollContainer) {
+    return;
+  }
+
+  const elementRect = element.getBoundingClientRect();
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const marginTop = getScrollMarginValue(element, "scrollMarginTop");
+  const marginBottom = getScrollMarginValue(element, "scrollMarginBottom");
+  const topDelta = elementRect.top - containerRect.top - marginTop;
+  const bottomDelta = elementRect.bottom - containerRect.bottom + marginBottom;
+  let nextScrollTop = scrollContainer.scrollTop;
+
+  if (block === "start") {
+    nextScrollTop += topDelta;
+  } else if (block === "end") {
+    nextScrollTop += bottomDelta;
+  } else if (block === "center") {
+    nextScrollTop +=
+      elementRect.top -
+      containerRect.top -
+      (containerRect.height - elementRect.height) / 2;
+  } else if (topDelta < 0) {
+    nextScrollTop += topDelta;
+  } else if (bottomDelta > 0) {
+    nextScrollTop += bottomDelta;
+  } else {
+    return;
+  }
+
+  scrollContainer.scrollTo({
+    top: Math.max(0, nextScrollTop),
+    behavior,
+  });
+};
+
+const isUsableClientRect = (rect) => {
+  if (!rect) {
+    return false;
+  }
+
+  const top = Number(rect.top);
+  const right = Number(rect.right);
+  const bottom = Number(rect.bottom);
+  const left = Number(rect.left);
+
+  if (
+    !Number.isFinite(top) ||
+    !Number.isFinite(right) ||
+    !Number.isFinite(bottom) ||
+    !Number.isFinite(left)
+  ) {
+    return false;
+  }
+
+  return (
+    rect.width > 0 ||
+    rect.height > 0 ||
+    top !== 0 ||
+    right !== 0 ||
+    bottom !== 0 ||
+    left !== 0
+  );
+};
+
+const scrollRectIntoNearestScrollableView = (
+  anchorElement,
+  targetRect,
+  {
+    behavior = "auto",
+    block = "nearest",
+    paddingTop = 8,
+    paddingBottom = 80,
+  } = {},
+) => {
+  if (
+    !anchorElement ||
+    !isUsableClientRect(targetRect) ||
+    typeof window === "undefined"
+  ) {
+    return false;
+  }
+
+  const scrollContainer = getNearestScrollableElement(anchorElement);
+  if (!scrollContainer) {
+    return false;
+  }
+
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const topDelta = targetRect.top - containerRect.top - paddingTop;
+  const bottomDelta = targetRect.bottom - containerRect.bottom + paddingBottom;
+  let nextScrollTop = scrollContainer.scrollTop;
+
+  if (block === "start") {
+    nextScrollTop += topDelta;
+  } else if (block === "end") {
+    nextScrollTop += bottomDelta;
+  } else if (block === "center") {
+    nextScrollTop +=
+      targetRect.top -
+      containerRect.top -
+      (containerRect.height - targetRect.height) / 2;
+  } else if (topDelta < 0) {
+    nextScrollTop += topDelta;
+  } else if (bottomDelta > 0) {
+    nextScrollTop += bottomDelta;
+  } else {
+    return true;
+  }
+
+  scrollContainer.scrollTo({
+    top: Math.max(0, nextScrollTop),
+    behavior,
+  });
+  return true;
+};
+
 const doesContentEndWithReference = (content = []) => {
   const items = mergeAdjacentContentItems(content);
   return items.at(-1)?.reference !== undefined;
@@ -1572,10 +1774,9 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       { discrete: true },
     );
     setSelectionFromRange(this.refs.editor, range);
-    lineElement.scrollIntoView?.({
+    scrollElementIntoNearestScrollableView(lineElement, {
       behavior: "auto",
       block: "nearest",
-      inline: "nearest",
     });
     return true;
   }
@@ -1686,20 +1887,52 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     });
   }
 
-  scrollLineIntoView({
-    lineId,
-    behavior = "auto",
-    block = "nearest",
-    inline = "nearest",
-  } = {}) {
+  scrollLineIntoView({ lineId, behavior = "auto", block = "nearest" } = {}) {
     const lineKey = this.lineKeyById.get(lineId);
     const lineElement = lineKey
       ? this.editor.getElementByKey(lineKey)
       : undefined;
-    lineElement?.scrollIntoView({
+    scrollElementIntoNearestScrollableView(lineElement, {
       behavior,
       block,
-      inline,
+    });
+  }
+
+  revealCurrentSelection({ behavior = "auto", direction } = {}) {
+    const range = getSelectionRange(this.refs?.editor);
+    const nativeSelection = this.getNativeLineSelectionContext(range);
+    const lineKey = nativeSelection?.lineId
+      ? this.lineKeyById.get(nativeSelection.lineId)
+      : undefined;
+    const lineElement = lineKey
+      ? this.editor.getElementByKey(lineKey)
+      : undefined;
+    const rangeRect = range?.getBoundingClientRect?.();
+    const lineRect = lineElement?.getBoundingClientRect?.();
+    const targetRect = isUsableClientRect(rangeRect) ? rangeRect : lineRect;
+    const anchorElement = lineElement ?? this.refs?.editor;
+    const lineHeight = Math.max(0, Number(lineRect?.height) || 0);
+    const paddingTop =
+      direction === "up" ? 12 + Math.round(lineHeight * 1.5) : 12;
+    const obscuredBottomInset = getViewportObscuredBottomInset();
+    const keyboardToolbarInset =
+      obscuredBottomInset > 0 ? MOBILE_KEYBOARD_TOOLBAR_HEIGHT_PX : 0;
+    const paddingBottom =
+      direction === "down"
+        ? Math.max(
+            112,
+            obscuredBottomInset +
+              keyboardToolbarInset +
+              12 +
+              Math.round(lineHeight * 0.5),
+          )
+        : 112;
+
+    return scrollRectIntoNearestScrollableView(anchorElement, targetRect, {
+      behavior,
+      block: "nearest",
+      paddingTop,
+      paddingBottom,
     });
   }
 
@@ -2468,6 +2701,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
             (nativeSelection.start !== initialNativeSelection.start ||
               nativeSelection.end !== initialNativeSelection.end);
           if (didMoveWithinCurrentLine) {
+            this.revealCurrentSelection({
+              behavior: "auto",
+              direction: navigationDirection,
+            });
             clearPendingSync();
             return;
           }
@@ -2492,6 +2729,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           cursorPosition: nativeSelection.start,
           isCollapsed: nativeSelection.start === nativeSelection.end,
           mode: "text-editor",
+        });
+        this.revealCurrentSelection({
+          behavior: "auto",
+          direction: navigationDirection,
         });
         clearPendingSync();
       });


### PR DESCRIPTION
## Summary
- add mobile resource page bottom padding and full-width item behavior
- simplify the mobile scene editor to preview + editor, hide the app mobile tab bar there, and move scene actions into the keyboard toolbar
- make keyboard toolbar arrows support left/up/down/right, caret reveal, keyboard-aware scrolling, and long-press repeat without native callouts
- remove Web Server from the mobile release tab and bump insieme to 2.1.1

## Testing
- bun run lint
- focused oxlint/YAML checks during implementation
- Android device screenshots for keyboard toolbar placement, bottom scrolling, caret reveal, and long-press repeat