### PR TITLE
Fix mobile resource delete icons and Android audio playback

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -661,12 +661,25 @@ public class MainActivity extends Activity {
                 return new WebResourceResponse(
                     mimeType,
                     null,
+                    200,
+                    "OK",
+                    createInternalFileResponseHeaders(),
                     new FileInputStream(file)
                 );
             } catch (Exception error) {
                 return null;
             }
         }
+    }
+
+    private Map<String, String> createInternalFileResponseHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Access-Control-Allow-Origin", "*");
+        headers.put("Access-Control-Allow-Methods", "GET, OPTIONS");
+        headers.put("Access-Control-Allow-Headers", "Origin, Range, Accept, Content-Type");
+        headers.put("Access-Control-Expose-Headers", "Content-Length, Content-Range, Accept-Ranges");
+        headers.put("Cross-Origin-Resource-Policy", "cross-origin");
+        return headers;
     }
 
     private final class AndroidBridge {

--- a/src/components/audioPlayer/audioPlayer.view.yaml
+++ b/src/components/audioPlayer/audioPlayer.view.yaml
@@ -17,12 +17,12 @@ template:
           - rtgl-view w=f av=c p=md h=f:
               - rtgl-text c=mu-fg: Loading audio...
         $else:
-          - rtgl-view w=f g=md bgc=mu:
-              - rtgl-view w=f:
+          - 'rtgl-view w=f h=f d=v bgc=mu style="min-height: 0;"':
+              - 'rtgl-view w=f style="flex: 0 0 6px;"':
                   - 'rtgl-view#progressBar w=f h=6 br=full cur=pointer pos=rel bgc=su style="overflow: hidden;"':
                       - 'rtgl-view h=f bgc=ac br=full style="width: ${progressPercentage}%; transition: width 0.1s ease;"': null
               - $if mobileLayout:
-                  - 'rtgl-view d=h av=c w=f h=f p=md g=md style="min-width: 0; box-sizing: border-box;"':
+                  - 'rtgl-view d=h av=c w=f h=1fg p=md g=md style="min-width: 0; min-height: 0; box-sizing: border-box;"':
                       - 'rtgl-text w=1fg ellipsis=true style="min-width: 0;"': ${title}
                       - 'rtgl-view d=h av=c g=md ah=c style="flex: 0 0 auto;"':
                           - 'rtgl-view d=h av=c g=xs ah=e style="width: 96px; flex: 0 0 96px; white-space: nowrap; font-variant-numeric: tabular-nums;"':
@@ -37,7 +37,7 @@ template:
                       - 'rtgl-view#playerCloser w=32 h=32 av=c ah=c cur=pointer style="flex: 0 0 32px;"':
                           - rtgl-svg svg=cross w=16 h=16: null
                 $else:
-                  - rtgl-view ph=md d=h av=c w=f h=f p=md:
+                  - 'rtgl-view ph=md d=h av=c w=f h=1fg p=md style="min-height: 0;"':
                       - rtgl-text w=250 ellipsis=true: ${title}
                       - rtgl-view d=h av=c g=lg w=1fg ah=c:
                           - rtgl-view#playPauseBtn cur=pointer:

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -99,7 +99,7 @@ template:
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view w=f pl=md pos=rel:
+                  - rtgl-view w=f ph=md pos=rel:
                       - 'rtgl-view d=h w=f av=c bgc=${group.headerBackgroundColor} z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:

--- a/src/components/charactersResourcesView/charactersResourcesView.view.yaml
+++ b/src/components/charactersResourcesView/charactersResourcesView.view.yaml
@@ -71,7 +71,7 @@ template:
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view w=f pl=md pos=rel:
+                  - rtgl-view w=f ph=md pos=rel:
                       - 'rtgl-view d=h w=f av=c bgc=${group.headerBackgroundColor} z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:

--- a/src/components/groupVariablesView/groupVariablesView.view.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.view.yaml
@@ -108,7 +108,7 @@ template:
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; min-height: 0; box-sizing: border-box;"':
           - $if flatGroups.length > 0:
               - $for group, i in flatGroups:
-                  - rtgl-view w=f pl=md pos=rel:
+                  - rtgl-view w=f ph=md pos=rel:
                       - 'rtgl-view d=h w=f av=c bgc=${group.headerBackgroundColor} z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupRef${i} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -263,7 +263,7 @@ export const showContextMenu = ({ state, props }, { itemId, x, y } = {}) => {
   state.dropdownMenu.y = y;
   state.dropdownMenu.targetItemId = itemId;
   state.dropdownMenu.items = props.itemContextMenuItems ?? [
-    { label: "Delete", type: "item", value: "delete-item" },
+    { label: "Delete", icon: "trash", type: "item", value: "delete-item" },
   ];
 };
 

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -132,7 +132,7 @@ template:
       - 'rtgl-view#scrollContainer h=1fg w=f sv style="min-width: 0; min-height: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view#groupDropRef${gIndex} data-group-id=${group.id} w=f pl=md pos=rel:
