### PR TITLE
Add Android project folder import and export

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -1170,29 +1170,49 @@ public class MainActivity extends Activity {
 
             if (!alreadyImported) {
                 closeDatabase(projectDbPath);
-                deleteRecursively(targetDbDirectory);
-                deleteRecursively(projectRoot);
+                try {
+                    deleteRecursively(targetDbDirectory);
+                    deleteRecursively(projectRoot);
 
-                copyFile(tempDbFile, targetDbFile);
-                File tempWalFile = new File(importWorkDir, "project.db-wal");
-                if (tempWalFile.isFile()) {
-                    copyFile(tempWalFile, new File(targetDbDirectory, "project.db-wal"));
-                }
-                File tempShmFile = new File(importWorkDir, "project.db-shm");
-                if (tempShmFile.isFile()) {
-                    copyFile(tempShmFile, new File(targetDbDirectory, "project.db-shm"));
-                }
-                File tempJournalFile = new File(importWorkDir, "project.db-journal");
-                if (tempJournalFile.isFile()) {
-                    copyFile(
-                        tempJournalFile,
-                        new File(targetDbDirectory, "project.db-journal")
+                    copyFile(tempDbFile, targetDbFile);
+                    File tempWalFile = new File(importWorkDir, "project.db-wal");
+                    if (tempWalFile.isFile()) {
+                        copyFile(
+                            tempWalFile,
+                            new File(targetDbDirectory, "project.db-wal")
+                        );
+                    }
+                    File tempShmFile = new File(importWorkDir, "project.db-shm");
+                    if (tempShmFile.isFile()) {
+                        copyFile(
+                            tempShmFile,
+                            new File(targetDbDirectory, "project.db-shm")
+                        );
+                    }
+                    File tempJournalFile = new File(
+                        importWorkDir,
+                        "project.db-journal"
                     );
-                }
+                    if (tempJournalFile.isFile()) {
+                        copyFile(
+                            tempJournalFile,
+                            new File(targetDbDirectory, "project.db-journal")
+                        );
+                    }
 
-                copyDocumentDirectoryContents(filesUri, targetFilesRoot);
-                if (metadataUri != null) {
-                    copyDocumentDirectoryContents(metadataUri, targetMetadataRoot);
+                    copyDocumentDirectoryContents(filesUri, targetFilesRoot);
+                    if (metadataUri != null) {
+                        copyDocumentDirectoryContents(metadataUri, targetMetadataRoot);
+                    }
+                } catch (Exception importError) {
+                    try {
+                        closeDatabase(projectDbPath);
+                        deleteRecursively(targetDbDirectory);
+                        deleteRecursively(projectRoot);
+                    } catch (Exception cleanupError) {
+                        importError.addSuppressed(cleanupError);
+                    }
+                    throw importError;
                 }
             }
 

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -689,8 +689,9 @@ public class MainActivity extends Activity {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
                 String requestId = safePathSegment(payload.getString("requestId"));
+                boolean writable = payload.optBoolean("writable", false);
 
-                runOnUiThread(() -> launchAndroidFolderPicker(requestId));
+                runOnUiThread(() -> launchAndroidFolderPicker(requestId, writable));
                 return bridgeSuccess(true);
             } catch (Exception error) {
                 return bridgeFailure(error);
@@ -703,6 +704,20 @@ public class MainActivity extends Activity {
                 JSONObject payload = new JSONObject(payloadJson);
                 JSONObject result = importProjectFolderFromTreeUri(
                     payload.getString("uri")
+                );
+                return bridgeSuccess(result);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        @JavascriptInterface
+        public String exportProjectFolder(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                JSONObject result = exportProjectFolderToTreeUri(
+                    payload.getString("projectId"),
+                    payload.getString("destinationUri")
                 );
                 return bridgeSuccess(result);
             } catch (Exception error) {
@@ -1175,6 +1190,85 @@ public class MainActivity extends Activity {
         } finally {
             deleteRecursively(importWorkDir);
         }
+    }
+
+    private JSONObject exportProjectFolderToTreeUri(
+        String projectId,
+        String destinationUriString
+    ) throws Exception {
+        String safeProjectId = safePathSegment(projectId);
+        String normalizedUri = destinationUriString == null
+            ? ""
+            : destinationUriString.trim();
+        if (normalizedUri.isEmpty()) {
+            throw new IllegalArgumentException("Export destination is required.");
+        }
+
+        File projectDbFile = getProjectDatabaseFile(safeProjectId);
+        File projectDbDirectory = projectDbFile.getParentFile();
+        File projectRoot = getProjectRoot(safeProjectId);
+        File projectFilesRoot = new File(projectRoot, "files");
+        File projectMetadataRoot = new File(projectRoot, "file-metadata");
+        if (!projectDbFile.isFile() || !projectFilesRoot.isDirectory()) {
+            throw new IllegalArgumentException("Project storage was not found.");
+        }
+
+        closeDatabase(getProjectDatabasePath(safeProjectId));
+        JSONObject projectInfo = readProjectInfoFromDatabaseFile(projectDbFile);
+        String projectInfoId = safePathSegment(projectInfo.optString("id", ""));
+        if (!safeProjectId.equals(projectInfoId)) {
+            throw new IllegalArgumentException("Project storage id does not match.");
+        }
+
+        Uri treeUri = Uri.parse(normalizedUri);
+        Uri destinationRootUri = getTreeRootDocumentUri(treeUri);
+        if (findChildDocument(destinationRootUri, safeProjectId, true) != null) {
+            throw new IllegalStateException(
+                "A folder named " + safeProjectId + " already exists."
+            );
+        }
+
+        Uri exportRootUri = createChildDirectory(
+            destinationRootUri,
+            safeProjectId
+        );
+        copyFileToDocumentDirectory(
+            projectDbFile,
+            exportRootUri,
+            "project.db",
+            "application/vnd.sqlite3"
+        );
+        copyOptionalFileToDocumentDirectory(
+            new File(projectDbDirectory, "project.db-wal"),
+            exportRootUri,
+            "application/octet-stream"
+        );
+        copyOptionalFileToDocumentDirectory(
+            new File(projectDbDirectory, "project.db-shm"),
+            exportRootUri,
+            "application/octet-stream"
+        );
+        copyOptionalFileToDocumentDirectory(
+            new File(projectDbDirectory, "project.db-journal"),
+            exportRootUri,
+            "application/octet-stream"
+        );
+
+        Uri filesUri = createChildDirectory(exportRootUri, "files");
+        copyFileDirectoryContentsToDocumentDirectory(projectFilesRoot, filesUri);
+
+        if (projectMetadataRoot.isDirectory()) {
+            Uri metadataUri = createChildDirectory(exportRootUri, "file-metadata");
+            copyFileDirectoryContentsToDocumentDirectory(
+                projectMetadataRoot,
+                metadataUri
+            );
+        }
+
+        JSONObject result = new JSONObject();
+        result.put("uri", exportRootUri.toString());
+        result.put("name", safeProjectId);
+        return result;
     }
 
     private String getProjectDatabasePath(String projectId) {
@@ -1676,7 +1770,7 @@ public class MainActivity extends Activity {
         pendingAndroidSaveFilePickerRequestId = null;
     }
 
-    private void launchAndroidFolderPicker(String requestId) {
+    private void launchAndroidFolderPicker(String requestId, boolean writable) {
         if (pendingAndroidFolderPickerRequestId != null) {
             sendAndroidFolderPickerError(
                 requestId,
@@ -1689,6 +1783,9 @@ public class MainActivity extends Activity {
 
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        if (writable) {
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        }
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
 
@@ -1725,7 +1822,7 @@ public class MainActivity extends Activity {
             }
 
             Uri treeUri = data.getData();
-            persistTreeReadPermission(treeUri, data.getFlags());
+            persistTreePermission(treeUri, data.getFlags());
             Uri rootDocumentUri = getTreeRootDocumentUri(treeUri);
             JSONObject folder = new JSONObject();
             folder.put("uri", treeUri.toString());
@@ -1749,20 +1846,23 @@ public class MainActivity extends Activity {
         pendingAndroidFolderPickerRequestId = null;
     }
 
-    private void persistTreeReadPermission(Uri treeUri, int flags) {
+    private void persistTreePermission(Uri treeUri, int flags) {
         if (treeUri == null) {
             return;
         }
 
-        int readFlag = Intent.FLAG_GRANT_READ_URI_PERMISSION;
-        if ((flags & readFlag) == 0) {
+        int persistableFlags =
+            flags &
+            (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        if (persistableFlags == 0) {
             return;
         }
 
         try {
-            getContentResolver().takePersistableUriPermission(treeUri, readFlag);
+            getContentResolver()
+                .takePersistableUriPermission(treeUri, persistableFlags);
         } catch (Exception error) {
-            Log.w(TAG, "Failed to persist folder read permission.", error);
+            Log.w(TAG, "Failed to persist folder permission.", error);
         }
     }
 
@@ -1863,6 +1963,55 @@ public class MainActivity extends Activity {
         return childUri;
     }
 
+    private Uri createChildDirectory(Uri parentDocumentUri, String directoryName)
+        throws Exception {
+        if (
+            findChildDocument(parentDocumentUri, directoryName, true) != null ||
+            findChildDocument(parentDocumentUri, directoryName, false) != null
+        ) {
+            throw new IllegalStateException(
+                "A file or folder named " + directoryName + " already exists."
+            );
+        }
+
+        Uri childUri = DocumentsContract.createDocument(
+            getContentResolver(),
+            parentDocumentUri,
+            DocumentsContract.Document.MIME_TYPE_DIR,
+            directoryName
+        );
+        if (childUri == null) {
+            throw new IllegalStateException("Failed to create export folder.");
+        }
+        return childUri;
+    }
+
+    private Uri createChildFile(
+        Uri parentDocumentUri,
+        String filename,
+        String mimeType
+    ) throws Exception {
+        if (
+            findChildDocument(parentDocumentUri, filename, false) != null ||
+            findChildDocument(parentDocumentUri, filename, true) != null
+        ) {
+            throw new IllegalStateException(
+                "A file named " + filename + " already exists."
+            );
+        }
+
+        Uri childUri = DocumentsContract.createDocument(
+            getContentResolver(),
+            parentDocumentUri,
+            normalizeMimeType(mimeType),
+            filename
+        );
+        if (childUri == null) {
+            throw new IllegalStateException("Failed to create export file.");
+        }
+        return childUri;
+    }
+
     private String resolveDocumentDisplayName(Uri documentUri, String fallback) {
         String[] projection = new String[] {
             DocumentsContract.Document.COLUMN_DISPLAY_NAME,
@@ -1883,6 +2032,80 @@ public class MainActivity extends Activity {
         }
 
         return fallback;
+    }
+
+    private void copyFileDirectoryContentsToDocumentDirectory(
+        File sourceDirectory,
+        Uri outputDirectoryUri
+    ) throws Exception {
+        File[] children = sourceDirectory.listFiles();
+        if (children == null) {
+            return;
+        }
+
+        for (File child : children) {
+            String childName = sanitizeExportFilename(child.getName());
+            if (child.isDirectory()) {
+                Uri childDirectoryUri = createChildDirectory(
+                    outputDirectoryUri,
+                    childName
+                );
+                copyFileDirectoryContentsToDocumentDirectory(
+                    child,
+                    childDirectoryUri
+                );
+                continue;
+            }
+
+            if (child.isFile()) {
+                copyFileToDocumentDirectory(
+                    child,
+                    outputDirectoryUri,
+                    childName,
+                    URLConnection.guessContentTypeFromName(childName)
+                );
+            }
+        }
+    }
+
+    private void copyOptionalFileToDocumentDirectory(
+        File sourceFile,
+        Uri outputDirectoryUri,
+        String mimeType
+    ) throws Exception {
+        if (!sourceFile.isFile()) {
+            return;
+        }
+
+        copyFileToDocumentDirectory(
+            sourceFile,
+            outputDirectoryUri,
+            sanitizeExportFilename(sourceFile.getName()),
+            mimeType
+        );
+    }
+
+    private void copyFileToDocumentDirectory(
+        File sourceFile,
+        Uri outputDirectoryUri,
+        String filename,
+        String mimeType
+    ) throws Exception {
+        Uri outputFileUri = createChildFile(
+            outputDirectoryUri,
+            sanitizeExportFilename(filename),
+            mimeType
+        );
+        try (
+            FileInputStream input = new FileInputStream(sourceFile);
+            OutputStream output = getContentResolver()
+                .openOutputStream(outputFileUri, "wt")
+        ) {
+            if (output == null) {
+                throw new IllegalStateException("Failed to open export file.");
+            }
+            writeOutputStream(output, input);
+        }
     }
 
     private void copyDocumentDirectoryContents(Uri directoryUri, File outputDirectory)
@@ -2020,6 +2243,14 @@ public class MainActivity extends Activity {
     }
 
     private String sanitizeImportedFilename(String filename) {
+        String resolvedFilename = filename == null ? "" : filename.trim();
+        if (resolvedFilename.isEmpty()) {
+            resolvedFilename = "file";
+        }
+        return resolvedFilename.replaceAll("[\\\\/]+", "-");
+    }
+
+    private String sanitizeExportFilename(String filename) {
         String resolvedFilename = filename == null ? "" : filename.trim();
         if (resolvedFilename.isEmpty()) {
             resolvedFilename = "file";
@@ -2343,14 +2574,19 @@ public class MainActivity extends Activity {
             throw new IllegalStateException("Failed to create output directory.");
         }
 
-        long totalBytes = 0;
         try (FileOutputStream output = new FileOutputStream(file)) {
-            byte[] buffer = new byte[8192];
-            int read;
-            while ((read = input.read(buffer)) != -1) {
-                output.write(buffer, 0, read);
-                totalBytes += read;
-            }
+            return writeOutputStream(output, input);
+        }
+    }
+
+    private long writeOutputStream(OutputStream output, InputStream input)
+        throws Exception {
+        long totalBytes = 0;
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+            totalBytes += read;
         }
         return totalBytes;
     }

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -50,7 +50,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -715,11 +718,32 @@ public class MainActivity extends Activity {
         public String exportProjectFolder(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
-                JSONObject result = exportProjectFolderToTreeUri(
-                    payload.getString("projectId"),
-                    payload.getString("destinationUri")
-                );
-                return bridgeSuccess(result);
+                String requestId = safePathSegment(payload.getString("requestId"));
+                String projectId = payload.getString("projectId");
+                String destinationUri = payload.getString("destinationUri");
+
+                Thread exportThread = new Thread(() -> {
+                    try {
+                        JSONObject exportResult = exportProjectFolderToTreeUri(
+                            projectId,
+                            destinationUri
+                        );
+                        JSONObject result = new JSONObject();
+                        result.put("requestId", requestId);
+                        result.put("export", exportResult);
+                        sendAndroidProjectExportResult(result);
+                    } catch (Exception error) {
+                        sendAndroidProjectExportError(
+                            requestId,
+                            error.getMessage() == null
+                                ? "Failed to export project."
+                                : error.getMessage(),
+                            error
+                        );
+                    }
+                });
+                exportThread.start();
+                return bridgeSuccess(true);
             } catch (Exception error) {
                 return bridgeFailure(error);
             }
@@ -745,6 +769,7 @@ public class MainActivity extends Activity {
     }
 
     private String bridgeFailure(Exception error) {
+        Log.e(TAG, "Android bridge call failed.", error);
         try {
             JSONObject result = new JSONObject();
             JSONObject errorBody = new JSONObject();
@@ -1219,18 +1244,14 @@ public class MainActivity extends Activity {
         if (!safeProjectId.equals(projectInfoId)) {
             throw new IllegalArgumentException("Project storage id does not match.");
         }
+        String exportFolderName = resolveProjectExportFolderName(projectInfo);
 
         Uri treeUri = Uri.parse(normalizedUri);
         Uri destinationRootUri = getTreeRootDocumentUri(treeUri);
-        if (findChildDocument(destinationRootUri, safeProjectId, true) != null) {
-            throw new IllegalStateException(
-                "A folder named " + safeProjectId + " already exists."
-            );
-        }
 
         Uri exportRootUri = createChildDirectory(
             destinationRootUri,
-            safeProjectId
+            exportFolderName
         );
         copyFileToDocumentDirectory(
             projectDbFile,
@@ -1267,8 +1288,17 @@ public class MainActivity extends Activity {
 
         JSONObject result = new JSONObject();
         result.put("uri", exportRootUri.toString());
-        result.put("name", safeProjectId);
+        result.put("name", exportFolderName);
         return result;
+    }
+
+    private String resolveProjectExportFolderName(JSONObject projectInfo) {
+        String title = sanitizeExportFolderTitle(projectInfo.optString("name", ""));
+        String timestamp = new SimpleDateFormat(
+            "yyyyMMdd-HHmmss-SSS",
+            Locale.US
+        ).format(new Date());
+        return title + "-" + timestamp;
     }
 
     private String getProjectDatabasePath(String projectId) {
@@ -2258,6 +2288,25 @@ public class MainActivity extends Activity {
         return resolvedFilename.replaceAll("[\\\\/]+", "-");
     }
 
+    private String sanitizeExportFolderTitle(String title) {
+        String resolvedTitle = title == null ? "" : title.trim();
+        if (resolvedTitle.isEmpty()) {
+            resolvedTitle = "RouteVN Project";
+        }
+
+        resolvedTitle = resolvedTitle.replaceAll("[\\\\/:*?\"<>|\\r\\n\\t]+", " ");
+        resolvedTitle = resolvedTitle.replaceAll("\\s+", " ").trim();
+        resolvedTitle = resolvedTitle.replaceAll("^\\.+", "");
+        resolvedTitle = resolvedTitle.replaceAll("\\.+$", "").trim();
+        if (resolvedTitle.isEmpty()) {
+            resolvedTitle = "RouteVN Project";
+        }
+        if (resolvedTitle.length() > 80) {
+            resolvedTitle = resolvedTitle.substring(0, 80).trim();
+        }
+        return resolvedTitle;
+    }
+
     private JSONObject createPickerFileResult(
         String requestId,
         Uri uri,
@@ -2514,6 +2563,42 @@ public class MainActivity extends Activity {
             ");",
             null
         );
+    }
+
+    private void sendAndroidProjectExportError(
+        String requestId,
+        String message,
+        Exception error
+    ) {
+        Log.e(TAG, "Failed to export Android project.", error);
+        try {
+            JSONObject result = new JSONObject();
+            JSONObject errorBody = new JSONObject();
+            result.put("requestId", requestId);
+            errorBody.put("message", message);
+            result.put("error", errorBody);
+            sendAndroidProjectExportResult(result);
+        } catch (Exception ignored) {
+            // Nothing useful to report if JSON construction fails.
+        }
+    }
+
+    private void sendAndroidProjectExportResult(JSONObject result) {
+        if (webView == null) {
+            return;
+        }
+
+        mainHandler.post(() -> {
+            if (webView == null) {
+                return;
+            }
+            webView.evaluateJavascript(
+                "(function(result){if(window.__routeVNAndroidProjectExportResult){window.__routeVNAndroidProjectExportResult(result);}})(" +
+                result.toString() +
+                ");",
+                null
+            );
+        });
     }
 
     private File resolveSafeRelativeFile(File root, String relativePath)

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -1293,7 +1293,7 @@ public class MainActivity extends Activity {
     private String resolveProjectExportFolderName(JSONObject projectInfo) {
         String title = sanitizeExportFolderTitle(projectInfo.optString("name", ""));
         String timestamp = new SimpleDateFormat(
-            "yyyyMMdd-HHmmss-SSS",
+            "yyyyMMdd-HHmmss",
             Locale.US
         ).format(new Date());
         return title + "-" + timestamp;

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -1230,15 +1230,13 @@ public class MainActivity extends Activity {
         }
 
         File projectDbFile = getProjectDatabaseFile(safeProjectId);
-        File projectDbDirectory = projectDbFile.getParentFile();
         File projectRoot = getProjectRoot(safeProjectId);
         File projectFilesRoot = new File(projectRoot, "files");
-        File projectMetadataRoot = new File(projectRoot, "file-metadata");
         if (!projectDbFile.isFile() || !projectFilesRoot.isDirectory()) {
             throw new IllegalArgumentException("Project storage was not found.");
         }
 
-        closeDatabase(getProjectDatabasePath(safeProjectId));
+        checkpointProjectDatabaseForExport(safeProjectId);
         JSONObject projectInfo = readProjectInfoFromDatabaseFile(projectDbFile);
         String projectInfoId = safePathSegment(projectInfo.optString("id", ""));
         if (!safeProjectId.equals(projectInfoId)) {
@@ -1259,37 +1257,37 @@ public class MainActivity extends Activity {
             "project.db",
             "application/vnd.sqlite3"
         );
-        copyOptionalFileToDocumentDirectory(
-            new File(projectDbDirectory, "project.db-wal"),
-            exportRootUri,
-            "application/octet-stream"
-        );
-        copyOptionalFileToDocumentDirectory(
-            new File(projectDbDirectory, "project.db-shm"),
-            exportRootUri,
-            "application/octet-stream"
-        );
-        copyOptionalFileToDocumentDirectory(
-            new File(projectDbDirectory, "project.db-journal"),
-            exportRootUri,
-            "application/octet-stream"
-        );
 
         Uri filesUri = createChildDirectory(exportRootUri, "files");
         copyFileDirectoryContentsToDocumentDirectory(projectFilesRoot, filesUri);
-
-        if (projectMetadataRoot.isDirectory()) {
-            Uri metadataUri = createChildDirectory(exportRootUri, "file-metadata");
-            copyFileDirectoryContentsToDocumentDirectory(
-                projectMetadataRoot,
-                metadataUri
-            );
-        }
 
         JSONObject result = new JSONObject();
         result.put("uri", exportRootUri.toString());
         result.put("name", exportFolderName);
         return result;
+    }
+
+    private void checkpointProjectDatabaseForExport(String projectId)
+        throws Exception {
+        String projectDbPath = getProjectDatabasePath(projectId);
+        closeDatabase(projectDbPath);
+
+        File projectDbFile = getProjectDatabaseFile(projectId);
+        SQLiteDatabase database = SQLiteDatabase.openDatabase(
+            projectDbFile.getAbsolutePath(),
+            null,
+            SQLiteDatabase.OPEN_READWRITE
+        );
+        try (
+            Cursor ignored = database.rawQuery(
+                "PRAGMA wal_checkpoint(TRUNCATE)",
+                null
+            )
+        ) {
+            // Materialize pending WAL frames into project.db before copying it.
+        } finally {
+            database.close();
+        }
     }
 
     private String resolveProjectExportFolderName(JSONObject projectInfo) {
@@ -2096,23 +2094,6 @@ public class MainActivity extends Activity {
                 );
             }
         }
-    }
-
-    private void copyOptionalFileToDocumentDirectory(
-        File sourceFile,
-        Uri outputDirectoryUri,
-        String mimeType
-    ) throws Exception {
-        if (!sourceFile.isFile()) {
-            return;
-        }
-
-        copyFileToDocumentDirectory(
-            sourceFile,
-            outputDirectoryUri,
-            sanitizeExportFilename(sourceFile.getName()),
-            mimeType
-        );
     }
 
     private void copyFileToDocumentDirectory(

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -1255,7 +1255,7 @@ public class MainActivity extends Activity {
             projectDbFile,
             exportRootUri,
             "project.db",
-            "application/vnd.sqlite3"
+            "application/octet-stream"
         );
 
         Uri filesUri = createChildDirectory(exportRootUri, "files");

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -18,6 +18,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.OpenableColumns;
 import android.provider.MediaStore;
+import android.provider.DocumentsContract;
 import android.util.Base64;
 import android.util.Log;
 import android.view.WindowInsets;
@@ -61,6 +62,7 @@ public class MainActivity extends Activity {
     private static final int FILE_CHOOSER_REQUEST_CODE = 3711;
     private static final int ANDROID_FILE_PICKER_REQUEST_CODE = 3712;
     private static final int ANDROID_SAVE_FILE_PICKER_REQUEST_CODE = 3713;
+    private static final int ANDROID_FOLDER_PICKER_REQUEST_CODE = 3714;
     private static final long SPLASH_MIN_VISIBLE_MS = 1400L;
     private static final long SPLASH_MAX_VISIBLE_MS = 5000L;
 
@@ -76,6 +78,7 @@ public class MainActivity extends Activity {
     private String pendingAndroidFilePickerRequestId;
     private boolean pendingAndroidFilePickerMultiple = false;
     private String pendingAndroidSaveFilePickerRequestId;
+    private String pendingAndroidFolderPickerRequestId;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final Runnable finishSplashRunnable = this::finishSplash;
     private final Map<String, SQLiteDatabase> sqliteDatabases = new HashMap<>();
@@ -335,6 +338,11 @@ public class MainActivity extends Activity {
             return;
         }
 
+        if (requestCode == ANDROID_FOLDER_PICKER_REQUEST_CODE) {
+            handleAndroidFolderPickerActivityResult(resultCode, data);
+            return;
+        }
+
         if (requestCode != FILE_CHOOSER_REQUEST_CODE || fileChooserCallback == null) {
             return;
         }
@@ -558,6 +566,15 @@ public class MainActivity extends Activity {
         }
 
         @JavascriptInterface
+        public String listProjectFolders(String payloadJson) {
+            try {
+                return bridgeSuccess(MainActivity.this.listProjectFolders());
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        @JavascriptInterface
         public String writeProjectFile(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -662,6 +679,32 @@ public class MainActivity extends Activity {
                     launchAndroidSaveFilePicker(requestId, filename, mimeType)
                 );
                 return bridgeSuccess(true);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        @JavascriptInterface
+        public String openFolderPicker(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                String requestId = safePathSegment(payload.getString("requestId"));
+
+                runOnUiThread(() -> launchAndroidFolderPicker(requestId));
+                return bridgeSuccess(true);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        @JavascriptInterface
+        public String importProjectFolder(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                JSONObject result = importProjectFolderFromTreeUri(
+                    payload.getString("uri")
+                );
+                return bridgeSuccess(result);
             } catch (Exception error) {
                 return bridgeFailure(error);
             }
@@ -1026,6 +1069,191 @@ public class MainActivity extends Activity {
         }
 
         return uri.toString();
+    }
+
+    private JSONObject importProjectFolderFromTreeUri(String uriString)
+        throws Exception {
+        String normalizedUri = uriString == null ? "" : uriString.trim();
+        if (normalizedUri.isEmpty()) {
+            throw new IllegalArgumentException("Project folder is required.");
+        }
+
+        Uri treeUri = Uri.parse(normalizedUri);
+        Uri rootDocumentUri = getTreeRootDocumentUri(treeUri);
+        Uri projectDbUri = requireChildDocument(
+            rootDocumentUri,
+            "project.db",
+            false
+        );
+        Uri filesUri = requireChildDocument(rootDocumentUri, "files", true);
+        Uri metadataUri = findChildDocument(rootDocumentUri, "file-metadata", true);
+        Uri projectWalUri = findChildDocument(rootDocumentUri, "project.db-wal", false);
+        Uri projectShmUri = findChildDocument(rootDocumentUri, "project.db-shm", false);
+        Uri projectJournalUri = findChildDocument(
+            rootDocumentUri,
+            "project.db-journal",
+            false
+        );
+
+        File importRoot = new File(getCacheDir(), "project-import");
+        File importWorkDir = new File(
+            importRoot,
+            String.valueOf(System.currentTimeMillis())
+        );
+        deleteRecursively(importWorkDir);
+
+        try {
+            File tempDbFile = new File(importWorkDir, "project.db");
+            copyDocumentToFile(projectDbUri, tempDbFile);
+            if (projectWalUri != null) {
+                copyDocumentToFile(projectWalUri, new File(importWorkDir, "project.db-wal"));
+            }
+            if (projectShmUri != null) {
+                copyDocumentToFile(projectShmUri, new File(importWorkDir, "project.db-shm"));
+            }
+            if (projectJournalUri != null) {
+                copyDocumentToFile(
+                    projectJournalUri,
+                    new File(importWorkDir, "project.db-journal")
+                );
+            }
+
+            JSONObject projectInfo = readProjectInfoFromDatabaseFile(tempDbFile);
+            String projectId = safePathSegment(projectInfo.optString("id", ""));
+            String projectDbPath = getProjectDatabasePath(projectId);
+            File targetDbFile = getProjectDatabaseFile(projectId);
+            File targetDbDirectory = targetDbFile.getParentFile();
+            File projectRoot = getProjectRoot(projectId);
+            File targetFilesRoot = new File(projectRoot, "files");
+            File targetMetadataRoot = new File(projectRoot, "file-metadata");
+            boolean alreadyImported = targetDbFile.isFile() && targetFilesRoot.isDirectory();
+
+            if (!alreadyImported) {
+                closeDatabase(projectDbPath);
+                deleteRecursively(targetDbDirectory);
+                deleteRecursively(projectRoot);
+
+                copyFile(tempDbFile, targetDbFile);
+                File tempWalFile = new File(importWorkDir, "project.db-wal");
+                if (tempWalFile.isFile()) {
+                    copyFile(tempWalFile, new File(targetDbDirectory, "project.db-wal"));
+                }
+                File tempShmFile = new File(importWorkDir, "project.db-shm");
+                if (tempShmFile.isFile()) {
+                    copyFile(tempShmFile, new File(targetDbDirectory, "project.db-shm"));
+                }
+                File tempJournalFile = new File(importWorkDir, "project.db-journal");
+                if (tempJournalFile.isFile()) {
+                    copyFile(
+                        tempJournalFile,
+                        new File(targetDbDirectory, "project.db-journal")
+                    );
+                }
+
+                copyDocumentDirectoryContents(filesUri, targetFilesRoot);
+                if (metadataUri != null) {
+                    copyDocumentDirectoryContents(metadataUri, targetMetadataRoot);
+                }
+            }
+
+            JSONObject result = new JSONObject();
+            result.put("id", projectId);
+            result.put("name", projectInfo.optString("name", ""));
+            result.put("description", projectInfo.optString("description", ""));
+            if (projectInfo.has("iconFileId") && !projectInfo.isNull("iconFileId")) {
+                result.put("iconFileId", projectInfo.optString("iconFileId", ""));
+            } else {
+                result.put("iconFileId", JSONObject.NULL);
+            }
+            result.put("sourceUri", normalizedUri);
+            result.put(
+                "sourceName",
+                resolveDocumentDisplayName(rootDocumentUri, "Selected Folder")
+            );
+            result.put("alreadyImported", alreadyImported);
+            return result;
+        } finally {
+            deleteRecursively(importWorkDir);
+        }
+    }
+
+    private String getProjectDatabasePath(String projectId) {
+        return "projects/" + safePathSegment(projectId) + "/project.db";
+    }
+
+    private File getProjectDatabaseFile(String projectId) throws Exception {
+        return resolveSafeRelativeFile(
+            new File(getFilesDir(), "databases"),
+            getProjectDatabasePath(projectId)
+        );
+    }
+
+    private JSONArray listProjectFolders() throws Exception {
+        JSONArray projects = new JSONArray();
+        File projectDatabasesRoot = new File(
+            new File(getFilesDir(), "databases"),
+            "projects"
+        );
+        File[] projectDirectories = projectDatabasesRoot.listFiles();
+        if (projectDirectories == null) {
+            return projects;
+        }
+
+        for (File projectDirectory : projectDirectories) {
+            if (!projectDirectory.isDirectory()) {
+                continue;
+            }
+
+            String projectId;
+            try {
+                projectId = safePathSegment(projectDirectory.getName());
+            } catch (Exception error) {
+                continue;
+            }
+
+            File projectDbFile = new File(projectDirectory, "project.db");
+            File projectFilesRoot = new File(getProjectRoot(projectId), "files");
+            if (!projectDbFile.isFile() || !projectFilesRoot.isDirectory()) {
+                continue;
+            }
+
+            try {
+                JSONObject projectInfo = readProjectInfoFromDatabaseFile(
+                    projectDbFile
+                );
+                String projectInfoId = safePathSegment(
+                    projectInfo.optString("id", "")
+                );
+                if (!projectId.equals(projectInfoId)) {
+                    continue;
+                }
+
+                JSONObject project = new JSONObject();
+                project.put("id", projectId);
+                project.put("name", projectInfo.optString("name", ""));
+                project.put(
+                    "description",
+                    projectInfo.optString("description", "")
+                );
+                if (
+                    projectInfo.has("iconFileId") &&
+                    !projectInfo.isNull("iconFileId")
+                ) {
+                    project.put("iconFileId", projectInfo.optString("iconFileId", ""));
+                } else {
+                    project.put("iconFileId", JSONObject.NULL);
+                }
+                projects.put(project);
+            } catch (Exception error) {
+                Log.w(
+                    TAG,
+                    "Skipping invalid Android project folder: " + projectId,
+                    error
+                );
+            }
+        }
+
+        return projects;
     }
 
     private File getProjectRoot(String projectId) throws Exception {
@@ -1448,6 +1676,96 @@ public class MainActivity extends Activity {
         pendingAndroidSaveFilePickerRequestId = null;
     }
 
+    private void launchAndroidFolderPicker(String requestId) {
+        if (pendingAndroidFolderPickerRequestId != null) {
+            sendAndroidFolderPickerError(
+                requestId,
+                "Another folder picker is already open."
+            );
+            return;
+        }
+
+        pendingAndroidFolderPickerRequestId = requestId;
+
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+        intent.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION);
+
+        try {
+            startActivityForResult(intent, ANDROID_FOLDER_PICKER_REQUEST_CODE);
+        } catch (ActivityNotFoundException error) {
+            clearPendingAndroidFolderPicker();
+            sendAndroidFolderPickerError(
+                requestId,
+                "No folder picker is available."
+            );
+        }
+    }
+
+    private void handleAndroidFolderPickerActivityResult(
+        int resultCode,
+        Intent data
+    ) {
+        String requestId = pendingAndroidFolderPickerRequestId;
+        clearPendingAndroidFolderPicker();
+
+        if (requestId == null) {
+            return;
+        }
+
+        try {
+            JSONObject result = new JSONObject();
+            result.put("requestId", requestId);
+
+            if (resultCode != RESULT_OK || data == null || data.getData() == null) {
+                result.put("folder", JSONObject.NULL);
+                sendAndroidFolderPickerResult(result);
+                return;
+            }
+
+            Uri treeUri = data.getData();
+            persistTreeReadPermission(treeUri, data.getFlags());
+            Uri rootDocumentUri = getTreeRootDocumentUri(treeUri);
+            JSONObject folder = new JSONObject();
+            folder.put("uri", treeUri.toString());
+            folder.put(
+                "name",
+                resolveDocumentDisplayName(rootDocumentUri, "Selected Folder")
+            );
+            result.put("folder", folder);
+            sendAndroidFolderPickerResult(result);
+        } catch (Exception error) {
+            sendAndroidFolderPickerError(
+                requestId,
+                error.getMessage() == null
+                    ? "Failed to select folder."
+                    : error.getMessage()
+            );
+        }
+    }
+
+    private void clearPendingAndroidFolderPicker() {
+        pendingAndroidFolderPickerRequestId = null;
+    }
+
+    private void persistTreeReadPermission(Uri treeUri, int flags) {
+        if (treeUri == null) {
+            return;
+        }
+
+        int readFlag = Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        if ((flags & readFlag) == 0) {
+            return;
+        }
+
+        try {
+            getContentResolver().takePersistableUriPermission(treeUri, readFlag);
+        } catch (Exception error) {
+            Log.w(TAG, "Failed to persist folder read permission.", error);
+        }
+    }
+
     private JSONArray collectPickedUris(Intent data, boolean multiple)
         throws Exception {
         JSONArray uris = new JSONArray();
@@ -1467,6 +1785,246 @@ public class MainActivity extends Activity {
             uris.put(uri.toString());
         }
         return uris;
+    }
+
+    private Uri getTreeRootDocumentUri(Uri treeUri) {
+        return DocumentsContract.buildDocumentUriUsingTree(
+            treeUri,
+            DocumentsContract.getTreeDocumentId(treeUri)
+        );
+    }
+
+    private Uri getChildDocumentsUri(Uri directoryUri) {
+        return DocumentsContract.buildChildDocumentsUriUsingTree(
+            directoryUri,
+            DocumentsContract.getDocumentId(directoryUri)
+        );
+    }
+
+    private Uri findChildDocument(
+        Uri parentDocumentUri,
+        String childName,
+        boolean shouldBeDirectory
+    ) throws Exception {
+        String[] projection = new String[] {
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            DocumentsContract.Document.COLUMN_MIME_TYPE,
+        };
+        Uri childrenUri = getChildDocumentsUri(parentDocumentUri);
+
+        try (
+            Cursor cursor = getContentResolver()
+                .query(childrenUri, projection, null, null, null)
+        ) {
+            if (cursor == null) {
+                return null;
+            }
+
+            while (cursor.moveToNext()) {
+                String displayName = cursor.getString(1);
+                if (!childName.equals(displayName)) {
+                    continue;
+                }
+
+                String mimeType = cursor.getString(2);
+                boolean isDirectory = DocumentsContract.Document.MIME_TYPE_DIR.equals(
+                    mimeType
+                );
+                if (shouldBeDirectory != isDirectory) {
+                    return null;
+                }
+
+                return DocumentsContract.buildDocumentUriUsingTree(
+                    parentDocumentUri,
+                    cursor.getString(0)
+                );
+            }
+        }
+
+        return null;
+    }
+
+    private Uri requireChildDocument(
+        Uri parentDocumentUri,
+        String childName,
+        boolean shouldBeDirectory
+    ) throws Exception {
+        Uri childUri = findChildDocument(
+            parentDocumentUri,
+            childName,
+            shouldBeDirectory
+        );
+        if (childUri == null) {
+            throw new IllegalArgumentException(
+                "Selected folder is missing " + childName + "."
+            );
+        }
+        return childUri;
+    }
+
+    private String resolveDocumentDisplayName(Uri documentUri, String fallback) {
+        String[] projection = new String[] {
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+        };
+
+        try (
+            Cursor cursor = getContentResolver()
+                .query(documentUri, projection, null, null, null)
+        ) {
+            if (cursor != null && cursor.moveToFirst()) {
+                String displayName = cursor.getString(0);
+                if (displayName != null && !displayName.trim().isEmpty()) {
+                    return displayName;
+                }
+            }
+        } catch (Exception ignored) {
+            // Keep the fallback if the provider cannot return a display name.
+        }
+
+        return fallback;
+    }
+
+    private void copyDocumentDirectoryContents(Uri directoryUri, File outputDirectory)
+        throws Exception {
+        if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
+            throw new IllegalStateException("Failed to create import directory.");
+        }
+
+        String[] projection = new String[] {
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            DocumentsContract.Document.COLUMN_MIME_TYPE,
+        };
+        Uri childrenUri = getChildDocumentsUri(directoryUri);
+
+        try (
+            Cursor cursor = getContentResolver()
+                .query(childrenUri, projection, null, null, null)
+        ) {
+            if (cursor == null) {
+                return;
+            }
+
+            while (cursor.moveToNext()) {
+                String childDocumentId = cursor.getString(0);
+                String displayName = sanitizeImportedFilename(cursor.getString(1));
+                String mimeType = cursor.getString(2);
+                Uri childUri = DocumentsContract.buildDocumentUriUsingTree(
+                    directoryUri,
+                    childDocumentId
+                );
+                File outputFile = resolveSafeRelativeFile(
+                    outputDirectory,
+                    displayName
+                );
+
+                if (DocumentsContract.Document.MIME_TYPE_DIR.equals(mimeType)) {
+                    copyDocumentDirectoryContents(childUri, outputFile);
+                } else {
+                    copyDocumentToFile(childUri, outputFile);
+                }
+            }
+        }
+    }
+
+    private void copyDocumentToFile(Uri documentUri, File outputFile)
+        throws Exception {
+        try (InputStream input = getContentResolver().openInputStream(documentUri)) {
+            if (input == null) {
+                throw new IllegalStateException("Failed to read selected project.");
+            }
+            writeStream(outputFile, input);
+        }
+    }
+
+    private void copyFile(File sourceFile, File outputFile) throws Exception {
+        try (FileInputStream input = new FileInputStream(sourceFile)) {
+            writeStream(outputFile, input);
+        }
+    }
+
+    private JSONObject readProjectInfoFromDatabaseFile(File databaseFile)
+        throws Exception {
+        SQLiteDatabase database = SQLiteDatabase.openDatabase(
+            databaseFile.getAbsolutePath(),
+            null,
+            SQLiteDatabase.OPEN_READONLY
+        );
+
+        try {
+            String rawProjectInfo = readAppStateValue(database, "projectInfo");
+            if (rawProjectInfo == null || rawProjectInfo.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Selected folder is not a RouteVN project."
+                );
+            }
+
+            JSONObject projectInfo = new JSONObject(rawProjectInfo);
+            if (projectInfo.optString("id", "").trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Selected project is missing an id."
+                );
+            }
+            return projectInfo;
+        } finally {
+            database.close();
+        }
+    }
+
+    private String readAppStateValue(SQLiteDatabase database, String key)
+        throws Exception {
+        if (hasTable(database, "app_state")) {
+            String value = readKeyValueTableValue(database, "app_state", key);
+            if (value != null) {
+                return value;
+            }
+        }
+
+        if (hasTable(database, "kv")) {
+            return readKeyValueTableValue(database, "kv", key);
+        }
+
+        return null;
+    }
+
+    private boolean hasTable(SQLiteDatabase database, String tableName)
+        throws Exception {
+        try (
+            Cursor cursor = database.rawQuery(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                new String[] { tableName }
+            )
+        ) {
+            return cursor.moveToFirst();
+        }
+    }
+
+    private String readKeyValueTableValue(
+        SQLiteDatabase database,
+        String tableName,
+        String key
+    ) throws Exception {
+        try (
+            Cursor cursor = database.rawQuery(
+                "SELECT value FROM " + tableName + " WHERE key = ?",
+                new String[] { key }
+            )
+        ) {
+            if (!cursor.moveToFirst()) {
+                return null;
+            }
+
+            return cursor.getString(0);
+        }
+    }
+
+    private String sanitizeImportedFilename(String filename) {
+        String resolvedFilename = filename == null ? "" : filename.trim();
+        if (resolvedFilename.isEmpty()) {
+            resolvedFilename = "file";
+        }
+        return resolvedFilename.replaceAll("[\\\\/]+", "-");
     }
 
     private JSONObject createPickerFileResult(
@@ -1695,6 +2253,32 @@ public class MainActivity extends Activity {
 
         webView.evaluateJavascript(
             "(function(result){if(window.__routeVNAndroidSaveFileResult){window.__routeVNAndroidSaveFileResult(result);}})(" +
+            result.toString() +
+            ");",
+            null
+        );
+    }
+
+    private void sendAndroidFolderPickerError(String requestId, String message) {
+        try {
+            JSONObject result = new JSONObject();
+            JSONObject error = new JSONObject();
+            result.put("requestId", requestId);
+            error.put("message", message);
+            result.put("error", error);
+            sendAndroidFolderPickerResult(result);
+        } catch (Exception ignored) {
+            // Nothing useful to report if JSON construction fails.
+        }
+    }
+
+    private void sendAndroidFolderPickerResult(JSONObject result) {
+        if (webView == null) {
+            return;
+        }
+
+        webView.evaluateJavascript(
+            "(function(result){if(window.__routeVNAndroidFolderPickerResult){window.__routeVNAndroidFolderPickerResult(result);}})(" +
             result.toString() +
             ");",
             null

--- a/src/deps/clients/android/filePicker.js
+++ b/src/deps/clients/android/filePicker.js
@@ -247,6 +247,7 @@ const requestNativeAndroidFolderPicker = (options = {}) => {
       callAndroidBridge("openFolderPicker", {
         requestId,
         title: options.title || "Select Folder",
+        writable: options.writable === true,
       });
     } catch (error) {
       pendingAndroidFolderPickers.delete(requestId);

--- a/src/deps/clients/android/filePicker.js
+++ b/src/deps/clients/android/filePicker.js
@@ -3,11 +3,14 @@ import { callAndroidBridge, uint8ArrayToBase64 } from "./bridge.js";
 const ANDROID_FILE_PICKER_INPUT_ID = "routevnAndroidFilePickerInput";
 const ANDROID_FILE_PICKER_CALLBACK = "__routeVNAndroidFilePickerResult";
 const ANDROID_SAVE_FILE_PICKER_CALLBACK = "__routeVNAndroidSaveFileResult";
+const ANDROID_FOLDER_PICKER_CALLBACK = "__routeVNAndroidFolderPickerResult";
 
 let nextAndroidFilePickerRequestId = 1;
 let nextAndroidSaveFilePickerRequestId = 1;
+let nextAndroidFolderPickerRequestId = 1;
 const pendingAndroidFilePickers = new Map();
 const pendingAndroidSaveFilePickers = new Map();
+const pendingAndroidFolderPickers = new Map();
 
 const isTruthyFlag = (value) => {
   if (typeof value === "boolean") {
@@ -135,6 +138,12 @@ const createAndroidSaveFilePickerRequestId = () => {
   return requestId;
 };
 
+const createAndroidFolderPickerRequestId = () => {
+  const requestId = `folder-${nextAndroidFolderPickerRequestId}`;
+  nextAndroidFolderPickerRequestId += 1;
+  return requestId;
+};
+
 const resolveSaveFilename = (options = {}) => {
   return options.defaultPath || options.filename || "download";
 };
@@ -183,6 +192,26 @@ const ensureAndroidSaveFilePickerCallback = () => {
   };
 };
 
+const ensureAndroidFolderPickerCallback = () => {
+  window[ANDROID_FOLDER_PICKER_CALLBACK] = (result = {}) => {
+    const requestId = result.requestId;
+    const pending = pendingAndroidFolderPickers.get(requestId);
+    if (!pending) {
+      return;
+    }
+
+    pendingAndroidFolderPickers.delete(requestId);
+    if (result.error) {
+      pending.reject(
+        new Error(result.error.message || "Failed to select folder."),
+      );
+      return;
+    }
+
+    pending.resolve(result.folder ?? null);
+  };
+};
+
 const requestNativeAndroidFilePicker = (options = {}) => {
   const requestId = createAndroidFilePickerRequestId();
   ensureAndroidFilePickerCallback();
@@ -198,6 +227,29 @@ const requestNativeAndroidFilePicker = (options = {}) => {
       });
     } catch (error) {
       pendingAndroidFilePickers.delete(requestId);
+      reject(error);
+    }
+  });
+};
+
+const requestNativeAndroidFolderPicker = (options = {}) => {
+  if (isVtMode()) {
+    return Promise.resolve(null);
+  }
+
+  const requestId = createAndroidFolderPickerRequestId();
+  ensureAndroidFolderPickerCallback();
+
+  return new Promise((resolve, reject) => {
+    pendingAndroidFolderPickers.set(requestId, { resolve, reject });
+
+    try {
+      callAndroidBridge("openFolderPicker", {
+        requestId,
+        title: options.title || "Select Folder",
+      });
+    } catch (error) {
+      pendingAndroidFolderPickers.delete(requestId);
       reject(error);
     }
   });
@@ -334,8 +386,8 @@ const openInputFilePicker = async (options = {}) => {
 
 export const createAndroidFilePicker = () => {
   return {
-    async openFolderPicker() {
-      return null;
+    async openFolderPicker(options = {}) {
+      return requestNativeAndroidFolderPicker(options);
     },
 
     async openFilePicker(options = {}) {

--- a/src/deps/services/android/appService.js
+++ b/src/deps/services/android/appService.js
@@ -1,0 +1,264 @@
+import { createAppServiceCore } from "../shared/appServiceCore.js";
+import { callAndroidBridge } from "../../clients/android/bridge.js";
+import { generateId } from "../../../internal/id.js";
+import { copyTextToClipboard } from "../../../internal/copyText.js";
+
+const normalizeFolderSelection = (selection) => {
+  if (typeof selection === "string") {
+    return {
+      uri: selection,
+      name: "",
+    };
+  }
+
+  return {
+    uri: selection?.uri ?? "",
+    name: selection?.name ?? "",
+  };
+};
+
+const listAndroidProjectFolders = () => {
+  try {
+    const projects = callAndroidBridge("listProjectFolders");
+    return Array.isArray(projects) ? projects : [];
+  } catch {
+    return undefined;
+  }
+};
+
+const toAndroidProjectEntry = ({ project, existingEntry } = {}) => {
+  const projectId = project?.id ?? "";
+  if (!projectId) {
+    return undefined;
+  }
+
+  const projectName = project.name?.trim?.() || existingEntry?.name;
+
+  return {
+    id: projectId,
+    name: projectName || "Untitled Project",
+    description: project.description ?? existingEntry?.description ?? "",
+    iconFileId: project.iconFileId ?? null,
+    createdAt: existingEntry?.createdAt ?? Date.now(),
+    lastOpenedAt: existingEntry?.lastOpenedAt ?? null,
+  };
+};
+
+export const createAppService = (params) => {
+  const appDb = params.db;
+
+  const syncAndroidProjectEntriesFromStorage = async () => {
+    const discoveredProjects = listAndroidProjectFolders();
+    if (!discoveredProjects) {
+      return;
+    }
+
+    const entries = (await appDb.get("projectEntries")) || [];
+    const existingEntries = Array.isArray(entries) ? entries : [];
+    const existingEntriesById = new Map(
+      existingEntries
+        .filter((entry) => entry?.id)
+        .map((entry) => [entry.id, entry]),
+    );
+
+    const nextEntries = [];
+    for (const project of discoveredProjects) {
+      const entry = toAndroidProjectEntry({
+        project,
+        existingEntry: existingEntriesById.get(project?.id),
+      });
+      if (entry) {
+        nextEntries.push(entry);
+      }
+    }
+
+    await appDb.set("projectEntries", nextEntries);
+  };
+
+  const platformAdapter = {
+    isDuplicateProjectEntry: ({ entries, entry }) => {
+      return entries.some((project) => project.id === entry.id);
+    },
+
+    mapProjectEntryToProject: () => ({}),
+
+    loadProjectIcon: async ({ entry, projectService }) => {
+      if (!entry?.iconFileId) return null;
+
+      try {
+        const blob = await projectService.getFileByProjectId(
+          entry.id,
+          entry.iconFileId,
+        );
+        if (!blob) {
+          return null;
+        }
+        const url = URL.createObjectURL(blob);
+        return {
+          url,
+          cleanup: () => URL.revokeObjectURL(url),
+        };
+      } catch (error) {
+        console.error("Failed to load project icon:", error);
+        return null;
+      }
+    },
+
+    validateProjectFolder: async () => {
+      return { isValid: false, error: "Not supported on Android." };
+    },
+
+    importProject: async () => {
+      throw new Error("Use openExistingProject to import Android projects.");
+    },
+
+    openExistingProject: async ({
+      folderPath,
+      addProjectEntry,
+      loadProjectIcon,
+      projectService,
+    }) => {
+      const folderSelection = normalizeFolderSelection(folderPath);
+      if (!folderSelection.uri) {
+        throw new Error("Project folder is required.");
+      }
+
+      const importedProject = callAndroidBridge("importProjectFolder", {
+        uri: folderSelection.uri,
+      });
+      const projectId = importedProject.id;
+      if (!projectId) {
+        throw new Error("Imported project is missing an id.");
+      }
+
+      const importedName = importedProject.name?.trim?.() ?? "";
+      let projectName = "Untitled Project";
+      if (importedName) {
+        projectName = importedName;
+      }
+
+      const projectEntry = {
+        id: projectId,
+        name: projectName,
+        description: importedProject.description ?? "",
+        iconFileId: importedProject.iconFileId ?? null,
+        createdAt: Date.now(),
+        lastOpenedAt: null,
+      };
+
+      await addProjectEntry(projectEntry);
+
+      const fullProject = { ...projectEntry };
+      if (projectEntry.iconFileId) {
+        const iconResult = await loadProjectIcon({
+          entry: projectEntry,
+          projectService,
+        });
+        if (typeof iconResult === "string") {
+          fullProject.iconUrl = iconResult;
+        } else if (iconResult?.url) {
+          fullProject.iconUrl = iconResult.url;
+        }
+      }
+
+      return fullProject;
+    },
+
+    createNewProject: async ({
+      name,
+      description,
+      template,
+      projectResolution,
+      iconFile,
+      addProjectEntry,
+      projectService,
+    }) => {
+      const projectId = generateId();
+      const namespace = generateId();
+
+      let iconFileId = null;
+      if (iconFile) {
+        const storedIcon = await projectService.storeFileForProject({
+          projectId,
+          file: iconFile,
+        });
+        iconFileId = storedIcon.fileId;
+      }
+
+      const projectEntry = {
+        id: projectId,
+        name,
+        description,
+        iconFileId,
+        createdAt: Date.now(),
+        lastOpenedAt: null,
+      };
+
+      await projectService.initializeProject({
+        projectId: projectEntry.id,
+        template,
+        projectResolution,
+        projectInfo: {
+          id: projectId,
+          namespace,
+          name,
+          description,
+          iconFileId,
+        },
+      });
+
+      await addProjectEntry(projectEntry);
+      const fullProject = { ...projectEntry };
+      if (iconFileId) {
+        const iconResult = await platformAdapter.loadProjectIcon({
+          entry: projectEntry,
+          projectService,
+        });
+        if (iconResult?.url) {
+          fullProject.iconUrl = iconResult.url;
+        }
+      }
+
+      return fullProject;
+    },
+
+    selectFiles: ({ options, multiple, filePicker }) => {
+      return filePicker.openFilePicker({
+        ...options,
+        multiple,
+      });
+    },
+  };
+
+  const appService = createAppServiceCore({
+    ...params,
+    platformAdapter,
+  });
+
+  return {
+    ...appService,
+
+    async loadAllProjects() {
+      await syncAndroidProjectEntriesFromStorage();
+      return appService.loadAllProjects();
+    },
+
+    copyText(value) {
+      return copyTextToClipboard(value);
+    },
+
+    async startStaticWebServer() {
+      throw new Error(
+        "Static web server is only available in the desktop app.",
+      );
+    },
+
+    async stopStaticWebServer() {
+      return false;
+    },
+
+    async listStaticWebServers() {
+      return [];
+    },
+  };
+};

--- a/src/deps/services/android/collabClientStore.js
+++ b/src/deps/services/android/collabClientStore.js
@@ -135,6 +135,10 @@ export const evictPersistedAndroidProjectStoreCache = async ({
 
   const cachedStorePromise = storePromisesByProjectId.get(projectId);
   storePromisesByProjectId.delete(projectId);
+  if (!cachedStorePromise) {
+    return;
+  }
+
   const cachedStore = await cachedStorePromise.catch(() => undefined);
   await cachedStore?.close?.();
 };

--- a/src/deps/services/android/projectService.js
+++ b/src/deps/services/android/projectService.js
@@ -1,5 +1,6 @@
 import { createProjectServiceCore } from "../shared/projectServiceCore.js";
 import { createAndroidProjectServiceAdapters } from "./projectServiceAdapters.js";
+import { callAndroidBridge } from "../../clients/android/bridge.js";
 import { generateId } from "../../../internal/id.js";
 
 const ENABLE_VERBOSE_COLLAB_LOGS = false;
@@ -27,7 +28,7 @@ export const createProjectService = ({
   const { storageAdapter, fileAdapter, collabAdapter } =
     createAndroidProjectServiceAdapters({ collabLog, creatorVersion });
 
-  return createProjectServiceCore({
+  const projectService = createProjectServiceCore({
     router,
     db,
     filePicker,
@@ -39,4 +40,25 @@ export const createProjectService = ({
     fileAdapter,
     collabAdapter,
   });
+
+  return {
+    ...projectService,
+
+    async exportProjectFolder({ projectId, destinationUri } = {}) {
+      const targetProjectId = projectId || projectService.getEnsuredProjectId();
+      if (!targetProjectId) {
+        throw new Error("No project selected.");
+      }
+
+      await projectService.releaseProjectRuntime(targetProjectId);
+      try {
+        return callAndroidBridge("exportProjectFolder", {
+          projectId: targetProjectId,
+          destinationUri,
+        });
+      } finally {
+        await projectService.ensureRepository().catch(() => {});
+      }
+    },
+  };
 };

--- a/src/deps/services/android/projectService.js
+++ b/src/deps/services/android/projectService.js
@@ -4,6 +4,56 @@ import { callAndroidBridge } from "../../clients/android/bridge.js";
 import { generateId } from "../../../internal/id.js";
 
 const ENABLE_VERBOSE_COLLAB_LOGS = false;
+const ANDROID_PROJECT_EXPORT_CALLBACK = "__routeVNAndroidProjectExportResult";
+
+let nextAndroidProjectExportRequestId = 1;
+const pendingAndroidProjectExports = new Map();
+
+const createAndroidProjectExportRequestId = () => {
+  const requestId = `export-${nextAndroidProjectExportRequestId}`;
+  nextAndroidProjectExportRequestId += 1;
+  return requestId;
+};
+
+const ensureAndroidProjectExportCallback = () => {
+  window[ANDROID_PROJECT_EXPORT_CALLBACK] = (result = {}) => {
+    const requestId = result.requestId;
+    const pending = pendingAndroidProjectExports.get(requestId);
+    if (!pending) {
+      return;
+    }
+
+    pendingAndroidProjectExports.delete(requestId);
+    if (result.error) {
+      pending.reject(
+        new Error(result.error.message || "Failed to export project."),
+      );
+      return;
+    }
+
+    pending.resolve(result.export ?? null);
+  };
+};
+
+const requestNativeAndroidProjectExport = ({ projectId, destinationUri }) => {
+  const requestId = createAndroidProjectExportRequestId();
+  ensureAndroidProjectExportCallback();
+
+  return new Promise((resolve, reject) => {
+    pendingAndroidProjectExports.set(requestId, { resolve, reject });
+
+    try {
+      callAndroidBridge("exportProjectFolder", {
+        requestId,
+        projectId,
+        destinationUri,
+      });
+    } catch (error) {
+      pendingAndroidProjectExports.delete(requestId);
+      reject(error);
+    }
+  });
+};
 
 export const createProjectService = ({
   router,
@@ -52,12 +102,16 @@ export const createProjectService = ({
 
       await projectService.releaseProjectRuntime(targetProjectId);
       try {
-        return callAndroidBridge("exportProjectFolder", {
+        return await requestNativeAndroidProjectExport({
           projectId: targetProjectId,
           destinationUri,
         });
       } finally {
-        await projectService.ensureRepository().catch(() => {});
+        try {
+          await projectService.ensureRepository();
+        } catch {
+          // The page can recover on the next project operation.
+        }
       }
     },
   };

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -10,6 +10,7 @@ const ICON_VALIDATIONS = [
 
 export const handleBeforeMount = (deps) => {
   const { appService, store } = deps;
+  store.setPlatform({ platform: appService.getPlatform() });
   store.setCurrentProject({
     project: {
       source: appService.getCurrentProjectEntry()?.source,
@@ -34,6 +35,112 @@ export const handleAfterMount = async (deps) => {
     },
   });
   render();
+};
+
+const getActionMenuPosition = (event) => {
+  const rect = event.currentTarget?.getBoundingClientRect?.();
+  return {
+    x: event.clientX || rect?.right || 0,
+    y: rect?.bottom || event.clientY || 0,
+  };
+};
+
+const resolveFolderUri = (folder) => {
+  if (typeof folder === "string") {
+    return folder;
+  }
+
+  return folder?.uri ?? "";
+};
+
+const exportCurrentAndroidProject = async (deps) => {
+  const { appService, projectService } = deps;
+  const currentProject = appService.getCurrentProjectEntry();
+  const projectId = currentProject?.id ?? "";
+
+  if (
+    appService.getPlatform() !== "android" ||
+    currentProject?.source !== "local"
+  ) {
+    return;
+  }
+
+  if (!projectId) {
+    appService.showAlert({
+      message: "No local project is currently open.",
+      title: "Warning",
+    });
+    return;
+  }
+
+  let folder;
+  try {
+    folder = await appService.openFolderPicker({
+      title: "Select Export Folder",
+      writable: true,
+    });
+  } catch {
+    appService.showAlert({
+      message: "Failed to select an export folder.",
+      title: "Error",
+    });
+    return;
+  }
+
+  const destinationUri = resolveFolderUri(folder);
+  if (!destinationUri) {
+    return;
+  }
+
+  try {
+    const result = await projectService.exportProjectFolder({
+      projectId,
+      destinationUri,
+    });
+    appService.showToast({
+      message: `Project exported to "${result.name}".`,
+    });
+  } catch (error) {
+    const message = String(error?.message ?? "");
+    appService.showAlert({
+      message: message.includes("already exists")
+        ? message
+        : "Failed to export project.",
+      title: "Error",
+    });
+  }
+};
+
+export const handleProjectActionsClick = (deps, payload) => {
+  const { store, render } = deps;
+  const event = payload._event;
+  event.preventDefault();
+  event.stopPropagation();
+
+  store.openProjectActionMenu(getActionMenuPosition(event));
+  render();
+};
+
+export const handleProjectActionMenuClose = (deps) => {
+  const { store, render } = deps;
+  if (!store.selectIsProjectActionMenuOpen()) {
+    return;
+  }
+
+  store.closeProjectActionMenu();
+  render();
+};
+
+export const handleProjectActionMenuClickItem = async (deps, payload) => {
+  const { store, render } = deps;
+  const item = payload._event.detail.item || payload._event.detail;
+
+  store.closeProjectActionMenu();
+  render();
+
+  if (item?.value === "export") {
+    await exportCurrentAndroidProject(deps);
+  }
 };
 
 export const handleEditButtonClick = (deps) => {

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -101,11 +101,9 @@ const exportCurrentAndroidProject = async (deps) => {
       message: `Project exported to "${result.name}".`,
     });
   } catch (error) {
-    const message = String(error?.message ?? "");
+    const message = String(error?.message ?? "").trim();
     appService.showAlert({
-      message: message.includes("already exists")
-        ? message
-        : "Failed to export project.",
+      message: message || "Failed to export project.",
       title: "Error",
     });
   }

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -54,7 +54,7 @@ const resolveFolderUri = (folder) => {
 };
 
 const exportCurrentAndroidProject = async (deps) => {
-  const { appService, projectService } = deps;
+  const { appService, projectService, store, render } = deps;
   const currentProject = appService.getCurrentProjectEntry();
   const projectId = currentProject?.id ?? "";
 
@@ -92,17 +92,25 @@ const exportCurrentAndroidProject = async (deps) => {
     return;
   }
 
+  store.setProjectExportLoading({ isLoading: true });
+  render();
+
   try {
     const result = await projectService.exportProjectFolder({
       projectId,
       destinationUri,
     });
-    appService.showToast({
+    store.setProjectExportLoading({ isLoading: false });
+    render();
+    await appService.showAlert({
       message: `Project exported to "${result.name}".`,
+      title: "Export Complete",
     });
   } catch (error) {
     const message = String(error?.message ?? "").trim();
-    appService.showAlert({
+    store.setProjectExportLoading({ isLoading: false });
+    render();
+    await appService.showAlert({
       message: message || "Failed to export project.",
       title: "Error",
     });

--- a/src/pages/project/project.store.js
+++ b/src/pages/project/project.store.js
@@ -26,6 +26,7 @@ export const createInitialState = () => ({
     y: 0,
     items: [],
   },
+  isProjectExportLoading: false,
   isEditDialogOpen: false,
   isEditIconCropDialogOpen: false,
   editDefaultValues: {
@@ -68,6 +69,10 @@ export const closeProjectActionMenu = ({ state }) => {
 
 export const selectIsProjectActionMenuOpen = ({ state }) =>
   state.projectActionMenu.isOpen;
+
+export const setProjectExportLoading = ({ state }, { isLoading } = {}) => {
+  state.isProjectExportLoading = !!isLoading;
+};
 
 export const openEditDialog = ({ state }, _payload = {}) => {
   state.isEditDialogOpen = true;
@@ -138,6 +143,8 @@ export const selectViewData = ({ state, constants }) => {
     editIconFileId: state.editIconFileId,
     editIconCropFile: state.editIconCropFile,
     editForm: constants.editProjectForm,
+    isProjectExportLoading: state.isProjectExportLoading,
+    projectExportLoadingStatusText: "Exporting project...",
     projectSource: state.project.source,
     projectActionMenu: state.projectActionMenu,
     showAndroidProjectActions:

--- a/src/pages/project/project.store.js
+++ b/src/pages/project/project.store.js
@@ -5,7 +5,7 @@ import {
 
 const PROJECT_ACTION_MENU_ITEMS = [
   {
-    label: "Export",
+    label: "Export project",
     type: "item",
     value: "export",
   },

--- a/src/pages/project/project.store.js
+++ b/src/pages/project/project.store.js
@@ -3,13 +3,28 @@ import {
   formatProjectResolution,
 } from "../../internal/projectResolution.js";
 
+const PROJECT_ACTION_MENU_ITEMS = [
+  {
+    label: "Export",
+    type: "item",
+    value: "export",
+  },
+];
+
 export const createInitialState = () => ({
+  platform: "web",
   project: {
     name: "",
     description: "",
     iconFileId: undefined,
     resolution: DEFAULT_PROJECT_RESOLUTION,
     source: "local",
+  },
+  projectActionMenu: {
+    isOpen: false,
+    x: 0,
+    y: 0,
+    items: [],
   },
   isEditDialogOpen: false,
   isEditIconCropDialogOpen: false,
@@ -21,6 +36,10 @@ export const createInitialState = () => ({
   editIconCropFile: undefined,
 });
 
+export const setPlatform = ({ state }, { platform } = {}) => {
+  state.platform = platform ?? "web";
+};
+
 export const setCurrentProject = ({ state }, { project } = {}) => {
   state.project = {
     name: project?.name ?? "",
@@ -30,6 +49,25 @@ export const setCurrentProject = ({ state }, { project } = {}) => {
     source: project?.source === "cloud" ? "cloud" : "local",
   };
 };
+
+export const openProjectActionMenu = ({ state }, { x, y } = {}) => {
+  state.projectActionMenu.isOpen = true;
+  state.projectActionMenu.x = x ?? 0;
+  state.projectActionMenu.y = y ?? 0;
+  state.projectActionMenu.items = PROJECT_ACTION_MENU_ITEMS.map((item) => ({
+    ...item,
+  }));
+};
+
+export const closeProjectActionMenu = ({ state }) => {
+  state.projectActionMenu.isOpen = false;
+  state.projectActionMenu.x = 0;
+  state.projectActionMenu.y = 0;
+  state.projectActionMenu.items = [];
+};
+
+export const selectIsProjectActionMenuOpen = ({ state }) =>
+  state.projectActionMenu.isOpen;
 
 export const openEditDialog = ({ state }, _payload = {}) => {
   state.isEditDialogOpen = true;
@@ -101,5 +139,8 @@ export const selectViewData = ({ state, constants }) => {
     editIconCropFile: state.editIconCropFile,
     editForm: constants.editProjectForm,
     projectSource: state.project.source,
+    projectActionMenu: state.projectActionMenu,
+    showAndroidProjectActions:
+      state.platform === "android" && state.project.source === "local",
   };
 };

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -73,3 +73,6 @@ template:
                       - rtgl-text c=mu-fg ta=c: Click to upload
   - rtgl-dropdown-menu#projectActionMenu :items=${projectActionMenu.items} x=${projectActionMenu.x} y=${projectActionMenu.y} ?open=${projectActionMenu.isOpen}: null
   - rvn-square-image-crop-dialog#editIconCropDialog :open=${isEditIconCropDialogOpen} :file=${editIconCropFile}: null
+  - $if isProjectExportLoading:
+      - 'rtgl-view pos=fix edge=f z=2050 bgc=bg d=v ah=c av=c g=sm style="min-width: 0; min-height: 0; pointer-events: auto;"':
+          - rtgl-text s=sm c=mu-fg: ${projectExportLoadingStatusText}

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -15,6 +15,16 @@ refs:
     eventListeners:
       click:
         handler: handleBackToProjects
+  projectActionsButton:
+    eventListeners:
+      click:
+        handler: handleProjectActionsClick
+  projectActionMenu:
+    eventListeners:
+      close:
+        handler: handleProjectActionMenuClose
+      item-click:
+        handler: handleProjectActionMenuClickItem
   editDialog:
     eventListeners:
       close:
@@ -39,6 +49,9 @@ template:
           - rtgl-button#backButton pre=chevronLeft v=gh: Back to Projects
           - $if projectSource == 'cloud':
               - rtgl-text s=xs c=mu-fg: Cloud Project
+          - rtgl-view w=1fg: null
+          - $if showAndroidProjectActions:
+              - rtgl-button#projectActionsButton sq v=gh pre=ellipsis: null
   - rtgl-view w=f h=f ph=lg pt=md:
       - rtgl-view w=f h=f d=v:
           - rvn-detail-view#detailView w=f h=1fg :fields=${detailFields}:
@@ -58,4 +71,5 @@ template:
                 $else:
                   - rtgl-view#editDialogIcon slot=project-icon-edit w=120 h=120 ah=c av=c bw=xs bc=bo br=md cur=pointer:
                       - rtgl-text c=mu-fg ta=c: Click to upload
+  - rtgl-dropdown-menu#projectActionMenu :items=${projectActionMenu.items} x=${projectActionMenu.x} y=${projectActionMenu.y} ?open=${projectActionMenu.isOpen}: null
   - rvn-square-image-crop-dialog#editIconCropDialog :open=${isEditIconCropDialogOpen} :file=${editIconCropFile}: null

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -74,5 +74,6 @@ template:
   - rtgl-dropdown-menu#projectActionMenu :items=${projectActionMenu.items} x=${projectActionMenu.x} y=${projectActionMenu.y} ?open=${projectActionMenu.isOpen}: null
   - rvn-square-image-crop-dialog#editIconCropDialog :open=${isEditIconCropDialogOpen} :file=${editIconCropFile}: null
   - $if isProjectExportLoading:
-      - 'rtgl-view pos=fix edge=f z=2050 bgc=bg d=v ah=c av=c g=sm style="min-width: 0; min-height: 0; pointer-events: auto;"':
-          - rtgl-text s=sm c=mu-fg: ${projectExportLoadingStatusText}
+      - 'rtgl-view pos=fix edge=f z=2050 d=v ah=c av=c g=sm style="min-width: 0; min-height: 0; pointer-events: auto; background: rgba(0, 0, 0, 0.42);"':
+          - rtgl-view bgc=su bc=bo bw=xs br=md shadow=md ph=lg pv=md:
+              - rtgl-text s=sm c=fg: ${projectExportLoadingStatusText}

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -355,7 +355,8 @@ export const handleCloudCreateFormAction = async (deps, payload) => {
 
 export const handleOpenButtonClick = async (deps) => {
   const { appService, store, render } = deps;
-  if (appService.getPlatform() !== "tauri") {
+  const platform = appService.getPlatform();
+  if (platform !== "tauri" && platform !== "android") {
     return;
   }
 
@@ -405,7 +406,7 @@ export const handleMobileActionMenuClose = (deps) => {
   render();
 };
 
-export const handleMobileActionMenuClickItem = (deps, payload) => {
+export const handleMobileActionMenuClickItem = async (deps, payload) => {
   const { store, render } = deps;
   const detail = payload._event.detail;
   const item = detail.item || detail;
@@ -414,6 +415,12 @@ export const handleMobileActionMenuClickItem = (deps, payload) => {
 
   if (item.value === "create-project") {
     store.openCreateDialog();
+  }
+
+  if (item.value === "import-project") {
+    render();
+    await handleOpenButtonClick(deps);
+    return;
   }
 
   render();

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -210,6 +210,8 @@ export const selectIsProfileMenuOpen = ({ state }) => {
 };
 
 export const openMobileActionMenu = ({ state }, { x, y } = {}) => {
+  const canImportProjects =
+    state.platform === "tauri" || state.platform === "android";
   state.mobileActionMenu.isOpen = true;
   state.mobileActionMenu.x = x;
   state.mobileActionMenu.y = y;
@@ -219,7 +221,7 @@ export const openMobileActionMenu = ({ state }, { x, y } = {}) => {
       label: "Import Project",
       type: "item",
       value: "import-project",
-      disabled: true,
+      disabled: !canImportProjects,
     },
   ];
 };

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -139,7 +139,7 @@ template:
                             $else:
                               - rtgl-view d=h g=sm:
                                   - rtgl-button#createButton data-testid=create-project-button: ${createButtonText}
-                                  - $if platform == 'tauri':
+                                  - $if platform == 'tauri' || platform == 'android':
                                       - rtgl-button#openButton variant=se: ${openButtonText}
                           - $if showProjectAccountActions:
                               - $if isLoggedIn:
@@ -166,9 +166,10 @@ template:
                                           - rtgl-image wh=56 src="/public/project_logo_placeholder.png" bw=xs bc=bo of=con br=md: null
                                       - rtgl-view w=1fg:
                                           - rtgl-text ellipsis w=f: ${project.name}
-                                          - rtgl-view d=h g=sm av=c mt=xs:
-                                              - rtgl-svg wh=14 svg=folder c=mu-fg: null
-                                              - rtgl-text s=xs c=mu-fg: ${project.projectPath}
+                                          - $if platform != 'android' && project.projectPath:
+                                              - rtgl-view d=h g=sm av=c mt=xs:
+                                                  - rtgl-svg wh=14 svg=folder c=mu-fg: null
+                                                  - rtgl-text s=xs c=mu-fg: ${project.projectPath}
                               - rtgl-view h="33vh": null
                           - $if showCloudProjects:
                               - rtgl-view w=f d=v g=md:

--- a/src/setup.android.js
+++ b/src/setup.android.js
@@ -4,7 +4,7 @@ import { createDb } from "./deps/clients/android/db.js";
 import { createAndroidFilePicker } from "./deps/clients/android/filePicker.js";
 import AndroidRouter from "./deps/clients/android/router.js";
 
-import { createAppService } from "./deps/services/web/appService.js";
+import { createAppService } from "./deps/services/android/appService.js";
 import { createProjectService } from "./deps/services/android/projectService.js";
 import { createPendingQueueService } from "./deps/services/pendingQueueService.js";
 import { createApiService } from "./deps/services/apiService.js";

--- a/tests/android/filePicker.test.js
+++ b/tests/android/filePicker.test.js
@@ -156,6 +156,42 @@ describe("android file picker", () => {
     });
   });
 
+  it("opens the native folder picker with writable access when requested", async () => {
+    let folderPayload;
+    mocked.callAndroidBridge.mockImplementation((method, payload) => {
+      if (method === "openFolderPicker") {
+        folderPayload = payload;
+        Promise.resolve().then(() => {
+          window.__routeVNAndroidFolderPickerResult({
+            requestId: payload.requestId,
+            folder: {
+              uri: "content://exports",
+              name: "Exports",
+            },
+          });
+        });
+        return true;
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
+
+    const folder = await createAndroidFilePicker().openFolderPicker({
+      title: "Select Export Folder",
+      writable: true,
+    });
+
+    expect(folder).toEqual({
+      uri: "content://exports",
+      name: "Exports",
+    });
+    expect(folderPayload).toEqual({
+      requestId: "folder-1",
+      title: "Select Export Folder",
+      writable: true,
+    });
+  });
+
   it("writes supplied bytes to a selected Android save URI", async () => {
     let writePayload;
     mocked.callAndroidBridge.mockImplementation((method, payload) => {


### PR DESCRIPTION
## Summary
- add Android SAF folder picker support for selecting existing RouteVN project folders (`project.db` plus `files/`)
- import selected RouteVN project folders into Android app-private storage, including project DB, files, optional metadata, and SQLite sidecars
- clean up failed first-time Android imports so partial projects are not treated as complete on the next import attempt
- keep Android live project storage private and project-id based, then discover valid private project folders for the Projects page
- add an Android-only Project page overflow menu with Export project, writing a portable project folder to a user-selected SAF destination
- add Android-specific app service wiring and enable Import Project in Android project-list UI
- hide local filepath labels on Android because project storage is an app-private implementation detail

## Known follow-up
- Android project removal currently removes the project listing entry but does not delete the app-private project folder, so discovered local folders can reappear. This PR leaves deletion/tombstone behavior for a separate follow-up.

## Validation
- bun run lint
- bunx vitest run tests/android/filePicker.test.js
- bun run build:android
- ./gradlew :app:assembleDebug
- ./gradlew :app:installDebug
- bun run check:contracts currently fails with existing repo-wide Rettangoli contract diagnostics unrelated to this PR