### PR TITLE
Preserve mobile layout preview state

### DIFF
--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -551,6 +551,12 @@ export const selectViewData = ({ state, constants, i18n }) => {
           itemId: item?.id,
         });
   const showMobileSelectedNodeDetail = state.isTouchMode && Boolean(item);
+  const previewPanelVisibilityStyle = showMobileSelectedNodeDetail
+    ? "display: none;"
+    : "";
+  const previewHydrationData = state.isTouchMode
+    ? state.previewData
+    : state.initialPreviewData;
 
   return {
     item,
@@ -571,6 +577,7 @@ export const selectViewData = ({ state, constants, i18n }) => {
     layoutEditorCanvasMaxWidth: selectLayoutEditorCanvasMaxWidth({ state }),
     previewData: state.previewData,
     initialPreviewData: state.initialPreviewData,
+    previewHydrationData,
     isPreviewMounted: state.isPreviewMounted,
     projectResolution: state.projectResolution,
     layout,
@@ -596,5 +603,6 @@ export const selectViewData = ({ state, constants, i18n }) => {
     showMobilePreviewButton: showMobileSelectedNodeDetail,
     showMobileNodeExplorer: state.isTouchMode && state.isMobileFileExplorerOpen,
     showMobileSelectedNodeDetail,
+    previewPanelVisibilityStyle,
   };
 };

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -73,6 +73,17 @@ template:
               - 'rtgl-view w=f style="min-width: 0;"':
                   - 'div style="position: relative; width: ${layoutEditorCanvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto;"':
                       - 'rvn-layout-editor-canvas#layoutEditorCanvas style="display: block; width: 100%;" :resolution=${projectResolution} :layoutState=${layoutState} selectedItemId=${selectedItemId} :previewData=${previewData} :disableMoveDrag=${selectedItemIsInsideDirectedContainer}': null
+              - 'rtgl-view h=1fg w=f sv style="min-height: 0; ${previewPanelVisibilityStyle}"':
+                  - $if showMobilePreviewHeader:
+                      - 'rtgl-view h=48 w=f d=h bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
+                          - rtgl-text w=1fg s=md ellipsis=true: ${previewTitle}
+                          - rtgl-button#saveButton ml=sm v=se: ${savePreviewButton}
+                  - $if isPreviewMounted:
+                      - rvn-layout-editor-preview#layoutEditorPreview :layoutState=${layoutState} :initialPreviewData=${previewHydrationData} :charactersData=${charactersData}: null
+                    $else:
+                      - rtgl-view wh=f av=c ah=c bgc=mu-fg:
+                          - rtgl-text s=sm c=mu-fg: ${loadingPreviewLabel}
+                  - 'rtgl-view w=f h=32vh style="flex-shrink: 0;"': null
               - $if showMobileSelectedNodeDetail:
                   - 'rtgl-view d=v h=1fg w=f style="min-height: 0;"':
                       - rtgl-view h=48 w=f d=h bgc=bg bwb=xs ph=md av=c:
@@ -82,18 +93,6 @@ template:
                       - 'rtgl-view w=f h=1fg sv pv=md style="min-height: 0;"':
                           - rvn-layout-edit-panel#layoutEditPanel layout-type=${layout.layoutType} resource-type=${layout.resourceType} item-type=${item.type} :projectResolution=${projectResolution} :selectedElementMetrics=${selectedElementMetrics} :isInsideSaveLoadSlot=${isInsideSaveLoadSlot} :isInsideDirectedContainer=${isInsideDirectedContainer} :values=${item} :imagesData=${imagesData} :soundsData=${soundsData} :spritesheetsData=${spritesheetsData} :particlesData=${particlesData} :charactersData=${charactersData} :textStylesData=${textStylesData} :variablesData=${variablesData} :layoutsData=${layoutsData}: null
                           - 'rtgl-view w=f h=32vh style="flex-shrink: 0;"': null
-                $else:
-                  - 'rtgl-view h=1fg w=f sv style="min-height: 0;"':
-                      - $if showMobilePreviewHeader:
-                          - 'rtgl-view h=48 w=f d=h bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
-                              - rtgl-text w=1fg s=md ellipsis=true: ${previewTitle}
-                              - rtgl-button#saveButton ml=sm v=se: ${savePreviewButton}
-                      - $if isPreviewMounted:
-                          - rvn-layout-editor-preview#layoutEditorPreview :layoutState=${layoutState} :initialPreviewData=${initialPreviewData} :charactersData=${charactersData}: null
-                        $else:
-                          - rtgl-view wh=f av=c ah=c bgc=mu-fg:
-                              - rtgl-text s=sm c=mu-fg: ${loadingPreviewLabel}
-                      - 'rtgl-view w=f h=32vh style="flex-shrink: 0;"': null
       - $if showDetailPanel:
           - rvn-resizable-panel#resizableDetailPanel panel-type=detail-panel w=300 min-w=200 max-w=500 resize-side="left":
               - rtgl-view wh=f slot="content":

--- a/tests/layoutEditor/layoutEditor.store.test.js
+++ b/tests/layoutEditor/layoutEditor.store.test.js
@@ -9,6 +9,7 @@ import {
   setLayout,
   setSelectedItemId,
   setDetailPanelSelectedItemId,
+  setPreviewData,
   setUiConfig,
 } from "../../src/pages/layoutEditor/layoutEditor.store.js";
 
@@ -370,6 +371,14 @@ describe("layoutEditor.store", () => {
       },
     );
     setUiConfig({ state }, { uiConfig: { inputMode: "touch" } });
+    setPreviewData(
+      { state },
+      {
+        previewData: {
+          backgroundImageId: "unsaved-preview-image",
+        },
+      },
+    );
     setSelectedItemId({ state }, { itemId: "node-1" });
     setDetailPanelSelectedItemId({ state }, { itemId: "node-1" });
 
@@ -386,6 +395,11 @@ describe("layoutEditor.store", () => {
     expect(viewData.showMobileNodeButton).toBe(true);
     expect(viewData.showMobilePreviewButton).toBe(true);
     expect(viewData.showMobileSelectedNodeDetail).toBe(true);
+    expect(viewData.previewPanelVisibilityStyle).toBe("display: none;");
+    expect(viewData.previewHydrationData).toEqual({
+      backgroundImageId: "unsaved-preview-image",
+    });
+    expect(viewData.initialPreviewData).toEqual({});
     expect(viewData.nodeButtonLabel).toBe("Node");
     expect(viewData.previewTitle).toBe("Preview");
     expect(viewData.item.name).toBe("Node 1");
@@ -406,6 +420,8 @@ describe("layoutEditor.store", () => {
     expect(viewData.showMobilePreviewHeader).toBe(true);
     expect(viewData.showMobilePreviewButton).toBe(false);
     expect(viewData.showMobileSelectedNodeDetail).toBe(false);
+    expect(viewData.previewPanelVisibilityStyle).toBe("");
+    expect(viewData.previewHydrationData).toEqual(viewData.previewData);
     expect(viewData.previewTitle).toBe("Preview");
     expect(viewData.savePreviewButton).toBe("Save Preview");
   });

--- a/tests/layoutEditor/layoutEditor.view.test.js
+++ b/tests/layoutEditor/layoutEditor.view.test.js
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("layoutEditor.view", () => {
+  it("keeps the mobile preview mounted while node detail is visible", () => {
+    const layoutEditorView = readFileSync(
+      new URL(
+        "../../src/pages/layoutEditor/layoutEditor.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    const previewPanelStart = layoutEditorView.indexOf(
+      "previewPanelVisibilityStyle",
+    );
+    const mobileDetailStart = layoutEditorView.indexOf(
+      "$if showMobileSelectedNodeDetail",
+      previewPanelStart,
+    );
+    const detailPanelStart = layoutEditorView.indexOf(
+      "$if showDetailPanel",
+      mobileDetailStart,
+    );
+    const mobileCenterBranch = layoutEditorView.slice(
+      previewPanelStart,
+      detailPanelStart,
+    );
+    const previewToDetailBoundary = layoutEditorView.slice(
+      mobileDetailStart,
+      detailPanelStart,
+    );
+
+    expect(previewPanelStart).toBeLessThan(mobileDetailStart);
+    expect(previewToDetailBoundary).not.toContain(
+      "rvn-layout-editor-preview#layoutEditorPreview",
+    );
+    expect(mobileCenterBranch).toContain("previewPanelVisibilityStyle");
+    expect(mobileCenterBranch).toContain(
+      ":initialPreviewData=${previewHydrationData}",
+    );
+    expect(mobileCenterBranch).toContain(
+      "rvn-layout-editor-preview#layoutEditorPreview",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep the mobile layout preview mounted while node detail is shown
- hydrate the mobile preview from current unsaved preview data instead of persisted initial data
- add store and view coverage for the mobile preview/detail structure

## Validation
- bunx vitest run tests/layoutEditor/layoutEditor.store.test.js tests/layoutEditor/layoutEditor.view.test.js tests/layoutEditor/layoutEditor.handlers.test.js
- bunx prettier --check src/pages/layoutEditor/layoutEditor.store.js src/pages/layoutEditor/layoutEditor.view.yaml tests/layoutEditor/layoutEditor.store.test.js tests/layoutEditor/layoutEditor.view.test.js
- bun run android:install
- Android WebView validation: unsaved preview background image id survived Node -> select Start Button -> Preview, same preview instance stayed mounted, no runtime exceptions