### PR TITLE
Refine Android navigation history

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -474,7 +474,7 @@ public class MainActivity extends Activity {
 
     private void handleBackPressed() {
         if (webView == null) {
-            finish();
+            moveTaskToBack(true);
             return;
         }
 
@@ -482,7 +482,7 @@ public class MainActivity extends Activity {
             "(function(){return Boolean(window.routeVNNativeBack && window.routeVNNativeBack());})()",
             value -> {
                 if (!"true".equals(value)) {
-                    finish();
+                    moveTaskToBack(true);
                 }
             }
         );

--- a/src/components/imagesMobileResourceTypes/imagesMobileResourceTypes.handlers.js
+++ b/src/components/imagesMobileResourceTypes/imagesMobileResourceTypes.handlers.js
@@ -26,7 +26,10 @@ export const handleItemClick = (deps, payload) => {
     event: payload._event,
     data: { itemId: id },
   });
-  appService.navigate(resourceItem.path, currentPayload, { timing });
+  appService.navigate(resourceItem.path, currentPayload, {
+    historyMode: "replace",
+    timing,
+  });
 };
 
 export const handleItemPointerDown = (deps, payload) => {

--- a/src/components/mobileSidebar/mobileSidebar.handlers.js
+++ b/src/components/mobileSidebar/mobileSidebar.handlers.js
@@ -74,9 +74,12 @@ export const handleItemClick = (deps, payload = {}) => {
     event: payload._event,
     data: { itemId },
   });
+  const historyMode =
+    item.path === "/project/scene-editor" ? "push" : "replace";
   subject.dispatch("redirect", {
     path: item.path,
     payload: nextPayload,
+    historyMode,
     timing,
   });
 };

--- a/src/deps/clients/android/router.js
+++ b/src/deps/clients/android/router.js
@@ -60,7 +60,7 @@ const readPersistedStack = () => {
   return undefined;
 };
 
