### PR TITLE
Add Docker AUR build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 !docker/appimage/
 !docker/appimage/build-in-container.sh
 !docker/appimage/ubuntu-22.04.Dockerfile
+!docker/aur/
+!docker/aur/build-in-container.sh
+!docker/aur/archlinux.Dockerfile

--- a/docker/aur/archlinux.Dockerfile
+++ b/docker/aur/archlinux.Dockerfile
@@ -1,0 +1,35 @@
+FROM archlinux:latest
+
+ENV BUN_INSTALL_CACHE_DIR=/cache/bun
+ENV CARGO_HOME=/cache/cargo-home
+ENV PATH=/usr/local/bin:/usr/bin:/bin
+
+RUN pacman -Syu --noconfirm --needed \
+    archlinux-keyring \
+    base-devel \
+    bun \
+    git \
+    gst-libav \
+    gst-plugins-bad \
+    gst-plugins-good \
+    gst-plugins-ugly \
+    gtk3 \
+    hicolor-icon-theme \
+    libayatana-appindicator \
+    librsvg \
+    openssl \
+    pkgconf \
+    rust \
+    sqlite \
+    webkit2gtk-4.1 \
+    xdg-utils \
+  && pacman -Scc --noconfirm \
+  && useradd --create-home --shell /bin/bash builder
+
+RUN pacman -Syu --noconfirm --needed node-gyp \
+  && pacman -Scc --noconfirm
+
+COPY docker/aur/build-in-container.sh /usr/local/bin/build-routevn-aur-package
+RUN chmod +x /usr/local/bin/build-routevn-aur-package
+
+ENTRYPOINT ["/usr/local/bin/build-routevn-aur-package"]

