### PR TITLE
chore: bump Tauri app version to 1.8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,5 @@ jobs:
       - name: Lint
         run: bun run lint
 
-      - name: Validate Linux Packaging Metadata
-        run: bun run tauri:validate:linux-packaging
-
       - name: Build Web
         run: bun run build:web

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- update `src-tauri/tauri.conf.json` app version from `1.7.3` to `1.8.0`
- remove the Linux packaging metadata validation step from PR CI because it requires release metadata to move in lockstep with the Tauri version

## Testing
- pre-push hook: `oxlint && bun prettier --check src`