### PR TITLE
Fix VN preview canvas sizing

### DIFF
--- a/src/components/vnPreview/vnPreview.store.js
+++ b/src/components/vnPreview/vnPreview.store.js
@@ -9,6 +9,57 @@ const createEmptyAssetLoadCache = () => ({
   fileIds: [],
 });
 
+const toPositiveDimension = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0
+    ? numericValue
+    : undefined;
+};
+
+const createViewportSize = () => ({
+  width:
+    toPositiveDimension(globalThis.window?.innerWidth) ??
+    DEFAULT_PROJECT_RESOLUTION.width,
+  height:
+    toPositiveDimension(globalThis.window?.innerHeight) ??
+    DEFAULT_PROJECT_RESOLUTION.height,
+});
+
+const formatCssPixels = (value) => `${Math.round(value * 100) / 100}px`;
+
+const createPreviewFrameStyle = ({ projectResolution, viewportSize }) => {
+  const projectWidth =
+    toPositiveDimension(projectResolution?.width) ??
+    DEFAULT_PROJECT_RESOLUTION.width;
+  const projectHeight =
+    toPositiveDimension(projectResolution?.height) ??
+    DEFAULT_PROJECT_RESOLUTION.height;
+  const viewportWidth =
+    toPositiveDimension(viewportSize?.width) ??
+    DEFAULT_PROJECT_RESOLUTION.width;
+  const viewportHeight =
+    toPositiveDimension(viewportSize?.height) ??
+    DEFAULT_PROJECT_RESOLUTION.height;
+  const scale = Math.min(
+    viewportWidth / projectWidth,
+    viewportHeight / projectHeight,
+  );
+  const width = projectWidth * scale;
+  const height = projectHeight * scale;
+
+  return [
+    "flex: 0 0 auto",
+    "position: relative",
+    `aspect-ratio: ${projectWidth} / ${projectHeight}`,
+    `width: ${formatCssPixels(width)}`,
+    `height: ${formatCssPixels(height)}`,
+    "max-width: 100vw",
+    "max-height: 100vh",
+    "overflow: hidden",
+    "background: #000",
+  ].join("; ");
+};
+
 const readAssetLoadCache = (state) => {
   if (!state || typeof state !== "object") {
     return createEmptyAssetLoadCache();
@@ -46,6 +97,7 @@ export const createInitialState = () => ({
   isPreviewReady: false,
   assetLoadCache: createEmptyAssetLoadCache(),
   projectResolution: DEFAULT_PROJECT_RESOLUTION,
+  viewportSize: createViewportSize(),
 });
 
 export const setAssetLoading = ({ state }, { isLoading } = {}) => {
@@ -65,6 +117,14 @@ export const setProjectResolution = ({ state }, { projectResolution } = {}) => {
     projectResolution,
     "Project resolution",
   );
+};
+
+export const setViewportSize = ({ state }, { width, height } = {}) => {
+  const currentViewportSize = state.viewportSize ?? createViewportSize();
+  state.viewportSize = {
+    width: toPositiveDimension(width) ?? currentViewportSize.width,
+    height: toPositiveDimension(height) ?? currentViewportSize.height,
+  };
 };
 
 export const selectAssetLoadCache = ({ state }) => readAssetLoadCache(state);
@@ -109,5 +169,9 @@ export const selectViewData = ({ props: attrs, state }) => {
     canvasAspectRatio: formatProjectResolutionAspectRatio(
       state.projectResolution,
     ),
+    previewFrameStyle: createPreviewFrameStyle({
+      projectResolution: state.projectResolution,
+      viewportSize: state.viewportSize,
+    }),
   };
 };

--- a/src/components/vnPreview/vnPreview.view.yaml
+++ b/src/components/vnPreview/vnPreview.view.yaml
@@ -1,11 +1,19 @@
 refs:
   previewSurface: {}
   canvas: {}
+  window:
+    eventListeners:
+      resize:
+        action: setViewportSize
+        throttle: 100
+        payload:
+          width: ${_event.target.innerWidth}
+          height: ${_event.target.innerHeight}
 template:
-  - 'rtgl-view#previewSurface pos=fix w=100vw h=100vh tabindex=-1 style="left: 0; top: 0; background: black; justify-content: center; align-items: center; outline: none;" z=3500 data-preview-ready=${isPreviewReady}':
-      - 'rtgl-view pos=rel bwb=xs style="aspect-ratio: ${canvasAspectRatio}; width: min(100vw, calc(100vh * (${canvasAspectRatio}))); height: min(100vh, calc(100vw / (${canvasAspectRatio}))); max-width: 100%; max-height: 100%"':
-          - rtgl-view pos=abs cor=full:
-              - 'div#canvas id=canvas style="width: 100%; height: 100%;display: flex; justify-content: center"': null
+  - 'rtgl-view#previewSurface pos=fix edge=f tabindex=-1 style="display: flex; justify-content: center; align-items: center; overflow: hidden; background: black; outline: none; min-width: 0; min-height: 0;" z=3500 data-preview-ready=${isPreviewReady}':
+      - 'rtgl-view bwb=xs style="${previewFrameStyle}"':
+          - rtgl-view pos=abs edge=f w=f h=f:
+              - 'div#canvas id=canvas style="width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; overflow: hidden; background: #000;"': null
           - $if isAssetLoading:
-              - rtgl-view pos=abs cor=full w=f h=f bgc=bg op=0.6 av=c ah=c:
+              - rtgl-view pos=abs edge=f w=f h=f bgc=bg op=0.6 av=c ah=c:
                   - rtgl-text s=h3: Loading preview...


### PR DESCRIPTION
## Summary
- compute fullscreen VN preview frame dimensions from viewport and project resolution
- remove fragile CSS calc multiplication/division from the preview frame
- keep the fitted canvas frame centered and update it on window resize

## Validation
- bun run build:tauri
- push hook: oxlint && bun prettier --check src

Note: rtgl check still reports existing repo-wide diagnostics for unrelated component naming and rtgl-* registry checks.