### PR TITLE
Add Ubuntu 22.04 AppImage Docker builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!docker/
+!docker/appimage/
+!docker/appimage/build-in-container.sh
+!docker/appimage/ubuntu-22.04.Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .temp
 .claude
 _site
+/dist/
 vt/static/public/main.js
 vt/static/public/main.js.map
 static/public/rtgl-icons.js

--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ Build the desktop application:
 bun run tauri:build
 ```
 
+Build the Linux AppImage on the host:
+```shell
+bun run tauri:build:appimage
+```
+
+Build the Linux AppImage in an Ubuntu 22.04 Docker builder for a more
+compatible release baseline:
+```shell
+bun run tauri:build:appimage:docker
+```
+The Docker-built AppImage, signature, and checksum are copied to
+`dist/appimage/ubuntu-22.04/`.
+
 Cross-compile for Windows:
 ```shell
 bun run tauri:build:win

--- a/docker/appimage/build-in-container.sh
+++ b/docker/appimage/build-in-container.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SRC_DIR="${ROUTEVN_SRC_DIR:-/src}"
+WORK_DIR="${ROUTEVN_WORK_DIR:-/work}"
+OUT_DIR="${ROUTEVN_OUT_DIR:-/out}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/cache/cargo-target}"
+BUN_INSTALL_CACHE_DIR="${BUN_INSTALL_CACHE_DIR:-/cache/bun}"
+CARGO_HOME="${CARGO_HOME:-/cache/cargo-home}"
+HOST_UID="${HOST_UID:-}"
+HOST_GID="${HOST_GID:-}"
+
+export CARGO_TARGET_DIR
+export BUN_INSTALL_CACHE_DIR
+export CARGO_HOME
+export RUSTUP_HOME="${RUSTUP_HOME:-/opt/rustup}"
+export APPIMAGE_EXTRACT_AND_RUN="${APPIMAGE_EXTRACT_AND_RUN:-1}"
+export NO_STRIP="${NO_STRIP:-1}"
+export PATH="/opt/cargo/bin:/opt/bun/bin:/usr/local/bin:${PATH}"
+
+if [ ! -f "${SRC_DIR}/package.json" ]; then
+  echo "Error: ${SRC_DIR} does not look like the RouteVN Creator repo."
+  exit 1
+fi
+
+if [ ! -f "${SRC_DIR}/.env" ]; then
+  echo "Error: ${SRC_DIR}/.env is required because the AppImage build signs updater artifacts."
+  exit 1
+fi
+
+if ! grep -q '^TAURI_SIGNING_PRIVATE_KEY=' "${SRC_DIR}/.env"; then
+  echo "Error: .env must define TAURI_SIGNING_PRIVATE_KEY."
+  exit 1
+fi
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}" "${OUT_DIR}" "${BUN_INSTALL_CACHE_DIR}" "${CARGO_HOME}" "${CARGO_TARGET_DIR}"
+
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude 'node_modules' \
+  --exclude '_site' \
+  --exclude '.rettangoli/vt/_site' \
+  --exclude 'src-tauri/target' \
+  --exclude 'test-results' \
+  "${SRC_DIR}/" "${WORK_DIR}/"
+
+cd "${WORK_DIR}"
+
+bun install --frozen-lockfile
+bun run tauri:build:appimage
+
+BUNDLE_DIR="${CARGO_TARGET_DIR%/}/release/bundle/appimage"
+if [ ! -d "${BUNDLE_DIR}" ]; then
+  echo "Error: expected AppImage bundle directory missing: ${BUNDLE_DIR}"
+  exit 1
+fi
+
+find "${OUT_DIR}" -maxdepth 1 -type f \
+  \( -name '*.AppImage' -o -name '*.AppImage.sig' -o -name '*.AppImage.sha256' \) \
+  -delete
+
+find "${BUNDLE_DIR}" -maxdepth 1 -type f \
+  \( -name '*.AppImage' -o -name '*.AppImage.sig' -o -name '*.AppImage.sha256' \) \
+  -exec cp -a {} "${OUT_DIR}/" \;
+
+if [ -n "${HOST_UID}" ] && [ -n "${HOST_GID}" ]; then
+  chown -R "${HOST_UID}:${HOST_GID}" "${OUT_DIR}"
+fi
+
+echo "AppImage artifacts copied to ${OUT_DIR}:"
+find "${OUT_DIR}" -maxdepth 1 -type f -printf '  %f\n' | sort

