### PR TITLE
Fix Android mobile resource UI defaults

### DIFF
--- a/src/components/catalogResourcesView/catalogResourcesView.handlers.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.handlers.js
@@ -272,8 +272,25 @@ const toItemsPerRowFromColumnZoomControlValue = (value, props) => {
   );
 };
 
-const getItemsPerRowConfigKey = (props) =>
-  props?.itemsPerRowConfigKey ?? undefined;
+const getMobileItemsPerRowConfigKey = (configKey) => {
+  const itemsPerRowSuffix = ".itemsPerRow";
+  if (configKey.endsWith(itemsPerRowSuffix)) {
+    return `${configKey.slice(0, -itemsPerRowSuffix.length)}.mobileItemsPerRow`;
+  }
+
+  return `${configKey}.mobile`;
+};
+
+const getItemsPerRowConfigKey = (props) => {
+  const configKey = props?.itemsPerRowConfigKey ?? undefined;
+  if (!configKey) {
+    return undefined;
+  }
+
+  return isMobileColumnZoomControl(props)
+    ? getMobileItemsPerRowConfigKey(configKey)
+    : configKey;
+};
 
 const syncPersistedItemsPerRow = ({ appService, props, store } = {}) => {
   if (!isColumnZoomControlMode(props)) {

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -79,8 +79,25 @@ const toItemsPerRowFromColumnZoomControlValue = (value, props) => {
   );
 };
 
-const getItemsPerRowConfigKey = (props) =>
-  props?.itemsPerRowConfigKey ?? undefined;
+const getMobileItemsPerRowConfigKey = (configKey) => {
+  const itemsPerRowSuffix = ".itemsPerRow";
+  if (configKey.endsWith(itemsPerRowSuffix)) {
+    return `${configKey.slice(0, -itemsPerRowSuffix.length)}.mobileItemsPerRow`;
+  }
+
+  return `${configKey}.mobile`;
+};
+
+const getItemsPerRowConfigKey = (props) => {
+  const configKey = props?.itemsPerRowConfigKey ?? undefined;
+  if (!configKey) {
+    return undefined;
+  }
+
+  return isMobileColumnZoomControl(props)
+    ? getMobileItemsPerRowConfigKey(configKey)
+    : configKey;
+};
 
 const syncPersistedItemsPerRow = ({ appService, props, store } = {}) => {
   if (!isColumnZoomControlMode(props)) {

--- a/src/components/mobileSidebar/mobileSidebar.store.js
+++ b/src/components/mobileSidebar/mobileSidebar.store.js
@@ -75,6 +75,21 @@ const userInterfaceItems = [
   },
 ];
 
+const systemItems = [
+  {
+    id: "controls",
+    label: "Controls",
+    path: "/project/controls",
+    icon: "sliders",
+  },
+  {
+    id: "variables",
+    label: "Variables",
+    path: "/project/variables",
+    icon: "variable",
+  },
+];
+
 const releaseItems = [
   {
     id: "versions",
@@ -120,6 +135,11 @@ const assetsSections = [
     id: "user-interface",
     label: "User Interface",
     items: userInterfaceItems,
+  },
+  {
+    id: "system",
+    label: "System",
+    items: systemItems,
   },
 ];
 

--- a/src/components/textStyleResourcesView/textStyleResourcesView.handlers.js
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.handlers.js
@@ -272,8 +272,25 @@ const toItemsPerRowFromColumnZoomControlValue = (value, props) => {
   );
 };
 
-const getItemsPerRowConfigKey = (props) =>
-  props?.itemsPerRowConfigKey ?? undefined;
+const getMobileItemsPerRowConfigKey = (configKey) => {
+  const itemsPerRowSuffix = ".itemsPerRow";
+  if (configKey.endsWith(itemsPerRowSuffix)) {
+    return `${configKey.slice(0, -itemsPerRowSuffix.length)}.mobileItemsPerRow`;
+  }
+
+  return `${configKey}.mobile`;
+};
+
+const getItemsPerRowConfigKey = (props) => {
+  const configKey = props?.itemsPerRowConfigKey ?? undefined;
+  if (!configKey) {
+    return undefined;
+  }
+
+  return isMobileColumnZoomControl(props)
+    ? getMobileItemsPerRowConfigKey(configKey)
+    : configKey;
+};
 
 const syncPersistedItemsPerRow = ({ appService, props, store } = {}) => {
   if (!isColumnZoomControlMode(props)) {

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -156,7 +156,7 @@ template:
                             $else:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
-      - rtgl-popover#sceneFormPopover ?open=${showSceneForm} x=${sceneFormPosition.x} y=${sceneFormPosition.y}:
+      - rtgl-popover#sceneFormPopover ?open=${showSceneForm} x=${sceneFormPosition.x} y=${sceneFormPosition.y} md-place=center md-overlay:
           - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=320: null
       - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
           - rtgl-view slot=content g=md:

--- a/tests/catalogResourcesView/catalogResourcesView.handlers.test.js
+++ b/tests/catalogResourcesView/catalogResourcesView.handlers.test.js
@@ -1,8 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleBeforeMount,
   handleItemContextMenu,
   handleItemDoubleClick,
+  handleZoomOut,
 } from "../../src/components/catalogResourcesView/catalogResourcesView.handlers.js";
+
+const createMobileColumnZoomProps = () => ({
+  mobileLayout: true,
+  showZoomControls: true,
+  zoomControlMode: "columns",
+  itemsPerRowConfigKey: "groupControlsView.itemsPerRow",
+});
 
 const createItemEvent = (itemId) => ({
   currentTarget: {
@@ -10,6 +19,13 @@ const createItemEvent = (itemId) => ({
       name === "data-item-id" ? itemId : undefined,
     ),
   },
+});
+
+const createProgressiveStore = (overrides = {}) => ({
+  selectProgressiveFrameId: () => undefined,
+  setProgressiveRenderSignature: vi.fn(),
+  setProgressiveRenderedItemCount: vi.fn(),
+  ...overrides,
 });
 
 describe("catalogResourcesView.handlers", () => {
@@ -95,5 +111,58 @@ describe("catalogResourcesView.handlers", () => {
     );
     expect(showContextMenu).not.toHaveBeenCalled();
     expect(render).not.toHaveBeenCalled();
+  });
+
+  it("does not restore desktop column counts for mobile column zoom", () => {
+    const getUserConfig = vi.fn((key) =>
+      key === "groupControlsView.itemsPerRow" ? 8 : undefined,
+    );
+    const setItemsPerRow = vi.fn();
+
+    handleBeforeMount({
+      props: createMobileColumnZoomProps(),
+      appService: {
+        getUserConfig,
+      },
+      store: createProgressiveStore({
+        setItemsPerRow,
+      }),
+    });
+
+    expect(getUserConfig).toHaveBeenCalledWith(
+      "groupControlsView.mobileItemsPerRow",
+    );
+    expect(getUserConfig).not.toHaveBeenCalledWith(
+      "groupControlsView.itemsPerRow",
+    );
+    expect(setItemsPerRow).not.toHaveBeenCalled();
+  });
+
+  it("persists mobile column counts separately from desktop", () => {
+    let itemsPerRow = 6;
+    const setUserConfig = vi.fn();
+    const render = vi.fn();
+
+    const handled = handleZoomOut({
+      props: createMobileColumnZoomProps(),
+      appService: {
+        setUserConfig,
+      },
+      store: {
+        selectItemsPerRow: () => itemsPerRow,
+        setItemsPerRow: ({ itemsPerRow: nextItemsPerRow }) => {
+          itemsPerRow = nextItemsPerRow;
+        },
+      },
+      render,
+    });
+
+    expect(handled).toBe(true);
+    expect(itemsPerRow).toBe(6);
+    expect(setUserConfig).toHaveBeenCalledWith(
+      "groupControlsView.mobileItemsPerRow",
+      6,
+    );
+    expect(render).toHaveBeenCalled();
   });
 });

--- a/tests/mediaResourcesView/mediaResourcesView.handlers.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.handlers.test.js
@@ -153,11 +153,14 @@ describe("mediaResourcesView.handlers", () => {
 
   it("clamps restored mobile column counts to six", () => {
     const setItemsPerRow = vi.fn();
+    const getUserConfig = vi.fn((key) =>
+      key === "groupImagesView.mobileItemsPerRow" ? 12 : undefined,
+    );
 
     handleBeforeMount({
       props: createMobileColumnZoomProps(),
       appService: {
-        getUserConfig: vi.fn(() => 12),
+        getUserConfig,
       },
       store: {
         setItemsPerRow,
@@ -167,6 +170,12 @@ describe("mediaResourcesView.handlers", () => {
       },
     });
 
+    expect(getUserConfig).toHaveBeenCalledWith(
+      "groupImagesView.mobileItemsPerRow",
+    );
+    expect(getUserConfig).not.toHaveBeenCalledWith(
+      "groupImagesView.itemsPerRow",
+    );
     expect(setItemsPerRow).toHaveBeenCalledWith({ itemsPerRow: 6 });
   });
 
@@ -192,7 +201,7 @@ describe("mediaResourcesView.handlers", () => {
     expect(handled).toBe(true);
     expect(itemsPerRow).toBe(6);
     expect(setUserConfig).toHaveBeenCalledWith(
-      "groupImagesView.itemsPerRow",
+      "groupImagesView.mobileItemsPerRow",
       6,
     );
     expect(render).toHaveBeenCalled();

--- a/tests/mobileSidebar/mobileSidebar.store.test.js
+++ b/tests/mobileSidebar/mobileSidebar.store.test.js
@@ -29,6 +29,32 @@ const createScenesData = () => ({
 });
 
 describe("mobileSidebar scene map sections", () => {
+  it("shows system resources under the assets sheet", () => {
+    const state = createInitialState();
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        variant: "assets",
+      },
+    });
+    const systemSection = viewData.sections.find(
+      (section) => section.id === "system",
+    );
+
+    expect(systemSection).toMatchObject({
+      label: "System",
+    });
+    expect(systemSection.items.map((item) => item.id)).toEqual([
+      "controls",
+      "variables",
+    ]);
+    expect(systemSection.items.map((item) => item.path)).toEqual([
+      "/project/controls",
+      "/project/variables",
+    ]);
+  });
+
   it("shows scene map and recently visited scenes instead of a full linear scene list", () => {
     const state = createInitialState();
     setScenesData({ state }, { scenesData: createScenesData() });

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -10,13 +10,21 @@ describe("scenes view", () => {
 
     expect(scenesView).toContain('style="right: 8px; top: 8px;"');
     expect(scenesView).toContain(
-      'rtgl-view#mobileFileExplorerOpenButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo title="${title}"',
+      'rtgl-button#mobileFileExplorerOpenButton sq pre=hamburger v=ol title="${title}" aria-label="${title}"',
     );
-    expect(scenesView).toContain("rtgl-svg svg=hamburger wh=16 c=mu-fg");
-    expect(scenesView).toContain(
-      "rtgl-button#mobileFileExplorerClose sq pre=x v=ol w=36 h=36",
-    );
+    expect(scenesView).toContain("rtgl-button#mobileFileExplorerClose sq pre=x v=ol");
     expect(scenesView).not.toContain("env(safe-area-inset-top)");
+  });
+
+  it("centers the create scene popover as an overlay on mobile", () => {
+    const scenesView = readFileSync(
+      new URL("../../src/pages/scenes/scenes.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    expect(scenesView).toContain(
+      "rtgl-popover#sceneFormPopover ?open=${showSceneForm} x=${sceneFormPosition.x} y=${sceneFormPosition.y} md-place=center md-overlay",
+    );
   });
 
   it("uses the same mobile file explorer navbar sizing as images", () => {

--- a/tests/textStyles/textStyleResourcesView.test.js
+++ b/tests/textStyles/textStyleResourcesView.test.js
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleBeforeMount,
   handleContextMenuClickItem,
   handleItemContextMenu,
   handleItemDoubleClick,
+  handleZoomOut,
 } from "../../src/components/textStyleResourcesView/textStyleResourcesView.handlers.js";
 import {
   createInitialState,
@@ -10,6 +12,20 @@ import {
   showContextMenu,
   setProgressiveRenderedItemCount,
 } from "../../src/components/textStyleResourcesView/textStyleResourcesView.store.js";
+
+const createMobileColumnZoomProps = () => ({
+  mobileLayout: true,
+  showZoomControls: true,
+  zoomControlMode: "columns",
+  itemsPerRowConfigKey: "groupTextStylesView.itemsPerRow",
+});
+
+const createProgressiveStore = (overrides = {}) => ({
+  selectProgressiveFrameId: () => undefined,
+  setProgressiveRenderSignature: vi.fn(),
+  setProgressiveRenderedItemCount: vi.fn(),
+  ...overrides,
+});
 
 describe("textStyleResourcesView", () => {
   it("ignores mobile item double clicks", () => {
@@ -239,6 +255,59 @@ describe("textStyleResourcesView", () => {
     expect(viewData.itemsPerRow).toBe(6);
     expect(viewData.cardGridColumns).toBe("6");
     expect(viewData.zoomControlMax).toBe(6);
+  });
+
+  it("does not restore desktop column counts for mobile text style zoom", () => {
+    const getUserConfig = vi.fn((key) =>
+      key === "groupTextStylesView.itemsPerRow" ? 8 : undefined,
+    );
+    const setItemsPerRow = vi.fn();
+
+    handleBeforeMount({
+      props: createMobileColumnZoomProps(),
+      appService: {
+        getUserConfig,
+      },
+      store: createProgressiveStore({
+        setItemsPerRow,
+      }),
+    });
+
+    expect(getUserConfig).toHaveBeenCalledWith(
+      "groupTextStylesView.mobileItemsPerRow",
+    );
+    expect(getUserConfig).not.toHaveBeenCalledWith(
+      "groupTextStylesView.itemsPerRow",
+    );
+    expect(setItemsPerRow).not.toHaveBeenCalled();
+  });
+
+  it("persists mobile text style columns separately from desktop", () => {
+    let itemsPerRow = 6;
+    const setUserConfig = vi.fn();
+    const render = vi.fn();
+
+    const handled = handleZoomOut({
+      props: createMobileColumnZoomProps(),
+      appService: {
+        setUserConfig,
+      },
+      store: {
+        selectItemsPerRow: () => itemsPerRow,
+        setItemsPerRow: ({ itemsPerRow: nextItemsPerRow }) => {
+          itemsPerRow = nextItemsPerRow;
+        },
+      },
+      render,
+    });
+
+    expect(handled).toBe(true);
+    expect(itemsPerRow).toBe(6);
+    expect(setUserConfig).toHaveBeenCalledWith(
+      "groupTextStylesView.mobileItemsPerRow",
+      6,
+    );
+    expect(render).toHaveBeenCalled();
   });
 
   it("reserves text style placeholders before progressive hydration", () => {


### PR DESCRIPTION
## Summary
- center the create-scene popover on mobile with the modal-style overlay
- show Controls and Variables under the Android Assets sheet System section
- isolate mobile resource grid column preferences from desktop so mobile falls back to 2 columns by default

## Tests
- bunx vitest run tests/catalogResourcesView/catalogResourcesView.handlers.test.js tests/mediaResourcesView/mediaResourcesView.handlers.test.js tests/textStyles/textStyleResourcesView.test.js
- bunx vitest run tests/mobileSidebar/mobileSidebar.store.test.js tests/sidebar/resourceTypes.store.test.js tests/app/app.store.test.js
- bunx vitest run tests/scenes/scenes.view.test.js
- bun run lint
- bun run build:android