### PR TITLE
Refactor shared image preview overlay logic

### DIFF
--- a/src/internal/ui/resourcePages/imagePreviewOverlay.js
+++ b/src/internal/ui/resourcePages/imagePreviewOverlay.js
@@ -1,0 +1,164 @@
+import { formatProjectResolutionAspectRatio } from "../../projectResolution.js";
+
+export const IMAGE_PREVIEW_DISPLAY_MODE_FIT = "fit";
+export const IMAGE_PREVIEW_DISPLAY_MODE_CANVAS = "canvas";
+
+export const isImagePreviewDisplayMode = (displayMode) =>
+  displayMode === IMAGE_PREVIEW_DISPLAY_MODE_FIT ||
+  displayMode === IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+
+export const createImagePreviewFrameStyle = (projectResolution) => {
+  const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
+
+  return [
+    `width: min(88vw, calc((100vh - 120px) * (${aspectRatio})))`,
+    `aspect-ratio: ${aspectRatio}`,
+    "max-width: 88vw",
+    "max-height: calc(100vh - 120px)",
+  ].join("; ");
+};
+
+const resolvePositiveNumber = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0
+    ? numericValue
+    : undefined;
+};
+
+export const createImagePreviewImageWrapperStyle = ({
+  image,
+  displayMode,
+  projectResolution,
+} = {}) => {
+  if (displayMode !== IMAGE_PREVIEW_DISPLAY_MODE_CANVAS) {
+    return "position: absolute; inset: 0;";
+  }
+
+  const imageWidth = resolvePositiveNumber(image?.width);
+  const imageHeight = resolvePositiveNumber(image?.height);
+  if (!imageWidth || !imageHeight) {
+    return "position: absolute; inset: 0;";
+  }
+
+  const widthPercent = (imageWidth / projectResolution.width) * 100;
+  const heightPercent = (imageHeight / projectResolution.height) * 100;
+
+  return [
+    "position: absolute",
+    "left: 50%",
+    "top: 50%",
+    `width: ${widthPercent}%`,
+    `height: ${heightPercent}%`,
+    "transform: translate(-50%, -50%)",
+  ].join("; ");
+};
+
+export const createImagePreviewModeButtonViewData = ({
+  displayMode,
+  mode,
+} = {}) => {
+  const selected = displayMode === mode;
+
+  return {
+    backgroundColor: selected ? "ac" : "bg",
+    borderColor: selected ? "ac" : "bo",
+    iconColor: selected ? "white" : "mu-fg",
+    selected,
+  };
+};
+
+export const createImagePreviewOverlayViewData = ({
+  state,
+  image,
+  projectResolution,
+  previousItemId,
+  nextItemId,
+  copy,
+} = {}) => ({
+  fullImagePreviewVisible: state.fullImagePreviewVisible,
+  fullImagePreviewFileId: state.fullImagePreviewFileId,
+  fullImagePreviewFrameStyle: createImagePreviewFrameStyle(projectResolution),
+  fullImagePreviewImageWrapperStyle: createImagePreviewImageWrapperStyle({
+    image,
+    displayMode: state.fullImagePreviewDisplayMode,
+    projectResolution,
+  }),
+  fullImagePreviewDisplayMode: state.fullImagePreviewDisplayMode,
+  fullImagePreviewFitModeButton: createImagePreviewModeButtonViewData({
+    displayMode: state.fullImagePreviewDisplayMode,
+    mode: IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+  }),
+  fullImagePreviewCanvasModeButton: createImagePreviewModeButtonViewData({
+    displayMode: state.fullImagePreviewDisplayMode,
+    mode: IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  }),
+  fullImagePreviewPreviousVisible: Boolean(previousItemId),
+  fullImagePreviewNextVisible: Boolean(nextItemId),
+  fullImagePreviewCanvasModeLabel: copy.previewCanvasModeLabel,
+  fullImagePreviewFitModeLabel: copy.previewFitModeLabel,
+  fullImagePreviewPreviousLabel: copy.previewPreviousLabel,
+  fullImagePreviewNextLabel: copy.previewNextLabel,
+});
+
+export const resolveImagePreviewNavigationDirection = (event) => {
+  if (event.key === "ArrowDown") {
+    return { direction: "next" };
+  }
+
+  if (event.key === "ArrowUp") {
+    return { direction: "previous" };
+  }
+
+  if (event.altKey || event.metaKey) {
+    return undefined;
+  }
+
+  if (event.ctrlKey) {
+    const key = String(event.key ?? "").toLowerCase();
+    if (key === "d") {
+      return { direction: "next", distance: 10, clamp: true };
+    }
+
+    if (key === "u") {
+      return { direction: "previous", distance: 10, clamp: true };
+    }
+
+    return undefined;
+  }
+
+  const key = String(event.key ?? "").toLowerCase();
+  if (key === "j") {
+    return { direction: "next" };
+  }
+
+  if (key === "k") {
+    return { direction: "previous" };
+  }
+
+  return undefined;
+};
+
+export const resolveImagePreviewDisplayMode = (event) => {
+  if (event.altKey || event.ctrlKey || event.metaKey) {
+    return undefined;
+  }
+
+  if (event.key === "ArrowLeft") {
+    return IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+  }
+
+  if (event.key === "ArrowRight") {
+    return IMAGE_PREVIEW_DISPLAY_MODE_FIT;
+  }
+
+  const key = String(event.key ?? "").toLowerCase();
+  if (key === "h") {
+    return IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+  }
+
+  if (key === "l") {
+    return IMAGE_PREVIEW_DISPLAY_MODE_FIT;
+  }
+
+  return undefined;
+};

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -19,6 +19,10 @@ import {
   showResourcePageError,
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
 import {
+  resolveImagePreviewDisplayMode as resolvePreviewDisplayMode,
+  resolveImagePreviewNavigationDirection as resolvePreviewNavigationDirection,
+} from "../../internal/ui/resourcePages/imagePreviewOverlay.js";
+import {
   createFileExplorerKeyboardScopeHandlers,
   isTextEntryKeyEvent,
 } from "../../internal/ui/fileExplorerKeyboardScope.js";
@@ -377,69 +381,6 @@ const navigateSpritePreview = (deps, { direction, distance, clamp } = {}) => {
 
   openSpritePreviewById({ deps, itemId: nextItemId, syncExplorer: true });
   return true;
-};
-
-const resolvePreviewNavigationDirection = (event) => {
-  if (event.key === "ArrowDown") {
-    return { direction: "next" };
-  }
-
-  if (event.key === "ArrowUp") {
-    return { direction: "previous" };
-  }
-
-  if (event.altKey || event.metaKey) {
-    return undefined;
-  }
-
-  if (event.ctrlKey) {
-    const key = String(event.key ?? "").toLowerCase();
-    if (key === "d") {
-      return { direction: "next", distance: 10, clamp: true };
-    }
-
-    if (key === "u") {
-      return { direction: "previous", distance: 10, clamp: true };
-    }
-
-    return undefined;
-  }
-
-  const key = String(event.key ?? "").toLowerCase();
-  if (key === "j") {
-    return { direction: "next" };
-  }
-
-  if (key === "k") {
-    return { direction: "previous" };
-  }
-
-  return undefined;
-};
-
-const resolvePreviewDisplayMode = (event) => {
-  if (event.altKey || event.ctrlKey || event.metaKey) {
-    return undefined;
-  }
-
-  if (event.key === "ArrowLeft") {
-    return "canvas";
-  }
-
-  if (event.key === "ArrowRight") {
-    return "fit";
-  }
-
-  const key = String(event.key ?? "").toLowerCase();
-  if (key === "h") {
-    return "canvas";
-  }
-
-  if (key === "l") {
-    return "fit";
-  }
-
-  return undefined;
 };
 
 const openEditDialogForSprite = ({

--- a/src/pages/characterSprites/characterSprites.store.js
+++ b/src/pages/characterSprites/characterSprites.store.js
@@ -9,9 +9,13 @@ import {
 import { formatI18nCopy } from "../../internal/ui/i18nCopy.js";
 import {
   DEFAULT_PROJECT_RESOLUTION,
-  formatProjectResolutionAspectRatio,
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
+import {
+  IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  createImagePreviewOverlayViewData,
+  isImagePreviewDisplayMode,
+} from "../../internal/ui/resourcePages/imagePreviewOverlay.js";
 import {
   INITIAL_SPRITESHEET_CLIP_FPS,
   formatSpritesheetFps,
@@ -59,68 +63,9 @@ const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
 const IMAGE_CARD_MAX_WIDTH = 400;
 const IMAGE_CARD_HEIGHT = 225;
-const FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT = "fit";
-const FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS = "canvas";
 const CREATE_TAG_DEFAULT_VALUES = Object.freeze({
   name: "",
 });
-
-const createPreviewFrameStyle = (projectResolution) => {
-  const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
-
-  return [
-    `width: min(88vw, calc((100vh - 120px) * (${aspectRatio})))`,
-    `aspect-ratio: ${aspectRatio}`,
-    "max-width: 88vw",
-    "max-height: calc(100vh - 120px)",
-  ].join("; ");
-};
-
-const resolvePositiveNumber = (value) => {
-  const numericValue = Number(value);
-  return Number.isFinite(numericValue) && numericValue > 0
-    ? numericValue
-    : undefined;
-};
-
-const createPreviewImageWrapperStyle = ({
-  image,
-  displayMode,
-  projectResolution,
-} = {}) => {
-  if (displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS) {
-    return "position: absolute; inset: 0;";
-  }
-
-  const imageWidth = resolvePositiveNumber(image?.width);
-  const imageHeight = resolvePositiveNumber(image?.height);
-  if (!imageWidth || !imageHeight) {
-    return "position: absolute; inset: 0;";
-  }
-
-  const widthPercent = (imageWidth / projectResolution.width) * 100;
-  const heightPercent = (imageHeight / projectResolution.height) * 100;
-
-  return [
-    "position: absolute",
-    "left: 50%",
-    "top: 50%",
-    `width: ${widthPercent}%`,
-    `height: ${heightPercent}%`,
-    "transform: translate(-50%, -50%)",
-  ].join("; ");
-};
-
-const createPreviewModeButtonViewData = ({ displayMode, mode } = {}) => {
-  const selected = displayMode === mode;
-
-  return {
-    backgroundColor: selected ? "ac" : "bg",
-    borderColor: selected ? "ac" : "bo",
-    iconColor: selected ? "white" : "mu-fg",
-    selected,
-  };
-};
 
 const matchesSpriteGroupTags = ({ item, tagIds } = {}) => {
   if (!Array.isArray(tagIds) || tagIds.length === 0) {
@@ -660,7 +605,7 @@ export const createInitialState = () => ({
   ...createMobileResourcePageState(),
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
-  fullImagePreviewDisplayMode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  fullImagePreviewDisplayMode: IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
   projectResolution: DEFAULT_PROJECT_RESOLUTION,
   isEditDialogOpen: false,
   editItemId: undefined,
@@ -805,7 +750,7 @@ export const clearCharacterSpritesView = ({ state }) => {
   state.selectedFolderId = undefined;
   state.fullImagePreviewVisible = false;
   state.fullImagePreviewFileId = undefined;
-  state.fullImagePreviewDisplayMode = FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+  state.fullImagePreviewDisplayMode = IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
   state.projectResolution = DEFAULT_PROJECT_RESOLUTION;
   state.isEditDialogOpen = false;
   state.editItemId = undefined;
@@ -1306,8 +1251,7 @@ export const showFullImagePreview = ({ state }, { itemId } = {}) => {
 
   if (item?.type === "image" && item.fileId) {
     if (!state.fullImagePreviewVisible) {
-      state.fullImagePreviewDisplayMode =
-        FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+      state.fullImagePreviewDisplayMode = IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
     }
     state.fullImagePreviewVisible = true;
     state.fullImagePreviewFileId = item.fileId;
@@ -1323,10 +1267,7 @@ export const setFullImagePreviewDisplayMode = (
   { state },
   { displayMode } = {},
 ) => {
-  if (
-    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT &&
-    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
-  ) {
+  if (!isImagePreviewDisplayMode(displayMode)) {
     return;
   }
 
@@ -1516,10 +1457,6 @@ export const selectViewData = ({ state, i18n }) => {
     dialogInstructions: copy.dialogInstructions,
     emptyPreviewLabel: copy.emptyPreviewLabel,
     filesLabel: copy.filesLabel,
-    fullImagePreviewCanvasModeLabel: copy.previewCanvasModeLabel,
-    fullImagePreviewFitModeLabel: copy.previewFitModeLabel,
-    fullImagePreviewPreviousLabel: copy.previewPreviousLabel,
-    fullImagePreviewNextLabel: copy.previewNextLabel,
     noAnimationsFound: copy.noAnimationsFound,
     noSelectionLabel: copy.noSelectionLabel,
     noSpriteGroups: copy.noSpriteGroups,
@@ -1562,25 +1499,14 @@ export const selectViewData = ({ state, i18n }) => {
     acceptedFileTypes: [".jpg", ".jpeg", ".png", ".webp", ".json"],
     imageHeight: IMAGE_CARD_HEIGHT,
     maxWidth: IMAGE_CARD_MAX_WIDTH,
-    fullImagePreviewVisible: state.fullImagePreviewVisible,
-    fullImagePreviewFileId: state.fullImagePreviewFileId,
-    fullImagePreviewFrameStyle: createPreviewFrameStyle(projectResolution),
-    fullImagePreviewImageWrapperStyle: createPreviewImageWrapperStyle({
+    ...createImagePreviewOverlayViewData({
+      state,
       image: previewImage,
-      displayMode: state.fullImagePreviewDisplayMode,
       projectResolution,
+      previousItemId,
+      nextItemId,
+      copy,
     }),
-    fullImagePreviewDisplayMode: state.fullImagePreviewDisplayMode,
-    fullImagePreviewFitModeButton: createPreviewModeButtonViewData({
-      displayMode: state.fullImagePreviewDisplayMode,
-      mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT,
-    }),
-    fullImagePreviewCanvasModeButton: createPreviewModeButtonViewData({
-      displayMode: state.fullImagePreviewDisplayMode,
-      mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
-    }),
-    fullImagePreviewPreviousVisible: Boolean(previousItemId),
-    fullImagePreviewNextVisible: Boolean(nextItemId),
     folderContextMenuItems: createFolderContextMenuItems(copy),
     itemContextMenuItems: createItemContextMenuItems(copy),
     emptyContextMenuItems: createEmptyContextMenuItems(copy),

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -15,6 +15,10 @@ import {
   runResourcePageMutation,
   showResourcePageError,
 } from "../../internal/ui/resourcePages/resourcePageErrors.js";
+import {
+  resolveImagePreviewDisplayMode as resolvePreviewDisplayMode,
+  resolveImagePreviewNavigationDirection as resolvePreviewNavigationDirection,
+} from "../../internal/ui/resourcePages/imagePreviewOverlay.js";
 import { buildImageResourcePatchFromUploadResult } from "../../deps/services/shared/resourceImports.js";
 import { withResolvedCollectionFileMetadata } from "../../internal/resourceFileMetadata.js";
 import {
@@ -495,69 +499,6 @@ const consumeSuppressedPreviewClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   store.clearFullImagePreviewSuppressNextClick?.();
   return true;
-};
-
-const resolvePreviewNavigationDirection = (event) => {
-  if (event.key === "ArrowDown") {
-    return { direction: "next" };
-  }
-
-  if (event.key === "ArrowUp") {
-    return { direction: "previous" };
-  }
-
-  if (event.altKey || event.metaKey) {
-    return undefined;
-  }
-
-  if (event.ctrlKey) {
-    const key = String(event.key ?? "").toLowerCase();
-    if (key === "d") {
-      return { direction: "next", distance: 10, clamp: true };
-    }
-
-    if (key === "u") {
-      return { direction: "previous", distance: 10, clamp: true };
-    }
-
-    return undefined;
-  }
-
-  const key = String(event.key ?? "").toLowerCase();
-  if (key === "j") {
-    return { direction: "next" };
-  }
-
-  if (key === "k") {
-    return { direction: "previous" };
-  }
-
-  return undefined;
-};
-
-const resolvePreviewDisplayMode = (event) => {
-  if (event.altKey || event.ctrlKey || event.metaKey) {
-    return undefined;
-  }
-
-  if (event.key === "ArrowLeft") {
-    return "canvas";
-  }
-
-  if (event.key === "ArrowRight") {
-    return "fit";
-  }
-
-  const key = String(event.key ?? "").toLowerCase();
-  if (key === "h") {
-    return "canvas";
-  }
-
-  if (key === "l") {
-    return "fit";
-  }
-
-  return undefined;
 };
 
 export const handleFileExplorerDoubleClick = (deps, payload) => {

--- a/src/pages/images/images.store.js
+++ b/src/pages/images/images.store.js
@@ -5,9 +5,13 @@ import { createTagField } from "../../internal/ui/resourcePages/tags.js";
 import { matchesTagAwareSearch } from "../../internal/resourceTags.js";
 import {
   DEFAULT_PROJECT_RESOLUTION,
-  formatProjectResolutionAspectRatio,
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
+import {
+  IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  createImagePreviewOverlayViewData,
+  isImagePreviewDisplayMode,
+} from "../../internal/ui/resourcePages/imagePreviewOverlay.js";
 import {
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD,
   shouldStartCollapsedFileExplorer,
@@ -18,8 +22,6 @@ const AUTO_COLLAPSE_FILE_EXPLORER_ITEM_THRESHOLD =
   DEFAULT_FILE_EXPLORER_AUTO_COLLAPSE_THRESHOLD;
 const IMAGE_CARD_MAX_WIDTH = 400;
 const IMAGE_CARD_HEIGHT = 225;
-const FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT = "fit";
-const FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS = "canvas";
 export const IMAGE_TAG_SCOPE_KEY = "images";
 
 const resolveImageAspectRatio = (item) => {
@@ -31,63 +33,6 @@ const resolveImageAspectRatio = (item) => {
   }
 
   return `${Math.max(1, Math.round(width))} / ${Math.max(1, Math.round(height))}`;
-};
-
-const createPreviewFrameStyle = (projectResolution) => {
-  const aspectRatio = formatProjectResolutionAspectRatio(projectResolution);
-
-  return [
-    `width: min(88vw, calc((100vh - 120px) * (${aspectRatio})))`,
-    `aspect-ratio: ${aspectRatio}`,
-    "max-width: 88vw",
-    "max-height: calc(100vh - 120px)",
-  ].join("; ");
-};
-
-const resolvePositiveNumber = (value) => {
-  const numericValue = Number(value);
-  return Number.isFinite(numericValue) && numericValue > 0
-    ? numericValue
-    : undefined;
-};
-
-const createPreviewImageWrapperStyle = ({
-  image,
-  displayMode,
-  projectResolution,
-} = {}) => {
-  if (displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS) {
-    return "position: absolute; inset: 0;";
-  }
-
-  const imageWidth = resolvePositiveNumber(image?.width);
-  const imageHeight = resolvePositiveNumber(image?.height);
-  if (!imageWidth || !imageHeight) {
-    return "position: absolute; inset: 0;";
-  }
-
-  const widthPercent = (imageWidth / projectResolution.width) * 100;
-  const heightPercent = (imageHeight / projectResolution.height) * 100;
-
-  return [
-    "position: absolute",
-    "left: 50%",
-    "top: 50%",
-    `width: ${widthPercent}%`,
-    `height: ${heightPercent}%`,
-    "transform: translate(-50%, -50%)",
-  ].join("; ");
-};
-
-const createPreviewModeButtonViewData = ({ displayMode, mode } = {}) => {
-  const selected = displayMode === mode;
-
-  return {
-    backgroundColor: selected ? "ac" : "bg",
-    borderColor: selected ? "ac" : "bo",
-    iconColor: selected ? "white" : "mu-fg",
-    selected,
-  };
 };
 
 const buildDetailFields = (item, { copy } = {}) => {
@@ -316,34 +261,17 @@ const {
       : undefined;
     const viewData = { ...baseViewData };
 
-    viewData.fullImagePreviewVisible = state.fullImagePreviewVisible;
-    viewData.fullImagePreviewFileId = state.fullImagePreviewFileId;
-    viewData.fullImagePreviewFrameStyle =
-      createPreviewFrameStyle(projectResolution);
-    viewData.fullImagePreviewImageWrapperStyle = createPreviewImageWrapperStyle(
-      {
+    Object.assign(
+      viewData,
+      createImagePreviewOverlayViewData({
+        state,
         image: previewImage,
-        displayMode: state.fullImagePreviewDisplayMode,
         projectResolution,
-      },
+        previousItemId,
+        nextItemId,
+        copy,
+      }),
     );
-    viewData.fullImagePreviewDisplayMode = state.fullImagePreviewDisplayMode;
-    viewData.fullImagePreviewFitModeButton = createPreviewModeButtonViewData({
-      displayMode: state.fullImagePreviewDisplayMode,
-      mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT,
-    });
-    viewData.fullImagePreviewCanvasModeButton = createPreviewModeButtonViewData(
-      {
-        displayMode: state.fullImagePreviewDisplayMode,
-        mode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
-      },
-    );
-    viewData.fullImagePreviewPreviousVisible = Boolean(previousItemId);
-    viewData.fullImagePreviewNextVisible = Boolean(nextItemId);
-    viewData.fullImagePreviewCanvasModeLabel = copy.previewCanvasModeLabel;
-    viewData.fullImagePreviewFitModeLabel = copy.previewFitModeLabel;
-    viewData.fullImagePreviewPreviousLabel = copy.previewPreviousLabel;
-    viewData.fullImagePreviewNextLabel = copy.previewNextLabel;
     const deleteDialogItem = state.mobileDeleteDialogItemId
       ? state.data?.items?.[state.mobileDeleteDialogItemId]
       : undefined;
@@ -366,7 +294,7 @@ export const createInitialState = () => ({
   ...createMediaInitialState(),
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
-  fullImagePreviewDisplayMode: FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  fullImagePreviewDisplayMode: IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
   fullImagePreviewTouchStartPoint: undefined,
   fullImagePreviewSuppressNextClick: false,
   mobileDeleteDialogOpen: false,
@@ -438,7 +366,7 @@ export const showFullImagePreview = ({ state }, { itemId } = {}) => {
   }
 
   if (!state.fullImagePreviewVisible) {
-    state.fullImagePreviewDisplayMode = FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
+    state.fullImagePreviewDisplayMode = IMAGE_PREVIEW_DISPLAY_MODE_CANVAS;
   }
   state.fullImagePreviewVisible = true;
   state.fullImagePreviewFileId = item.fileId;
@@ -481,10 +409,7 @@ export const setFullImagePreviewDisplayMode = (
   { state },
   { displayMode } = {},
 ) => {
-  if (
-    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_FIT &&
-    displayMode !== FULL_IMAGE_PREVIEW_DISPLAY_MODE_CANVAS
-  ) {
+  if (!isImagePreviewDisplayMode(displayMode)) {
     return;
   }
 

--- a/tests/images/images.handlers.test.js
+++ b/tests/images/images.handlers.test.js
@@ -473,6 +473,21 @@ describe("images handlers", () => {
         subscribeProjectState: vi.fn(() => () => {}),
       },
       store: {
+        selectCreateTagContext: vi.fn(() => ({
+          mode: "item",
+          itemId: "image-1",
+          draftTagIds: [],
+        })),
+        selectTagsData: vi.fn(() => ({
+          tree: [{ id: "image-tag-1" }],
+          items: {
+            "image-tag-1": {
+              id: "image-tag-1",
+              type: "tag",
+              name: "Background",
+            },
+          },
+        })),
         getState: vi.fn(() => ({
           createTagContext: {
             mode: "item",
@@ -564,6 +579,7 @@ describe("images handlers", () => {
     const deps = {
       i18n: EN_I18N,
       store: {
+        selectDetailTagIds: vi.fn(() => ["image-tag-1"]),
         getState: vi.fn(() => ({
           detailTagIds: ["image-tag-1"],
         })),
@@ -599,6 +615,11 @@ describe("images handlers", () => {
     const deps = {
       i18n: EN_I18N,
       store: {
+        selectCreateTagContext: vi.fn(() => ({
+          mode: "item",
+          itemId: "image-1",
+          draftTagIds: ["image-tag-1"],
+        })),
         getState: vi.fn(() => ({
           createTagContext: {
             mode: "item",

--- a/tests/resourcePages/imagePreviewOverlay.test.js
+++ b/tests/resourcePages/imagePreviewOverlay.test.js
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+  IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+  createImagePreviewImageWrapperStyle,
+  createImagePreviewModeButtonViewData,
+  createImagePreviewOverlayViewData,
+  resolveImagePreviewDisplayMode,
+  resolveImagePreviewNavigationDirection,
+} from "../../src/internal/ui/resourcePages/imagePreviewOverlay.js";
+
+const createKeyEvent = (key, overrides = {}) => ({
+  key,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  ...overrides,
+});
+
+describe("imagePreviewOverlay", () => {
+  it("builds canvas-scale wrapper styles for images with dimensions", () => {
+    const style = createImagePreviewImageWrapperStyle({
+      image: {
+        width: 48,
+        height: 48,
+      },
+      displayMode: IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+      projectResolution: {
+        width: 1920,
+        height: 1080,
+      },
+    });
+
+    expect(style).toContain("width: 2.5%");
+    expect(style).toContain("height: 4.444444444444445%");
+  });
+
+  it("uses full-frame wrapper styles for fit mode and missing dimensions", () => {
+    expect(
+      createImagePreviewImageWrapperStyle({
+        image: {
+          width: 48,
+          height: 48,
+        },
+        displayMode: IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+        projectResolution: {
+          width: 1920,
+          height: 1080,
+        },
+      }),
+    ).toBe("position: absolute; inset: 0;");
+
+    expect(
+      createImagePreviewImageWrapperStyle({
+        image: {},
+        displayMode: IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+        projectResolution: {
+          width: 1920,
+          height: 1080,
+        },
+      }),
+    ).toBe("position: absolute; inset: 0;");
+  });
+
+  it("builds overlay view data with mode button and adjacent item state", () => {
+    const viewData = createImagePreviewOverlayViewData({
+      state: {
+        fullImagePreviewVisible: true,
+        fullImagePreviewFileId: "file-1",
+        fullImagePreviewDisplayMode: IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+      },
+      image: {
+        width: 48,
+        height: 48,
+      },
+      projectResolution: {
+        width: 1920,
+        height: 1080,
+      },
+      previousItemId: "image-0",
+      nextItemId: "image-2",
+      copy: {
+        previewCanvasModeLabel: "Canvas scale",
+        previewFitModeLabel: "Fit to frame",
+        previewPreviousLabel: "Previous",
+        previewNextLabel: "Next",
+      },
+    });
+
+    expect(viewData.fullImagePreviewVisible).toBe(true);
+    expect(viewData.fullImagePreviewFrameStyle).toContain(
+      "aspect-ratio: 1920 / 1080",
+    );
+    expect(viewData.fullImagePreviewCanvasModeButton.selected).toBe(true);
+    expect(viewData.fullImagePreviewFitModeButton.selected).toBe(false);
+    expect(viewData.fullImagePreviewPreviousVisible).toBe(true);
+    expect(viewData.fullImagePreviewNextVisible).toBe(true);
+    expect(viewData.fullImagePreviewCanvasModeLabel).toBe("Canvas scale");
+  });
+
+  it("resolves shared keyboard navigation shortcuts", () => {
+    expect(
+      resolveImagePreviewNavigationDirection(createKeyEvent("ArrowDown")),
+    ).toEqual({
+      direction: "next",
+    });
+    expect(
+      resolveImagePreviewNavigationDirection(createKeyEvent("ArrowUp")),
+    ).toEqual({
+      direction: "previous",
+    });
+    expect(
+      resolveImagePreviewNavigationDirection(
+        createKeyEvent("d", {
+          ctrlKey: true,
+        }),
+      ),
+    ).toEqual({
+      direction: "next",
+      distance: 10,
+      clamp: true,
+    });
+    expect(resolveImagePreviewNavigationDirection(createKeyEvent("j"))).toEqual(
+      {
+        direction: "next",
+      },
+    );
+    expect(
+      resolveImagePreviewNavigationDirection(
+        createKeyEvent("j", {
+          metaKey: true,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("resolves shared display mode shortcuts", () => {
+    expect(resolveImagePreviewDisplayMode(createKeyEvent("ArrowLeft"))).toBe(
+      IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+    );
+    expect(resolveImagePreviewDisplayMode(createKeyEvent("ArrowRight"))).toBe(
+      IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+    );
+    expect(resolveImagePreviewDisplayMode(createKeyEvent("h"))).toBe(
+      IMAGE_PREVIEW_DISPLAY_MODE_CANVAS,
+    );
+    expect(resolveImagePreviewDisplayMode(createKeyEvent("l"))).toBe(
+      IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+    );
+    expect(
+      resolveImagePreviewDisplayMode(
+        createKeyEvent("l", {
+          ctrlKey: true,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("marks the selected mode button", () => {
+    expect(
+      createImagePreviewModeButtonViewData({
+        displayMode: IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+        mode: IMAGE_PREVIEW_DISPLAY_MODE_FIT,
+      }),
+    ).toMatchObject({
+      backgroundColor: "ac",
+      borderColor: "ac",
+      iconColor: "white",
+      selected: true,
+    });
+  });
+});

--- a/vt/specs/project/character-sprites.yaml
+++ b/vt/specs/project/character-sprites.yaml
@@ -168,6 +168,26 @@ steps:
   - action: wait
     ms: 400
   - action: screenshot
+  - action: keypress
+    key: l
+  - action: wait
+    ms: 200
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return deepQuery(document, '#previewFitModeButton')?.getAttribute('aria-pressed'); })()"
+    value: "true"
+  - action: keypress
+    key: h
+  - action: wait
+    ms: 200
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return deepQuery(document, '#previewCanvasModeButton')?.getAttribute('aria-pressed'); })()"
+    value: "true"
   - action: select
     selector: "#previewOverlay"
     steps:

--- a/vt/specs/project/images.yaml
+++ b/vt/specs/project/images.yaml
@@ -129,6 +129,12 @@ steps:
     key: ArrowRight
   - action: wait
     ms: 300
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return deepQuery(document, '#previewFitModeButton')?.getAttribute('aria-pressed'); })()"
+    value: "true"
   - action: screenshot
   - action: keypress
     key: h
@@ -138,6 +144,12 @@ steps:
     key: ArrowLeft
   - action: wait
     ms: 300
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return deepQuery(document, '#previewCanvasModeButton')?.getAttribute('aria-pressed'); })()"
+    value: "true"
   - action: screenshot
   - action: select
     selector: "#previewOverlay"


### PR DESCRIPTION
## Summary
- extract shared image preview overlay view-data, styles, display modes, and keyboard shortcut parsing into internal resource-page UI helper
- wire images and character sprites pages to the shared helper
- strengthen unit and VT coverage for overlay display-mode behavior

## Validation
- bunx vitest run tests/resourcePages/imagePreviewOverlay.test.js tests/images/images.store.test.js tests/images/images.handlers.test.js tests/characterSprites/characterSprites.store.test.js tests/characterSprites/characterSprites.handlers.test.js
- bun run build:web
- env RTGL_VT_IMAGE=han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.0.12 bash ./scripts/run-vt-docker.sh vt screenshot --item project/images --item project/character-sprites
- env RTGL_VT_IMAGE=han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.0.12 bash ./scripts/run-vt-docker.sh vt report --item project/images --item project/character-sprites
  - 20 selected screenshots, 0 mismatches
- bun run lint
- bun prettier --check tests/resourcePages/imagePreviewOverlay.test.js tests/images/images.handlers.test.js vt/specs/project/images.yaml vt/specs/project/character-sprites.yaml