### PR TITLE
test(vt): fix project sidebar selectors

### DIFF
--- a/vt/specs/project/about.yaml
+++ b/vt/specs/project/about.yaml
@@ -57,7 +57,7 @@ steps:
   - action: wait
     ms: 500
   - action: select
-    selector: "#sidebar [data-item-id='/project/about']"
+    selector: "#sidebar [data-item-id='settings']"
     steps:
       - action: click
   - action: waitFor

--- a/vt/specs/project/animations.yaml
+++ b/vt/specs/project/animations.yaml
@@ -57,7 +57,7 @@ steps:
   - action: wait
     ms: 500
   - action: select
-    selector: "#sidebar [data-item-id='/project/animations']"
+    selector: "#sidebar [data-item-id='animatedAssets']"
     steps:
       - action: click
   - action: waitFor

--- a/vt/specs/project/controls.yaml
+++ b/vt/specs/project/controls.yaml
@@ -57,7 +57,7 @@ steps:
   - action: wait
     ms: 500
   - action: select
-    selector: "#sidebar [data-item-id='/project/controls']"
+    selector: "#sidebar [data-item-id='system']"
     steps:
       - action: click
   - action: waitFor

--- a/vt/specs/project/scenes.yaml
+++ b/vt/specs/project/scenes.yaml
@@ -57,7 +57,7 @@ steps:
   - action: wait
     ms: 500
   - action: select
-    selector: "#sidebar [data-item-id='/project/scenes']"
+    selector: "#sidebar [data-item-id='scenes']"
     steps:
       - action: click
   - action: waitFor

--- a/vt/specs/project/versions.yaml
+++ b/vt/specs/project/versions.yaml
@@ -57,7 +57,7 @@ steps:
   - action: wait
     ms: 500
   - action: select
-    selector: "#sidebar [data-item-id='/project/releases/versions']"
+    selector: "#sidebar [data-item-id='release']"
     steps:
       - action: click
   - action: waitFor


### PR DESCRIPTION
## Summary
- update five project VT specs to click the sidebar item ids rendered by `rtgl-sidebar`
- replace stale route-path `data-item-id` selectors for scenes, animations, versions, controls, and about/settings

## Testing
- targeted local VT: `bunx rtgl vt screenshot --item project/scenes --item project/animations --item project/versions --item project/controls --item project/about --isolation strict --concurrency 1` (5/5 passed; run on temporary port 3101 because local 3001 was occupied)
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`

## Notes
- full Docker VT rerun was not performed because Docker escalation was rejected due third-party image/repo mount risk
- unrelated local edits in `static/public/theme.css` and `tests/theme/themeCss.test.js` were left unstaged and are not part of this PR