### PR TITLE
Fix mobile appearance theme cards

### DIFF
--- a/src/pages/appearance/appearance.store.js
+++ b/src/pages/appearance/appearance.store.js
@@ -63,6 +63,10 @@ export const selectViewData = ({ state, i18n }) => {
     contentPadding: state.isTouchMode ? "0" : "lg",
     contentBodyPadding: state.isTouchMode ? "lg" : "0",
     contentBodyMarginTop: state.isTouchMode ? "0" : "lg",
+    themeGridColumns: state.isTouchMode
+      ? "2"
+      : "repeat(auto-fill, minmax(min(320px, 100%), 320px))",
+    themePreviewAspectRatio: "16 / 9",
     title: copy.title ?? "Appearance",
     themesTitle: copy.themesTitle ?? "Themes",
   };

--- a/src/pages/appearance/appearance.view.yaml
+++ b/src/pages/appearance/appearance.view.yaml
@@ -9,7 +9,7 @@ refs:
         handler: handleThemeCardClick
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
-      - 'rtgl-view d=h h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
           - $if showExplorerPanel:
               - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
                   - rtgl-view slot="content" w=f h=f:
@@ -25,13 +25,11 @@ template:
               - 'rtgl-view w=f h=1fg mt=${contentBodyMarginTop} p=${contentBodyPadding} sv style="min-width: 0; min-height: 0;"':
                   - rtgl-view g=sm:
                       - rtgl-text s=h4: ${themesTitle}
-                  - rtgl-view d=h g=lg wrap mt=lg:
+                  - 'rtgl-grid w=f mt=lg g=md cols="${themeGridColumns}" style="min-width: 0; align-content: start; align-items: start;"':
                       - $for item, i in themes:
-                          - 'rtgl-view#themeCard${i} data-theme=${item.id} d=v g=md w=320 sm-w=f p=md bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} bgc=bg br=md cur=pointer':
-                              - 'rtgl-view d=v g=sm w=f p=md br=md bw=xs style="background-color: ${item.previewPageBackground}; border-color: ${item.previewBorder}; min-height: 152px;"':
-                                  - 'rtgl-view h=88 w=f br=md style="background-color: ${item.previewPanelBackground};"': null
-                                  - rtgl-view d=h g=sm:
-                                      - 'rtgl-view w=1fg h=36 br=md style="background-color: ${item.previewCardBackground};"': null
-                                      - 'rtgl-view w=1fg h=36 br=md style="background-color: ${item.previewAccent}; opacity: 0.3;"': null
-                                      - 'rtgl-view w=1fg h=36 br=md style="background-color: ${item.previewAccent}; opacity: 0.65;"': null
-                              - rtgl-text s=xs c=mu-fg ellipsis=true w=f mt=auto: ${item.name}
+                          - 'rtgl-view#themeCard${i} data-theme=${item.id} d=v w=f bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} bgc=bg br=md cur=pointer overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
+                              - 'rtgl-view w=f p=xs style="background-color: ${item.previewPageBackground}; aspect-ratio: ${themePreviewAspectRatio}; border-bottom: 1px solid ${item.previewBorder}; box-sizing: border-box;"':
+                                  - 'rtgl-view w=f h=f p=xs br=sm style="background-color: ${item.previewPanelBackground}; box-sizing: border-box;"':
+                                      - 'rtgl-view w=f h=f br=sm style="background-color: ${item.previewCardBackground};"': null
+                              - rtgl-view w=f p=md:
+                                  - rtgl-text s=xs c=mu-fg ellipsis=true w=f: ${item.name}

--- a/tests/app/app.store.test.js
+++ b/tests/app/app.store.test.js
@@ -24,11 +24,13 @@ describe("app.store repository loading progress", () => {
     );
   });
 
