### PR TITLE
Add Android dev server workflow and navbar button styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ Open: http://localhost:3001/project
 - `bun run build` or `bun run build:web` - Build for web platform
 - `bun run watch:web` - Watch mode for web development
 
+### Android Application
+
+Install the debug shell once after native Android changes:
+
+```shell
+bun run android:install
+```
+
+Start the Android JS dev server:
+
+```shell
+bun run watch:android
+```
+
+The debug app loads `http://127.0.0.1:3001/android/index.html`. The watch
+script prepares `_site`, configures `adb reverse tcp:3001 tcp:3001` when a
+device is connected, and serves `src/setup.android.js` so frontend changes can
+be refreshed without reinstalling the APK.
+
 ### Desktop Application (Tauri)
 
 RouteVN Creator also supports running as a native desktop application using [Tauri](https://tauri.app/), providing better performance and system integration.

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -64,6 +64,10 @@ public class MainActivity extends Activity {
     private static final String TAG = "RouteVNAndroid";
     private static final String APP_ASSET_HOST = "appassets.androidplatform.net";
     private static final String APP_URL = "https://" + APP_ASSET_HOST + "/web/index.html";
+    private static final String DEV_SERVER_HOST = "127.0.0.1";
+    private static final int DEV_SERVER_PORT = 3001;
+    private static final String DEV_SERVER_URL =
+        "http://" + DEV_SERVER_HOST + ":" + DEV_SERVER_PORT + "/android/index.html";
     private static final int FILE_CHOOSER_REQUEST_CODE = 3711;
     private static final int ANDROID_FILE_PICKER_REQUEST_CODE = 3712;
     private static final int ANDROID_SAVE_FILE_PICKER_REQUEST_CODE = 3713;
@@ -324,7 +328,7 @@ public class MainActivity extends Activity {
 
         webView.setWebViewClient(new RouteVNWebViewClient());
         webView.setWebChromeClient(new RouteVNWebChromeClient());
-        webView.loadUrl(APP_URL);
+        webView.loadUrl(getInitialAppUrl());
 
         FrameLayout rootView = new FrameLayout(this);
         rootView.setBackgroundColor(Color.BLACK);
@@ -420,11 +424,30 @@ public class MainActivity extends Activity {
         cookieManager.setAcceptThirdPartyCookies(webView, true);
     }
 
+    private String getInitialAppUrl() {
+        if (BuildConfig.DEBUG) {
+            Log.i(TAG, "Loading Android dev server URL: " + DEV_SERVER_URL);
+            return DEV_SERVER_URL;
+        }
+
+        return APP_URL;
+    }
+
     private boolean isAppAssetUrl(Uri uri) {
         return (
             uri != null &&
             "https".equals(uri.getScheme()) &&
             APP_ASSET_HOST.equals(uri.getHost())
+        );
+    }
+
+    private boolean isDebugDevServerUrl(Uri uri) {
+        return (
+            BuildConfig.DEBUG &&
+            uri != null &&
+            "http".equals(uri.getScheme()) &&
+            DEV_SERVER_HOST.equals(uri.getHost()) &&
+            uri.getPort() == DEV_SERVER_PORT
         );
     }
 
@@ -535,7 +558,7 @@ public class MainActivity extends Activity {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
             Uri uri = request.getUrl();
-            if (isAppAssetUrl(uri)) {
+            if (isAppAssetUrl(uri) || isDebugDevServerUrl(uri)) {
                 return false;
             }
 
@@ -546,7 +569,7 @@ public class MainActivity extends Activity {
         @SuppressWarnings("deprecation")
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
             Uri uri = Uri.parse(url);
-            if (isAppAssetUrl(uri)) {
+            if (isAppAssetUrl(uri) || isDebugDevServerUrl(uri)) {
                 return false;
             }
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -76,7 +76,7 @@ the project service's local command session and native SQLite-backed storage.
 - `android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java`:
   native WebView shell and JavaScript bridge.
 
-The WebView loads packaged assets through `WebViewAssetLoader` at:
+Release builds load packaged assets through `WebViewAssetLoader` at:
 
 ```text
 https://appassets.androidplatform.net/web/index.html
@@ -86,13 +86,52 @@ This gives the local bundle an HTTPS origin while serving packaged app files.
 
 ## Build And Install
 
+### Android JS Watch Mode
+
+Debug Android builds load the local Android dev server instead of packaged
+assets:
+
+```text
+http://127.0.0.1:3001/android/index.html
+```
+
+Install the debug app once after native Android changes:
+
+```bash
+bun run android:install
+```
+
+Then run the Android frontend watch server:
+
+```bash
+bun run watch:android
+```
+
+`watch:android` prepares `_site`, runs `adb reverse tcp:3001 tcp:3001` when a
+device is connected, and starts `rtgl fe watch` with `src/setup.android.js`.
+After that, JS, YAML view, store, handler, i18n, and setup changes are served
+from the dev server. Refresh or relaunch the app without reinstalling the APK.
+
+If multiple Android devices are connected, set `ANDROID_SERIAL` before running
+the watch command:
+
+```bash
+ANDROID_SERIAL=<device-serial> bun run watch:android
+```
+
+Release builds still load packaged assets through `WebViewAssetLoader`. Debug
+builds are dev-server shells by default.
+
+### Native Shell And Packaged Assets
+
 Build Android web assets:
 
 ```bash
 bun run build:android
 ```
 
-Build the debug APK:
+Build the debug APK. Debug builds load the dev server and use these packaged
+assets only as fallback development artifacts:
 
 ```bash
 cd android/routevn
@@ -111,7 +150,7 @@ Or use the combined script:
 bun run android:install
 ```
 
-Build a release app bundle:
+Build a release app bundle to validate packaged web assets:
 
 ```bash
 bun run android:bundle
@@ -224,9 +263,15 @@ can miss Android-specific parser, layout, asset, and bridge behavior.
 
 ### Build And Blank Screens
 
-- After JS, YAML view, or setup changes, reinstall with `bun run
-  android:install`. A native reinstall without rebuilding Android web assets can
-  leave the device running stale JavaScript.
+- During Android JS watch mode, JS, YAML view, store, handler, i18n, and setup
+  changes should refresh from `http://127.0.0.1:3001/android/index.html`
+  without reinstalling the APK.
+- For packaged-asset validation, build a release bundle with `bun run
+  android:bundle`. A native release build without rebuilding Android web assets
+  can package stale JavaScript.
+- If a debug app shows a WebView network error on launch, start
+  `bun run watch:android` and confirm `adb reverse tcp:3001 tcp:3001` is active
+  for the device.
 - Android builds must use the local `rtgl` dev dependency through
   `scripts/build.sh`, not a globally installed `rtgl` CLI. The local build
   preserves the repo's `rettangoli.config.yaml` options, including `i18n`.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build:android:assets": "node scripts/build-android-assets.js",
     "watch:web": "rtgl fe watch -s src/setup.web.js",
     "watch:tauri": "rtgl fe watch -s src/setup.tauri.js",
+    "watch:android": "./scripts/watch-android.sh",
     "android:install": "bun run build:android && cd android/routevn && ./gradlew installDebug",
     "android:bundle": "bun run build:android && cd android/routevn && ./gradlew bundleRelease",
     "test": "node scripts/test.js",

--- a/scripts/watch-android.sh
+++ b/scripts/watch-android.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+PORT="3001"
+RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.8.2")
+RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
+RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
+
+RTGL_BIN="node_modules/.bin/rtgl"
+RETTANGOLI_DIR="static/public/@rettangoli/ui@${RETTANGOLI_VERSION}/dist"
+RETTANGOLI_FILE="${RETTANGOLI_DIR}/rettangoli-iife-ui.min.js"
+LOCAL_RETTANGOLI_PACKAGE="node_modules/@rettangoli/ui/package.json"
+LOCAL_RETTANGOLI_FILE="node_modules/@rettangoli/ui/dist/rettangoli-iife-ui.min.js"
+
+if [ ! -x "${RTGL_BIN}" ]; then
+  echo "Error: local rtgl CLI is missing. Run bun install before watching."
+  exit 1
+fi
+
+echo "Preparing Android watch assets..."
+bun run build:bundle
+
+if [ ! -f "${RETTANGOLI_FILE}" ]; then
+  mkdir -p "${RETTANGOLI_DIR}"
+
+  if [ ! -f "${LOCAL_RETTANGOLI_FILE}" ]; then
+    echo "Error: Rettangoli UI bundle is missing from node_modules."
+    echo "Run bun install before watching Android."
+    exit 1
+  fi
+
+  LOCAL_RETTANGOLI_VERSION=$(node -p "require('./${LOCAL_RETTANGOLI_PACKAGE}').version" 2>/dev/null || true)
+  if [ "${LOCAL_RETTANGOLI_VERSION}" != "${RETTANGOLI_VERSION}" ]; then
+    echo "Error: node_modules has Rettangoli UI v${LOCAL_RETTANGOLI_VERSION:-unknown}, expected v${RETTANGOLI_VERSION}."
+    echo "Run bun install before watching Android."
+    exit 1
+  fi
+
+  cp "${LOCAL_RETTANGOLI_FILE}" "${RETTANGOLI_FILE}"
+fi
+
+rm -rf _site
+mkdir -p _site
+cp -rf static/* _site/
+
+"${RTGL_BIN}" ui build-svg
+mkdir -p _site/public
+cp -f static/public/rtgl-icons.js _site/public/rtgl-icons.js
+
+if command -v adb >/dev/null 2>&1; then
+  ADB_ARGS=()
+  if [ -n "${ANDROID_SERIAL:-}" ]; then
+    ADB_ARGS=(-s "${ANDROID_SERIAL}")
+  fi
+
+  if adb "${ADB_ARGS[@]}" get-state >/dev/null 2>&1; then
+    if adb "${ADB_ARGS[@]}" reverse "tcp:${PORT}" "tcp:${PORT}" >/dev/null 2>&1; then
+      echo "ADB reverse active: tcp:${PORT} -> tcp:${PORT}"
+    else
+      echo "Warning: failed to configure adb reverse for tcp:${PORT}."
+    fi
+  else
+    echo "No Android device detected for adb reverse. Connect a device or run: adb reverse tcp:${PORT} tcp:${PORT}"
+  fi
+else
+  echo "adb not found. Install Android platform tools or run adb reverse manually."
+fi
+
+echo "Android debug app URL: http://127.0.0.1:${PORT}/android/index.html"
+exec "${RTGL_BIN}" fe watch -s src/setup.android.js -p "${PORT}"

--- a/src/components/catalogResourcesView/catalogResourcesView.store.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.store.js
@@ -17,6 +17,9 @@ const MIN_ITEMS_PER_ROW = 1;
 const MAX_ITEMS_PER_ROW = 12;
 const MAX_MOBILE_ITEMS_PER_ROW = 6;
 const DEFAULT_CARD_WIDTH = 225;
+const MENU_BUTTON_LABEL = "Menu";
+const ZOOM_BUTTON_LABEL = "Zoom";
+const FILTER_BUTTON_LABEL = "Filter";
 const DEFAULT_ZOOM_POPOVER_POSITION = Object.freeze({
   x: 0,
   y: 0,
@@ -348,9 +351,7 @@ export const selectViewData = ({ state, props }) => {
     },
     showTagFilter: parseBooleanProp(props.showTagFilter),
     hasActiveTagFilter,
-    tagFilterButtonBackgroundColor: hasActiveFilter ? "ac" : "bg",
-    tagFilterButtonBorderColor: hasActiveFilter ? "ac" : "bo",
-    tagFilterButtonIconColor: hasActiveFilter ? "white" : "mu-fg",
+    tagFilterButtonVariant: hasActiveFilter ? "pr" : "ol",
     itemsPerRow,
     cardGridColumns,
     zoomControlValue: toColumnZoomControlValue(itemsPerRow, props),
@@ -360,6 +361,9 @@ export const selectViewData = ({ state, props }) => {
     showZoomControls:
       useColumnZoomControl && parseBooleanProp(props.showZoomControls),
     zoomPopover: state.zoomPopover,
+    menuButtonLabel: MENU_BUTTON_LABEL,
+    zoomButtonLabel: ZOOM_BUTTON_LABEL,
+    filterButtonLabel: FILTER_BUTTON_LABEL,
     showSearch:
       parseBooleanProp(props.showSearch, true) && !searchInFilterPopover,
     showFilterPopoverSearch: searchInFilterPopover,

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -81,24 +81,19 @@ template:
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if showLeadingMenuButton:
-                      - rtgl-view#menuButton w=36 h=36 ah=c av=c cur=pointer:
-                          - rtgl-svg svg=hamburger wh=22 c=mu-fg: null
+                      - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
                   - $if navTitle:
                       - rtgl-text: ${navTitle}
               - $if showZoomControls:
-                  - rtgl-view#zoomButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=zoomIn wh=16 c=mu-fg: null
+                  - 'rtgl-button#zoomButton sq pre=zoomIn v=ol aria-label="${zoomButtonLabel}" title="${zoomButtonLabel}"': null
               - $if showSearch:
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
               - $if showTagFilter:
-                  - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
-                      - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
+                  - 'rtgl-button#tagFilterButton sq pre=filter v=${tagFilterButtonVariant} aria-label="${filterButtonLabel}" title="${filterButtonLabel}"': null
               - $if showIconImportButton:
-                  - rtgl-view#importBtn w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=upload wh=16 c=mu-fg: null
+                  - 'rtgl-button#importBtn sq pre=upload v=ol aria-label="${importText}" title="${importText}"': null
               - $if showTrailingMenuButton:
-                  - rtgl-view#menuButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
+                  - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
               - $if showTextImportButton:
                   - rtgl-button#importBtn s=sm pre=upload v=se: ${importText}
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; box-sizing: border-box;"':
@@ -248,7 +243,7 @@ template:
       - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
           - rtgl-text s=md: Zoom
           - rtgl-view d=h av=c g=sm w=f:
-              - rtgl-button#zoomOut sq v="gh" s=sm: '-'
+              - rtgl-button#zoomOut sq v=ol: '-'
               - rtgl-slider#zoomSlider w=160 min=${zoomControlMin} max=${zoomControlMax} step=${zoomControlStep} value=${zoomControlValue}: null
-              - rtgl-button#zoomIn sq v="gh" s=sm: +
+              - rtgl-button#zoomIn sq v=ol: +
   - rtgl-dropdown-menu#contextMenu :items=${dropdownMenu.items} ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null

--- a/src/components/charactersResourcesView/charactersResourcesView.store.js
+++ b/src/components/charactersResourcesView/charactersResourcesView.store.js
@@ -11,6 +11,8 @@ import {
 import { resolveResourceScrollBottomPadding } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const DEFAULT_PROGRESSIVE_INITIAL_ITEM_COUNT = 4;
+const MENU_BUTTON_LABEL = "Menu";
+const FILTER_BUTTON_LABEL = "Filter";
 
 export const createInitialState = () => ({
   collapsedIds: [],
@@ -221,9 +223,9 @@ export const selectViewData = ({ state, props }) => {
     },
     showTagFilter: parseBooleanProp(props.showTagFilter),
     hasActiveTagFilter,
-    tagFilterButtonBackgroundColor: hasActiveFilter ? "ac" : "bg",
-    tagFilterButtonBorderColor: hasActiveFilter ? "ac" : "bo",
-    tagFilterButtonIconColor: hasActiveFilter ? "white" : "mu-fg",
+    tagFilterButtonVariant: hasActiveFilter ? "pr" : "ol",
+    menuButtonLabel: MENU_BUTTON_LABEL,
+    filterButtonLabel: FILTER_BUTTON_LABEL,
     showSearch:
       parseBooleanProp(props.showSearch, true) && !searchInFilterPopover,
     showFilterPopoverSearch: searchInFilterPopover,

--- a/src/components/charactersResourcesView/charactersResourcesView.view.yaml
+++ b/src/components/charactersResourcesView/charactersResourcesView.view.yaml
@@ -59,18 +59,15 @@ template:
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if showLeadingMenuButton:
-                      - rtgl-view#menuButton w=36 h=36 ah=c av=c cur=pointer:
-                          - rtgl-svg svg=hamburger wh=22 c=mu-fg: null
+                      - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
                   - $if navTitle:
                       - rtgl-text: ${navTitle}
               - $if showSearch:
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
               - $if showTagFilter:
-                  - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
-                      - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
+                  - 'rtgl-button#tagFilterButton sq pre=filter v=${tagFilterButtonVariant} aria-label="${filterButtonLabel}" title="${filterButtonLabel}"': null
               - $if showTrailingMenuButton:
-                  - rtgl-view#menuButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
+                  - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:

--- a/src/components/groupVariablesView/groupVariablesView.store.js
+++ b/src/components/groupVariablesView/groupVariablesView.store.js
@@ -36,6 +36,7 @@ const DEFAULT_ENUM_VALUE_FORM_VALUES = {
   value: "",
 };
 const DEFAULT_PROGRESSIVE_INITIAL_ITEM_COUNT = 4;
+const MENU_BUTTON_LABEL = "Menu";
 
 const selectGroupVariablesViewCopy = (i18n = {}) =>
   selectI18nCopy(i18n, ["resourcePages", "variablesPage"]);
@@ -671,9 +672,8 @@ export const selectViewData = ({ state, props, i18n }) => {
     mobileLayout,
     scrollBottomPadding,
     hasActiveTagFilter,
-    tagFilterButtonBackgroundColor: hasActiveFilter ? "ac" : "bg",
-    tagFilterButtonBorderColor: hasActiveFilter ? "ac" : "bo",
-    tagFilterButtonIconColor: hasActiveFilter ? "white" : "mu-fg",
+    tagFilterButtonVariant: hasActiveFilter ? "pr" : "ol",
+    menuButtonLabel: copy.menuButtonLabel ?? MENU_BUTTON_LABEL,
     isDialogOpen: state.isDialogOpen,
     defaultValues: defaultValues,
     form,

--- a/src/components/groupVariablesView/groupVariablesView.view.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.view.yaml
@@ -96,18 +96,15 @@ template:
       - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c d=h g=md style="position: sticky; top: 0px; z-index: 1000;"':
           - rtgl-view w=1fg d=h av=c g=md:
               - $if showLeadingMenuButton:
-                  - rtgl-view#menuButton w=36 h=36 ah=c av=c cur=pointer:
-                      - rtgl-svg svg=hamburger wh=22 c=mu-fg: null
+                  - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
               - $if navTitle:
                   - rtgl-text: ${navTitle}
           - $if showSearch:
               - rtgl-input#searchInput s=sm placeholder="${searchPlaceholder}" value=${searchQuery} h=1fg: null
           - $if showTagFilter:
-              - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
-                  - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
+              - 'rtgl-button#tagFilterButton sq pre=filter v=${tagFilterButtonVariant} aria-label="${filterLabel}" title="${filterLabel}"': null
           - $if showTrailingMenuButton:
-              - rtgl-view#menuButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
+              - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; min-height: 0; box-sizing: border-box;"':
           - $if flatGroups.length > 0:
               - $for group, i in flatGroups:

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -17,6 +17,10 @@ const DEFAULT_MOBILE_ITEMS_PER_ROW = 2;
 const MIN_ITEMS_PER_ROW = 1;
 const MAX_ITEMS_PER_ROW = 12;
 const MAX_MOBILE_ITEMS_PER_ROW = 6;
+const MENU_BUTTON_LABEL = "Menu";
+const BACK_BUTTON_LABEL = "Back";
+const ZOOM_BUTTON_LABEL = "Zoom";
+const FILTER_BUTTON_LABEL = "Filter";
 const DEFAULT_ZOOM_POPOVER_POSITION = Object.freeze({
   x: 0,
   y: 0,
@@ -518,9 +522,7 @@ export const selectViewData = ({ state, props }) => {
         !(searchInFilterPopover && hasActiveSearch),
     },
     hasActiveTagFilter,
-    tagFilterButtonBackgroundColor: hasActiveFilter ? "ac" : "bg",
-    tagFilterButtonBorderColor: hasActiveFilter ? "ac" : "bo",
-    tagFilterButtonIconColor: hasActiveFilter ? "white" : "mu-fg",
+    tagFilterButtonVariant: hasActiveFilter ? "pr" : "ol",
     showTagFilter: parseBooleanProp(props.showTagFilter),
     uploadText: props.uploadText ?? "Upload Files",
     uploadIcon: props.uploadIcon ?? "upload",
@@ -549,6 +551,10 @@ export const selectViewData = ({ state, props }) => {
     showInlineZoomControls: shouldShowZoomControls && !zoomInPopover,
     showZoomPopoverButton: shouldShowZoomControls && zoomInPopover,
     zoomPopover: state.zoomPopover,
+    menuButtonLabel: MENU_BUTTON_LABEL,
+    backButtonLabel: BACK_BUTTON_LABEL,
+    zoomButtonLabel: ZOOM_BUTTON_LABEL,
+    filterButtonLabel: FILTER_BUTTON_LABEL,
     showSearch:
       parseBooleanProp(props.showSearch, true) && !searchInFilterPopover,
     showFilterPopoverSearch: searchInFilterPopover,

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -110,30 +110,25 @@ template:
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if showLeadingMenuButton:
-                      - rtgl-view#menuButton w=36 h=36 ah=c av=c cur=pointer:
-                          - rtgl-svg svg=hamburger wh=22 c=mu-fg: null
+                      - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
                   - $if showBackButton:
-                      - rtgl-view#backButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                          - rtgl-svg svg=chevronLeft wh=16 c=mu-fg: null
+                      - 'rtgl-button#backButton sq pre=chevronLeft v=ol aria-label="${backButtonLabel}" title="${backButtonLabel}"': null
                   - $if navTitle:
                       - rtgl-text: ${navTitle}
               - rtgl-view d=h av=c g=md:
                   - $if showInlineZoomControls:
                       - rtgl-view d=h av=c g=sm:
-                          - rtgl-button#zoomOut sq v="gh" s=sm: '-'
+                          - rtgl-button#zoomOut sq v=ol: '-'
                           - rtgl-slider#zoomSlider w=120 min=${zoomControlMin} max=${zoomControlMax} step=${zoomControlStep} value=${zoomControlValue}: null
-                          - rtgl-button#zoomIn sq v="gh" s=sm: +
+                          - rtgl-button#zoomIn sq v=ol: +
                   - $if showZoomPopoverButton:
-                      - rtgl-view#zoomButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                          - rtgl-svg svg=zoomIn wh=16 c=mu-fg: null
+                      - 'rtgl-button#zoomButton sq pre=zoomIn v=ol aria-label="${zoomButtonLabel}" title="${zoomButtonLabel}"': null
                   - $if showSearch:
                       - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
                   - $if showTagFilter:
-                      - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
-                          - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
+                      - 'rtgl-button#tagFilterButton sq pre=filter v=${tagFilterButtonVariant} aria-label="${filterButtonLabel}" title="${filterButtonLabel}"': null
                   - $if showTrailingMenuButton:
-                      - rtgl-view#menuButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                          - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
+                      - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
       - 'rtgl-view#scrollContainer h=1fg w=f sv style="min-width: 0; min-height: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
@@ -306,7 +301,7 @@ template:
       - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
           - rtgl-text s=md: Zoom
           - rtgl-view d=h av=c g=sm w=f:
-              - rtgl-button#zoomOut sq v="gh" s=sm: '-'
+              - rtgl-button#zoomOut sq v=ol: '-'
               - rtgl-slider#zoomSlider w=160 min=${zoomControlMin} max=${zoomControlMax} step=${zoomControlStep} value=${zoomControlValue}: null
-              - rtgl-button#zoomIn sq v="gh" s=sm: +
+              - rtgl-button#zoomIn sq v=ol: +
   - rtgl-dropdown-menu#contextMenu :items=${dropdownMenu.items} ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null

--- a/src/components/textStyleResourcesView/textStyleResourcesView.store.js
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.store.js
@@ -17,6 +17,9 @@ const MIN_ITEMS_PER_ROW = 1;
 const MAX_ITEMS_PER_ROW = 12;
 const MAX_MOBILE_ITEMS_PER_ROW = 6;
 const DEFAULT_CARD_WIDTH = 360;
+const MENU_BUTTON_LABEL = "Menu";
+const ZOOM_BUTTON_LABEL = "Zoom";
+const FILTER_BUTTON_LABEL = "Filter";
 const DEFAULT_ZOOM_POPOVER_POSITION = Object.freeze({
   x: 0,
   y: 0,
@@ -322,9 +325,7 @@ export const selectViewData = ({ state, props }) => {
     },
     showTagFilter: parseBooleanProp(props.showTagFilter),
     hasActiveTagFilter,
-    tagFilterButtonBackgroundColor: hasActiveFilter ? "ac" : "bg",
-    tagFilterButtonBorderColor: hasActiveFilter ? "ac" : "bo",
-    tagFilterButtonIconColor: hasActiveFilter ? "white" : "mu-fg",
+    tagFilterButtonVariant: hasActiveFilter ? "pr" : "ol",
     itemsPerRow,
     cardGridColumns,
     zoomControlValue: toColumnZoomControlValue(itemsPerRow, props),
@@ -334,6 +335,9 @@ export const selectViewData = ({ state, props }) => {
     showZoomControls:
       useColumnZoomControl && parseBooleanProp(props.showZoomControls),
     zoomPopover: state.zoomPopover,
+    menuButtonLabel: MENU_BUTTON_LABEL,
+    zoomButtonLabel: ZOOM_BUTTON_LABEL,
+    filterButtonLabel: FILTER_BUTTON_LABEL,
     showSearch:
       parseBooleanProp(props.showSearch, true) && !searchInFilterPopover,
     showFilterPopoverSearch: searchInFilterPopover,

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -77,21 +77,17 @@ template:
           - rtgl-view w=f d=h av=c g=md wrap:
               - rtgl-view av=c g=sm d=h w=1fg:
                   - $if showLeadingMenuButton:
-                      - rtgl-view#menuButton w=36 h=36 ah=c av=c cur=pointer:
-                          - rtgl-svg svg=hamburger wh=22 c=mu-fg: null
+                      - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
                   - $if navTitle:
                       - rtgl-text c=mu-fg: ${navTitle}
               - $if showZoomControls:
-                  - rtgl-view#zoomButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=zoomIn wh=16 c=mu-fg: null
+                  - 'rtgl-button#zoomButton sq pre=zoomIn v=ol aria-label="${zoomButtonLabel}" title="${zoomButtonLabel}"': null
               - $if showSearch:
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
               - $if showTagFilter:
-                  - rtgl-view#tagFilterButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=${tagFilterButtonBackgroundColor} bc=${tagFilterButtonBorderColor}:
-                      - rtgl-svg svg=filter wh=16 c=${tagFilterButtonIconColor}: null
+                  - 'rtgl-button#tagFilterButton sq pre=filter v=${tagFilterButtonVariant} aria-label="${filterButtonLabel}" title="${filterButtonLabel}"': null
               - $if showTrailingMenuButton:
-                  - rtgl-view#menuButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                      - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
+                  - 'rtgl-button#menuButton sq pre=hamburger v=ol aria-label="${menuButtonLabel}" title="${menuButtonLabel}"': null
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
@@ -161,7 +157,7 @@ template:
       - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
           - rtgl-text s=md: Zoom
           - rtgl-view d=h av=c g=sm w=f:
-              - rtgl-button#zoomOut sq v="gh" s=sm: '-'
+              - rtgl-button#zoomOut sq v=ol: '-'
               - rtgl-slider#zoomSlider w=160 min=${zoomControlMin} max=${zoomControlMax} step=${zoomControlStep} value=${zoomControlValue}: null
-              - rtgl-button#zoomIn sq v="gh" s=sm: +
+              - rtgl-button#zoomIn sq v=ol: +
   - rtgl-dropdown-menu#contextMenu :items=${dropdownMenu.items} ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null

--- a/src/internal/ui/resourcePages/imagePreviewOverlay.js
+++ b/src/internal/ui/resourcePages/imagePreviewOverlay.js
@@ -64,6 +64,7 @@ export const createImagePreviewModeButtonViewData = ({
     borderColor: selected ? "ac" : "bo",
     iconColor: selected ? "white" : "mu-fg",
     selected,
+    variant: selected ? "pr" : "ol",
   };
 };
 

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -300,8 +300,7 @@ template:
               - rtgl-view w=f h=f bgc=bg: null
       - 'rtgl-view w=2fg h=f style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 bwb=xs bc=bo d=h av=c w=f ph=md g=md:
-              - rtgl-view#backButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=chevronLeft wh=16 c=mu-fg: null
+              - rtgl-button#backButton sq pre=chevronLeft v=ol: null
               - rtgl-view w=1fg:
                   - rtgl-text: ${animationName}
               - rtgl-button#playButton s=sm: ${playButton}

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -182,7 +182,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -296,7 +296,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
@@ -381,10 +381,8 @@ template:
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
           - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 8px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
-              - 'rtgl-view#previewCanvasModeButton role=button aria-label="${fullImagePreviewCanvasModeLabel}" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="${fullImagePreviewCanvasModeLabel}" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewCanvasModeButton.borderColor} bgc=${fullImagePreviewCanvasModeButton.backgroundColor} cur=pointer':
-                  - rtgl-svg svg=canvas-scale wh=18 c=${fullImagePreviewCanvasModeButton.iconColor}: null
-              - 'rtgl-view#previewFitModeButton role=button aria-label="${fullImagePreviewFitModeLabel}" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="${fullImagePreviewFitModeLabel}" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewFitModeButton.borderColor} bgc=${fullImagePreviewFitModeButton.backgroundColor} cur=pointer':
-                  - rtgl-svg svg=fit-to-frame wh=18 c=${fullImagePreviewFitModeButton.iconColor}: null
+              - 'rtgl-button#previewCanvasModeButton sq pre=canvas-scale v=${fullImagePreviewCanvasModeButton.variant} aria-label="${fullImagePreviewCanvasModeLabel}" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="${fullImagePreviewCanvasModeLabel}"': null
+              - 'rtgl-button#previewFitModeButton sq pre=fit-to-frame v=${fullImagePreviewFitModeButton.variant} aria-label="${fullImagePreviewFitModeLabel}" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="${fullImagePreviewFitModeLabel}"': null
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
               - 'div#previewImageFrame.imagePreviewFrame.imagePreviewTransparencyGrid style="${fullImagePreviewFrameStyle}"':
                   - 'div style="${fullImagePreviewImageWrapperStyle}"':

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -204,7 +204,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -153,7 +153,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -187,7 +187,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -154,7 +154,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -253,7 +253,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag bottom-empty-space-height=80vh start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
@@ -298,10 +298,8 @@ template:
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: default; outline: none; background-color: rgba(0, 0, 0, 0.9);"':
       - $if fullImagePreviewFileId:
           - 'rtgl-view pos=fix z=3002 d=h g=xs bgc=bg bw=xs bc=bo br=md p=xs style="top: 8px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);"':
-              - 'rtgl-view#previewCanvasModeButton role=button aria-label="${fullImagePreviewCanvasModeLabel}" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="${fullImagePreviewCanvasModeLabel}" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewCanvasModeButton.borderColor} bgc=${fullImagePreviewCanvasModeButton.backgroundColor} cur=pointer':
-                  - rtgl-svg svg=canvas-scale wh=18 c=${fullImagePreviewCanvasModeButton.iconColor}: null
-              - 'rtgl-view#previewFitModeButton role=button aria-label="${fullImagePreviewFitModeLabel}" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="${fullImagePreviewFitModeLabel}" w=36 h=36 ah=c av=c br=md bw=xs bc=${fullImagePreviewFitModeButton.borderColor} bgc=${fullImagePreviewFitModeButton.backgroundColor} cur=pointer':
-                  - rtgl-svg svg=fit-to-frame wh=18 c=${fullImagePreviewFitModeButton.iconColor}: null
+              - 'rtgl-button#previewCanvasModeButton sq pre=canvas-scale v=${fullImagePreviewCanvasModeButton.variant} aria-label="${fullImagePreviewCanvasModeLabel}" aria-pressed="${fullImagePreviewCanvasModeButton.selected}" title="${fullImagePreviewCanvasModeLabel}"': null
+              - 'rtgl-button#previewFitModeButton sq pre=fit-to-frame v=${fullImagePreviewFitModeButton.variant} aria-label="${fullImagePreviewFitModeLabel}" aria-pressed="${fullImagePreviewFitModeButton.selected}" title="${fullImagePreviewFitModeLabel}"': null
           - rtgl-view pos=fix edge=f ah=c av=c z=3001:
               - 'div#previewImageFrame.imagePreviewFrame.imagePreviewTransparencyGrid style="${fullImagePreviewFrameStyle}"':
                   - 'div style="${fullImagePreviewImageWrapperStyle}"':

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -60,7 +60,7 @@ template:
                       - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
       - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 bwb=xs bc=bo d=h av=c w=f ph=md:
-              - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
+              - rtgl-button#backButton sq pre=chevronLeft v=ol mr=sm: null
               - 'rtgl-view w=1fg style="min-width: 0;"':
                   - rtgl-text w=f ellipsis=true: ${layout.name}
               - $if showMobileNodeButton:
@@ -111,6 +111,6 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${nodeExplorerTitle}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag bottom-empty-space-height=80vh :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -157,7 +157,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -185,7 +185,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -48,16 +48,13 @@ refs:
 template:
   - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
       - rtgl-view w=f d=h av=c g=sm:
-          - rtgl-view#backButton d=h av=c g=sm cur=pointer tabindex=0 role=button title="${i18n.projectPage.backToProjects}":
-              - rtgl-view w=36 h=36 bw=xs br=md ah=c av=c bgc=bg bc=bo:
-                  - rtgl-svg svg=chevronLeft wh=16 c=mu-fg: null
-              - rtgl-text s=sm: ${i18n.projectPage.backToProjects}
+          - 'rtgl-button#backButton sq pre=chevronLeft v=ol title="${i18n.projectPage.backToProjects}" aria-label="${i18n.projectPage.backToProjects}"': null
+          - rtgl-text s=sm ml=xs: ${i18n.projectPage.backToProjects}
           - $if projectSource == 'cloud':
               - rtgl-text s=xs c=mu-fg: ${i18n.projectPage.cloudProject}
           - rtgl-view w=1fg: null
           - $if showAndroidProjectActions:
-              - rtgl-view#projectActionsButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                  - rtgl-svg svg=ellipsis wh=16 c=mu-fg: null
+              - 'rtgl-button#projectActionsButton sq pre=ellipsis v=ol title="${i18n.projectPage.exportProject}" aria-label="${i18n.projectPage.exportProject}"': null
   - rtgl-view w=f h=f pt=md:
       - rtgl-view w=f h=f d=v:
           - rvn-detail-view#detailView w=f h=1fg :fields=${detailFields}:

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -149,8 +149,7 @@ template:
                   - rtgl-text: ${localTitle}
                   - rtgl-view w=1fg: null
                   - $if showMobileProjectActions:
-                      - rtgl-view#mobileCreateMenuButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo:
-                          - rtgl-svg svg=plus wh=16 c=mu-fg: null
+                      - 'rtgl-button#mobileCreateMenuButton sq pre=plus v=ol title="${createButtonText}" aria-label="${createButtonText}"': null
                     $else:
                       - rtgl-view d=h g=sm:
                           - rtgl-button#createButton data-testid=create-project-button: ${createButtonText}

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -179,11 +179,11 @@ template:
           - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
               - 'rtgl-view w="calc((100vw - 64px) / 2)" d=v h=f style="min-width: 0; min-height: 0;"':
                   - rtgl-view bwb=xs w=f h=48 av=c ph=sm d=h:
-                      - rtgl-button#backButton sq pre="chevronLeft" v="gh" mr=sm: null
+                      - rtgl-button#backButton sq pre=chevronLeft v=ol mr=sm: null
                       - rtgl-view w=1fg d=h av=c:
                           - rtgl-text w=1fg ellipsis=true: ${scene.name}
-                          - rtgl-button#sectionsOverview sq pre=hamburger v="gh" ml=sm: null
-                          - rtgl-button#sceneSettingsButton sq pre=settings v="gh": null
+                          - rtgl-button#sectionsOverview sq pre=hamburger v=ol ml=sm: null
+                          - rtgl-button#sceneSettingsButton sq pre=settings v=ol: null
                   - $if sectionsGraphView:
                       - rtgl-view w=f h=1fg:
                           - rtgl-view d=h w=f:

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -165,13 +165,12 @@ template:
       - rtgl-tooltip ?open=${deadEndTooltip.open} x=${deadEndTooltip.x} y=${deadEndTooltip.y} place="t" content="${deadEndTooltip.content}": null
       - $if showMobileScenesControls:
           - 'rtgl-view pos=abs z=200 style="right: 8px; top: 8px;"':
-              - rtgl-view#mobileFileExplorerOpenButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo title="${title}":
-                  - rtgl-svg svg=hamburger wh=16 c=mu-fg: null
+              - 'rtgl-button#mobileFileExplorerOpenButton sq pre=hamburger v=ol title="${title}" aria-label="${title}"': null
       - $if showMobileFileExplorer:
           - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
               - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
                   - rtgl-text w=1fg s=md: ${filesLabel}
-                  - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+                  - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
               - 'rtgl-view w=f h=1fg style="min-height: 0;"':
                   - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
       - $if showMapAddHint:

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -184,7 +184,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -180,7 +180,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -177,7 +177,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -216,7 +216,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -115,7 +115,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:

--- a/src/pages/versions/versions.view.yaml
+++ b/src/pages/versions/versions.view.yaml
@@ -51,7 +51,7 @@ template:
                       - rtgl-view w=f d=h av=c g=md wrap:
                           - rtgl-view av=c g=sm d=h w=1fg:
                               - rtgl-text: ${title}
-                          - rtgl-button#saveVersionBtn v=pr s=sm pre=plus: ${addButton}
+                          - 'rtgl-button#saveVersionBtn v=pr sq pre=plus title="${addButton}" aria-label="${addButton}"': null
                   - 'rtgl-view h=1fg w=f sv style="min-width: 0;"':
                       - $if versions.length == 0:
                           - rtgl-view w=f h=f av=c ah=c:

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -174,7 +174,7 @@ template:
       - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
-              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36: null
+              - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
               - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:


### PR DESCRIPTION
## Summary
- add Android JS watch mode and debug WebView dev-server loading for fast refresh without APK reinstall
- document the Android dev workflow and add the watch:android script
- standardize navbar/header icon controls on square Rettangoli buttons across resource pages and editors

## Validation
- bun run lint
- bun run test:smoke
- git diff --check

Note: left an unrelated local change in src/pages/appearance/appearance.store.js unstaged.