### PR TITLE
Add Android WebView dev refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ bun run build:android
 bun run android:install
 ```
 
+For frontend-only Android iteration after one debug install:
+
+```shell
+bun run android:dev
+```
+
 ## Community
 
 Join us on [Discord](https://discord.gg/8J9dyZSu9C) to ask questions, report bugs, and stay up to date.

--- a/android/routevn/app/src/main/AndroidManifest.xml
+++ b/android/routevn/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -59,6 +59,8 @@ public class MainActivity extends Activity {
     private static final String TAG = "RouteVNAndroid";
     private static final String APP_ASSET_HOST = "appassets.androidplatform.net";
     private static final String APP_URL = "https://" + APP_ASSET_HOST + "/web/index.html";
+    private static final String DEV_SERVER_URL_EXTRA = "routevnDevServerUrl";
+    private static final String DEV_RELOAD_TOKEN_EXTRA = "routevnDevReloadToken";
     private static final int FILE_CHOOSER_REQUEST_CODE = 3711;
     private static final int ANDROID_FILE_PICKER_REQUEST_CODE = 3712;
     private static final int ANDROID_SAVE_FILE_PICKER_REQUEST_CODE = 3713;
@@ -75,6 +77,9 @@ public class MainActivity extends Activity {
     private ValueCallback<Uri[]> fileChooserCallback;
     private boolean canGoBackInWebApp = false;
     private Object backInvokedCallback;
+    private RouteVNInternalFilePathHandler internalFilePathHandler;
+    private String currentAppUrl = APP_URL;
+    private String currentDevReloadToken;
     private String pendingAndroidFilePickerRequestId;
     private boolean pendingAndroidFilePickerMultiple = false;
     private String pendingAndroidSaveFilePickerRequestId;
@@ -99,6 +104,39 @@ public class MainActivity extends Activity {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerBackInvokedCallback();
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+
+        String nextAppUrl = resolveAppUrl(intent);
+        String nextReloadToken = resolveDevReloadToken(intent);
+        if (webView == null) {
+            currentAppUrl = nextAppUrl;
+            currentDevReloadToken = nextReloadToken;
+            return;
+        }
+
+        if (!nextAppUrl.equals(currentAppUrl)) {
+            currentAppUrl = nextAppUrl;
+            currentDevReloadToken = nextReloadToken;
+            webView.loadUrl(currentAppUrl);
+            return;
+        }
+
+        if (!isAllowedDebugAppUrl(currentAppUrl)) {
+            return;
+        }
+
+        if (
+            nextReloadToken == null ||
+            !nextReloadToken.equals(currentDevReloadToken)
+        ) {
+            currentDevReloadToken = nextReloadToken;
+            webView.reload();
         }
     }
 
@@ -134,13 +172,16 @@ public class MainActivity extends Activity {
 
     private void configureWebView() {
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG);
+        currentAppUrl = resolveAppUrl(getIntent());
+        currentDevReloadToken = resolveDevReloadToken(getIntent());
+        internalFilePathHandler = new RouteVNInternalFilePathHandler();
 
         assetLoader =
             new WebViewAssetLoader.Builder()
                 .setDomain(APP_ASSET_HOST)
                 .addPathHandler(
                     "/android-files/",
-                    new RouteVNInternalFilePathHandler()
+                    internalFilePathHandler
                 )
                 .addPathHandler("/", new WebViewAssetLoader.AssetsPathHandler(this))
                 .build();
@@ -159,7 +200,7 @@ public class MainActivity extends Activity {
 
         webView.setWebViewClient(new RouteVNWebViewClient());
         webView.setWebChromeClient(new RouteVNWebChromeClient());
-        webView.loadUrl(APP_URL);
+        webView.loadUrl(currentAppUrl);
 
         FrameLayout rootView = new FrameLayout(this);
         rootView.setBackgroundColor(Color.BLACK);
@@ -263,6 +304,80 @@ public class MainActivity extends Activity {
         );
     }
 
+    private boolean isInternalAppUrl(Uri uri) {
+        return isAppAssetUrl(uri) || isAllowedDebugAppUri(uri);
+    }
+
+    private String resolveAppUrl(Intent intent) {
+        // Production invariant: release builds always load packaged assets.
+        if (!BuildConfig.DEBUG || intent == null) {
+            return APP_URL;
+        }
+
+        String devServerUrl = intent.getStringExtra(DEV_SERVER_URL_EXTRA);
+        if (devServerUrl == null || devServerUrl.trim().isEmpty()) {
+            return APP_URL;
+        }
+
+        if (!isAllowedDebugAppUrl(devServerUrl)) {
+            Log.w(TAG, "Ignoring unsupported Android dev server URL: " + devServerUrl);
+            return APP_URL;
+        }
+
+        Log.i(TAG, "Using Android dev server URL: " + devServerUrl);
+        return devServerUrl;
+    }
+
+    private String resolveDevReloadToken(Intent intent) {
+        if (!BuildConfig.DEBUG || intent == null) {
+            return null;
+        }
+
+        return intent.getStringExtra(DEV_RELOAD_TOKEN_EXTRA);
+    }
+
+    private boolean isAllowedDebugAppUrl(String url) {
+        if (url == null || url.trim().isEmpty()) {
+            return false;
+        }
+
+        try {
+            return isAllowedDebugAppUri(Uri.parse(url));
+        } catch (Exception error) {
+            return false;
+        }
+    }
+
+    private boolean isAllowedDebugAppUri(Uri uri) {
+        if (!BuildConfig.DEBUG || uri == null) {
+            return false;
+        }
+
+        String scheme = uri.getScheme();
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            return false;
+        }
+
+        String host = uri.getHost();
+        return (
+            ("127.0.0.1".equals(host) || "localhost".equals(host)) &&
+            uri.getPort() > 0
+        );
+    }
+
+    private WebResourceResponse interceptAndroidFilesRequest(Uri uri) {
+        if (!isInternalAppUrl(uri) || internalFilePathHandler == null) {
+            return null;
+        }
+
+        String path = uri.getPath();
+        if (path == null || !path.startsWith("/android-files/")) {
+            return null;
+        }
+
+        return internalFilePathHandler.handle(path);
+    }
+
     private boolean openExternalUri(Uri uri) {
         if (uri == null) {
             return false;
@@ -358,19 +473,34 @@ public class MainActivity extends Activity {
             WebView view,
             WebResourceRequest request
         ) {
+            WebResourceResponse internalFileResponse = interceptAndroidFilesRequest(
+                request.getUrl()
+            );
+            if (internalFileResponse != null) {
+                return internalFileResponse;
+            }
+
             return assetLoader.shouldInterceptRequest(request.getUrl());
         }
 
         @Override
         @SuppressWarnings("deprecation")
         public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-            return assetLoader.shouldInterceptRequest(Uri.parse(url));
+            Uri uri = Uri.parse(url);
+            WebResourceResponse internalFileResponse = interceptAndroidFilesRequest(
+                uri
+            );
+            if (internalFileResponse != null) {
+                return internalFileResponse;
+            }
+
+            return assetLoader.shouldInterceptRequest(uri);
         }
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
             Uri uri = request.getUrl();
-            if (isAppAssetUrl(uri)) {
+            if (isInternalAppUrl(uri)) {
                 return false;
             }
 
@@ -381,7 +511,7 @@ public class MainActivity extends Activity {
         @SuppressWarnings("deprecation")
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
             Uri uri = Uri.parse(url);
-            if (isAppAssetUrl(uri)) {
+            if (isInternalAppUrl(uri)) {
                 return false;
             }
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -111,6 +111,70 @@ Or use the combined script:
 bun run android:install
 ```
 
