### PR TITLE
Add Android navigation diagnostics

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -486,6 +486,11 @@ public class MainActivity extends Activity {
 
     private final class AndroidBridge {
         @JavascriptInterface
+        public boolean isDebugBuild() {
+            return BuildConfig.DEBUG;
+        }
+
+        @JavascriptInterface
         public void updateBackState(boolean canGoBack) {
             canGoBackInWebApp = canGoBack;
         }

--- a/src/components/imagesMobileResourceTypes/imagesMobileResourceTypes.handlers.js
+++ b/src/components/imagesMobileResourceTypes/imagesMobileResourceTypes.handlers.js
@@ -1,3 +1,8 @@
+import {
+  createNavigationTiming,
+  logNavigationInteractionTiming,
+} from "../../internal/navigationTiming.js";
+
 export const handleItemClick = (deps, payload) => {
   const { appService, store } = deps;
   const id =
@@ -12,5 +17,38 @@ export const handleItemClick = (deps, payload) => {
     return;
   }
 
-  appService.navigate(resourceItem.path, appService.getPayload());
+  const currentPayload = appService.getPayload();
+  const timing = createNavigationTiming({
+    appService,
+    source: "images-mobile-resource-types.item.click",
+    path: resourceItem.path,
+    payload: currentPayload,
+    event: payload._event,
+    data: { itemId: id },
+  });
+  appService.navigate(resourceItem.path, currentPayload, { timing });
+};
+
+export const handleItemPointerDown = (deps, payload) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "images-mobile-resource-types.item.pointerdown",
+    event: payload._event,
+    data: {
+      itemId: payload._event.currentTarget.getAttribute?.("data-item-id"),
+    },
+  });
+};
+
+export const handleItemPointerUp = (deps, payload) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "images-mobile-resource-types.item.pointerup",
+    event: payload._event,
+    data: {
+      itemId: payload._event.currentTarget.getAttribute?.("data-item-id"),
+    },
+  });
 };

--- a/src/components/imagesMobileResourceTypes/imagesMobileResourceTypes.view.yaml
+++ b/src/components/imagesMobileResourceTypes/imagesMobileResourceTypes.view.yaml
@@ -1,6 +1,10 @@
 refs:
   item*:
     eventListeners:
+      pointerdown:
+        handler: handleItemPointerDown
+      pointerup:
+        handler: handleItemPointerUp
       click:
         handler: handleItemClick
 template:

--- a/src/components/mobileSidebar/mobileSidebar.handlers.js
+++ b/src/components/mobileSidebar/mobileSidebar.handlers.js
@@ -2,6 +2,10 @@ import {
   getRecentSceneIds,
   recordRecentSceneVisit,
 } from "../../internal/ui/recentScenes.js";
+import {
+  createNavigationTiming,
+  logNavigationInteractionTiming,
+} from "../../internal/navigationTiming.js";
 
 const resolveProjectId = (appService) => {
   return (
@@ -62,8 +66,37 @@ export const handleItemClick = (deps, payload = {}) => {
     });
   }
 
+  const timing = createNavigationTiming({
+    appService,
+    source: "mobile-sidebar.item.click",
+    path: item.path,
+    payload: nextPayload,
+    event: payload._event,
+    data: { itemId },
+  });
   subject.dispatch("redirect", {
     path: item.path,
     payload: nextPayload,
+    timing,
+  });
+};
+
+export const handleItemPointerDown = (deps, payload = {}) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "mobile-sidebar.item.pointerdown",
+    event: payload._event,
+    data: { itemId: payload._event.currentTarget.dataset.itemId },
+  });
+};
+
+export const handleItemPointerUp = (deps, payload = {}) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "mobile-sidebar.item.pointerup",
+    event: payload._event,
+    data: { itemId: payload._event.currentTarget.dataset.itemId },
   });
 };

--- a/src/components/mobileSidebar/mobileSidebar.view.yaml
+++ b/src/components/mobileSidebar/mobileSidebar.view.yaml
@@ -1,6 +1,10 @@
 refs:
   mobileSidebarItem*:
     eventListeners:
+      pointerdown:
+        handler: handleItemPointerDown
+      pointerup:
+        handler: handleItemPointerUp
       click:
         handler: handleItemClick
 template:

