### PR TITLE
Align mobile file explorer close buttons

### DIFF
--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -182,8 +182,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -296,8 +296,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -204,8 +204,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -153,8 +153,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -187,8 +187,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -154,8 +154,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -253,8 +253,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag bottom-empty-space-height=80vh start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -111,7 +111,6 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${nodeExplorerTitle}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag bottom-empty-space-height=80vh :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -157,8 +157,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -185,8 +185,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -627,6 +627,7 @@ export const selectViewData = ({ state, i18n }) => {
       state.isTouchMode && state.isTouchMinimapReady,
     whiteboardMinimapPlacement: state.isTouchMode ? "top-left" : "bottom-left",
     whiteboardMinimapHeightScale: state.isTouchMode ? 2 / 3 : 1,
+    filesLabel: copy.filesLabel ?? "Files",
     title: copy.title ?? "Scenes",
     previewButton: copy.previewMenuItem ?? "Preview",
     sectionsLabel: copy.sectionsLabel ?? "Sections",

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -165,14 +165,13 @@ template:
       - rtgl-tooltip ?open=${deadEndTooltip.open} x=${deadEndTooltip.x} y=${deadEndTooltip.y} place="t" content="${deadEndTooltip.content}": null
       - $if showMobileScenesControls:
           - 'rtgl-view pos=abs z=200 style="right: 8px; top: 8px;"':
-              - rtgl-view#mobileFileExplorerOpenButton w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo title="${title}":
-                  - rtgl-svg svg=hamburger wh=20 c=mu-fg: null
+              - rtgl-view#mobileFileExplorerOpenButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo title="${title}":
+                  - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
       - $if showMobileFileExplorer:
           - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
               - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
-                  - rtgl-text w=1fg s=md: ${title}
-                  - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=x wh=20 c=mu-fg: null
+                  - rtgl-text w=1fg s=md: ${filesLabel}
+                  - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
               - 'rtgl-view w=f h=1fg style="min-height: 0;"':
                   - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
       - $if showMapAddHint:

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -184,8 +184,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -180,8 +180,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -177,8 +177,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -216,8 +216,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -115,8 +115,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -174,8 +174,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=x wh=20 c=mu-fg: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/tests/characters/characters.view.test.js
+++ b/tests/characters/characters.view.test.js
@@ -27,7 +27,7 @@ describe("characters view", () => {
       "rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",
     );
     expect(mobileExplorerBranch).toContain(
-      "rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo",
+      "rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36",
     );
     expect(mobileExplorerBranch).not.toContain("rtgl-view h=56 w=f d=h");
   });

--- a/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
+++ b/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
@@ -2,13 +2,21 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const mobileFileExplorerPages = [
-  ["animations", "animations/animations.view.yaml", "$if showMobileFileExplorer"],
+  [
+    "animations",
+    "animations/animations.view.yaml",
+    "$if showMobileFileExplorer",
+  ],
   [
     "character sprites",
     "characterSprites/characterSprites.view.yaml",
     "$if showMobileFileExplorer",
   ],
-  ["characters", "characters/characters.view.yaml", "$if showMobileFileExplorer"],
+  [
+    "characters",
+    "characters/characters.view.yaml",
+    "$if showMobileFileExplorer",
+  ],
   ["colors", "colors/colors.view.yaml", "$if showMobileFileExplorer"],
   ["controls", "controls/controls.view.yaml", "$if showMobileFileExplorer"],
   ["fonts", "fonts/fonts.view.yaml", "$if showMobileFileExplorer"],
@@ -21,9 +29,21 @@ const mobileFileExplorerPages = [
   ["layouts", "layouts/layouts.view.yaml", "$if showMobileFileExplorer"],
   ["particles", "particles/particles.view.yaml", "$if showMobileFileExplorer"],
   ["sounds", "sounds/sounds.view.yaml", "$if showMobileFileExplorer"],
-  ["spritesheets", "spritesheets/spritesheets.view.yaml", "$if showMobileFileExplorer"],
-  ["text styles", "textStyles/textStyles.view.yaml", "$if showMobileFileExplorer"],
-  ["transforms", "transforms/transforms.view.yaml", "$if showMobileFileExplorer"],
+  [
+    "spritesheets",
+    "spritesheets/spritesheets.view.yaml",
+    "$if showMobileFileExplorer",
+  ],
+  [
+    "text styles",
+    "textStyles/textStyles.view.yaml",
+    "$if showMobileFileExplorer",
+  ],
+  [
+    "transforms",
+    "transforms/transforms.view.yaml",
+    "$if showMobileFileExplorer",
+  ],
   ["variables", "variables/variables.view.yaml", "$if showMobileFileExplorer"],
   ["videos", "videos/videos.view.yaml", "$if showMobileFileExplorer"],
 ];
@@ -42,7 +62,7 @@ describe("mobile file explorer navbar", () => {
         "rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",
       );
       expect(view).toContain(
-        "rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo",
+        "rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36",
       );
       expect(view).not.toContain(
         "rtgl-view h=56 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -10,13 +10,12 @@ describe("scenes view", () => {
 
     expect(scenesView).toContain('style="right: 8px; top: 8px;"');
     expect(scenesView).toContain(
-      'rtgl-view#mobileFileExplorerOpenButton w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo title="${title}"',
+      'rtgl-view#mobileFileExplorerOpenButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo title="${title}"',
     );
-    expect(scenesView).toContain("rtgl-svg svg=hamburger wh=20 c=mu-fg");
+    expect(scenesView).toContain("rtgl-svg svg=hamburger wh=16 c=mu-fg");
     expect(scenesView).toContain(
-      "rtgl-view#mobileFileExplorerClose w=40 h=40 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo",
+      "rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36",
     );
-    expect(scenesView).toContain("rtgl-svg svg=x wh=20 c=mu-fg");
     expect(scenesView).not.toContain("env(safe-area-inset-top)");
   });
 


### PR DESCRIPTION
## Summary
- replace mobile file explorer close controls with square `rtgl-button` controls using `pre=x` and `v=ol`
- keep close controls at the same 36px square shell as the Images hamburger/menu control
- align the Scenes mobile opener and file explorer navbar label with Images
- update navbar view tests to cover the new shared close-button pattern

## Verification
- `bunx vitest run tests/images/images.view.test.js tests/scenes/scenes.view.test.js tests/resourcePages/mobileFileExplorerNavbar.view.test.js tests/characters/characters.view.test.js tests/scenes/scenes.store.test.js`
- `bun run lint`
- `bun run build:android && cd android/routevn && ./gradlew assembleDebug`

Note: attempted final Vivo install after packaging, but ADB reported no connected device.
