### PR TITLE
Update mobile resource action sheets

### DIFF
--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -961,6 +961,7 @@ charactersPage:
   spriteGroupTagRequiredAtIndex: "Sprite group {index} must have at least one tag."
   spriteGroupsCreateMessage: "Create the character first, then add groups."
   spriteGroupsLabel: "Sprite Groups"
+  spritesButtonLabel: "Sprites"
   title: "Characters"
   updateCharacterButton: "Update Character"
   updateGroupButton: "Update Group"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -961,6 +961,7 @@ charactersPage:
   spriteGroupTagRequiredAtIndex: "立ち絵グループ{index}には少なくとも1つのタグが必要です。"
   spriteGroupsCreateMessage: "先にキャラクターを作成してから、グループを追加してください。"
   spriteGroupsLabel: "立ち絵グループ"
+  spritesButtonLabel: "立ち絵"
   title: "キャラクター"
   updateCharacterButton: "キャラクターを更新"
   updateGroupButton: "グループを更新"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -961,6 +961,7 @@ charactersPage:
   spriteGroupTagRequiredAtIndex: "立绘组 {index} 必须至少有一个标签。"
   spriteGroupsCreateMessage: "请先创建角色，然后再添加组。"
   spriteGroupsLabel: "立绘组"
+  spritesButtonLabel: "立绘"
   title: "角色"
   updateCharacterButton: "更新角色"
   updateGroupButton: "更新组"

--- a/src/pages/animations/animations.store.js
+++ b/src/pages/animations/animations.store.js
@@ -338,6 +338,7 @@ const {
         ? getAnimationTypeLabel(selectedAnimationItem.animationType, copy)
         : "",
       descriptionLabel: copy.descriptionLabel ?? "Description",
+      editButton: copy.editMenuItem ?? "Edit",
       importButton: copy.importMenuButton ?? copy.importButton ?? "Import",
       tagsLabel: copy.tagsLabel ?? "Tags",
       typeLabel: copy.typeLabel ?? "Type",

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -192,8 +192,8 @@ template:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
-                  - rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}
-                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
+                  - rtgl-button#mobileDetailOpenButton w=1fg v=se pre=edit: ${editButton}
+                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se pre=duplicate: ${duplicateButton}
                   - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rtgl-view d=v w=f p=md g=md:

--- a/src/pages/characters/characters.store.js
+++ b/src/pages/characters/characters.store.js
@@ -1122,6 +1122,7 @@ export const selectViewData = ({ state, i18n }) => {
     noSpriteGroups: copy.noSpriteGroups,
     noSpriteGroupsYet: copy.noSpriteGroupsYet,
     spriteGroupsLabel: copy.spriteGroupsLabel,
+    spritesButtonLabel: copy.spritesButtonLabel ?? "Sprites",
     resourceCategory: "assets",
     selectedResourceId: "characters",
     selectedItemId: state.selectedItemId,

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -214,7 +214,7 @@ template:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
-                  - rtgl-button#mobileDetailSpritesButton w=1fg v=se pre=image: ${spriteGroupsLabel}
+                  - rtgl-button#mobileDetailSpritesButton w=1fg v=se pre=image: ${spritesButtonLabel}
                   - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:

--- a/src/pages/transforms/transforms.store.js
+++ b/src/pages/transforms/transforms.store.js
@@ -532,6 +532,7 @@ const {
             ? copy.selectBackgroundTitle
             : copy.selectTargetImageTitle,
       },
+      showTransformPreviewImageSelectorFileExplorer: !state.isTouchMode,
       canvasAspectRatio: formatProjectResolutionAspectRatio(
         state.projectResolution,
       ),

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -230,7 +230,7 @@ template:
                       - rtgl-button#mobileDetailEditButton w=1fg v=se pre=edit: ${editButton}
                       - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
                   - rtgl-view d=h w=f g=sm:
-                      - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
+                      - rtgl-button#mobileDetailDuplicateButton w=1fg v=se pre=duplicate: ${duplicateButton}
                       - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
@@ -283,8 +283,9 @@ template:
       - $if imageSelectorDialog.open:
           - rtgl-view slot=content d=v w=f g=md:
               - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                      - rvn-base-file-explorer#transformPreviewImageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
+                  - $if showTransformPreviewImageSelectorFileExplorer:
+                      - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                          - rvn-base-file-explorer#transformPreviewImageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
                   - 'rtgl-view#transformPreviewImageSelectorKeyboardScope tabindex=-1 w=1fg h=f style="min-width: 0; min-height: 0; outline: none;"':
                       - rvn-image-selector#transformPreviewImageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
               - rtgl-view d=h g=sm w=f ah=e:

--- a/svg/duplicate.svg
+++ b/svg/duplicate.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="8" y="8" width="11" height="11" rx="2" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+<path d="M5 15H4.5C3.67157 15 3 14.3284 3 13.5V4.5C3 3.67157 3.67157 3 4.5 3H13.5C14.3284 3 15 3.67157 15 4.5V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tests/animations/animations.store.test.js
+++ b/tests/animations/animations.store.test.js
@@ -42,6 +42,7 @@ describe("animations.store", () => {
 
     const viewData = selectViewData({ state, i18n: EN_I18N });
 
+    expect(viewData.editButton).toBe("Edit");
     expect(viewData).not.toHaveProperty("selectedAnimationPreviewFileId");
     expect(viewData.selectedAnimationPreviewAspectRatio).toBe("1920 / 1080");
     expect(viewData.animationPreviewOpacity).toBe(0);

--- a/tests/animations/animations.view.test.js
+++ b/tests/animations/animations.view.test.js
@@ -1,0 +1,39 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+describe("animations view", () => {
+  it("uses edit, duplicate, and delete icons in the mobile detail sheet", () => {
+    const animationsView = readFileSync(
+      new URL(
+        "../../src/pages/animations/animations.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    const mobileDetailStart = animationsView.indexOf(
+      "$if showMobileDetailSheet",
+    );
+    const folderDialogStart = animationsView.indexOf(
+      "rtgl-dialog#folderNameDialog",
+      mobileDetailStart,
+    );
+    const mobileDetailBranch = animationsView.slice(
+      mobileDetailStart,
+      folderDialogStart,
+    );
+
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailOpenButton w=1fg v=se pre=edit: ${editButton}",
+    );
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailDuplicateButton w=1fg v=se pre=duplicate: ${duplicateButton}",
+    );
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}",
+    );
+    expect(mobileDetailBranch).not.toContain(
+      "rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}",
+    );
+  });
+});