-  it("does not resolve the hidden appearance route", () => {
+  it("resolves the appearance route", () => {
     const state = createInitialState();
     state.currentRoute = "/project/appearance";
 
-    expect(selectViewData({ state }).currentRoutePattern).toBeUndefined();
+    expect(selectViewData({ state }).currentRoutePattern).toBe(
+      "/project/appearance",
+    );
   });
 
   it("derives a percentage-based loading message and bar width", () => {

--- a/tests/appearance/appearance.store.test.js
+++ b/tests/appearance/appearance.store.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setUiConfig,
+} from "../../src/pages/appearance/appearance.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("appearance store", () => {
+  it("uses an images-style two-column touch grid", () => {
+    const state = createInitialState();
+
+    setUiConfig({ state }, { uiConfig: { id: "touch" } });
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(viewData.showExplorerPanel).toBe(false);
+    expect(viewData.contentPadding).toBe("0");
+    expect(viewData.contentBodyPadding).toBe("lg");
+    expect(viewData.contentBodyMarginTop).toBe("0");
+    expect(viewData.themeGridColumns).toBe("2");
+    expect(viewData.themePreviewAspectRatio).toBe("16 / 9");
+  });
+
+  it("keeps desktop cards in fixed-width autofill columns", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(viewData.showExplorerPanel).toBe(true);
+    expect(viewData.themeGridColumns).toBe(
+      "repeat(auto-fill, minmax(min(320px, 100%), 320px))",
+    );
+    expect(viewData.themePreviewAspectRatio).toBe("16 / 9");
+  });
+});

--- a/tests/appearance/appearance.view.test.js
+++ b/tests/appearance/appearance.view.test.js
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("appearance view", () => {
+  it("fills the mobile shell and uses an images-style theme grid", () => {
+    const appearanceView = readFileSync(
+      new URL(
+        "../../src/pages/appearance/appearance.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(appearanceView).toContain(
+      'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"',
+    );
+    expect(appearanceView).toContain(
+      'rtgl-grid w=f mt=lg g=md cols="${themeGridColumns}"',
+    );
+    expect(appearanceView).toContain(
+      "aspect-ratio: ${themePreviewAspectRatio};",
+    );
+    expect(appearanceView).toContain("w=f bw=xs");
+    expect(appearanceView).not.toContain("w=320 sm-w=f");
+    expect(appearanceView).not.toContain("min-height: 152px");
+  });
+});

--- a/tests/sidebar/resourceTypes.store.test.js
+++ b/tests/sidebar/resourceTypes.store.test.js
@@ -20,7 +20,7 @@ describe("resource type navigation", () => {
     expect(mobileViewData.items.map((item) => item.id)).toEqual(["controls"]);
   });
 
-  it("hides appearance from settings resource menus", () => {
+  it("shows appearance in settings resource menus", () => {
     const desktopViewData = selectDesktopResourceTypesViewData({
       props: {
         resourceCategory: "settings",
@@ -34,11 +34,14 @@ describe("resource type navigation", () => {
       },
     });
 
-    expect(desktopViewData.items.map((item) => item.id)).toEqual(["about"]);
+    expect(desktopViewData.items.map((item) => item.id)).toEqual([
+      "about",
+      "appearance",
+    ]);
     expect(
       mobileSidebarViewData.sections.flatMap((section) =>
         section.items.map((item) => item.id),
       ),
-    ).toEqual(["project", "about"]);
+    ).toEqual(["project", "about", "appearance"]);
   });
 });


### PR DESCRIPTION
## Summary
- make the Appearance page content fill the mobile viewport width
- render theme choices as a horizontal, image-style grid on touch devices
- adjust theme previews so the inner swatch fills evenly with consistent inset
- add focused store/view coverage for the Appearance page

## Verification
- bunx vitest run tests/appearance/appearance.view.test.js tests/appearance/appearance.store.test.js tests/app/app.store.test.js tests/sidebar/resourceTypes.store.test.js
- bun prettier --check src/pages/appearance/appearance.view.yaml src/pages/appearance/appearance.store.js tests/appearance/appearance.view.test.js tests/appearance/appearance.store.test.js tests/app/app.store.test.js tests/sidebar/resourceTypes.store.test.js
- bun run lint
- bun run android:install
- verified on attached Android device screenshot