--- a/src/deps/clients/android/bridge.js
+++ b/src/deps/clients/android/bridge.js
@@ -1,3 +1,8 @@
+import {
+  getNavigationTimingNow,
+  logAndroidBridgeTiming,
+} from "../../../internal/navigationTiming.js";
+
 const getAndroidBridge = () => {
   const bridge = window.RouteVNAndroid;
   if (!bridge) {
@@ -6,31 +11,60 @@ const getAndroidBridge = () => {
   return bridge;
 };
 
+const getBridgeResultSize = (value) => {
+  if (Array.isArray(value) || typeof value === "string") {
+    return value.length;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value).length;
+  }
+
+  return undefined;
+};
+
 export const callAndroidBridge = (method, payload = {}) => {
+  const startedAt = getNavigationTimingNow();
   const bridge = getAndroidBridge();
   const fn = bridge[method];
   if (typeof fn !== "function") {
     throw new Error(`Android bridge method is not available: ${method}`);
   }
 
-  const rawResult = fn.call(bridge, JSON.stringify(payload));
-  let result;
+  let ok = false;
+  let errorCode;
+  let resultSize;
   try {
-    result = JSON.parse(rawResult);
-  } catch {
-    throw new Error(`Android bridge returned invalid JSON for ${method}.`);
-  }
+    const rawResult = fn.call(bridge, JSON.stringify(payload));
+    let result;
+    try {
+      result = JSON.parse(rawResult);
+    } catch {
+      throw new Error(`Android bridge returned invalid JSON for ${method}.`);
+    }
 
-  if (!result?.ok) {
-    const error = new Error(
-      result?.error?.message || `Android bridge call failed: ${method}`,
-    );
-    error.code = result?.error?.code;
-    error.details = result?.error?.details;
-    throw error;
-  }
+    ok = !!result?.ok;
+    if (!ok) {
+      const error = new Error(
+        result?.error?.message || `Android bridge call failed: ${method}`,
+      );
+      error.code = result?.error?.code;
+      error.details = result?.error?.details;
+      errorCode = error.code;
+      throw error;
+    }
 
-  return result.value;
+    resultSize = getBridgeResultSize(result.value);
+    return result.value;
+  } finally {
+    logAndroidBridgeTiming({
+      method,
+      durationMs: getNavigationTimingNow() - startedAt,
+      resultSize,
+      ok,
+      errorCode,
+    });
+  }
 };
 
 export const uint8ArrayToBase64 = (bytes) => {

--- a/src/deps/clients/android/sqlite.js
+++ b/src/deps/clients/android/sqlite.js
@@ -1,4 +1,8 @@
 import { base64ToUint8Array, callAndroidBridge } from "./bridge.js";
+import {
+  getNavigationTimingNow,
+  logAndroidBridgeTiming,
+} from "../../../internal/navigationTiming.js";
 
 const isByteNumber = (value) =>
   typeof value === "number" &&
@@ -86,12 +90,29 @@ export const createAndroidSqliteConnection = ({ dbPath }) => {
     },
 
     async select(sql, args = []) {
-      const rows = callAndroidBridge("sqliteQuery", {
-        dbPath,
-        sql,
-        args: normalizeArgs(args),
-      });
-      return normalizeSqlResultRows(rows);
+      const startedAt = getNavigationTimingNow();
+      let ok = false;
+      let resultSize;
+      try {
+        const rows = callAndroidBridge("sqliteQuery", {
+          dbPath,
+          sql,
+          args: normalizeArgs(args),
+        });
+        const normalizedRows = normalizeSqlResultRows(rows);
+        resultSize = Array.isArray(normalizedRows)
+          ? normalizedRows.length
+          : undefined;
+        ok = true;
+        return normalizedRows;
+      } finally {
+        logAndroidBridgeTiming({
+          method: "sqlite.select.total",
+          durationMs: getNavigationTimingNow() - startedAt,
+          resultSize,
+          ok,
+        });
+      }
     },
 
     async execute(sql, args = []) {

--- a/src/deps/services/android/appService.js
+++ b/src/deps/services/android/appService.js
@@ -1,5 +1,6 @@
 import { createAppServiceCore } from "../shared/appServiceCore.js";
 import { callAndroidBridge } from "../../clients/android/bridge.js";
+import { getAndroidProjectFileUrl } from "./projectFileUrls.js";
 import { generateId } from "../../../internal/id.js";
 import { copyTextToClipboard } from "../../../internal/copyText.js";
 
@@ -82,22 +83,14 @@ export const createAppService = (params) => {
 
     mapProjectEntryToProject: () => ({}),
 
-    loadProjectIcon: async ({ entry, projectService }) => {
-      if (!entry?.iconFileId) return null;
+    loadProjectIcon: async ({ entry }) => {
+      if (!entry?.id || !entry?.iconFileId) return null;
 
       try {
-        const blob = await projectService.getFileByProjectId(
-          entry.id,
-          entry.iconFileId,
-        );
-        if (!blob) {
-          return null;
-        }
-        const url = URL.createObjectURL(blob);
-        return {
-          url,
-          cleanup: () => URL.revokeObjectURL(url),
-        };
+        return getAndroidProjectFileUrl({
+          projectId: entry.id,
+          fileId: entry.iconFileId,
+        });
       } catch (error) {
         console.error("Failed to load project icon:", error);
         return null;
@@ -214,7 +207,9 @@ export const createAppService = (params) => {
           entry: projectEntry,
           projectService,
         });
-        if (iconResult?.url) {
+        if (typeof iconResult === "string") {
+          fullProject.iconUrl = iconResult;
+        } else if (iconResult?.url) {
           fullProject.iconUrl = iconResult.url;
         }
       }

--- a/src/deps/services/android/projectFileUrls.js
+++ b/src/deps/services/android/projectFileUrls.js
@@ -1,0 +1,33 @@
+import { assertSafeAndroidStorageSegment } from "../../clients/android/storagePaths.js";
+import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
+
+const PROJECT_FILE_EXTENSION_BY_MIME_TYPE = {
+  "image/gif": "gif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+  "video/quicktime": "mov",
+  "video/webm": "webm",
+};
+
+const getProjectFileExtension = (mimeType) => {
+  const normalizedMimeType = String(mimeType ?? "")
+    .trim()
+    .toLowerCase();
+  return PROJECT_FILE_EXTENSION_BY_MIME_TYPE[normalizedMimeType];
+};
+
+export const getAndroidProjectFileUrl = ({ projectId, fileId, mimeType }) => {
+  const safeProjectId = assertSafeAndroidStorageSegment(projectId, {
+    label: "Android project id",
+  });
+  const safeFileId = assertSafeProjectFileId(fileId);
+  const extension = getProjectFileExtension(mimeType);
+  if (extension) {
+    return `https://appassets.androidplatform.net/android-files/projects/${safeProjectId}/typed-files/${safeFileId}/asset.${extension}`;
+  }
+
+  return `https://appassets.androidplatform.net/android-files/projects/${safeProjectId}/files/${safeFileId}`;
+};

--- a/src/deps/services/android/projectServiceAdapters.js
+++ b/src/deps/services/android/projectServiceAdapters.js
@@ -9,6 +9,7 @@ import {
   uint8ArrayToBase64,
 } from "../../clients/android/bridge.js";
 import { assertSafeAndroidStorageSegment } from "../../clients/android/storagePaths.js";
+import { getAndroidProjectFileUrl } from "./projectFileUrls.js";
 import {
   createPersistedAndroidProjectStore,
   evictPersistedAndroidProjectStoreCache,
@@ -37,16 +38,6 @@ import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
 
 const PROJECT_INFO_KEY = "projectInfo";
 const CREATOR_VERSION_KEY = "creatorVersion";
-const PROJECT_FILE_EXTENSION_BY_MIME_TYPE = {
-  "image/gif": "gif",
-  "image/jpeg": "jpg",
-  "image/png": "png",
-  "image/svg+xml": "svg",
-  "image/webp": "webp",
-  "video/mp4": "mp4",
-  "video/quicktime": "mov",
-  "video/webm": "webm",
-};
 
 const normalizeProjectInfo = (projectInfo = {}) => ({
   id: projectInfo.id ?? "",
@@ -338,24 +329,54 @@ const readAndroidProjectFileMetadata = ({ projectId, fileId }) => {
   };
 };
 
-const getProjectFileExtension = (mimeType) => {
-  const normalizedMimeType = String(mimeType ?? "")
-    .trim()
-    .toLowerCase();
-  return PROJECT_FILE_EXTENSION_BY_MIME_TYPE[normalizedMimeType];
+const getAndroidProjectFileUrlCacheKey = ({
+  projectId,
+  fileId,
+  mimeType,
+  sha256,
+}) => {
+  return [
+    assertSafeAndroidStorageSegment(projectId, {
+      label: "Android project id",
+    }),
+    assertSafeProjectFileId(fileId),
+    mimeType ?? "",
+    sha256 ?? "",
+  ].join(":");
 };
 
-const getAndroidProjectFileUrl = ({ projectId, fileId, mimeType }) => {
-  const safeProjectId = assertSafeAndroidStorageSegment(projectId, {
-    label: "Android project id",
-  });
-  const safeFileId = assertSafeProjectFileId(fileId);
-  const extension = getProjectFileExtension(mimeType);
-  if (extension) {
-    return `https://appassets.androidplatform.net/android-files/projects/${safeProjectId}/typed-files/${safeFileId}/asset.${extension}`;
+const resolveKnownFileMetadata = (fileMetadata) => {
+  if (!fileMetadata || typeof fileMetadata !== "object") {
+    return undefined;
   }
 
-  return `https://appassets.androidplatform.net/android-files/projects/${safeProjectId}/files/${safeFileId}`;
+  const mimeType =
+    typeof fileMetadata.mimeType === "string" && fileMetadata.mimeType
+      ? fileMetadata.mimeType
+      : undefined;
+  if (!mimeType) {
+    return undefined;
+  }
+
+  return {
+    mimeType,
+    size: Number.isFinite(fileMetadata.size) ? fileMetadata.size : undefined,
+    sha256:
+      typeof fileMetadata.sha256 === "string" && fileMetadata.sha256
+        ? fileMetadata.sha256
+        : undefined,
+  };
+};
+
+const resolveAndroidProjectFileMetadata = ({
+  projectId,
+  fileId,
+  fileMetadata,
+}) => {
+  return (
+    resolveKnownFileMetadata(fileMetadata) ??
+    readAndroidProjectFileMetadata({ projectId, fileId })
+  );
 };
 
 const copyTemplateFiles = async ({ templateId, projectId, templateData }) => {
@@ -468,6 +489,8 @@ export const createAndroidProjectServiceAdapters = ({
   collabLog,
   creatorVersion,
 }) => {
+  const projectFileUrlByCacheKey = new Map();
+
   const storageAdapter = {
     resolveProjectReferenceByProjectId: async ({ projectId }) => ({
       projectId,
@@ -610,21 +633,35 @@ export const createAndroidProjectServiceAdapters = ({
       };
     },
 
-    getFileContent: async ({ fileId, getCurrentReference }) => {
+    getFileContent: async ({ fileId, fileMetadata, getCurrentReference }) => {
       const reference = getCurrentReference();
       const projectId = reference?.repositoryProjectId || reference?.projectId;
       const safeFileId = assertSafeProjectFileId(fileId);
-      const { mimeType } = readAndroidProjectFileMetadata({
+      const metadata = resolveAndroidProjectFileMetadata({
         projectId,
         fileId: safeFileId,
+        fileMetadata,
       });
-      return {
-        url: getAndroidProjectFileUrl({
+      const cacheKey = getAndroidProjectFileUrlCacheKey({
+        projectId,
+        fileId: safeFileId,
+        mimeType: metadata.mimeType,
+        sha256: metadata.sha256,
+      });
+      let url = projectFileUrlByCacheKey.get(cacheKey);
+      if (!url) {
+        url = getAndroidProjectFileUrl({
           projectId,
           fileId: safeFileId,
-          mimeType,
-        }),
-        type: mimeType,
+          mimeType: metadata.mimeType,
+        });
+        projectFileUrlByCacheKey.set(cacheKey, url);
+      }
+
+      return {
+        url,
+        type: metadata.mimeType,
+        size: metadata.size,
       };
     },
 

--- a/src/deps/services/android/projectServiceAdapters.js
+++ b/src/deps/services/android/projectServiceAdapters.js
@@ -593,6 +593,7 @@ export const createAndroidProjectServiceAdapters = ({
 
   const fileAdapter = {
     continueOnUploadError: false,
+    requiresFileMetadata: true,
 
     storeFile: async ({
       file,

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -1,4 +1,8 @@
 import { loadFont } from "./fontLoader.js";
+import {
+  createNavigationTiming,
+  markNavigationTiming,
+} from "../../../internal/navigationTiming.js";
 
 const createNoopUpdater = () => ({
   checkForUpdates: async () => null,
@@ -73,8 +77,17 @@ export const createAppShellService = ({
   };
 
   return {
-    navigate(path, payload) {
-      subject.dispatch("redirect", { path, payload });
+    navigate(path, payload, options = {}) {
+      const timing =
+        options.timing ??
+        createNavigationTiming({
+          platform,
+          source: "appService.navigate",
+          path,
+          payload,
+        });
+      markNavigationTiming(timing, "appService.navigate.dispatch");
+      subject.dispatch("redirect", { path, payload, timing });
     },
 
     redirect(path, payload) {

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -73,6 +73,7 @@ export const createProjectAssetService = ({
   getCurrentStore,
   getCurrentReference,
   getStoreByProject,
+  getCurrentRepositoryState,
 }) => {
   const shouldSkipImageThumbnail = (options = {}) =>
     options?.skipImageThumbnail === true;
@@ -136,9 +137,22 @@ export const createProjectAssetService = ({
     };
   };
 
+  const resolveFileMetadata = (fileId) => {
+    try {
+      const repositoryState = getCurrentRepositoryState?.();
+      const fileRecord = repositoryState?.files?.items?.[fileId];
+      return fileRecord && typeof fileRecord === "object"
+        ? fileRecord
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
   const getFileContent = async (fileId) => {
     return fileAdapter.getFileContent({
       fileId,
+      fileMetadata: resolveFileMetadata(fileId),
       getCurrentStore,
       getCurrentReference,
       getStoreByProject,

--- a/src/deps/services/shared/projectAssetService.js
+++ b/src/deps/services/shared/projectAssetService.js
@@ -73,7 +73,7 @@ export const createProjectAssetService = ({
   getCurrentStore,
   getCurrentReference,
   getStoreByProject,
-  getCurrentRepositoryState,
+  resolveFileMetadata,
 }) => {
   const shouldSkipImageThumbnail = (options = {}) =>
     options?.skipImageThumbnail === true;
@@ -137,26 +137,21 @@ export const createProjectAssetService = ({
     };
   };
 
-  const resolveFileMetadata = (fileId) => {
-    try {
-      const repositoryState = getCurrentRepositoryState?.();
-      const fileRecord = repositoryState?.files?.items?.[fileId];
-      return fileRecord && typeof fileRecord === "object"
-        ? fileRecord
-        : undefined;
-    } catch {
-      return undefined;
-    }
-  };
-
   const getFileContent = async (fileId) => {
-    return fileAdapter.getFileContent({
+    const payload = {
       fileId,
-      fileMetadata: resolveFileMetadata(fileId),
       getCurrentStore,
       getCurrentReference,
       getStoreByProject,
-    });
+    };
+    if (
+      fileAdapter.requiresFileMetadata === true &&
+      typeof resolveFileMetadata === "function"
+    ) {
+      payload.fileMetadata = resolveFileMetadata(fileId);
+    }
+
+    return fileAdapter.getFileContent(payload);
   };
 
   const processFile = async (file, options = {}) => {

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -890,6 +890,13 @@ export const createProjectRepositoryRuntime = async ({
       activeSceneState,
     });
 
+  const getFileRecord = (fileId) => {
+    const fileRecord = currentMainState?.files?.items?.[fileId];
+    return fileRecord && typeof fileRecord === "object"
+      ? structuredClone(fileRecord)
+      : undefined;
+  };
+
   const notifyStateListeners = () => {
     const repositoryState = structuredClone(getCurrentComposedState());
     const revision = currentRevision;
@@ -1143,6 +1150,8 @@ export const createProjectRepositoryRuntime = async ({
         reduceEventsToState,
       });
     },
+
+    getFileRecord,
 
     getRevision(untilEventIndex) {
       if (untilEventIndex === undefined || untilEventIndex === null) {

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -40,8 +40,8 @@ export const createProjectServiceCore = ({
     getCurrentStore: repositoryService.getCachedStore,
     getCurrentReference: repositoryService.getCachedReference,
     getStoreByProject: repositoryService.getStoreByProject,
-    getCurrentRepositoryState: () =>
-      repositoryService.getCachedRepository().getState(),
+    resolveFileMetadata: (fileId) =>
+      repositoryService.getCachedRepository().getFileRecord(fileId),
   });
 
   const collabService = createProjectCollabCore({

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -40,6 +40,8 @@ export const createProjectServiceCore = ({
     getCurrentStore: repositoryService.getCachedStore,
     getCurrentReference: repositoryService.getCachedReference,
     getStoreByProject: repositoryService.getStoreByProject,
+    getCurrentRepositoryState: () =>
+      repositoryService.getCachedRepository().getState(),
   });
 
   const collabService = createProjectCollabCore({

--- a/src/internal/navigationTiming.js
+++ b/src/internal/navigationTiming.js
@@ -1,0 +1,212 @@
+const LOG_PREFIX = "[rvn.nav-timing]";
+const ACTIVE_TRACE_TTL_MS = 2000;
+
+let nextTraceId = 0;
+let activeTraceId;
+let activeTraceClearTimer;
+let cachedAndroidDebugBuild;
+
+export const getNavigationTimingNow = () => {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+const roundMs = (value) => Number(value.toFixed(2));
+
+const isAndroidDebugBuild = () => {
+  if (cachedAndroidDebugBuild !== undefined) {
+    return cachedAndroidDebugBuild;
+  }
+
+  const bridge =
+    typeof window !== "undefined" ? window.RouteVNAndroid : undefined;
+  if (typeof bridge?.isDebugBuild === "function") {
+    try {
+      cachedAndroidDebugBuild = bridge.isDebugBuild() === true;
+      return cachedAndroidDebugBuild;
+    } catch {
+      cachedAndroidDebugBuild = false;
+      return cachedAndroidDebugBuild;
+    }
+  }
+
+  cachedAndroidDebugBuild = false;
+  return cachedAndroidDebugBuild;
+};
+
+export const isNavigationTimingEnabledForPlatform = (platform) => {
+  return platform === "android" && isAndroidDebugBuild();
+};
+
+export const isNavigationTimingEnabled = (appService) => {
+  return isNavigationTimingEnabledForPlatform(appService?.getPlatform?.());
+};
+
+const getEventTimingData = (event) => {
+  if (!event) {
+    return undefined;
+  }
+
+  const now = getNavigationTimingNow();
+  const eventTimeStamp = Number(event.timeStamp);
+  const hasEventTimeStamp = Number.isFinite(eventTimeStamp);
+  const eventAge =
+    hasEventTimeStamp && eventTimeStamp > 100000000000
+      ? Date.now() - eventTimeStamp
+      : now - eventTimeStamp;
+  const eventAgeMs = hasEventTimeStamp ? roundMs(eventAge) : undefined;
+
+  return {
+    eventType: event.type,
+    pointerType: event.pointerType,
+    eventTimeStamp: hasEventTimeStamp ? roundMs(eventTimeStamp) : undefined,
+    eventAgeMs,
+  };
+};
+
+const emitTimingLog = (entry) => {
+  try {
+    console.info(`${LOG_PREFIX} ${JSON.stringify(entry)}`);
+  } catch {
+    console.info(LOG_PREFIX, entry);
+  }
+};
+
+const setActiveTrace = (traceId) => {
+  activeTraceId = traceId;
+  if (activeTraceClearTimer) {
+    clearTimeout(activeTraceClearTimer);
+  }
+
+  activeTraceClearTimer = setTimeout(() => {
+    if (activeTraceId === traceId) {
+      activeTraceId = undefined;
+    }
+  }, ACTIVE_TRACE_TTL_MS);
+};
+
+export const getActiveNavigationTimingId = () => activeTraceId;
+
+export const createNavigationTiming = ({
+  appService,
+  platform,
+  source,
+  path,
+  payload,
+  event,
+  data,
+} = {}) => {
+  const resolvedPlatform = platform ?? appService?.getPlatform?.();
+  if (!isNavigationTimingEnabledForPlatform(resolvedPlatform)) {
+    return undefined;
+  }
+
+  const startedAt = getNavigationTimingNow();
+  const trace = {
+    id: ++nextTraceId,
+    startedAt,
+    lastAt: startedAt,
+    source,
+    path,
+  };
+  setActiveTrace(trace.id);
+  emitTimingLog({
+    id: trace.id,
+    event: "start",
+    source,
+    path,
+    payloadKeys: payload ? Object.keys(payload) : [],
+    ts: roundMs(startedAt),
+    ...getEventTimingData(event),
+    ...data,
+  });
+  return trace;
+};
+
+export const markNavigationTiming = (trace, event, data = {}) => {
+  if (!trace) {
+    return;
+  }
+
+  const now = getNavigationTimingNow();
+  emitTimingLog({
+    id: trace.id,
+    event,
+    source: trace.source,
+    path: trace.path,
+    ts: roundMs(now),
+    totalMs: roundMs(now - trace.startedAt),
+    deltaMs: roundMs(now - trace.lastAt),
+    ...data,
+  });
+  trace.lastAt = now;
+  setActiveTrace(trace.id);
+};
+
+export const finishNavigationTiming = (trace, event = "finish", data = {}) => {
+  markNavigationTiming(trace, event, data);
+};
+
+export const markNavigationPaintTiming = (trace, event, data = {}) => {
+  if (!trace || typeof requestAnimationFrame !== "function") {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    markNavigationTiming(trace, `${event}.raf1`, data);
+    requestAnimationFrame(() => {
+      markNavigationTiming(trace, `${event}.raf2`, data);
+    });
+  });
+};
+
+export const logNavigationInteractionTiming = ({
+  appService,
+  platform,
+  source,
+  event,
+  data,
+} = {}) => {
+  const resolvedPlatform = platform ?? appService?.getPlatform?.();
+  if (!isNavigationTimingEnabledForPlatform(resolvedPlatform)) {
+    return;
+  }
+
+  emitTimingLog({
+    event: "interaction",
+    activeTraceId,
+    source,
+    ts: roundMs(getNavigationTimingNow()),
+    ...getEventTimingData(event),
+    ...data,
+  });
+};
+
+export const logAndroidBridgeTiming = ({
+  method,
+  durationMs,
+  resultSize,
+  ok,
+  errorCode,
+} = {}) => {
+  if (!isNavigationTimingEnabledForPlatform("android")) {
+    return;
+  }
+
+  emitTimingLog({
+    id: activeTraceId,
+    event: "android.bridge",
+    method,
+    durationMs: roundMs(durationMs),
+    resultSize,
+    ok,
+    errorCode,
+    ts: roundMs(getNavigationTimingNow()),
+  });
+};

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -12,6 +12,13 @@ import {
   getProjectOpenErrorMessage,
   isIncompatibleProjectOpenError,
 } from "../../internal/projectOpenErrors.js";
+import {
+  createNavigationTiming,
+  finishNavigationTiming,
+  logNavigationInteractionTiming,
+  markNavigationPaintTiming,
+  markNavigationTiming,
+} from "../../internal/navigationTiming.js";
 import { getRoutevnCreatorDocsUrl } from "../../internal/routevnUrls.js";
 import { resolveUpdatesEnabled } from "../../internal/updates.js";
 import { recordRecentSceneVisit } from "../../internal/ui/recentScenes.js";
@@ -125,19 +132,46 @@ const mountSubscriptions = (deps) => {
   return () => active.forEach((subscription) => subscription?.unsubscribe?.());
 };
 
+const renderWithNavigationTiming = ({ render, timing, event }) => {
+  markNavigationTiming(timing, `${event}.render.start`);
+  render();
+  markNavigationTiming(timing, `${event}.render.end`);
+  markNavigationPaintTiming(timing, `${event}.paint`);
+};
+
 const createRouteTransitionRunner = (deps) => {
   let transitionToken = 0;
 
-  return async ({ path, payload, shouldUpdateHistory = false } = {}) => {
+  return async ({
+    path,
+    payload,
+    shouldUpdateHistory = false,
+    timing,
+  } = {}) => {
     const { appService, projectService, store, render } = deps;
     const currentTransitionToken = ++transitionToken;
     const nextPayload = normalizePayload(payload);
     const canonicalPath = getCanonicalRoutePath(path);
+    const routeTiming =
+      timing ??
+      createNavigationTiming({
+        appService,
+        source: "route.transition",
+        path: canonicalPath,
+        payload: nextPayload,
+      });
+    markNavigationTiming(routeTiming, "route.transition.start", {
+      shouldUpdateHistory,
+      requestedPath: path,
+      canonicalPath,
+    });
 
     if (shouldUpdateHistory) {
       appService.redirect(canonicalPath, nextPayload);
+      markNavigationTiming(routeTiming, "route.history.redirected");
     } else if (canonicalPath !== path) {
       appService.replace(canonicalPath, nextPayload);
+      markNavigationTiming(routeTiming, "route.history.replaced");
     }
 
     const currentProjectId = appService.getCurrentProjectId();
@@ -158,6 +192,13 @@ const createRouteTransitionRunner = (deps) => {
     const shouldReleaseEnsuredRepository =
       !!ensuredProjectId &&
       (!needsRepository || ensuredProjectId !== currentProjectId);
+    markNavigationTiming(routeTiming, "route.state.resolved", {
+      currentProjectId,
+      ensuredProjectId,
+      needsRepository,
+      isAlreadyEnsured,
+      shouldReleaseEnsuredRepository,
+    });
     store.setCurrentRoute({ route: canonicalPath });
     store.closeMobileSheet();
     store.setRepositoryLoading({
@@ -168,10 +209,20 @@ const createRouteTransitionRunner = (deps) => {
         phase: "Refreshing project entry...",
       });
     }
-    render();
+    renderWithNavigationTiming({
+      render,
+      timing: routeTiming,
+      event: "route.initial",
+    });
 
     if (shouldReleaseEnsuredRepository) {
+      markNavigationTiming(routeTiming, "repository.release.start", {
+        ensuredProjectId,
+      });
       await projectService.releaseProjectRuntime(ensuredProjectId);
+      markNavigationTiming(routeTiming, "repository.release.end", {
+        ensuredProjectId,
+      });
     }
 
     if (!needsRepository) {
@@ -180,13 +231,24 @@ const createRouteTransitionRunner = (deps) => {
       }
 
       void appService.refreshCurrentProjectEntry();
+      markNavigationTiming(routeTiming, "project-entry.refresh.detached");
       store.setRepositoryLoading({ isLoading: false });
-      render();
+      renderWithNavigationTiming({
+        render,
+        timing: routeTiming,
+        event: "route.non-project-final",
+      });
+      finishNavigationTiming(routeTiming, "route.transition.complete", {
+        needsRepository,
+      });
       return;
     }
 
     try {
+      markNavigationTiming(routeTiming, "project-entry.refresh.start");
       await appService.refreshCurrentProjectEntry();
+      markNavigationTiming(routeTiming, "project-entry.refresh.end");
+      markNavigationTiming(routeTiming, "repository.ensure.start");
       await projectService.ensureRepository({
         onLoadStage: ({ label } = {}) => {
           if (currentTransitionToken !== transitionToken) {
@@ -201,7 +263,11 @@ const createRouteTransitionRunner = (deps) => {
               current: 0,
               total: 0,
             });
-            render();
+            renderWithNavigationTiming({
+              render,
+              timing: routeTiming,
+              event: "repository.load-stage",
+            });
           }
         },
         onEventLoadProgress: ({ current, total, label } = {}) => {
@@ -219,7 +285,11 @@ const createRouteTransitionRunner = (deps) => {
             current,
             total,
           });
-          render();
+          renderWithNavigationTiming({
+            render,
+            timing: routeTiming,
+            event: "repository.event-progress",
+          });
         },
         onHydrationProgress: ({ current, total } = {}) => {
           if (currentTransitionToken !== transitionToken) {
@@ -234,21 +304,36 @@ const createRouteTransitionRunner = (deps) => {
             current,
             total,
           });
-          render();
+          renderWithNavigationTiming({
+            render,
+            timing: routeTiming,
+            event: "repository.hydration-progress",
+          });
         },
       });
+      markNavigationTiming(routeTiming, "repository.ensure.end");
 
       if (currentTransitionToken !== transitionToken) {
         return;
       }
 
       store.setRepositoryLoading({ isLoading: false });
-      render();
+      renderWithNavigationTiming({
+        render,
+        timing: routeTiming,
+        event: "route.project-final",
+      });
+      finishNavigationTiming(routeTiming, "route.transition.complete", {
+        needsRepository,
+      });
     } catch (error) {
       if (currentTransitionToken !== transitionToken) {
         return;
       }
 
+      markNavigationTiming(routeTiming, "route.transition.error", {
+        message: error?.message,
+      });
       store.setRepositoryLoading({ isLoading: false });
       if (isIncompatibleProjectOpenError(error)) {
         await appService.showAlert({
@@ -261,7 +346,15 @@ const createRouteTransitionRunner = (deps) => {
       }
       appService.redirect("/projects");
       store.setCurrentRoute({ route: "/projects" });
-      render();
+      renderWithNavigationTiming({
+        render,
+        timing: routeTiming,
+        event: "route.error-final",
+      });
+      finishNavigationTiming(routeTiming, "route.transition.complete", {
+        needsRepository,
+        error: true,
+      });
     }
   };
 };
@@ -347,8 +440,14 @@ export const handleHelpFloatingButtonClick = (deps) => {
 };
 
 export const handleMobileTabClick = (deps, payload = {}) => {
-  const { store, render } = deps;
+  const { appService, store, render } = deps;
   const tabId = payload._event.currentTarget.dataset.tabId;
+  logNavigationInteractionTiming({
+    appService,
+    source: "app.mobile-tab.click",
+    event: payload._event,
+    data: { tabId },
+  });
 
   if (
     tabId === "assets" ||
@@ -356,9 +455,41 @@ export const handleMobileTabClick = (deps, payload = {}) => {
     tabId === "release" ||
     tabId === "settings"
   ) {
+    const timing = createNavigationTiming({
+      appService,
+      source: "app.mobile-tab.open-sheet",
+      path: `mobile-sheet:${tabId}`,
+      event: payload._event,
+      data: { tabId },
+    });
     store.openMobileSheet({ variant: tabId });
-    render();
+    renderWithNavigationTiming({
+      render,
+      timing,
+      event: "mobile-sheet.open",
+    });
+    finishNavigationTiming(timing, "mobile-sheet.open.complete");
   }
+};
+
+export const handleMobileTabPointerDown = (deps, payload = {}) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "app.mobile-tab.pointerdown",
+    event: payload._event,
+    data: { tabId: payload._event.currentTarget.dataset.tabId },
+  });
+};
+
+export const handleMobileTabPointerUp = (deps, payload = {}) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "app.mobile-tab.pointerup",
+    event: payload._event,
+    data: { tabId: payload._event.currentTarget.dataset.tabId },
+  });
 };
 
 export const handleMobileSheetClose = (deps) => {
@@ -392,13 +523,30 @@ const subscriptions = (deps) => {
         const nextPayload = shouldUpdateHistory
           ? payload.payload
           : payload?.payload;
+        const timing =
+          payload?.timing ??
+          createNavigationTiming({
+            appService,
+            source: `subject.${action}`,
+            path,
+            payload: nextPayload,
+          });
+        markNavigationTiming(timing, "route.subscription.received", {
+          action,
+          shouldUpdateHistory:
+            shouldUpdateHistory || !!payload?.shouldUpdateHistory,
+        });
 
         runRouteTransition({
           path,
           payload: nextPayload,
           shouldUpdateHistory:
             shouldUpdateHistory || !!payload?.shouldUpdateHistory,
+          timing,
         }).catch((error) => {
+          markNavigationTiming(timing, "route.subscription.error", {
+            message: error?.message,
+          });
           console.error("Failed to navigate:", error);
         });
       }),

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -5,6 +5,10 @@ refs:
         handler: handleHelpFloatingButtonClick
   mobileTabItem*:
     eventListeners:
+      pointerdown:
+        handler: handleMobileTabPointerDown
+      pointerup:
+        handler: handleMobileTabPointerUp
       click:
         handler: handleMobileTabClick
   mobileSheet:

--- a/src/pages/resourceTypes/resourceTypes.handlers.js
+++ b/src/pages/resourceTypes/resourceTypes.handlers.js
@@ -1,3 +1,8 @@
+import {
+  createNavigationTiming,
+  logNavigationInteractionTiming,
+} from "../../internal/navigationTiming.js";
+
 export const handleItemClick = (deps, payload) => {
   const { appService, store } = deps;
   const id =
@@ -11,5 +16,37 @@ export const handleItemClick = (deps, payload) => {
     return;
   }
   const currentPayload = appService.getPayload();
-  appService.navigate(resourceItem.path, currentPayload);
+  const timing = createNavigationTiming({
+    appService,
+    source: "resource-types.item.click",
+    path: resourceItem.path,
+    payload: currentPayload,
+    event: payload._event,
+    data: { itemId: id },
+  });
+  appService.navigate(resourceItem.path, currentPayload, { timing });
+};
+
+export const handleItemPointerDown = (deps, payload) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "resource-types.item.pointerdown",
+    event: payload._event,
+    data: {
+      itemId: payload._event.currentTarget.getAttribute?.("data-item-id"),
+    },
+  });
+};
+
+export const handleItemPointerUp = (deps, payload) => {
+  const { appService } = deps;
+  logNavigationInteractionTiming({
+    appService,
+    source: "resource-types.item.pointerup",
+    event: payload._event,
+    data: {
+      itemId: payload._event.currentTarget.getAttribute?.("data-item-id"),
+    },
+  });
 };

--- a/src/pages/resourceTypes/resourceTypes.view.yaml
+++ b/src/pages/resourceTypes/resourceTypes.view.yaml
@@ -1,6 +1,10 @@
 refs:
   item*:
     eventListeners:
+      pointerdown:
+        handler: handleItemPointerDown
+      pointerup:
+        handler: handleItemPointerUp
       click:
         handler: handleItemClick
 template:

--- a/src/pages/sidebar/sidebar.handlers.js
+++ b/src/pages/sidebar/sidebar.handlers.js
@@ -1,4 +1,8 @@
 import { filter, tap } from "rxjs";
+import {
+  createNavigationTiming,
+  markNavigationTiming,
+} from "../../internal/navigationTiming.js";
 
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
@@ -29,18 +33,34 @@ export const handleAfterMount = async (deps) => {
 export const handleItemClick = async (deps, payload) => {
   const { subject, appService } = deps;
   const currentPayload = appService.getPayload();
+  const path = payload._event.detail.item.id;
+  const timing = createNavigationTiming({
+    appService,
+    source: "sidebar.item-click",
+    path,
+    payload: currentPayload,
+    event: payload._event,
+  });
   subject.dispatch("redirect", {
-    path: payload._event.detail.item.id,
+    path,
     payload: currentPayload, // Pass through current payload (including projectId)
+    timing,
   });
 };
 
 export const handleHeaderClick = (deps) => {
   const { subject, appService } = deps;
   const currentPayload = appService.getPayload();
+  const timing = createNavigationTiming({
+    appService,
+    source: "sidebar.header-click",
+    path: "/project",
+    payload: currentPayload,
+  });
   subject.dispatch("redirect", {
     path: "/project",
     payload: currentPayload, // Pass through current payload (including projectId)
+    timing,
   });
 };
 
@@ -61,9 +81,11 @@ const subscriptions = (deps) => {
     ),
     subject.pipe(
       filter(({ action }) => action === "redirect"),
-      tap(() => {
+      tap(({ payload }) => {
         // Small delay to ensure route has changed
+        markNavigationTiming(payload?.timing, "sidebar.redirect.render.start");
         render();
+        markNavigationTiming(payload?.timing, "sidebar.redirect.render.end");
       }),
     ),
   ];

--- a/src/setup.android.js
+++ b/src/setup.android.js
@@ -154,6 +154,37 @@ const deps = {
   pages: pageDependencies,
 };
 
+const installAndroidDebugHooks = () => {
+  let isDebugBuild = false;
+  try {
+    isDebugBuild = window.RouteVNAndroid?.isDebugBuild?.() === true;
+  } catch {
+    isDebugBuild = false;
+  }
+
+  if (!isDebugBuild) {
+    return;
+  }
+
+  window.__RVN_DEBUG_APP__ = {
+    listProjects: () => appService.loadAllProjects(),
+    async openProject(projectId) {
+      const projects = await appService.loadAllProjects();
+      const project = projects.find((entry) => entry?.id === projectId);
+      if (project) {
+        appService.setCurrentProjectEntry(project);
+      }
+      await projectService.ensureProjectCompatibleById(projectId);
+      appService.navigate("/project", { p: projectId });
+    },
+    navigate: (path, payload) => {
+      appService.navigate(path, payload);
+    },
+    getPayload: () => appService.getPayload(),
+  };
+};
+
+installAndroidDebugHooks();
 notifyAndroidBackState();
 
 export { deps };


### PR DESCRIPTION
Summary
- Add Android-only navigation, interaction, render, paint, bridge, and SQLite timing logs.
- Gate diagnostics and debug app hooks behind the native Android debug-build check so they stay disabled in release builds.
- Reuse repository file metadata to build Android appassets URLs directly for project files and icons, avoiding synchronous metadata bridge calls on normal render paths.
- Add a debug-only Android app hook for device testing on devices where input injection is blocked.

Validation
- bun run lint
- bun run build:android