--- a/docker/appimage/ubuntu-22.04.Dockerfile
+++ b/docker/appimage/ubuntu-22.04.Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:22.04
+
+ARG BUN_VERSION=1.3.11
+ARG NODE_MAJOR=22
+ARG RUST_TOOLCHAIN=stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV BUN_INSTALL=/opt/bun
+ENV PATH=/opt/cargo/bin:/opt/bun/bin:/usr/local/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    wget \
+    gnupg \
+    file \
+    build-essential \
+    pkg-config \
+    git \
+    rsync \
+    xz-utils \
+    unzip \
+    libssl-dev \
+    libwebkit2gtk-4.1-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev \
+    patchelf \
+    xdg-utils \
+    libfuse2 \
+    libgtk-3-bin \
+    libglib2.0-bin \
+    libgdk-pixbuf2.0-bin \
+    webp-pixbuf-loader \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-libav \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}" \
+  && chmod -R a+rwx /opt/rustup /opt/cargo
+
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+  && chmod -R a+rx /opt/bun \
+  && bun --version \
+  && node --version \
+  && rustc --version
+
+COPY docker/appimage/build-in-container.sh /usr/local/bin/build-routevn-appimage
+RUN chmod +x /usr/local/bin/build-routevn-appimage
+
+ENTRYPOINT ["/usr/local/bin/build-routevn-appimage"]

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "tauri:dev:win": "CARGO_BUILD_JOBS=2 tauri dev --runner ../scripts/tauri-wsl-windows-runner.sh --target x86_64-pc-windows-msvc",
     "tauri:build": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json",
     "tauri:build:appimage": "./scripts/tauri-build-appimage.sh",
+    "tauri:build:appimage:docker": "./scripts/tauri-build-appimage-docker.sh",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
     "tauri:build:win:steam": "./scripts/tauri-build-win-steam.sh",
     "tauri:build:mac": "./scripts/tauri-build-mac.sh",

--- a/scripts/tauri-build-appimage-docker.sh
+++ b/scripts/tauri-build-appimage-docker.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_NAME="${ROUTEVN_APPIMAGE_DOCKER_IMAGE:-routevn-creator-appimage-builder:ubuntu-22.04}"
+OUT_DIR="${ROUTEVN_APPIMAGE_OUT_DIR:-${ROOT_DIR}/dist/appimage/ubuntu-22.04}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required for the Ubuntu 22.04 AppImage build."
+  exit 1
+fi
+
+if [ ! -f "${ROOT_DIR}/.env" ]; then
+  echo "Error: ${ROOT_DIR}/.env is required because the AppImage build signs updater artifacts."
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+docker build \
+  --platform linux/amd64 \
+  -f "${ROOT_DIR}/docker/appimage/ubuntu-22.04.Dockerfile" \
+  -t "${IMAGE_NAME}" \
+  "${ROOT_DIR}"
+
+docker run --rm \
+  --platform linux/amd64 \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
+  -e APPIMAGE_EXTRACT_AND_RUN=1 \
+  -e NO_STRIP="${NO_STRIP:-1}" \
+  -v "${ROOT_DIR}:/src:ro" \
+  -v "${OUT_DIR}:/out" \
+  -v routevn-appimage-bun-cache:/cache/bun \
+  -v routevn-appimage-cargo-home:/cache/cargo-home \
+  -v routevn-appimage-cargo-target:/cache/cargo-target \
+  "${IMAGE_NAME}"
+
+echo "Ubuntu 22.04 AppImage artifacts are in ${OUT_DIR}"

--- a/scripts/tauri-build-appimage.sh
+++ b/scripts/tauri-build-appimage.sh
@@ -11,13 +11,24 @@ load_env() {
   fi
 }
 
+get_target_dir() {
+  if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    echo "${CARGO_TARGET_DIR%/}"
+    return
+  fi
+
+  echo "src-tauri/target"
+}
+
 write_appimage_checksum() {
-  local bundle_dir="src-tauri/target/release/bundle/appimage"
+  local bundle_dir
   local appimage
   local appimage_path
   local appimage_file
   local checksum_file
   local appimages=()
+
+  bundle_dir="$(get_target_dir)/release/bundle/appimage"
 
   while IFS= read -r -d '' appimage; do
     appimages+=("${appimage}")


### PR DESCRIPTION
## Summary
- Add an Ubuntu 22.04 Docker builder for release-baseline AppImage builds.
- Add `bun run tauri:build:appimage:docker` to build and copy AppImage artifacts into `dist/appimage/ubuntu-22.04/`.
- Make the existing AppImage checksum helper respect `CARGO_TARGET_DIR` so Docker can use persistent Cargo volumes.
- Ignore generated `dist/` artifacts and document the host and Docker AppImage build commands.

## Validation
- `bun run tauri:build:appimage:docker`
- `sha256sum -c RouteVN Creator_1.6.6_amd64.AppImage.sha256`
- `bash -n scripts/tauri-build-appimage.sh`
- `bash -n scripts/tauri-build-appimage-docker.sh`
- `bash -n docker/appimage/build-in-container.sh`
- `git diff --check`
- Push hook: `oxlint && bun prettier --check src`