### PR TITLE
Fix Linux package release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ bun run tauri:build:linux:rpm:docker
 bun run tauri:build:linux:aur:docker
 ```
 
+Before rebuilding RPM packages for the same app version, increment
+`bundle.linux.rpm.release` in `src-tauri/tauri.conf.json`. Reset it to `"1"`
+when the app version changes. Debian package filenames stay on the app version.
+See `docs/runbooks/linux-release.md`.
+
 The Docker-built packages and checksums are copied to
 `dist/linux-packages/ubuntu-22.04/x86_64/`,
 `dist/linux-packages/fedora-43/x86_64/`, and `dist/aur/x86_64/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@
 2. [macOS Signing And Notarization](./runbooks/macos-signing-and-notarization.md)
 3. [Project Database Audit](./runbooks/project-database-audit.md)
 4. [Steam Release](./runbooks/steam-release.md)
+5. [Linux Release](./runbooks/linux-release.md)
 
 ## Platform Spec
 

--- a/docs/runbooks/linux-release.md
+++ b/docs/runbooks/linux-release.md
@@ -1,0 +1,36 @@
+# Linux Release
+
+This runbook covers the direct-download Linux package release flow for RouteVN
+Creator.
+
+## Versioning
+
+- Keep the app version in `src-tauri/tauri.conf.json` and
+  `src-tauri/Cargo.toml` aligned.
+- Debian packages use the app version only. For example, app version `1.7.2`
+  should build `routevn-creator_1.7.2_amd64.deb`.
+- For RPM package rebuilds of the same app version, increment
+  `bundle.linux.rpm.release` in `src-tauri/tauri.conf.json` before building.
+  For example, the second RPM build for app version `1.7.2` should be
+  `routevn-creator-1.7.2-2.x86_64.rpm`.
+- Reset `bundle.linux.rpm.release` to `"1"` when the app version changes.
+- For AUR package rebuilds of the same app version, increment `pkgrel` in
+  `packaging/aur/PKGBUILD` and regenerate `packaging/aur/.SRCINFO`.
+- Do not change the app version only to represent an RPM or AUR package
+  release.
+
+## Build
+
+Build Linux x86_64 native packages in Docker:
+
+```shell
+bun run tauri:build:linux:deb:docker
+bun run tauri:build:linux:rpm:docker
+bun run tauri:build:linux:aur:docker
+```
+
+The Docker-built packages and checksums are copied to:
+
+- `dist/linux-packages/ubuntu-22.04/x86_64/`
+- `dist/linux-packages/fedora-43/x86_64/`
+- `dist/aur/x86_64/`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routevn-creator-client",
-  "description": "Free and Open Source tool to create Visual Novels without any coding. Live preview, asset manager, layout editor. Fast, intuitive, reliable. Follow us on social media to stay updated.",
+  "description": "RouteVN Creator. Follow us on social media to stay updated.",
   "homepage": "https://routevn.com",
   "keywords": [
     "game-engine",

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = routevn-creator
-	pkgdesc = Free and Open Source tool to create Visual Novels without any coding.
+	pkgdesc = RouteVN Creator
 	pkgver = 1.7.2
-	pkgrel = 2
+	pkgrel = 3
 	url = https://routevn.com
 	arch = x86_64
 	license = MIT

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=routevn-creator
 pkgver=1.7.2
-pkgrel=2
-pkgdesc="Free and Open Source tool to create Visual Novels without any coding."
+pkgrel=3
+pkgdesc="RouteVN Creator"
 arch=("x86_64")
 url="https://routevn.com"
 license=("MIT")

--- a/scripts/validate-linux-packaging.js
+++ b/scripts/validate-linux-packaging.js
@@ -16,7 +16,12 @@ const legacyPackageName = packageName.replace(
   ["route", "vn"].join("-"),
 );
 const forbiddenCopy = "Join our Discord server to stay updated.";
-const expectedCopy = "Follow us on social media to stay updated.";
+const expectedSocialCopy = "Follow us on social media to stay updated.";
+const stalePackageDescription = [
+  "create",
+  "visual novels",
+  "without any coding",
+].join(" ");
 
 const args = new Set(process.argv.slice(2));
 const failures = [];
@@ -55,6 +60,7 @@ function expect(condition, message) {
 
 function scanTextFile(relativePath) {
   const contents = readText(relativePath);
+  const lowerContents = contents.toLowerCase();
 
   expect(
     !contents.includes(legacyPackageName),
@@ -63,6 +69,10 @@ function scanTextFile(relativePath) {
   expect(
     !contents.includes(forbiddenCopy),
     `${relativePath} contains stale Discord update copy`,
+  );
+  expect(
+    !lowerContents.includes(stalePackageDescription),
+    `${relativePath} contains stale package description copy`,
   );
 }
 
@@ -98,6 +108,10 @@ function inspectBinary(filePath, { requirePackageName }) {
     !contents.includes(Buffer.from(forbiddenCopy)),
     `${path.relative(repoRoot, filePath)} contains stale Discord update copy`,
   );
+  expect(
+    !contents.toString("utf8").toLowerCase().includes(stalePackageDescription),
+    `${path.relative(repoRoot, filePath)} contains stale package description copy`,
+  );
   if (requirePackageName) {
     expect(
       contents.includes(Buffer.from(packageName)),
@@ -109,20 +123,19 @@ function inspectBinary(filePath, { requirePackageName }) {
 function inspectArtifact(kind, extension) {
   const tauriConfig = readJson("src-tauri/tauri.conf.json");
   const bundleDirectory = path.join(getTargetDir(), "release", "bundle", kind);
-  const artifactPrefix =
+  const packageRelease = tauriConfig.bundle?.linux?.rpm?.release ?? "1";
+  const expectedArtifactName =
     kind === "deb"
-      ? `${packageName}_${tauriConfig.version}`
-      : `${packageName}-${tauriConfig.version}`;
+      ? `${packageName}_${tauriConfig.version}_${debArchitecture}${extension}`
+      : `${packageName}-${tauriConfig.version}-${packageRelease}.${rpmArchitecture}${extension}`;
   const artifacts = collectFiles(
     bundleDirectory,
-    (filePath) =>
-      path.basename(filePath).startsWith(artifactPrefix) &&
-      filePath.endsWith(extension),
+    (filePath) => path.basename(filePath) === expectedArtifactName,
   );
 
   expect(
     artifacts.length > 0,
-    `No ${kind} artifact found for ${packageName} ${tauriConfig.version}`,
+    `No ${kind} artifact found for ${expectedArtifactName}`,
   );
 
   for (const artifact of artifacts) {
@@ -136,6 +149,10 @@ function inspectArtifact(kind, extension) {
       artifactName.endsWith(expectedArchitectureSuffix),
       `${artifactName} must include ${kind === "deb" ? debArchitecture : rpmArchitecture} architecture`,
     );
+    expect(
+      artifactName === expectedArtifactName,
+      `${artifactName} must be ${expectedArtifactName}`,
+    );
 
     inspectBinary(artifact, { requirePackageName: kind === "rpm" });
   }
@@ -144,6 +161,7 @@ function inspectArtifact(kind, extension) {
 const sourceFiles = [
   "package.json",
   "src-tauri/tauri.conf.json",
+  "src-tauri/Cargo.toml",
   "src-tauri/tauri.prod.conf.json",
   "src-tauri/tauri.linux.conf.json",
   "src-tauri/tauri.linux-packages.conf.json",
@@ -163,10 +181,13 @@ const linuxConfig = readJson("src-tauri/tauri.linux.conf.json");
 const metainfo = readText("src-tauri/assets/com.routevn.creator.metainfo.xml");
 const desktopTemplate = readText("src-tauri/assets/linux-desktop.desktop.hbs");
 const aurPkgbuild = readText("packaging/aur/PKGBUILD");
+const aurSrcinfo = readText("packaging/aur/.SRCINFO");
+const aurPkgrel = aurPkgbuild.match(/^pkgrel=(\d+)$/m)?.[1];
 
 expect(
-  packageJson.description.includes(expectedCopy),
-  "package.json description does not use social media update copy",
+  packageJson.description.startsWith(displayName) &&
+    packageJson.description.includes(expectedSocialCopy),
+  "package.json description must use social media update copy",
 );
 expect(
   tauriConfig.productName === displayName,
@@ -177,8 +198,9 @@ expect(
   `Tauri mainBinaryName must be ${packageName}`,
 );
 expect(
-  tauriConfig.bundle.longDescription.includes(expectedCopy),
-  "Tauri longDescription does not use social media update copy",
+  tauriConfig.bundle.longDescription.startsWith(displayName) &&
+    tauriConfig.bundle.longDescription.includes(expectedSocialCopy),
+  "Tauri longDescription must use social media update copy",
 );
 expect(
   tauriConfig.bundle.shortDescription === displayName,
@@ -207,8 +229,12 @@ expect(
   "AppStream binary must be routevn-creator",
 );
 expect(
-  metainfo.includes(expectedCopy),
-  "AppStream description does not use social media update copy",
+  metainfo.includes(`<p>${displayName}. ${expectedSocialCopy}</p>`),
+  "AppStream description must use social media update copy",
+);
+expect(
+  metainfo.includes(`<release version="${tauriConfig.version}"`),
+  `AppStream release version must be ${tauriConfig.version}`,
 );
 expect(
   desktopTemplate.includes(`Name=${displayName}`),
@@ -217,6 +243,19 @@ expect(
 expect(
   aurPkgbuild.includes("pkgname=routevn-creator"),
   "AUR pkgname must be routevn-creator",
+);
+expect(
+  aurPkgbuild.includes(`pkgdesc="${displayName}"`),
+  "AUR pkgdesc must use RouteVN Creator",
+);
+expect(Boolean(aurPkgrel), "AUR pkgrel must be set");
+expect(
+  aurSrcinfo.includes(`\tpkgrel = ${aurPkgrel}`),
+  "AUR .SRCINFO pkgrel must match PKGBUILD",
+);
+expect(
+  aurSrcinfo.includes(`\tpkgdesc = ${displayName}`),
+  "AUR .SRCINFO pkgdesc must use RouteVN Creator",
 );
 expect(
   aurPkgbuild.includes("Comment=RouteVN Creator"),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "routevn-creator"
 version = "1.7.2"
-description = "Free and Open Source tool to create Visual Novels without any coding."
+description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"
 repository = "https://github.com/RouteVN/routevn-creator-client"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -9,7 +9,7 @@
     <name>RouteVN Team</name>
   </developer>
   <description>
-    <p>Free and Open Source tool to create Visual Novels without any coding. Live preview, asset manager, layout editor. Fast, intuitive, reliable. Follow us on social media to stay updated.</p>
+    <p>RouteVN Creator. Follow us on social media to stay updated.</p>
   </description>
   <launchable type="desktop-id">routevn-creator.desktop</launchable>
   <icon type="stock">routevn-creator</icon>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -81,7 +81,7 @@
     "license": "MIT",
     "category": "GraphicsAndDesign",
     "shortDescription": "RouteVN Creator",
-    "longDescription": "Free and Open Source tool to create Visual Novels without any coding. Live preview, asset manager, layout editor. Fast, intuitive, reliable. Follow us on social media to stay updated.",
+    "longDescription": "RouteVN Creator. Follow us on social media to stay updated.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -107,6 +107,7 @@
         }
       },
       "rpm": {
+        "release": "2",
         "files": {
           "/usr/share/metainfo/com.routevn.creator.metainfo.xml": "assets/com.routevn.creator.metainfo.xml"
         }


### PR DESCRIPTION
## Summary
- simplify Linux package descriptions to RouteVN Creator metadata and social-media update copy
- keep Debian package versions on the app version while preserving RPM release-number validation
- bump AUR pkgrel for the metadata rebuild and validate .SRCINFO against PKGBUILD
- document the full Linux package release flow, including AUR Docker builds

## Validation
- makepkg --printsrcinfo
- node scripts/validate-linux-packaging.js
- git diff --check
- bun prettier --check docs/runbooks/linux-release.md scripts/validate-linux-packaging.js
- push hook: oxlint && bun prettier --check src