### PR TITLE
Prepare Android release version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ src/setup.js
 /android/routevn/**/*.jks
 /android/routevn/**/*.keystore
 /android/routevn/*.iml
+/*.jks
+/*.keystore

--- a/android/routevn/app/build.gradle.kts
+++ b/android/routevn/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         minSdk = 24
         targetSdk = 37
         versionCode = 1
-        versionName = "1.0.0"
+        versionName = "0.0.1"
         manifestPlaceholders["usesCleartextTraffic"] = "false"
     }
 


### PR DESCRIPTION
## Summary
- set Android release versionName to 0.0.1
- ignore root-level Android keystore files so local signing keys stay untracked

## Validation
- bundletool validate --bundle=android/routevn/app/build/outputs/bundle/release/app-release.aab
- git push hook: oxlint && bun prettier --check src