### PR TITLE
fix: layout editor created element selection and anchors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
         "route-engine-js": "1.26.1",
-        "route-graphics": "1.23.5",
+        "route-graphics": "1.23.6",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
         "snabbdom-to-html": "7.1.0",
@@ -732,7 +732,7 @@
 
     "route-engine-js": ["route-engine-js@1.26.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-azxqZKV8jxh+6WBm8tiLuW2hCNTjzKsS/a3EBJ5yuzToC+fIVyXz0KaQaGbXFBZu4Ha778d5dQlpwR2ZsZaUuA=="],
 
-    "route-graphics": ["route-graphics@1.23.5", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-M5FxInUKqTj0/1GuvNoLw/iBjNGf7WPeE2ynrs21cvx9p8oaCgZLpC8H3C4hu5Gy+CD2hJcYlEZFJum7cbmKww=="],
+    "route-graphics": ["route-graphics@1.23.6", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-25vRko5C1lZpBJeTwGnnm4yYYUPWo6NCZ9Td45xSrquJMVawDr2kD5sleM9XoTs1cAXidWb3MMO4w45dFM2Mww=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
     "route-engine-js": "1.26.1",
-    "route-graphics": "1.23.5",
+    "route-graphics": "1.23.6",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",
     "snabbdom-to-html": "7.1.0",

--- a/src/components/layoutEditPanel/support/layoutEditPanelViewData.js
+++ b/src/components/layoutEditPanel/support/layoutEditPanelViewData.js
@@ -176,10 +176,7 @@ export const toSoundOptions = (soundsData = {}) => {
 };
 
 const toAnchorValue = (values = {}) => {
-  if (
-    Number.isFinite(values.anchor?.x) &&
-    Number.isFinite(values.anchor?.y)
-  ) {
+  if (Number.isFinite(values.anchor?.x) && Number.isFinite(values.anchor?.y)) {
     return values.anchor;
   }
 

--- a/src/components/layoutEditPanel/support/layoutEditPanelViewData.js
+++ b/src/components/layoutEditPanel/support/layoutEditPanelViewData.js
@@ -175,6 +175,20 @@ export const toSoundOptions = (soundsData = {}) => {
     }));
 };
 
+const toAnchorValue = (values = {}) => {
+  if (
+    Number.isFinite(values.anchor?.x) &&
+    Number.isFinite(values.anchor?.y)
+  ) {
+    return values.anchor;
+  }
+
+  return {
+    x: Number.isFinite(values.anchorX) ? values.anchorX : 0,
+    y: Number.isFinite(values.anchorY) ? values.anchorY : 0,
+  };
+};
+
 export const toInspectorValues = ({
   values,
   firstTextStyleId,
@@ -241,6 +255,7 @@ export const toInspectorValues = ({
     textContentSummary,
     textContentSummaryParts,
     opacity: values?.opacity ?? 1,
+    anchor: toAnchorValue(values),
     aspectRatioMode: derivedAspectRatioLock !== undefined ? "fixed" : "free",
     aspectRatioLock: derivedAspectRatioLock,
     revealEffect,

--- a/src/internal/layoutEditorElementRegistry.js
+++ b/src/internal/layoutEditorElementRegistry.js
@@ -363,8 +363,7 @@ const CREATE_TEMPLATES = {
   rect: () => ({
     type: "rect",
     name: "Rect",
-    x: 0,
-    y: 0,
+    ...BASE_TRANSFORM,
     width: 100,
     height: 100,
   }),

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -599,9 +599,11 @@ const refreshLayoutEditorData = async (deps, payload = {}) => {
   if (payload.selectedItemId) {
     store.setSelectedItemId({ itemId: payload.selectedItemId });
     store.setDetailPanelSelectedItemId({ itemId: payload.selectedItemId });
-    refs.fileExplorer.selectItem({ itemId: payload.selectedItemId });
   }
   render();
+  if (payload.selectedItemId) {
+    refs.fileExplorer.selectItem({ itemId: payload.selectedItemId });
+  }
 };
 
 const {

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -602,7 +602,13 @@ const refreshLayoutEditorData = async (deps, payload = {}) => {
   }
   render();
   if (payload.selectedItemId) {
-    refs.fileExplorer.selectItem({ itemId: payload.selectedItemId });
+    scheduleAfterNextPaint(() => {
+      if (store.selectSelectedItemId() !== payload.selectedItemId) {
+        return;
+      }
+
+      refs.fileExplorer.selectItem({ itemId: payload.selectedItemId });
+    });
   }
 };
 

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -419,7 +419,11 @@ export const handleMobileActionMenuClickItem = (deps, payload) => {
 };
 
 export const handleAppVersionClick = (deps, payload) => {
-  const { store, render } = deps;
+  const { appService, store, render } = deps;
+  if (appService.getPlatform() === "web") {
+    return;
+  }
+
   const rect = payload._event.currentTarget.getBoundingClientRect();
 
   store.openAppVersionMenu({
@@ -439,14 +443,14 @@ export const handleAppVersionMenuClose = (deps) => {
 };
 
 export const handleAppVersionMenuClickItem = async (deps, payload) => {
-  const { store, render, updaterService } = deps;
+  const { appService, store, render, updaterService } = deps;
   const detail = payload._event.detail;
   const item = detail.item || detail;
 
   store.closeAppVersionMenu();
   render();
 
-  if (item.value === "check-update") {
+  if (item.value === "check-update" && appService.getPlatform() !== "web") {
     await updaterService.checkForUpdates(false);
   }
 };

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -236,6 +236,14 @@ export const selectIsMobileActionMenuOpen = ({ state }) => {
 };
 
 export const openAppVersionMenu = ({ state }, { x, y } = {}) => {
+  if (state.platform === "web") {
+    state.appVersionMenu.isOpen = false;
+    state.appVersionMenu.x = 0;
+    state.appVersionMenu.y = 0;
+    state.appVersionMenu.items = [];
+    return;
+  }
+
   state.appVersionMenu.isOpen = true;
   state.appVersionMenu.x = x;
   state.appVersionMenu.y = y;

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -200,8 +200,12 @@ template:
                                   - rtgl-view h="33vh": null
           - 'rtgl-view w=f ah=c bgc=bg style="flex-shrink: 0; padding-bottom: env(safe-area-inset-bottom);"':
               - 'rtgl-view sm-w=f w=640 ph=lg pv=lg ah=c':
-                  - rtgl-view#appVersionButton d=h av=c ah=c ph=md pv=sm br=sm h-bgc=mu cur=pointer:
-                      - rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}
+                  - $if platform != 'web':
+                      - rtgl-view#appVersionButton d=h av=c ah=c ph=md pv=sm br=sm h-bgc=mu cur=pointer:
+                          - rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}
+                    $else:
+                      - rtgl-view d=h av=c ah=c ph=md pv=sm:
+                          - rtgl-text s=xs c=mu-fg: RouteVN Creator ${appVersion}
   - rtgl-dialog#deleteProjectDialog ?open=${deleteDialog.isOpen} s=sm:
       - rtgl-view slot=content g=lg p=lg:
           - rtgl-view d=v g=md:

--- a/tests/layoutEditPanel/layoutEditPanel.gapFields.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.gapFields.test.js
@@ -2,6 +2,38 @@ import { describe, expect, it } from "vitest";
 import { toInspectorValues } from "../../src/components/layoutEditPanel/support/layoutEditPanelViewData.js";
 
 describe("layoutEditPanel spacing axes", () => {
+  it("maps anchor coordinates to the inspector anchor value", () => {
+    const values = toInspectorValues({
+      values: {
+        type: "sprite",
+        anchorX: 0,
+        anchorY: 0,
+      },
+      firstTextStyleId: "",
+      hiddenActionModes: new Set(),
+    });
+
+    expect(values.anchor).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("defaults missing anchor coordinates to top left", () => {
+    const values = toInspectorValues({
+      values: {
+        type: "sprite",
+      },
+      firstTextStyleId: "",
+      hiddenActionModes: new Set(),
+    });
+
+    expect(values.anchor).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
   it("shows absolute as the default direction for containers", () => {
     const values = toInspectorValues({
       values: {

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -401,8 +401,10 @@ describe("layoutEditor.handleLayoutEditPanelUpdateHandler", () => {
 
 describe("layoutEditor.handleFileExplorerAction", () => {
   it("creates image elements at the top of the selected parent", async () => {
+    vi.useFakeTimers();
     const createLayoutElement = vi.fn(async () => ({ valid: true }));
     const deps = createLayoutEditorDeps();
+    let selectedItemId;
     deps.appService.showComponentDialog = vi.fn(async () => ({
       actionId: "create",
       values: {
@@ -425,50 +427,61 @@ describe("layoutEditor.handleFileExplorerAction", () => {
       },
       tree: [{ id: "image-1" }],
     }));
-    deps.store.setSelectedItemId = vi.fn();
+    deps.store.selectSelectedItemId = vi.fn(() => selectedItemId);
+    deps.store.setSelectedItemId = vi.fn(({ itemId } = {}) => {
+      selectedItemId = itemId;
+    });
     deps.store.setDetailPanelSelectedItemId = vi.fn();
     deps.refs.fileExplorer = {
       selectItem: vi.fn(),
     };
 
-    await handleFileExplorerAction(deps, {
-      _event: {
-        detail: {
-          itemId: "parent-1",
-          item: {
-            value: {
-              action: "new-child-item",
-              type: "sprite",
+    try {
+      await handleFileExplorerAction(deps, {
+        _event: {
+          detail: {
+            itemId: "parent-1",
+            item: {
+              value: {
+                action: "new-child-item",
+                type: "sprite",
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expect(createLayoutElement).toHaveBeenCalledWith({
-      layoutId: "layout-1",
-      elementId: expect.any(String),
-      data: expect.objectContaining({
-        type: "sprite",
-        name: "Hero Image",
-        imageId: "image-1",
-      }),
-      parentId: "parent-1",
-      position: "first",
-    });
-    const createdElementId = createLayoutElement.mock.calls[0][0].elementId;
-    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
-      itemId: createdElementId,
-    });
-    expect(deps.store.setDetailPanelSelectedItemId).toHaveBeenCalledWith({
-      itemId: createdElementId,
-    });
-    expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
-      itemId: createdElementId,
-    });
-    expect(deps.render.mock.invocationCallOrder[0]).toBeLessThan(
-      deps.refs.fileExplorer.selectItem.mock.invocationCallOrder[0],
-    );
+      expect(createLayoutElement).toHaveBeenCalledWith({
+        layoutId: "layout-1",
+        elementId: expect.any(String),
+        data: expect.objectContaining({
+          type: "sprite",
+          name: "Hero Image",
+          imageId: "image-1",
+        }),
+        parentId: "parent-1",
+        position: "first",
+      });
+      const createdElementId = createLayoutElement.mock.calls[0][0].elementId;
+      expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+        itemId: createdElementId,
+      });
+      expect(deps.store.setDetailPanelSelectedItemId).toHaveBeenCalledWith({
+        itemId: createdElementId,
+      });
+      expect(deps.refs.fileExplorer.selectItem).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(32);
+
+      expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
+        itemId: createdElementId,
+      });
+      expect(deps.render.mock.invocationCallOrder[0]).toBeLessThan(
+        deps.refs.fileExplorer.selectItem.mock.invocationCallOrder[0],
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -456,6 +456,19 @@ describe("layoutEditor.handleFileExplorerAction", () => {
       parentId: "parent-1",
       position: "first",
     });
+    const createdElementId = createLayoutElement.mock.calls[0][0].elementId;
+    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: createdElementId,
+    });
+    expect(deps.store.setDetailPanelSelectedItemId).toHaveBeenCalledWith({
+      itemId: createdElementId,
+    });
+    expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
+      itemId: createdElementId,
+    });
+    expect(deps.render.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.refs.fileExplorer.selectItem.mock.invocationCallOrder[0],
+    );
   });
 });
 

--- a/tests/layoutEditor/layoutEditorViewData.test.js
+++ b/tests/layoutEditor/layoutEditorViewData.test.js
@@ -18,6 +18,8 @@ describe("layoutEditorViewData", () => {
       action: "new-child-item",
       type: "container",
       direction: "absolute",
+      anchorX: 0,
+      anchorY: 0,
     });
   });
 
@@ -52,6 +54,26 @@ describe("layoutEditorViewData", () => {
       action: "new-child-item",
       type: "sprite",
       name: "Image",
+      anchorX: 0,
+      anchorY: 0,
+    });
+  });
+
+  it("builds rect create actions with top-left anchor coordinates", () => {
+    const [rectItem] = toLayoutEditorContextMenuItems([
+      {
+        label: "Rect",
+        type: "item",
+        createType: "rect",
+      },
+    ]);
+
+    expect(rectItem.value).toMatchObject({
+      action: "new-child-item",
+      type: "rect",
+      name: "Rect",
+      anchorX: 0,
+      anchorY: 0,
     });
   });
 

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -13,9 +13,10 @@ import {
 
 const createDeps = ({
   ensureProjectCompatibleById = vi.fn(async () => {}),
+  platform = "tauri",
 } = {}) => {
   const appService = {
-    getPlatform: vi.fn(() => "tauri"),
+    getPlatform: vi.fn(() => platform),
     openFolderPicker: vi.fn(),
     openExistingProject: vi.fn(),
     loadAllProjects: vi.fn(async () => []),
@@ -311,6 +312,25 @@ describe("projects app version menu", () => {
     expect(deps.render).toHaveBeenCalledTimes(1);
   });
 
+  it("does not open the app version dropdown on web", () => {
+    const deps = createDeps({ platform: "web" });
+
+    handleAppVersionClick(deps, {
+      _event: {
+        currentTarget: {
+          getBoundingClientRect: () => ({
+            left: 100,
+            width: 80,
+            top: 700,
+          }),
+        },
+      },
+    });
+
+    expect(deps.store.openAppVersionMenu).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+  });
+
   it("closes the app version dropdown", () => {
     const deps = createDeps();
 
@@ -336,6 +356,24 @@ describe("projects app version menu", () => {
     expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
     expect(deps.render).toHaveBeenCalledTimes(1);
     expect(deps.updaterService.checkForUpdates).toHaveBeenCalledWith(false);
+  });
+
+  it("does not check for updates from a stale web menu event", async () => {
+    const deps = createDeps({ platform: "web" });
+
+    await handleAppVersionMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "check-update",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.updaterService.checkForUpdates).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/projects/projects.store.test.js
+++ b/tests/projects/projects.store.test.js
@@ -4,6 +4,7 @@ import {
   closeAppVersionMenu,
   createInitialState,
   openAppVersionMenu,
+  setPlatform,
 } from "../../src/pages/projects/projects.store.js";
 
 describe("projects.store addProject", () => {
@@ -64,6 +65,20 @@ describe("projects.store addProject", () => {
     });
 
     closeAppVersionMenu({ state });
+
+    expect(state.appVersionMenu).toEqual({
+      isOpen: false,
+      x: 0,
+      y: 0,
+      items: [],
+    });
+  });
+
+  it("does not open the app version update menu on web", () => {
+    const state = createInitialState();
+    setPlatform({ state }, { platform: "web" });
+
+    openAppVersionMenu({ state }, { x: 120, y: 320 });
 
     expect(state.appVersionMenu).toEqual({
       isOpen: false,

--- a/tests/projects/projects.view.test.js
+++ b/tests/projects/projects.view.test.js
@@ -21,6 +21,7 @@ describe("projects view", () => {
     expect(scrollContainerIndex).toBeGreaterThan(-1);
     expect(footerContainerIndex).toBeGreaterThan(scrollContainerIndex);
     expect(projectsView).toContain("rtgl-view sm-w=f w=640 ph=lg pv=lg ah=c");
+    expect(projectsView).toContain("$if platform != 'web'");
     expect(projectsView).toContain("rtgl-view#appVersionButton");
     expect(projectsView).toContain(
       "rtgl-dropdown-menu#appVersionDropdownMenu ?open=${appVersionMenu.isOpen} x=${appVersionMenu.x} y=${appVersionMenu.y} place=t :items=${appVersionMenu.items}",


### PR DESCRIPTION
## Summary
- select newly-created layout editor elements in both the canvas and file explorer after refresh
- default created layout editor elements to top-left anchor values in the inspector/create templates
- bump `route-graphics` to 1.23.6
- hide projects footer update checks on web builds

## Testing
- `bunx vitest run tests/layoutEditPanel/layoutEditPanel.gapFields.test.js tests/layoutEditor/layoutEditorViewData.test.js tests/layoutEditor/layoutEditor.handlers.test.js tests/projects/projects.store.test.js tests/projects/projects.handlers.test.js tests/projects/projects.view.test.js`
- pre-push hook: `oxlint && bun prettier --check src`