--- a/tests/characters/characters.store.test.js
+++ b/tests/characters/characters.store.test.js
@@ -119,6 +119,8 @@ describe("characters store sprite group tags", () => {
 
     const viewData = selectViewData({ state, i18n: EN_I18N });
 
+    expect(viewData.spriteGroupsLabel).toBe("Sprite Groups");
+    expect(viewData.spritesButtonLabel).toBe("Sprites");
     expect(viewData.selectedItemSpriteGroups.map((group) => group.id)).toEqual([
       "group-face",
       "group-body",

--- a/tests/characters/characters.view.test.js
+++ b/tests/characters/characters.view.test.js
@@ -27,8 +27,25 @@ describe("characters view", () => {
       "rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",
     );
     expect(mobileExplorerBranch).toContain(
-      "rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36",
+      "rtgl-button#mobileFileExplorerClose sq pre=x v=ol",
     );
     expect(mobileExplorerBranch).not.toContain("rtgl-view h=56 w=f d=h");
+  });
+
+  it("uses a sprites label for the mobile action sheet button", () => {
+    const charactersView = readFileSync(
+      new URL(
+        "../../src/pages/characters/characters.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(charactersView).toContain(
+      "rtgl-button#mobileDetailSpritesButton w=1fg v=se pre=image: ${spritesButtonLabel}",
+    );
+    expect(charactersView).not.toContain(
+      "rtgl-button#mobileDetailSpritesButton w=1fg v=se pre=image: ${spriteGroupsLabel}",
+    );
   });
 });

--- a/tests/transforms/transforms.store.test.js
+++ b/tests/transforms/transforms.store.test.js
@@ -40,6 +40,22 @@ describe("transforms.store", () => {
     expect(selectViewData({ state, i18n: EN_I18N }).editButton).toBe("Edit");
   });
 
+  it("hides the preview image selector file explorer in touch mode", () => {
+    const state = createInitialState();
+
+    expect(
+      selectViewData({ state, i18n: EN_I18N })
+        .showTransformPreviewImageSelectorFileExplorer,
+    ).toBe(true);
+
+    state.isTouchMode = true;
+
+    expect(
+      selectViewData({ state, i18n: EN_I18N })
+        .showTransformPreviewImageSelectorFileExplorer,
+    ).toBe(false);
+  });
+
   it("applies preview image selections immediately and restores them on cancel", () => {
     const state = createInitialState();
     setImagesData({ state }, { imagesData });

--- a/tests/transforms/transforms.view.test.js
+++ b/tests/transforms/transforms.view.test.js
@@ -1,0 +1,62 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+describe("transforms view", () => {
+  it("uses icons for duplicate and delete actions in the mobile detail sheet", () => {
+    const transformsView = readFileSync(
+      new URL(
+        "../../src/pages/transforms/transforms.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    const mobileDetailStart = transformsView.indexOf(
+      "$if showMobileDetailSheet",
+    );
+    const folderDialogStart = transformsView.indexOf(
+      "rtgl-dialog#folderNameDialog",
+      mobileDetailStart,
+    );
+    const mobileDetailBranch = transformsView.slice(
+      mobileDetailStart,
+      folderDialogStart,
+    );
+
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailDuplicateButton w=1fg v=se pre=duplicate: ${duplicateButton}",
+    );
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}",
+    );
+  });
+
+  it("hides the preview image selector file explorer behind touch-mode view data", () => {
+    const transformsView = readFileSync(
+      new URL(
+        "../../src/pages/transforms/transforms.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    const selectorDialogStart = transformsView.indexOf(
+      "rtgl-dialog#transformPreviewImageSelectorDialog",
+    );
+    const previewOverlayStart = transformsView.indexOf(
+      "$when: fullImagePreviewVisible",
+      selectorDialogStart,
+    );
+    const selectorDialogBranch = transformsView.slice(
+      selectorDialogStart,
+      previewOverlayStart,
+    );
+
+    expect(selectorDialogBranch).toContain(
+      "$if showTransformPreviewImageSelectorFileExplorer",
+    );
+    expect(selectorDialogBranch).toContain(
+      "rvn-base-file-explorer#transformPreviewImageSelectorFileExplorer",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add the tracked duplicate SVG asset and use it in transforms/animations mobile action sheets
- show animations mobile open action as Edit with the edit icon
- change the characters mobile action-sheet label to Sprites
- hide the transforms preview image selector file explorer in touch mode

## Tests
- bunx vitest run tests/characters/characters.view.test.js tests/characters/characters.store.test.js tests/transforms/transforms.view.test.js tests/transforms/transforms.store.test.js tests/animations/animations.view.test.js tests/animations/animations.store.test.js
- bun run lint