### PR TITLE
Preserve Android dev route on refresh

### DIFF
--- a/scripts/watch-android.sh
+++ b/scripts/watch-android.sh
@@ -48,6 +48,9 @@ cp -rf static/* _site/
 mkdir -p _site/public
 cp -f static/public/rtgl-icons.js _site/public/rtgl-icons.js
 
+echo "Building initial Android frontend bundle..."
+"${RTGL_BIN}" fe build -s src/setup.android.js
+
 if command -v adb >/dev/null 2>&1; then
   ADB_ARGS=()
   if [ -n "${ANDROID_SERIAL:-}" ]; then

--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -78,6 +78,13 @@ const isDragEnabledForAttrs = (attrs) => {
   );
 };
 
+const isFolderArrowEvent = (event) => {
+  return (
+    typeof event?.target?.closest === "function" &&
+    Boolean(event.target.closest("[data-file-explorer-arrow]"))
+  );
+};
+
 const calculateForbiddenTargets = (sourceItem, allItems) => {
   if (!sourceItem) return [];
 
@@ -673,9 +680,11 @@ const scrollRootByTouchDelta = (deps, { fromPoint, toPoint } = {}) => {
 
 const startTouchScroll = (deps, { fromPoint, toPoint } = {}) => {
   const { store } = deps;
+  const pointerId = store.selectTouchDragPointerId();
   clearTouchDragTimer(store);
   store.clearPendingDrag();
   store.clearTouchDrag();
+  store.setTouchDragPointerId({ pointerId });
   store.setTouchScrollActive({ active: true });
   store.setTouchScrollLastPoint({ point: toPoint });
   scrollRootByTouchDelta(deps, { fromPoint, toPoint });
@@ -850,20 +859,21 @@ const updateDragTarget = (deps, { clientY } = {}) => {
 
 export const handleItemMouseDown = (deps, payload) => {
   const { store } = deps;
+  const event = payload?._event;
 
   if (store.selectTouchContextMenuSuppressUntil() > Date.now()) {
     return;
   }
 
   // Drag should start only on primary button.
-  if (payload?._event?.button !== 0) {
+  if (event?.button !== 0 || isFolderArrowEvent(event)) {
     return;
   }
 
   createPendingDrag(deps, {
-    event: payload._event,
-    clientX: payload._event.clientX,
-    clientY: payload._event.clientY,
+    event,
+    clientX: event.clientX,
+    clientY: event.clientY,
   });
 };
 
@@ -872,6 +882,10 @@ export const handleItemPointerDown = (deps, payload) => {
   const event = payload?._event;
 
   if (event?.pointerType === "mouse" || event?.isPrimary === false) {
+    return;
+  }
+
+  if (isFolderArrowEvent(event)) {
     return;
   }
 
@@ -902,12 +916,17 @@ export const handleItemPointerDown = (deps, payload) => {
 
 export const handleItemTouchStart = (deps, payload) => {
   const { store } = deps;
+  const event = payload?._event;
   if (store.selectTouchDragPointerId() !== undefined) {
     return;
   }
 
-  const touchPoint = getTouchPoint(payload?._event);
-  if (!touchPoint || payload?._event?.touches?.length !== 1) {
+  if (isFolderArrowEvent(event)) {
+    return;
+  }
+
+  const touchPoint = getTouchPoint(event);
+  if (!touchPoint || event?.touches?.length !== 1) {
     return;
   }
 
@@ -920,7 +939,7 @@ export const handleItemTouchStart = (deps, payload) => {
   };
 
   const hasPendingDrag = createPendingDrag(deps, {
-    event: payload._event,
+    event,
     clientX: point.x,
     clientY: point.y,
   });
@@ -929,8 +948,8 @@ export const handleItemTouchStart = (deps, payload) => {
     return;
   }
 
-  payload._event?.preventDefault?.();
-  payload._event?.stopPropagation?.();
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
   startMobileLongPressTimer(deps, { point });
 };
 

--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -41,11 +41,41 @@ const initializeCollapsedFolders = (deps) => {
 
 export const handleBeforeMount = (deps) => {
   initializeCollapsedFolders(deps);
-  return mountSubscriptions(deps);
+  const cleanupSubscriptions = mountSubscriptions(deps);
+  return () => {
+    clearTouchDragTimer(deps.store);
+    clearDragAutoScrollTimer(deps.store);
+    cleanupSubscriptions();
+  };
 };
 
 const getItemIdFromEvent = (event) => {
   return event?.currentTarget?.getAttribute?.("data-item-id") || "";
+};
+
+const getTouchPoint = (event) => {
+  return event?.touches?.[0] ?? event?.changedTouches?.[0];
+};
+
+const getPointerPoint = (event) => {
+  if (
+    typeof event?.clientX !== "number" ||
+    typeof event?.clientY !== "number"
+  ) {
+    return undefined;
+  }
+
+  return {
+    x: event.clientX,
+    y: event.clientY,
+  };
+};
+
+const isDragEnabledForAttrs = (attrs) => {
+  return (
+    isBooleanAttrEnabled(attrs, "allowDrag", "allow-drag") ||
+    isBooleanAttrEnabled(attrs, "draggable", "draggable")
+  );
 };
 
 const calculateForbiddenTargets = (sourceItem, allItems) => {
@@ -288,6 +318,13 @@ const isDropPlacementAllowed = ({
 };
 
 const DRAG_ACTIVATION_DISTANCE = 4;
+const TOUCH_LONG_PRESS_DELAY_MS = 360;
+const TOUCH_SCROLL_CANCEL_DISTANCE = 8;
+const TOUCH_CONTEXT_MENU_SUPPRESS_MS = 1200;
+const DRAG_AUTO_SCROLL_EDGE_SIZE = 48;
+const DRAG_AUTO_SCROLL_INTERVAL_MS = 50;
+const DRAG_AUTO_SCROLL_MIN_STEP = 4;
+const DRAG_AUTO_SCROLL_MAX_STEP = 20;
 
 /**
  *  we need to find the item that is under the mouse
@@ -422,56 +459,266 @@ export const getSelectedItemIndex = (
   };
 };
 
-export const handleItemMouseDown = (deps, payload) => {
-  const { store, refs, props, props: attrs } = deps;
+const getItemRefEntries = (refs = {}) => {
+  return Object.entries(refs).filter(([key]) => key.startsWith("itemRef"));
+};
 
-  // Drag should start only on primary button.
-  if (payload?._event?.button !== 0) {
+const getDragContainerRect = (deps, { event } = {}) => {
+  const eventContainerRect =
+    event?.currentTarget?.parentElement?.getBoundingClientRect?.();
+  if (eventContainerRect) {
+    return eventContainerRect;
+  }
+
+  const firstItemElement = getItemRefEntries(deps.refs ?? [])[0]?.[1];
+  return firstItemElement?.parentElement?.getBoundingClientRect?.();
+};
+
+const measureDragLayout = (deps, { event } = {}) => {
+  const containerRect = getDragContainerRect(deps, { event });
+  if (!containerRect) {
+    return undefined;
+  }
+
+  const itemRects = getItemRefEntries(deps.refs ?? {}).reduce(
+    (acc, [, ref]) => {
+      const itemId = ref?.getAttribute?.("data-item-id");
+      if (!itemId) {
+        return acc;
+      }
+
+      const rect = ref.getBoundingClientRect();
+      acc[itemId] = {
+        top: rect.top,
+        bottom: rect.bottom,
+        height: rect.height,
+        y: rect.top,
+        relativeTop: rect.top - containerRect.top,
+        relativeBottom: rect.bottom - containerRect.top,
+      };
+      return acc;
+    },
+    {},
+  );
+
+  return {
+    itemRects,
+    containerTop: containerRect.top,
+  };
+};
+
+const refreshDragLayout = (deps) => {
+  const layout = measureDragLayout(deps);
+  if (!layout) {
+    return false;
+  }
+
+  deps.store.setDragLayout(layout);
+  return true;
+};
+
+const clearDragAutoScrollTimer = (store) => {
+  const timerId = store.selectDragAutoScrollTimerId();
+  if (timerId !== undefined) {
+    clearInterval(timerId);
+  }
+
+  store.clearDragAutoScroll();
+};
+
+const getRootMaxScrollTop = (root) => {
+  const scrollHeight = Number(root?.scrollHeight);
+  const clientHeight = Number(root?.clientHeight);
+  if (!Number.isFinite(scrollHeight) || !Number.isFinite(clientHeight)) {
+    return 0;
+  }
+
+  return Math.max(0, scrollHeight - clientHeight);
+};
+
+const getDragAutoScrollStep = (root, point) => {
+  const rect = root?.getBoundingClientRect?.();
+  if (!rect || !point) {
+    return 0;
+  }
+
+  const maxScrollTop = getRootMaxScrollTop(root);
+  if (maxScrollTop <= 0) {
+    return 0;
+  }
+
+  const distanceToTop = point.y - rect.top;
+  if (distanceToTop < DRAG_AUTO_SCROLL_EDGE_SIZE && root.scrollTop > 0) {
+    const ratio = Math.min(
+      1,
+      (DRAG_AUTO_SCROLL_EDGE_SIZE - distanceToTop) / DRAG_AUTO_SCROLL_EDGE_SIZE,
+    );
+    return -Math.round(
+      DRAG_AUTO_SCROLL_MIN_STEP +
+        ratio * (DRAG_AUTO_SCROLL_MAX_STEP - DRAG_AUTO_SCROLL_MIN_STEP),
+    );
+  }
+
+  const distanceToBottom = rect.bottom - point.y;
+  if (
+    distanceToBottom < DRAG_AUTO_SCROLL_EDGE_SIZE &&
+    root.scrollTop < maxScrollTop
+  ) {
+    const ratio = Math.min(
+      1,
+      (DRAG_AUTO_SCROLL_EDGE_SIZE - distanceToBottom) /
+        DRAG_AUTO_SCROLL_EDGE_SIZE,
+    );
+    return Math.round(
+      DRAG_AUTO_SCROLL_MIN_STEP +
+        ratio * (DRAG_AUTO_SCROLL_MAX_STEP - DRAG_AUTO_SCROLL_MIN_STEP),
+    );
+  }
+
+  return 0;
+};
+
+const applyDragAutoScroll = (deps) => {
+  const { refs, store } = deps;
+  const root = refs?.root;
+  const point = store.selectDragAutoScrollPoint();
+  const step = getDragAutoScrollStep(root, point);
+  if (step === 0) {
+    clearDragAutoScrollTimer(store);
     return;
   }
 
-  const isDragEnabled =
-    isBooleanAttrEnabled(attrs, "allowDrag", "allow-drag") ||
-    isBooleanAttrEnabled(attrs, "draggable", "draggable");
-
-  if (!isDragEnabled) {
+  const maxScrollTop = getRootMaxScrollTop(root);
+  const previousScrollTop = root.scrollTop;
+  root.scrollTop = Math.max(
+    0,
+    Math.min(maxScrollTop, previousScrollTop + step),
+  );
+  if (root.scrollTop === previousScrollTop) {
+    clearDragAutoScrollTimer(store);
     return;
   }
 
-  const refIds = refs;
+  refreshDragLayout(deps);
+  updateDragTarget(deps, { clientY: point.y });
+};
 
-  // Get the container element to calculate relative positions
-  const containerRect =
-    payload._event.currentTarget.parentElement.getBoundingClientRect();
+const updateDragAutoScroll = (deps, { point } = {}) => {
+  const { store, refs } = deps;
+  store.setDragAutoScrollPoint({ point });
 
-  const itemRects = Object.keys(refIds).reduce((acc, key) => {
-    const ref = refIds[key];
-    if (!key.startsWith("itemRef")) {
-      return acc;
+  if (!store.selectIsDragging()) {
+    clearDragAutoScrollTimer(store);
+    return;
+  }
+
+  if (getDragAutoScrollStep(refs?.root, point) === 0) {
+    clearDragAutoScrollTimer(store);
+    return;
+  }
+
+  if (store.selectDragAutoScrollTimerId() !== undefined) {
+    return;
+  }
+
+  const timerId = setInterval(() => {
+    if (!store.selectIsDragging()) {
+      clearDragAutoScrollTimer(store);
+      return;
     }
-    const itemId = ref?.getAttribute?.("data-item-id");
-    if (!itemId) {
-      return acc;
-    }
-    const rect = ref.getBoundingClientRect();
-    acc[itemId] = {
-      top: rect.top,
-      bottom: rect.bottom,
-      height: rect.height,
-      y: rect.top,
-      relativeTop: rect.top - containerRect.top,
-      relativeBottom: rect.bottom - containerRect.top,
-    };
-    return acc;
-  }, {});
 
-  const itemId = getItemIdFromEvent(payload._event);
+    applyDragAutoScroll(deps);
+  }, DRAG_AUTO_SCROLL_INTERVAL_MS);
+  store.setDragAutoScrollTimerId({ timerId });
+  applyDragAutoScroll(deps);
+};
+
+const suppressTouchContextMenu = (store) => {
+  store.setTouchContextMenuSuppressUntil({
+    suppressUntil: Date.now() + TOUCH_CONTEXT_MENU_SUPPRESS_MS,
+  });
+};
+
+const clearTouchDragTimer = (store) => {
+  const timerId = store.selectTouchDragTimerId();
+  if (timerId === undefined) {
+    return;
+  }
+
+  clearTimeout(timerId);
+  store.setTouchDragTimerId({ timerId: undefined });
+};
+
+const cancelPendingTouchDrag = (deps) => {
+  const { store } = deps;
+  clearTouchDragTimer(store);
+  clearDragAutoScrollTimer(store);
+  store.clearPendingDrag();
+  store.clearTouchDrag();
+};
+
+const scrollRootByTouchDelta = (deps, { fromPoint, toPoint } = {}) => {
+  const root = deps.refs?.root;
+  if (!root || !fromPoint || !toPoint) {
+    return;
+  }
+
+  const deltaY = fromPoint.y - toPoint.y;
+  if (deltaY === 0) {
+    return;
+  }
+
+  root.scrollTop += deltaY;
+};
+
+const startTouchScroll = (deps, { fromPoint, toPoint } = {}) => {
+  const { store } = deps;
+  clearTouchDragTimer(store);
+  store.clearPendingDrag();
+  store.clearTouchDrag();
+  store.setTouchScrollActive({ active: true });
+  store.setTouchScrollLastPoint({ point: toPoint });
+  scrollRootByTouchDelta(deps, { fromPoint, toPoint });
+};
+
+const selectPendingTouchItem = (deps) => {
+  const { dispatchEvent, props, render, store } = deps;
+  const pendingDrag = store.selectPendingDrag();
+  const itemId = pendingDrag?.id;
   if (!itemId) {
-    return;
+    return false;
   }
-  const sourceItem = props.items.find((item) => item.id === itemId);
-  const forbiddenTargetIds = calculateForbiddenTargets(sourceItem, props.items);
-  const visibleItems = getVisibleItems(props.items, store.selectCollapsedIds());
+
+  const item = props.items?.find((entry) => entry.id === itemId);
+  store.clearPendingDrag();
+  store.setSelectedItemId({ itemId });
+  render();
+  scrollItemIntoView({ deps, itemId });
+  emitItemClick({ dispatchEvent, item });
+  return true;
+};
+
+const createPendingDrag = (deps, { event, clientX, clientY } = {}) => {
+  const { store, props, props: attrs } = deps;
+
+  if (!isDragEnabledForAttrs(attrs)) {
+    return false;
+  }
+
+  const dragLayout = measureDragLayout(deps, { event });
+  if (!dragLayout) {
+    return false;
+  }
+
+  const itemId = getItemIdFromEvent(event);
+  if (!itemId) {
+    return false;
+  }
+
+  const allItems = props.items ?? [];
+  const sourceItem = allItems.find((item) => item.id === itemId);
+  const forbiddenTargetIds = calculateForbiddenTargets(sourceItem, allItems);
+  const visibleItems = getVisibleItems(allItems, store.selectCollapsedIds());
   const forbiddenIndices = forbiddenTargetIds
     .map((id) => visibleItems.findIndex((item) => item.id === id))
     .filter((index) => index !== -1);
@@ -479,13 +726,212 @@ export const handleItemMouseDown = (deps, payload) => {
   store.setPendingDrag({
     pendingDrag: {
       id: itemId,
-      itemRects,
-      containerTop: containerRect.top,
+      itemRects: dragLayout.itemRects,
+      containerTop: dragLayout.containerTop,
       forbiddenIndices,
-      startX: payload._event.clientX,
-      startY: payload._event.clientY,
+      startX: clientX,
+      startY: clientY,
     },
   });
+
+  return true;
+};
+
+const startDraggingFromPending = (deps) => {
+  const { store } = deps;
+  const pendingDrag = store.selectPendingDrag();
+  if (!pendingDrag) {
+    return false;
+  }
+
+  store.startDragging({
+    id: pendingDrag.id,
+    itemRects: pendingDrag.itemRects,
+    containerTop: pendingDrag.containerTop,
+    forbiddenIndices: pendingDrag.forbiddenIndices,
+  });
+
+  return true;
+};
+
+const startMobileLongPressTimer = (deps, { point } = {}) => {
+  const { store } = deps;
+
+  store.setTouchDragStartPoint({ point });
+  store.setTouchDragCurrentPoint({ point });
+  suppressTouchContextMenu(store);
+
+  const timerId = setTimeout(() => {
+    store.setTouchDragTimerId({ timerId: undefined });
+
+    if (!startDraggingFromPending(deps)) {
+      store.clearTouchDrag();
+      return;
+    }
+
+    store.setTouchDragActive({ active: true });
+    store.setSuppressNextClick({ suppress: true });
+
+    const currentPoint = store.selectTouchDragCurrentPoint() ?? point;
+    updateDragTarget(deps, { clientY: currentPoint.y });
+    updateDragAutoScroll(deps, { point: currentPoint });
+  }, TOUCH_LONG_PRESS_DELAY_MS);
+
+  store.setTouchDragTimerId({ timerId });
+};
+
+const updateDragTarget = (deps, { clientY } = {}) => {
+  const { store, render, props } = deps;
+
+  if (!store.selectIsDragging()) {
+    return;
+  }
+
+  const itemRects = store.selectItemRects();
+  const containerTop = store.selectContainerTop();
+  const items = props.items ?? [];
+  const visibleItems = getVisibleItems(items, store.selectCollapsedIds());
+  const sourceId = store.selectSelectedItemId();
+  const sourceItem = items.find((item) => item.id === sourceId);
+  const forbiddenIndices = store.selectForbiddenIndices();
+
+  const result = getSelectedItemIndex(clientY, itemRects, 0, items);
+
+  const isDropAllowed = isDropPlacementAllowed({
+    sourceItem,
+    visibleItems,
+    targetIndex: result.index,
+    dropPosition: result.dropPosition,
+    forbiddenIndices,
+  });
+
+  if (!isDropAllowed) {
+    store.setTargetDragIndex({ index: -2 });
+    store.setTargetDragPosition({ position: 0 });
+    store.setTargetDropPosition({ dropPosition: "none" });
+    render();
+    return;
+  }
+
+  const sourceIndex = visibleItems.findIndex((item) => item.id === sourceId);
+  let isNoOpDrop = false;
+
+  if (result.dropPosition === "inside") {
+    isNoOpDrop = visibleItems[result.index]?.id === sourceId;
+  } else if (result.dropPosition === "above") {
+    isNoOpDrop = result.index === sourceIndex;
+  } else if (result.dropPosition === "below") {
+    isNoOpDrop = result.index === sourceIndex;
+  }
+
+  if (isNoOpDrop) {
+    store.setTargetDragIndex({ index: -2 });
+    store.setTargetDragPosition({ position: 0 });
+    store.setTargetDropPosition({ dropPosition: "none" });
+    render();
+    return;
+  }
+
+  const relativePosition = result.position - containerTop;
+
+  if (
+    store.selectTargetDragIndex() === result.index &&
+    store.selectTargetDragPosition() === relativePosition &&
+    store.selectTargetDropPosition() === result.dropPosition
+  ) {
+    return;
+  }
+
+  store.setTargetDragIndex({ index: result.index });
+  store.setTargetDragPosition({ position: relativePosition });
+  store.setTargetDropPosition({ dropPosition: result.dropPosition });
+  render();
+};
+
+export const handleItemMouseDown = (deps, payload) => {
+  const { store } = deps;
+
+  if (store.selectTouchContextMenuSuppressUntil() > Date.now()) {
+    return;
+  }
+
+  // Drag should start only on primary button.
+  if (payload?._event?.button !== 0) {
+    return;
+  }
+
+  createPendingDrag(deps, {
+    event: payload._event,
+    clientX: payload._event.clientX,
+    clientY: payload._event.clientY,
+  });
+};
+
+export const handleItemPointerDown = (deps, payload) => {
+  const { store } = deps;
+  const event = payload?._event;
+
+  if (event?.pointerType === "mouse" || event?.isPrimary === false) {
+    return;
+  }
+
+  const point = getPointerPoint(event);
+  if (!point) {
+    return;
+  }
+
+  clearTouchDragTimer(store);
+  store.clearTouchDrag();
+
+  const hasPendingDrag = createPendingDrag(deps, {
+    event,
+    clientX: point.x,
+    clientY: point.y,
+  });
+
+  if (!hasPendingDrag) {
+    return;
+  }
+
+  event.preventDefault?.();
+  event.stopPropagation?.();
+  event.currentTarget?.setPointerCapture?.(event.pointerId);
+  store.setTouchDragPointerId({ pointerId: event.pointerId });
+  startMobileLongPressTimer(deps, { point });
+};
+
+export const handleItemTouchStart = (deps, payload) => {
+  const { store } = deps;
+  if (store.selectTouchDragPointerId() !== undefined) {
+    return;
+  }
+
+  const touchPoint = getTouchPoint(payload?._event);
+  if (!touchPoint || payload?._event?.touches?.length !== 1) {
+    return;
+  }
+
+  clearTouchDragTimer(store);
+  store.clearTouchDrag();
+
+  const point = {
+    x: touchPoint.clientX,
+    y: touchPoint.clientY,
+  };
+
+  const hasPendingDrag = createPendingDrag(deps, {
+    event: payload._event,
+    clientX: point.x,
+    clientY: point.y,
+  });
+
+  if (!hasPendingDrag) {
+    return;
+  }
+
+  payload._event?.preventDefault?.();
+  payload._event?.stopPropagation?.();
+  startMobileLongPressTimer(deps, { point });
 };
 
 export const handleWindowMouseUp = (deps) => {
@@ -493,6 +939,7 @@ export const handleWindowMouseUp = (deps) => {
   const isDragging = store.selectIsDragging();
 
   if (!isDragging) {
+    clearDragAutoScrollTimer(store);
     if (store.selectPendingDrag()) {
       store.clearPendingDrag();
     }
@@ -506,6 +953,7 @@ export const handleWindowMouseUp = (deps) => {
   const sourceItem = allItems.find((item) => item.id === sourceId);
   const forbiddenIndices = store.selectForbiddenIndices();
   const finishDragging = () => {
+    clearDragAutoScrollTimer(store);
     store.stopDragging();
     render();
   };
@@ -560,7 +1008,7 @@ export const handleWindowMouseUp = (deps) => {
 };
 
 export const handleWindowMouseMove = (deps, payload) => {
-  const { store, render, props } = deps;
+  const { store } = deps;
   let isDragging = store.selectIsDragging();
   const isPrimaryButtonPressed = (payload?._event?.buttons & 1) === 1;
 
@@ -588,12 +1036,7 @@ export const handleWindowMouseMove = (deps, payload) => {
       return;
     }
 
-    store.startDragging({
-      id: pendingDrag.id,
-      itemRects: pendingDrag.itemRects,
-      containerTop: pendingDrag.containerTop,
-      forbiddenIndices: pendingDrag.forbiddenIndices,
-    });
+    startDraggingFromPending(deps);
 
     isDragging = true;
   }
@@ -602,77 +1045,206 @@ export const handleWindowMouseMove = (deps, payload) => {
     return;
   }
 
-  const itemRects = store.selectItemRects();
-  const containerTop = store.selectContainerTop();
-  const items = props.items || [];
-  const visibleItems = getVisibleItems(items, store.selectCollapsedIds());
-  const sourceId = store.selectSelectedItemId();
-  const sourceItem = items.find((item) => item.id === sourceId);
-  const forbiddenIndices = store.selectForbiddenIndices();
+  const point = {
+    x: payload._event.clientX,
+    y: payload._event.clientY,
+  };
+  updateDragTarget(deps, { clientY: point.y });
+  updateDragAutoScroll(deps, { point });
+};
 
-  const result = getSelectedItemIndex(
-    payload._event.clientY,
-    itemRects,
-    0,
-    items,
-  );
+const handleMobilePointMove = (deps, payload, { point } = {}) => {
+  const { store } = deps;
 
-  const isDropAllowed = isDropPlacementAllowed({
-    sourceItem,
-    visibleItems,
-    targetIndex: result.index,
-    dropPosition: result.dropPosition,
-    forbiddenIndices,
+  if (store.selectTouchScrollActive()) {
+    payload._event.preventDefault();
+    payload._event.stopPropagation();
+
+    const lastPoint = store.selectTouchScrollLastPoint();
+    scrollRootByTouchDelta(deps, { fromPoint: lastPoint, toPoint: point });
+    store.setTouchScrollLastPoint({ point });
+    return;
+  }
+
+  if (!store.selectTouchDragActive()) {
+    const startPoint = store.selectTouchDragStartPoint();
+    const pendingDrag = store.selectPendingDrag();
+    if (!startPoint || !pendingDrag) {
+      return;
+    }
+
+    store.setTouchDragCurrentPoint({ point });
+
+    const deltaX = point.x - startPoint.x;
+    const deltaY = point.y - startPoint.y;
+    const dragDistance = Math.hypot(deltaX, deltaY);
+
+    if (dragDistance > TOUCH_SCROLL_CANCEL_DISTANCE) {
+      payload._event.preventDefault();
+      payload._event.stopPropagation();
+      startTouchScroll(deps, { fromPoint: startPoint, toPoint: point });
+    }
+    return;
+  }
+
+  if (!store.selectIsDragging()) {
+    cancelPendingTouchDrag(deps);
+    return;
+  }
+
+  payload._event.preventDefault();
+  payload._event.stopPropagation();
+  store.setTouchDragCurrentPoint({ point });
+  updateDragTarget(deps, { clientY: point.y });
+  updateDragAutoScroll(deps, { point });
+};
+
+export const handleWindowTouchMove = (deps, payload) => {
+  const touchPoint = getTouchPoint(payload?._event);
+  if (!touchPoint) {
+    return;
+  }
+
+  handleMobilePointMove(deps, payload, {
+    point: {
+      x: touchPoint.clientX,
+      y: touchPoint.clientY,
+    },
   });
+};
 
-  if (!isDropAllowed) {
-    store.setTargetDragIndex({ index: -2 });
-    store.setTargetDragPosition({ position: 0 });
-    store.setTargetDropPosition({ dropPosition: "none" });
-    render();
-    return;
-  }
-
-  const sourceIndex = visibleItems.findIndex((item) => item.id === sourceId);
-
-  // Check if the drop position would result in no movement
-  let isNoOpDrop = false;
-
-  if (result.dropPosition === "inside") {
-    // Dropping inside the source itself
-    isNoOpDrop = visibleItems[result.index]?.id === sourceId;
-  } else if (result.dropPosition === "above") {
-    // Dropping above the source (which means index would be sourceIndex)
-    isNoOpDrop = result.index === sourceIndex;
-  } else if (result.dropPosition === "below") {
-    // Dropping below the source (which means index would be sourceIndex)
-    isNoOpDrop = result.index === sourceIndex;
-  }
-
-  // If dragging would result in no movement, hide the drag indicators
-  if (isNoOpDrop) {
-    store.setTargetDragIndex({ index: -2 }); // -2 means no drag indicator
-    store.setTargetDragPosition({ position: 0 });
-    store.setTargetDropPosition({ dropPosition: "none" });
-    render();
-    return;
-  }
-
-  // Convert absolute position to relative position
-  const relativePosition = result.position - containerTop;
+export const handleWindowPointerMove = (deps, payload) => {
+  const { store } = deps;
+  const event = payload?._event;
+  const pointerId = store.selectTouchDragPointerId();
 
   if (
-    store.selectTargetDragIndex() === result.index &&
-    store.selectTargetDragPosition() === relativePosition &&
-    store.selectTargetDropPosition() === result.dropPosition
+    pointerId === undefined ||
+    event?.pointerId !== pointerId ||
+    event?.pointerType === "mouse"
   ) {
     return;
   }
 
-  store.setTargetDragIndex({ index: result.index });
-  store.setTargetDragPosition({ position: relativePosition });
-  store.setTargetDropPosition({ dropPosition: result.dropPosition });
-  render();
+  const point = getPointerPoint(event);
+  if (!point) {
+    return;
+  }
+
+  handleMobilePointMove(deps, payload, { point });
+};
+
+const handleMobilePointEnd = (deps, payload, { point } = {}) => {
+  const { store } = deps;
+  const hasTouchPointEndState =
+    store.selectTouchScrollActive() ||
+    store.selectTouchDragActive() ||
+    store.selectPendingDrag() ||
+    store.selectTouchDragStartPoint() !== undefined ||
+    store.selectTouchDragPointerId() !== undefined;
+
+  if (!hasTouchPointEndState) {
+    return;
+  }
+
+  if (store.selectTouchScrollActive()) {
+    payload?._event?.preventDefault?.();
+    clearDragAutoScrollTimer(store);
+    store.clearTouchDrag();
+    return;
+  }
+
+  if (!store.selectTouchDragActive()) {
+    clearTouchDragTimer(store);
+    payload?._event?.preventDefault?.();
+    payload?._event?.stopPropagation?.();
+    if (selectPendingTouchItem(deps)) {
+      store.clearTouchDrag();
+      return;
+    }
+
+    cancelPendingTouchDrag(deps);
+    return;
+  }
+
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+  store.setSuppressNextClick({ suppress: true });
+  suppressTouchContextMenu(store);
+  if (point) {
+    store.setTouchDragCurrentPoint({ point });
+    updateDragTarget(deps, { clientY: point.y });
+  }
+  deps.handlers.handleWindowMouseUp(deps, payload);
+  clearTouchDragTimer(store);
+  store.clearTouchDrag();
+};
+
+export const handleWindowTouchEnd = (deps, payload) => {
+  const touchPoint = getTouchPoint(payload?._event);
+  handleMobilePointEnd(deps, payload, {
+    point: touchPoint
+      ? {
+          x: touchPoint.clientX,
+          y: touchPoint.clientY,
+        }
+      : undefined,
+  });
+};
+
+export const handleWindowPointerUp = (deps, payload) => {
+  const { store } = deps;
+  const event = payload?._event;
+  const pointerId = store.selectTouchDragPointerId();
+
+  if (
+    pointerId === undefined ||
+    event?.pointerId !== pointerId ||
+    event?.pointerType === "mouse"
+  ) {
+    return;
+  }
+
+  handleMobilePointEnd(deps, payload, {
+    point: getPointerPoint(event),
+  });
+};
+
+export const handleWindowTouchCancel = (deps, payload) => {
+  const { store, render } = deps;
+
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  if (store.selectTouchDragActive()) {
+    suppressTouchContextMenu(store);
+    return;
+  }
+
+  if (store.selectIsDragging()) {
+    clearDragAutoScrollTimer(store);
+    store.stopDragging();
+    render();
+  }
+
+  suppressTouchContextMenu(store);
+  cancelPendingTouchDrag(deps);
+};
+
+export const handleWindowPointerCancel = (deps, payload) => {
+  const { store } = deps;
+  const event = payload?._event;
+  const pointerId = store.selectTouchDragPointerId();
+
+  if (
+    pointerId === undefined ||
+    event?.pointerId !== pointerId ||
+    event?.pointerType === "mouse"
+  ) {
+    return;
+  }
+
+  deps.handlers.handleWindowTouchCancel(deps, payload);
 };
 
 const subscriptions = (deps) => {
@@ -687,11 +1259,62 @@ const subscriptions = (deps) => {
         deps.handlers.handleWindowMouseUp(deps, { _event: e });
       }),
     ),
+    fromEvent(window, "touchmove", { passive: false }).pipe(
+      tap((e) => {
+        deps.handlers.handleWindowTouchMove(deps, { _event: e });
+      }),
+    ),
+    fromEvent(window, "touchend", { passive: false }).pipe(
+      tap((e) => {
+        deps.handlers.handleWindowTouchEnd(deps, { _event: e });
+      }),
+    ),
+    fromEvent(window, "touchcancel", { passive: false }).pipe(
+      tap((e) => {
+        deps.handlers.handleWindowTouchCancel(deps, { _event: e });
+      }),
+    ),
+    fromEvent(window, "pointermove", { passive: false }).pipe(
+      tap((e) => {
+        deps.handlers.handleWindowPointerMove(deps, { _event: e });
+      }),
+    ),
+    fromEvent(window, "pointerup", { passive: false }).pipe(
+      tap((e) => {
+        deps.handlers.handleWindowPointerUp(deps, { _event: e });
+      }),
+    ),
+    fromEvent(window, "pointercancel", { passive: false }).pipe(
+      tap((e) => {
+        deps.handlers.handleWindowPointerCancel(deps, { _event: e });
+      }),
+    ),
   ];
+};
+
+const shouldSuppressTouchContextMenu = (deps, event) => {
+  const { store, props: attrs } = deps;
+  if (!isDragEnabledForAttrs(attrs)) {
+    return false;
+  }
+
+  return (
+    event?.sourceCapabilities?.firesTouchEvents === true ||
+    store.selectTouchDragActive() ||
+    store.selectTouchScrollActive() ||
+    store.selectTouchDragStartPoint() !== undefined ||
+    store.selectTouchContextMenuSuppressUntil() > Date.now()
+  );
 };
 
 export const handleContainerContextMenu = (deps, payload) => {
   const { store, render, props } = deps;
+  if (shouldSuppressTouchContextMenu(deps, payload._event)) {
+    payload._event.preventDefault();
+    payload._event.stopPropagation();
+    return;
+  }
+
   const target = payload._event.target;
   if (
     typeof target?.closest === "function" &&
@@ -742,6 +1365,10 @@ export const handleItemContextMenu = (deps, payload) => {
   payload._event.preventDefault();
   payload._event.stopPropagation();
 
+  if (shouldSuppressTouchContextMenu(deps, payload._event)) {
+    return;
+  }
+
   const itemId = getItemIdFromEvent(payload._event);
   if (!itemId) {
     return;
@@ -781,6 +1408,13 @@ export const handleItemContextMenu = (deps, payload) => {
 
 export const handleItemClick = (deps, payload) => {
   const { store, render, props } = deps;
+  if (store.selectSuppressNextClick()) {
+    payload?._event?.preventDefault?.();
+    payload?._event?.stopPropagation?.();
+    store.setSuppressNextClick({ suppress: false });
+    return;
+  }
+
   const itemId = getItemIdFromEvent(payload._event);
   if (!itemId) {
     return;

--- a/src/components/baseFileExplorer/baseFileExplorer.store.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.store.js
@@ -30,6 +30,17 @@ export const createInitialState = () => ({
   containerTop: 0,
   forbiddenIndices: [],
   pendingDrag: null,
+  touchDragTimerId: undefined,
+  touchDragStartPoint: undefined,
+  touchDragCurrentPoint: undefined,
+  touchDragPointerId: undefined,
+  touchDragActive: false,
+  touchScrollActive: false,
+  touchScrollLastPoint: undefined,
+  touchContextMenuSuppressUntil: 0,
+  suppressNextClick: false,
+  dragAutoScrollTimerId: undefined,
+  dragAutoScrollPoint: undefined,
 
   // Track collapsed folder IDs
   collapsedIds: [],
@@ -64,7 +75,6 @@ export const startDragging = (
 
 export const stopDragging = ({ state }, _payload = {}) => {
   state.isDragging = false;
-  state.selectedItemId = undefined;
   state.targetDragIndex = -2;
   state.targetDragPosition = 0;
   state.targetDropPosition = "above";
@@ -96,6 +106,73 @@ export const setPendingDrag = ({ state }, { pendingDrag } = {}) => {
 
 export const clearPendingDrag = ({ state }, _payload = {}) => {
   state.pendingDrag = null;
+};
+
+export const setTouchDragTimerId = ({ state }, { timerId } = {}) => {
+  state.touchDragTimerId = timerId;
+};
+
+export const setTouchDragStartPoint = ({ state }, { point } = {}) => {
+  state.touchDragStartPoint = point;
+};
+
+export const setTouchDragCurrentPoint = ({ state }, { point } = {}) => {
+  state.touchDragCurrentPoint = point;
+};
+
+export const setTouchDragPointerId = ({ state }, { pointerId } = {}) => {
+  state.touchDragPointerId = pointerId;
+};
+
+export const setTouchDragActive = ({ state }, { active } = {}) => {
+  state.touchDragActive = active === true;
+};
+
+export const setTouchScrollActive = ({ state }, { active } = {}) => {
+  state.touchScrollActive = active === true;
+};
+
+export const setTouchScrollLastPoint = ({ state }, { point } = {}) => {
+  state.touchScrollLastPoint = point;
+};
+
+export const clearTouchDrag = ({ state }, _payload = {}) => {
+  state.touchDragTimerId = undefined;
+  state.touchDragStartPoint = undefined;
+  state.touchDragCurrentPoint = undefined;
+  state.touchDragPointerId = undefined;
+  state.touchDragActive = false;
+  state.touchScrollActive = false;
+  state.touchScrollLastPoint = undefined;
+};
+
+export const setTouchContextMenuSuppressUntil = (
+  { state },
+  { suppressUntil } = {},
+) => {
+  state.touchContextMenuSuppressUntil = suppressUntil ?? 0;
+};
+
+export const setSuppressNextClick = ({ state }, { suppress } = {}) => {
+  state.suppressNextClick = suppress === true;
+};
+
+export const setDragAutoScrollTimerId = ({ state }, { timerId } = {}) => {
+  state.dragAutoScrollTimerId = timerId;
+};
+
+export const setDragAutoScrollPoint = ({ state }, { point } = {}) => {
+  state.dragAutoScrollPoint = point;
+};
+
+export const clearDragAutoScroll = ({ state }, _payload = {}) => {
+  state.dragAutoScrollTimerId = undefined;
+  state.dragAutoScrollPoint = undefined;
+};
+
+export const setDragLayout = ({ state }, { itemRects, containerTop } = {}) => {
+  state.itemRects = itemRects ?? {};
+  state.containerTop = containerTop ?? 0;
 };
 
 export const selectTargetDragIndex = ({ state }) => {
@@ -132,6 +209,50 @@ export const selectForbiddenIndices = ({ state }) => {
 
 export const selectPendingDrag = ({ state }) => {
   return state.pendingDrag;
+};
+
+export const selectTouchDragTimerId = ({ state }) => {
+  return state.touchDragTimerId;
+};
+
+export const selectTouchDragStartPoint = ({ state }) => {
+  return state.touchDragStartPoint;
+};
+
+export const selectTouchDragCurrentPoint = ({ state }) => {
+  return state.touchDragCurrentPoint;
+};
+
+export const selectTouchDragPointerId = ({ state }) => {
+  return state.touchDragPointerId;
+};
+
+export const selectTouchDragActive = ({ state }) => {
+  return state.touchDragActive;
+};
+
+export const selectTouchScrollActive = ({ state }) => {
+  return state.touchScrollActive;
+};
+
+export const selectTouchScrollLastPoint = ({ state }) => {
+  return state.touchScrollLastPoint;
+};
+
+export const selectTouchContextMenuSuppressUntil = ({ state }) => {
+  return state.touchContextMenuSuppressUntil;
+};
+
+export const selectSuppressNextClick = ({ state }) => {
+  return state.suppressNextClick;
+};
+
+export const selectDragAutoScrollTimerId = ({ state }) => {
+  return state.dragAutoScrollTimerId;
+};
+
+export const selectDragAutoScrollPoint = ({ state }) => {
+  return state.dragAutoScrollPoint;
 };
 
 export const selectCollapsedIds = ({ state }) => {
@@ -291,6 +412,11 @@ export const selectViewData = ({ state, props, props: attrs }) => {
   });
 
   const targetDragItem = visibleItems[state.targetDragIndex];
+  const suppressItemHover = state.isDragging || state.suppressNextClick;
+  const dragEnabled =
+    getBooleanAttr(attrs, "allowDrag", "allow-drag") ||
+    getBooleanAttr(attrs, "draggable", "draggable");
+  const touchAction = dragEnabled ? "none" : "pan-y";
 
   // Map items with additional UI properties
   const processedItems = visibleItems.map((item) => {
@@ -311,7 +437,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       bc = "fg";
     }
 
-    if (state.isDragging) {
+    if (suppressItemHover) {
       hBgc = "";
     }
 
@@ -346,6 +472,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       bc,
       hBgc,
       bgc,
+      touchAction,
     };
   });
 

--- a/src/components/baseFileExplorer/baseFileExplorer.view.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.view.yaml
@@ -60,7 +60,7 @@ template:
                       - 'rtgl-view#itemRef${i} data-item-id=${item.id} h-bgc=${item.hBgc} bgc=${item.bgc} d=h g=xs style="padding-left: ${item.ml}px; min-width: 0; box-sizing: border-box; touch-action: ${item.touchAction}; -webkit-touch-callout: none; -webkit-tap-highlight-color: transparent;" w=f pv=md pr=md h=32 cur=pointer av=c bc=${item.bc} bw=xs':
                           - $if shrinkable && item.hasChildren:
                               - rtgl-view d=h av=c ah=c w=16 h=16 min-w=16:
-                                  - rtgl-svg#arrowRef${i} data-item-id=${item.id} svg=${item.arrowIcon} wh=16 cur=pointer: null
+                                  - rtgl-svg#arrowRef${i} data-item-id=${item.id} data-file-explorer-arrow=true svg=${item.arrowIcon} wh=16 cur=pointer: null
                             $else:
                               - rtgl-view d=h av=c ah=c w=16 h=16 min-w=16: null
                           - 'rtgl-view d=h g=md av=c w=1fg style="min-width: 0; overflow: hidden;"':

--- a/src/components/baseFileExplorer/baseFileExplorer.view.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.view.yaml
@@ -8,6 +8,10 @@ refs:
       mousedown:
         required: true
         handler: handleItemMouseDown
+      pointerdown:
+        handler: handleItemPointerDown
+      touchstart:
+        handler: handleItemTouchStart
       contextmenu:
         handler: handleItemContextMenu
       click:
@@ -39,6 +43,8 @@ refs:
 styles:
   ':host':
     '-webkit-user-select': none
+    '-webkit-touch-callout': none
+    '-webkit-tap-highlight-color': transparent
     '-moz-user-select': none
     '-ms-user-select': none
     user-select: none
@@ -51,7 +57,7 @@ template:
             $else:
               - rtgl-view w=f:
                   - $for item, i in items:
-                      - 'rtgl-view#itemRef${i} data-item-id=${item.id} h-bgc=${item.hBgc} bgc=${item.bgc} d=h g=xs style="padding-left: ${item.ml}px; min-width: 0; box-sizing: border-box;" w=f pv=md pr=md h=32 cur=pointer av=c bc=${item.bc} bw=xs':
+                      - 'rtgl-view#itemRef${i} data-item-id=${item.id} h-bgc=${item.hBgc} bgc=${item.bgc} d=h g=xs style="padding-left: ${item.ml}px; min-width: 0; box-sizing: border-box; touch-action: ${item.touchAction}; -webkit-touch-callout: none; -webkit-tap-highlight-color: transparent;" w=f pv=md pr=md h=32 cur=pointer av=c bc=${item.bc} bw=xs':
                           - $if shrinkable && item.hasChildren:
                               - rtgl-view d=h av=c ah=c w=16 h=16 min-w=16:
                                   - rtgl-svg#arrowRef${i} data-item-id=${item.id} svg=${item.arrowIcon} wh=16 cur=pointer: null

--- a/src/deps/clients/android/router.js
+++ b/src/deps/clients/android/router.js
@@ -13,6 +13,53 @@ const createPathWithPayload = (path, payload) => {
   return query ? `${path}?${query}` : path;
 };
 
+const ANDROID_ROUTER_STACK_STORAGE_KEY = "routevn.android.router.stack.v1";
+
+const getRouterStorage = () => {
+  try {
+    return globalThis.window?.sessionStorage;
+  } catch {
+    return undefined;
+  }
+};
+
+const isPersistedStack = (stack) => {
+  return (
+    Array.isArray(stack) &&
+    stack.length > 0 &&
+    stack.every((entry) => typeof entry === "string" && entry.trim())
+  );
+};
+
+const readPersistedStack = () => {
+  const storage = getRouterStorage();
+  if (!storage) {
+    return undefined;
+  }
+
+  try {
+    const rawStack = storage.getItem(ANDROID_ROUTER_STACK_STORAGE_KEY);
+    if (!rawStack) {
+      return undefined;
+    }
+
+    const stack = JSON.parse(rawStack);
+    if (isPersistedStack(stack)) {
+      return stack;
+    }
+
+    storage.removeItem(ANDROID_ROUTER_STACK_STORAGE_KEY);
+  } catch {
+    try {
+      storage.removeItem(ANDROID_ROUTER_STACK_STORAGE_KEY);
+    } catch {
+      // Storage can be disabled in restricted WebView contexts.
+    }
+  }
+
+  return undefined;
+};
+
 const parsePathAndPayload = (path, payload) => {
   const parsed = new URL(path || "/projects", "https://routevn.android");
   const nextPayload = {};
@@ -31,11 +78,30 @@ export default class AndroidRouter {
   onStackChange = undefined;
 
   constructor({ initialPath = "/projects", onStackChange } = {}) {
-    this.stackEntries = [parsePathAndPayload(initialPath)];
+    const persistedStack = readPersistedStack();
+    const stack = persistedStack ?? [initialPath];
+    this.stackEntries = stack.map((path) => parsePathAndPayload(path));
     this.onStackChange = onStackChange;
   }
 
+  persistStack = () => {
+    const storage = getRouterStorage();
+    if (!storage) {
+      return;
+    }
+
+    try {
+      storage.setItem(
+        ANDROID_ROUTER_STACK_STORAGE_KEY,
+        JSON.stringify(this.stack),
+      );
+    } catch {
+      // Navigation should keep working even if session storage is unavailable.
+    }
+  };
+
   emitStackChange = () => {
+    this.persistStack();
     this.onStackChange?.({
       canGoBack: this.canGoBack(),
       stack: this.stack,

--- a/tests/android/router.test.js
+++ b/tests/android/router.test.js
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import AndroidRouter from "../../src/deps/clients/android/router.js";
+
+const ROUTER_STACK_STORAGE_KEY = "routevn.android.router.stack.v1";
+
+const createStorageMock = () => {
+  const entries = new Map();
+
+  return {
+    getItem: vi.fn((key) => entries.get(key) ?? undefined),
+    setItem: vi.fn((key, value) => {
+      entries.set(key, value);
+    }),
+    removeItem: vi.fn((key) => {
+      entries.delete(key);
+    }),
+  };
+};
+
+const installStorage = (storage) => {
+  vi.stubGlobal("window", {
+    sessionStorage: storage,
+  });
+};
+
+describe("android router", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("restores the route stack after a WebView reload", () => {
+    const storage = createStorageMock();
+    installStorage(storage);
+
+    const router = new AndroidRouter({ initialPath: "/projects" });
+    router.redirect("/project", { p: "project-1" });
+    router.redirect("/project/images", {
+      p: "project-1",
+      folderId: "folder-1",
+    });
+
+    const reloadedRouter = new AndroidRouter({ initialPath: "/projects" });
+
+    expect(reloadedRouter.getPathName()).toBe("/project/images");
+    expect(reloadedRouter.getPayload()).toEqual({
+      p: "project-1",
+      folderId: "folder-1",
+    });
+    expect(reloadedRouter.canGoBack()).toBe(true);
+    expect(reloadedRouter.stack).toEqual([
+      "/projects",
+      "/project?p=project-1",
+      "/project/images?p=project-1&folderId=folder-1",
+    ]);
+  });
+
+  it("updates the persisted stack when navigating back", () => {
+    const storage = createStorageMock();
+    installStorage(storage);
+
+    const router = new AndroidRouter({ initialPath: "/projects" });
+    router.redirect("/project", { p: "project-1" });
+    router.redirect("/project/images", { p: "project-1" });
+
+    router.back();
+
+    const reloadedRouter = new AndroidRouter({ initialPath: "/projects" });
+    expect(reloadedRouter.getPathName()).toBe("/project");
+    expect(reloadedRouter.getPayload()).toEqual({ p: "project-1" });
+    expect(reloadedRouter.stack).toEqual(["/projects", "/project?p=project-1"]);
+  });
+
+  it("ignores invalid persisted stacks", () => {
+    const storage = createStorageMock();
+    storage.setItem(ROUTER_STACK_STORAGE_KEY, JSON.stringify([]));
+    installStorage(storage);
+
+    const router = new AndroidRouter({ initialPath: "/projects" });
+
+    expect(router.getPathName()).toBe("/projects");
+    expect(storage.removeItem).toHaveBeenCalledWith(ROUTER_STACK_STORAGE_KEY);
+  });
+});

--- a/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
@@ -63,9 +63,16 @@ const createItemElement = ({ id, top, parentElement, getScrollTop }) => {
   };
 };
 
-const createPointerEvent = ({ currentTarget, x, y, pointerId = 1 } = {}) => {
+const createPointerEvent = ({
+  currentTarget,
+  target = currentTarget,
+  x,
+  y,
+  pointerId = 1,
+} = {}) => {
   return {
     currentTarget,
+    target,
     pointerId,
     pointerType: "touch",
     isPrimary: true,
@@ -76,10 +83,17 @@ const createPointerEvent = ({ currentTarget, x, y, pointerId = 1 } = {}) => {
   };
 };
 
-const createTouchEvent = ({ currentTarget, x, y, ended = false } = {}) => {
+const createTouchEvent = ({
+  currentTarget,
+  target = currentTarget,
+  x,
+  y,
+  ended = false,
+} = {}) => {
   const touch = { clientX: x, clientY: y };
   return {
     currentTarget,
+    target,
     touches: ended ? [] : [touch],
     changedTouches: [touch],
     preventDefault: vi.fn(),
@@ -96,6 +110,13 @@ const createContextMenuEvent = ({ currentTarget, firesTouchEvents } = {}) => {
     stopPropagation: vi.fn(),
     sourceCapabilities:
       firesTouchEvents === undefined ? undefined : { firesTouchEvents },
+  };
+};
+
+const createArrowTarget = () => {
+  return {
+    closest: (selector) =>
+      selector === "[data-file-explorer-arrow]" ? {} : undefined,
   };
 };
 
@@ -424,6 +445,102 @@ describe("baseFileExplorer handlers", () => {
     expect(deps.store.selectIsDragging()).toBe(false);
     expect(deps.store.selectTouchScrollActive()).toBe(true);
     expect(deps.refs.root.scrollTop).toBe(12);
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps pointer scroll active after pre-longpress pointer movement", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps({
+      itemCount: 12,
+      rootHeight: 96,
+    });
+
+    handleItemPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.itemRef0,
+        pointerId: 7,
+        x: 10,
+        y: 32,
+      }),
+    });
+
+    handleWindowPointerMove(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.itemRef0,
+        pointerId: 7,
+        x: 10,
+        y: 20,
+      }),
+    });
+
+    expect(deps.store.selectTouchScrollActive()).toBe(true);
+    expect(deps.store.selectTouchDragPointerId()).toBe(7);
+    expect(deps.refs.root.scrollTop).toBe(12);
+
+    handleWindowPointerMove(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.itemRef0,
+        pointerId: 7,
+        x: 10,
+        y: 8,
+      }),
+    });
+
+    expect(deps.refs.root.scrollTop).toBe(24);
+
+    handleWindowPointerUp(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.itemRef0,
+        pointerId: 7,
+        x: 10,
+        y: 8,
+      }),
+    });
+
+    expect(deps.store.selectTouchScrollActive()).toBe(false);
+    expect(deps.store.selectTouchDragPointerId()).toBeUndefined();
+  });
+
+  it("does not claim touch or pointer starts from the folder arrow", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+    const arrowTarget = createArrowTarget();
+    const pointerDownEvent = createPointerEvent({
+      currentTarget: deps.refs.itemRef0,
+      target: arrowTarget,
+      x: 10,
+      y: 16,
+    });
+    const touchStartEvent = createTouchEvent({
+      currentTarget: deps.refs.itemRef0,
+      target: arrowTarget,
+      x: 10,
+      y: 16,
+    });
+
+    handleItemPointerDown(deps, {
+      _event: pointerDownEvent,
+    });
+    handleItemTouchStart(deps, {
+      _event: touchStartEvent,
+    });
+    handleWindowTouchEnd(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        target: arrowTarget,
+        x: 10,
+        y: 16,
+        ended: true,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(pointerDownEvent.preventDefault).not.toHaveBeenCalled();
+    expect(touchStartEvent.preventDefault).not.toHaveBeenCalled();
+    expect(deps.refs.itemRef0.setPointerCapture).not.toHaveBeenCalled();
+    expect(deps.store.selectPendingDrag()).toBeNull();
+    expect(deps.store.selectIsDragging()).toBe(false);
+    expect(deps.store.selectSelectedItemId()).toBeUndefined();
     expect(deps.dispatchEvent).not.toHaveBeenCalled();
   });
 

--- a/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleNavigateSelection } from "../../src/components/baseFileExplorer/baseFileExplorer.handlers.js";
+import {
+  handleItemContextMenu,
+  handleItemPointerDown,
+  handleItemTouchStart,
+  handleNavigateSelection,
+  handleWindowMouseUp,
+  handleWindowPointerMove,
+  handleWindowPointerUp,
+  handleWindowTouchCancel,
+  handleWindowTouchEnd,
+  handleWindowTouchMove,
+} from "../../src/components/baseFileExplorer/baseFileExplorer.handlers.js";
+import * as baseFileExplorerStore from "../../src/components/baseFileExplorer/baseFileExplorer.store.js";
 
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
 
@@ -11,6 +23,132 @@ const createItems = (count) => {
     _level: 0,
     parentId: null,
   }));
+};
+
+const createBoundStore = ({ state, props }) => {
+  const context = { state, props };
+  const store = {};
+
+  for (const [name, fn] of Object.entries(baseFileExplorerStore)) {
+    if (
+      typeof fn !== "function" ||
+      name === "createInitialState" ||
+      name === "selectViewData"
+    ) {
+      continue;
+    }
+
+    store[name] = (payload) => fn(context, payload);
+  }
+
+  return store;
+};
+
+const createItemElement = ({ id, top, parentElement, getScrollTop }) => {
+  return {
+    parentElement,
+    getAttribute: (name) => (name === "data-item-id" ? id : undefined),
+    getBoundingClientRect: () => {
+      const scrollTop = getScrollTop?.() ?? 0;
+      const adjustedTop = top - scrollTop;
+      return {
+        top: adjustedTop,
+        bottom: adjustedTop + 32,
+        height: 32,
+        y: adjustedTop,
+      };
+    },
+    scrollIntoView: vi.fn(),
+    setPointerCapture: vi.fn(),
+  };
+};
+
+const createPointerEvent = ({ currentTarget, x, y, pointerId = 1 } = {}) => {
+  return {
+    currentTarget,
+    pointerId,
+    pointerType: "touch",
+    isPrimary: true,
+    clientX: x,
+    clientY: y,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  };
+};
+
+const createTouchEvent = ({ currentTarget, x, y, ended = false } = {}) => {
+  const touch = { clientX: x, clientY: y };
+  return {
+    currentTarget,
+    touches: ended ? [] : [touch],
+    changedTouches: [touch],
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  };
+};
+
+const createContextMenuEvent = ({ currentTarget, firesTouchEvents } = {}) => {
+  return {
+    currentTarget,
+    clientX: 10,
+    clientY: 16,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    sourceCapabilities:
+      firesTouchEvents === undefined ? undefined : { firesTouchEvents },
+  };
+};
+
+const createDragDeps = ({ itemCount = 4, rootHeight = 128 } = {}) => {
+  const items = createItems(itemCount);
+  const props = {
+    items,
+    allowDrag: true,
+    contextMenuItems: [{ label: "Rename", value: "rename-item" }],
+  };
+  const state = baseFileExplorerStore.createInitialState();
+  const store = createBoundStore({ state, props });
+  const refs = {};
+  refs.root = {
+    scrollTop: 0,
+    scrollHeight: items.length * 32,
+    clientHeight: rootHeight,
+    getBoundingClientRect: () => ({
+      top: 0,
+      bottom: rootHeight,
+      height: rootHeight,
+    }),
+  };
+  const getScrollTop = () => refs.root.scrollTop;
+  const parentElement = {
+    getBoundingClientRect: () => ({
+      top: -getScrollTop(),
+      bottom: items.length * 32 - getScrollTop(),
+      height: items.length * 32,
+    }),
+  };
+
+  items.forEach((item, index) => {
+    refs[`itemRef${index}`] = createItemElement({
+      id: item.id,
+      top: index * 32,
+      parentElement,
+      getScrollTop,
+    });
+  });
+
+  const deps = {
+    dispatchEvent: vi.fn(),
+    props,
+    refs,
+    render: vi.fn(),
+    store,
+    handlers: {},
+  };
+  deps.handlers.handleWindowMouseUp = (nextDeps, payload) =>
+    handleWindowMouseUp(nextDeps, payload);
+
+  return { deps, state };
 };
 
 const createDeps = ({ selectedItemId, itemCount = 15 } = {}) => {
@@ -45,6 +183,7 @@ describe("baseFileExplorer handlers", () => {
 
   afterEach(() => {
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    vi.useRealTimers();
   });
 
   it("jumps selection by distance and clamps to the visible list bounds", () => {
@@ -102,5 +241,353 @@ describe("baseFileExplorer handlers", () => {
     expect(result).toBeUndefined();
     expect(deps.store.setSelectedItemId).not.toHaveBeenCalled();
     expect(deps.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it("starts mobile drag after long press and drops on touch release", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+    const startEvent = createTouchEvent({
+      currentTarget: deps.refs.itemRef0,
+      x: 10,
+      y: 16,
+    });
+
+    handleItemTouchStart(deps, {
+      _event: startEvent,
+    });
+
+    expect(startEvent.preventDefault).toHaveBeenCalled();
+    expect(deps.store.selectPendingDrag().id).toBe("item-1");
+    expect(deps.store.selectIsDragging()).toBe(false);
+
+    vi.advanceTimersByTime(400);
+
+    expect(deps.store.selectIsDragging()).toBe(true);
+    expect(deps.store.selectTouchDragActive()).toBe(true);
+
+    const moveEvent = createTouchEvent({
+      currentTarget: deps.refs.itemRef0,
+      x: 10,
+      y: 90,
+    });
+
+    handleWindowTouchMove(deps, { _event: moveEvent });
+
+    expect(moveEvent.preventDefault).toHaveBeenCalled();
+    expect(deps.store.selectTargetDropPosition()).toBe("below");
+
+    const endEvent = createTouchEvent({
+      currentTarget: deps.refs.itemRef0,
+      x: 10,
+      y: 90,
+      ended: true,
+    });
+
+    handleWindowTouchEnd(deps, { _event: endEvent });
+
+    expect(endEvent.preventDefault).toHaveBeenCalled();
+    expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchEvent.mock.calls[0][0].type).toBe("target-changed");
+    expect(deps.dispatchEvent.mock.calls[0][0].detail).toMatchObject({
+      position: "below",
+      source: { id: "item-1" },
+      target: { id: "item-3" },
+    });
+    expect(deps.store.selectIsDragging()).toBe(false);
+    expect(deps.store.selectTouchDragActive()).toBe(false);
+    expect(deps.store.selectSelectedItemId()).toBe("item-1");
+  });
+
+  it("starts Android pointer drag after long press and drops on release", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+    const pointerDownEvent = createPointerEvent({
+      currentTarget: deps.refs.itemRef0,
+      x: 10,
+      y: 16,
+    });
+
+    handleItemPointerDown(deps, {
+      _event: pointerDownEvent,
+    });
+
+    expect(pointerDownEvent.preventDefault).toHaveBeenCalled();
+    expect(deps.refs.itemRef0.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(deps.store.selectTouchDragPointerId()).toBe(1);
+    expect(deps.store.selectPendingDrag().id).toBe("item-1");
+
+    vi.advanceTimersByTime(400);
+
+    expect(deps.store.selectIsDragging()).toBe(true);
+    expect(deps.store.selectTouchDragActive()).toBe(true);
+
+    const moveEvent = createPointerEvent({
+      currentTarget: deps.refs.itemRef0,
+      x: 10,
+      y: 90,
+    });
+
+    handleWindowPointerMove(deps, { _event: moveEvent });
+
+    expect(moveEvent.preventDefault).toHaveBeenCalled();
+    expect(deps.store.selectTargetDropPosition()).toBe("below");
+
+    const upEvent = createPointerEvent({
+      currentTarget: deps.refs.itemRef0,
+      x: 10,
+      y: 90,
+    });
+
+    handleWindowPointerUp(deps, { _event: upEvent });
+
+    expect(upEvent.preventDefault).toHaveBeenCalled();
+    expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchEvent.mock.calls[0][0].detail).toMatchObject({
+      position: "below",
+      source: { id: "item-1" },
+      target: { id: "item-3" },
+    });
+    expect(deps.store.selectIsDragging()).toBe(false);
+    expect(deps.store.selectTouchDragPointerId()).toBeUndefined();
+  });
+
+  it("keeps the active mobile drag when Android sends cancel after long press", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    handleWindowTouchCancel(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+
+    expect(deps.store.selectIsDragging()).toBe(true);
+    expect(deps.store.selectTouchDragActive()).toBe(true);
+
+    handleWindowTouchMove(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 90,
+      }),
+    });
+    handleWindowTouchEnd(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 90,
+        ended: true,
+      }),
+    });
+
+    expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchEvent.mock.calls[0][0].detail).toMatchObject({
+      position: "below",
+      source: { id: "item-1" },
+      target: { id: "item-3" },
+    });
+  });
+
+  it("scrolls the explorer when touch moves before long press", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+
+    handleWindowTouchMove(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 4,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(deps.store.selectPendingDrag()).toBeNull();
+    expect(deps.store.selectIsDragging()).toBe(false);
+    expect(deps.store.selectTouchScrollActive()).toBe(true);
+    expect(deps.refs.root.scrollTop).toBe(12);
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores unrelated window touchend events when no touch drag is pending", () => {
+    const { deps } = createDragDeps();
+    const endEvent = createTouchEvent({
+      x: 10,
+      y: 16,
+      ended: true,
+    });
+
+    handleWindowTouchEnd(deps, {
+      _event: endEvent,
+    });
+
+    expect(endEvent.preventDefault).not.toHaveBeenCalled();
+    expect(endEvent.stopPropagation).not.toHaveBeenCalled();
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+    expect(deps.store.selectSelectedItemId()).toBeUndefined();
+  });
+
+  it("cancels the previous long-press timeout when a tap selects before dragging", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+    vi.advanceTimersByTime(250);
+    handleWindowTouchEnd(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+        ended: true,
+      }),
+    });
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef1,
+        x: 10,
+        y: 48,
+      }),
+    });
+    vi.advanceTimersByTime(111);
+
+    expect(deps.store.selectIsDragging()).toBe(false);
+    expect(deps.store.selectPendingDrag().id).toBe("item-2");
+
+    vi.advanceTimersByTime(249);
+
+    expect(deps.store.selectIsDragging()).toBe(true);
+    expect(deps.store.selectSelectedItemId()).toBe("item-2");
+  });
+
+  it("auto-scrolls while active mobile drag stays near the bottom edge", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps({
+      itemCount: 12,
+      rootHeight: 96,
+    });
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    handleWindowTouchMove(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 94,
+      }),
+    });
+
+    const firstScrollTop = deps.refs.root.scrollTop;
+    vi.advanceTimersByTime(50);
+
+    expect(firstScrollTop).toBeGreaterThan(0);
+    expect(deps.refs.root.scrollTop).toBeGreaterThan(firstScrollTop);
+    expect(deps.store.selectItemRects()["item-1"].top).toBe(
+      -deps.refs.root.scrollTop,
+    );
+
+    handleWindowTouchEnd(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 94,
+        ended: true,
+      }),
+    });
+
+    expect(deps.store.selectDragAutoScrollTimerId()).toBeUndefined();
+  });
+
+  it("selects the item when claimed mobile touch ends before long press", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+    handleWindowTouchEnd(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+        ended: true,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(deps.store.selectSelectedItemId()).toBe("item-1");
+    expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchEvent.mock.calls[0][0].detail).toMatchObject({
+      itemId: "item-1",
+    });
+    expect(deps.store.selectIsDragging()).toBe(false);
+  });
+
+  it("suppresses touch context menu while preserving desktop context menu", () => {
+    vi.useFakeTimers();
+    const { deps } = createDragDeps();
+
+    handleItemTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.itemRef0,
+        x: 10,
+        y: 16,
+      }),
+    });
+
+    const touchContextMenuEvent = createContextMenuEvent({
+      currentTarget: deps.refs.itemRef0,
+      firesTouchEvents: true,
+    });
+
+    handleItemContextMenu(deps, { _event: touchContextMenuEvent });
+
+    expect(touchContextMenuEvent.preventDefault).toHaveBeenCalled();
+    expect(touchContextMenuEvent.stopPropagation).toHaveBeenCalled();
+    expect(deps.store.selectDropdownMenuItemId()).toBeNull();
+
+    const { deps: desktopDeps } = createDragDeps();
+    const mouseContextMenuEvent = createContextMenuEvent({
+      currentTarget: desktopDeps.refs.itemRef0,
+    });
+
+    handleItemContextMenu(desktopDeps, { _event: mouseContextMenuEvent });
+
+    expect(desktopDeps.store.selectDropdownMenuItemId()).toBe("item-1");
   });
 });

--- a/tests/baseFileExplorer/baseFileExplorer.store.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.store.test.js
@@ -94,4 +94,68 @@ describe("baseFileExplorer.store", () => {
     expect(viewData.items).toHaveLength(1);
     expect(viewData.items[0].svg).toBe("component");
   });
+
+  it("keeps only the selected row highlighted while suppressing the post-drag touch click", () => {
+    const state = createInitialState();
+    state.selectedItemId = "item-1";
+    state.suppressNextClick = true;
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        items: [
+          {
+            id: "item-1",
+            type: "image",
+            name: "Image 1",
+            _level: 0,
+            hasChildren: false,
+            parentId: null,
+          },
+          {
+            id: "item-2",
+            type: "image",
+            name: "Image 2",
+            _level: 0,
+            hasChildren: false,
+            parentId: null,
+          },
+        ],
+      },
+    });
+
+    expect(viewData.items[0].bgc).toBe("mu");
+    expect(viewData.items[0].hBgc).toBe("");
+    expect(viewData.items[1].bgc).toBe("");
+    expect(viewData.items[1].hBgc).toBe("");
+  });
+
+  it("keeps native touch panning when drag is disabled", () => {
+    const state = createInitialState();
+    const item = {
+      id: "item-1",
+      type: "image",
+      name: "Image 1",
+      _level: 0,
+      hasChildren: false,
+      parentId: null,
+    };
+
+    const disabledViewData = selectViewData({
+      state,
+      props: {
+        items: [item],
+      },
+    });
+    const enabledViewData = selectViewData({
+      state,
+      props: {
+        items: [item],
+        allowDrag: true,
+      },
+    });
+
+    expect(disabledViewData.items[0].touchAction).toBe("pan-y");
+    expect(enabledViewData.items[0].touchAction).toBe("none");
+  });
 });

--- a/tests/baseFileExplorer/baseFileExplorer.view.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.view.test.js
@@ -36,5 +36,6 @@ describe("baseFileExplorer view", () => {
     expect(view).toContain("touchstart:");
     expect(view).toContain("handler: handleItemTouchStart");
     expect(view).toContain("touch-action: ${item.touchAction};");
+    expect(view).toContain("data-file-explorer-arrow=true");
   });
 });

--- a/tests/baseFileExplorer/baseFileExplorer.view.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.view.test.js
@@ -27,4 +27,14 @@ describe("baseFileExplorer view", () => {
     expect(view).not.toContain("rtgl-view w=f h=f:");
     expect(view).not.toContain("rtgl-view#container w=f h=1fg");
   });
+
+  it("wires touchstart for mobile long-press drag", () => {
+    const view = readView();
+
+    expect(view).toContain("pointerdown:");
+    expect(view).toContain("handler: handleItemPointerDown");
+    expect(view).toContain("touchstart:");
+    expect(view).toContain("handler: handleItemTouchStart");
+    expect(view).toContain("touch-action: ${item.touchAction};");
+  });
 });

--- a/tests/images/images.fileExplorer.test.js
+++ b/tests/images/images.fileExplorer.test.js
@@ -110,4 +110,42 @@ describe("images file explorer", () => {
       message: "Cannot delete resource, it is currently in use.",
     });
   });
+
+  it("refreshes after drag reorder without changing page selection", async () => {
+    const refresh = vi.fn(async () => {});
+    const moveImage = vi.fn(async () => {});
+    const deps = {
+      projectService: {
+        ensureRepository: vi.fn(async () => {}),
+        moveImage,
+      },
+    };
+    const handlers = createResourceFileExplorerHandlers({
+      resourceType: "images",
+      refresh,
+    });
+
+    await handlers.handleFileExplorerTargetChanged(deps, {
+      _event: {
+        detail: {
+          source: {
+            id: "image-1",
+          },
+          target: {
+            id: "image-2",
+            parentId: "folder-1",
+          },
+          position: "below",
+        },
+      },
+    });
+
+    expect(moveImage).toHaveBeenCalledWith({
+      imageId: "image-1",
+      parentId: "folder-1",
+      position: "after",
+      positionTargetId: "image-2",
+    });
+    expect(refresh).toHaveBeenCalledWith(deps);
+  });
 });


### PR DESCRIPTION
## Summary
- Persist the Android router stack in sessionStorage so WebView reloads restore the current path and payload.
- Clear invalid persisted stacks and keep navigation working if storage is unavailable.
- Build the initial Android frontend bundle before starting watch mode so the dev server has the expected JS entrypoint on startup.

## Tests
- bunx vitest run tests/android/router.test.js
- bash -n scripts/watch-android.sh
- bun prettier --check src/deps/clients/android/router.js tests/android/router.test.js
- bunx oxlint src/deps/clients/android/router.js tests/android/router.test.js
- push hook: oxlint && bun prettier --check src

## Android dev refresh
- Restarted bun run watch:android on port 3001
- Verified adb reverse tcp:3001 -> tcp:3001
- Reloaded the running Android WebView through CDP