### PR TITLE
chore: bump feature version and scrollbar theme

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/static/public/theme.css
+++ b/static/public/theme.css
@@ -36,7 +36,7 @@ body::-webkit-scrollbar {
 
 /* Firefox */
 * {
-  scrollbar-color: var(--input) transparent;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 *,
@@ -168,6 +168,19 @@ body {
 
   /* ring of text inputs */
   --ring: oklch(0.708 0 0);
+
+  --scrollbar-size: 6px;
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: color-mix(
+    in oklch,
+    var(--background) 82%,
+    var(--foreground) 18%
+  );
+  --scrollbar-thumb-hover: color-mix(
+    in oklch,
+    var(--background) 76%,
+    var(--foreground) 24%
+  );
 }
 
 .dark {

--- a/tests/theme/themeCss.test.js
+++ b/tests/theme/themeCss.test.js
@@ -14,4 +14,17 @@ describe("theme css", () => {
     expect(themeCss).toContain("*::before");
     expect(themeCss).toContain("*::after");
   });
+
+  it("uses app scrollbar theme tokens", () => {
+    const themeCss = readFileSync(
+      new URL("../../static/public/theme.css", import.meta.url),
+      "utf8",
+    );
+
+    expect(themeCss).toContain("--scrollbar-thumb:");
+    expect(themeCss).toContain("--scrollbar-thumb-hover:");
+    expect(themeCss).toContain(
+      "scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- bump Tauri app version from `1.6.6` to `1.7.0`
- add app scrollbar theme tokens and use them for Firefox scrollbar colors
- add theme CSS coverage for scrollbar token usage

## Testing
- `bunx vitest run tests/theme/themeCss.test.js`
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`