+## Fast WebView Development
+
+For frontend-only Android iteration, install the debug APK once:
+
+```bash
+bun run android:install
+```
+
+Then keep the fast WebView dev runner open:
+
+```bash
+bun run android:dev
+```
+
+The dev runner:
+
+- builds the Android web bundle once
+- serves `_site` from `http://127.0.0.1:3003/web/index.html`
+- runs `adb reverse tcp:3003 tcp:3003`
+- watches frontend source files under `src/`
+- rebuilds with `rtgl fe build -s src/setup.android.js`
+- reloads the existing Android WebView after successful rebuilds
+
+This avoids reinstalling the APK for routine Android frontend source iteration.
+Reinstall the debug APK only when native Android code, manifest, Gradle config,
+or packaged native resources change.
+
+Stop the dev runner with `Ctrl-C`. It removes its `adb reverse` port mapping on
+shutdown.
+
+Use a specific device or port when needed:
+
+```bash
+ANDROID_SERIAL=<adb-serial> bun run android:dev
+ROUTEVN_ANDROID_DEV_PORT=3004 bun run android:dev
+```
+
+Skip the initial web build if `_site` is already current:
+
+```bash
+ROUTEVN_ANDROID_DEV_SKIP_BUILD=1 bun run android:dev
+```
+
+### Production Safety
+
+The fast WebView runner must never affect production builds.
+
+The native shell enforces this contract:
+
+- release builds ignore the `routevnDevServerUrl` launch extra completely
+- dev-server URLs are only honored when `BuildConfig.DEBUG` is `true`
+- accepted dev-server hosts are limited to `localhost` or `127.0.0.1`
+- accepted dev-server URLs must include an explicit port
+- release builds keep `android:usesCleartextTraffic="false"`
+- release builds keep loading packaged assets from:
+
+```text
+https://appassets.androidplatform.net/web/index.html
+```
+
+Do not add a release build type, product flavor, or manifest override that
+enables cleartext traffic or bypasses the `BuildConfig.DEBUG` gate for the dev
+server URL.
+
 Build a release app bundle:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build:android:assets": "node scripts/build-android-assets.js",
     "watch:web": "rtgl fe watch -s src/setup.web.js",
     "watch:tauri": "rtgl fe watch -s src/setup.tauri.js",
