### PR TITLE
Fix Android scene editor mobile dialogs

### DIFF
--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.methods.js
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.methods.js
@@ -85,6 +85,10 @@ export function focusContainer() {
   getEditor(this)?.focusContainer?.();
 }
 
+export function blurEditor(payload = {}) {
+  getEditor(this)?.blurEditor?.(payload);
+}
+
 export function scrollLineIntoView(payload = {}) {
   getEditor(this)?.scrollLineIntoView?.(payload);
 }

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
@@ -55,6 +55,10 @@ methods:
       description: Focuses the document editor surface.
       params: []
       returns: void
+    blurEditor:
+      description: Blurs the document editor surface and prevents focus restoration.
+      params: []
+      returns: void
     scrollLineIntoView:
       description: Scrolls a specific line block into view.
       params: []

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -250,7 +250,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     showSelected: !!attrs.showSelected,
     showEmbeddedClose: shouldShowEmbeddedClose(attrs),
     dialogVariant: getDialogVariant(attrs),
-    actionsDialogWidth: state.isTouchMode ? "100vw" : "800",
+    actionsDialogWidth: state.isTouchMode ? "100%" : "800",
     actionsDialogHeight: state.isTouchMode ? "100vh" : "80vh",
     actionsDialogPanelWidth: state.isTouchMode
       ? "100vw"

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -242,7 +242,7 @@ template:
                   - rtgl-button#embeddedCloseButton: Confirm
   - rvn-system-actions-dialog-surface#actionsDialog key=${mode} :open=${isActionsDialogOpen} variant=${dialogVariant} :dialogWidth=${actionsDialogWidth} :dialogHeight=${actionsDialogHeight} :panelWidth=${actionsDialogPanelWidth} :suppressClose=${suppressDialogClose}:
       - $if isActionsDialogOpen:
-          - 'rtgl-view slot=content w=f h=f pos=rel style="min-width: 0; min-height: 0;"':
+          - 'rtgl-view slot=content w=f h=f pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y;"':
               - 'rtgl-view#helpFloatingButton pos=abs z=10 w=28 h=28 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="top: 10px; right: 10px; box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);"':
                   - rtgl-text s=xs c=mu-fg: '?'
               - $if mode == "actions":

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
@@ -7,6 +7,10 @@ const normalizeVariant = (variant) =>
 
 const isBooleanPropEnabled = (value) => value === true || value === "true";
 
+const selectDialogSize = (dialogWidth) => {
+  return dialogWidth === "100%" ? "md" : undefined;
+};
+
 export const setSuppressClose = ({ state }, { suppressClose } = {}) => {
   state.suppressClose = suppressClose === true;
 };
