### PR TITLE
feat: add Steam Tauri build flavor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ static/bundle/main.js
 /test-versions
 /test-update-server
 /src-tauri/*.bak
-/src-tauri/steam-runtime/
 .env
 /.rettangoli/
 /.artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,15 @@ static/bundle/main.js
 /test-versions
 /test-update-server
 /src-tauri/*.bak
+/src-tauri/steam-runtime/
 .env
 /.rettangoli/
 /.artifacts/
+/_steam/
+/steam/*.local.vdf
+/steam/config.vdf
+/steamcmd/
+/steam_appid.txt
 /project.db
 /project.db-shm
 /project.db-wal

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 1. [Collab Server Bootstrap](./runbooks/collab-server-bootstrap.md)
 2. [macOS Signing And Notarization](./runbooks/macos-signing-and-notarization.md)
 3. [Project Database Audit](./runbooks/project-database-audit.md)
+4. [Steam Release](./runbooks/steam-release.md)
 
 ## Platform Spec
 

--- a/docs/runbooks/steam-release.md
+++ b/docs/runbooks/steam-release.md
@@ -374,6 +374,14 @@ machine.
 SteamPipe should upload the launchable installed payload, not the public
 installer artifact.
 
+Artifact policy:
+
+- Direct-download Windows releases publish the NSIS installer produced by the
+  normal Tauri build.
+- Steam Windows releases upload a staged launchable executable payload. Do not
+  use the NSIS installer as the Steam launch target.
+- Steamworks launch options should point at the staged executable.
+
 ### Windows WebView2 Runtime
 
 The Windows Steam build uses `--no-bundle`, so Steam launches the raw Tauri

--- a/docs/runbooks/steam-release.md
+++ b/docs/runbooks/steam-release.md
@@ -50,10 +50,12 @@ Do not commit:
 - `steam_appid.txt`
 - Steamworks SDK files
 - Steam API runtime libraries copied from the SDK
+- Microsoft WebView2 fixed runtime files
 
-Recommended future `.gitignore` entries:
+Ignored local/generated entries:
 
 ```gitignore
+src-tauri/steam-runtime/
 _steam/
 steam/*.local.vdf
 steam/config.vdf
@@ -152,9 +154,11 @@ Preferred implementation:
 1. Keep using `src/setup.tauri.js`.
 2. Read the build distribution from `import.meta.env.VITE_ROUTEVN_DISTRIBUTION`.
 3. Pass `distribution` and `updatesEnabled` through page and component deps.
-4. Skip automatic update checks when updates are disabled.
-5. Hide manual update UI in Steam builds.
-6. Set Tauri updater artifacts off in the Steam Tauri config.
+4. Import the Tauri updater client statically, but instantiate it only when
+   updates are enabled.
+5. Skip automatic update checks when updates are disabled.
+6. Hide manual update UI in Steam builds.
+7. Set Tauri updater artifacts off in the Steam Tauri config.
 
 Distribution setup shape:
 
@@ -372,10 +376,53 @@ machine.
 SteamPipe should upload the launchable installed payload, not the public
 installer artifact.
 
+### Windows WebView2 Runtime
+
+Do not upload the raw Windows `app.exe` by itself. The direct-download NSIS
+installer handles WebView2 prerequisites, but Steam launch options start the
+staged executable directly.
+
+The Windows Steam flavor uses Tauri's `fixedRuntime` WebView2 mode:
+
+```json
+{
+  "bundle": {
+    "windows": {
+      "webviewInstallMode": {
+        "type": "fixedRuntime",
+        "path": "steam-runtime/webview2"
+      }
+    }
+  }
+}
+```
+
+Local setup:
+
+1. Download the Microsoft Edge WebView2 Fixed Version Runtime.
+2. Extract the runtime locally to `src-tauri/steam-runtime/webview2/`.
+3. Confirm `src-tauri/steam-runtime/webview2/msedgewebview2.exe` exists.
+
+`src-tauri/steam-runtime/` is ignored and must not be committed. The Windows
+Steam build script fails before compiling if the runtime is missing.
+
+The build copies the fixed runtime to:
+
+```text
+src-tauri/target/x86_64-pc-windows-msvc/release/steam-runtime/webview2/
+```
+
+Stage both of these into the Windows depot content root:
+
+- `src-tauri/target/x86_64-pc-windows-msvc/release/app.exe`
+- `src-tauri/target/x86_64-pc-windows-msvc/release/steam-runtime/webview2/**`
+
 Windows:
 
 - Build a Steam-specific Windows Tauri release.
-- Stage the launchable `.exe` payload into `_steam/windows/`.
+- Stage the launchable `.exe` payload and fixed WebView2 runtime into
+  `_steam/windows/`.
+- Do not stage `app.exe` without `steam-runtime/webview2/`.
 - Exclude `.pdb` files.
 - Configure Steam launch options to run the staged executable.
 - Validate on a clean Windows machine or VM.
@@ -432,6 +479,8 @@ Before uploading:
 - Tauri updater artifacts are not generated for the Steam build.
 - Automatic update checks do not run at startup.
 - Manual update UI is hidden or disabled.
+- Windows depot content includes `steam-runtime/webview2/msedgewebview2.exe`
+  when shipping Windows.
 - No `steam_appid.txt` exists in the staged depot.
 - No Steamworks SDK files exist in the staged depot.
 - No `.pdb` files exist in the staged depot unless intentionally uploading

--- a/docs/runbooks/steam-release.md
+++ b/docs/runbooks/steam-release.md
@@ -1,0 +1,492 @@
+# Steam Release
+
+This runbook covers the intended Steam release flow for RouteVN Creator.
+
+The repository is public. Do not commit Steam credentials, SteamCMD auth
+tokens, generated local VDF files, `steam_appid.txt`, or Steamworks SDK files.
+
+## Goals
+
+- Ship RouteVN Creator on Steam with the lightest possible integration.
+- Let Steam handle distribution and updates for Steam users.
+- Keep the existing direct-download Tauri updater for non-Steam builds.
+- Avoid adding the Steamworks SDK unless a product feature requires it.
+- Keep all credentials and private release metadata out of git.
+
+## Current Decision
+
+The first Steam build should not include Steamworks SDK integration.
+
+Do not add:
+
+- Steamworks SDK folders
+- `steam_api64.dll`, `libsteam_api.so`, or `libsteam_api.dylib`
+- Rust Steamworks crates
+- `steam_appid.txt`
+- Steam DRM wrapping
+
+Add Steamworks SDK only when the app needs a Steam API feature such as Steam
+Cloud, Workshop, overlay-specific behavior, achievements, stats, or ownership
+checks.
+
+## Repo Safety Rules
+
+Allowed in git:
+
+- Steam documentation
+- VDF templates with placeholders
+- scripts that generate local VDF files from environment variables
+- packaging scripts that stage Steam upload content
+
+Do not commit:
+
+- Steam account usernames if they are not intended to be public
+- Steam account passwords
+- Steam Guard codes
+- SteamCMD `config.vdf`
+- generated `*.local.vdf`
+- `_steam/` staged build output
+- downloaded `steamcmd/` folders
+- `steam_appid.txt`
+- Steamworks SDK files
+- Steam API runtime libraries copied from the SDK
+
+Recommended future `.gitignore` entries:
+
+```gitignore
+_steam/
+steam/*.local.vdf
+steam/config.vdf
+steamcmd/
+steam_appid.txt
+```
+
+## Steam Concepts
+
+`App ID`
+
+- The Steam application id assigned in Steamworks.
+- This is not a password.
+- Keep it in environment variables or generated local files while the Steam
+  page is private.
+
+`Depot ID`
+
+- A depot is a platform/content bucket under the Steam app.
+- Typical first depots:
+  - Windows 64-bit depot
+  - macOS depot, if shipping macOS through Steam
+  - Linux depot, if shipping Linux/Steam Deck through Steam
+
+`Build`
+
+- A SteamPipe build is a set of depot manifests uploaded for an app.
+- Steam clients download only the depots that match their platform/package.
+
+`Branch`
+
+- A branch is a release channel such as `default`, `beta`, or `internal`.
+- Use a private branch for first uploads and review builds.
+
+`Launch Option`
+
+- Steamworks Admin defines the command Steam launches after installing the app.
+- This is configured in Steamworks, not in the VDF build scripts.
+
+## Steamworks Admin Setup
+
+1. Create a Steam Direct app credit.
+2. Create the Steamworks app.
+3. Categorize RouteVN Creator as `Software`, unless there is a deliberate
+   product decision to list it as a game.
+4. Create platform depots.
+5. Configure launch options:
+   - Windows: launch the staged `.exe`
+   - macOS: launch the staged `.app`
+   - Linux: launch the staged AppImage or Linux executable
+6. Create a private branch for internal testing.
+7. Complete store and build review checklists.
+8. Keep the Coming Soon page visible for the required Steam period before
+   public release.
+
+## Steam-Specific Build Flavor
+
+The Steam flavor should be separate from the existing direct-download Tauri
+build.
+
+Steam build files:
+
+```text
+src-tauri/tauri.steam.conf.json
+scripts/tauri-build-win-steam.sh
+scripts/tauri-build-mac-steam.sh
+scripts/tauri-build-linux-steam.sh
+steam/app_build.vdf.template
+steam/depot_build_windows.vdf.template
+```
+
+Optional later files:
+
+```text
+steam/depot_build_macos.vdf.template
+steam/depot_build_linux.vdf.template
+```
+
+### Updater Behavior
+
+The existing direct-download build uses the Tauri updater:
+
+- Rust plugin registration:
+  `src-tauri/src/lib.rs`
+- updater permissions:
+  `src-tauri/capabilities/default.json`
+- production updater endpoint:
+  `src-tauri/tauri.prod.conf.json`
+- frontend update checks:
+  `src/deps/clients/tauri/updater.js`
+
+The Steam build should not check RouteVN's updater endpoint.
+
+Preferred implementation:
+
+1. Keep using `src/setup.tauri.js`.
+2. Read the build distribution from `import.meta.env.VITE_ROUTEVN_DISTRIBUTION`.
+3. Pass `distribution` and `updatesEnabled` through page and component deps.
+4. Skip automatic update checks when updates are disabled.
+5. Hide manual update UI in Steam builds.
+6. Set Tauri updater artifacts off in the Steam Tauri config.
+
+Distribution setup shape:
+
+```js
+const rawDistribution = import.meta.env?.VITE_ROUTEVN_DISTRIBUTION;
+const distribution = rawDistribution === "steam" ? "steam" : "direct";
+const updatesEnabled = distribution !== "steam";
+```
+
+Pass those values through deps:
+
+```js
+const componentDependencies = {
+  distribution,
+  updatesEnabled,
+  // ...
+};
+
+const pageDependencies = {
+  distribution,
+  updatesEnabled,
+  // ...
+};
+```
+
+The normal direct-download build does not need to set any environment variable.
+Unset distribution defaults to `direct`.
+
+The Steam build script should set:
+
+```bash
+export VITE_ROUTEVN_DISTRIBUTION=steam
+bun run build:tauri
+```
+
+`VITE_` is required because Vite exposes only `VITE_*` environment variables to
+frontend code. `rtgl fe build` uses Vite internally, and this mechanism was
+validated with the actual Rettangoli build path:
+
+```text
+VITE_ROUTEVN_DISTRIBUTION=steam  -> distribution compiled as "steam"
+VITE_ROUTEVN_DISTRIBUTION=direct -> distribution compiled as "direct"
+unset                            -> falls back to "direct"
+```
+
+The generated bundle does not retain `import.meta.env` for set values. The
+distribution value is public build metadata, not a credential.
+
+No-op updater shape:
+
+```js
+const updater = {
+  checkForUpdates: async () => undefined,
+  downloadAndInstall: async () => undefined,
+  startAutomaticChecks: () => undefined,
+  getUpdateInfo: () => undefined,
+  getDownloadProgress: () => 0,
+  isUpdateAvailable: () => false,
+};
+```
+
+Minimal Steam Tauri config overlay:
+
+```json
+{
+  "bundle": {
+    "createUpdaterArtifacts": false
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [],
+      "dangerousInsecureTransportProtocol": false
+    }
+  }
+}
+```
+
+Keeping the updater crate and Rust plugin registered is acceptable for the
+first Steam flavor if the frontend never calls it and updater artifacts are not
+generated. Removing or feature-gating the plugin can be a later cleanup if the
+extra build complexity is worth it.
+
+## SteamPipe VDF Files
+
+VDF files are SteamPipe build scripts. They describe which staged files are
+uploaded to which Steam depots.
+
+They do not contain credentials.
+
+Commit templates with placeholders. Generate local VDF files before upload.
+
+Recommended layout:
+
+```text
+steam/
+  app_build.vdf.template
+  depot_build_windows.vdf.template
+
+_steam/
+  windows/
+  output/
+```
+
+`_steam/` is generated and must stay ignored.
+
+### App Build Template
+
+`steam/app_build.vdf.template`:
+
+```vdf
+"AppBuild"
+{
+  "AppID" "${STEAM_APP_ID}"
+  "Desc" "RouteVN Creator ${APP_VERSION} Windows"
+  "ContentRoot" "../_steam/windows"
+  "BuildOutput" "../_steam/output"
+  "Preview" "0"
+
+  "Depots"
+  {
+    "${STEAM_WINDOWS_DEPOT_ID}" "depot_build_windows.local.vdf"
+  }
+}
+```
+
+### Depot Build Template
+
+`steam/depot_build_windows.vdf.template`:
+
+```vdf
+"DepotBuild"
+{
+  "DepotID" "${STEAM_WINDOWS_DEPOT_ID}"
+
+  "FileMapping"
+  {
+    "LocalPath" "*"
+    "DepotPath" "."
+    "Recursive" "1"
+  }
+
+  "FileExclusion" "*.pdb"
+}
+```
+
+The generated local files should be named like:
+
+```text
+steam/app_build.local.vdf
+steam/depot_build_windows.local.vdf
+```
+
+Do not commit those generated files.
+
+## Credentials
+
+Credentials are supplied to SteamCMD, not VDF files.
+
+Use a dedicated Steam build account, not a personal owner account. Give that
+account only the permissions needed to upload builds and manage app metadata.
+
+Local first-time login:
+
+```bash
+steamcmd +login "$STEAM_USERNAME"
+```
+
+SteamCMD will ask for the password and Steam Guard code. After successful
+login, SteamCMD writes an auth token into its `config/config.vdf`.
+
+Future local uploads can usually use the saved token:
+
+```bash
+steamcmd +login "$STEAM_USERNAME" +run_app_build ../steam/app_build.local.vdf +quit
+```
+
+Treat SteamCMD `config/config.vdf` as a secret. It should not be copied into the
+repo and should not be printed in logs.
+
+## Local Environment
+
+Use local shell environment variables or a local ignored `.env` file.
+
+Example:
+
+```env
+STEAM_APP_ID=000000
+STEAM_WINDOWS_DEPOT_ID=000001
+STEAM_USERNAME=routevn-build
+APP_VERSION=1.6.6
+```
+
+Do not commit this file if it contains private Steam metadata or usernames.
+
+## CI Safety
+
+Do not run Steam uploads on pull requests from forks.
+
+If Steam uploads are automated later:
+
+- use manual workflow dispatch or protected release tags
+- use GitHub protected environments
+- restrict approval to maintainers
+- store `STEAM_USERNAME` as a secret if the username should be private
+- store SteamCMD `config.vdf` as a protected secret/file or preserve it in a
+  locked CI cache
+- never expose Steam account passwords to untrusted workflow contexts
+- never upload from workflows that run arbitrary contributor code
+
+The safest first implementation is local manual upload from a maintainer
+machine.
+
+## Staging Content
+
+SteamPipe should upload the launchable installed payload, not the public
+installer artifact.
+
+Windows:
+
+- Build a Steam-specific Windows Tauri release.
+- Stage the launchable `.exe` payload into `_steam/windows/`.
+- Exclude `.pdb` files.
+- Configure Steam launch options to run the staged executable.
+- Validate on a clean Windows machine or VM.
+
+macOS:
+
+- Build a Steam-specific signed/notarized `.app` if shipping macOS on Steam.
+- Stage the `.app` bundle into the macOS depot content root.
+- Configure Steam launch options to run the `.app`.
+- Keep direct-download `.dmg` distribution separate from Steam depot content.
+
+Linux:
+
+- Build a Steam-specific Linux artifact if shipping Linux/Steam Deck.
+- Prefer the simplest artifact that runs reliably through Steam.
+- If using AppImage, verify executable permissions after SteamPipe upload and
+  after install through Steam.
+
+## Upload Flow
+
+Expected future local flow for Windows:
+
+```bash
+bun run tauri:build:win:steam
+./scripts/stage-steam-win.sh
+./scripts/render-steam-vdf.sh
+steamcmd +login "$STEAM_USERNAME" +run_app_build ../steam/app_build.local.vdf +quit
+```
+
+Steam build commands:
+
+```bash
+bun run tauri:build:win:steam
+bun run tauri:build:mac:steam
+bun run tauri:build:linux:steam
+```
+
+The flow should remain:
+
+1. Build Steam flavor.
+2. Stage clean depot content.
+3. Generate local VDF files from templates and env vars.
+4. Upload through SteamCMD.
+5. Assign the build to a private branch in Steamworks.
+6. Install from Steam and smoke test.
+7. Promote the build to the intended release branch when ready.
+
+## Validation Checklist
+
+Before uploading:
+
+- Steam build uses Steam setup, not direct-download setup.
+- RouteVN updater endpoint is not referenced by the built frontend bundle.
+- Tauri updater artifacts are not generated for the Steam build.
+- Automatic update checks do not run at startup.
+- Manual update UI is hidden or disabled.
+- No `steam_appid.txt` exists in the staged depot.
+- No Steamworks SDK files exist in the staged depot.
+- No `.pdb` files exist in the staged depot unless intentionally uploading
+  symbols to a private symbol depot.
+
+After upload:
+
+- Install from a private Steam branch.
+- Launch from Steam.
+- Confirm app starts without external installer steps.
+- Confirm project create/open/save works.
+- Confirm media import/export surfaces work.
+- Confirm update UI is absent.
+- Confirm no updater network request is made.
+- Confirm logs do not expose credentials or local paths that should remain
+  private.
+
+## When To Add Steamworks SDK
+
+Add Steamworks SDK only for a specific feature.
+
+Common reasons:
+
+- Steam Cloud sync
+- Steam Workshop
+- achievements or stats
+- overlay integration
+- rich presence
+- explicit ownership checks
+
+If adding SDK integration later:
+
+- keep SDK downloads outside the public repo
+- do not commit SDK archives or SDK source/header/lib folders
+- do not commit `steam_appid.txt`
+- ship only runtime files that Steam permits redistributing with the app
+- document the exact runtime files staged into each depot
+- add a clean local development setup path for contributors who do not have
+  Steamworks access
+
+## References
+
+- Steamworks SteamPipe uploading:
+  https://partner.steamgames.com/doc/sdk/uploading
+- Steamworks SDK API:
+  https://partner.steamgames.com/doc/sdk/api
+- Steamworks DRM:
+  https://partner.steamgames.com/doc/features/drm
+- Steam store release process:
+  https://partner.steamgames.com/doc/store/releasing
+- Steam application types:
+  https://partner.steamgames.com/doc/store/application
+- Steam Direct app fee:
+  https://partner.steamgames.com/doc/gettingstarted/appfee
+- Tauri updater:
+  https://v2.tauri.app/plugin/updater/
+- Tauri Windows distribution:
+  https://v2.tauri.app/distribute/windows-installer/

--- a/docs/runbooks/steam-release.md
+++ b/docs/runbooks/steam-release.md
@@ -50,12 +50,10 @@ Do not commit:
 - `steam_appid.txt`
 - Steamworks SDK files
 - Steam API runtime libraries copied from the SDK
-- Microsoft WebView2 fixed runtime files
 
 Ignored local/generated entries:
 
 ```gitignore
-src-tauri/steam-runtime/
 _steam/
 steam/*.local.vdf
 steam/config.vdf
@@ -378,54 +376,23 @@ installer artifact.
 
 ### Windows WebView2 Runtime
 
-Do not upload the raw Windows `app.exe` by itself. The direct-download NSIS
-installer handles WebView2 prerequisites, but Steam launch options start the
-staged executable directly.
+The Windows Steam build uses `--no-bundle`, so Steam launches the raw Tauri
+executable directly. The direct-download NSIS installer handles WebView2
+prerequisites, but the Steam depot does not run that installer path.
 
-The Windows Steam flavor uses Tauri's `fixedRuntime` WebView2 mode:
-
-```json
-{
-  "bundle": {
-    "windows": {
-      "webviewInstallMode": {
-        "type": "fixedRuntime",
-        "path": "steam-runtime/webview2"
-      }
-    }
-  }
-}
-```
-
-Local setup:
-
-1. Download the Microsoft Edge WebView2 Fixed Version Runtime.
-2. Extract the runtime locally to `src-tauri/steam-runtime/webview2/`.
-3. Confirm `src-tauri/steam-runtime/webview2/msedgewebview2.exe` exists.
-
-`src-tauri/steam-runtime/` is ignored and must not be committed. The Windows
-Steam build script fails before compiling if the runtime is missing.
-
-The build copies the fixed runtime to:
-
-```text
-src-tauri/target/x86_64-pc-windows-msvc/release/steam-runtime/webview2/
-```
-
-Stage both of these into the Windows depot content root:
-
-- `src-tauri/target/x86_64-pc-windows-msvc/release/app.exe`
-- `src-tauri/target/x86_64-pc-windows-msvc/release/steam-runtime/webview2/**`
+For the first Steam flavor, assume supported Windows machines already have the
+Microsoft Edge WebView2 Runtime installed. If WebView2 is missing, Tauri/WRY
+will fail during startup before the RouteVN UI loads. Do not add a fixed
+WebView2 runtime folder unless the product decision changes to support machines
+without system WebView2.
 
 Windows:
 
 - Build a Steam-specific Windows Tauri release.
-- Stage the launchable `.exe` payload and fixed WebView2 runtime into
-  `_steam/windows/`.
-- Do not stage `app.exe` without `steam-runtime/webview2/`.
+- Stage the launchable `.exe` payload into `_steam/windows/`.
 - Exclude `.pdb` files.
 - Configure Steam launch options to run the staged executable.
-- Validate on a clean Windows machine or VM.
+- Validate on a clean Windows machine or VM that has WebView2 installed.
 
 macOS:
 
@@ -479,8 +446,7 @@ Before uploading:
 - Tauri updater artifacts are not generated for the Steam build.
 - Automatic update checks do not run at startup.
 - Manual update UI is hidden or disabled.
-- Windows depot content includes `steam-runtime/webview2/msedgewebview2.exe`
-  when shipping Windows.
+- Windows smoke-test machine has Microsoft Edge WebView2 Runtime installed.
 - No `steam_appid.txt` exists in the staged depot.
 - No Steamworks SDK files exist in the staged depot.
 - No `.pdb` files exist in the staged depot unless intentionally uploading

--- a/package.json
+++ b/package.json
@@ -82,7 +82,10 @@
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
     "tauri:build:appimage": "./scripts/tauri-build-appimage.sh",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
-    "tauri:build:mac": "./scripts/tauri-build-mac.sh"
+    "tauri:build:win:steam": "./scripts/tauri-build-win-steam.sh",
+    "tauri:build:mac": "./scripts/tauri-build-mac.sh",
+    "tauri:build:mac:steam": "./scripts/tauri-build-mac-steam.sh",
+    "tauri:build:linux:steam": "./scripts/tauri-build-linux-steam.sh"
   },
   "devDependencies": {
     "@tauri-apps/cli": "2.11.1",

--- a/scripts/tauri-build-linux-steam.sh
+++ b/scripts/tauri-build-linux-steam.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+load_env() {
+  if [ -f ".env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+  fi
+}
+
+write_appimage_checksum() {
+  local bundle_dir="src-tauri/target/release/bundle/appimage"
+  local appimage
+  local appimage_path
+  local appimage_file
+  local checksum_file
+  local appimages=()
+
+  while IFS= read -r -d '' appimage; do
+    appimages+=("${appimage}")
+  done < <(find "${bundle_dir}" -maxdepth 1 -type f -name "*.AppImage" -print0)
+
+  if [ "${#appimages[@]}" -eq 0 ]; then
+    echo "Error: no AppImage found in ${bundle_dir}."
+    exit 1
+  fi
+
+  appimage_path="${appimages[0]}"
+  for appimage in "${appimages[@]}"; do
+    if [ "${appimage}" -nt "${appimage_path}" ]; then
+      appimage_path="${appimage}"
+    fi
+  done
+
+  appimage_file=$(basename "${appimage_path}")
+  checksum_file="${appimage_file}.sha256"
+
+  (
+    cd "${bundle_dir}"
+    sha256sum "${appimage_file}" > "${checksum_file}"
+  )
+
+  echo "Final Steam Linux AppImage: ${bundle_dir}/${appimage_file}"
+  echo "SHA256 checksum: ${bundle_dir}/${checksum_file}"
+}
+
+load_env
+
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "Error: patchelf is required for AppImage media framework bundling."
+  echo "Install it before building the AppImage. On Ubuntu: sudo apt install patchelf"
+  exit 1
+fi
+
+if [ ! -x "/usr/bin/xdg-open" ]; then
+  echo "Error: /usr/bin/xdg-open is required for AppImage bundling because tauri-plugin-opener is enabled."
+  echo "Install xdg-utils before building the AppImage."
+  echo "Ubuntu/Debian: sudo apt install xdg-utils"
+  echo "Fedora: sudo dnf install xdg-utils"
+  echo "Arch: sudo pacman -S xdg-utils"
+  exit 1
+fi
+
+export VITE_ROUTEVN_DISTRIBUTION=steam
+export NO_STRIP="${NO_STRIP:-1}"
+
+bun run build:tauri
+tauri build \
+  --config src-tauri/tauri.steam.conf.json \
+  --bundles appimage
+
+write_appimage_checksum

--- a/scripts/tauri-build-mac-steam.sh
+++ b/scripts/tauri-build-mac-steam.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+has_notarization_credentials() {
+  [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]
+}
+
+read_tauri_config_value() {
+  bun --print "JSON.parse(await Bun.file('src-tauri/tauri.conf.json').text()).${1}"
+}
+
+if [ -f ".env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  echo "Error: APPLE_SIGNING_IDENTITY is not set. Add it to .env."
+  exit 1
+fi
+
+APP_NAME=$(read_tauri_config_value "productName")
+APP_PATH="src-tauri/target/universal-apple-darwin/release/bundle/macos/${APP_NAME}.app"
+
+echo "Building Steam macOS app with signing identity: ${APPLE_SIGNING_IDENTITY}"
+
+if has_notarization_credentials; then
+  if ! xcrun notarytool --version >/dev/null 2>&1; then
+    echo "Error: xcrun notarytool is required for notarization."
+    exit 1
+  fi
+
+  echo "Notarization enabled with APPLE_ID credentials for team: ${APPLE_TEAM_ID}"
+else
+  echo "Warning: notarization is not configured."
+  echo "Set APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID in .env."
+fi
+
+export VITE_ROUTEVN_DISTRIBUTION=steam
+
+bun run build:tauri
+tauri build \
+  --config src-tauri/tauri.steam.conf.json \
+  --target universal-apple-darwin \
+  --bundles app
+
+if [ ! -d "${APP_PATH}" ]; then
+  echo "Error: no macOS app bundle found at ${APP_PATH}."
+  exit 1
+fi
+
+echo "Final Steam macOS app: ${APP_PATH}"

--- a/scripts/tauri-build-win-steam.sh
+++ b/scripts/tauri-build-win-steam.sh
@@ -2,6 +2,22 @@
 
 set -euo pipefail
 
+WEBVIEW2_FIXED_RUNTIME_DIR="src-tauri/steam-runtime/webview2"
+WINDOWS_RELEASE_DIR="src-tauri/target/x86_64-pc-windows-msvc/release"
+
+if [ ! -d "${WEBVIEW2_FIXED_RUNTIME_DIR}" ]; then
+  echo "Error: WebView2 fixed runtime is required for the raw Windows Steam executable."
+  echo "Extract the Microsoft Edge WebView2 Fixed Version Runtime to:"
+  echo "  ${WEBVIEW2_FIXED_RUNTIME_DIR}"
+  exit 1
+fi
+
+if [ ! -f "${WEBVIEW2_FIXED_RUNTIME_DIR}/msedgewebview2.exe" ]; then
+  echo "Error: ${WEBVIEW2_FIXED_RUNTIME_DIR}/msedgewebview2.exe was not found."
+  echo "The fixed runtime folder must contain the extracted WebView2 runtime files directly."
+  exit 1
+fi
+
 export VITE_ROUTEVN_DISTRIBUTION=steam
 
 bun run build:tauri
@@ -11,4 +27,10 @@ tauri build \
   --target x86_64-pc-windows-msvc \
   --no-bundle
 
-echo "Final Steam Windows executable: src-tauri/target/x86_64-pc-windows-msvc/release/app.exe"
+if [ ! -d "${WINDOWS_RELEASE_DIR}/steam-runtime/webview2" ]; then
+  echo "Error: fixed WebView2 runtime was not copied to ${WINDOWS_RELEASE_DIR}/steam-runtime/webview2."
+  exit 1
+fi
+
+echo "Final Steam Windows executable: ${WINDOWS_RELEASE_DIR}/app.exe"
+echo "Staged WebView2 fixed runtime: ${WINDOWS_RELEASE_DIR}/steam-runtime/webview2"

--- a/scripts/tauri-build-win-steam.sh
+++ b/scripts/tauri-build-win-steam.sh
@@ -2,21 +2,7 @@
 
 set -euo pipefail
 
-WEBVIEW2_FIXED_RUNTIME_DIR="src-tauri/steam-runtime/webview2"
 WINDOWS_RELEASE_DIR="src-tauri/target/x86_64-pc-windows-msvc/release"
-
-if [ ! -d "${WEBVIEW2_FIXED_RUNTIME_DIR}" ]; then
-  echo "Error: WebView2 fixed runtime is required for the raw Windows Steam executable."
-  echo "Extract the Microsoft Edge WebView2 Fixed Version Runtime to:"
-  echo "  ${WEBVIEW2_FIXED_RUNTIME_DIR}"
-  exit 1
-fi
-
-if [ ! -f "${WEBVIEW2_FIXED_RUNTIME_DIR}/msedgewebview2.exe" ]; then
-  echo "Error: ${WEBVIEW2_FIXED_RUNTIME_DIR}/msedgewebview2.exe was not found."
-  echo "The fixed runtime folder must contain the extracted WebView2 runtime files directly."
-  exit 1
-fi
 
 export VITE_ROUTEVN_DISTRIBUTION=steam
 
@@ -27,10 +13,5 @@ tauri build \
   --target x86_64-pc-windows-msvc \
   --no-bundle
 
-if [ ! -d "${WINDOWS_RELEASE_DIR}/steam-runtime/webview2" ]; then
-  echo "Error: fixed WebView2 runtime was not copied to ${WINDOWS_RELEASE_DIR}/steam-runtime/webview2."
-  exit 1
-fi
-
 echo "Final Steam Windows executable: ${WINDOWS_RELEASE_DIR}/app.exe"
-echo "Staged WebView2 fixed runtime: ${WINDOWS_RELEASE_DIR}/steam-runtime/webview2"
+echo "Requires Microsoft Edge WebView2 Runtime on the target Windows machine."

--- a/scripts/tauri-build-win-steam.sh
+++ b/scripts/tauri-build-win-steam.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export VITE_ROUTEVN_DISTRIBUTION=steam
+
+bun run build:tauri
+tauri build \
+  --config src-tauri/tauri.steam.conf.json \
+  --runner cargo-xwin \
+  --target x86_64-pc-windows-msvc \
+  --no-bundle
+
+echo "Final Steam Windows executable: src-tauri/target/x86_64-pc-windows-msvc/release/app.exe"

--- a/src-tauri/tauri.steam.conf.json
+++ b/src-tauri/tauri.steam.conf.json
@@ -1,12 +1,6 @@
 {
   "bundle": {
-    "createUpdaterArtifacts": false,
-    "windows": {
-      "webviewInstallMode": {
-        "type": "fixedRuntime",
-        "path": "steam-runtime/webview2"
-      }
-    }
+    "createUpdaterArtifacts": false
   },
   "plugins": {
     "updater": {

--- a/src-tauri/tauri.steam.conf.json
+++ b/src-tauri/tauri.steam.conf.json
@@ -1,6 +1,12 @@
 {
   "bundle": {
-    "createUpdaterArtifacts": false
+    "createUpdaterArtifacts": false,
+    "windows": {
+      "webviewInstallMode": {
+        "type": "fixedRuntime",
+        "path": "steam-runtime/webview2"
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/src-tauri/tauri.steam.conf.json
+++ b/src-tauri/tauri.steam.conf.json
@@ -1,0 +1,11 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": false
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [],
+      "dangerousInsecureTransportProtocol": false
+    }
+  }
+}

--- a/src/deps/services/shared/appServiceCore.js
+++ b/src/deps/services/shared/appServiceCore.js
@@ -15,6 +15,8 @@ export const createAppServiceCore = ({
   openUrl,
   appVersion,
   platform,
+  distribution,
+  updatesEnabled,
   updater,
   audioService,
   projectService,
@@ -47,6 +49,8 @@ export const createAppServiceCore = ({
     openUrl,
     appVersion,
     platform,
+    distribution,
+    updatesEnabled,
     updater,
     audioService,
   });

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -58,6 +58,8 @@ export const createAppShellService = ({
   openUrl: openExternalUrl,
   appVersion,
   platform,
+  distribution = "direct",
+  updatesEnabled = false,
   updater,
   audioService,
 }) => {
@@ -174,6 +176,14 @@ export const createAppShellService = ({
 
     getPlatform() {
       return platform;
+    },
+
+    getDistribution() {
+      return distribution;
+    },
+
+    areUpdatesEnabled() {
+      return Boolean(updatesEnabled);
     },
 
     checkForUpdates(silent) {

--- a/src/internal/updates.js
+++ b/src/internal/updates.js
@@ -1,0 +1,15 @@
+export const resolveUpdatesEnabled = ({
+  appService,
+  updatesEnabled,
+  updaterService,
+} = {}) => {
+  if (updatesEnabled !== undefined) {
+    return Boolean(updatesEnabled);
+  }
+
+  if (appService?.getPlatform?.() === "web") {
+    return false;
+  }
+
+  return Boolean(updaterService);
+};

--- a/src/pages/about/about.handlers.js
+++ b/src/pages/about/about.handlers.js
@@ -1,8 +1,10 @@
+import { resolveUpdatesEnabled } from "../../internal/updates.js";
+
 export const handleBeforeMount = (deps) => {
-  const { appService, store, uiConfig, updatesEnabled } = deps;
+  const { appService, store, uiConfig } = deps;
 
   store.setUiConfig({ uiConfig });
-  store.setUpdatesEnabled({ updatesEnabled });
+  store.setUpdatesEnabled({ updatesEnabled: resolveUpdatesEnabled(deps) });
   const appVersion = appService.getAppVersion();
   if (appVersion) {
     store.setAppVersion({ version: appVersion });
@@ -16,8 +18,8 @@ export const handleDataChanged = () => {
 };
 
 export const handleCheckForUpdates = async (deps) => {
-  const { updaterService, updatesEnabled } = deps;
-  if (!updatesEnabled || !updaterService) {
+  const { updaterService } = deps;
+  if (!resolveUpdatesEnabled(deps) || !updaterService) {
     return;
   }
 

--- a/src/pages/about/about.handlers.js
+++ b/src/pages/about/about.handlers.js
@@ -1,7 +1,8 @@
 export const handleBeforeMount = (deps) => {
-  const { appService, store, uiConfig } = deps;
+  const { appService, store, uiConfig, updatesEnabled } = deps;
 
   store.setUiConfig({ uiConfig });
+  store.setUpdatesEnabled({ updatesEnabled });
   const appVersion = appService.getAppVersion();
   if (appVersion) {
     store.setAppVersion({ version: appVersion });
@@ -15,7 +16,10 @@ export const handleDataChanged = () => {
 };
 
 export const handleCheckForUpdates = async (deps) => {
-  const { updaterService } = deps;
+  const { updaterService, updatesEnabled } = deps;
+  if (!updatesEnabled || !updaterService) {
+    return;
+  }
 
   // Check for updates with UI feedback
   await updaterService.checkForUpdates(false);

--- a/src/pages/about/about.store.js
+++ b/src/pages/about/about.store.js
@@ -39,6 +39,7 @@ export const createInitialState = () => ({
   flatItems: [],
   appVersion: "",
   platform: "tauri",
+  updatesEnabled: false,
   isTouchMode: false,
 });
 
@@ -69,6 +70,10 @@ export const setAppVersion = ({ state }, { version } = {}) => {
 
 export const setPlatform = ({ state }, { platform } = {}) => {
   state.platform = platform;
+};
+
+export const setUpdatesEnabled = ({ state }, { updatesEnabled } = {}) => {
+  state.updatesEnabled = Boolean(updatesEnabled);
 };
 
 export const setUiConfig = ({ state }, { uiConfig } = {}) => {

--- a/src/pages/about/about.view.yaml
+++ b/src/pages/about/about.view.yaml
@@ -32,7 +32,7 @@ template:
                       - rtgl-view av=c g=sm:
                           - rtgl-text s=sm: RouteVN Creator ${appVersion}
                       - rtgl-view d=h g=md:
-                          - $if platform == 'tauri':
+                          - $if platform == 'tauri' && updatesEnabled:
                               - rtgl-button#checkUpdateButton v=se: Check for Updates
                   - rtgl-view g=md:
                       - rtgl-text s=h4: Community

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -13,6 +13,7 @@ import {
   isIncompatibleProjectOpenError,
 } from "../../internal/projectOpenErrors.js";
 import { getRoutevnCreatorDocsUrl } from "../../internal/routevnUrls.js";
+import { resolveUpdatesEnabled } from "../../internal/updates.js";
 import { recordRecentSceneVisit } from "../../internal/ui/recentScenes.js";
 
 const GLOBAL_NAV_TIMEOUT_MS = 1500;
@@ -301,9 +302,11 @@ export const handleBeforeMount = (deps) => {
 };
 
 export const handleAfterMount = (deps) => {
+  const { updaterService } = deps;
+
   // Start checking for updates on app startup (Tauri only)
-  if (deps.updatesEnabled && deps.updaterService) {
-    deps.updaterService.startAutomaticChecks();
+  if (resolveUpdatesEnabled(deps) && updaterService) {
+    updaterService.startAutomaticChecks();
   }
 };
 

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -302,7 +302,7 @@ export const handleBeforeMount = (deps) => {
 
 export const handleAfterMount = (deps) => {
   // Start checking for updates on app startup (Tauri only)
-  if (deps.updaterService) {
+  if (deps.updatesEnabled && deps.updaterService) {
     deps.updaterService.startAutomaticChecks();
   }
 };

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -419,8 +419,8 @@ export const handleMobileActionMenuClickItem = (deps, payload) => {
 };
 
 export const handleAppVersionClick = (deps, payload) => {
-  const { appService, store, render } = deps;
-  if (appService.getPlatform() === "web") {
+  const { appService, store, render, updatesEnabled } = deps;
+  if (appService.getPlatform() === "web" || !updatesEnabled) {
     return;
   }
 
@@ -443,14 +443,19 @@ export const handleAppVersionMenuClose = (deps) => {
 };
 
 export const handleAppVersionMenuClickItem = async (deps, payload) => {
-  const { appService, store, render, updaterService } = deps;
+  const { appService, store, render, updaterService, updatesEnabled } = deps;
   const detail = payload._event.detail;
   const item = detail.item || detail;
 
   store.closeAppVersionMenu();
   render();
 
-  if (item.value === "check-update" && appService.getPlatform() !== "web") {
+  if (
+    item.value === "check-update" &&
+    appService.getPlatform() !== "web" &&
+    updatesEnabled &&
+    updaterService
+  ) {
     await updaterService.checkForUpdates(false);
   }
 };

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -13,6 +13,7 @@ import {
   CUSTOM_PROJECT_RESOLUTION_PRESET,
   resolveProjectResolution,
 } from "../../internal/projectResolution.js";
+import { resolveUpdatesEnabled } from "../../internal/updates.js";
 
 const mapCloudProject = (project) => {
   const projectId = project?.id;
@@ -419,8 +420,8 @@ export const handleMobileActionMenuClickItem = (deps, payload) => {
 };
 
 export const handleAppVersionClick = (deps, payload) => {
-  const { appService, store, render, updatesEnabled } = deps;
-  if (appService.getPlatform() === "web" || !updatesEnabled) {
+  const { appService, store, render } = deps;
+  if (appService.getPlatform() === "web" || !resolveUpdatesEnabled(deps)) {
     return;
   }
 
@@ -443,7 +444,7 @@ export const handleAppVersionMenuClose = (deps) => {
 };
 
 export const handleAppVersionMenuClickItem = async (deps, payload) => {
-  const { appService, store, render, updaterService, updatesEnabled } = deps;
+  const { appService, store, render, updaterService } = deps;
   const detail = payload._event.detail;
   const item = detail.item || detail;
 
@@ -453,7 +454,7 @@ export const handleAppVersionMenuClickItem = async (deps, payload) => {
   if (
     item.value === "check-update" &&
     appService.getPlatform() !== "web" &&
-    updatesEnabled &&
+    resolveUpdatesEnabled(deps) &&
     updaterService
   ) {
     await updaterService.checkForUpdates(false);

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -7,6 +7,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 // Infra - Tauri
 import { createDb } from "./deps/clients/tauri/db";
 import { createTauriFilePicker } from "./deps/clients/tauri/filePicker";
+import createUpdater from "./deps/clients/tauri/updater";
 import { setupCloseListener } from "./deps/clients/tauri/windowClose";
 
 // Services
@@ -45,7 +46,7 @@ const creatorVersion = deriveProjectFormatVersionFromAppVersion(appVersion);
 
 // Create updater
 const updater = updatesEnabled
-  ? (await import("./deps/clients/tauri/updater")).default({
+  ? createUpdater({
       globalUI,
       keyValueStore: appDb,
     })

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -7,7 +7,6 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 // Infra - Tauri
 import { createDb } from "./deps/clients/tauri/db";
 import { createTauriFilePicker } from "./deps/clients/tauri/filePicker";
-import createUpdater from "./deps/clients/tauri/updater";
 import { setupCloseListener } from "./deps/clients/tauri/windowClose";
 
 // Services
@@ -25,6 +24,10 @@ import { registerPrimitives } from "./primitives/registerPrimitives";
 
 registerPrimitives();
 
+const rawDistribution = import.meta.env?.VITE_ROUTEVN_DISTRIBUTION;
+const distribution = rawDistribution === "steam" ? "steam" : "direct";
+const updatesEnabled = distribution !== "steam";
+
 // Initialize app database
 const appDb = createDb({ path: "sqlite:app.db" });
 await appDb.init();
@@ -41,7 +44,12 @@ const appVersion = await getVersion();
 const creatorVersion = deriveProjectFormatVersionFromAppVersion(appVersion);
 
 // Create updater
-const updater = createUpdater({ globalUI, keyValueStore: appDb });
+const updater = updatesEnabled
+  ? (await import("./deps/clients/tauri/updater")).default({
+      globalUI,
+      keyValueStore: appDb,
+    })
+  : undefined;
 
 // Create subject for inter-component communication
 const subject = new Subject();
@@ -63,6 +71,8 @@ const appService = createAppService({
   openUrl,
   appVersion,
   platform: "tauri",
+  distribution,
+  updatesEnabled,
   updater,
   audioService,
   projectService,
@@ -87,6 +97,8 @@ const dialogueQueueService = createPendingQueueService({ debounceMs: 2000 });
 setupCloseListener({ globalUI });
 
 const componentDependencies = {
+  distribution,
+  updatesEnabled,
   subject,
   graphicsService,
   appService,
@@ -96,6 +108,8 @@ const componentDependencies = {
 };
 
 const pageDependencies = {
+  distribution,
+  updatesEnabled,
   subject,
   graphicsService,
   appService,

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -370,6 +370,26 @@ describe("projects app version menu", () => {
     expect(deps.render).not.toHaveBeenCalled();
   });
 
+  it("does not open the app version dropdown when updates are disabled", () => {
+    const deps = createDeps();
+    deps.updatesEnabled = false;
+
+    handleAppVersionClick(deps, {
+      _event: {
+        currentTarget: {
+          getBoundingClientRect: () => ({
+            left: 100,
+            width: 80,
+            top: 700,
+          }),
+        },
+      },
+    });
+
+    expect(deps.store.openAppVersionMenu).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+  });
+
   it("closes the app version dropdown", () => {
     const deps = createDeps();
 
@@ -399,6 +419,25 @@ describe("projects app version menu", () => {
 
   it("does not check for updates from a stale web menu event", async () => {
     const deps = createDeps({ platform: "web" });
+
+    await handleAppVersionMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "check-update",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.updaterService.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it("does not check for updates when updates are disabled", async () => {
+    const deps = createDeps();
+    deps.updatesEnabled = false;
 
     await handleAppVersionMenuClickItem(deps, {
       _event: {


### PR DESCRIPTION
## Summary
- add Steam distribution plumbing to the existing Tauri setup via `VITE_ROUTEVN_DISTRIBUTION=steam`
- disable updater checks/UI for Steam builds and avoid importing the updater client when updates are disabled
- add Steam-specific Tauri config and win/mac/linux build scripts
- document Steam release, VDF, credential, and open-source safety guidance

## Testing
- `VITE_ROUTEVN_DISTRIBUTION=steam rtgl fe build -s src/setup.tauri.js -o /tmp/routevn-tauri-steam-main.js`
- `env -u VITE_ROUTEVN_DISTRIBUTION rtgl fe build -s src/setup.tauri.js -o /tmp/routevn-tauri-direct-main.js`
- `bun prettier --check src/setup.tauri.js src/deps/services/shared/appServiceCore.js src/deps/services/shared/appShellService.js src/pages/app/app.handlers.js src/pages/projects/projects.handlers.js src/pages/about/about.handlers.js src/pages/about/about.store.js src/pages/about/about.view.yaml`
- `bunx oxlint src/setup.tauri.js src/deps/services/shared/appServiceCore.js src/deps/services/shared/appShellService.js src/pages/app/app.handlers.js src/pages/projects/projects.handlers.js src/pages/about/about.handlers.js src/pages/about/about.store.js`
- `bash -n scripts/tauri-build-win-steam.sh scripts/tauri-build-mac-steam.sh scripts/tauri-build-linux-steam.sh`
- `bun prettier --check package.json src-tauri/tauri.steam.conf.json docs/runbooks/steam-release.md docs/README.md`
- `VITE_ROUTEVN_DISTRIBUTION=steam tauri build --config src-tauri/tauri.steam.conf.json --no-bundle --debug --ci`
- pre-push hook: `oxlint && bun prettier --check src`