### PR TITLE
fix: stabilize whiteboard node hover border

### DIFF
--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -751,12 +751,7 @@ export const selectViewData = ({ state, props }) => {
       props.selectedItemId === item.id || state.hoveredItemId === item.id
         ? "fg"
         : "ac",
-    borderWidth:
-      props.selectedItemId === item.id
-        ? "sm"
-        : state.hoveredItemId === item.id
-          ? "xs"
-          : "sm",
+    borderWidth: "sm",
   }));
 
   const containerCursor = normalizeCursorValue(props.cursor);

--- a/src/components/whiteboard/whiteboard.view.yaml
+++ b/src/components/whiteboard/whiteboard.view.yaml
@@ -62,8 +62,8 @@ template:
                           - rtgl-text s=sm: Start
                       - rtgl-view w=${startLineWidth} h=${startLineHeight} bgc=ac: null
               - 'rtgl-view#itemRef${itemIndex} data-item-id=${item.id} w=${sceneBoxWidth} h=${sceneBoxHeight} d=h ah=e av=c pos=abs cur=${itemCursor} style="left: ${item.x}px; top: ${item.y}px; z-index: 10; user-select: none;"':
-                  - rtgl-view cur=${itemCursor} w=${sceneBoxWidth} h=f av=c ah=c p=md bgc=mu bw=${item.borderWidth} bc=${item.borderColor} br=md:
-                      - rtgl-text s=sm: ${item.name}
+                  - 'rtgl-view cur=${itemCursor} w=f h=f av=c ah=c p=md bgc=mu bw=${item.borderWidth} bc=${item.borderColor} br=md style="box-sizing: border-box; min-width: 0; overflow: hidden;"':
+                      - 'rtgl-text s=sm w=f style="min-width: 0; max-width: 100%; text-align: center; overflow-wrap: anywhere;"': ${item.name}
           - $for arrow in arrowsList:
               - svg data-arrow-id="${arrow.id}" style="${arrow.style}" width="${arrow.svgWidth}" height="${arrow.svgHeight}":
                   - defs:

--- a/tests/whiteboard/whiteboard.store.test.js
+++ b/tests/whiteboard/whiteboard.store.test.js
@@ -5,6 +5,7 @@ import {
   selectMinimapData,
   selectViewData,
   setContainerSize,
+  setHoveredItemId,
   setInitialZoomAndPan,
   startMinimapViewportDragging,
   stopMinimapViewportDragging,
@@ -178,5 +179,40 @@ describe("whiteboard minimap viewport drag", () => {
     expect(forcedTouchViewData.minimapData.minimap.height).toBe(100);
     expect(forcedTouchViewData.minimapContainerStyle).toContain("right: 20px");
     expect(forcedTouchViewData.minimapContainerStyle).toContain("top: 20px");
+  });
+});
+
+describe("whiteboard.store", () => {
+  it("keeps scene node border width stable across hover and selection", () => {
+    const state = createInitialState();
+    const props = {
+      items: [
+        {
+          id: "scene-1",
+          name: "A scene title that may wrap",
+          x: 0,
+          y: 0,
+        },
+      ],
+    };
+
+    const normalItem = selectViewData({ state, props }).items[0];
+
+    setHoveredItemId({ state }, { itemId: "scene-1" });
+    const hoveredItem = selectViewData({ state, props }).items[0];
+
+    const selectedItem = selectViewData({
+      state,
+      props: {
+        ...props,
+        selectedItemId: "scene-1",
+      },
+    }).items[0];
+
+    expect(normalItem.borderWidth).toBe("sm");
+    expect(hoveredItem.borderWidth).toBe(normalItem.borderWidth);
+    expect(selectedItem.borderWidth).toBe(normalItem.borderWidth);
+    expect(hoveredItem.borderColor).toBe("fg");
+    expect(selectedItem.borderColor).toBe("fg");
   });
 });


### PR DESCRIPTION
## Summary
- keep whiteboard scene node border width constant across normal, hover, and selected states
- constrain the node content box so title wrapping does not shift when the border color changes
- add a store regression test for hover and selection border width

## Testing
- bunx vitest run tests/whiteboard/whiteboard.store.test.js
- bun prettier --check src/components/whiteboard/whiteboard.store.js src/components/whiteboard/whiteboard.view.yaml tests/whiteboard/whiteboard.store.test.js
- bunx oxlint src/components/whiteboard/whiteboard.store.js tests/whiteboard/whiteboard.store.test.js
- push hook: oxlint && bun prettier --check src