### PR TITLE
Use manual download URL for Linux updates

### DIFF
--- a/src-tauri/src/updater_manifest.rs
+++ b/src-tauri/src/updater_manifest.rs
@@ -14,6 +14,8 @@ struct UpdateManifest {
     date: Option<String>,
     notes: Option<String>,
     body: Option<String>,
+    #[serde(rename = "manualDownloadUrl")]
+    manual_download_url: Option<String>,
     platforms: Option<serde_json::Value>,
 }
 
@@ -23,6 +25,7 @@ pub struct ManualUpdateManifest {
     version: String,
     date: Option<String>,
     body: Option<String>,
+    manual_download_url: Option<String>,
     platforms: Option<serde_json::Value>,
 }
 
@@ -77,6 +80,7 @@ pub async fn fetch_manual_update_manifest(
         version,
         date: manifest.pub_date.or(manifest.date),
         body: manifest.notes.or(manifest.body),
+        manual_download_url: manifest.manual_download_url,
         platforms: manifest.platforms,
     })
 }

--- a/src/deps/clients/tauri/updater.js
+++ b/src/deps/clients/tauri/updater.js
@@ -2,9 +2,6 @@ import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 
 const LINUX_DOWNLOAD_URL = "https://routevn.com/en/creator/download/";
-const LINUX_UPDATE_TARGET = "linux";
-const LINUX_UPDATE_ARCH = "x86_64";
-const LINUX_UPDATE_PLATFORM = `${LINUX_UPDATE_TARGET}-${LINUX_UPDATE_ARCH}`;
 
 const isMacOs = () => {
   if (typeof navigator === "undefined") {
@@ -83,10 +80,6 @@ const isNewerVersion = (version, currentVersion) => {
   return false;
 };
 
-const hasManualLinuxUpdatePlatform = (manifest = {}) => {
-  return Boolean(manifest.platforms?.[LINUX_UPDATE_PLATFORM]);
-};
-
 const createUpdater = ({
   globalUI,
   keyValueStore,
@@ -153,7 +146,7 @@ const createUpdater = ({
 
         if (shouldUpdate) {
           if (linux) {
-            await openLinuxDownloadPage(copy);
+            await openLinuxDownloadPage(copy, update.manualDownloadUrl);
           } else {
             await downloadAndInstall(update, copy);
           }
@@ -189,9 +182,6 @@ const createUpdater = ({
     const manifest = await fetchManualUpdateManifest(
       normalizeVersion(appVersion),
     );
-    if (!hasManualLinuxUpdatePlatform(manifest)) {
-      return null;
-    }
 
     const version = normalizeVersion(manifest?.version);
     if (!isNewerVersion(version, appVersion)) {
@@ -202,12 +192,13 @@ const createUpdater = ({
       version,
       date: manifest?.pub_date ?? manifest?.date,
       body: manifest?.notes ?? manifest?.body,
+      manualDownloadUrl: manifest?.manualDownloadUrl ?? LINUX_DOWNLOAD_URL,
     };
   };
 
-  const openLinuxDownloadPage = async (copy = {}) => {
+  const openLinuxDownloadPage = async (copy = {}, url = LINUX_DOWNLOAD_URL) => {
     try {
-      await openUrl(LINUX_DOWNLOAD_URL);
+      await openUrl(url);
     } catch (error) {
       console.error("Failed to open manual download page:", error);
       if (globalUI) {

--- a/tests/appService/tauriUpdater.test.js
+++ b/tests/appService/tauriUpdater.test.js
@@ -14,6 +14,7 @@ vi.mock("@tauri-apps/plugin-process", () => ({
 import createUpdater from "../../src/deps/clients/tauri/updater.js";
 
 const DOWNLOAD_PAGE_URL = "https://routevn.com/en/creator/download/";
+const CUSTOM_DOWNLOAD_PAGE_URL = `${DOWNLOAD_PAGE_URL}?from=updater`;
 
 const createGlobalUI = () => ({
   showAlert: vi.fn(() => Promise.resolve()),
@@ -26,11 +27,7 @@ const createUpdaterClient = ({
     version: "1.7.3",
     date: "2026-07-03",
     body: "Fix packaging.",
-    platforms: {
-      "linux-x86_64": {
-        url: "https://routevn.com/en/creator/download/",
-      },
-    },
+    manualDownloadUrl: CUSTOM_DOWNLOAD_PAGE_URL,
   },
   openUrl,
 } = {}) => {
@@ -99,11 +96,11 @@ describe("tauri updater", () => {
       confirmText: "Open Download Page",
       cancelText: "Later",
     });
-    expect(openUrl).toHaveBeenCalledWith(DOWNLOAD_PAGE_URL);
+    expect(openUrl).toHaveBeenCalledWith(CUSTOM_DOWNLOAD_PAGE_URL);
     expect(relaunchMock).not.toHaveBeenCalled();
   });
 
-  it("does not prompt on Linux when the manifest has no x86_64 platform", async () => {
+  it("does not prompt on Linux when the manifest version is not newer", async () => {
     vi.stubGlobal("navigator", {
       platform: "Linux x86_64",
       userAgent: "RouteVN Creator Linux",
@@ -114,14 +111,10 @@ describe("tauri updater", () => {
     const { fetchManualUpdateManifest, updater } = createUpdaterClient({
       globalUI,
       manifest: {
-        version: "1.7.3",
+        version: "1.7.2",
         date: "2026-07-03",
         body: "Fix packaging.",
-        platforms: {
-          "windows-x86_64": {
-            url: "https://static-1.routevn.com/windows.msi",
-          },
-        },
+        manualDownloadUrl: CUSTOM_DOWNLOAD_PAGE_URL,
       },
       openUrl,
     });


### PR DESCRIPTION
## Summary
- make Linux update checks depend only on the top-level manifest version
- read top-level manualDownloadUrl from the update manifest and open it for Linux updates
- remove the fake linux-x86_64 platform requirement from Linux manual update tests

## Validation
- bunx vitest run tests/appService/tauriUpdater.test.js
- bun prettier --check src/deps/clients/tauri/updater.js tests/appService/tauriUpdater.test.js
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- git diff --check
- push hook: oxlint && bun prettier --check src