### PR TITLE
fix: add Projects appearance menu

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,7 @@ RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 RETTANGOLI_URL="https://cdn.jsdelivr.net/npm/@rettangoli/ui@${RETTANGOLI_VERSION}/dist/rettangoli-iife-ui.min.js"
 RETTANGOLI_DIR="static/public/@rettangoli/ui@${RETTANGOLI_VERSION}/dist"
 RETTANGOLI_FILE="${RETTANGOLI_DIR}/rettangoli-iife-ui.min.js"
+LOCAL_RETTANGOLI_PACKAGE="node_modules/@rettangoli/ui/package.json"
 LOCAL_RETTANGOLI_FILE="node_modules/@rettangoli/ui/dist/rettangoli-iife-ui.min.js"
 LOCK_FILE="/tmp/routevn-creator-client-build.lock"
 RTGL_BIN="node_modules/.bin/rtgl"
@@ -53,6 +54,14 @@ if [ ! -f "${RETTANGOLI_FILE}" ]; then
   mkdir -p "${RETTANGOLI_DIR}"
 
   if [ -f "${LOCAL_RETTANGOLI_FILE}" ]; then
+    LOCAL_RETTANGOLI_VERSION=$(node -p "require('./${LOCAL_RETTANGOLI_PACKAGE}').version" 2>/dev/null || true)
+    if [ "${LOCAL_RETTANGOLI_VERSION}" != "${RETTANGOLI_VERSION}" ]; then
+      echo "Error: node_modules has Rettangoli UI v${LOCAL_RETTANGOLI_VERSION:-unknown}, expected v${RETTANGOLI_VERSION}."
+      echo "Run bun install before building so the local Rettangoli UI bundle matches package.json."
+      exit 1
+    fi
+
+    echo "Verified Rettangoli UI v${LOCAL_RETTANGOLI_VERSION} in node_modules."
     echo "Copying Rettangoli UI v${RETTANGOLI_VERSION} from node_modules..."
     cp "${LOCAL_RETTANGOLI_FILE}" "${RETTANGOLI_FILE}"
   # Download with curl or wget when local package asset is not available

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -153,8 +153,11 @@ export const handleAfterMount = async (deps) => {
 };
 
 export const handleBeforeMount = (deps) => {
-  const { store, uiConfig } = deps;
+  const { appService, store, uiConfig } = deps;
   store.setUiConfig({ uiConfig });
+  store.setCurrentTheme({
+    theme: appService.getTheme(),
+  });
 };
 
 const getProjectIdFromEvent = (event) => {
@@ -508,26 +511,32 @@ export const handleMobileActionMenuClickItem = async (deps, payload) => {
 export const handleAppVersionClick = (deps, payload) => {
   const { appService, store, render, i18n } = deps;
   const copy = selectProjectsPageCopy(i18n);
-  if (appService.getPlatform() === "web" || !resolveUpdatesEnabled(deps)) {
-    return;
+  const rect = payload._event.currentTarget.getBoundingClientRect();
+  const items = [];
+
+  if (appService.getPlatform() !== "web" && resolveUpdatesEnabled(deps)) {
+    items.push({
+      label: copy.checkUpdateMenuItem,
+      type: "item",
+      value: "check-update",
+    });
   }
 
-  const rect = payload._event.currentTarget.getBoundingClientRect();
+  items.push({
+    label: copy.languageMenuItem,
+    type: "item",
+    value: "language",
+  });
+  items.push({
+    label: copy.appearanceMenuItem,
+    type: "item",
+    value: "appearance",
+  });
+
   const menuPayload = {
     x: rect.left + rect.width / 2,
     y: rect.top,
-    items: [
-      {
-        label: copy.checkUpdateMenuItem,
-        type: "item",
-        value: "check-update",
-      },
-      {
-        label: copy.languageMenuItem,
-        type: "item",
-        value: "language",
-      },
-    ],
+    items,
   };
 
   store.openAppVersionMenu(menuPayload);
@@ -553,6 +562,14 @@ export const handleAppVersionMenuClickItem = async (deps, payload) => {
   if (item.value === "language") {
     store.openLanguageDialog({
       locale: resolveProjectsLocale({ appService, localeService: locale }),
+    });
+    render();
+    return;
+  }
+
+  if (item.value === "appearance") {
+    store.openAppearanceDialog({
+      theme: appService.getTheme(),
     });
     render();
     return;
@@ -608,6 +625,41 @@ export const handleLanguageFormAction = async (deps, payload) => {
     render();
   } catch {
     appService.showAlert({ message: copy.failedChangeLanguage });
+  }
+};
+
+export const handleAppearanceDialogClose = (deps) => {
+  const { store, render } = deps;
+  if (!store.selectIsAppearanceDialogOpen()) {
+    return;
+  }
+  store.closeAppearanceDialog();
+  render();
+};
+
+export const handleAppearanceFormAction = (deps, payload) => {
+  const { appService, store, render, i18n } = deps;
+  const copy = selectProjectsPageCopy(i18n);
+  const detail = payload?._event?.detail || {};
+  const actionId = detail.actionId;
+
+  if (actionId === "cancel") {
+    store.closeAppearanceDialog();
+    render();
+    return;
+  }
+
+  if (actionId !== "save-appearance") {
+    return;
+  }
+
+  try {
+    const nextTheme = appService.setTheme(detail?.values?.theme);
+    store.setCurrentTheme({ theme: nextTheme });
+    store.closeAppearanceDialog();
+    render();
+  } catch {
+    appService.showAlert({ message: copy.failedChangeAppearance });
   }
 };
 

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -1,3 +1,4 @@
+import { normalizeTheme } from "../../internal/theme.js";
 import {
   formatProjectsPageCopy,
   selectProjectsPageCopy,
@@ -23,6 +24,7 @@ export const createInitialState = () => ({
   platform: "tauri",
   appVersion: "",
   currentLocale: "en",
+  currentTheme: "dark",
 
   profileMenu: {
     isOpen: false,
@@ -50,6 +52,14 @@ export const createInitialState = () => ({
     formKey: 0,
     defaultValues: {
       locale: "en",
+    },
+  },
+
+  appearanceDialog: {
+    isOpen: false,
+    formKey: 0,
+    defaultValues: {
+      theme: "dark",
     },
   },
 
@@ -162,6 +172,10 @@ export const setCurrentLocale = ({ state }, { locale } = {}) => {
   state.currentLocale = locale ?? "en";
 };
 
+export const setCurrentTheme = ({ state }, { theme } = {}) => {
+  state.currentTheme = normalizeTheme(theme);
+};
+
 export const setAuthUser = ({ state }, { user } = {}) => {
   const name = user?.name?.trim?.() || "";
   const email = user?.email?.trim?.() || "";
@@ -242,14 +256,6 @@ export const selectIsMobileActionMenuOpen = ({ state }) => {
 };
 
 export const openAppVersionMenu = ({ state }, { x, y, items } = {}) => {
-  if (state.platform === "web") {
-    state.appVersionMenu.isOpen = false;
-    state.appVersionMenu.x = 0;
-    state.appVersionMenu.y = 0;
-    state.appVersionMenu.items = [];
-    return;
-  }
-
   state.appVersionMenu.isOpen = true;
   state.appVersionMenu.x = x;
   state.appVersionMenu.y = y;
@@ -281,6 +287,22 @@ export const closeLanguageDialog = ({ state }, _payload = {}) => {
 
 export const selectIsLanguageDialogOpen = ({ state }) => {
   return Boolean(state.languageDialog?.isOpen);
+};
+
+export const openAppearanceDialog = ({ state }, { theme } = {}) => {
+  state.appearanceDialog.isOpen = true;
+  state.appearanceDialog.formKey += 1;
+  state.appearanceDialog.defaultValues = {
+    theme: normalizeTheme(theme ?? state.currentTheme),
+  };
+};
+
+export const closeAppearanceDialog = ({ state }, _payload = {}) => {
+  state.appearanceDialog.isOpen = false;
+};
+
+export const selectIsAppearanceDialogOpen = ({ state }) => {
+  return Boolean(state.appearanceDialog?.isOpen);
 };
 
 export const selectIsProfileDialogOpen = ({ state }) => {
@@ -637,6 +659,43 @@ export const selectViewData = ({ state, i18n }) => {
       ],
     },
   };
+  const appearanceForm = {
+    title: copy.appearanceTitle,
+    fields: [
+      {
+        name: "theme",
+        type: "select",
+        label: copy.themeLabel,
+        required: true,
+        options: [
+          {
+            value: "dark",
+            label: copy.darkThemeName,
+          },
+          {
+            value: "light",
+            label: copy.lightThemeName,
+          },
+        ],
+      },
+    ],
+    actions: {
+      buttons: [
+        {
+          id: "cancel",
+          variant: "se",
+          label: copy.cancelButton,
+        },
+        {
+          id: "save-appearance",
+          variant: "pr",
+          label: copy.saveButton,
+          type: "submit",
+          validate: true,
+        },
+      ],
+    },
+  };
 
   const localProjects = Array.isArray(state.projects) ? state.projects : [];
   const cloudProjects = Array.isArray(state.cloudProjects)
@@ -683,6 +742,7 @@ export const selectViewData = ({ state, i18n }) => {
     cloudCreateForm,
     addMemberForm,
     languageForm,
+    appearanceForm,
     profileDialogForm,
     settingsDialogForm,
   };

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -37,6 +37,14 @@ refs:
     eventListeners:
       form-action:
         handler: handleLanguageFormAction
+  appearanceDialog:
+    eventListeners:
+      close:
+        handler: handleAppearanceDialogClose
+  appearanceForm:
+    eventListeners:
+      form-action:
+        handler: handleAppearanceFormAction
   cloudCreateButton:
     eventListeners:
       click:
@@ -241,6 +249,9 @@ template:
   - rtgl-dialog#languageDialog ?open=${languageDialog.isOpen} s=sm:
       - rtgl-view slot=content w=f p=lg:
           - rtgl-form#languageForm key=${languageDialog.formKey} :form=${languageForm} :defaultValues=${languageDialog.defaultValues} w=f: null
+  - rtgl-dialog#appearanceDialog ?open=${appearanceDialog.isOpen} s=sm:
+      - rtgl-view slot=content w=f p=lg:
+          - rtgl-form#appearanceForm key=${appearanceDialog.formKey} :form=${appearanceForm} :defaultValues=${appearanceDialog.defaultValues} w=f: null
   - rtgl-dialog#editProfileDialog ?open=${profileDialog.isOpen} s=f:
       - rtgl-view slot=content w=f h=f p=xl:
           - rtgl-view w=f h=f ah=c av=s:

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -5,6 +5,8 @@ import {
   handleAppVersionClick,
   handleAppVersionMenuClickItem,
   handleAppVersionMenuClose,
+  handleAppearanceDialogClose,
+  handleAppearanceFormAction,
   handleCreateButtonClick,
   handleCreateDialogSubmit,
   handleDeleteDialogConfirm,
@@ -37,6 +39,8 @@ const createDeps = ({
     setCurrentProjectEntry: vi.fn(),
     getUserConfig: vi.fn(),
     setUserConfig: vi.fn(),
+    getTheme: vi.fn(() => "dark"),
+    setTheme: vi.fn((theme) => theme),
     navigate: vi.fn(),
   };
 
@@ -71,6 +75,10 @@ const createDeps = ({
       closeLanguageDialog: vi.fn(),
       selectIsLanguageDialogOpen: vi.fn(() => true),
       setCurrentLocale: vi.fn(),
+      openAppearanceDialog: vi.fn(),
+      closeAppearanceDialog: vi.fn(),
+      selectIsAppearanceDialogOpen: vi.fn(() => true),
+      setCurrentTheme: vi.fn(),
       openCreateDialog: vi.fn(),
       closeCreateDialog: vi.fn(),
       selectIsCreateDialogOpen: vi.fn(() => true),
@@ -378,12 +386,17 @@ describe("projects app version menu", () => {
           type: "item",
           value: "language",
         },
+        {
+          label: EN_I18N.projectsPage.appearanceMenuItem,
+          type: "item",
+          value: "appearance",
+        },
       ],
     });
     expect(deps.render).toHaveBeenCalledTimes(1);
   });
 
-  it("does not open the app version dropdown on web", () => {
+  it("opens the app version dropdown on web without the update item", () => {
     const deps = createDeps({ platform: "web" });
 
     handleAppVersionClick(deps, {
@@ -398,11 +411,26 @@ describe("projects app version menu", () => {
       },
     });
 
-    expect(deps.store.openAppVersionMenu).not.toHaveBeenCalled();
-    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.store.openAppVersionMenu).toHaveBeenCalledWith({
+      x: 140,
+      y: 700,
+      items: [
+        {
+          label: EN_I18N.projectsPage.languageMenuItem,
+          type: "item",
+          value: "language",
+        },
+        {
+          label: EN_I18N.projectsPage.appearanceMenuItem,
+          type: "item",
+          value: "appearance",
+        },
+      ],
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
   });
 
-  it("does not open the app version dropdown when updates are disabled", () => {
+  it("opens the app version dropdown without the update item when updates are disabled", () => {
     const deps = createDeps();
     deps.updatesEnabled = false;
 
@@ -418,8 +446,23 @@ describe("projects app version menu", () => {
       },
     });
 
-    expect(deps.store.openAppVersionMenu).not.toHaveBeenCalled();
-    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.store.openAppVersionMenu).toHaveBeenCalledWith({
+      x: 140,
+      y: 700,
+      items: [
+        {
+          label: EN_I18N.projectsPage.languageMenuItem,
+          type: "item",
+          value: "language",
+        },
+        {
+          label: EN_I18N.projectsPage.appearanceMenuItem,
+          type: "item",
+          value: "appearance",
+        },
+      ],
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
   });
 
   it("closes the app version dropdown", () => {
@@ -446,7 +489,9 @@ describe("projects app version menu", () => {
 
     expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
     expect(deps.render).toHaveBeenCalledTimes(1);
-    expect(deps.updaterService.checkForUpdates).toHaveBeenCalledWith(false);
+    expect(deps.updaterService.checkForUpdates).toHaveBeenCalledWith(false, {
+      copy: EN_I18N.appPage,
+    });
   });
 
   it("opens the language dialog from the app version dropdown", async () => {
@@ -469,6 +514,60 @@ describe("projects app version menu", () => {
     });
     expect(deps.render).toHaveBeenCalledTimes(1);
     expect(deps.updaterService.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it("opens the appearance dialog from the app version dropdown", async () => {
+    const deps = createDeps();
+    deps.appService.getTheme.mockReturnValue("light");
+
+    await handleAppVersionMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "appearance",
+          },
+        },
+      },
+    });
+
+    expect(deps.store.closeAppVersionMenu).toHaveBeenCalledTimes(1);
+    expect(deps.store.openAppearanceDialog).toHaveBeenCalledWith({
+      theme: "light",
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.updaterService.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it("closes the appearance dialog", () => {
+    const deps = createDeps();
+
+    handleAppearanceDialogClose(deps);
+
+    expect(deps.store.closeAppearanceDialog).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves the selected appearance theme", () => {
+    const deps = createDeps();
+    deps.appService.setTheme.mockReturnValue("light");
+
+    handleAppearanceFormAction(deps, {
+      _event: {
+        detail: {
+          actionId: "save-appearance",
+          values: {
+            theme: "light",
+          },
+        },
+      },
+    });
+
+    expect(deps.appService.setTheme).toHaveBeenCalledWith("light");
+    expect(deps.store.setCurrentTheme).toHaveBeenCalledWith({
+      theme: "light",
+    });
+    expect(deps.store.closeAppearanceDialog).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
   });
 
   it("closes the language dialog", () => {


### PR DESCRIPTION
## Summary
- add Appearance to the Projects footer menu alongside Language
- wire the Projects appearance dialog to the current app theme and save through appService
- guard the build script against copying a mismatched local Rettangoli UI bundle

## Testing
- bunx vitest run tests/projects/projects.handlers.test.js tests/projects/projects.view.test.js
- git diff --check
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src