+    "android:dev": "node scripts/android-dev.js",
     "android:install": "bun run build:android && cd android/routevn && ./gradlew installDebug",
     "android:bundle": "bun run build:android && cd android/routevn && ./gradlew bundleRelease",
     "test": "node scripts/test.js",

--- a/scripts/android-dev.js
+++ b/scripts/android-dev.js
@@ -1,0 +1,471 @@
+import { spawn, spawnSync } from "node:child_process";
+import {
+  createReadStream,
+  existsSync,
+  statSync,
+  unwatchFile,
+  watch,
+  watchFile,
+} from "node:fs";
+import { createServer } from "node:http";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const siteDir = join(rootDir, "_site");
+const publicDir = join(siteDir, "public");
+const mainJsPath = join(publicDir, "main.js");
+const sourceDir = join(rootDir, "src");
+const tauriConfigPath = join(rootDir, "src-tauri", "tauri.conf.json");
+const port = Number.parseInt(
+  process.env.ROUTEVN_ANDROID_DEV_PORT ?? "3003",
+  10,
+);
+const requestedSerial = process.env.ANDROID_SERIAL;
+const packageName = "com.routevn.creator";
+const activityName = `${packageName}/.MainActivity`;
+const adbCommand = process.env.ADB ?? "adb";
+const rtglCommand = process.env.ROUTEVN_RTGL_BIN ?? "rtgl";
+const devPath = "/web/index.html";
+const devUrl = `http://127.0.0.1:${port}${devPath}`;
+const skipInitialBuild = process.env.ROUTEVN_ANDROID_DEV_SKIP_BUILD === "1";
+
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  throw new Error("ROUTEVN_ANDROID_DEV_PORT must be a valid TCP port.");
+}
+
+const contentTypes = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".mp3": "audio/mpeg",
+  ".ogg": "audio/ogg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".webp": "image/webp",
+};
+
+const runSync = ({ command, args, cwd = rootDir, stdio = "pipe" }) => {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio,
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+    throw new Error(stderr || stdout || `${command} ${args.join(" ")} failed`);
+  }
+
+  return result.stdout?.trim() ?? "";
+};
+
+const runAdb = ({ serial, args, stdio = "pipe" }) => {
+  const adbArgs = serial ? ["-s", serial, ...args] : args;
+  return runSync({ command: adbCommand, args: adbArgs, stdio });
+};
+
+const readDevices = () => {
+  const output = runAdb({ args: ["devices", "-l"] });
+  return output
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [serial, status] = line.split(/\s+/, 2);
+      return { line, serial, status };
+    });
+};
+
+const selectDevice = () => {
+  const devices = readDevices();
+  const readyDevices = devices.filter((device) => device.status === "device");
+  if (requestedSerial) {
+    const requestedDevice = readyDevices.find(
+      (device) => device.serial === requestedSerial,
+    );
+    if (requestedDevice) {
+      return requestedDevice;
+    }
+
+    const availableSerials = readyDevices
+      .map((device) => device.serial)
+      .join(", ");
+    throw new Error(
+      `ANDROID_SERIAL=${requestedSerial} is not available. Ready devices: ${availableSerials || "none"}.`,
+    );
+  }
+
+  if (readyDevices.length === 0) {
+    const blockedDevices = devices
+      .map((device) => `${device.serial} (${device.status})`)
+      .join(", ");
+    throw new Error(
+      `No authorized Android device found. adb devices: ${blockedDevices || "none"}.`,
+    );
+  }
+
+  return readyDevices[0];
+};
+
+const assertAppInstalled = (serial) => {
+  let output;
+  try {
+    output = runAdb({
+      serial,
+      args: ["shell", "pm", "path", packageName],
+    });
+  } catch {
+    output = "";
+  }
+
+  if (!output.startsWith("package:")) {
+    throw new Error(
+      `Android package ${packageName} is not installed. Run bun run android:install once, then restart android:dev.`,
+    );
+  }
+};
+
+const resolveRequestPath = (requestUrl) => {
+  const url = new URL(requestUrl, devUrl);
+  if (
+    url.pathname === "/" ||
+    url.pathname === "/web" ||
+    url.pathname === "/web/"
+  ) {
+    return join(siteDir, "android", "index.html");
+  }
+
+  if (url.pathname === devPath) {
+    return join(siteDir, "android", "index.html");
+  }
+
+  const requestPath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+  const filePath = resolve(siteDir, requestPath);
+  const relativePath = relative(siteDir, filePath);
+  if (relativePath === "" || relativePath.startsWith("..")) {
+    return undefined;
+  }
+
+  return filePath;
+};
+
+const serveFile = (request, response) => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405, { Allow: "GET, HEAD" });
+    response.end();
+    return;
+  }
+
+  let filePath;
+  try {
+    filePath = resolveRequestPath(request.url ?? "/");
+  } catch {
+    response.writeHead(400);
+    response.end("Bad request");
+    return;
+  }
+
+  if (!filePath || !existsSync(filePath)) {
+    response.writeHead(404, { "Cache-Control": "no-store" });
+    response.end("Not found");
+    return;
+  }
+
+  let stats = statSync(filePath);
+  if (stats.isDirectory()) {
+    filePath = join(filePath, "index.html");
+    if (!existsSync(filePath)) {
+      response.writeHead(404, { "Cache-Control": "no-store" });
+      response.end("Not found");
+      return;
+    }
+    stats = statSync(filePath);
+  }
+
+  if (!stats.isFile()) {
+    response.writeHead(404, { "Cache-Control": "no-store" });
+    response.end("Not found");
+    return;
+  }
+
+  const contentType =
+    contentTypes[extname(filePath).toLowerCase()] ?? "application/octet-stream";
+  response.writeHead(200, {
+    "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+    "Content-Length": stats.size,
+    "Content-Type": contentType,
+  });
+
+  if (request.method === "HEAD") {
+    response.end();
+    return;
+  }
+
+  createReadStream(filePath).pipe(response);
+};
+
+const listen = async (server) =>
+  new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+
+const launchApp = (serial) => {
+  const reloadToken = `${Date.now()}`;
+  runAdb({
+    serial,
+    args: [
+      "shell",
+      "am",
+      "start",
+      "-n",
+      activityName,
+      "--es",
+      "routevnDevServerUrl",
+      devUrl,
+      "--es",
+      "routevnDevReloadToken",
+      reloadToken,
+    ],
+  });
+};
+
+const createFrontendBuildProcess = () => {
+  return spawn(rtglCommand, ["fe", "build", "-s", "src/setup.android.js"], {
+    cwd: rootDir,
+    env: process.env,
+    stdio: "inherit",
+  });
+};
+
+const startSourceWatcher = ({ onChange }) => {
+  const cleanupFns = [];
+
+  try {
+    const sourceWatcher = watch(
+      sourceDir,
+      { persistent: true, recursive: true },
+      (_eventType, filename) => {
+        if (!filename) {
+          onChange();
+          return;
+        }
+
+        const normalizedFilename = filename.toString().replaceAll("\\", "/");
+        if (
+          normalizedFilename.endsWith(".js") ||
+          normalizedFilename.endsWith(".json") ||
+          normalizedFilename.endsWith(".yaml") ||
+          normalizedFilename.endsWith(".yml")
+        ) {
+          onChange();
+        }
+      },
+    );
+    cleanupFns.push(() => sourceWatcher.close());
+  } catch {
+    console.warn(
+      "Recursive source watching is unavailable on this platform. Restart android:dev after frontend source changes.",
+    );
+  }
+
+  if (existsSync(tauriConfigPath)) {
+    watchFile(tauriConfigPath, { interval: 500 }, (current, previous) => {
+      if (current.mtimeMs !== previous.mtimeMs) {
+        onChange();
+      }
+    });
+    cleanupFns.push(() => unwatchFile(tauriConfigPath));
+  }
+
+  return () => {
+    for (const cleanup of cleanupFns) {
+      cleanup();
+    }
+  };
+};
+
+const createFrontendBuildRunner = ({ onBuildSuccess }) => {
+  let buildProcess;
+  let buildQueued = false;
+
+  const runBuild = () => {
+    if (buildProcess) {
+      buildQueued = true;
+      return;
+    }
+
+    console.log("Rebuilding Android frontend bundle...");
+    buildProcess = createFrontendBuildProcess();
+    buildProcess.on("exit", (code, signal) => {
+      buildProcess = undefined;
+
+      if (code === 0) {
+        onBuildSuccess();
+      } else {
+        const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+        console.error(`Android frontend rebuild failed with ${reason}.`);
+      }
+
+      if (buildQueued) {
+        buildQueued = false;
+        runBuild();
+      }
+    });
+    buildProcess.on("error", (error) => {
+      buildProcess = undefined;
+      console.error(
+        `Failed to start Android frontend rebuild: ${error.message}`,
+      );
+      if (buildQueued) {
+        buildQueued = false;
+        runBuild();
+      }
+    });
+  };
+
+  return {
+    runBuild,
+    stop() {
+      if (buildProcess) {
+        buildProcess.kill();
+      }
+    },
+  };
+};
+
+const createDebouncedBuildRequest = ({ runBuild }) => {
+  let buildTimer;
+
+  return {
+    requestBuild() {
+      clearTimeout(buildTimer);
+      buildTimer = setTimeout(runBuild, 200);
+    },
+    clear() {
+      clearTimeout(buildTimer);
+    },
+  };
+};
+
+const createReloadHandler = ({ serial }) => {
+  return () => {
+    launchApp(serial);
+    console.log(`Reloaded Android WebView from ${devUrl}`);
+  };
+};
+
+const assertFrontendOutput = () => {
+  if (!existsSync(mainJsPath)) {
+    throw new Error(
+      "_site/public/main.js is missing. Run bun run build:android before android:dev.",
+    );
+  }
+};
+
+const runInitialBuild = () => {
+  if (skipInitialBuild) {
+    return;
+  }
+
+  console.log("Building Android web assets...");
+  runSync({
+    command: "bun",
+    args: ["run", "build:android"],
+    stdio: "inherit",
+  });
+};
+
+const verifyRtglAvailable = () => {
+  try {
+    runSync({ command: rtglCommand, args: ["--version"] });
+  } catch {
+    console.warn(
+      `Could not run \`${rtglCommand} --version\`; android:dev will still try to use it for frontend rebuilds.`,
+    );
+  }
+};
+
+verifyRtglAvailable();
+runInitialBuild();
+assertFrontendOutput();
+
+const device = selectDevice();
+assertAppInstalled(device.serial);
+runAdb({
+  serial: device.serial,
+  args: ["reverse", `tcp:${port}`, `tcp:${port}`],
+});
+
+const server = createServer(serveFile);
+await listen(server);
+
+let shutdownStarted = false;
+let launched = false;
+const reloadAfterBuild = createReloadHandler({ serial: device.serial });
+const frontendBuildRunner = createFrontendBuildRunner({
+  onBuildSuccess: () => {
+    if (launched) {
+      reloadAfterBuild();
+    }
+  },
+});
+const debouncedBuild = createDebouncedBuildRequest({
+  runBuild: frontendBuildRunner.runBuild,
+});
+const stopSourceWatcher = startSourceWatcher({
+  onChange: () => {
+    if (launched) {
+      debouncedBuild.requestBuild();
+    }
+  },
+});
+
+const shutdown = () => {
+  if (shutdownStarted) {
+    return;
+  }
+
+  shutdownStarted = true;
+  debouncedBuild.clear();
+  stopSourceWatcher();
+  frontendBuildRunner.stop();
+  server.close();
+  try {
+    runAdb({
+      serial: device.serial,
+      args: ["reverse", "--remove", `tcp:${port}`],
+    });
+  } catch {
+    // The device may already be disconnected.
+  }
+};
+
+process.on("SIGINT", () => {
+  shutdown();
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  shutdown();
+  process.exit(0);
+});
+
+launchApp(device.serial);
+launched = true;
+console.log(`Serving Android dev build at ${devUrl}`);
+console.log(`Device: ${device.line}`);
+console.log(
+  "Edit frontend source files; successful rebuilds will reload the WebView.",
+);


### PR DESCRIPTION
## Summary
- add debug-only Android WebView dev URL support with reload intents
- add bun run android:dev to serve _site through adb reverse and rebuild/reload frontend changes
- document the fast Android WebView workflow and production safety contract

## Production safety
- release builds ignore routevnDevServerUrl because dev URLs are gated behind BuildConfig.DEBUG
- dev URLs are restricted to localhost/127.0.0.1 with an explicit port
- release builds continue loading packaged assets from https://appassets.androidplatform.net/web/index.html

## Verification
- node --check scripts/android-dev.js
- bun prettier --check scripts/android-dev.js package.json docs/android.md
- git diff --check
- ./gradlew assembleRelease
- generated release manifest has android:usesCleartextTraffic=false
- installed and launched updated debug APK on Vivo device
- android:dev rebuilt and reloaded the WebView after src/pages/projects title test