### PR TITLE
fix(projects): align desktop navbar content width

### DIFF
--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -704,6 +704,8 @@ export const selectViewData = ({ state, i18n }) => {
   const hasLocalProjects = localProjects.length > 0;
   const hasCloudProjects = cloudProjects.length > 0;
   const showCloudLoginHint = !state.isLoggedIn;
+  const isDesktopProjectLayout =
+    !state.isTouchMode && state.platform !== "android";
 
   return {
     ...state,
@@ -715,6 +717,7 @@ export const selectViewData = ({ state, i18n }) => {
     openButtonText: copy.importButton,
     profileDisplayName,
     avatarImageSrc,
+    navbarContentWidth: isDesktopProjectLayout ? "640" : "f",
     showMobileProjectActions: Boolean(state.isTouchMode),
     showProjectAccountActions: Boolean(
       state.showCloudProjects && !state.isTouchMode,

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -144,8 +144,8 @@ refs:
 template:
   - rtgl-view h=100vh w=100vw d=v:
       - 'rtgl-view w=f h=f d=v style="min-height: 0;"':
-          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c:
-              - rtgl-view w=f d=h av=c g=md wrap:
+          - rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c ah=c:
+              - 'rtgl-view sm-w=f w=${navbarContentWidth} d=h av=c g=md wrap':
                   - rtgl-text: ${localTitle}
                   - rtgl-view w=1fg: null
                   - $if showMobileProjectActions:


### PR DESCRIPTION
## Summary
- keep the projects navbar bar full-width while centering its content row
- match desktop navbar content width to the 640px project item column
- preserve full-width behavior for touch/mobile and Android layouts

## Testing
- bun prettier --check src/pages/projects/projects.store.js src/pages/projects/projects.view.yaml
- bunx rtgl fe check
- bunx oxlint src/pages/projects/projects.store.js
- pre-push hook: oxlint
- pre-push hook: bun prettier --check src