### PR TITLE
chore: bump Tauri version to 1.6.6

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- bump `src-tauri/tauri.conf.json` from `1.6.5` to `1.6.6`

## Testing
- `bun prettier --check src-tauri/tauri.conf.json`
- pre-push hook: `oxlint && bun prettier --check src`