### PR TITLE
fix: add project validation update hint

### DIFF
--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -18,7 +18,8 @@ const withLatestCreatorVersionHint = (message) => {
     return detail;
   }
 
-  return `${detail} ${LATEST_CREATOR_VERSION_HINT}`;
+  const separator = /[.!?]$/.test(detail) ? " " : ". ";
+  return `${detail}${separator}${LATEST_CREATOR_VERSION_HINT}`;
 };
 
 export const isIncompatibleProjectOpenError = (error) => {
@@ -82,9 +83,7 @@ const isProjectDataStructureValidationError = (error) => {
   return (
     message.includes("validation failed") ||
     message.includes("failed validation") ||
-    message.includes("data structure") ||
-    message.includes("must reference an existing") ||
-    message.includes("must reference existing")
+    message.includes("data structure")
   );
 };
 
@@ -111,12 +110,14 @@ export const getProjectOpenErrorMessage = (error) => {
 
   const detail = typeof error?.message === "string" ? error.message.trim() : "";
   if (!detail || detail === "Failed to open project.") {
-    return "Failed to open project. An unexpected error occurred while preparing the project.";
+    return withLatestCreatorVersionHint(
+      "Failed to open project. An unexpected error occurred while preparing the project.",
+    );
   }
 
   if (detail.toLowerCase().startsWith("failed to open project")) {
-    return detail;
+    return withLatestCreatorVersionHint(detail);
   }
 
-  return `Failed to open project. ${detail}`;
+  return withLatestCreatorVersionHint(`Failed to open project. ${detail}`);
 };

--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -18,7 +18,7 @@ const withLatestCreatorVersionHint = (message) => {
     return detail;
   }
 
-  const separator = /[.!?]$/.test(detail) ? " " : ". ";
+  const separator = /[.!?]$/.test(detail) ? "\n" : ".\n";
   return `${detail}${separator}${LATEST_CREATOR_VERSION_HINT}`;
 };
 

--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -82,7 +82,9 @@ const isProjectDataStructureValidationError = (error) => {
   return (
     message.includes("validation failed") ||
     message.includes("failed validation") ||
-    message.includes("data structure")
+    message.includes("data structure") ||
+    message.includes("must reference an existing") ||
+    message.includes("must reference existing")
   );
 };
 

--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -4,6 +4,23 @@ export const UNSUPPORTED_PROJECT_STORE_FORMAT_MESSAGE =
 const LATEST_CREATOR_VERSION_HINT =
   "Make sure you're using the latest version of RouteVN Creator.";
 
