### PR TITLE
fix: recover duplicate file creates during history replay

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -207,6 +207,40 @@ const collectionTreeContainsItemId = (nodes = [], itemId) => {
   });
 };
 
+const hasReplayStringConflict = (leftValue, rightValue) => {
+  if (!isNonEmptyString(leftValue) || !isNonEmptyString(rightValue)) {
+    return false;
+  }
+
+  return leftValue !== rightValue;
+};
+
+const hasReplayNumberConflict = (leftValue, rightValue) => {
+  const leftNumber = Number(leftValue);
+  const rightNumber = Number(rightValue);
+  if (!Number.isFinite(leftNumber) || !Number.isFinite(rightNumber)) {
+    return false;
+  }
+
+  return leftNumber !== rightNumber;
+};
+
+const isReplayFileCreateDataCompatible = (existingFile, fileData) => {
+  if (existingFile?.type === "folder" || fileData?.type === "folder") {
+    return (
+      existingFile?.type === "folder" &&
+      fileData?.type === "folder" &&
+      !hasReplayStringConflict(existingFile.name, fileData.name)
+    );
+  }
+
+  return (
+    !hasReplayStringConflict(existingFile.mimeType, fileData.mimeType) &&
+    !hasReplayNumberConflict(existingFile.size, fileData.size) &&
+    !hasReplayStringConflict(existingFile.sha256, fileData.sha256)
+  );
+};
+
 const getReplayFailedCommandIndex = (error) => {
   const failedIndex = Number(error?.details?.commandIndex);
   return Number.isInteger(failedIndex) && failedIndex >= 0
@@ -246,9 +280,8 @@ const canSkipDuplicateFileCreateDuringReplay = ({
 
   return (
     existingFile.id === fileId &&
-    existingFile.mimeType === fileData.mimeType &&
-    Number(existingFile.size) === Number(fileData.size) &&
-    existingFile.sha256 === fileData.sha256
+    collectionTreeContainsItemId(repositoryState?.files?.tree, fileId) &&
+    isReplayFileCreateDataCompatible(existingFile, fileData)
   );
 };
 
@@ -300,22 +333,33 @@ const canSkipDuplicateResourceCreateDuringReplay = ({
 };
 
 const canAttemptSequentialReplayRecovery = ({ events, error } = {}) => {
+  const replayEvents = Array.isArray(events) ? events : [];
   const failedIndex = getReplayFailedCommandIndex(error);
-  if (!Number.isInteger(failedIndex) || failedIndex >= (events?.length || 0)) {
-    return false;
+  if (Number.isInteger(failedIndex) && failedIndex < replayEvents.length) {
+    const failedEvent = replayEvents[failedIndex];
+
+    return (
+      isDuplicateFileCreateReplayFailure({
+        event: failedEvent,
+        error,
+      }) ||
+      isDuplicateResourceCreateReplayFailure({
+        event: failedEvent,
+        error,
+      })
+    );
   }
 
-  const failedEvent = events[failedIndex];
-
-  return (
-    isDuplicateFileCreateReplayFailure({
-      event: failedEvent,
-      error,
-    }) ||
-    isDuplicateResourceCreateReplayFailure({
-      event: failedEvent,
-      error,
-    })
+  return replayEvents.some(
+    (event) =>
+      isDuplicateFileCreateReplayFailure({
+        event,
+        error,
+      }) ||
+      isDuplicateResourceCreateReplayFailure({
+        event,
+        error,
+      }),
   );
 };
 

--- a/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
+++ b/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
@@ -479,6 +479,109 @@ describe("projectRepositoryRuntime replay diagnostics", () => {
     expect(state.files.tree).toEqual([{ id: "file-1" }]);
   });
 
+  it("recovers duplicate file.create events when batched replay omits command index", () => {
+    const reduceEventToState = createFileReplayReducer();
+    const events = [
+      {
+        id: "event-1",
+        type: "file.create",
+        partition: "m",
+        payload: {
+          fileId: "file-1",
+          data: {
+            mimeType: "image/png",
+            size: 123,
+            sha256: "hash-1",
+          },
+        },
+      },
+      {
+        id: "event-2",
+        type: "file.create",
+        partition: "m",
+        payload: {
+          fileId: "file-1",
+          data: {
+            mimeType: "image/png",
+            size: 123,
+            sha256: "hash-1",
+          },
+        },
+      },
+    ];
+
+    const state = replayEventsToRepositoryState({
+      events,
+      untilEventIndex: events.length,
+      createInitialState: () => structuredClone(initialProjectData),
+      reduceEventToState,
+      reduceEventsToState: createBatchedReducer(reduceEventToState),
+    });
+
+    expect(state.files.items["file-1"]).toEqual({
+      id: "file-1",
+      mimeType: "image/png",
+      size: 123,
+      sha256: "hash-1",
+    });
+    expect(state.files.tree).toEqual([{ id: "file-1" }]);
+  });
+
+  it("recovers duplicate file.create events with compatible legacy file metadata", () => {
+    const reduceFileEventToState = createFileReplayReducer();
+    const snapshotState = structuredClone(initialProjectData);
+    snapshotState.files.items["file-1"] = {
+      id: "file-1",
+      mimeType: "image/png",
+    };
+    snapshotState.files.tree = [{ id: "file-1" }];
+    const reduceEventToState = ({ repositoryState, event }) => {
+      if (event?.type === "project.create") {
+        return structuredClone(event.payload.state);
+      }
+
+      return reduceFileEventToState({ repositoryState, event });
+    };
+    const events = [
+      {
+        id: "event-1",
+        type: "project.create",
+        partition: "m",
+        payload: {
+          state: snapshotState,
+        },
+      },
+      {
+        id: "event-2",
+        type: "file.create",
+        partition: "m",
+        payload: {
+          fileId: "file-1",
+          data: {
+            mimeType: "image/png",
+            size: 123,
+            sha256: "hash-1",
+          },
+        },
+      },
+    ];
+
+    const state = replayEventsToRepositoryState({
+      events,
+      untilEventIndex: events.length,
+      createInitialState: () => structuredClone(initialProjectData),
+      reduceEventToState,
+      reduceEventsToState:
+        createBatchedReducerWithCommandIndex(reduceEventToState),
+    });
+
+    expect(state.files.items["file-1"]).toEqual({
+      id: "file-1",
+      mimeType: "image/png",
+    });
+    expect(state.files.tree).toEqual([{ id: "file-1" }]);
+  });
+
   it("recovers identical duplicate image.create events during batched historical replay", () => {
     const reduceEventToState = createImageReplayReducer();
     const events = [


### PR DESCRIPTION
## Summary
- retry historical replay sequentially when a duplicate create batch error does not include a command index
- make duplicate file.create recovery require an existing tree entry and tolerate compatible legacy file metadata
- add regression coverage for duplicate file.create recovery used by version export

## Testing
- bunx vitest run tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
- bunx vitest run tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js tests/versions/versions.handlers.test.js
- bun prettier --check src/deps/services/shared/projectRepositoryRuntime.js tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
- bun run lint