### PR TITLE
Adjust mobile animation editor and whiteboard touch interactions

### DIFF
--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -177,6 +177,13 @@ const getPrimaryTouchPoint = (event, element) => {
   return getTouchPointWithinElement(event?.touches?.[0], element);
 };
 
+const getActiveTouchPoint = (event, element) => {
+  return getTouchPointWithinElement(
+    event?.touches?.[0] ?? event?.changedTouches?.[0],
+    element,
+  );
+};
+
 const getTouchClientPoint = (event) => {
   const touch = event?.touches?.[0];
   if (!touch) {
@@ -740,6 +747,60 @@ const dispatchZoomChanged = ({ store, dispatchEvent } = {}) => {
   );
 };
 
+const startMinimapViewportDrag = (deps, { mouseX, mouseY } = {}) => {
+  const { store } = deps;
+  const minimapData = store.selectMinimapData({
+    items: deps.props?.items ?? [],
+    heightScale: deps.props?.minimapHeightScale,
+  });
+
+  if (!minimapData?.viewport?.visible) {
+    return false;
+  }
+
+  store.startMinimapViewportDragging({
+    mouseX,
+    mouseY,
+    minimapData,
+  });
+  renderWithCursorSync(deps);
+  return true;
+};
+
+const updateMinimapViewportDrag = (deps, { mouseX, mouseY } = {}) => {
+  const { store, refs } = deps;
+
+  if (!store.selectIsDraggingMinimapViewport()) {
+    return false;
+  }
+
+  if (!refs.minimapContainer) {
+    store.stopMinimapViewportDragging();
+    renderWithCursorSync(deps);
+    return false;
+  }
+
+  store.updatePanFromMinimapViewportDragging({
+    mouseX,
+    mouseY,
+  });
+  syncPanPresentation(deps);
+  return true;
+};
+
+const finishMinimapViewportDrag = (deps) => {
+  const { store, dispatchEvent } = deps;
+
+  if (!store.selectIsDraggingMinimapViewport()) {
+    return false;
+  }
+
+  store.stopMinimapViewportDragging();
+  dispatchPanChanged({ store, dispatchEvent });
+  renderWithCursorSync(deps);
+  return true;
+};
+
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
   const active = streams.map((stream) => stream.subscribe());
@@ -1190,7 +1251,7 @@ export const handleZoomOutClick = (deps) => {
 };
 
 export const handleMinimapViewportMouseDown = (deps, payload) => {
-  const { store, refs } = deps;
+  const { refs } = deps;
   const { _event: event } = payload;
 
   if (!isPrimaryMouseButton(event)) {
@@ -1204,14 +1265,6 @@ export const handleMinimapViewportMouseDown = (deps, payload) => {
     return;
   }
 
-  const minimapData = store.selectMinimapData({
-    items: deps.props?.items || [],
-    heightScale: deps.props?.minimapHeightScale,
-  });
-  if (!minimapData?.viewport?.visible) {
-    return;
-  }
-
   event.preventDefault();
   event.stopPropagation();
 
@@ -1220,12 +1273,75 @@ export const handleMinimapViewportMouseDown = (deps, payload) => {
     minimapContainer,
   );
 
-  store.startMinimapViewportDragging({
-    mouseX,
-    mouseY,
-    minimapData,
+  startMinimapViewportDrag(deps, { mouseX, mouseY });
+};
+
+export const handleMinimapViewportTouchStart = (deps, payload) => {
+  const { refs, store } = deps;
+  const { _event: event } = payload;
+
+  preventTouchDefault(event);
+  event?.stopPropagation?.();
+  cancelPanAnimation(deps);
+  syncContainerSize(deps);
+  clearTouchLongPressTimeout(deps);
+  store.clearLastTouchTap();
+
+  const point = getActiveTouchPoint(event, refs.minimapContainer);
+  if (!point) {
+    return;
+  }
+
+  startMinimapViewportDrag(deps, {
+    mouseX: point.x,
+    mouseY: point.y,
   });
-  renderWithCursorSync(deps);
+};
+
+export const handleMinimapViewportTouchMove = (deps, payload) => {
+  const { refs } = deps;
+  const { _event: event } = payload;
+
+  preventTouchDefault(event);
+  event?.stopPropagation?.();
+
+  const point = getActiveTouchPoint(event, refs.minimapContainer);
+  if (!point) {
+    return;
+  }
+
+  updateMinimapViewportDrag(deps, {
+    mouseX: point.x,
+    mouseY: point.y,
+  });
+};
+
+export const handleMinimapViewportTouchEnd = (deps, payload) => {
+  const { refs } = deps;
+  const { _event: event } = payload;
+
+  preventTouchDefault(event);
+  event?.stopPropagation?.();
+
+  const point = getActiveTouchPoint(event, refs.minimapContainer);
+  if (point) {
+    updateMinimapViewportDrag(deps, {
+      mouseX: point.x,
+      mouseY: point.y,
+    });
+  }
+
+  if ((event?.touches?.length ?? 0) === 0) {
+    finishMinimapViewportDrag(deps);
+  }
+};
+
+export const handleMinimapViewportTouchCancel = (deps, payload) => {
+  const { _event: event } = payload;
+
+  preventTouchDefault(event);
+  event?.stopPropagation?.();
+  finishMinimapViewportDrag(deps);
 };
 
 export const handleItemMouseDown = (deps, payload) => {

--- a/src/components/whiteboard/whiteboard.view.yaml
+++ b/src/components/whiteboard/whiteboard.view.yaml
@@ -48,6 +48,14 @@ refs:
     eventListeners:
       mousedown:
         handler: handleMinimapViewportMouseDown
+      touchstart:
+        handler: handleMinimapViewportTouchStart
+      touchmove:
+        handler: handleMinimapViewportTouchMove
+      touchend:
+        handler: handleMinimapViewportTouchEnd
+      touchcancel:
+        handler: handleMinimapViewportTouchCancel
   panBtn:
     eventListeners:
       click:

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -569,6 +569,8 @@ animationEditorPage:
   keyframeValueTooltip: "The final value of the property at the end of the animation"
   kindLabel: "Kind"
   linearEasingLabel: "Linear"
+  maskRemoveConfirmMessage: "Remove this transition mask? This cannot be undone."
+  maskRemoveConfirmTitle: "Remove Mask"
   maskTitle: "Mask"
   maxCombineLabel: "Max"
   minCombineLabel: "Min"

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -553,6 +553,7 @@ animationEditorPage:
   editKeyframeMenuItem: "Edit keyframe"
   editKeyframeTitle: "Edit Keyframe"
   editMaskTitle: "Edit Mask"
+  editPreviewButton: "Edit Preview"
   failedSaveAnimationPreview: "Failed to save animation preview."
   failedUpdatePreviewImage: "Failed to update preview image."
   greyscaleChannel: "Greyscale"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -569,6 +569,8 @@ animationEditorPage:
   keyframeValueTooltip: "アニメーション終了時のプロパティの最終値です。"
   kindLabel: "種類"
   linearEasingLabel: "リニア"
+  maskRemoveConfirmMessage: "このトランジションマスクを削除しますか？この操作は元に戻せません。"
+  maskRemoveConfirmTitle: "マスクを削除"
   maskTitle: "マスク"
   maxCombineLabel: "最大"
   minCombineLabel: "最小"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -553,6 +553,7 @@ animationEditorPage:
   editKeyframeMenuItem: "キーフレームを編集"
   editKeyframeTitle: "キーフレームを編集"
   editMaskTitle: "マスクを編集"
+  editPreviewButton: "プレビューを編集"
   failedSaveAnimationPreview: "アニメーションプレビューを保存できませんでした。"
   failedUpdatePreviewImage: "プレビュー画像を更新できませんでした。"
   greyscaleChannel: "グレースケール"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -553,6 +553,7 @@ animationEditorPage:
   editKeyframeMenuItem: "编辑关键帧"
   editKeyframeTitle: "编辑关键帧"
   editMaskTitle: "编辑遮罩"
+  editPreviewButton: "编辑预览"
   failedSaveAnimationPreview: "无法保存动画预览。"
   failedUpdatePreviewImage: "无法更新预览图像。"
   greyscaleChannel: "灰度"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -569,6 +569,8 @@ animationEditorPage:
   keyframeValueTooltip: "动画结束时该属性的最终值。"
   kindLabel: "类型"
   linearEasingLabel: "线性"
+  maskRemoveConfirmMessage: "要移除这个转场遮罩吗？此操作无法撤消。"
+  maskRemoveConfirmTitle: "移除遮罩"
   maskTitle: "遮罩"
   maxCombineLabel: "最大"
   minCombineLabel: "最小"

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -1364,6 +1364,13 @@ export const handleDisableMaskClick = (deps) => {
   commitMaskChange(deps);
 };
 
+export const handleMobileDisableMaskClick = (deps) => {
+  const { store } = deps;
+  store.disableTransitionMask({});
+  store.closePopover();
+  commitMaskChange(deps);
+};
+
 export const handleMaskKindChange = (deps, payload) => {
   const { store } = deps;
   store.setTransitionMaskKind({

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -676,6 +676,11 @@ const syncEditorState = async ({ deps, repositoryState } = {}) => {
   return true;
 };
 
+export const handleBeforeMount = (deps) => {
+  const { store, uiConfig } = deps;
+  store.setUiConfig({ uiConfig });
+};
+
 export const handleAfterMount = async (deps) => {
   const { projectService } = deps;
   await projectService.ensureRepository();
@@ -763,6 +768,52 @@ export const handleSavePreviewClick = async (deps) => {
 export const handleClosePopover = (deps) => {
   const { render, store } = deps;
   store.closePopover();
+  render();
+};
+
+export const handleMobileMaskClick = (deps, payload = {}) => {
+  const { render, store } = deps;
+
+  if (store.selectDialogType() !== "transition") {
+    return;
+  }
+
+  const event = payload._event;
+  const popoverPosition = {
+    x: event?.clientX ?? 0,
+    y: event?.clientY ?? 0,
+  };
+
+  if (store.selectHasEffectiveTransitionMask()) {
+    store.setPopover({
+      mode: "editMask",
+      x: popoverPosition.x,
+      y: popoverPosition.y,
+      payload: {},
+    });
+    render();
+    return;
+  }
+
+  store.startPendingTransitionMask({});
+  store.setPopover({
+    mode: "addMask",
+    x: popoverPosition.x,
+    y: popoverPosition.y,
+    payload: {},
+  });
+  render();
+};
+
+export const handleOpenPreviewDialog = (deps) => {
+  const { render, store } = deps;
+  store.openPreviewDialog({});
+  render();
+};
+
+export const handleClosePreviewDialog = (deps) => {
+  const { render, store } = deps;
+  store.closePreviewDialog({});
   render();
 };
 

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -1365,8 +1365,21 @@ export const handleDisableMaskClick = (deps) => {
 };
 
 export const handleMobileDisableMaskClick = (deps) => {
+  const { render, store } = deps;
+  store.openMaskRemoveConfirmDialog({});
+  render();
+};
+
+export const handleMaskRemoveConfirmDialogClose = (deps) => {
+  const { render, store } = deps;
+  store.closeMaskRemoveConfirmDialog({});
+  render();
+};
+
+export const handleMaskRemoveConfirmClick = (deps) => {
   const { store } = deps;
   store.disableTransitionMask({});
+  store.closeMaskRemoveConfirmDialog({});
   store.closePopover();
   commitMaskChange(deps);
 };

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -752,6 +752,9 @@ export const handleSavePreviewClick = async (deps) => {
     store.setItems({
       data: projectService.getRepositoryState()?.animations,
     });
+    if (store.selectIsTouchMode()) {
+      store.closePreviewDialog({});
+    }
     render();
     appService.showToast({
       message: copy.animationPreviewSaved ?? "Animation preview saved.",

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -1264,6 +1264,10 @@ export const setUiConfig = ({ state }, { uiConfig } = {}) => {
   state.isTouchMode = isTouchUiConfig(uiConfig);
 };
 
+export const selectIsTouchMode = ({ state }) => {
+  return state.isTouchMode;
+};
+
 export const setAnimationName = ({ state }, { name } = {}) => {
   state.dialogDefaultValues.name = name ?? "";
 };

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -1227,6 +1227,7 @@ export const createInitialState = () => ({
   previewImages: createInitialPreviewImages(),
   isTouchMode: false,
   isPreviewDialogOpen: false,
+  maskRemoveConfirmDialogOpen: false,
   popover: {
     mode: "none",
     x: undefined,
@@ -2412,6 +2413,14 @@ export const closePreviewDialog = ({ state }, _payload = {}) => {
   state.isPreviewDialogOpen = false;
 };
 
+export const openMaskRemoveConfirmDialog = ({ state }, _payload = {}) => {
+  state.maskRemoveConfirmDialogOpen = true;
+};
+
+export const closeMaskRemoveConfirmDialog = ({ state }, _payload = {}) => {
+  state.maskRemoveConfirmDialogOpen = false;
+};
+
 const buildTransitionMaskPanelDataForMask = (
   state,
   transitionMask,
@@ -2809,6 +2818,7 @@ export const selectViewData = ({ state, i18n }) => {
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewImageId: state.fullImagePreviewImageId,
     isPreviewDialogOpen: state.isPreviewDialogOpen,
+    maskRemoveConfirmDialogOpen: state.maskRemoveConfirmDialogOpen,
     showRightPanel: !state.isTouchMode,
     showMobileTweenActions: state.isTouchMode,
     showMobileMaskButton: state.isTouchMode && dialogType === "transition",
@@ -2825,6 +2835,10 @@ export const selectViewData = ({ state, i18n }) => {
     inTimelineLabel: copy.inTimelineLabel ?? "In",
     invertLabel: copy.invertLabel ?? "Invert",
     kindLabel: copy.kindLabel ?? "Kind",
+    maskRemoveConfirmMessage:
+      copy.maskRemoveConfirmMessage ??
+      "Remove this transition mask? This cannot be undone.",
+    maskRemoveConfirmTitle: copy.maskRemoveConfirmTitle ?? "Remove Mask",
     maskTitle: copy.maskTitle ?? "Mask",
     noMaskAvailable: copy.noMaskAvailable ?? "No mask available.",
     noPreviewLabel: copy.noPreviewLabel ?? "No preview",

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -4,6 +4,7 @@ import {
   requireProjectResolution,
 } from "../../internal/projectResolution.js";
 import { toFlatItems } from "../../internal/project/tree.js";
+import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 import {
   compileTransitionMaskForRuntime,
   createDefaultTransitionMask,
@@ -1224,6 +1225,8 @@ export const createInitialState = () => ({
   previewPlaybackDurationMs: undefined,
   previewPlaybackRequestId: undefined,
   previewImages: createInitialPreviewImages(),
+  isTouchMode: false,
+  isPreviewDialogOpen: false,
   popover: {
     mode: "none",
     x: undefined,
@@ -1254,6 +1257,10 @@ export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
     projectResolution,
     "Project resolution",
   );
+};
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode = isTouchUiConfig(uiConfig);
 };
 
 export const setAnimationName = ({ state }, { name } = {}) => {
@@ -1871,6 +1878,10 @@ export const selectTransitionMask = ({ state }) => {
   return getTransitionMask(state);
 };
 
+export const selectHasEffectiveTransitionMask = ({ state }) => {
+  return Boolean(getEffectiveTransitionMask(state));
+};
+
 export const selectMaskEditorTransitionMask = ({ state }) => {
   return getMaskEditorTransitionMask(state);
 };
@@ -2393,6 +2404,14 @@ export const selectPreviewPlaybackRequestId = ({ state }) => {
   return state.previewPlaybackRequestId;
 };
 
+export const openPreviewDialog = ({ state }, _payload = {}) => {
+  state.isPreviewDialogOpen = true;
+};
+
+export const closePreviewDialog = ({ state }, _payload = {}) => {
+  state.isPreviewDialogOpen = false;
+};
+
 const buildTransitionMaskPanelDataForMask = (
   state,
   transitionMask,
@@ -2789,6 +2808,10 @@ export const selectViewData = ({ state, i18n }) => {
     imageFolderItems,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewImageId: state.fullImagePreviewImageId,
+    isPreviewDialogOpen: state.isPreviewDialogOpen,
+    showRightPanel: !state.isTouchMode,
+    showMobileTweenActions: state.isTouchMode,
+    showMobileMaskButton: state.isTouchMode && dialogType === "transition",
     addButton: copy.addButton ?? "Add",
     addMaskButton: copy.addMaskButton ?? "Add Mask",
     addMaskTitle: copy.addMaskTitle ?? "Add Mask",
@@ -2797,6 +2820,7 @@ export const selectViewData = ({ state, i18n }) => {
     doneButton: copy.doneButton ?? "Done",
     editButton: copy.editMenuItem ?? "Edit",
     editMaskTitle: copy.editMaskTitle ?? "Edit Mask",
+    editPreviewButton: copy.editPreviewButton ?? "Edit Preview",
     imageLabel: copy.imageLabel ?? "Image",
     inTimelineLabel: copy.inTimelineLabel ?? "In",
     invertLabel: copy.invertLabel ?? "Invert",

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -129,6 +129,10 @@ refs:
     eventListeners:
       click:
         handler: handleDisableMaskClick
+  mobileDisableMaskButton:
+    eventListeners:
+      click:
+        handler: handleMobileDisableMaskClick
   editMaskButton:
     eventListeners:
       click:
@@ -460,6 +464,8 @@ template:
                       - rtgl-button#addMaskButton s=sm v=pr: ${addMaskButton}
               - $if popover.mode == 'editMask':
                   - rtgl-view d=h g=sm w=f ah=e pt=sm:
+                      - $if showMobileMaskButton:
+                          - rtgl-button#mobileDisableMaskButton s=sm v=se: ${removeButton}
                       - rtgl-button#editMaskDoneButton s=sm v=pr: ${saveButton}
   - rtgl-dialog#previewDialog ?open=${isPreviewDialogOpen} s=md:
       - $if isPreviewDialogOpen:

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -11,6 +11,22 @@ refs:
     eventListeners:
       click:
         handler: handleSavePreviewClick
+  mobileMaskButton:
+    eventListeners:
+      click:
+        handler: handleMobileMaskClick
+  mobilePreviewDialogButton:
+    eventListeners:
+      click:
+        handler: handleOpenPreviewDialog
+  previewDialog:
+    eventListeners:
+      close:
+        handler: handleClosePreviewDialog
+  previewDialogSaveButton:
+    eventListeners:
+      click:
+        handler: handleSavePreviewClick
   addPropertiesButton:
     eventListeners:
       click:
@@ -134,6 +150,10 @@ refs:
       click:
         handler: handleClosePopover
   previewImageButton*:
+    eventListeners:
+      click:
+        handler: handlePreviewImageClick
+  previewDialogImageButton*:
     eventListeners:
       click:
         handler: handlePreviewImageClick
@@ -274,6 +294,11 @@ template:
                       - rtgl-view pos=abs cor=full:
                           - 'div#canvas style="width: 100%; height: 100%; display: flex;"': null
               - rtgl-view d=v w=f g=md:
+                  - $if showMobileTweenActions:
+                      - rtgl-view d=h w=f g=sm wrap:
+                          - $if showMobileMaskButton:
+                              - rtgl-button#mobileMaskButton v=se s=sm pre=image: ${maskTitle}
+                          - rtgl-button#mobilePreviewDialogButton v=se s=sm pre=image: ${editPreviewButton}
                   - rtgl-view d=h av=c w=f:
                       - rtgl-text: ${tweenPropertiesTitle}
                       - rtgl-view w=1fg: null
@@ -292,85 +317,86 @@ template:
                           - rtgl-view d=v w=f g=xs:
                               - rtgl-text s=sm c=mu-fg: ${inTimelineLabel}
                               - rvn-keyframe-timeline#nextTimeline editable=true side=next ?showRuler=false ?showTotalDuration=false timelineDuration=${transitionTimelineDuration} ?indicatorVisible=${previewPlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} :properties=${nextProperties} :defaultValues=${transitionTimelineDefaultValues}: null
-      - 'rtgl-view w=1fg h=f bgc=bg bwl=xs bc=bo d=v style="min-width: 0; min-height: 0;"':
-          - 'rtgl-view w=f h=1fg d=v style="min-height: 0;"':
-              - rtgl-view h=48 w=f d=h av=c ph=md bwb=xs bc=bo g=sm:
-                  - rtgl-text w=1fg: ${maskTitle}
-                  - $if dialogType == 'transition' && !transitionMaskPanel.enabled && popover.mode != 'addMask':
-                      - rtgl-button#openAddMaskButton pre=plus s=sm: ${addMaskButton}
-                  - $if transitionMaskPanel.enabled && !transitionMaskPanel.unsupported:
-                      - rtgl-button#editMaskButton s=sm: ${editButton}
-                  - $if transitionMaskPanel.enabled:
-                      - rtgl-button#disableMaskButton s=sm v=se: ${removeButton}
-              - 'rtgl-view w=f h=1fg p=md sv style="min-height: 0;"':
-                  - $if !transitionMaskPanel.enabled:
-                      - rtgl-view w=f h=f av=c ah=c:
-                          - rtgl-view w=300 h=160 bw=xs bc=bo br=md ah=c av=c:
-                              - rtgl-text s=sm c=mu-fg ta=c: ${noMaskAvailable}
-                    $else:
-                      - $if transitionMaskPanel.unsupported:
-                          - rtgl-view d=v w=f g=sm p=md bgc=mu bc=bo bw=xs br=md:
-                              - rtgl-text s=sm: ${transitionMaskPanel.unsupportedMessage}
-                              - rtgl-text s=xs c=mu-fg: ${transitionMaskPanel.unsupportedDescription}
+      - $if showRightPanel:
+          - 'rtgl-view w=1fg h=f bgc=bg bwl=xs bc=bo d=v style="min-width: 0; min-height: 0;"':
+              - 'rtgl-view w=f h=1fg d=v style="min-height: 0;"':
+                  - rtgl-view h=48 w=f d=h av=c ph=md bwb=xs bc=bo g=sm:
+                      - rtgl-text w=1fg: ${maskTitle}
+                      - $if dialogType == 'transition' && !transitionMaskPanel.enabled && popover.mode != 'addMask':
+                          - rtgl-button#openAddMaskButton pre=plus s=sm: ${addMaskButton}
+                      - $if transitionMaskPanel.enabled && !transitionMaskPanel.unsupported:
+                          - rtgl-button#editMaskButton s=sm: ${editButton}
+                      - $if transitionMaskPanel.enabled:
+                          - rtgl-button#disableMaskButton s=sm v=se: ${removeButton}
+                  - 'rtgl-view w=f h=1fg p=md sv style="min-height: 0;"':
+                      - $if !transitionMaskPanel.enabled:
+                          - rtgl-view w=f h=f av=c ah=c:
+                              - rtgl-view w=300 h=160 bw=xs bc=bo br=md ah=c av=c:
+                                  - rtgl-text s=sm c=mu-fg ta=c: ${noMaskAvailable}
                         $else:
-                          - rtgl-view d=v w=f g=lg:
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${kindLabel}
-                                  - rtgl-text s=sm: ${transitionMaskPanel.kindLabel}
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${channelLabel}
-                                  - rtgl-text s=sm: ${transitionMaskPanel.channelLabel}
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${invertLabel}
-                                  - rtgl-text s=sm: ${transitionMaskPanel.invertLabel}
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${softnessLabel}
-                                  - rtgl-text s=sm: ${transitionMaskPanel.softness}
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${imageLabel}
-                                  - $if transitionMaskPanel.imageItems.length > 0:
-                                      - rtgl-view d=h wrap g=md w=f:
-                                          - $for image, i in transitionMaskPanel.imageItems:
-                                              - 'rtgl-view bw=xs bc=bo br=md w=160 style="max-width: 100%; box-sizing: border-box;"':
-                                                  - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
-                                                      - $if image.previewFileId:
-                                                          - 'rtgl-view w=f br=md style="aspect-ratio: ${image.previewAspectRatio}; overflow: hidden;"':
-                                                              - rvn-file-image w=f h=f fileId=${image.previewFileId}: null
-                                                        $else:
+                          - $if transitionMaskPanel.unsupported:
+                              - rtgl-view d=v w=f g=sm p=md bgc=mu bc=bo bw=xs br=md:
+                                  - rtgl-text s=sm: ${transitionMaskPanel.unsupportedMessage}
+                                  - rtgl-text s=xs c=mu-fg: ${transitionMaskPanel.unsupportedDescription}
+                            $else:
+                              - rtgl-view d=v w=f g=lg:
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${kindLabel}
+                                      - rtgl-text s=sm: ${transitionMaskPanel.kindLabel}
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${channelLabel}
+                                      - rtgl-text s=sm: ${transitionMaskPanel.channelLabel}
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${invertLabel}
+                                      - rtgl-text s=sm: ${transitionMaskPanel.invertLabel}
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${softnessLabel}
+                                      - rtgl-text s=sm: ${transitionMaskPanel.softness}
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${imageLabel}
+                                      - $if transitionMaskPanel.imageItems.length > 0:
+                                          - rtgl-view d=h wrap g=md w=f:
+                                              - $for image, i in transitionMaskPanel.imageItems:
+                                                  - 'rtgl-view bw=xs bc=bo br=md w=160 style="max-width: 100%; box-sizing: border-box;"':
+                                                      - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
+                                                          - $if image.previewFileId:
+                                                              - 'rtgl-view w=f br=md style="aspect-ratio: ${image.previewAspectRatio}; overflow: hidden;"':
+                                                                  - rvn-file-image w=f h=f fileId=${image.previewFileId}: null
+                                                            $else:
                                                               - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
-                                                              - rtgl-text s=xs c=mu-fg: ${noPreviewLabel}
-                                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${image.name}
+                                                                  - rtgl-text s=xs c=mu-fg: ${noPreviewLabel}
+                                                          - rtgl-text s=xs c=mu-fg ellipsis w=f: ${image.name}
+                                        $else:
+                                          - rtgl-text s=sm c=mu-fg: ${transitionMaskPanel.imageLabel}
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${progressDurationLabel}
+                                      - rtgl-text s=sm: ${transitionMaskPanel.progressDurationLabel}
+                                  - rtgl-view d=v g=xs w=f:
+                                      - rtgl-text s=sm c=mu-fg: ${progressEasingLabel}
+                                      - rtgl-text s=sm: ${transitionMaskPanel.progressEasingLabel}
+              - rtgl-view w=f h=1 bgc=bo: null
+              - 'rtgl-view w=f h=1fg d=v style="min-height: 0;"':
+                  - rtgl-view h=48 w=f d=h av=c ph=md bwb=xs bc=bo g=sm:
+                      - rtgl-text w=1fg: ${previewTitle}
+                      - rtgl-button#savePreviewButton s=sm: ${saveButton}
+                  - 'rtgl-view w=f h=1fg p=md sv style="min-height: 0;"':
+                      - rtgl-view d=v w=f g=md:
+                          - $for item, i in previewPanel.items:
+                              - rtgl-view d=v w=f g=xs:
+                                  - rtgl-text s=sm c=mu-fg: ${item.label}
+                                  - $if item.image:
+                                      - 'rtgl-view#previewImageButton${i} data-target=${item.target} cur=pointer bw=xs bc=${item.image.itemBorderColor} h-bc=${item.image.itemHoverBorderColor} br=md w=160 style="max-width: 100%; box-sizing: border-box;"':
+                                          - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
+                                              - $if item.image.previewFileId:
+                                                  - 'rtgl-view w=f br=md style="aspect-ratio: ${item.image.previewAspectRatio}; overflow: hidden;"':
+                                                      - rvn-file-image w=f h=f fileId=${item.image.previewFileId}: null
+                                                $else:
+                                                  - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
+                                                      - rtgl-text s=xs c=mu-fg: ${noPreviewLabel}
+                                              - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.image.name}
                                     $else:
-                                      - rtgl-text s=sm c=mu-fg: ${transitionMaskPanel.imageLabel}
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${progressDurationLabel}
-                                  - rtgl-text s=sm: ${transitionMaskPanel.progressDurationLabel}
-                              - rtgl-view d=v g=xs w=f:
-                                  - rtgl-text s=sm c=mu-fg: ${progressEasingLabel}
-                                  - rtgl-text s=sm: ${transitionMaskPanel.progressEasingLabel}
-          - rtgl-view w=f h=1 bgc=bo: null
-          - 'rtgl-view w=f h=1fg d=v style="min-height: 0;"':
-              - rtgl-view h=48 w=f d=h av=c ph=md bwb=xs bc=bo g=sm:
-                  - rtgl-text w=1fg: ${previewTitle}
-                  - rtgl-button#savePreviewButton s=sm: ${saveButton}
-              - 'rtgl-view w=f h=1fg p=md sv style="min-height: 0;"':
-                  - rtgl-view d=v w=f g=md:
-                      - $for item, i in previewPanel.items:
-                          - rtgl-view d=v w=f g=xs:
-                              - rtgl-text s=sm c=mu-fg: ${item.label}
-                              - $if item.image:
-                                  - 'rtgl-view#previewImageButton${i} data-target=${item.target} cur=pointer bw=xs bc=${item.image.itemBorderColor} h-bc=${item.image.itemHoverBorderColor} br=md w=160 style="max-width: 100%; box-sizing: border-box;"':
-                                      - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
-                                          - $if item.image.previewFileId:
-                                              - 'rtgl-view w=f br=md style="aspect-ratio: ${item.image.previewAspectRatio}; overflow: hidden;"':
-                                                  - rvn-file-image w=f h=f fileId=${item.image.previewFileId}: null
-                                            $else:
-                                              - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
-                                                  - rtgl-text s=xs c=mu-fg: ${noPreviewLabel}
-                                          - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.image.name}
-                                $else:
-                                  - 'rtgl-view#previewImageButton${i} data-target=${item.target} w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
-                                      - rtgl-text c=mu-fg s=sm: ${selectImageLabel}
+                                      - 'rtgl-view#previewImageButton${i} data-target=${item.target} w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
+                                          - rtgl-text c=mu-fg s=sm: ${selectImageLabel}
   - rtgl-popover#addPropertyPopover ?open=${popover.popoverIsOpen} x=${popover.x} y=${popover.y}:
       - $if popover.mode == 'addProperty':
           - rtgl-view slot=content:
@@ -434,7 +460,31 @@ template:
                       - rtgl-button#addMaskButton s=sm v=pr: ${addMaskButton}
               - $if popover.mode == 'editMask':
                   - rtgl-view d=h g=sm w=f ah=e pt=sm:
-                      - rtgl-button#editMaskDoneButton s=sm v=pr: ${doneButton}
+                      - rtgl-button#editMaskDoneButton s=sm v=pr: ${saveButton}
+  - rtgl-dialog#previewDialog ?open=${isPreviewDialogOpen} s=md:
+      - $if isPreviewDialogOpen:
+          - 'rtgl-view slot=content d=v w=f g=md style="max-width: calc(100vw - 32px); max-height: calc(100vh - 96px);"':
+              - rtgl-text: ${previewTitle}
+              - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
+                  - rtgl-view d=v w=f g=md:
+                      - $for item, i in previewPanel.items:
+                          - rtgl-view d=v w=f g=xs:
+                              - rtgl-text s=sm c=mu-fg: ${item.label}
+                              - $if item.image:
+                                  - 'rtgl-view#previewDialogImageButton${i} data-target=${item.target} cur=pointer bw=xs bc=${item.image.itemBorderColor} h-bc=${item.image.itemHoverBorderColor} br=md w=160 style="max-width: 100%; box-sizing: border-box;"':
+                                      - 'rtgl-view p=md g=md br=md w=f style="max-width: 100%; box-sizing: border-box;"':
+                                          - $if item.image.previewFileId:
+                                              - 'rtgl-view w=f br=md style="aspect-ratio: ${item.image.previewAspectRatio}; overflow: hidden;"':
+                                                  - rvn-file-image w=f h=f fileId=${item.image.previewFileId}: null
+                                            $else:
+                                              - rtgl-view w=f h=90 br=md bw=xs bc=bo av=c ah=c:
+                                                  - rtgl-text s=xs c=mu-fg: ${noPreviewLabel}
+                                          - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.image.name}
+                                $else:
+                                  - 'rtgl-view#previewDialogImageButton${i} data-target=${item.target} w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
+                                      - rtgl-text c=mu-fg s=sm: ${selectImageLabel}
+              - rtgl-view d=h g=sm w=f ah=e pt=sm:
+                  - rtgl-button#previewDialogSaveButton s=sm: ${saveButton}
   - rtgl-dropdown-menu#keyframeDropdownMenu :items=${keyframeDropdownItems} ?open=${popover.dropdownMenuIsOpen} x=${popover.x} y=${popover.y}: null
   - rtgl-dropdown-menu#addPropertySideMenu :items=${addPropertySideMenuItems} ?open=${popover.addPropertySideMenuIsOpen} x=${popover.x} y=${popover.y}: null
   - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -27,6 +27,18 @@ refs:
     eventListeners:
       click:
         handler: handleSavePreviewClick
+  maskRemoveConfirmDialog:
+    eventListeners:
+      close:
+        handler: handleMaskRemoveConfirmDialogClose
+  maskRemoveCancelButton:
+    eventListeners:
+      click:
+        handler: handleMaskRemoveConfirmDialogClose
+  maskRemoveConfirmButton:
+    eventListeners:
+      click:
+        handler: handleMaskRemoveConfirmClick
   addPropertiesButton:
     eventListeners:
       click:
@@ -463,10 +475,20 @@ template:
                       - rtgl-button#cancelMaskButton s=sm v=se: ${cancelButton}
                       - rtgl-button#addMaskButton s=sm v=pr: ${addMaskButton}
               - $if popover.mode == 'editMask':
-                  - rtgl-view d=h g=sm w=f ah=e pt=sm:
+                  - rtgl-view d=h g=sm w=f av=c pt=sm:
                       - $if showMobileMaskButton:
                           - rtgl-button#mobileDisableMaskButton s=sm v=se: ${removeButton}
+                      - rtgl-view w=1fg: null
                       - rtgl-button#editMaskDoneButton s=sm v=pr: ${saveButton}
+  - rtgl-dialog#maskRemoveConfirmDialog ?open=${maskRemoveConfirmDialogOpen} s=sm:
+      - $if maskRemoveConfirmDialogOpen:
+          - rtgl-view slot=content d=v w=f g=lg p=lg:
+              - rtgl-view d=v w=f g=md:
+                  - rtgl-text s=lg: ${maskRemoveConfirmTitle}
+                  - rtgl-text c=mu-fg: ${maskRemoveConfirmMessage}
+              - rtgl-view d=h g=sm w=f ah=e:
+                  - rtgl-button#maskRemoveCancelButton s=sm v=se: ${cancelButton}
+                  - rtgl-button#maskRemoveConfirmButton s=sm v=pr: ${removeButton}
   - rtgl-dialog#previewDialog ?open=${isPreviewDialogOpen} s=md:
       - $if isPreviewDialogOpen:
           - 'rtgl-view slot=content d=v w=f g=md style="max-width: calc(100vw - 32px); max-height: calc(100vh - 96px);"':

--- a/tests/whiteboard/whiteboard.handlers.test.js
+++ b/tests/whiteboard/whiteboard.handlers.test.js
@@ -8,6 +8,9 @@ import {
   handleEnsureItemVisible,
   handleItemMouseDown,
   handleMinimapViewportMouseDown,
+  handleMinimapViewportTouchEnd,
+  handleMinimapViewportTouchMove,
+  handleMinimapViewportTouchStart,
   handleWindowMouseMove,
   handleWindowMouseUp,
 } from "../../src/components/whiteboard/whiteboard.handlers.js";
@@ -78,6 +81,7 @@ const createDeps = ({
     startMinimapViewportDragging: vi.fn(),
     updatePanFromMinimapViewportDragging: vi.fn(),
     stopMinimapViewportDragging: vi.fn(),
+    clearLastTouchTap: vi.fn(),
     setPan: vi.fn(({ panX, panY }) => {
       currentPan = { x: panX, y: panY };
     }),
@@ -305,6 +309,7 @@ const createTouchEvent = ({
   clientX,
   clientY,
   touches,
+  changedTouches,
   timeStamp,
 } = {}) => ({
   target,
@@ -314,6 +319,7 @@ const createTouchEvent = ({
       clientY,
     },
   ],
+  changedTouches: changedTouches ?? [],
   timeStamp,
   preventDefault: vi.fn(),
   stopPropagation: vi.fn(),
@@ -434,6 +440,83 @@ describe("whiteboard minimap drag handlers", () => {
           visible: true,
         }),
       }),
+    });
+  });
+
+  it("drags the minimap viewport with one-finger touch events", () => {
+    const deps = createDeps({ minimapHeightScale: 2 / 3 });
+    const touchStartEvent = createTouchEvent({
+      clientX: 150,
+      clientY: 230,
+    });
+
+    handleMinimapViewportTouchStart(deps, {
+      _event: touchStartEvent,
+    });
+
+    expect(touchStartEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(touchStartEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(deps.store.selectMinimapData).toHaveBeenCalledWith({
+      items: [],
+      heightScale: 2 / 3,
+    });
+    expect(deps.store.startMinimapViewportDragging).toHaveBeenCalledWith({
+      mouseX: 50,
+      mouseY: 30,
+      minimapData: expect.objectContaining({
+        viewport: expect.objectContaining({
+          visible: true,
+        }),
+      }),
+    });
+
+    const touchMoveEvent = createTouchEvent({
+      clientX: 180,
+      clientY: 255,
+    });
+
+    handleMinimapViewportTouchMove(deps, {
+      _event: touchMoveEvent,
+    });
+
+    expect(touchMoveEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(touchMoveEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(
+      deps.store.updatePanFromMinimapViewportDragging,
+    ).toHaveBeenCalledWith({
+      mouseX: 80,
+      mouseY: 55,
+    });
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+
+    const touchEndEvent = createTouchEvent({
+      touches: [],
+      changedTouches: [
+        {
+          clientX: 190,
+          clientY: 265,
+        },
+      ],
+    });
+
+    handleMinimapViewportTouchEnd(deps, {
+      _event: touchEndEvent,
+    });
+
+    expect(
+      deps.store.updatePanFromMinimapViewportDragging,
+    ).toHaveBeenLastCalledWith({
+      mouseX: 90,
+      mouseY: 65,
+    });
+    expect(deps.store.stopMinimapViewportDragging).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
+
+    const dispatchedEvent = deps.dispatchEvent.mock.calls[0][0];
+    expect(dispatchedEvent.type).toBe("pan-changed");
+    expect(dispatchedEvent.detail).toEqual({
+      panX: -120,
+      panY: -80,
     });
   });
 

--- a/tests/whiteboard/whiteboard.view.test.js
+++ b/tests/whiteboard/whiteboard.view.test.js
@@ -1,0 +1,27 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+describe("whiteboard view", () => {
+  it("wires touch events for dragging the minimap viewport", () => {
+    const whiteboardView = readFileSync(
+      new URL(
+        "../../src/components/whiteboard/whiteboard.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(whiteboardView).toContain(
+      "touchstart:\n        handler: handleMinimapViewportTouchStart",
+    );
+    expect(whiteboardView).toContain(
+      "touchmove:\n        handler: handleMinimapViewportTouchMove",
+    );
+    expect(whiteboardView).toContain(
+      "touchend:\n        handler: handleMinimapViewportTouchEnd",
+    );
+    expect(whiteboardView).toContain(
+      "touchcancel:\n        handler: handleMinimapViewportTouchCancel",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- hide the animation editor right panel on touch/mobile layouts
- add mobile Mask and Edit Preview actions above Tween Properties
- move preview dialog Save to the footer and close the mobile preview dialog after a successful save
- make Edit Mask removal reachable on mobile with a left-aligned Remove action and confirmation dialog
- support one-finger touch dragging of the whiteboard minimap viewport

## Verification
- bunx prettier --check src/pages/animationEditor/animationEditor.view.yaml src/pages/animationEditor/animationEditor.handlers.js src/pages/animationEditor/animationEditor.store.js src/i18n/en.yaml src/i18n/ja.yaml src/i18n/zh-hans.yaml
- bunx prettier --check src/components/whiteboard/whiteboard.handlers.js src/components/whiteboard/whiteboard.view.yaml tests/whiteboard/whiteboard.handlers.test.js tests/whiteboard/whiteboard.view.test.js
- bunx rtgl fe check
- bunx vitest run tests/whiteboard/whiteboard.handlers.test.js tests/whiteboard/whiteboard.store.test.js tests/whiteboard/whiteboard.view.test.js
- bun run android:install
- Android device check on Redmi K30 5G - 12: verified mobile animation editor mask, preview, save-close, and remove-confirm flows
- push hook: oxlint && bun prettier --check src