### PR TITLE
Defer and batch scene overview loading

### DIFF
--- a/src/deps/services/shared/projectRepositoryViews/sceneBundleRuntime.js
+++ b/src/deps/services/shared/projectRepositoryViews/sceneBundleRuntime.js
@@ -60,6 +60,60 @@ export const createSceneBundleRuntime = ({
     return latestRelevantRevision;
   };
 
+  const getLatestOverviewRevisionsForScenes = async (sceneIds = []) => {
+    const normalizedSceneIds = sceneIds.filter(isNonEmptyString);
+    const revisionsBySceneId = new Map(
+      normalizedSceneIds.map((sceneId) => [sceneId, 0]),
+    );
+    if (normalizedSceneIds.length === 0) {
+      return revisionsBySceneId;
+    }
+
+    const sceneIdByPartition = new Map();
+    for (const sceneId of normalizedSceneIds) {
+      sceneIdByPartition.set(scenePartitionFor(sceneId), sceneId);
+      sceneIdByPartition.set(mainScenePartitionFor(sceneId), sceneId);
+    }
+
+    let latestRelevantMainRevision = 0;
+
+    for await (const committedBatch of iterateCommittedEventBatches({
+      listCommittedAfter,
+    })) {
+      for (const event of committedBatch) {
+        const partition = event?.partition;
+        const revision = getCommittedEventRevision(event);
+        const sceneId = sceneIdByPartition.get(partition);
+
+        if (sceneId) {
+          revisionsBySceneId.set(sceneId, revision);
+          continue;
+        }
+
+        if (
+          isMainPartition(partition) &&
+          doesCommittedEventAffectSceneOverview(event)
+        ) {
+          latestRelevantMainRevision = revision;
+        }
+      }
+    }
+
+    if (latestRelevantMainRevision > 0) {
+      for (const sceneId of normalizedSceneIds) {
+        revisionsBySceneId.set(
+          sceneId,
+          Math.max(
+            revisionsBySceneId.get(sceneId) || 0,
+            latestRelevantMainRevision,
+          ),
+        );
+      }
+    }
+
+    return revisionsBySceneId;
+  };
+
   const getSceneStateForOverview = async (sceneId) => {
     const activeSceneId = getActiveSceneId();
     const activeSceneState = getActiveSceneState();
@@ -157,7 +211,11 @@ export const createSceneBundleRuntime = ({
     scheduleOverviewWriteFlush();
   };
 
-  const buildAndStoreSceneOverview = async ({ sceneId, checkpoint = null }) => {
+  const buildAndStoreSceneOverview = async ({
+    sceneId,
+    checkpoint = null,
+    latestRelevantRevision,
+  }) => {
     if (!isNonEmptyString(sceneId)) {
       return undefined;
     }
@@ -189,7 +247,9 @@ export const createSceneBundleRuntime = ({
     queueSceneOverviewSave({
       sceneId,
       overview,
-      lastCommittedId: await getLatestOverviewRevisionForScene(sceneId),
+      lastCommittedId: Number.isFinite(latestRelevantRevision)
+        ? latestRelevantRevision
+        : await getLatestOverviewRevisionForScene(sceneId),
     });
 
     return structuredClone(overview);
@@ -198,6 +258,7 @@ export const createSceneBundleRuntime = ({
   const ensureSceneOverviewWithCheckpoint = async ({
     sceneId,
     checkpoint = null,
+    latestRelevantRevision,
   }) => {
     if (!isNonEmptyString(sceneId)) {
       return undefined;
@@ -216,15 +277,19 @@ export const createSceneBundleRuntime = ({
       return buildAndStoreSceneOverview({
         sceneId,
         checkpoint,
+        latestRelevantRevision,
       });
     }
 
-    const latestRelevantRevision =
-      await getLatestOverviewRevisionForScene(sceneId);
+    const resolvedLatestRelevantRevision = Number.isFinite(
+      latestRelevantRevision,
+    )
+      ? latestRelevantRevision
+      : await getLatestOverviewRevisionForScene(sceneId);
     if (
       isSceneOverviewCheckpointFresh({
         checkpoint,
-        latestRelevantRevision,
+        latestRelevantRevision: resolvedLatestRelevantRevision,
       })
     ) {
       return structuredClone(checkpoint.value);
@@ -233,6 +298,7 @@ export const createSceneBundleRuntime = ({
     return buildAndStoreSceneOverview({
       sceneId,
       checkpoint,
+      latestRelevantRevision: resolvedLatestRelevantRevision,
     });
   };
 
@@ -268,11 +334,14 @@ export const createSceneBundleRuntime = ({
         store,
         sceneIds,
       });
+      const latestRevisionsBySceneId =
+        await getLatestOverviewRevisionsForScenes(sceneIds);
 
       for (const sceneId of sceneIds) {
         const overview = await ensureSceneOverviewWithCheckpoint({
           sceneId,
           checkpoint: checkpointsBySceneId.get(sceneId),
+          latestRelevantRevision: latestRevisionsBySceneId.get(sceneId),
         });
         if (overview) {
           overviewsBySceneId[sceneId] = overview;

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -26,6 +26,7 @@ const DEFAULT_SCENES_MAP_VIEWPORT = {
 const TOUCH_MINIMAP_HYDRATION_FRAME_COUNT = 6;
 const WHITEBOARD_CONNECTIONS_HYDRATION_FRAME_COUNT = 4;
 const SCENE_OVERVIEW_HYDRATION_FRAME_COUNT = 8;
+const SCENE_OVERVIEW_IDLE_TIMEOUT_MS = 4000;
 
 const getProjectErrorMessage = (result, fallbackMessage) => {
   return (
@@ -403,7 +404,7 @@ const cancelTouchMinimapHydrationFrame = (store) => {
     return;
   }
 
-  globalThis.cancelAnimationFrame?.(frameId);
+  cancelScheduledWork(frameId);
   store.clearTouchMinimapFrameId?.();
 };
 
@@ -413,7 +414,7 @@ const cancelWhiteboardConnectionsHydrationFrame = (store) => {
     return;
   }
 
-  globalThis.cancelAnimationFrame?.(frameId);
+  cancelScheduledWork(frameId);
   store.clearWhiteboardConnectionsFrameId?.();
 };
 
@@ -423,8 +424,31 @@ const cancelSceneOverviewRefreshFrame = (store) => {
     return;
   }
 
-  globalThis.cancelAnimationFrame?.(frameId);
+  cancelScheduledWork(frameId);
   store.clearSceneOverviewFrameId?.();
+};
+
+const cancelScheduledWork = (handle) => {
+  if (handle === undefined) {
+    return;
+  }
+
+  if (handle?.type === "idle") {
+    globalThis.cancelIdleCallback?.(handle.id);
+    return;
+  }
+
+  if (handle?.type === "timeout") {
+    globalThis.clearTimeout?.(handle.id);
+    return;
+  }
+
+  if (handle?.type === "animationFrame") {
+    globalThis.cancelAnimationFrame?.(handle.id);
+    return;
+  }
+
+  globalThis.cancelAnimationFrame?.(handle);
 };
 
 const scheduleAfterFrames = ({
@@ -454,6 +478,22 @@ const scheduleAfterFrames = ({
   };
 
   scheduleNextFrame(frameCount);
+};
+
+const scheduleIdleWork = ({ setFrameId, clearFrameId, callback } = {}) => {
+  if (typeof globalThis.requestIdleCallback === "function") {
+    const idleId = globalThis.requestIdleCallback(
+      () => {
+        clearFrameId?.();
+        callback?.();
+      },
+      { timeout: SCENE_OVERVIEW_IDLE_TIMEOUT_MS },
+    );
+    setFrameId?.({ type: "idle", id: idleId });
+    return;
+  }
+
+  callback?.();
 };
 
 const scheduleTouchMinimapHydration = ({ store, render } = {}) => {
@@ -517,12 +557,18 @@ const scheduleSceneOverviewRefresh = ({
     setFrameId: (frameId) => store.setSceneOverviewFrameId?.({ frameId }),
     clearFrameId: () => store.clearSceneOverviewFrameId?.(),
     callback: () => {
-      void refreshSceneOverviews({
-        store,
-        render,
-        projectService,
-        orderedSceneIds,
-        requestId,
+      scheduleIdleWork({
+        setFrameId: (frameId) => store.setSceneOverviewFrameId?.({ frameId }),
+        clearFrameId: () => store.clearSceneOverviewFrameId?.(),
+        callback: () => {
+          void refreshSceneOverviews({
+            store,
+            render,
+            projectService,
+            orderedSceneIds,
+            requestId,
+          });
+        },
       });
     },
   });
@@ -554,17 +600,6 @@ const hydrateDeferredWhiteboardWork = ({
 } = {}) => {
   scheduleWhiteboardConnectionsHydration({ store, render });
   scheduleTouchMinimapHydration({ store, render });
-
-  if (!store.selectIsTouchMode?.()) {
-    void refreshSceneOverviews({
-      store,
-      render,
-      projectService,
-      orderedSceneIds,
-      requestId,
-    });
-    return;
-  }
 
   scheduleSceneOverviewRefresh({
     store,

--- a/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
+++ b/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
@@ -1231,6 +1231,147 @@ describe("projectRepositoryRuntime replay diagnostics", () => {
     });
   });
 
+  it("loads multiple fresh scene overviews with one committed-history scan", async () => {
+    const sceneIds = ["scene-1", "scene-2"];
+    const mainState = {
+      project: {},
+      story: {
+        initialSceneId: "scene-1",
+      },
+      layouts: {
+        items: {},
+        tree: [],
+      },
+      controls: {
+        items: {},
+        tree: [],
+      },
+      scenes: {
+        items: Object.fromEntries(
+          sceneIds.map((sceneId, index) => [
+            sceneId,
+            {
+              id: sceneId,
+              type: "scene",
+              name: `Scene ${index + 1}`,
+              position: {
+                x: index * 100,
+                y: 0,
+              },
+              sections: {
+                items: {},
+                tree: [],
+              },
+            },
+          ]),
+        ),
+        tree: sceneIds.map((sceneId) => ({ id: sceneId })),
+      },
+    };
+    const committedEvents = [
+      createProjectCreateRepositoryEvent({
+        projectId: "project-1",
+        state: mainState,
+      }),
+    ].map((event, index) => ({
+      ...structuredClone(event),
+      committedId: index + 1,
+    }));
+    const checkpoints = Object.fromEntries(
+      sceneIds.map((sceneId) => {
+        const partition = scenePartitionFor(sceneId);
+        return [
+          partition,
+          {
+            viewName: SCENE_OVERVIEW_VIEW_NAME,
+            viewVersion: "1",
+            partition,
+            lastCommittedId: committedEvents.length,
+            value: {
+              sceneId,
+              name: mainState.scenes.items[sceneId].name,
+              position: structuredClone(
+                mainState.scenes.items[sceneId].position,
+              ),
+              outgoingSceneIds: [],
+              sections: [],
+            },
+          },
+        ];
+      }),
+    );
+    const loadEvents = vi.fn(async () => structuredClone(committedEvents));
+    const listCommittedAfter = vi.fn(
+      async ({ sinceCommittedId = 0, limit } = {}) => {
+        const startIndex = Math.max(0, Number(sinceCommittedId) || 0);
+        const normalizedLimit =
+          Number.isInteger(limit) && limit > 0 ? limit : committedEvents.length;
+        return committedEvents
+          .slice(startIndex, startIndex + normalizedLimit)
+          .map((event) => structuredClone(event));
+      },
+    );
+    const saveMaterializedViewCheckpoint = vi.fn(async () => {});
+    const reduceEventToState = ({ repositoryState, event }) =>
+      event?.payload?.state
+        ? structuredClone(event.payload.state)
+        : repositoryState;
+
+    const repository = await createProjectRepositoryRuntime({
+      projectId: "project-1",
+      store: {
+        listCommittedAfter,
+        loadMaterializedViewCheckpoint: async ({ viewName, partition }) => {
+          if (viewName === MAIN_VIEW_NAME && partition === "m") {
+            return {
+              viewName,
+              viewVersion: "1",
+              partition,
+              lastCommittedId: committedEvents.length,
+              value: structuredClone(mainState),
+            };
+          }
+
+          return checkpoints[partition];
+        },
+        loadMaterializedViewCheckpoints: async ({ partitions }) =>
+          partitions
+            .map((partition) => checkpoints[partition])
+            .filter(Boolean)
+            .map((checkpoint) => structuredClone(checkpoint)),
+        saveMaterializedViewCheckpoint,
+        deleteMaterializedViewCheckpoint: async () => {},
+      },
+      initialRevision: committedEvents.length,
+      historyStats: {
+        committedCount: committedEvents.length,
+        latestCommittedId: committedEvents.length,
+        draftCount: 0,
+        latestDraftClock: 0,
+      },
+      loadEvents,
+      createInitialState: () => ({
+        scenes: {
+          items: {},
+          tree: [],
+        },
+      }),
+      reduceEventToState,
+      reduceEventsToState: createBatchedReducer(reduceEventToState),
+    });
+
+    listCommittedAfter.mockClear();
+
+    const overviews = await repository.loadSceneOverviews({ sceneIds });
+
+    expect(Object.keys(overviews)).toEqual(sceneIds);
+    expect(listCommittedAfter).toHaveBeenCalledTimes(2);
+    expect(
+      listCommittedAfter.mock.calls.map(([call]) => call.sinceCommittedId),
+    ).toEqual([0, 1]);
+    expect(saveMaterializedViewCheckpoint).not.toHaveBeenCalled();
+  });
+
   it("pages committed history when activating a scene on a checkpoint-backed repository without drafts", async () => {
     const sceneId = "scene-1";
     const sectionId = "section-1";

--- a/tests/scenes/scenes.handlers.test.js
+++ b/tests/scenes/scenes.handlers.test.js
@@ -14,6 +14,8 @@ import { EN_I18N } from "../support/i18n.js";
 
 const originalWindow = globalThis.window;
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalRequestIdleCallback = globalThis.requestIdleCallback;
+const originalCancelIdleCallback = globalThis.cancelIdleCallback;
 
 const createDeps = ({ userConfig = {}, projectId = "project-1" } = {}) => {
   const getUserConfig = vi.fn((key) => userConfig[key]);
@@ -95,6 +97,7 @@ const createDeps = ({ userConfig = {}, projectId = "project-1" } = {}) => {
       openMobileFileExplorer: vi.fn(),
       closeMobileFileExplorer: vi.fn(),
       selectIsMobileFileExplorerOpen: vi.fn(() => false),
+      selectShowSceneForm: vi.fn(() => true),
       resetSceneForm: vi.fn(),
       addWhiteboardItem: vi.fn(),
       selectSceneWhiteboardPosition: vi.fn(() => ({
@@ -130,11 +133,15 @@ describe("scenes.handlers config keys", () => {
       callback();
       return 1;
     };
+    globalThis.requestIdleCallback = undefined;
+    globalThis.cancelIdleCallback = undefined;
   });
 
   afterEach(() => {
     globalThis.window = originalWindow;
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.requestIdleCallback = originalRequestIdleCallback;
+    globalThis.cancelIdleCallback = originalCancelIdleCallback;
   });
 
   it("loads the scenes viewport from project-scoped userConfig keys", async () => {
@@ -236,6 +243,30 @@ describe("scenes.handlers config keys", () => {
 
     resolveOverviews({});
     await Promise.resolve();
+  });
+
+  it("waits for idle time before loading scene overviews", async () => {
+    let idleCallback;
+    globalThis.requestIdleCallback = vi.fn((callback) => {
+      idleCallback = callback;
+      return 1;
+    });
+    globalThis.cancelIdleCallback = vi.fn();
+
+    const deps = createDeps();
+
+    await handleAfterMount(deps);
+
+    expect(deps.projectService.loadSceneOverviews).not.toHaveBeenCalled();
+    expect(deps.render).toHaveBeenCalledTimes(1);
+
+    idleCallback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deps.projectService.loadSceneOverviews).toHaveBeenCalledWith({
+      sceneIds: ["scene-1"],
+    });
   });
 
   it("animates scene map centering from file explorer scene selection", () => {


### PR DESCRIPTION
## Summary
- batch latest-revision checks when loading multiple scene overviews
- defer scene overview refresh work until after hydration frames and idle time
- support canceling deferred overview work across animation-frame and idle handles

## Verification
- bunx prettier --check src/deps/services/shared/projectRepositoryViews/sceneBundleRuntime.js src/pages/scenes/scenes.handlers.js tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js tests/scenes/scenes.handlers.test.js
- bunx vitest run tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js tests/scenes/scenes.handlers.test.js
- push hook: oxlint && bun prettier --check src