### PR TITLE
Fix scene editor navigation and touch interactions

### DIFF
--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.schema.yaml
@@ -16,6 +16,10 @@ propsSchema:
       type: string
     selectionActive:
       type: boolean
+    hasPreviousSectionLine:
+      type: boolean
+    hasNextSectionLine:
+      type: boolean
     showLineNumbers:
       type: boolean
     fontSize:

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.store.js
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.store.js
@@ -5,6 +5,8 @@ export const selectViewData = ({ props }) => ({
   lineDecorations: props.lineDecorations || [],
   selectedLineId: props.selectedLineId,
   selectionActive: props.selectionActive ?? true,
+  hasPreviousSectionLine: props.hasPreviousSectionLine ?? false,
+  hasNextSectionLine: props.hasNextSectionLine ?? false,
   showLineNumbers: props.showLineNumbers ?? true,
   fontSize: props.fontSize ?? "md",
   textStyles: props.textStyles || [],

--- a/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
+++ b/src/components/sceneDocumentEditorLexical/sceneDocumentEditorLexical.view.yaml
@@ -26,4 +26,4 @@ refs:
       furigana-dialog-request:
         handler: handleFuriganaDialogRequest
 template:
-  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectionActive=${selectionActive} :selectedLineId=${selectedLineId} :showLineNumbers=${showLineNumbers} :fontSize=${fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+  - rvn-lexical-scene-document-editor#editor :lines=${lines} :lineDecorations=${lineDecorations} :selectionActive=${selectionActive} :selectedLineId=${selectedLineId} :hasPreviousSectionLine=${hasPreviousSectionLine} :hasNextSectionLine=${hasNextSectionLine} :showLineNumbers=${showLineNumbers} :fontSize=${fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null

--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -39,6 +39,17 @@ const dispatchTemporaryPresentationStateChange = (
   );
 };
 
+const dispatchActionsDialogOpen = ({ dispatchEvent, props }, mode) => {
+  dispatchEvent(
+    new CustomEvent("actions-dialog-open", {
+      detail: {
+        mode,
+        selectedLineId: props.selectedLineId,
+      },
+    }),
+  );
+};
+
 const syncRepositoryState = (deps) => {
   const { store, projectService } = deps;
   store.setRepositoryState({
@@ -293,9 +304,17 @@ export const handleCommandLineSubmit = (deps, payload) => {
 
 export const handleAddActionButtonClicked = (deps) => {
   const { store, render } = deps;
+  dispatchActionsDialogOpen(deps, "actions");
   store.showActionsDialog();
   store.setMode({ mode: "actions" });
   render();
+};
+
+export const handleActionControlMouseDown = (_deps, payload) => {
+  const event = payload?._event;
+  if (event?.button === undefined || event.button === 0) {
+    event.preventDefault?.();
+  }
 };
 
 export const handleEmbeddedCloseClick = (deps, payload) => {
@@ -368,6 +387,7 @@ export const handleActionItemClick = (deps, payload) => {
   const { store, render } = deps;
   const event = payload._event;
   const mode = event.currentTarget?.dataset?.mode;
+  dispatchActionsDialogOpen(deps, mode);
   store.showActionsDialog();
   store.setMode({ mode });
   render();

--- a/src/components/systemActions/systemActions.schema.yaml
+++ b/src/components/systemActions/systemActions.schema.yaml
@@ -40,3 +40,6 @@ propsSchema:
       type: boolean
     suppressDialogClose:
       type: boolean
+events:
+  actions-dialog-open:
+    type: object

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -19,6 +19,8 @@ refs:
         handler: handleCommandLineSubmit
   addActionButton:
     eventListeners:
+      mousedown:
+        handler: handleActionControlMouseDown
       click:
         handler: handleAddActionButtonClicked
   embeddedCloseButton:
@@ -45,6 +47,8 @@ refs:
         handler: handleActionsDialogClose
   actionItem*:
     eventListeners:
+      mousedown:
+        handler: handleActionControlMouseDown
       click:
         handler: handleActionItemClick
       contextmenu:

--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -208,6 +208,28 @@ const getTouchPairMetrics = (event, element) => {
   };
 };
 
+const getGesturePointWithinElement = (event, element) => {
+  if (!element) {
+    return undefined;
+  }
+
+  const rect = element.getBoundingClientRect();
+  const clientX = Number(event?.clientX);
+  const clientY = Number(event?.clientY);
+
+  if (Number.isFinite(clientX) && Number.isFinite(clientY)) {
+    return {
+      x: clientX - rect.left,
+      y: clientY - rect.top,
+    };
+  }
+
+  return {
+    x: rect.width / 2,
+    y: rect.height / 2,
+  };
+};
+
 const getActiveElement = (root = document) => {
   let active = root?.activeElement;
   while (active?.shadowRoot?.activeElement) {
@@ -1064,9 +1086,57 @@ export const handleContainerTouchCancel = (deps, payload) => {
   stopTouchGesture(deps);
 };
 
-export const handleContainerGestureEvent = (_deps, payload) => {
-  preventTouchDefault(payload?._event);
-  payload?._event?.stopPropagation?.();
+export const handleContainerGestureEvent = (deps, payload) => {
+  const { store, refs, dispatchEvent } = deps;
+  const event = payload?._event;
+
+  preventTouchDefault(event);
+  event?.stopPropagation?.();
+
+  if (store.selectIsDraggingMinimapViewport()) {
+    return;
+  }
+
+  const point = getGesturePointWithinElement(event, refs.container);
+  if (!point) {
+    return;
+  }
+
+  if (event?.type === "gesturestart") {
+    cancelPanAnimation(deps);
+    syncContainerSize(deps);
+    store.startTrackpadPinch({
+      centerX: point.x,
+      centerY: point.y,
+    });
+    return;
+  }
+
+  if (event?.type === "gesturechange") {
+    cancelPanAnimation(deps);
+    syncContainerSize(deps);
+
+    if (!store.selectTrackpadPinchGesture?.()) {
+      store.startTrackpadPinch({
+        centerX: point.x,
+        centerY: point.y,
+      });
+    }
+
+    store.updateTrackpadPinch({
+      centerX: point.x,
+      centerY: point.y,
+      scale: event.scale,
+    });
+    renderWithCursorSync(deps);
+    dispatchZoomChanged({ store, dispatchEvent });
+    dispatchPanChanged({ store, dispatchEvent });
+    return;
+  }
+
+  if (event?.type === "gestureend") {
+    store.stopTrackpadPinch();
+  }
 };
 
 export const handleZoomInClick = (deps) => {
@@ -1385,6 +1455,11 @@ export const handleWindowBlur = (deps) => {
   if (store.selectTouchGesture()) {
     clearTouchLongPressTimeout(deps);
     store.stopTouchGesture();
+    didChange = true;
+  }
+
+  if (store.selectTrackpadPinchGesture?.()) {
+    store.stopTrackpadPinch?.();
     didChange = true;
   }
 

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -74,6 +74,7 @@ export const createInitialState = () => ({
   mouseItemPress: undefined,
   hoveredItemId: undefined,
   touchGesture: undefined,
+  trackpadPinchGesture: undefined,
   lastTouchTap: undefined,
   isDraggingMinimapViewport: false,
   minimapViewportDrag: undefined,
@@ -374,6 +375,54 @@ export const stopTouchGesture = ({ state }, _payload = {}) => {
 };
 
 export const selectTouchGesture = ({ state }) => state.touchGesture;
+
+export const startTrackpadPinch = ({ state }, { centerX, centerY } = {}) => {
+  const startCenterX = Number(centerX);
+  const startCenterY = Number(centerY);
+
+  if (!Number.isFinite(startCenterX) || !Number.isFinite(startCenterY)) {
+    return;
+  }
+
+  state.trackpadPinchGesture = {
+    startZoomLevel: state.zoomLevel,
+    anchorCanvasX: (startCenterX - state.panX) / state.zoomLevel,
+    anchorCanvasY: (startCenterY - state.panY) / state.zoomLevel,
+  };
+};
+
+export const updateTrackpadPinch = (
+  { state },
+  { centerX, centerY, scale } = {},
+) => {
+  const gesture = state.trackpadPinchGesture;
+  const nextCenterX = Number(centerX);
+  const nextCenterY = Number(centerY);
+  const nextScale = Number(scale);
+
+  if (
+    !gesture ||
+    !Number.isFinite(nextCenterX) ||
+    !Number.isFinite(nextCenterY) ||
+    !Number.isFinite(nextScale) ||
+    nextScale <= 0
+  ) {
+    return;
+  }
+
+  const nextZoomLevel = clampZoomLevel(gesture.startZoomLevel * nextScale);
+
+  state.zoomLevel = nextZoomLevel;
+  state.panX = nextCenterX - gesture.anchorCanvasX * nextZoomLevel;
+  state.panY = nextCenterY - gesture.anchorCanvasY * nextZoomLevel;
+};
+
+export const stopTrackpadPinch = ({ state }, _payload = {}) => {
+  state.trackpadPinchGesture = undefined;
+};
+
+export const selectTrackpadPinchGesture = ({ state }) =>
+  state.trackpadPinchGesture;
 
 export const setLastTouchTap = (
   { state },

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -2243,6 +2243,15 @@ export const handleAddActionsButtonClick = (deps) => {
   render();
 };
 
+export const handleSystemActionsDialogOpen = (deps, payload) => {
+  const { store } = deps;
+  const detail = payload?._event?.detail || {};
+  const lineId = detail.selectedLineId || store.selectSelectedLineId();
+  if (lineId) {
+    store.setActionTargetLineId({ lineId });
+  }
+};
+
 export const handleMobileKeyboardToolbarActionClick = (deps, payload) => {
   const actionId = payload?._event?.detail?.actionId;
   payload?._event?.preventDefault?.();

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -1884,6 +1884,12 @@ export const selectViewData = ({ state, i18n }) => {
         section.id === state.selectedSectionId
           ? (state.selectedLineId ?? INACTIVE_SECTION_EDITOR_SELECTED_LINE_ID)
           : INACTIVE_SECTION_EDITOR_SELECTED_LINE_ID,
+      hasPreviousSectionLine: sections
+        .slice(0, index)
+        .some((item) => item.lines?.[0]?.id),
+      hasNextSectionLine: sections
+        .slice(index + 1)
+        .some((item) => item.lines?.[0]?.id),
       editorKey: `document-${section.id}-${state.sceneSettings.showLineNumbers ? "line-numbers-show" : "line-numbers-hide"}`,
       documentEditorLines: sectionLines,
       documentLineDecorations: buildSceneDocumentLineDecorations({

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -93,6 +93,8 @@ refs:
         handler: handleActionsDialogClose
   systemActions:
     eventListeners:
+      actions-dialog-open:
+        handler: handleSystemActionsDialogOpen
       action-delete:
         handler: handleSystemActionsActionDelete
       actions-change:
@@ -169,7 +171,7 @@ template:
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
                                       - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
                                       - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm pre=ellipsis: null
-                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :fontSize=${sceneSettings.fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+                                  - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :hasPreviousSectionLine=${section.hasPreviousSectionLine} :hasNextSectionLine=${section.hasNextSectionLine} :showLineNumbers=${sceneSettings.showLineNumbers} :fontSize=${sceneSettings.fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
                           - rtgl-view h=${mobileEditorBottomSpacerHeight}: null
               - rvn-mobile-keyboard-toolbar#mobileKeyboardToolbar: null
               - 'rvn-system-actions#systemActions :actions=${selectedLineActions} :selectedLineId=${selectedLineId} :selectedLine=${selectedLine} :currentSceneId=${scene.id} actionType=presentation :presentationState=${presentationState} :backgroundTransformEditor=${backgroundTransformEditor} :suppressDialogClose=${backgroundTransformEditor.suppressActionsDialogClose}': null
@@ -196,7 +198,7 @@ template:
                                       - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c w=f h=40 ph=sm bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0;"':
                                           - rtgl-text s=sm w=1fg ellipsis=true: ${section.name}
                                           - rtgl-button#sectionMenu${sectionIndex} data-section-id=${section.id} sq v=gh s=sm pre=ellipsis: null
-                                      - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :showLineNumbers=${sceneSettings.showLineNumbers} :fontSize=${sceneSettings.fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
+                                      - rvn-scene-document-editor-lexical#sectionEditor${sectionIndex} key=${section.editorKey} data-section-id=${section.id} :lines=${section.documentEditorLines} :lineDecorations=${section.documentLineDecorations} :selectionActive=${section.selectionActive} :selectedLineId=${section.selectedLineId} :hasPreviousSectionLine=${section.hasPreviousSectionLine} :hasNextSectionLine=${section.hasNextSectionLine} :showLineNumbers=${sceneSettings.showLineNumbers} :fontSize=${sceneSettings.fontSize} :textStyles=${textStyles} :mentionTargets=${mentionTargets}: null
                               - rtgl-view h=30vh: null
               - rtgl-view w=1 h=f bgc=mu: null
               - 'rtgl-view w=1fg d=v h=f style="min-width: 0; min-height: 0;"':

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -900,6 +900,24 @@ export const handleTransformItemDoubleClick = async (deps, payload) => {
   });
 };
 
+const openTransformEditDialog = async ({ deps, itemId } = {}) => {
+  if (!itemId) {
+    return;
+  }
+
+  const itemData = deps.store.selectTransformItemById({ itemId });
+  if (!itemData) {
+    return;
+  }
+
+  await openTransformDialog({
+    deps,
+    editMode: true,
+    itemId,
+    itemData,
+  });
+};
+
 export const handleMobileDetailPreviewClick = async (deps, payload) => {
   payload?._event?.preventDefault?.();
   payload?._event?.stopPropagation?.();
@@ -915,6 +933,17 @@ export const handleMobileDetailPreviewClick = async (deps, payload) => {
         itemId,
       },
     },
+  });
+};
+
+export const handleMobileDetailEditClick = async (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const { store } = deps;
+  await openTransformEditDialog({
+    deps,
+    itemId: store.selectSelectedItemId(),
   });
 };
 
@@ -956,20 +985,9 @@ export const handleMobileDetailDeleteClick = async (deps, payload) => {
 
 export const handleTransformItemEdit = async (deps, payload) => {
   const { itemId } = payload._event.detail;
-  if (!itemId) {
-    return;
-  }
-
-  const itemData = deps.store.selectTransformItemById({ itemId });
-  if (!itemData) {
-    return;
-  }
-
-  await openTransformDialog({
+  await openTransformEditDialog({
     deps,
-    editMode: true,
     itemId,
-    itemData,
   });
 };
 
@@ -984,16 +1002,9 @@ export const handleDetailHeaderClick = async (deps) => {
     return;
   }
 
-  const itemData = store.selectTransformItemById({ itemId });
-  if (!itemData) {
-    return;
-  }
-
-  await openTransformDialog({
+  await openTransformEditDialog({
     deps,
-    editMode: true,
     itemId,
-    itemData,
   });
 };
 

--- a/src/pages/transforms/transforms.store.js
+++ b/src/pages/transforms/transforms.store.js
@@ -517,6 +517,7 @@ const {
       noPreviewLabel: copy.noPreviewLabel,
       noPreviewImageLabel: copy.noPreviewImageLabel,
       previewLabel: copy.previewLabel,
+      editButton: copy.editMenuItem ?? "Edit",
       selectImageLabel: copy.selectImageLabel,
       updateToSetPreviewLabel: copy.updateToSetPreviewLabel,
       imageSelectorDialog: {

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -47,6 +47,12 @@ refs:
         handler: handleMobileDetailPreviewClick
         preventDefault: true
         stopPropagation: true
+  mobileDetailEditButton:
+    eventListeners:
+      click:
+        handler: handleMobileDetailEditClick
+        preventDefault: true
+        stopPropagation: true
   mobileDetailDuplicateButton:
     eventListeners:
       click:
@@ -219,10 +225,13 @@ template:
               - rtgl-view#detailHeader h=56 w=f d=h bgc=bg bwb=xs ph=md av=c g=sm cur=pointer:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
-              - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
-                  - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+              - rtgl-view d=v w=f g=sm p=md bgc=su bwb=xs:
+                  - rtgl-view d=h w=f g=sm:
+                      - rtgl-button#mobileDetailEditButton w=1fg v=se pre=edit: ${editButton}
+                      - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
+                  - rtgl-view d=h w=f g=sm:
+                      - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
+                      - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="transform-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1147,6 +1147,8 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       textStyles: [],
       selectedLineId: undefined,
       selectionActive: true,
+      hasPreviousSectionLine: false,
+      hasNextSectionLine: false,
       showLineNumbers: true,
       fontSize: DEFAULT_EDITOR_FONT_SIZE,
       mode: "block",
@@ -1681,6 +1683,22 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
   get selectionActive() {
     return this.state.selectionActive !== false;
+  }
+
+  set hasPreviousSectionLine(value) {
+    this.state.hasPreviousSectionLine = value === true || value === "true";
+  }
+
+  get hasPreviousSectionLine() {
+    return this.state.hasPreviousSectionLine === true;
+  }
+
+  set hasNextSectionLine(value) {
+    this.state.hasNextSectionLine = value === true || value === "true";
+  }
+
+  get hasNextSectionLine() {
+    return this.state.hasNextSectionLine === true;
   }
 
   set showLineNumbers(value) {
@@ -2574,6 +2592,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
+    if (this.handleImmediateTextModeVerticalBoundaryNavigation(event)) {
+      return;
+    }
+
     this.scheduleNativeSelectionLineSyncAfterVerticalNavigation(event);
     if (this.state?.mentionMenu?.isOpen && isArrowKeyEvent(event)) {
       this.closeMentionMenu({ dismissCurrentTrigger: true });
@@ -2658,13 +2680,61 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.clearPendingTextInputFallback();
   }
 
+  getTextModeVerticalNavigationDirection(event) {
+    return event.key === "ArrowUp"
+      ? "up"
+      : event.key === "ArrowDown"
+        ? "down"
+        : undefined;
+  }
+
+  hasAdjacentSectionLineForVerticalNavigation(direction) {
+    return direction === "up"
+      ? this.state.hasPreviousSectionLine === true
+      : this.state.hasNextSectionLine === true;
+  }
+
+  handleImmediateTextModeVerticalBoundaryNavigation(event) {
+    const navigationDirection =
+      this.getTextModeVerticalNavigationDirection(event);
+    if (
+      this.state?.mode !== "text-editor" ||
+      event.isComposing ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.altKey ||
+      event.shiftKey ||
+      !navigationDirection ||
+      !this.hasAdjacentSectionLineForVerticalNavigation(navigationDirection)
+    ) {
+      return false;
+    }
+
+    const nativeSelection = this.getNativeLineSelectionContext();
+    const lineId = nativeSelection?.lineId || this.state.selectedLineId;
+    if (
+      !this.isTextModeVerticalNavigationBoundary(lineId, navigationDirection)
+    ) {
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    if (this.state?.mentionMenu?.isOpen && isArrowKeyEvent(event)) {
+      this.closeMentionMenu({ dismissCurrentTrigger: true });
+    }
+    this.dispatchTextModeVerticalBoundaryNavigation({
+      lineId,
+      nativeSelection,
+      direction: navigationDirection,
+    });
+    return true;
+  }
+
   scheduleNativeSelectionLineSyncAfterVerticalNavigation(event) {
     const navigationDirection =
-      event.key === "ArrowUp"
-        ? "up"
-        : event.key === "ArrowDown"
-          ? "down"
-          : undefined;
+      this.getTextModeVerticalNavigationDirection(event);
     if (
       this.state?.mode !== "text-editor" ||
       event.isComposing ||

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1039,6 +1039,7 @@ describe("lexical scene document editor line editing", () => {
         },
       };
       editorElement.hideSelectionPopover = vi.fn();
+      editorElement.lineKeyById = new Map();
       editorElement.updatePendingTextInputFallback = vi.fn();
       editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
       editorElement.clearSelectedReferenceNodeKey = vi.fn();
@@ -1082,6 +1083,119 @@ describe("lexical scene document editor line editing", () => {
       } else {
         globalThis.requestAnimationFrame = previousRequestAnimationFrame;
       }
+      restoreDomGlobals();
+    }
+  });
+
+  it("emits section-boundary ArrowDown before native caret movement on the last line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+        hasNextSectionLine: true,
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation =
+        vi.fn();
+      editorElement.getNativeLineSelectionContext = vi.fn(() => ({
+        lineId: "line-2",
+        start: 6,
+        end: 6,
+      }));
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      const event = {
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalledOnce();
+      expect(event.stopPropagation).toHaveBeenCalledOnce();
+      expect(event.stopImmediatePropagation).toHaveBeenCalledOnce();
+      expect(
+        editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation,
+      ).not.toHaveBeenCalled();
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-2",
+        {
+          cursorPosition: 6,
+          isCollapsed: true,
+          mode: "text-editor",
+          navigationDirection: "down",
+          isBoundaryNavigation: true,
+        },
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("keeps final-section ArrowDown on the native text navigation path", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+
+      editorElement.state = {
+        mode: "text-editor",
+        selectedLineId: "line-2",
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+        hasNextSectionLine: false,
+        mentionMenu: {
+          isOpen: false,
+        },
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation =
+        vi.fn();
+      editorElement.updatePendingTextInputFallback = vi.fn();
+      editorElement.handleReferenceArrowNavigation = vi.fn(() => false);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+
+      const event = {
+        key: "ArrowDown",
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        isComposing: false,
+        preventDefault: vi.fn(),
+      };
+
+      editorElement.handleNativeKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(
+        editorElement.scheduleNativeSelectionLineSyncAfterVerticalNavigation,
+      ).toHaveBeenCalledWith(event);
+    } finally {
       restoreDomGlobals();
     }
   });

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -12,6 +12,7 @@ import {
   setTemporaryPresentationState,
   showSectionDropdownMenu,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.store.js";
+import { EN_I18N } from "../support/i18n.js";
 
 describe("sceneEditorLexical.store", () => {
   it("presents text size as a select with full labels", () => {
@@ -40,7 +41,7 @@ describe("sceneEditorLexical.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     const fontSizeField = viewData.sceneSettingsForm.fields.find(
       (field) => field.name === "fontSize",
     );
@@ -78,7 +79,7 @@ describe("sceneEditorLexical.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.canvasAspectRatio).toBe("1080 / 1920");
     expect(viewData.previewCanvasMaxWidth).toBe("min(100%, 28.125vh)");
@@ -187,7 +188,7 @@ describe("sceneEditorLexical.store", () => {
       },
     ]);
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     expect(viewData.sections[0].isDeadEnd).toBe(false);
     expect(viewData.sectionsOverviewItems[0].isDeadEnd).toBe(false);
   });
@@ -227,7 +228,9 @@ describe("sceneEditorLexical.store", () => {
         resourceId: "background-1",
       },
     });
-    expect(selectViewData({ state }).presentationState.dialogue).toEqual({
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).presentationState.dialogue,
+    ).toEqual({
       mode: "nvl",
     });
 
@@ -348,17 +351,21 @@ describe("sceneEditorLexical.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.sectionEditorItems).toHaveLength(2);
     expect(viewData.sectionEditorItems[0].selectedLineId).toBe("line-1");
     expect(viewData.sectionEditorItems[0].selectionActive).toBe(true);
+    expect(viewData.sectionEditorItems[0].hasPreviousSectionLine).toBe(false);
+    expect(viewData.sectionEditorItems[0].hasNextSectionLine).toBe(true);
     expect(viewData.sectionEditorItems[0].documentEditorLines).toHaveLength(2);
     expect(viewData.sectionEditorItems[0].documentLineDecorations[0]).toEqual(
       expect.objectContaining({ id: "line-1", lineNumber: 1 }),
     );
     expect(viewData.sectionEditorItems[1].selectedLineId).toBe("");
     expect(viewData.sectionEditorItems[1].selectionActive).toBe(false);
+    expect(viewData.sectionEditorItems[1].hasPreviousSectionLine).toBe(true);
+    expect(viewData.sectionEditorItems[1].hasNextSectionLine).toBe(false);
     expect(viewData.sectionEditorItems[1].documentEditorLines).toHaveLength(1);
     expect(viewData.sectionEditorItems[1].documentLineDecorations[0]).toEqual(
       expect.objectContaining({ id: "line-3", lineNumber: 1 }),
@@ -467,7 +474,7 @@ describe("sceneEditorLexical.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(
       viewData.sectionEditorItems[0].documentLineDecorations[0].characterFileId,

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -15,6 +15,7 @@ import {
   handlePreviewClick,
   handleSectionMoveSceneFormActionClick,
   handleSelectedLineChanged,
+  handleSystemActionsDialogOpen,
   handleTemporaryPresentationStateChange,
   scrollEntrySelectionIntoView,
   syncSceneEditorRoutePayload,
@@ -471,6 +472,31 @@ describe("sceneEditorLexical.handlers transform editor resize", () => {
 });
 
 describe("sceneEditorLexical.handlers actions dialog", () => {
+  it("stores the system action dialog target line before the dialog opens", () => {
+    let actionTargetLineId;
+
+    handleSystemActionsDialogOpen(
+      {
+        store: {
+          selectSelectedLineId: vi.fn(() => "fallback-line"),
+          setActionTargetLineId: vi.fn(({ lineId }) => {
+            actionTargetLineId = lineId;
+          }),
+        },
+      },
+      {
+        _event: {
+          detail: {
+            selectedLineId: "line-2",
+            mode: "actions",
+          },
+        },
+      },
+    );
+
+    expect(actionTargetLineId).toBe("line-2");
+  });
+
   it("opens the background transform editor from the predefined transform when stale inline fields are present", () => {
     const openBackgroundTransformEditor = vi.fn();
     const open = vi.fn();

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -11,6 +11,9 @@ import {
 import {
   handleActionsDialogClose,
   handleActionsDialogCloseRequest,
+  handleActionControlMouseDown,
+  handleActionItemClick,
+  handleAddActionButtonClicked,
   handleBackgroundTransformCustomize,
   handleBackgroundTransformEditorDone,
   handleGetBackgroundTransformPreviewCanvasRoot,
@@ -26,6 +29,112 @@ import {
 } from "../../src/components/systemActions/systemActions.handlers.js";
 
 describe("systemActions.handlers", () => {
+  it("announces the selected line before opening the add-action dialog", () => {
+    const state = createInitialState();
+    const dispatchedEvents = [];
+
+    handleAddActionButtonClicked({
+      props: {
+        selectedLineId: "line-2",
+      },
+      store: {
+        showActionsDialog: () => {
+          state.isActionsDialogOpen = true;
+        },
+        setMode: ({ mode }) => {
+          state.mode = mode;
+        },
+      },
+      render: vi.fn(),
+      dispatchEvent: (event) => {
+        dispatchedEvents.push(event);
+      },
+    });
+
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("actions-dialog-open");
+    expect(dispatchedEvents[0].detail).toEqual({
+      mode: "actions",
+      selectedLineId: "line-2",
+    });
+    expect(state.isActionsDialogOpen).toBe(true);
+    expect(state.mode).toBe("actions");
+  });
+
+  it("announces the selected line before opening an existing action editor", () => {
+    const state = createInitialState();
+    const dispatchedEvents = [];
+
+    handleActionItemClick(
+      {
+        props: {
+          selectedLineId: "line-3",
+        },
+        store: {
+          showActionsDialog: () => {
+            state.isActionsDialogOpen = true;
+          },
+          setMode: ({ mode }) => {
+            state.mode = mode;
+          },
+        },
+        render: vi.fn(),
+        dispatchEvent: (event) => {
+          dispatchedEvents.push(event);
+        },
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {
+              mode: "dialogue",
+            },
+          },
+        },
+      },
+    );
+
+    expect(dispatchedEvents).toHaveLength(1);
+    expect(dispatchedEvents[0].type).toBe("actions-dialog-open");
+    expect(dispatchedEvents[0].detail).toEqual({
+      mode: "dialogue",
+      selectedLineId: "line-3",
+    });
+    expect(state.isActionsDialogOpen).toBe(true);
+    expect(state.mode).toBe("dialogue");
+  });
+
+  it("prevents action controls from stealing editor focus on mousedown", () => {
+    const preventDefault = vi.fn();
+
+    handleActionControlMouseDown(
+      {},
+      {
+        _event: {
+          preventDefault,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves secondary action-control mousedown events available for context menus", () => {
+    const preventDefault = vi.fn();
+
+    handleActionControlMouseDown(
+      {},
+      {
+        _event: {
+          button: 2,
+          preventDefault,
+        },
+      },
+    );
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
   it("keeps local merged actions but emits only the submitted action delta", () => {
     const state = createInitialState();
     const dispatchedEvents = [];

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -45,6 +45,32 @@ describe("systemActions view", () => {
     );
   });
 
+  it("preserves scene editor selection before action dialog controls open", () => {
+    const systemActionsView = readFileSync(
+      new URL(
+        "../../src/components/systemActions/systemActions.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const sceneEditorLexicalView = readFileSync(
+      new URL(
+        "../../src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(systemActionsView).toContain("mousedown:");
+    expect(systemActionsView).toContain(
+      "handler: handleActionControlMouseDown",
+    );
+    expect(sceneEditorLexicalView).toContain("actions-dialog-open:");
+    expect(sceneEditorLexicalView).toContain(
+      "handler: handleSystemActionsDialogOpen",
+    );
+  });
+
   it("uses a shared dialog surface with a scene-only left-docked variant", () => {
     const systemActionsView = readFileSync(
       new URL(

--- a/tests/transforms/transforms.handlers.test.js
+++ b/tests/transforms/transforms.handlers.test.js
@@ -3,6 +3,7 @@ import { EN_I18N } from "../support/i18n.js";
 import {
   handleImportFormActionClick,
   handleImportTransformClick,
+  handleMobileDetailEditClick,
   handleTransformPreviewImageContextMenu,
   handleTransformPreviewImageMenuItemClick,
   handleTransformPreviewImageSelected,
@@ -24,6 +25,56 @@ describe("transforms.handlers", () => {
     handleImportTransformClick({ render, store });
 
     expect(store.openImportDialog).toHaveBeenCalledWith();
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("opens the selected transform from the mobile detail edit action", async () => {
+    const render = vi.fn();
+    const transform = {
+      id: "transform-1",
+      type: "transform",
+      name: "Center",
+      x: 960,
+      y: 540,
+      scaleX: 1,
+      scaleY: 1,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      rotation: 0,
+    };
+    const store = {
+      openTransformFormDialog: vi.fn(),
+      selectProjectResolution: vi.fn(() => ({
+        width: 1920,
+        height: 1080,
+      })),
+      selectSelectedItemId: vi.fn(() => "transform-1"),
+      selectTransformItemById: vi.fn(() => transform),
+    };
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    await handleMobileDetailEditClick(
+      {
+        refs: {},
+        render,
+        store,
+      },
+      {
+        _event: event,
+      },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(store.openTransformFormDialog).toHaveBeenCalledWith({
+      editMode: true,
+      itemId: "transform-1",
+      itemData: transform,
+      targetGroupId: undefined,
+    });
     expect(render).toHaveBeenCalled();
   });
 

--- a/tests/transforms/transforms.store.test.js
+++ b/tests/transforms/transforms.store.test.js
@@ -34,6 +34,12 @@ const imagesData = {
 };
 
 describe("transforms.store", () => {
+  it("exposes the mobile edit action label", () => {
+    const state = createInitialState();
+
+    expect(selectViewData({ state, i18n: EN_I18N }).editButton).toBe("Edit");
+  });
+
   it("applies preview image selections immediately and restores them on cancel", () => {
     const state = createInitialState();
     setImagesData({ state }, { imagesData });

--- a/tests/whiteboard/whiteboard.handlers.test.js
+++ b/tests/whiteboard/whiteboard.handlers.test.js
@@ -3,6 +3,7 @@ import {
   handleContainerTouchEnd,
   handleContainerTouchMove,
   handleContainerTouchStart,
+  handleContainerGestureEvent,
   handleContainerWheel,
   handleEnsureItemVisible,
   handleItemMouseDown,
@@ -44,7 +45,9 @@ const createDeps = ({
 } = {}) => {
   const minimapItemRefs = createMinimapItemRefs();
   let currentPan = pan;
+  let currentZoomLevel = zoomLevel;
   let panAnimationFrameId;
+  let trackpadPinchGesture;
 
   const store = {
     selectContainerSize: vi.fn(() => ({
@@ -55,7 +58,7 @@ const createDeps = ({
     selectIsPanMode: vi.fn(() => false),
     selectIsPanning: vi.fn(() => false),
     selectPan: vi.fn(() => currentPan),
-    selectZoomLevel: vi.fn(() => zoomLevel),
+    selectZoomLevel: vi.fn(() => currentZoomLevel),
     selectMouseItemPress: vi.fn(() => undefined),
     clearMouseItemPress: vi.fn(),
     selectMinimapData: vi.fn(() => ({
@@ -86,6 +89,28 @@ const createDeps = ({
       panAnimationFrameId = undefined;
     }),
     zoomAt: vi.fn(),
+    startTrackpadPinch: vi.fn(({ centerX, centerY }) => {
+      trackpadPinchGesture = {
+        startZoomLevel: currentZoomLevel,
+        anchorCanvasX: (centerX - currentPan.x) / currentZoomLevel,
+        anchorCanvasY: (centerY - currentPan.y) / currentZoomLevel,
+      };
+    }),
+    updateTrackpadPinch: vi.fn(({ centerX, centerY, scale }) => {
+      if (!trackpadPinchGesture) {
+        return;
+      }
+
+      currentZoomLevel = trackpadPinchGesture.startZoomLevel * scale;
+      currentPan = {
+        x: centerX - trackpadPinchGesture.anchorCanvasX * currentZoomLevel,
+        y: centerY - trackpadPinchGesture.anchorCanvasY * currentZoomLevel,
+      };
+    }),
+    stopTrackpadPinch: vi.fn(() => {
+      trackpadPinchGesture = undefined;
+    }),
+    selectTrackpadPinchGesture: vi.fn(() => trackpadPinchGesture),
   };
   const refs = {
     container: {
@@ -126,6 +151,7 @@ const createDeps = ({
     dispatchEvent: vi.fn(),
     minimapItemRefs,
     getPan: () => currentPan,
+    getZoomLevel: () => currentZoomLevel,
   };
 };
 
@@ -309,6 +335,21 @@ const createMouseEvent = ({
   stopPropagation: vi.fn(),
 });
 
+const createGestureEvent = ({
+  type,
+  clientX = 0,
+  clientY = 0,
+  scale = 1,
+} = {}) => ({
+  type,
+  clientX,
+  clientY,
+  scale,
+  preventDefault: vi.fn(),
+  stopPropagation: vi.fn(),
+  cancelable: true,
+});
+
 describe("whiteboard minimap drag handlers", () => {
   beforeAll(() => {
     if (typeof globalThis.HTMLElement === "undefined") {
@@ -426,6 +467,69 @@ describe("whiteboard minimap drag handlers", () => {
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(deps.store.zoomAt).not.toHaveBeenCalled();
     expect(deps.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it("zooms with macOS trackpad gesture events", () => {
+    const deps = createDeps({
+      isDraggingMinimapViewport: false,
+      pan: { x: -100, y: -50 },
+      zoomLevel: 1,
+      containerWidth: 500,
+      containerHeight: 300,
+    });
+    const startEvent = createGestureEvent({
+      type: "gesturestart",
+      clientX: 250,
+      clientY: 150,
+    });
+    const changeEvent = createGestureEvent({
+      type: "gesturechange",
+      clientX: 250,
+      clientY: 150,
+      scale: 1.5,
+    });
+
+    handleContainerGestureEvent(deps, {
+      _event: startEvent,
+    });
+    handleContainerGestureEvent(deps, {
+      _event: changeEvent,
+    });
+
+    expect(startEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(changeEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(deps.store.startTrackpadPinch).toHaveBeenCalledWith({
+      centerX: 250,
+      centerY: 150,
+    });
+    expect(deps.store.updateTrackpadPinch).toHaveBeenCalledWith({
+      centerX: 250,
+      centerY: 150,
+      scale: 1.5,
+    });
+    expect(deps.getZoomLevel()).toBe(1.5);
+    expect(deps.getPan()).toEqual({ x: -275, y: -150 });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+
+    const dispatchedEvents = deps.dispatchEvent.mock.calls.map(
+      ([event]) => event,
+    );
+    expect(dispatchedEvents.map((event) => event.type)).toEqual([
+      "zoom-changed",
+      "pan-changed",
+    ]);
+    expect(dispatchedEvents[0].detail).toEqual({ zoomLevel: 1.5 });
+    expect(dispatchedEvents[1].detail).toEqual({
+      panX: -275,
+      panY: -150,
+    });
+
+    const endEvent = createGestureEvent({ type: "gestureend" });
+    handleContainerGestureEvent(deps, {
+      _event: endEvent,
+    });
+
+    expect(deps.store.stopTrackpadPinch).toHaveBeenCalledTimes(1);
   });
 
   it("drags the selected item after a one-finger touch moves", () => {

--- a/tests/whiteboard/whiteboard.store.test.js
+++ b/tests/whiteboard/whiteboard.store.test.js
@@ -7,8 +7,11 @@ import {
   setContainerSize,
   setHoveredItemId,
   setInitialZoomAndPan,
+  startTrackpadPinch,
   startMinimapViewportDragging,
+  stopTrackpadPinch,
   stopMinimapViewportDragging,
+  updateTrackpadPinch,
   updatePanFromMinimapViewportDragging,
 } from "../../src/components/whiteboard/whiteboard.store.js";
 
@@ -184,6 +187,43 @@ describe("whiteboard minimap viewport drag", () => {
 });
 
 describe("whiteboard.store", () => {
+  it("zooms desktop pinch gestures around their anchor point", () => {
+    const state = createInitialState();
+
+    setInitialZoomAndPan({ state }, { zoomLevel: 1, panX: -100, panY: -50 });
+    startTrackpadPinch({ state }, { centerX: 240, centerY: 160 });
+
+    updateTrackpadPinch(
+      { state },
+      {
+        centerX: 240,
+        centerY: 160,
+        scale: 1.5,
+      },
+    );
+
+    expect(state.zoomLevel).toBe(1.5);
+    expect(state.panX).toBe(-270);
+    expect(state.panY).toBe(-155);
+
+    updateTrackpadPinch(
+      { state },
+      {
+        centerX: 260,
+        centerY: 150,
+        scale: 0.5,
+      },
+    );
+
+    expect(state.zoomLevel).toBe(0.5);
+    expect(state.panX).toBe(90);
+    expect(state.panY).toBe(45);
+
+    stopTrackpadPinch({ state });
+
+    expect(state.trackpadPinchGesture).toBeUndefined();
+  });
+
   it("keeps scene node border width stable across hover and selection", () => {
     const state = createInitialState();
     const props = {


### PR DESCRIPTION
## Summary
- Fix scene editor action dialog target capture so plus/edit actions keep the intended selected line.
- Fix text-mode ArrowUp/ArrowDown section-boundary navigation so it moves directly across sections.
- Add mobile/Android transform detail edit support.
- Add whiteboard desktop trackpad pinch gesture handling.

## Validation
- bun run lint
- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js --reporter=dot
- bunx vitest run tests/sceneEditor/sceneEditor.store.test.js --reporter=dot
- bunx vitest run tests/sceneEditor/sceneEditorLexical.handlers.test.js -t "moves text selection from the last line|moves text selection from the first line" --reporter=dot
- bunx vitest run tests/systemActions/systemActions.handlers.test.js tests/systemActions/systemActions.view.test.js -t "announces the selected line|prevents action controls|secondary action-control|preserves scene editor selection" --reporter=dot
- bunx vitest run tests/transforms/transforms.handlers.test.js tests/transforms/transforms.store.test.js tests/whiteboard/whiteboard.handlers.test.js tests/whiteboard/whiteboard.store.test.js --reporter=dot

Note: the full sceneEditorLexical.handlers test file still has existing i18n fixture/async preview failures unrelated to this PR; focused changed-path tests pass.