### PR TITLE
fix: add projects footer update menu

### DIFF
--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -418,6 +418,39 @@ export const handleMobileActionMenuClickItem = (deps, payload) => {
   render();
 };
 
+export const handleAppVersionClick = (deps, payload) => {
+  const { store, render } = deps;
+  const rect = payload._event.currentTarget.getBoundingClientRect();
+
+  store.openAppVersionMenu({
+    x: rect.left + rect.width / 2,
+    y: rect.top,
+  });
+  render();
+};
+
+export const handleAppVersionMenuClose = (deps) => {
+  const { store, render } = deps;
+  if (!store.selectIsAppVersionMenuOpen()) {
+    return;
+  }
+  store.closeAppVersionMenu();
+  render();
+};
+
+export const handleAppVersionMenuClickItem = async (deps, payload) => {
+  const { store, render, updaterService } = deps;
+  const detail = payload._event.detail;
+  const item = detail.item || detail;
+
+  store.closeAppVersionMenu();
+  render();
+
+  if (item.value === "check-update") {
+    await updaterService.checkForUpdates(false);
+  }
+};
+
 export const handleLoginButtonClick = (deps) => {
   const { appService } = deps;
   appService.navigate("/authenticate");

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -32,6 +32,13 @@ export const createInitialState = () => ({
     items: [],
   },
 
+  appVersionMenu: {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    items: [],
+  },
+
   profileDialog: {
     isOpen: false,
     formKey: 0,
@@ -226,6 +233,26 @@ export const closeMobileActionMenu = ({ state }, _payload = {}) => {
 
 export const selectIsMobileActionMenuOpen = ({ state }) => {
   return Boolean(state.mobileActionMenu?.isOpen);
+};
+
+export const openAppVersionMenu = ({ state }, { x, y } = {}) => {
+  state.appVersionMenu.isOpen = true;
+  state.appVersionMenu.x = x;
+  state.appVersionMenu.y = y;
+  state.appVersionMenu.items = [
+    { label: "Check for update", type: "item", value: "check-update" },
+  ];
+};
+
+export const closeAppVersionMenu = ({ state }, _payload = {}) => {
+  state.appVersionMenu.isOpen = false;
+  state.appVersionMenu.x = 0;
+  state.appVersionMenu.y = 0;
+  state.appVersionMenu.items = [];
+};
+
+export const selectIsAppVersionMenuOpen = ({ state }) => {
+  return Boolean(state.appVersionMenu?.isOpen);
 };
 
 export const selectIsProfileDialogOpen = ({ state }) => {

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -19,6 +19,16 @@ refs:
         handler: handleMobileActionMenuClose
       item-click:
         handler: handleMobileActionMenuClickItem
+  appVersionButton:
+    eventListeners:
+      click:
+        handler: handleAppVersionClick
+  appVersionDropdownMenu:
+    eventListeners:
+      close:
+        handler: handleAppVersionMenuClose
+      item-click:
+        handler: handleAppVersionMenuClickItem
   cloudCreateButton:
     eventListeners:
       click:
@@ -188,8 +198,10 @@ template:
                                                   - rtgl-text s=xs c=mu-fg: Members
                                                   - rtgl-text s=xs c=mu-fg: ${project.memberCount}
                                   - rtgl-view h="33vh": null
-                          - rtgl-view w=f ah=c pb=lg:
-                              - rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}
+          - 'rtgl-view w=f ah=c bgc=bg style="flex-shrink: 0; padding-bottom: env(safe-area-inset-bottom);"':
+              - 'rtgl-view sm-w=f w=640 ph=lg pv=lg ah=c':
+                  - rtgl-view#appVersionButton d=h av=c ah=c ph=md pv=sm br=sm h-bgc=mu cur=pointer:
+                      - rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}
   - rtgl-dialog#deleteProjectDialog ?open=${deleteDialog.isOpen} s=sm:
       - rtgl-view slot=content g=lg p=lg:
           - rtgl-view d=v g=md:
@@ -212,6 +224,7 @@ template:
           - rtgl-form#addMemberForm key=${addMemberDialog.formKey} :form=${addMemberForm} :defaultValues=${addMemberDialog.defaultValues} w=f: null
   - rtgl-dropdown-menu#dropdownMenu ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y} :items=${dropdownMenu.items}: null
   - rtgl-dropdown-menu#mobileActionMenu ?open=${mobileActionMenu.isOpen} x=${mobileActionMenu.x} y=${mobileActionMenu.y} place=be :items=${mobileActionMenu.items}: null
+  - rtgl-dropdown-menu#appVersionDropdownMenu ?open=${appVersionMenu.isOpen} x=${appVersionMenu.x} y=${appVersionMenu.y} place=t :items=${appVersionMenu.items}: null
   - rtgl-dropdown-menu#profileDropdownMenu ?open=${profileMenu.isOpen} x=${profileMenu.x} y=${profileMenu.y} :items=${profileMenu.items}: null
   - rtgl-dialog#editProfileDialog ?open=${profileDialog.isOpen} s=f:
       - rtgl-view slot=content w=f h=f p=xl:

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleAppVersionClick,
+  handleAppVersionMenuClickItem,
+  handleAppVersionMenuClose,
   handleCreateButtonClick,
   handleCreateDialogSubmit,
   handleDeleteDialogConfirm,
@@ -51,6 +54,9 @@ const createDeps = ({
         },
       ]),
       openDropdownMenu: vi.fn(),
+      openAppVersionMenu: vi.fn(),
+      closeAppVersionMenu: vi.fn(),
+      selectIsAppVersionMenuOpen: vi.fn(() => true),
       openCreateDialog: vi.fn(),
       closeCreateDialog: vi.fn(),
       selectIsCreateDialogOpen: vi.fn(() => true),
@@ -59,6 +65,9 @@ const createDeps = ({
       selectDeleteDialogProjectPath: vi.fn(() => ""),
       closeDeleteDialog: vi.fn(),
       removeProject: vi.fn(),
+    },
+    updaterService: {
+      checkForUpdates: vi.fn(async () => {}),
     },
     render: vi.fn(),
     refs: {
@@ -276,6 +285,57 @@ describe("projects create dialog", () => {
       },
     });
     expect(deps.store.closeCreateDialog).toHaveBeenCalled();
+  });
+});
+
+describe("projects app version menu", () => {
+  it("opens the app version dropdown from the footer label", () => {
+    const deps = createDeps();
+
+    handleAppVersionClick(deps, {
+      _event: {
+        currentTarget: {
+          getBoundingClientRect: () => ({
+            left: 100,
+            width: 80,
+            top: 700,
+          }),
+        },
+      },
+    });
+
+    expect(deps.store.openAppVersionMenu).toHaveBeenCalledWith({
+      x: 140,
+      y: 700,
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the app version dropdown", () => {
+    const deps = createDeps();
+
+    handleAppVersionMenuClose(deps);
+
+    expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks for updates from the app version dropdown", async () => {
+    const deps = createDeps();
+
+    await handleAppVersionMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "check-update",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.updaterService.checkForUpdates).toHaveBeenCalledWith(false);
   });
 });
 

--- a/tests/projects/projects.store.test.js
+++ b/tests/projects/projects.store.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   addProject,
+  closeAppVersionMenu,
   createInitialState,
+  openAppVersionMenu,
 } from "../../src/pages/projects/projects.store.js";
 
 describe("projects.store addProject", () => {
@@ -41,5 +43,33 @@ describe("projects.store addProject", () => {
         projectPath: "/new/DiaLune-migrated",
       },
     ]);
+  });
+
+  it("opens the app version menu with a check update action", () => {
+    const state = createInitialState();
+
+    openAppVersionMenu({ state }, { x: 120, y: 320 });
+
+    expect(state.appVersionMenu).toEqual({
+      isOpen: true,
+      x: 120,
+      y: 320,
+      items: [
+        {
+          label: "Check for update",
+          type: "item",
+          value: "check-update",
+        },
+      ],
+    });
+
+    closeAppVersionMenu({ state });
+
+    expect(state.appVersionMenu).toEqual({
+      isOpen: false,
+      x: 0,
+      y: 0,
+      items: [],
+    });
   });
 });

