### PR TITLE
Reduce scenes whiteboard render cost

### DIFF
--- a/src/components/whiteboard/whiteboard.schema.yaml
+++ b/src/components/whiteboard/whiteboard.schema.yaml
@@ -23,6 +23,8 @@ propsSchema:
       type: boolean
     showMinimapInTouchMode:
       type: boolean
+    showArrows:
+      type: boolean
     minimapPlacement:
       type: string
     minimapHeightScale:

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -759,6 +759,7 @@ export const selectViewData = ({ state, props }) => {
   const minimapViewportCursor = state.isDraggingMinimapViewport
     ? "grabbing"
     : "grab";
+  const showArrows = parseBooleanProp(props.showArrows, true);
 
   // Calculate adaptive grid size for container background
   const getAdaptiveGridSize = (zoomLevel) => {
@@ -779,26 +780,29 @@ export const selectViewData = ({ state, props }) => {
   const startLineHeight = Math.max(2, Math.round(SCENE_BOX_HEIGHT / 45));
 
   // Generate arrows for each scene's transitions
-  items.forEach((sourceItem) => {
-    if (sourceItem.transitions && sourceItem.transitions.length > 0) {
-      sourceItem.transitions.forEach((targetSceneId) => {
-        const targetItem = items.find((item) => item.id === targetSceneId);
-        if (targetItem && targetItem.id !== sourceItem.id) {
-          const arrowData = drawArrowBetweenScenes(sourceItem, targetItem);
-          // Add unique identifier for DOM reference
-          arrowData.id = `arrow-${sourceItem.id}-to-${targetSceneId}`;
-          const selectedItemId = props.selectedItemId;
-          const isConnectedToSelected =
-            selectedItemId &&
-            (sourceItem.id === selectedItemId ||
-              targetSceneId === selectedItemId);
-          arrowData.strokeColor = "var(--foreground)";
-          arrowData.strokeWidth = isConnectedToSelected ? 2.25 : 1.5;
-          arrowsList.push(arrowData);
-        }
-      });
-    }
-  });
+  if (showArrows) {
+    const itemById = new Map(items.map((item) => [item.id, item]));
+    items.forEach((sourceItem) => {
+      if (sourceItem.transitions && sourceItem.transitions.length > 0) {
+        sourceItem.transitions.forEach((targetSceneId) => {
+          const targetItem = itemById.get(targetSceneId);
+          if (targetItem && targetItem.id !== sourceItem.id) {
+            const arrowData = drawArrowBetweenScenes(sourceItem, targetItem);
+            // Add unique identifier for DOM reference
+            arrowData.id = `arrow-${sourceItem.id}-to-${targetSceneId}`;
+            const selectedItemId = props.selectedItemId;
+            const isConnectedToSelected =
+              selectedItemId &&
+              (sourceItem.id === selectedItemId ||
+                targetSceneId === selectedItemId);
+            arrowData.strokeColor = "var(--foreground)";
+            arrowData.strokeWidth = isConnectedToSelected ? 2.25 : 1.5;
+            arrowsList.push(arrowData);
+          }
+        });
+      }
+    });
+  }
 
   const showTouchMinimap =
     isTouchMode &&
@@ -809,18 +813,21 @@ export const selectViewData = ({ state, props }) => {
   const minimapHeightScale = resolveMinimapHeightScale(
     props.minimapHeightScale,
   );
+  const showMinimap = showTouchMinimap || showDesktopMinimap;
 
   return {
     items,
-    showMinimap: showTouchMinimap || showDesktopMinimap,
+    showMinimap,
     showControls: !isTouchMode,
-    minimapData: selectMinimapData(
-      { state },
-      {
-        items,
-        heightScale: minimapHeightScale,
-      },
-    ),
+    minimapData: showMinimap
+      ? selectMinimapData(
+          { state },
+          {
+            items,
+            heightScale: minimapHeightScale,
+          },
+        )
+      : undefined,
     minimapContainerStyle: resolveMinimapContainerStyle(minimapPlacement),
     arrowsList,
     selectedItemId: props.selectedItemId,

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -23,6 +23,9 @@ const DEFAULT_SCENES_MAP_VIEWPORT = {
   panX: -80,
   panY: -40,
 };
+const TOUCH_MINIMAP_HYDRATION_FRAME_COUNT = 6;
+const WHITEBOARD_CONNECTIONS_HYDRATION_FRAME_COUNT = 4;
+const SCENE_OVERVIEW_HYDRATION_FRAME_COUNT = 8;
 
 const getProjectErrorMessage = (result, fallbackMessage) => {
   return (
@@ -394,7 +397,207 @@ const openSceneForm = ({
   sceneForm.setValues({ values: sceneFormValues });
 };
 
-const syncScenesState = ({ store, render, projectService } = {}) => {
+const cancelTouchMinimapHydrationFrame = (store) => {
+  const frameId = store.selectTouchMinimapFrameId?.();
+  if (frameId === undefined) {
+    return;
+  }
+
+  globalThis.cancelAnimationFrame?.(frameId);
+  store.clearTouchMinimapFrameId?.();
+};
+
+const cancelWhiteboardConnectionsHydrationFrame = (store) => {
+  const frameId = store.selectWhiteboardConnectionsFrameId?.();
+  if (frameId === undefined) {
+    return;
+  }
+
+  globalThis.cancelAnimationFrame?.(frameId);
+  store.clearWhiteboardConnectionsFrameId?.();
+};
+
+const cancelSceneOverviewRefreshFrame = (store) => {
+  const frameId = store.selectSceneOverviewFrameId?.();
+  if (frameId === undefined) {
+    return;
+  }
+
+  globalThis.cancelAnimationFrame?.(frameId);
+  store.clearSceneOverviewFrameId?.();
+};
+
+const scheduleAfterFrames = ({
+  frameCount,
+  setFrameId,
+  clearFrameId,
+  callback,
+} = {}) => {
+  if (typeof globalThis.requestAnimationFrame !== "function") {
+    callback?.();
+    return;
+  }
+
+  const scheduleNextFrame = (remainingFrameCount) => {
+    const frameId = globalThis.requestAnimationFrame(() => {
+      clearFrameId?.();
+
+      if (remainingFrameCount <= 1) {
+        callback?.();
+        return;
+      }
+
+      scheduleNextFrame(remainingFrameCount - 1);
+    });
+
+    setFrameId?.(frameId);
+  };
+
+  scheduleNextFrame(frameCount);
+};
+
+const scheduleTouchMinimapHydration = ({ store, render } = {}) => {
+  if (
+    !store.selectIsTouchMode?.() ||
+    store.selectIsTouchMinimapReady?.() ||
+    store.selectTouchMinimapFrameId?.() !== undefined
+  ) {
+    return;
+  }
+
+  scheduleAfterFrames({
+    frameCount: TOUCH_MINIMAP_HYDRATION_FRAME_COUNT,
+    setFrameId: (frameId) => store.setTouchMinimapFrameId?.({ frameId }),
+    clearFrameId: () => store.clearTouchMinimapFrameId?.(),
+    callback: () => {
+      store.setTouchMinimapReady?.({ isReady: true });
+      render?.();
+    },
+  });
+};
+
+const scheduleWhiteboardConnectionsHydration = ({ store, render } = {}) => {
+  if (
+    !store.selectIsTouchMode?.() ||
+    store.selectIsWhiteboardConnectionsReady?.() ||
+    store.selectWhiteboardConnectionsFrameId?.() !== undefined
+  ) {
+    return;
+  }
+
+  scheduleAfterFrames({
+    frameCount: WHITEBOARD_CONNECTIONS_HYDRATION_FRAME_COUNT,
+    setFrameId: (frameId) =>
+      store.setWhiteboardConnectionsFrameId?.({ frameId }),
+    clearFrameId: () => store.clearWhiteboardConnectionsFrameId?.(),
+    callback: () => {
+      store.setWhiteboardConnectionsReady?.({ isReady: true });
+      render?.();
+    },
+  });
+};
+
+const scheduleSceneOverviewRefresh = ({
+  store,
+  render,
+  projectService,
+  orderedSceneIds = [],
+  requestId,
+} = {}) => {
+  if (orderedSceneIds.length === 0) {
+    return;
+  }
+
+  if (store.selectSceneOverviewFrameId?.() !== undefined) {
+    return;
+  }
+
+  scheduleAfterFrames({
+    frameCount: SCENE_OVERVIEW_HYDRATION_FRAME_COUNT,
+    setFrameId: (frameId) => store.setSceneOverviewFrameId?.({ frameId }),
+    clearFrameId: () => store.clearSceneOverviewFrameId?.(),
+    callback: () => {
+      void refreshSceneOverviews({
+        store,
+        render,
+        projectService,
+        orderedSceneIds,
+        requestId,
+      });
+    },
+  });
+};
+
+const setInitialWhiteboardHydrationState = ({ store } = {}) => {
+  if (store.selectIsTouchMode?.()) {
+    store.setTouchMinimapReady?.({ isReady: false });
+    store.setWhiteboardConnectionsReady?.({ isReady: false });
+    return;
+  }
+
+  store.setTouchMinimapReady?.({ isReady: true });
+  store.setWhiteboardConnectionsReady?.({ isReady: true });
+};
+
+const cancelDeferredWhiteboardWork = (store) => {
+  cancelTouchMinimapHydrationFrame(store);
+  cancelWhiteboardConnectionsHydrationFrame(store);
+  cancelSceneOverviewRefreshFrame(store);
+};
+
+const hydrateDeferredWhiteboardWork = ({
+  store,
+  render,
+  projectService,
+  orderedSceneIds = [],
+  requestId,
+} = {}) => {
+  scheduleWhiteboardConnectionsHydration({ store, render });
+  scheduleTouchMinimapHydration({ store, render });
+
+  if (!store.selectIsTouchMode?.()) {
+    void refreshSceneOverviews({
+      store,
+      render,
+      projectService,
+      orderedSceneIds,
+      requestId,
+    });
+    return;
+  }
+
+  scheduleSceneOverviewRefresh({
+    store,
+    render,
+    projectService,
+    orderedSceneIds,
+    requestId,
+  });
+};
+
+const selectFileExplorerItemAfterRender = ({ refs, itemId } = {}) => {
+  if (!itemId) {
+    return;
+  }
+
+  const selectItem = () => {
+    refs.fileexplorer?.selectItem?.({ itemId });
+  };
+
+  if (typeof globalThis.requestAnimationFrame !== "function") {
+    selectItem();
+    return;
+  }
+
+  globalThis.requestAnimationFrame(selectItem);
+};
+
+const syncScenesState = ({
+  store,
+  render,
+  projectService,
+  shouldRender = true,
+} = {}) => {
   const baseSnapshot = buildScenesStateSnapshot({
     store,
     projectService,
@@ -411,7 +614,9 @@ const syncScenesState = ({ store, render, projectService } = {}) => {
 
   const requestId = store.selectSceneOverviewRequestId() + 1;
   store.setSceneOverviewRequestId({ requestId });
-  render?.();
+  if (shouldRender) {
+    render?.();
+  }
 
   return {
     ...baseSnapshot,
@@ -522,16 +727,19 @@ export const handleBeforeMount = (deps) => {
 
   return () => {
     subscription.unsubscribe();
+    cancelDeferredWhiteboardWork(store);
   };
 };
 
 export const handleAfterMount = async (deps) => {
   const { store, projectService, render, refs, appService } = deps;
   await projectService.ensureRepository();
+  setInitialWhiteboardHydrationState({ store });
   const initialSnapshot = syncScenesState({
     store,
     render,
     projectService,
+    shouldRender: false,
   });
   const sceneItems = initialSnapshot?.sceneItems ?? [];
 
@@ -551,8 +759,6 @@ export const handleAfterMount = async (deps) => {
       appService,
       sceneId: persistedSelectedSceneId,
     });
-    const { fileexplorer } = refs;
-    fileexplorer?.selectItem({ itemId: persistedSelectedSceneId });
   }
 
   const initialViewport = resolveInitialWhiteboardViewport({
@@ -578,14 +784,20 @@ export const handleAfterMount = async (deps) => {
   }
 
   render();
-  focusFileExplorerKeyboardScope(deps);
-  void refreshSceneOverviews({
+  if (persistedSelectedSceneId && !store.selectIsTouchMode?.()) {
+    selectFileExplorerItemAfterRender({
+      refs,
+      itemId: persistedSelectedSceneId,
+    });
+  }
+  hydrateDeferredWhiteboardWork({
     store,
     render,
     projectService,
     orderedSceneIds: initialSnapshot?.orderedSceneIds ?? [],
     requestId: initialSnapshot?.requestId,
   });
+  focusFileExplorerKeyboardScope(deps);
 };
 
 export const handleSetInitialScene = async (sceneId, deps) => {
@@ -595,12 +807,14 @@ export const handleSetInitialScene = async (sceneId, deps) => {
 
 const refreshScenesData = async (deps) => {
   const { store, render, projectService } = deps;
+  cancelDeferredWhiteboardWork(store);
+  setInitialWhiteboardHydrationState({ store });
   const snapshot = syncScenesState({
     store,
     render,
     projectService,
   });
-  void refreshSceneOverviews({
+  hydrateDeferredWhiteboardWork({
     store,
     render,
     projectService,

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -112,12 +112,19 @@ export const createInitialState = () => ({
   sceneOverviewRequestId: 0,
   isTouchMode: false,
   isMobileFileExplorerOpen: false,
+  isTouchMinimapReady: false,
+  touchMinimapFrameId: undefined,
+  isWhiteboardConnectionsReady: false,
+  whiteboardConnectionsFrameId: undefined,
+  sceneOverviewFrameId: undefined,
 });
 
 export const setUiConfig = ({ state }, { uiConfig } = {}) => {
   state.isTouchMode =
     uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
 };
+
+export const selectIsTouchMode = ({ state }) => state.isTouchMode;
 
 export const openMobileFileExplorer = ({ state }, _payload = {}) => {
   state.isMobileFileExplorerOpen = true;
@@ -130,6 +137,56 @@ export const closeMobileFileExplorer = ({ state }, _payload = {}) => {
 export const selectIsMobileFileExplorerOpen = ({ state }) => {
   return Boolean(state.isMobileFileExplorerOpen);
 };
+
+export const setTouchMinimapReady = ({ state }, { isReady } = {}) => {
+  state.isTouchMinimapReady = isReady === true;
+};
+
+export const selectIsTouchMinimapReady = ({ state }) =>
+  state.isTouchMinimapReady;
+
+export const setTouchMinimapFrameId = ({ state }, { frameId } = {}) => {
+  state.touchMinimapFrameId = frameId;
+};
+
+export const clearTouchMinimapFrameId = ({ state }) => {
+  state.touchMinimapFrameId = undefined;
+};
+
+export const selectTouchMinimapFrameId = ({ state }) =>
+  state.touchMinimapFrameId;
+
+export const setWhiteboardConnectionsReady = ({ state }, { isReady } = {}) => {
+  state.isWhiteboardConnectionsReady = isReady === true;
+};
+
+export const selectIsWhiteboardConnectionsReady = ({ state }) =>
+  state.isWhiteboardConnectionsReady;
+
+export const setWhiteboardConnectionsFrameId = (
+  { state },
+  { frameId } = {},
+) => {
+  state.whiteboardConnectionsFrameId = frameId;
+};
+
+export const clearWhiteboardConnectionsFrameId = ({ state }) => {
+  state.whiteboardConnectionsFrameId = undefined;
+};
+
+export const selectWhiteboardConnectionsFrameId = ({ state }) =>
+  state.whiteboardConnectionsFrameId;
+
+export const setSceneOverviewFrameId = ({ state }, { frameId } = {}) => {
+  state.sceneOverviewFrameId = frameId;
+};
+
+export const clearSceneOverviewFrameId = ({ state }) => {
+  state.sceneOverviewFrameId = undefined;
+};
+
+export const selectSceneOverviewFrameId = ({ state }) =>
+  state.sceneOverviewFrameId;
 
 export const setItems = ({ state }, { scenesData } = {}) => {
   state.scenesData = scenesData;
@@ -527,6 +584,8 @@ export const selectViewData = ({ state, i18n }) => {
     selectedDetailType,
     addSceneButtonVariant: state.isWaitingForTransform ? "pr" : "se",
     whiteboardItems: state.whiteboardItems,
+    showWhiteboardConnections:
+      !state.isTouchMode || state.isWhiteboardConnectionsReady,
     selectedSceneName: selectedItemName,
     selectedItemDescription,
     isWaitingForTransform: state.isWaitingForTransform,
@@ -560,7 +619,8 @@ export const selectViewData = ({ state, i18n }) => {
     showDetailPanel: !state.isTouchMode,
     showMobileScenesControls: state.isTouchMode,
     showMobileFileExplorer: state.isTouchMode && state.isMobileFileExplorerOpen,
-    showWhiteboardMinimapInTouchMode: state.isTouchMode,
+    showWhiteboardMinimapInTouchMode:
+      state.isTouchMode && state.isTouchMinimapReady,
     whiteboardMinimapPlacement: state.isTouchMode ? "top-right" : "bottom-left",
     whiteboardMinimapHeightScale: state.isTouchMode ? 2 / 3 : 1,
     title: copy.title ?? "Scenes",

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -113,7 +113,7 @@ template:
                       - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
           - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
-                  - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId} :isTouchMode=${isTouchMode} :showMinimapInTouchMode=${showWhiteboardMinimapInTouchMode} :minimapPlacement=${whiteboardMinimapPlacement} :minimapHeightScale=${whiteboardMinimapHeightScale}: null
+                  - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId} :isTouchMode=${isTouchMode} :showArrows=${showWhiteboardConnections} :showMinimapInTouchMode=${showWhiteboardMinimapInTouchMode} :minimapPlacement=${whiteboardMinimapPlacement} :minimapHeightScale=${whiteboardMinimapHeightScale}: null
           - $if showDetailPanel:
               - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
                   - rtgl-view wh=f slot="content":

--- a/tests/scenes/scenes.handlers.test.js
+++ b/tests/scenes/scenes.handlers.test.js
@@ -232,7 +232,7 @@ describe("scenes.handlers config keys", () => {
         },
       ],
     });
-    expect(deps.render).toHaveBeenCalled();
+    expect(deps.render).toHaveBeenCalledTimes(1);
 
     resolveOverviews({});
     await Promise.resolve();

--- a/tests/scenes/scenes.store.test.js
+++ b/tests/scenes/scenes.store.test.js
@@ -5,7 +5,9 @@ import {
   openMobileFileExplorer,
   selectIsMobileFileExplorerOpen,
   selectViewData,
+  setTouchMinimapReady,
   setUiConfig,
+  setWhiteboardConnectionsReady,
 } from "../../src/pages/scenes/scenes.store.js";
 import { EN_I18N } from "../support/i18n.js";
 
@@ -31,9 +33,17 @@ describe("scenes.store mobile layout", () => {
     expect(viewData.showDetailPanel).toBe(false);
     expect(viewData.showMobileScenesControls).toBe(true);
     expect(viewData.showMobileFileExplorer).toBe(true);
-    expect(viewData.showWhiteboardMinimapInTouchMode).toBe(true);
+    expect(viewData.showWhiteboardMinimapInTouchMode).toBe(false);
+    expect(viewData.showWhiteboardConnections).toBe(false);
     expect(viewData.whiteboardMinimapPlacement).toBe("top-right");
     expect(viewData.whiteboardMinimapHeightScale).toBe(2 / 3);
+
+    setTouchMinimapReady({ state }, { isReady: true });
+    setWhiteboardConnectionsReady({ state }, { isReady: true });
+
+    const hydratedViewData = selectViewData({ state, i18n: EN_I18N });
+    expect(hydratedViewData.showWhiteboardMinimapInTouchMode).toBe(true);
+    expect(hydratedViewData.showWhiteboardConnections).toBe(true);
 
     closeMobileFileExplorer({ state });
 

--- a/tests/whiteboard/whiteboard.store.test.js
+++ b/tests/whiteboard/whiteboard.store.test.js
@@ -162,6 +162,7 @@ describe("whiteboard minimap viewport drag", () => {
     });
 
     expect(defaultTouchViewData.showMinimap).toBe(false);
+    expect(defaultTouchViewData.minimapData).toBeUndefined();
 
     const forcedTouchViewData = selectViewData({
       state,
@@ -214,5 +215,29 @@ describe("whiteboard.store", () => {
     expect(selectedItem.borderWidth).toBe(normalItem.borderWidth);
     expect(hoveredItem.borderColor).toBe("fg");
     expect(selectedItem.borderColor).toBe("fg");
+  });
+
+  it("skips arrow data when showArrows is false", () => {
+    const state = createInitialState();
+    const props = {
+      showArrows: false,
+      items: [
+        {
+          id: "scene-1",
+          name: "Scene 1",
+          x: 0,
+          y: 0,
+          transitions: ["scene-2"],
+        },
+        {
+          id: "scene-2",
+          name: "Scene 2",
+          x: 240,
+          y: 0,
+        },
+      ],
+    };
+
+    expect(selectViewData({ state, props }).arrowsList).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- defer touch-only scenes whiteboard minimap, connection arrows, and scene overview hydration until after first paint
- keep desktop scene overview refresh immediate while avoiding hidden minimap/arrow computation
- add focused store coverage for deferred whiteboard state

## Android measurement
Large project: Makkuro's Curious Guide to RouteVN on Redmi K30 5G / Android 12, opening Scenes from the bottom action sheet.
- before: click to second paint ~688 ms, pointerdown to second paint ~778 ms
- after: click to second paint 262 ms on cold repeat, 213 ms warm; pointerdown to second paint 347 ms

## Validation
- bunx vitest run tests/scenes/scenes.handlers.test.js tests/scenes/scenes.store.test.js tests/scenes/scenes.view.test.js tests/whiteboard/whiteboard.store.test.js tests/whiteboard/whiteboard.handlers.test.js
- bun run lint
- bun run android:install