+                  - rtgl-view#groupDropRef${gIndex} data-group-id=${group.id} w=f ph=md pos=rel:
                       - 'rtgl-view d=h w=f av=c bgc=${group.headerBackgroundColor} z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -29,6 +29,7 @@ export const createInitialState = () => ({
     items: [
       {
         label: "Delete",
+        icon: "trash",
         type: "item",
         value: "delete",
       },

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -91,7 +91,7 @@ template:
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; box-sizing: border-box;"':
           - $if groups.length > 0:
               - $for group, gIndex in groups:
-                  - rtgl-view w=f pl=md pos=rel:
+                  - rtgl-view w=f ph=md pos=rel:
                       - 'rtgl-view d=h w=f av=c bgc=${group.headerBackgroundColor} z=100 pv=sm style="position: sticky; top: 0px;"':
                           - rtgl-view#groupToggleRef${gIndex} data-group-id=${group.id} d=h av=c g=md cur=pointer:
                               - $if group.isCollapsed:

--- a/src/deps/services/android/projectFileUrls.js
+++ b/src/deps/services/android/projectFileUrls.js
@@ -2,6 +2,12 @@ import { assertSafeAndroidStorageSegment } from "../../clients/android/storagePa
 import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
 
 const PROJECT_FILE_EXTENSION_BY_MIME_TYPE = {
+  "audio/mpeg": "mp3",
+  "audio/mp3": "mp3",
+  "audio/ogg": "ogg",
+  "audio/wav": "wav",
+  "audio/wave": "wav",
+  "audio/x-wav": "wav",
   "image/gif": "gif",
   "image/jpeg": "jpg",
   "image/png": "png",

--- a/src/deps/services/audioService.js
+++ b/src/deps/services/audioService.js
@@ -90,6 +90,14 @@ export const createAudioService = () => {
       gainNode.connect(audioContext.destination);
     },
 
+    async unlock() {
+      service.init();
+
+      if (audioContext?.state === "suspended") {
+        await audioContext.resume();
+      }
+    },
+
     cleanup() {
       if (audioContext && audioContext.state !== "closed") {
         audioContext.close();

--- a/src/internal/ui/resourcePages/media/createMediaPageStore.js
+++ b/src/internal/ui/resourcePages/media/createMediaPageStore.js
@@ -51,6 +51,7 @@ const createFolderContextMenuItems = (copy = {}) => [
   },
   {
     label: copy.deleteMenuItem ?? "Delete",
+    icon: "trash",
     type: "item",
     value: "delete-item",
   },
@@ -64,6 +65,7 @@ const createItemContextMenuItems = (copy = {}) => [
   },
   {
     label: copy.deleteMenuItem ?? "Delete",
+    icon: "trash",
     type: "item",
     value: "delete-item",
   },
@@ -92,6 +94,7 @@ const createMediaCenterItemContextMenuItems = (previewMenuLabel, copy = {}) => {
 
   items.push({
     label: copy.deleteMenuItem ?? "Delete",
+    icon: "trash",
     type: "item",
     value: "delete-item",
   });

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -194,7 +194,7 @@ template:
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}
                   - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rtgl-view d=v w=f p=md g=md:
                       - $if selectedItemDescription:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -307,7 +307,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="sprite-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -215,7 +215,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailSpritesButton w=1fg v=se pre=image: ${spriteGroupsLabel}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="character-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -164,7 +164,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="color-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -198,7 +198,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="control-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -165,7 +165,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="font-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -264,7 +264,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null
@@ -276,7 +276,7 @@ template:
                   - rtgl-text c=mu-fg: ${mobileDeleteDialogMessage}
               - rtgl-view d=h g=sm w=f ah=e:
                   - rtgl-button#mobileDeleteCancelButton v=se: ${cancelButton}
-                  - rtgl-button#mobileDeleteConfirmButton v=pr: ${mobileDeleteDialogConfirmLabel}
+                  - rtgl-button#mobileDeleteConfirmButton v=pr pre=trash: ${mobileDeleteDialogConfirmLabel}
   - $if isEditDialogOpen:
       - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
           - rtgl-view slot=content g=md:

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -169,7 +169,7 @@ template:
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}
                   - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="layout-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -196,7 +196,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - $if selectedTextureImageFileId:

--- a/src/pages/sounds/sounds.handlers.js
+++ b/src/pages/sounds/sounds.handlers.js
@@ -332,7 +332,7 @@ const openSoundPreviewById = ({
   syncExplorer = false,
   suppressMobileDetailSheet = false,
 } = {}) => {
-  const { refs, store, render } = deps;
+  const { appService, refs, store, render } = deps;
   if (!itemId) {
     return;
   }
@@ -341,6 +341,11 @@ const openSoundPreviewById = ({
   if (!soundItem?.fileId) {
     return;
   }
+
+  void appService
+    .getAudioService?.()
+    ?.unlock?.()
+    ?.catch?.(() => {});
 
   store.setSelectedItemId({
     itemId,

--- a/src/pages/sounds/sounds.store.js
+++ b/src/pages/sounds/sounds.store.js
@@ -180,6 +180,9 @@ const {
       showAudioPlayer: state.showAudioPlayer,
       audioPlayerLeft: state.isTouchMode ? 0 : state.audioPlayerLeft,
       audioPlayerRight: state.isTouchMode ? 0 : state.audioPlayerRight,
+      audioPlayerBottom: state.isTouchMode
+        ? "calc(64px + env(safe-area-inset-bottom))"
+        : "0px",
       mobileDeleteDialogOpen: state.mobileDeleteDialogOpen,
       mobileDeleteDialogTitle: copy.deleteTitle,
       mobileDeleteDialogMessage: copy.deleteMessage.replace(

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -195,7 +195,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPlayButton w=1fg v=se pre=play: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="sound-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null
@@ -207,7 +207,7 @@ template:
                   - rtgl-text c=mu-fg: ${mobileDeleteDialogMessage}
               - rtgl-view d=h g=sm w=f ah=e:
                   - rtgl-button#mobileDeleteCancelButton v=se: ${cancelButton}
-                  - rtgl-button#mobileDeleteConfirmButton v=pr: ${mobileDeleteDialogConfirmLabel}
+                  - rtgl-button#mobileDeleteConfirmButton v=pr pre=trash: ${mobileDeleteDialogConfirmLabel}
   - $if isEditDialogOpen:
       - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
           - rtgl-view slot=content g=md:
@@ -225,5 +225,5 @@ template:
       - rtgl-dialog#createTagDialog ?open=${isCreateTagDialogOpen} s=sm:
           - rtgl-form#createTagForm key=${isCreateTagDialogOpen} slot=content :defaultValues=${createTagDefaultValues} :form=${createTagForm} w=f: null
   - $if showAudioPlayer:
-      - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: ${audioPlayerLeft}px; right: ${audioPlayerRight}px;"':
+      - 'rtgl-view h=72 pos=fix z=1500 style="left: ${audioPlayerLeft}px; right: ${audioPlayerRight}px; bottom: ${audioPlayerBottom};"':
           - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :mobileLayout=${mobileLayout} :title=${playingSound.title}: null

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -191,7 +191,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="spritesheet-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -189,7 +189,7 @@ template:
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailEditButton w=1fg v=se pre=edit: ${editButton}
                   - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="text-style-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -231,7 +231,7 @@ template:
                       - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
                   - rtgl-view d=h w=f g=sm:
                       - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
-                      - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                      - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="transform-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -125,7 +125,7 @@ template:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="variable-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -185,7 +185,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=play: ${previewButton}
-                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se: ${deleteButton}
+                  - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-tag-select#detailTagSelect slot="video-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null

--- a/svg/trash.svg
+++ b/svg/trash.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 7H20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 11V17M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 7L7 20H17L18 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 7V4H15V7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tests/audioPlayer/audioPlayer.view.test.js
+++ b/tests/audioPlayer/audioPlayer.view.test.js
@@ -2,6 +2,30 @@ import { readFileSync } from "fs";
 import { describe, expect, it } from "vitest";
 
 describe("audio player view", () => {
+  it("fills the player height without pushing controls below center", () => {
+    const audioPlayerView = readFileSync(
+      new URL(
+        "../../src/components/audioPlayer/audioPlayer.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(audioPlayerView).toContain(
+      'rtgl-view w=f h=f d=v bgc=mu style="min-height: 0;"',
+    );
+    expect(audioPlayerView).toContain(
+      'rtgl-view w=f style="flex: 0 0 6px;"',
+    );
+    expect(audioPlayerView).toContain(
+      'rtgl-view d=h av=c w=f h=1fg p=md g=md style="min-width: 0; min-height: 0; box-sizing: border-box;"',
+    );
+    expect(audioPlayerView).toContain(
+      'rtgl-view ph=md d=h av=c w=f h=1fg p=md style="min-height: 0;"',
+    );
+    expect(audioPlayerView).not.toContain("rtgl-view w=f g=md bgc=mu");
+  });
+
   it("keeps desktop playback controls centered after the title", () => {
     const audioPlayerView = readFileSync(
       new URL(

--- a/tests/resourcePages/mobileResourceGridZoom.view.test.js
+++ b/tests/resourcePages/mobileResourceGridZoom.view.test.js
@@ -98,6 +98,20 @@ describe("mobile resource grid zoom wiring", () => {
     },
   );
 
+  it.each(mobileMenuResourcePages)(
+    "uses a trash icon for the mobile delete action on %s",
+    (_name, relativePath) => {
+      const view = readFileSync(
+        new URL(`../../src/pages/${relativePath}`, import.meta.url),
+        "utf8",
+      );
+
+      expect(view).toContain(
+        "rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}",
+      );
+    },
+  );
+
   it.each(mobileIconOnlyImportPages)(
     "uses an icon-only mobile import action before the menu on %s",
     (_name, relativePath) => {
@@ -121,7 +135,7 @@ describe("mobile resource grid zoom wiring", () => {
     const importIndex = catalogView.indexOf("showIconImportButton");
     const menuIndex = catalogView.indexOf("showTrailingMenuButton");
 
-    expect(catalogView).toContain("rtgl-view#importBtn w=36 h=36");
+    expect(catalogView).toContain("rtgl-button#importBtn sq pre=upload v=ol");
     expect(filterIndex).toBeGreaterThan(-1);
     expect(importIndex).toBeGreaterThan(filterIndex);
     expect(importIndex).toBeLessThan(menuIndex);
@@ -141,7 +155,7 @@ describe("mobile resource grid zoom wiring", () => {
     expect(mediaView).toContain("height: 1px");
   });
 
-  it("uses left-only item surface inset in shared resource views", () => {
+  it("uses normal horizontal item surface inset in shared resource views", () => {
     const sharedViews = [
       "mediaResourcesView/mediaResourcesView.view.yaml",
       "catalogResourcesView/catalogResourcesView.view.yaml",
@@ -156,8 +170,8 @@ describe("mobile resource grid zoom wiring", () => {
         "utf8",
       );
 
-      expect(view).toContain("pl=md pos=rel");
-      expect(view).not.toContain("ph=md pos=rel");
+      expect(view).toContain("ph=md pos=rel");
+      expect(view).not.toContain("pl=md pos=rel");
       expect(view).not.toContain("rtgl-grid w=f ph=sm");
       expect(view).not.toContain("rtgl-view w=f d=v ph=sm");
       expect(view).not.toContain("rtgl-view w=f mb=md p=sm");

--- a/tests/sounds/sounds.handlers.test.js
+++ b/tests/sounds/sounds.handlers.test.js
@@ -74,8 +74,12 @@ describe("sounds handlers", () => {
   });
 
   it("plays mobile long-press previews without opening the detail sheet", () => {
+    const unlock = vi.fn(() => Promise.resolve());
     const deps = {
       i18n: EN_I18N,
+      appService: {
+        getAudioService: vi.fn(() => ({ unlock })),
+      },
       store: {
         selectSoundItemById: vi.fn(({ itemId }) => ({
           id: itemId,
@@ -114,14 +118,23 @@ describe("sounds handlers", () => {
       fileId: "sound-file-1",
       fileName: "Theme",
     });
+    expect(deps.appService.getAudioService).toHaveBeenCalledTimes(1);
+    expect(unlock).toHaveBeenCalledTimes(1);
+    expect(unlock.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.store.openAudioPlayer.mock.invocationCallOrder[0],
+    );
     expect(deps.render).toHaveBeenCalledTimes(1);
   });
 
   it("plays selected mobile detail sounds", () => {
     const preventDefault = vi.fn();
     const stopPropagation = vi.fn();
+    const unlock = vi.fn(() => Promise.resolve());
     const deps = {
       i18n: EN_I18N,
+      appService: {
+        getAudioService: vi.fn(() => ({ unlock })),
+      },
       store: {
         selectSelectedItemId: vi.fn(() => "sound-1"),
         selectSoundItemById: vi.fn(({ itemId }) => ({
@@ -161,6 +174,11 @@ describe("sounds handlers", () => {
       fileId: "sound-file-1",
       fileName: "Theme",
     });
+    expect(deps.appService.getAudioService).toHaveBeenCalledTimes(1);
+    expect(unlock).toHaveBeenCalledTimes(1);
+    expect(unlock.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.store.openAudioPlayer.mock.invocationCallOrder[0],
+    );
   });
 
   it("opens a confirmation dialog for selected mobile detail sound deletes", () => {

--- a/tests/sounds/sounds.store.test.js
+++ b/tests/sounds/sounds.store.test.js
@@ -71,6 +71,7 @@ describe("sounds store audio player layout", () => {
 
     expect(selectViewData(context).audioPlayerLeft).toBe(364);
     expect(selectViewData(context).audioPlayerRight).toBe(270);
+    expect(selectViewData(context).audioPlayerBottom).toBe("0px");
 
     setUiConfig(context, {
       uiConfig: {
@@ -80,5 +81,8 @@ describe("sounds store audio player layout", () => {
 
     expect(selectViewData(context).audioPlayerLeft).toBe(0);
     expect(selectViewData(context).audioPlayerRight).toBe(0);
+    expect(selectViewData(context).audioPlayerBottom).toBe(
+      "calc(64px + env(safe-area-inset-bottom))",
+    );
   });
 });

--- a/tests/sounds/sounds.view.test.js
+++ b/tests/sounds/sounds.view.test.js
@@ -40,6 +40,7 @@ describe("sounds view", () => {
     expect(mobileDetailBranch).toContain("mobileDetailPlayButton");
     expect(mobileDetailBranch).toContain("mobileDetailDeleteButton");
     expect(mobileDetailBranch).toContain("pre=play: ${previewButton}");
+    expect(mobileDetailBranch).toContain("pre=trash: ${deleteButton}");
 
     expect(soundsView).toContain("handler: handleMobileDetailPlayClick");
     expect(soundsView).toContain("handler: handleMobileDetailDeleteClick");
@@ -58,6 +59,9 @@ describe("sounds view", () => {
     expect(soundsView).toContain("handler: handleMobileDeleteDialogCancel");
     expect(soundsView).toContain("handler: handleMobileDeleteDialogConfirm");
     expect(soundsView).toContain("mobileDeleteDialogMessage");
+    expect(soundsView).toContain(
+      "rtgl-button#mobileDeleteConfirmButton v=pr pre=trash",
+    );
   });
 
   it("sizes the bottom audio player from view data offsets", () => {
@@ -67,9 +71,11 @@ describe("sounds view", () => {
     );
 
     expect(soundsView).toContain(
-      'style="left: ${audioPlayerLeft}px; right: ${audioPlayerRight}px;"',
+      'style="left: ${audioPlayerLeft}px; right: ${audioPlayerRight}px; bottom: ${audioPlayerBottom};"',
     );
     expect(soundsView).toContain(":mobileLayout=${mobileLayout}");
+    expect(soundsView).toContain("z=1500");
+    expect(soundsView).toContain("bottom: ${audioPlayerBottom};");
   });
 
   it("passes bottom scroll room to the media grid", () => {


### PR DESCRIPTION
Summary:
- Add trash icons to mobile resource delete actions and delete context menu items.
- Fix Android sound playback by unlocking Web Audio from the tap path and adding CORS headers for appasset file responses.
- Center the audio player controls and restore normal horizontal padding in shared resource grids instead of compensating for scrollbars.

Tests:
- bunx vitest run tests/resourcePages/mobileResourceGridZoom.view.test.js tests/audioPlayer/audioPlayer.view.test.js tests/sounds/sounds.handlers.test.js tests/sounds/sounds.store.test.js tests/sounds/sounds.view.test.js tests/images/images.view.test.js
- bun run lint