--- a/tests/projects/projects.view.test.js
+++ b/tests/projects/projects.view.test.js
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("projects view", () => {
+  it("keeps the app version visible outside the scrollable project list", () => {
+    const projectsView = readFileSync(
+      new URL("../../src/pages/projects/projects.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    const scrollContainerIndex = projectsView.indexOf(
+      'rtgl-view w=f h=1fg ah=c sv style="min-height: 0;"',
+    );
+    const footerContainerIndex = projectsView.indexOf(
+      'rtgl-view w=f ah=c bgc=bg style="flex-shrink: 0; padding-bottom: env(safe-area-inset-bottom);"',
+    );
+    const footerTextIndex = projectsView.indexOf(
+      "rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}",
+    );
+
+    expect(scrollContainerIndex).toBeGreaterThan(-1);
+    expect(footerContainerIndex).toBeGreaterThan(scrollContainerIndex);
+    expect(projectsView).toContain("rtgl-view sm-w=f w=640 ph=lg pv=lg ah=c");
+    expect(projectsView).toContain("rtgl-view#appVersionButton");
+    expect(projectsView).toContain(
+      "rtgl-dropdown-menu#appVersionDropdownMenu ?open=${appVersionMenu.isOpen} x=${appVersionMenu.x} y=${appVersionMenu.y} place=t :items=${appVersionMenu.items}",
+    );
+    expect(projectsView).toContain("handler: handleAppVersionClick");
+    expect(projectsView).toContain("handler: handleAppVersionMenuClickItem");
+    expect(footerTextIndex).toBeGreaterThan(footerContainerIndex);
+    expect(projectsView).not.toContain("rtgl-view w=f ah=c pb=lg");
+  });
+});


### PR DESCRIPTION
## Summary
- keep the Projects page app/version footer visible outside the scrollable project list
- make the footer app/version label clickable with a single `Check for update` dropdown item
- route the dropdown action through `updaterService.checkForUpdates(false)`
- add focused store, handler, and view tests for the footer menu

## Testing
- bunx vitest run tests/projects/projects.view.test.js tests/projects/projects.store.test.js tests/projects/projects.handlers.test.js
- bun prettier --check src/pages/projects/projects.view.yaml src/pages/projects/projects.store.js src/pages/projects/projects.handlers.js tests/projects/projects.view.test.js tests/projects/projects.store.test.js tests/projects/projects.handlers.test.js

## Note
- `bun run lint` is currently blocked by unrelated dirty layout-editor files in the local worktree (`src/components/layoutEditPanel/support/layoutEditPanelViewData.js` fails prettier). Those files are not included in this PR.