### PR TITLE
Update mobile resource action sheet icons

### DIFF
--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -177,6 +177,18 @@ export const handleMobileDetailPreviewClick = (deps, payload) => {
   });
 };
 
+export const handleMobileDetailEditClick = (deps, payload) => {
+  payload?._event?.preventDefault?.();
+  payload?._event?.stopPropagation?.();
+
+  const itemId = deps.store.selectSelectedItemId();
+  if (!itemId) {
+    return;
+  }
+
+  openEditDialogWithValues({ deps, itemId });
+};
+
 export const handleMobileDetailDeleteClick = async (deps, payload) => {
   payload?._event?.preventDefault?.();
   payload?._event?.stopPropagation?.();

--- a/src/pages/colors/colors.store.js
+++ b/src/pages/colors/colors.store.js
@@ -209,6 +209,7 @@ const {
       ...baseViewData,
       selectedColorHex: selectedItem?.hex ?? "",
       isEditDialogOpen: state.isEditDialogOpen,
+      editButton: copy.editMenuItem ?? "Edit",
       editDefaultValues: {
         name: editItem?.name ?? "",
         hex: editItem?.hex ?? "",

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -41,6 +41,12 @@ refs:
         handler: handleMobileDetailPreviewClick
         preventDefault: true
         stopPropagation: true
+  mobileDetailEditButton:
+    eventListeners:
+      click:
+        handler: handleMobileDetailEditClick
+        preventDefault: true
+        stopPropagation: true
   mobileDetailDeleteButton:
     eventListeners:
       click:
@@ -163,6 +169,7 @@ template:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
+                  - rtgl-button#mobileDetailEditButton w=1fg v=se pre=edit: ${editButton}
                   - rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}
                   - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -197,7 +197,7 @@ template:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
-                  - rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}
+                  - rtgl-button#mobileDetailOpenButton w=1fg v=se pre=edit: ${openButton}
                   - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -167,8 +167,8 @@ template:
                   - rtgl-text w=1fg ellipsis=true: ${selectedItemName}
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
-                  - rtgl-button#mobileDetailOpenButton w=1fg v=se: ${openButton}
-                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
+                  - rtgl-button#mobileDetailOpenButton w=1fg v=se pre=edit: ${openButton}
+                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se pre=duplicate: ${duplicateButton}
                   - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -188,7 +188,7 @@ template:
                   - rtgl-svg svg=edit wh=16: null
               - rtgl-view d=h w=f g=sm p=md bgc=su bwb=xs:
                   - rtgl-button#mobileDetailEditButton w=1fg v=se pre=edit: ${editButton}
-                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se: ${duplicateButton}
+                  - rtgl-button#mobileDetailDuplicateButton w=1fg v=se pre=duplicate: ${duplicateButton}
                   - rtgl-button#mobileDetailDeleteButton w=1fg v=se pre=trash: ${deleteButton}
               - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:

--- a/tests/colors/colors.store.test.js
+++ b/tests/colors/colors.store.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/pages/colors/colors.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("colors.store", () => {
+  it("exposes the mobile edit button label", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(viewData.editButton).toBe("Edit");
+  });
+});

--- a/tests/colors/colors.view.test.js
+++ b/tests/colors/colors.view.test.js
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("colors view", () => {
+  it("shows an edit action in the mobile detail sheet", () => {
+    const colorsView = readFileSync(
+      new URL("../../src/pages/colors/colors.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    const mobileDetailStart = colorsView.indexOf("$if showMobileDetailSheet");
+    const folderDialogStart = colorsView.indexOf(
+      "rtgl-dialog#folderNameDialog",
+      mobileDetailStart,
+    );
+    const mobileDetailBranch = colorsView.slice(
+      mobileDetailStart,
+      folderDialogStart,
+    );
+
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailEditButton w=1fg v=se pre=edit: ${editButton}",
+    );
+    expect(mobileDetailBranch).toContain(
+      "rtgl-button#mobileDetailPreviewButton w=1fg v=se pre=zoomIn: ${previewButton}",
+    );
+    expect(colorsView).toContain("handler: handleMobileDetailEditClick");
+  });
+});

--- a/tests/mobileActionSheets.view.test.js
+++ b/tests/mobileActionSheets.view.test.js
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SOURCE_ROOT = new URL("../src/", import.meta.url);
+
+const collectViewFiles = (directoryUrl) => {
+  const files = [];
+
+  for (const entry of readdirSync(directoryUrl, { withFileTypes: true })) {
+    const entryUrl = new URL(
+      `${entry.name}${entry.isDirectory() ? "/" : ""}`,
+      directoryUrl,
+    );
+
+    if (entry.isDirectory()) {
+      files.push(...collectViewFiles(entryUrl));
+      continue;
+    }
+
+    if (entry.name.endsWith(".view.yaml")) {
+      files.push(entryUrl);
+    }
+  }
+
+  return files;
+};
+
+const getIndent = (line) => line.match(/^\s*/)[0].length;
+
+describe("mobile action sheets", () => {
+  it("uses prefix icons on secondary action buttons", () => {
+    const missingIcons = [];
+
+    for (const fileUrl of collectViewFiles(SOURCE_ROOT)) {
+      const lines = readFileSync(fileUrl, "utf8").split("\n");
+      const filePath = relative(
+        new URL("..", import.meta.url).pathname,
+        fileUrl.pathname,
+      );
+
+      for (let i = 0; i < lines.length; i += 1) {
+        if (!lines[i].includes("rvn-mobile-sheet")) {
+          continue;
+        }
+
+        const sheetIndent = getIndent(lines[i]);
+
+        for (let j = i + 1; j < lines.length; j += 1) {
+          const line = lines[j];
+          if (line.trim() && getIndent(line) <= sheetIndent) {
+            break;
+          }
+
+          if (
+            line.includes("rtgl-button") &&
+            /\bv=se\b/.test(line) &&
+            !/\bpre=/.test(line)
+          ) {
+            missingIcons.push(`${filePath}:${j + 1}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+
+    expect(missingIcons).toEqual([]);
+  });
+});


### PR DESCRIPTION
Summary:
- Add an Edit action to the colors mobile detail sheet.
- Add prefix icons to remaining secondary mobile resource action-sheet buttons.
- Add view/store coverage for colors and a generic mobile action-sheet icon regression test.

Validation:
- bunx vitest run tests/colors/colors.store.test.js tests/colors/colors.view.test.js tests/mobileActionSheets.view.test.js
- git diff --check main...HEAD
- push hook: oxlint && bun prettier --check src