### PR TITLE
Hide image selector explorers on Android

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -295,7 +295,11 @@ export const handleGetBackgroundTransformPreviewCanvasRoot = ({ refs }) => {
 };
 
 export const handleBeforeMount = (deps) => {
-  const { store, props } = deps;
+  const { store, props, uiConfig } = deps;
+
+  store.setUiConfig({
+    uiConfig,
+  });
 
   if (!props.background) {
     return;

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -10,6 +10,7 @@ import {
   localizeCommandLineText,
   selectCommandLineCopy,
 } from "../../internal/ui/sceneEditor/commandLineCopy.js";
+import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const tabs = [
   {
@@ -180,7 +181,12 @@ export const createInitialState = () => ({
   fullImagePreviewVisible: false,
   fullImagePreviewFileId: undefined,
   searchQuery: "",
+  isTouchMode: false,
 });
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode = isTouchUiConfig(uiConfig);
+};
 
 export const selectTempSelectedResourceId = ({ state }) => {
   return state.tempSelectedResourceId;
@@ -845,6 +851,7 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
     tabs: localizeCommandLineOptions(tabs, copy),
     breadcrumb: localizeCommandLineBreadcrumb(breadcrumb, copy),
     items: flatItems,
+    showImageSelectorFileExplorer: !state.isTouchMode,
     groups: flatGroups,
     tempSelectedResourceId: state.tempSelectedResourceId,
     selectedResource,

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -148,8 +148,9 @@ template:
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
           - 'rtgl-view d=h w=f g=lg mt=sm h=1fg style="min-height: 0;"':
-              - rtgl-view h=f w=1fg sv:
-                  - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
+              - $if showImageSelectorFileExplorer:
+                  - rtgl-view h=f w=1fg sv:
+                      - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
               - rtgl-view h=f w=2fg sv g=lg:
                   - $if tab == 'image':
                       - rvn-image-selector#rvnImageSelector selectedImageId=${tempSelectedResourceId} searchQuery=${searchQuery}: null

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -597,8 +597,11 @@ const applyPanelValueUpdate = (
 };
 
 export const handleBeforeMount = (deps) => {
-  const { props, store } = deps;
+  const { props, store, uiConfig } = deps;
   const values = props.values || {};
+  store.setUiConfig({
+    uiConfig,
+  });
   store.setValues({
     values,
   });

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -13,6 +13,7 @@ import { getFragmentLayoutOptions } from "../../pages/layoutEditor/support/layou
 import { getLayoutEditorElementDefinition } from "../../internal/layoutEditorElementRegistry.js";
 import { splitLayoutConditionFromWhen } from "../../internal/layoutConditions.js";
 import { formatI18nCopy } from "../../internal/ui/i18nCopy.js";
+import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 import {
   getVisibilityConditionCharacterValueOptions,
   toVisibilityConditionTargetTypeByTarget,
@@ -729,10 +730,15 @@ export const createInitialState = () => {
     textStylesData: { tree: [], items: {} },
     variablesData: { tree: [], items: {} },
     values: createDefaultValues(),
+    isTouchMode: false,
   };
 
   resetSelectionUiState(state);
   return state;
+};
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode = isTouchUiConfig(uiConfig);
 };
 
 export const updateValueProperty = ({ state }, { value, name } = {}) => {
@@ -1776,6 +1782,7 @@ export const selectViewData = ({ state, props, constants, i18n }) => {
     imageSelectorDialog: state.imageSelectorDialog,
     tempSelectedImageId: state.tempSelectedImageId,
     imageFolderItems,
+    showImageSelectorFileExplorer: !state.isTouchMode,
     soundSelectorDialog: state.soundSelectorDialog,
     tempSelectedSoundId: state.tempSelectedSoundId,
     soundFolderItems,

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -440,8 +440,9 @@ template:
       - $if imageSelectorDialog.open:
           - rtgl-view slot=content d=v w=f g=md:
               - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                      - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
+                  - $if showImageSelectorFileExplorer:
+                      - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                          - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
                   - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
                       - rvn-image-selector#imageSelector selectedImageId=${tempSelectedImageId}: null
               - rtgl-view d=h g=sm w=f ah=e:

--- a/src/components/layoutEditorPreview/layoutEditorPreview.handlers.js
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.handlers.js
@@ -74,6 +74,9 @@ const didInitialPreviewDataChange = (oldProps = {}, newProps = {}) => {
 };
 
 export const handleBeforeMount = (deps) => {
+  deps.store.setUiConfig({
+    uiConfig: deps.uiConfig,
+  });
   deps.store.setLayoutState({
     layoutState: deps.props.layoutState,
   });

--- a/src/components/layoutEditorPreview/layoutEditorPreview.store.js
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.store.js
@@ -15,6 +15,7 @@ import {
 import { createPersistedPreviewState } from "./support/layoutEditorPreviewPersistence.js";
 import { toFlatItems } from "../../internal/project/tree.js";
 import { toCharacterSelectOptions } from "../../internal/characterOptions.js";
+import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const EMPTY_LAYOUT_DATA = {
   items: {},
@@ -244,7 +245,12 @@ export const createInitialState = () => ({
   },
   fullImagePreviewVisible: false,
   fullImagePreviewImageId: undefined,
+  isTouchMode: false,
 });
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode = isTouchUiConfig(uiConfig);
+};
 
 export const setLayoutState = ({ state }, { layoutState } = {}) => {
   state.layoutState = layoutState;
@@ -685,6 +691,7 @@ export const selectViewData = ({ state, constants, props = {} }) => {
     imageSelectorDialog: state.imageSelectorDialog,
     dropdownMenu: state.dropdownMenu,
     fileExplorerItems,
+    showImageSelectorFileExplorer: !state.isTouchMode,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewImageId: state.fullImagePreviewImageId,
     showDialogueForm: previewBackgroundFormTarget === "dialogue",

--- a/src/components/layoutEditorPreview/layoutEditorPreview.view.yaml
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.view.yaml
@@ -176,8 +176,9 @@ template:
   - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
       - rtgl-view slot=content d=v w=f g=md:
           - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                  - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
+              - $if showImageSelectorFileExplorer:
+                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                      - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
               - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
                   - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
           - rtgl-view d=h g=sm w=f ah=e:

--- a/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.handlers.js
+++ b/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.handlers.js
@@ -26,6 +26,9 @@ const syncImagesData = (deps) => {
 };
 
 export const handleBeforeMount = (deps) => {
+  deps.store.setUiConfig({
+    uiConfig: deps.uiConfig,
+  });
   syncImagesData(deps);
   deps.store.syncFromProps({
     props: deps.props,

--- a/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js
+++ b/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js
@@ -1,4 +1,5 @@
 import { toFlatItems } from "../../internal/project/tree.js";
+import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const createEmptyImages = () => ({
   barImageId: undefined,
@@ -48,7 +49,12 @@ export const createInitialState = () => {
     fullImagePreviewVisible: false,
     fullImagePreviewImageId: undefined,
     validationErrors: {},
+    isTouchMode: false,
   };
+};
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode = isTouchUiConfig(uiConfig);
 };
 
 export const syncFromProps = ({ state }, { props } = {}) => {
@@ -142,6 +148,7 @@ export const selectViewData = ({ state, constants }) => {
     images: state.images,
     imageSelectorDialog: state.imageSelectorDialog,
     fileExplorerItems,
+    showImageSelectorFileExplorer: !state.isTouchMode,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewImageId: state.fullImagePreviewImageId,
     validationErrors: state.validationErrors,

--- a/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml
+++ b/src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml
@@ -83,8 +83,9 @@ template:
   - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
       - rtgl-view slot=content d=v w=f g=md:
           - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                  - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
+              - $if showImageSelectorFileExplorer:
+                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                      - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
               - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
                   - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
           - rtgl-view d=h g=sm w=f ah=e:

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.handlers.js
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.handlers.js
@@ -19,6 +19,9 @@ const syncImagesData = (deps) => {
 };
 
 export const handleBeforeMount = (deps) => {
+  deps.store.setUiConfig({
+    uiConfig: deps.uiConfig,
+  });
   syncImagesData(deps);
   deps.store.syncFromProps({
     props: deps.props,

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js
@@ -1,4 +1,5 @@
 import { toFlatItems } from "../../internal/project/tree.js";
+import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourcePage.js";
 
 const createDefaultValuesFromProps = (props = {}) => {
   const source = props.defaultValues ?? {};
@@ -24,7 +25,12 @@ export const createInitialState = () => {
     fullImagePreviewVisible: false,
     fullImagePreviewImageId: undefined,
     validationErrors: {},
+    isTouchMode: false,
   };
+};
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode = isTouchUiConfig(uiConfig);
 };
 
 export const syncFromProps = ({ state }, { props } = {}) => {
@@ -104,6 +110,7 @@ export const selectViewData = ({ state, constants }) => {
     imageId: state.imageId,
     imageSelectorDialog: state.imageSelectorDialog,
     fileExplorerItems,
+    showImageSelectorFileExplorer: !state.isTouchMode,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewImageId: state.fullImagePreviewImageId,
     validationErrors: state.validationErrors,

--- a/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml
+++ b/src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml
@@ -52,8 +52,9 @@ template:
   - rtgl-dialog#imageSelectorDialog ?open=${imageSelectorDialog.open} s=xl:
       - rtgl-view slot=content d=v w=f g=md:
           - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-              - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                  - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
+              - $if showImageSelectorFileExplorer:
+                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                      - rvn-base-file-explorer#baseFileExplorer :items=${fileExplorerItems} shrinkable: null
               - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
                   - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
           - rtgl-view d=h g=sm w=f ah=e:

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -2819,6 +2819,7 @@ export const selectViewData = ({ state, i18n }) => {
     addPropertyFormDefaultValues,
     imageSelectorDialog: state.imageSelectorDialog,
     imageFolderItems,
+    showImageSelectorFileExplorer: !state.isTouchMode,
     fullImagePreviewVisible: state.fullImagePreviewVisible,
     fullImagePreviewImageId: state.fullImagePreviewImageId,
     isPreviewDialogOpen: state.isPreviewDialogOpen,

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -519,8 +519,9 @@ template:
       - $if imageSelectorDialog.open:
           - rtgl-view slot=content d=v w=f g=md:
               - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                      - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
+                  - $if showImageSelectorFileExplorer:
+                      - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                          - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
                   - 'rtgl-view#imageSelectorKeyboardScope tabindex=-1 w=1fg h=f style="min-width: 0; min-height: 0; outline: none;"':
                       - rvn-image-selector#imageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
               - rtgl-view d=h g=sm w=f ah=e:

--- a/src/pages/particles/particles.store.js
+++ b/src/pages/particles/particles.store.js
@@ -240,6 +240,7 @@ const {
       dialogPreviewAspectRatio: state.dialogPreviewAspectRatio,
       dialogPreviewBackgroundImage: buildDialogPreviewBackgroundImage(state),
       previewImageSelectorDialog: state.previewImageSelectorDialog,
+      showImageSelectorFileExplorer: !state.isTouchMode,
       imageFolderItems: toFlatItems(state.imagesData).filter(
         (item) => item.type === "folder",
       ),

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -238,8 +238,9 @@ template:
       - $if previewImageSelectorDialog.open:
           - rtgl-view slot=content d=v w=f g=md:
               - 'rtgl-view d=h w=f h=70vh g=lg style="min-width: 0; min-height: 0;"':
-                  - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
-                      - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
+                  - $if showImageSelectorFileExplorer:
+                      - 'rtgl-view w=300 h=f style="min-width: 0; min-height: 0;"':
+                          - rvn-base-file-explorer#imageSelectorFileExplorer :items=${imageFolderItems} shrinkable: null
                   - 'rtgl-view#imageSelectorKeyboardScope tabindex=-1 w=1fg h=f style="min-width: 0; min-height: 0; outline: none;"':
                       - rvn-image-selector#imageSelector selectedImageId=${previewImageSelectorDialog.selectedImageId}: null
               - rtgl-view d=h g=sm w=f ah=e:

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -129,10 +129,6 @@ refs:
     eventListeners:
       item-click:
         handler: handleTransformPreviewImageSelectorFileExplorerClick
-  cancelTransformPreviewImageSelection:
-    eventListeners:
-      click:
-        handler: handleTransformPreviewImageSelectorCancel
   confirmTransformPreviewImageSelection:
     eventListeners:
       click:
@@ -289,7 +285,6 @@ template:
                   - 'rtgl-view#transformPreviewImageSelectorKeyboardScope tabindex=-1 w=1fg h=f style="min-width: 0; min-height: 0; outline: none;"':
                       - rvn-image-selector#transformPreviewImageSelector selectedImageId=${imageSelectorDialog.selectedImageId}: null
               - rtgl-view d=h g=sm w=f ah=e:
-                  - rtgl-button#cancelTransformPreviewImageSelection variant=se: ${cancelButton}
                   - rtgl-button#confirmTransformPreviewImageSelection variant=pr: ${confirmButton}
   - $when: fullImagePreviewVisible
     'div#previewOverlay tabindex=0 style="position: fixed; inset: 0; z-index: 3000; cursor: pointer; outline: none;"':

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -49,6 +49,7 @@ import {
   setSelectedTransform,
   setTab,
   setTempSelectedResource,
+  setUiConfig,
 } from "../../src/components/commandLineBackground/commandLineBackground.store.js";
 
 const createEmptyCollection = () => ({
@@ -107,6 +108,7 @@ const createStoreApi = (state) => ({
   setTab: (payload) => setTab({ state }, payload),
   setTempSelectedResource: (payload) =>
     setTempSelectedResource({ state }, payload),
+  setUiConfig: (payload) => setUiConfig({ state }, payload),
 });
 
 const setRepositoryCollections = (state) => {

--- a/tests/layoutEditor/mobileImageSelectorFileExplorer.test.js
+++ b/tests/layoutEditor/mobileImageSelectorFileExplorer.test.js
@@ -1,0 +1,245 @@
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState as createAnimationEditorState,
+  selectViewData as selectAnimationEditorViewData,
+  setUiConfig as setAnimationEditorUiConfig,
+} from "../../src/pages/animationEditor/animationEditor.store.js";
+import {
+  createInitialState as createParticlesState,
+  selectViewData as selectParticlesViewData,
+  setUiConfig as setParticlesUiConfig,
+} from "../../src/pages/particles/particles.store.js";
+import {
+  createInitialState as createSliderDialogState,
+  selectViewData as selectSliderDialogViewData,
+  setUiConfig as setSliderDialogUiConfig,
+} from "../../src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.store.js";
+import {
+  createInitialState as createSpriteDialogState,
+  selectViewData as selectSpriteDialogViewData,
+  setUiConfig as setSpriteDialogUiConfig,
+} from "../../src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.store.js";
+import {
+  createInitialState as createPreviewState,
+  selectViewData as selectPreviewViewData,
+  setUiConfig as setPreviewUiConfig,
+} from "../../src/components/layoutEditorPreview/layoutEditorPreview.store.js";
+import {
+  createInitialState as createLayoutEditPanelState,
+  selectViewData as selectLayoutEditPanelViewData,
+  setUiConfig as setLayoutEditPanelUiConfig,
+} from "../../src/components/layoutEditPanel/layoutEditPanel.store.js";
+import {
+  createInitialState as createCommandLineBackgroundState,
+  selectViewData as selectCommandLineBackgroundViewData,
+  setUiConfig as setCommandLineBackgroundUiConfig,
+} from "../../src/components/commandLineBackground/commandLineBackground.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const EMPTY_TREE = { items: {}, tree: [] };
+
+const LAYOUT_EDIT_PANEL_CONSTANTS = yaml.load(
+  readFileSync(
+    new URL(
+      "../../src/components/layoutEditPanel/layoutEditPanel.constants.yaml",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+
+const PREVIEW_CONSTANTS = {
+  dialogueForm: { fields: [] },
+  nvlForm: { fields: [] },
+  choiceForm: { fields: [] },
+  historyForm: { fields: [] },
+  saveLoadForm: { fields: [] },
+};
+
+const createLayoutEditPanelProps = () => ({
+  itemType: "container",
+  layoutType: "general",
+  resourceType: "layouts",
+  layoutsData: EMPTY_TREE,
+  charactersData: EMPTY_TREE,
+  isInsideSaveLoadSlot: false,
+  isInsideDirectedContainer: false,
+});
+
+const viewCases = [
+  {
+    name: "animation editor",
+    path: "../../src/pages/animationEditor/animationEditor.view.yaml",
+    start: "rtgl-dialog#imageSelectorDialog",
+    end: "$when: fullImagePreviewVisible",
+    explorer: "rvn-base-file-explorer#imageSelectorFileExplorer",
+  },
+  {
+    name: "particles",
+    path: "../../src/pages/particles/particles.view.yaml",
+    start: "rtgl-dialog#previewImageSelectorDialog",
+    end: undefined,
+    explorer: "rvn-base-file-explorer#imageSelectorFileExplorer",
+  },
+  {
+    name: "layout editor slider create dialog",
+    path: "../../src/components/layoutEditorSliderCreateDialog/layoutEditorSliderCreateDialog.view.yaml",
+    start: "rtgl-dialog#imageSelectorDialog",
+    end: "$when: fullImagePreviewVisible",
+    explorer: "rvn-base-file-explorer#baseFileExplorer",
+  },
+  {
+    name: "layout editor sprite create dialog",
+    path: "../../src/components/layoutEditorSpriteCreateDialog/layoutEditorSpriteCreateDialog.view.yaml",
+    start: "rtgl-dialog#imageSelectorDialog",
+    end: "$when: fullImagePreviewVisible",
+    explorer: "rvn-base-file-explorer#baseFileExplorer",
+  },
+  {
+    name: "layout editor preview",
+    path: "../../src/components/layoutEditorPreview/layoutEditorPreview.view.yaml",
+    start: "rtgl-dialog#imageSelectorDialog",
+    end: "$when: fullImagePreviewVisible",
+    explorer: "rvn-base-file-explorer#baseFileExplorer",
+  },
+  {
+    name: "layout edit panel",
+    path: "../../src/components/layoutEditPanel/layoutEditPanel.view.yaml",
+    start: "rtgl-dialog#imageSelectorDialog",
+    end: "rtgl-dialog#soundSelectorDialog",
+    explorer: "rvn-base-file-explorer#imageSelectorFileExplorer",
+  },
+  {
+    name: "command line background",
+    path: "../../src/components/commandLineBackground/commandLineBackground.view.yaml",
+    start: "$if mode == 'gallery'",
+    end: "$if tab == 'image'",
+    explorer: "rvn-base-file-explorer#baseFileExplorer",
+  },
+];
+
+const storeCases = [
+  {
+    name: "animation editor",
+    createState: createAnimationEditorState,
+    setUiConfig: setAnimationEditorUiConfig,
+    selectViewData: (state) =>
+      selectAnimationEditorViewData({
+        state,
+        i18n: EN_I18N,
+      }),
+  },
+  {
+    name: "particles",
+    createState: createParticlesState,
+    setUiConfig: setParticlesUiConfig,
+    selectViewData: (state) =>
+      selectParticlesViewData({
+        state,
+        i18n: EN_I18N,
+      }),
+  },
+  {
+    name: "layout editor slider create dialog",
+    createState: createSliderDialogState,
+    setUiConfig: setSliderDialogUiConfig,
+    selectViewData: (state) =>
+      selectSliderDialogViewData({
+        state,
+        constants: {
+          sliderCreateForm: {},
+        },
+      }),
+  },
+  {
+    name: "layout editor sprite create dialog",
+    createState: createSpriteDialogState,
+    setUiConfig: setSpriteDialogUiConfig,
+    selectViewData: (state) =>
+      selectSpriteDialogViewData({
+        state,
+        constants: {
+          spriteCreateForm: {},
+        },
+      }),
+  },
+  {
+    name: "layout editor preview",
+    createState: createPreviewState,
+    setUiConfig: setPreviewUiConfig,
+    selectViewData: (state) =>
+      selectPreviewViewData({
+        state,
+        constants: PREVIEW_CONSTANTS,
+      }),
+  },
+  {
+    name: "layout edit panel",
+    createState: createLayoutEditPanelState,
+    setUiConfig: setLayoutEditPanelUiConfig,
+    selectViewData: (state) =>
+      selectLayoutEditPanelViewData({
+        state,
+        props: createLayoutEditPanelProps(),
+        constants: LAYOUT_EDIT_PANEL_CONSTANTS,
+        i18n: EN_I18N,
+      }),
+  },
+  {
+    name: "command line background",
+    createState: createCommandLineBackgroundState,
+    setUiConfig: setCommandLineBackgroundUiConfig,
+    selectViewData: (state) =>
+      selectCommandLineBackgroundViewData({
+        state,
+        i18n: EN_I18N,
+      }),
+  },
+];
+
+const readView = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+const sliceBranch = (view, startText, endText) => {
+  const start = view.indexOf(startText);
+  expect(start).toBeGreaterThan(-1);
+  const end = endText ? view.indexOf(endText, start) : view.length;
+  expect(end).toBeGreaterThan(start);
+
+  return view.slice(start, end);
+};
+
+describe("mobile image selector file explorers", () => {
+  it.each(viewCases)(
+    "guards the $name file explorer behind touch-mode view data",
+    ({ path, start, end, explorer }) => {
+      const branch = sliceBranch(readView(path), start, end);
+      const guardIndex = branch.indexOf("$if showImageSelectorFileExplorer");
+      const explorerIndex = branch.indexOf(explorer);
+
+      expect(guardIndex).toBeGreaterThan(-1);
+      expect(explorerIndex).toBeGreaterThan(guardIndex);
+    },
+  );
+
+  it.each(storeCases)(
+    "hides the $name file explorer in touch mode",
+    ({ createState, setUiConfig, selectViewData }) => {
+      const state = createState();
+
+      expect(selectViewData(state).showImageSelectorFileExplorer).toBe(true);
+
+      setUiConfig(
+        { state },
+        {
+          uiConfig: {
+            inputMode: "touch",
+          },
+        },
+      );
+
+      expect(selectViewData(state).showImageSelectorFileExplorer).toBe(false);
+    },
+  );
+});

--- a/tests/transforms/transforms.view.test.js
+++ b/tests/transforms/transforms.view.test.js
@@ -59,4 +59,18 @@ describe("transforms view", () => {
       "rvn-base-file-explorer#transformPreviewImageSelectorFileExplorer",
     );
   });
+
+  it("does not show a cancel button in the preview image selector", () => {
+    const transformsView = readFileSync(
+      new URL(
+        "../../src/pages/transforms/transforms.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(transformsView).not.toContain(
+      "rtgl-button#cancelTransformPreviewImageSelection",
+    );
+  });
 });


### PR DESCRIPTION
Summary:
- Hide file explorer columns in image selectors when running in touch/Android mode.
- Wire touch-mode UI config into layout editor image selector components and command-line background.
- Keep the transforms selector Cancel button removed.

Validation:
- bunx vitest run tests/layoutEditor/mobileImageSelectorFileExplorer.test.js tests/transforms/transforms.store.test.js tests/transforms/transforms.view.test.js
- rtgl fe build -s src/setup.android.js
- git diff --check
- push hook: oxlint && bun prettier --check src

Note:
- bun run check:contracts was attempted and fails on existing repo-wide diagnostics unrelated to this change.