+const hasLatestCreatorVersionHint = (message) => {
+  const normalizedMessage = message.toLowerCase();
+  return (
+    normalizedMessage.includes("latest version of routevn creator") ||
+    normalizedMessage.includes("update routevn creator")
+  );
+};
+
+const withLatestCreatorVersionHint = (message) => {
+  const detail = message.trim();
+  if (hasLatestCreatorVersionHint(detail)) {
+    return detail;
+  }
+
+  return `${detail} ${LATEST_CREATOR_VERSION_HINT}`;
+};
+
 export const isIncompatibleProjectOpenError = (error) => {
   if (
     error?.code === "project_projection_gap_incompatible" ||
@@ -22,15 +39,20 @@ export const isIncompatibleProjectOpenError = (error) => {
 
 export const getIncompatibleProjectOpenMessage = (error) => {
   if (error?.code === "project_store_format_unsupported") {
-    return UNSUPPORTED_PROJECT_STORE_FORMAT_MESSAGE;
+    return withLatestCreatorVersionHint(
+      UNSUPPORTED_PROJECT_STORE_FORMAT_MESSAGE,
+    );
   }
 
-  const message = error?.message ?? "";
+  const message =
+    typeof error?.message === "string" ? error.message.trim() : "";
   if (message.includes("requires reset for schema version")) {
-    return "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project.";
+    return withLatestCreatorVersionHint(
+      "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project.",
+    );
   }
 
-  return message;
+  return withLatestCreatorVersionHint(message || "Incompatible project.");
 };
 
 const isMissingProjectResolutionError = (error) => {
@@ -70,11 +92,15 @@ export const getProjectOpenErrorMessage = (error) => {
   }
 
   if (isMissingProjectResolutionError(error)) {
-    return `Project is missing required resolution settings. ${LATEST_CREATOR_VERSION_HINT}`;
+    return withLatestCreatorVersionHint(
+      "Project is missing required resolution settings.",
+    );
   }
 
   if (isProjectDataStructureValidationError(error)) {
-    return `Project data structure failed validation. ${LATEST_CREATOR_VERSION_HINT}`;
+    return withLatestCreatorVersionHint(
+      "Project data structure failed validation.",
+    );
   }
 
   if (isProjectDatabaseOpenError(error)) {

--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -1,6 +1,9 @@
 export const UNSUPPORTED_PROJECT_STORE_FORMAT_MESSAGE =
   "Unsupported project store format. This RouteVN Creator build only supports the current project storage layout and will not repair older local stores automatically.";
 
+const LATEST_CREATOR_VERSION_HINT =
+  "Make sure you're using the latest version of RouteVN Creator.";
+
 export const isIncompatibleProjectOpenError = (error) => {
   if (
     error?.code === "project_projection_gap_incompatible" ||
@@ -31,7 +34,7 @@ export const getIncompatibleProjectOpenMessage = (error) => {
 };
 
 const isMissingProjectResolutionError = (error) => {
-  const message = String(error?.message || "").toLowerCase();
+  const message = String(error?.message ?? "").toLowerCase();
   return (
     message.includes("project resolution is required") &&
     message.includes("width") &&
@@ -40,10 +43,24 @@ const isMissingProjectResolutionError = (error) => {
 };
 
 const isProjectDatabaseOpenError = (error) => {
-  const message = String(error?.message || "").toLowerCase();
+  const message = String(error?.message ?? "").toLowerCase();
   return (
     message.includes("unable to open database file") ||
     message.includes("(code: 14)")
+  );
+};
+
+const isProjectDataStructureValidationError = (error) => {
+  const code = String(error?.code ?? "");
+  if (code.includes("validation_failed")) {
+    return true;
+  }
+
+  const message = String(error?.message ?? "").toLowerCase();
+  return (
+    message.includes("validation failed") ||
+    message.includes("failed validation") ||
+    message.includes("data structure")
   );
 };
 
@@ -53,7 +70,11 @@ export const getProjectOpenErrorMessage = (error) => {
   }
 
   if (isMissingProjectResolutionError(error)) {
-    return "Project is missing required resolution settings.";
+    return `Project is missing required resolution settings. ${LATEST_CREATOR_VERSION_HINT}`;
+  }
+
+  if (isProjectDataStructureValidationError(error)) {
+    return `Project data structure failed validation. ${LATEST_CREATOR_VERSION_HINT}`;
   }
 
   if (isProjectDatabaseOpenError(error)) {

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -116,7 +116,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "You're trying to open an incompatible project with version 1 using RouteVN Creator project format 2. For assistance, please reach out to RouteVN staff for support.",
+        "You're trying to open an incompatible project with version 1 using RouteVN Creator project format 2. For assistance, please reach out to RouteVN staff for support. Make sure you're using the latest version of RouteVN Creator.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -136,7 +136,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project.",
+        "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project. Make sure you're using the latest version of RouteVN Creator.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -178,7 +178,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "Unsupported project store format. This RouteVN Creator build only supports the current project storage layout and will not repair older local stores automatically.",
+        "Unsupported project store format. This RouteVN Creator build only supports the current project storage layout and will not repair older local stores automatically. Make sure you're using the latest version of RouteVN Creator.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -238,6 +238,24 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
 
+  it("suggests updating RouteVN Creator for model reference validation errors", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        throw new Error(
+          "character.spriteGroups[0].tags[0] must reference an existing tag in scope 'characterSprites:g2PMeSgDVtoZ'",
+        );
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message:
+        "Project data structure failed validation. Make sure you're using the latest version of RouteVN Creator.",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
   it("shows a clearer message for missing project database file errors", async () => {
     const deps = createDeps({
       ensureProjectCompatibleById: vi.fn(async () => {

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -116,7 +116,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "You're trying to open an incompatible project with version 1 using RouteVN Creator project format 2. For assistance, please reach out to RouteVN staff for support. Make sure you're using the latest version of RouteVN Creator.",
+        "You're trying to open an incompatible project with version 1 using RouteVN Creator project format 2. For assistance, please reach out to RouteVN staff for support.\nMake sure you're using the latest version of RouteVN Creator.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -136,7 +136,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project. Make sure you're using the latest version of RouteVN Creator.",
+        "Unsupported project version. Make sure the project was created with RouteVN Creator v1 or later. Contact RouteVN for support on migrating the old project.\nMake sure you're using the latest version of RouteVN Creator.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -178,7 +178,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       title: "Incompatible Project",
       message:
-        "Unsupported project store format. This RouteVN Creator build only supports the current project storage layout and will not repair older local stores automatically. Make sure you're using the latest version of RouteVN Creator.",
+        "Unsupported project store format. This RouteVN Creator build only supports the current project storage layout and will not repair older local stores automatically.\nMake sure you're using the latest version of RouteVN Creator.",
       status: "error",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
@@ -195,7 +195,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Failed to open project. An unexpected error occurred while preparing the project. Make sure you're using the latest version of RouteVN Creator.",
+        "Failed to open project. An unexpected error occurred while preparing the project.\nMake sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
@@ -213,7 +213,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Project is missing required resolution settings. Make sure you're using the latest version of RouteVN Creator.",
+        "Project is missing required resolution settings.\nMake sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
@@ -233,7 +233,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Project data structure failed validation. Make sure you're using the latest version of RouteVN Creator.",
+        "Project data structure failed validation.\nMake sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
@@ -251,7 +251,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Failed to open project. character.spriteGroups[0].tags[0] must reference an existing tag in scope 'characterSprites:g2PMeSgDVtoZ'. Make sure you're using the latest version of RouteVN Creator.",
+        "Failed to open project. character.spriteGroups[0].tags[0] must reference an existing tag in scope 'characterSprites:g2PMeSgDVtoZ'.\nMake sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -212,7 +212,28 @@ describe("projects.handleProjectsClick", () => {
     await handleProjectsClick(deps, createPayload());
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
-      message: "Project is missing required resolution settings.",
+      message:
+        "Project is missing required resolution settings. Make sure you're using the latest version of RouteVN Creator.",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+  });
+
+  it("suggests updating RouteVN Creator for project data validation errors", async () => {
+    const deps = createDeps({
+      ensureProjectCompatibleById: vi.fn(async () => {
+        const error = new Error(
+          "payload.sectionId must reference an existing section",
+        );
+        error.code = "validation_failed";
+        throw error;
+      }),
+    });
+
+    await handleProjectsClick(deps, createPayload());
+
+    expect(deps.appService.showAlert).toHaveBeenCalledWith({
+      message:
+        "Project data structure failed validation. Make sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -195,7 +195,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Failed to open project. An unexpected error occurred while preparing the project.",
+        "Failed to open project. An unexpected error occurred while preparing the project. Make sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
@@ -238,7 +238,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
 
-  it("suggests updating RouteVN Creator for model reference validation errors", async () => {
+  it("suggests updating RouteVN Creator for generic model reference errors", async () => {
     const deps = createDeps({
       ensureProjectCompatibleById: vi.fn(async () => {
         throw new Error(
@@ -251,7 +251,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Project data structure failed validation. Make sure you're using the latest version of RouteVN Creator.",
+        "Failed to open project. character.spriteGroups[0].tags[0] must reference an existing tag in scope 'characterSprites:g2PMeSgDVtoZ'. Make sure you're using the latest version of RouteVN Creator.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- map coded project-open validation/data-structure failures to a stable user-facing error
- add a shared latest-version hint for incompatible project-open errors
- append the latest-version hint from the generic project-open fallback so uncoded model errors still get guidance
- avoid duplicating the hint when an error already tells users to update RouteVN Creator
- cover the Projects open flow with focused validation, incompatible-error, and generic model-error tests

## Testing
- bunx vitest run tests/projects/projects.handlers.test.js
- bun prettier --check src/internal/projectOpenErrors.js tests/projects/projects.handlers.test.js
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src