-const parsePathAndPayload = (path, payload) => {
+const parsePathAndPayload = (path, payload, state) => {
   const parsed = new URL(path || "/projects", "https://routevn.android");
   const nextPayload = {};
   for (const [key, value] of parsed.searchParams.entries()) {
@@ -70,6 +70,7 @@ const parsePathAndPayload = (path, payload) => {
   return {
     path: parsed.pathname || "/projects",
     payload: payload ? { ...payload } : nextPayload,
+    state: state && typeof state === "object" ? { ...state } : {},
   };
 };
 
@@ -125,20 +126,25 @@ export default class AndroidRouter {
     return { ...this.getCurrentEntry().payload };
   };
 
+  getHistoryState = () => {
+    return { ...this.getCurrentEntry().state };
+  };
+
   setPayload = (payload) => {
     this.getCurrentEntry().payload = { ...payload };
     this.emitStackChange();
   };
 
-  redirect = (path, payload) => {
-    this.stackEntries.push(parsePathAndPayload(path, payload));
+  redirect = (path, payload, options = {}) => {
+    this.stackEntries.push(parsePathAndPayload(path, payload, options.state));
     this.emitStackChange();
   };
 
-  replace = (path, payload) => {
+  replace = (path, payload, options = {}) => {
     this.stackEntries[this.stackEntries.length - 1] = parsePathAndPayload(
       path,
       payload,
+      options.state,
     );
     this.emitStackChange();
   };

--- a/src/deps/clients/router.js
+++ b/src/deps/clients/router.js
@@ -66,7 +66,7 @@ export default class WebRouter {
       return;
     }
 
-    window.history.replaceState({}, "", finalPath);
+    window.history.replaceState(this.getHistoryState(), "", finalPath);
     this.lastPayloadReplaceAt = Date.now();
   };
 
@@ -117,16 +117,24 @@ export default class WebRouter {
     this.schedulePendingPayload(throttleMs - elapsedMs);
   };
 
-  redirect = (path, payload) => {
-    this.clearPendingPayload();
-    const finalPath = createPathWithPayload(path, payload);
-    window.history.pushState({}, "", finalPath);
+  getHistoryState = () => {
+    const state = window.history.state;
+    if (state && typeof state === "object") {
+      return { ...state };
+    }
+    return {};
   };
 
-  replace = (path, payload) => {
+  redirect = (path, payload, options = {}) => {
     this.clearPendingPayload();
     const finalPath = createPathWithPayload(path, payload);
-    window.history.replaceState({}, "", finalPath);
+    window.history.pushState(options.state ?? {}, "", finalPath);
+  };
+
+  replace = (path, payload, options = {}) => {
+    this.clearPendingPayload();
+    const finalPath = createPathWithPayload(path, payload);
+    window.history.replaceState(options.state ?? {}, "", finalPath);
   };
 
   back = () => {

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -120,8 +120,9 @@ export const createAppShellService = ({
           path,
           payload,
         });
+      const historyMode = options.historyMode;
       markNavigationTiming(timing, "appService.navigate.dispatch");
-      subject.dispatch("redirect", { path, payload, timing });
+      subject.dispatch("redirect", { path, payload, timing, historyMode });
     },
 
     redirect(path, payload) {

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -121,16 +121,23 @@ export const createAppShellService = ({
           payload,
         });
       const historyMode = options.historyMode;
+      const historyState = options.historyState;
       markNavigationTiming(timing, "appService.navigate.dispatch");
-      subject.dispatch("redirect", { path, payload, timing, historyMode });
+      subject.dispatch("redirect", {
+        path,
+        payload,
+        timing,
+        historyMode,
+        historyState,
+      });
     },
 
-    redirect(path, payload) {
-      router.redirect(path, payload);
+    redirect(path, payload, options) {
+      router.redirect(path, payload, options);
     },
 
-    replace(path, payload) {
-      router.replace(path, payload);
+    replace(path, payload, options) {
+      router.replace(path, payload, options);
     },
 
     getPath() {
@@ -139,6 +146,10 @@ export const createAppShellService = ({
 
     getPayload() {
       return router.getPayload();
+    },
+
+    getHistoryState() {
+      return router.getHistoryState?.() ?? {};
     },
 
     getCurrentProjectId() {

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -645,6 +645,7 @@ const syncEditorState = async ({ deps, repositoryState } = {}) => {
         createAnimationEditorPayload({
           payload: appService.getPayload() || {},
         }),
+        { historyMode: "replace" },
       );
       return false;
     }
@@ -707,6 +708,7 @@ export const handleBackClick = async (deps) => {
     createAnimationEditorPayload({
       payload: currentPayload,
     }),
+    { historyMode: "replace" },
   );
 };
 

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -152,6 +152,7 @@ const createRouteTransitionRunner = (deps) => {
     path,
     payload,
     historyMode,
+    historyState,
     shouldUpdateHistory = false,
     timing,
   } = {}) => {
@@ -179,10 +180,10 @@ const createRouteTransitionRunner = (deps) => {
     });
 
     if (routeHistoryMode === "push") {
-      appService.redirect(canonicalPath, nextPayload);
+      appService.redirect(canonicalPath, nextPayload, { state: historyState });
       markNavigationTiming(routeTiming, "route.history.redirected");
     } else if (routeHistoryMode === "replace" || canonicalPath !== path) {
-      appService.replace(canonicalPath, nextPayload);
+      appService.replace(canonicalPath, nextPayload, { state: historyState });
       markNavigationTiming(routeTiming, "route.history.replaced");
     }
 
@@ -577,6 +578,7 @@ const subscriptions = (deps) => {
           path,
           payload: nextPayload,
           historyMode,
+          historyState: payload?.historyState,
           timing,
         }).catch((error) => {
           markNavigationTiming(timing, "route.subscription.error", {

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -24,6 +24,10 @@ import { resolveUpdatesEnabled } from "../../internal/updates.js";
 import { recordRecentSceneVisit } from "../../internal/ui/recentScenes.js";
 
 const GLOBAL_NAV_TIMEOUT_MS = 1500;
+const ROUTE_HISTORY_MODES = new Set(["push", "replace", "none"]);
+
+const normalizeRouteHistoryMode = (historyMode, fallback = "none") =>
+  ROUTE_HISTORY_MODES.has(historyMode) ? historyMode : fallback;
 
 const selectAppCopy = (i18n = {}) => i18n.appPage ?? {};
 
@@ -147,6 +151,7 @@ const createRouteTransitionRunner = (deps) => {
   return async ({
     path,
     payload,
+    historyMode,
     shouldUpdateHistory = false,
     timing,
   } = {}) => {
@@ -155,6 +160,10 @@ const createRouteTransitionRunner = (deps) => {
     const currentTransitionToken = ++transitionToken;
     const nextPayload = normalizePayload(payload);
     const canonicalPath = getCanonicalRoutePath(path);
+    const routeHistoryMode = normalizeRouteHistoryMode(
+      historyMode,
+      shouldUpdateHistory ? "push" : "none",
+    );
     const routeTiming =
       timing ??
       createNavigationTiming({
@@ -164,15 +173,15 @@ const createRouteTransitionRunner = (deps) => {
         payload: nextPayload,
       });
     markNavigationTiming(routeTiming, "route.transition.start", {
-      shouldUpdateHistory,
+      historyMode: routeHistoryMode,
       requestedPath: path,
       canonicalPath,
     });
 
-    if (shouldUpdateHistory) {
+    if (routeHistoryMode === "push") {
       appService.redirect(canonicalPath, nextPayload);
       markNavigationTiming(routeTiming, "route.history.redirected");
-    } else if (canonicalPath !== path) {
+    } else if (routeHistoryMode === "replace" || canonicalPath !== path) {
       appService.replace(canonicalPath, nextPayload);
       markNavigationTiming(routeTiming, "route.history.replaced");
     }
@@ -545,6 +554,12 @@ const subscriptions = (deps) => {
         const nextPayload = shouldUpdateHistory
           ? payload.payload
           : payload?.payload;
+        const historyMode = normalizeRouteHistoryMode(
+          payload?.historyMode,
+          shouldUpdateHistory || !!payload?.shouldUpdateHistory
+            ? "push"
+            : "none",
+        );
         const timing =
           payload?.timing ??
           createNavigationTiming({
@@ -555,15 +570,13 @@ const subscriptions = (deps) => {
           });
         markNavigationTiming(timing, "route.subscription.received", {
           action,
-          shouldUpdateHistory:
-            shouldUpdateHistory || !!payload?.shouldUpdateHistory,
+          historyMode,
         });
 
         runRouteTransition({
           path,
           payload: nextPayload,
-          shouldUpdateHistory:
-            shouldUpdateHistory || !!payload?.shouldUpdateHistory,
+          historyMode,
           timing,
         }).catch((error) => {
           markNavigationTiming(timing, "route.subscription.error", {
@@ -595,7 +608,13 @@ const subscriptions = (deps) => {
 
             event.preventDefault();
             event.stopPropagation();
-            appService.navigate(targetPath, getCurrentQueryPayload(appService));
+            appService.navigate(
+              targetPath,
+              getCurrentQueryPayload(appService),
+              {
+                historyMode: "replace",
+              },
+            );
           }),
         ),
       ),

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -2071,7 +2071,9 @@ export const handleItemDelete = async (deps, payload) => {
 
 export const handleBackClick = (deps) => {
   const { appService } = deps;
-  appService.navigate("/project/characters", appService.getPayload());
+  appService.navigate("/project/characters", appService.getPayload(), {
+    historyMode: "replace",
+  });
 };
 
 const {

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -485,7 +485,13 @@ export const handleBackClick = async (deps) => {
   }
   const currentPayload = appService.getPayload() || {};
   const nextPath = getLayoutEditorBackPath(currentPayload);
-  appService.navigate(nextPath, { p: currentPayload.p });
+  appService.navigate(
+    nextPath,
+    { p: currentPayload.p },
+    {
+      historyMode: "replace",
+    },
+  );
 };
 
 export const handleSaveButtonClick = async (deps) => {

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -301,7 +301,9 @@ export const handleEditIconCropDialogConfirm = async (deps) => {
 
 export const handleBackToProjects = async (deps) => {
   const { appService } = deps;
-  appService.navigate("/projects");
+  appService.navigate("/projects", undefined, {
+    historyState: { preserveProjectsEntryOnProjectOpen: true },
+  });
 };
 
 export const handleBackButtonKeyDown = (deps, payload) => {

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -215,7 +215,11 @@ const navigateToProjectRoute = async (
     appService.setCurrentProjectEntry(project);
   }
 
-  appService.navigate(path, { p: projectId }, { historyMode: "replace" });
+  const currentHistoryState = appService.getHistoryState?.() ?? {};
+  const historyMode = currentHistoryState.preserveProjectsEntryOnProjectOpen
+    ? "push"
+    : "replace";
+  appService.navigate(path, { p: projectId }, { historyMode });
 };
 
 const createProjectFromValues = async (deps, values = {}) => {

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -215,7 +215,7 @@ const navigateToProjectRoute = async (
     appService.setCurrentProjectEntry(project);
   }
 
-  appService.navigate(path, { p: projectId });
+  appService.navigate(path, { p: projectId }, { historyMode: "replace" });
 };
 
 const createProjectFromValues = async (deps, values = {}) => {

--- a/src/pages/resourceTypes/resourceTypes.handlers.js
+++ b/src/pages/resourceTypes/resourceTypes.handlers.js
@@ -24,7 +24,10 @@ export const handleItemClick = (deps, payload) => {
     event: payload._event,
     data: { itemId: id },
   });
-  appService.navigate(resourceItem.path, currentPayload, { timing });
+  appService.navigate(resourceItem.path, currentPayload, {
+    historyMode: "replace",
+    timing,
+  });
 };
 
 export const handleItemPointerDown = (deps, payload) => {

--- a/src/pages/resources/resources.handlers.js
+++ b/src/pages/resources/resources.handlers.js
@@ -21,5 +21,6 @@ export const handleResourcesClick = (deps, payload) => {
   subject.dispatch("redirect", {
     path: route,
     payload: appService.getPayload(),
+    historyMode: "replace",
   });
 };

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -3601,7 +3601,7 @@ export const handleBackClick = async (deps) => {
   const { appService } = deps;
   await flushSceneEditorDrafts(deps, { force: true });
   const { p } = appService.getPayload();
-  appService.navigate("/project/scenes", { p });
+  appService.navigate("/project/scenes", { p }, { historyMode: "replace" });
 };
 
 export const handleSystemActionsActionDelete = async (deps, payload) => {

--- a/src/pages/sidebar/sidebar.handlers.js
+++ b/src/pages/sidebar/sidebar.handlers.js
@@ -45,6 +45,7 @@ export const handleItemClick = async (deps, payload) => {
   subject.dispatch("redirect", {
     path,
     payload: currentPayload, // Pass through current payload (including projectId)
+    historyMode: "replace",
     timing,
   });
 };
@@ -61,6 +62,7 @@ export const handleHeaderClick = (deps) => {
   subject.dispatch("redirect", {
     path: "/project",
     payload: currentPayload, // Pass through current payload (including projectId)
+    historyMode: "replace",
     timing,
   });
 };


### PR DESCRIPTION
Summary:
- Add explicit route history modes so tab/menu navigation can replace instead of push.
- Switch in-project tab/menu/resource navigation and editor back actions to replace while preserving push for editor drill-down openings.
- Make Android native Back background the task instead of finishing when the web app has no internal back entry.

Validation:
- bun run lint
- git diff --check
- ./gradlew installDebug