@@ -17,12 +21,14 @@ export const selectSuppressClose = ({ state }) => {
 
 export const selectViewData = ({ state, props }) => {
   const variant = normalizeVariant(props.variant);
+  const dialogWidth = props.dialogWidth ?? "800";
 
   return {
     open: props.open === true,
     variant,
     isSceneEditorLeft: variant === "scene-editor-left",
-    dialogWidth: props.dialogWidth ?? "800",
+    dialogWidth,
+    dialogSize: selectDialogSize(dialogWidth),
     dialogHeight: props.dialogHeight ?? "80vh",
     panelWidth: props.panelWidth ?? "50vw",
     suppressClose:

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
@@ -21,6 +21,11 @@ template:
           - 'rtgl-view pos=fix bgc=bg bw=xs bc=bo br=md style="left: ${panelHorizontalInset}; top: ${panelVerticalInset}; bottom: ${panelVerticalInset}; width: calc(${panelWidth} - ${panelWidthReduction}); max-width: calc(100vw - ${panelHorizontalInset}); min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden; z-index: 2002; box-shadow: 8px 0 24px rgba(15, 23, 42, 0.10);"':
               - slot name=content: null
     $else:
-      - rtgl-dialog#dialog ?open=${open}:
-          - rtgl-view slot=content w=${dialogWidth} h=${dialogHeight} pos=rel:
-              - slot name=content: null
+      - $if dialogSize:
+          - rtgl-dialog#dialog ?open=${open} s=${dialogSize}:
+              - 'rtgl-view slot=content w=${dialogWidth} h=${dialogHeight} pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y;"':
+                  - slot name=content: null
+        $else:
+          - rtgl-dialog#dialog ?open=${open}:
+              - 'rtgl-view slot=content w=${dialogWidth} h=${dialogHeight} pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y;"':
+                  - slot name=content: null

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -54,6 +54,12 @@ const isInputFocused = (root = document) => {
   return false;
 };
 
+const hideVirtualKeyboard = (root = document) => {
+  const resolvedWindow =
+    root?.defaultView || (typeof window === "undefined" ? undefined : window);
+  resolvedWindow?.navigator?.virtualKeyboard?.hide?.();
+};
+
 export const createAppShellService = ({
   router,
   subject,
@@ -177,6 +183,7 @@ export const createAppShellService = ({
       if (active?.blur) {
         active.blur();
       }
+      hideVirtualKeyboard(root);
     },
 
     applyTheme(theme) {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -523,6 +523,14 @@ const focusLinesEditorContainer = (refs, sectionId) => {
   });
 };
 
+const blurLinesEditorFocus = (refs) => {
+  forEachLinesEditorRef(refs, (linesEditorRef) => {
+    linesEditorRef.blurEditor?.({
+      lineId: linesEditorRef.getSelectedLineId?.(),
+    });
+  });
+};
+
 const shouldAnimateLineNavigation = (
   store,
   { previousLineId, nextLineId } = {},
@@ -3167,6 +3175,7 @@ export const handlePreviewClick = (deps, payload) => {
       syncStoreProjectState(store, projectService);
       didPersistDraft = true;
       store.setSkipNextEditorBlurDraftFlush({ value: true });
+      blurLinesEditorFocus(deps.refs);
       appService?.blurActiveElement?.();
       store.showPreviewSceneId({ sceneId, sectionId, lineId });
       store.setSkipNextEditorBlurDraftFlush({ value: false });

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1887,6 +1887,28 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     });
   }
 
+  blurEditor({ lineId = this.state.selectedLineId } = {}) {
+    this.clearPointerDownInsideEditor();
+    this.lastProgrammaticFocusTarget = undefined;
+    this.programmaticFocusRestoreUntil = 0;
+    this.invalidatePendingFocusRestore();
+    this.refs?.editor?.blur?.();
+    this.refs?.surface?.blur?.();
+    this.blur?.();
+    this.isEditorFocused = false;
+    this.hideSelectionPopover();
+    this.closeMentionMenu({
+      dismissCurrentTrigger: this.state.mentionMenu?.isOpen === true,
+    });
+    this.pendingSelectionSnapshot = undefined;
+    this.enterBlockMode({
+      focusSurface: false,
+      emitSelectionChange: false,
+      lineId,
+      scrollLine: false,
+    });
+  }
+
   scrollLineIntoView({ lineId, behavior = "auto", block = "nearest" } = {}) {
     const lineKey = this.lineKeyById.get(lineId);
     const lineElement = lineKey

--- a/tests/appService/appShellService.test.js
+++ b/tests/appService/appShellService.test.js
@@ -96,6 +96,30 @@ describe("appShellService", () => {
     });
   });
 
+  it("blurs the active element and asks the virtual keyboard to hide", () => {
+    const deps = createDeps();
+    const service = createAppShellService(deps);
+    const activeElement = {
+      blur: vi.fn(),
+    };
+    const hideKeyboard = vi.fn();
+    const root = {
+      activeElement,
+      defaultView: {
+        navigator: {
+          virtualKeyboard: {
+            hide: hideKeyboard,
+          },
+        },
+      },
+    };
+
+    service.blurActiveElement(root);
+
+    expect(activeElement.blur).toHaveBeenCalled();
+    expect(hideKeyboard).toHaveBeenCalled();
+  });
+
   it("shows a toast when opening an external URL fails", async () => {
     const deps = createDeps();
     deps.openUrl.mockRejectedValue(new Error("blocked"));

--- a/tests/sceneEditor/sceneDocumentEditorLexical.methods.test.js
+++ b/tests/sceneEditor/sceneDocumentEditorLexical.methods.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { focusLine } from "../../src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.methods.js";
+import {
+  blurEditor,
+  focusLine,
+} from "../../src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.methods.js";
 
 const createHostElement = (editor) => {
   return {
@@ -101,5 +104,19 @@ describe("sceneDocumentEditorLexical methods", () => {
     } finally {
       animationFrame.restore();
     }
+  });
+
+  it("forwards blur requests to the mounted primitive editor", () => {
+    const payload = {
+      lineId: "line-1",
+    };
+    const editor = {
+      blurEditor: vi.fn(),
+    };
+    const hostElement = createHostElement(editor);
+
+    blurEditor.call(hostElement, payload);
+
+    expect(editor.blurEditor).toHaveBeenCalledWith(payload);
   });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -12,6 +12,7 @@ import {
   handleDropdownMenuClickItem,
   handleEditorBlur,
   handleNewLine,
+  handlePreviewClick,
   handleSectionMoveSceneFormActionClick,
   handleSelectedLineChanged,
   handleTemporaryPresentationStateChange,
@@ -38,6 +39,76 @@ const installAnimationFrameQueue = () => {
     },
   };
 };
+
+const waitForAsyncHandler = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("sceneEditorLexical.handlers preview", () => {
+  it("blurs mounted line editors before showing fullscreen preview", async () => {
+    const calls = [];
+    const line = { id: "line-1", actions: {} };
+    const draftSection = {
+      sceneId: "scene-1",
+      sectionId: "section-1",
+      lines: [line],
+    };
+    const linesEditor = {
+      dataset: { sectionId: "section-1" },
+      getLines: vi.fn(() => [line]),
+      getSelectedLineId: vi.fn(() => "line-1"),
+      blurEditor: vi.fn(() => calls.push("editor-blur")),
+      focusLine: vi.fn(),
+    };
+    const store = {
+      selectSceneId: vi.fn(() => "scene-1"),
+      selectSelectedSectionId: vi.fn(() => "section-1"),
+      selectSelectedLineId: vi.fn(() => "line-1"),
+      selectDraftSaveTimerId: vi.fn(() => undefined),
+      clearDraftSaveTimer: vi.fn(),
+      selectDraftSectionBySectionId: vi.fn(() => draftSection),
+      selectDraftSection: vi.fn(() => draftSection),
+      selectPendingDraftSections: vi.fn(() => []),
+      setDraftSavePendingSinceAt: vi.fn(),
+      setSkipNextEditorBlurDraftFlush: vi.fn(),
+      showPreviewSceneId: vi.fn(() => calls.push("show-preview")),
+      setRepositoryState: vi.fn(),
+      setDomainState: vi.fn(),
+      setRepositoryRevision: vi.fn(),
+    };
+    const deps = {
+      store,
+      refs: {
+        sectionEditor0: linesEditor,
+      },
+      appService: {
+        blurActiveElement: vi.fn(() => calls.push("app-blur")),
+        showAlert: vi.fn(),
+      },
+      projectService: {
+        getRepositoryState: vi.fn(() => ({})),
+        getDomainState: vi.fn(() => ({})),
+        getRepositoryRevision: vi.fn(() => 1),
+      },
+      render: vi.fn(),
+    };
+
+    handlePreviewClick(deps, {});
+    await waitForAsyncHandler();
+
+    expect(linesEditor.blurEditor).toHaveBeenCalledWith({
+      lineId: "line-1",
+    });
+    expect(deps.appService.blurActiveElement).toHaveBeenCalled();
+    expect(store.showPreviewSceneId).toHaveBeenCalledWith({
+      sceneId: "scene-1",
+      sectionId: "section-1",
+      lineId: "line-1",
+    });
+    expect(calls).toEqual(["editor-blur", "app-blur", "show-preview"]);
+  });
+});
 
 describe("sceneEditorLexical.handlers route payload sync", () => {
   it("switches scene state when the mounted editor receives a new scene route payload", async () => {

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -5,6 +5,7 @@ import {
   openAudioPlayer,
   selectActionsData,
   selectViewData,
+  setUiConfig,
   setRepositoryState,
   updateActions,
 } from "../../src/components/systemActions/systemActions.store.js";
@@ -1174,6 +1175,20 @@ describe("systemActions.store", () => {
     expect(sceneViewData.actionsDialogPanelWidth).toBe(
       "calc((100vw - 64px) / 2)",
     );
+  });
+
+  it("uses slot-relative dialog width in touch mode", () => {
+    const state = createInitialState();
+    setUiConfig({ state }, { uiConfig: { id: "touch" } });
+
+    const viewData = selectViewData({
+      state,
+      props: {},
+    });
+
+    expect(viewData.actionsDialogWidth).toBe("100%");
+    expect(viewData.actionsDialogHeight).toBe("100vh");
+    expect(viewData.actionsDialogPanelWidth).toBe("100vw");
   });
 
   it("can hide the embedded close button for inline selected action lists", () => {

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -67,6 +67,7 @@ describe("systemActions view", () => {
     expect(systemActionsView).toContain(
       ":suppressClose=${suppressDialogClose}",
     );
+    expect(systemActionsView).toContain("overflow-x: hidden");
     expect(sceneEditorLexicalView).toContain(
       "dialog-variant=scene-editor-left",
     );
@@ -79,5 +80,21 @@ describe("systemActions view", () => {
     expect(sceneEditorLexicalView).toContain(
       'dialog-panel-width="${systemActionsDialogPanelWidth}"',
     );
+  });
+
+  it("lets the dialog surface activate mobile-safe dialog sizing", () => {
+    const dialogSurfaceView = readFileSync(
+      new URL(
+        "../../src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(dialogSurfaceView).toContain(
+      "rtgl-dialog#dialog ?open=${open} s=${dialogSize}",
+    );
+    expect(dialogSurfaceView).toContain("overflow-x: hidden");
+    expect(dialogSurfaceView).toContain("touch-action: pan-y");
   });
 });

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
@@ -16,6 +16,7 @@ describe("systemActionsDialogSurface.store", () => {
       variant: "default",
       isSceneEditorLeft: false,
       dialogWidth: "800",
+      dialogSize: undefined,
       dialogHeight: "80vh",
       panelWidth: "50vw",
       suppressClose: false,
@@ -25,6 +26,18 @@ describe("systemActionsDialogSurface.store", () => {
       panelWidthReduction: "64px",
       panelVerticalInset: "32px",
     });
+  });
+
+  it("uses the md dialog size for touch-width content", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        dialogWidth: "100%",
+      },
+    });
+
+    expect(viewData.dialogWidth).toBe("100%");
+    expect(viewData.dialogSize).toBe("md");
   });
 
   it("normalizes the scene editor left panel variant", () => {


### PR DESCRIPTION
## Summary
- blur the Lexical scene editor and hide the virtual keyboard before opening fullscreen preview
- make the mobile system-actions dialog use slot-relative sizing and disable horizontal panning
- add focused tests for preview blur, virtual keyboard hiding, and mobile dialog sizing

## Validation
- bunx vitest run tests/appService/appShellService.test.js tests/sceneEditor/sceneDocumentEditorLexical.methods.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/vnPreview/vnPreview.handlers.test.js
- bunx vitest run tests/systemActions/systemActions.store.test.js tests/systemActions/systemActions.view.test.js tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
- bun run lint
- bun run android:install
- Android WebView verification: scene editor actions dialog measured clientWidth=393 and scrollWidth=393 with no overflowing elements