--- a/docker/aur/build-in-container.sh
+++ b/docker/aur/build-in-container.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SRC_DIR="${ROUTEVN_SRC_DIR:-/src}"
+WORK_DIR="${ROUTEVN_WORK_DIR:-/work}"
+OUT_DIR="${ROUTEVN_OUT_DIR:-/out}"
+PKG_NAME="routevn-creator"
+AUR_BUILD_DIR="${WORK_DIR}/aur-build"
+BUN_INSTALL_CACHE_DIR="${BUN_INSTALL_CACHE_DIR:-/cache/bun}"
+CARGO_HOME="${CARGO_HOME:-/cache/cargo-home}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/cache/cargo-target}"
+HOST_UID="${HOST_UID:-}"
+HOST_GID="${HOST_GID:-}"
+
+export BUN_INSTALL_CACHE_DIR
+export CARGO_HOME
+export CARGO_TARGET_DIR
+
+if [ ! -f "${SRC_DIR}/package.json" ]; then
+  echo "Error: ${SRC_DIR} does not look like the RouteVN Creator repo."
+  exit 1
+fi
+
+if [ ! -d "${SRC_DIR}/.git" ]; then
+  echo "Error: ${SRC_DIR}/.git is required because AUR source archives are created from HEAD."
+  exit 1
+fi
+
+APP_VERSION="$(bun --print "JSON.parse(await Bun.file('${SRC_DIR}/src-tauri/tauri.conf.json').text()).version")"
+ARCHIVE_FILE="${PKG_NAME}-${APP_VERSION}.tar.gz"
+PKGBUILD_SOURCE="${SRC_DIR}/packaging/aur/PKGBUILD"
+
+if ! grep -q "^pkgver=${APP_VERSION}$" "${PKGBUILD_SOURCE}"; then
+  echo "Error: ${PKGBUILD_SOURCE} pkgver does not match Tauri version ${APP_VERSION}."
+  exit 1
+fi
+
+if [ -n "$(git -c safe.directory="${SRC_DIR}" -C "${SRC_DIR}" status --porcelain)" ]; then
+  echo "Warning: uncommitted changes are not included. AUR source archive is created from HEAD."
+fi
+
+rm -rf "${AUR_BUILD_DIR}"
+mkdir -p "${AUR_BUILD_DIR}" "${OUT_DIR}" "${BUN_INSTALL_CACHE_DIR}" "${CARGO_HOME}" "${CARGO_TARGET_DIR}"
+
+git -c safe.directory="${SRC_DIR}" -C "${SRC_DIR}" archive \
+  --format=tar.gz \
+  --prefix="${PKG_NAME}-${APP_VERSION}/" \
+  --output="${AUR_BUILD_DIR}/${ARCHIVE_FILE}" \
+  HEAD
+
+cp "${PKGBUILD_SOURCE}" "${AUR_BUILD_DIR}/PKGBUILD"
+sed -i "s|^source=.*|source=(\"${ARCHIVE_FILE}\")|" "${AUR_BUILD_DIR}/PKGBUILD"
+
+chown -R builder:builder "${WORK_DIR}" "${BUN_INSTALL_CACHE_DIR}" "${CARGO_HOME}" "${CARGO_TARGET_DIR}"
+
+run_as_builder() {
+  runuser -u builder -- env \
+    HOME=/home/builder \
+    BUN_INSTALL_CACHE_DIR="${BUN_INSTALL_CACHE_DIR}" \
+    CARGO_HOME="${CARGO_HOME}" \
+    CARGO_TARGET_DIR="${CARGO_TARGET_DIR}" \
+    PATH="${PATH}" \
+    bash -lc "$1"
+}
+
+run_as_builder "cd '${AUR_BUILD_DIR}' && makepkg --force --cleanbuild"
+run_as_builder "cd '${AUR_BUILD_DIR}' && makepkg --printsrcinfo > .SRCINFO"
+
+find "${OUT_DIR}" -maxdepth 1 -type f \
+  \( -name "${PKG_NAME}-*.pkg.tar.*" -o -name "${PKG_NAME}-*.pkg.tar.*.sha256" \) \
+  -delete
+
+find "${AUR_BUILD_DIR}" -maxdepth 1 -type f -name "*.pkg.tar.*" \
+  -exec cp -a {} "${OUT_DIR}/" \;
+
+cp "${AUR_BUILD_DIR}/PKGBUILD" "${OUT_DIR}/PKGBUILD"
+cp "${AUR_BUILD_DIR}/.SRCINFO" "${OUT_DIR}/.SRCINFO"
+
+for artifact in "${OUT_DIR}"/*.pkg.tar.*; do
+  [ -e "${artifact}" ] || continue
+
+  case "${artifact}" in
+    *.sha256)
+      continue
+      ;;
+  esac
+
+  (
+    cd "${OUT_DIR}"
+    sha256sum "$(basename "${artifact}")" > "$(basename "${artifact}").sha256"
+  )
+done
+
+if [ -n "${HOST_UID}" ] && [ -n "${HOST_GID}" ]; then
+  chown -R "${HOST_UID}:${HOST_GID}" "${OUT_DIR}"
+fi
+
+echo "AUR package artifacts copied to ${OUT_DIR}:"
+find "${OUT_DIR}" -maxdepth 1 -type f -printf '  %f\n' | sort

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "tauri:build:linux:rpm": "bun run build:tauri && rm -rf src-tauri/target/release/bundle/rpm && tauri build --config src-tauri/tauri.prod.conf.json --config src-tauri/tauri.linux-packages.conf.json --bundles rpm && node scripts/validate-linux-packaging.js --rpm",
     "tauri:build:linux:rpm:docker": "./scripts/tauri-build-linux-package-docker.sh rpm",
     "tauri:build:linux:aur": "./scripts/tauri-build-linux-aur.sh",
+    "tauri:build:linux:aur:docker": "./scripts/tauri-build-linux-aur-docker.sh",
     "tauri:build:win": "bun run build:tauri && tauri build --config src-tauri/tauri.prod.conf.json --runner cargo-xwin --target x86_64-pc-windows-msvc",
     "tauri:build:win:steam": "./scripts/tauri-build-win-steam.sh",
     "tauri:build:mac": "./scripts/tauri-build-mac.sh",

--- a/scripts/tauri-build-linux-aur-docker.sh
+++ b/scripts/tauri-build-linux-aur-docker.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_NAME="${ROUTEVN_AUR_DOCKER_IMAGE:-routevn-creator-aur-builder:archlinux}"
+OUT_DIR="${ROUTEVN_AUR_OUT_DIR:-${ROOT_DIR}/dist/aur}"
+DOCKERFILE="${ROOT_DIR}/docker/aur/archlinux.Dockerfile"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required for AUR package builds."
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+docker build \
+  --platform linux/amd64 \
+  -f "${DOCKERFILE}" \
+  -t "${IMAGE_NAME}" \
+  "${ROOT_DIR}"
+
+docker run --rm \
+  --platform linux/amd64 \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
+  -v "${ROOT_DIR}:/src:ro" \
+  -v "${OUT_DIR}:/out" \
+  -v routevn-linux-aur-bun-cache:/cache/bun \
+  -v routevn-linux-aur-cargo-home:/cache/cargo-home \
+  -v routevn-linux-aur-cargo-target:/cache/cargo-target \
+  "${IMAGE_NAME}"
+
+echo "AUR package artifacts are in ${OUT_DIR}"


### PR DESCRIPTION
## Summary
- add the tracked script behind `tauri:build:linux:aur:docker`
- add the Arch Linux Docker builder and in-container AUR packaging helper
- allow the AUR Docker context files through `.dockerignore`

## Validation
- `bash -n scripts/tauri-build-linux-aur-docker.sh`
- `bash -n docker/aur/build-in-container.sh`
- `git diff --cached --check`
- push hook: `oxlint && bun prettier --check src`

This addresses the review comment about the package script pointing at a missing file on clean checkouts.