### PR TITLE
Harden iOS simulator coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,14 +4,16 @@
 
 1. [Product](./product.md)
 2. [Engineering](./engineering.md)
-3. [Upload File Types](./upload-file-types.md)
-4. [Project Storage And Sync Redesign](./project-storage-and-sync-redesign.md)
-5. [Insieme 2.1.0 Hard Cutover Checklist](./insieme-2.1.0-hard-cutover-checklist.md)
-6. [Animation Editor Transition Mask Plan](./animation-editor-transition-mask-plan.md)
-7. [Resource Tags Spec](./resource-tags-spec.md)
-8. [Import Packages](./import-packages.md)
-9. [Observability Proposal](./observability.md)
-10. [Android Development](./android.md)
+3. [Roadmap Status](./roadmap.md)
+4. [Upload File Types](./upload-file-types.md)
+5. [Project Storage And Sync Redesign](./project-storage-and-sync-redesign.md)
+6. [Insieme 2.1.0 Hard Cutover Checklist](./insieme-2.1.0-hard-cutover-checklist.md)
+7. [Animation Editor Transition Mask Plan](./animation-editor-transition-mask-plan.md)
+8. [Resource Tags Spec](./resource-tags-spec.md)
+9. [Import Packages](./import-packages.md)
+10. [Observability Proposal](./observability.md)
+11. [Android Development](./android.md)
+12. [iOS Development](./ios.md)
 
 ## Runbooks
 

--- a/docs/animation-editor-transition-mask-plan.md
+++ b/docs/animation-editor-transition-mask-plan.md
@@ -1,5 +1,16 @@
 # Animation Editor Transition Mask Plan
 
+## Status
+
+Status as of 2026-07-08: the client already contains transition-mask editor
+state, UI wiring, persistence, and serialization paths. This document remains
+useful as an end-state checklist, but it should not be read as an unstarted
+plan.
+
+Before continuing mask work, audit the current implementation against the done
+criteria below, especially real transition preview parity, export/runtime asset
+reachability, and image usage/deletion protection.
+
 ## Purpose
 
 This document defines the end state and implementation path for adding

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -154,6 +154,28 @@ The native bridge in `RouteVNApp.swift` handles:
 - iOS document picker results
 - local project folder import/export
 
+## Simulator Validation
+
+Simulator validation is the active mobile gate until physical-device testing is
+available.
+
+Current simulator-safe checks:
+
+- `bun run ios:run -- --smoke-test`
+- ZIP integrity check on the smoke-test export
+- iOS adapter tests under `tests/ios/`
+- shared mobile viewport/unit tests under `tests/`
+
+The adapter tests cover:
+
+- iOS router stack persistence
+- file picker fallback and native-result cleanup
+- save picker and selected-file writes
+- opaque folder-picker URI forwarding
+- native streamed ZIP export delegation
+- JavaScript ZIP fallback writes to the selected URI
+- disabled remote collaboration behavior
+
 ## Current Device Test Needs
 
 Simulator is enough for initial shell, SQLite, and packaged asset validation.

--- a/docs/resource-tags-spec.md
+++ b/docs/resource-tags-spec.md
@@ -1,5 +1,16 @@
 # Resource Tags Spec
 
+## Status
+
+Status as of 2026-07-08: implementation has moved beyond the original plan in
+this document. The client contains tag commands, projected tag state, tag-select
+UI, and tag filtering/assignment behavior across multiple resource areas.
+
+Use this document as an audit checklist for future tag work, not as proof that
+resource tags are unstarted. Before adding new tag scope or UI behavior, first
+compare this spec against the current model package, `src/internal/project/`,
+and the resource-page tests.
+
 ## Purpose
 
 This document defines the persisted model and editor behavior for resource tags.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,69 @@
+# Roadmap Status
+
+Last reviewed: 2026-07-08.
+
+This document is the current maintainer-level roadmap summary. Older feature
+plans remain useful for implementation details, but some of them describe work
+that has already moved forward in code.
+
+## Current Baseline
+
+- Desktop/Tauri remains the production desktop shell.
+- Android has a native WebView shell with local SQLite, files, picker, and
+  local project storage adapters.
+- iOS has a native WKWebView shell with local SQLite, files, picker, streamed
+  ZIP export, and local project import/export adapters.
+- Insieme 2.1 hard cutover is complete.
+- Export bundle v4, reachability filtering, whole-file dedupe, and diced-image
+  runtime parsing are implemented. Remaining export work is mainly regression
+  coverage and startup-cost monitoring.
+- Resource tags and animation transition masks have implementation in the
+  client. Their older plan docs should be treated as audit checklists before
+  further feature work, not as unstarted roadmaps.
+
+## Current Priority
+
+### 1. Simulator-Only Mobile Hardening
+
+Until a physical iPhone or iPad is available, keep hardening iOS through:
+
+- Node adapter tests for iOS bridge-facing clients and services
+- iOS Simulator smoke tests
+- ZIP integrity checks for simulator exports
+- mobile viewport and safe-area visual checks where simulator behavior is
+  representative
+
+Do not claim full iOS device readiness from simulator-only validation. The
+simulator cannot prove Files-provider security-scope behavior, iCloud Drive
+provider quirks, physical keyboard/touch edge cases, or signing/install flows.
+
+### 2. Roadmap And Spec Reconciliation
+
+Before starting another large feature, reconcile these docs against the current
+code:
+
+- `docs/resource-tags-spec.md`
+- `docs/animation-editor-transition-mask-plan.md`
+- `docs/export-bundle-size-reduction-plan.md`
+
+The outcome should be either an updated done/remaining checklist or a short
+replacement status doc for each area.
+
+### 3. Compatibility Policy
+
+Do not start project/model compatibility work by changing validators. First
+write and agree on the policy questions in
+`docs/platform/10-model-compatibility-and-upgrades.md`:
+
+- supported single-user upgrade contract
+- supported mixed-version collaboration contract
+- authoritative project-open version field
+- read-only versus refused behavior for incompatible collaborative clients
+
+## Later Work
+
+- Physical iOS/iPadOS validation and release signing flow.
+- TestFlight/App Store automation after signing decisions are made.
+- Import packages MVP once compatibility and package trust policy are clear.
+- Layout editor refactor, starting with shared conditions.
+- Observability implementation for local logs and explicit error capture.

--- a/src/deps/clients/android/filePicker.js
+++ b/src/deps/clients/android/filePicker.js
@@ -67,6 +67,28 @@ const toUint8Array = (value) => {
   return undefined;
 };
 
+const readBlobBytes = async (blob) => {
+  if (typeof blob?.arrayBuffer === "function") {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  const FileReaderCtor = globalThis.FileReader ?? globalThis.window?.FileReader;
+  if (!FileReaderCtor) {
+    throw new Error("Blob reading is not supported.");
+  }
+
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReaderCtor();
+    reader.onload = () => {
+      resolve(new Uint8Array(reader.result));
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read blob."));
+    };
+    reader.readAsArrayBuffer(blob);
+  });
+};
+
 const createFileFromBytes = ({ file, bytes }) => {
   const name = file?.name || "selected-file";
   const options = {
@@ -401,7 +423,7 @@ export const createAndroidFilePicker = () => {
 
     async saveFilePicker(blobOrOptions, maybeFilename) {
       if (blobOrOptions instanceof Blob) {
-        const bytes = new Uint8Array(await blobOrOptions.arrayBuffer());
+        const bytes = await readBlobBytes(blobOrOptions);
         return callAndroidBridge("writeDownloadFile", {
           filename: maybeFilename || "download",
           mimeType: blobOrOptions.type || "application/octet-stream",

--- a/src/deps/clients/ios/filePicker.js
+++ b/src/deps/clients/ios/filePicker.js
@@ -67,6 +67,28 @@ const toUint8Array = (value) => {
   return undefined;
 };
 
+const readBlobBytes = async (blob) => {
+  if (typeof blob?.arrayBuffer === "function") {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+
+  const FileReaderCtor = globalThis.FileReader ?? globalThis.window?.FileReader;
+  if (!FileReaderCtor) {
+    throw new Error("Blob reading is not supported.");
+  }
+
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReaderCtor();
+    reader.onload = () => {
+      resolve(new Uint8Array(reader.result));
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read blob."));
+    };
+    reader.readAsArrayBuffer(blob);
+  });
+};
+
 const createFileFromBytes = ({ file, bytes }) => {
   const name = file?.name || "selected-file";
   const options = {
@@ -393,7 +415,7 @@ export const createIOSFilePicker = () => {
 
     async saveFilePicker(blobOrOptions, maybeFilename) {
       if (blobOrOptions instanceof Blob) {
-        const bytes = new Uint8Array(await blobOrOptions.arrayBuffer());
+        const bytes = await readBlobBytes(blobOrOptions);
         return callIOSBridge("writeDownloadFile", {
           filename: maybeFilename || "download",
           mimeType: blobOrOptions.type || "application/octet-stream",

--- a/tests/ios/filePicker.test.js
+++ b/tests/ios/filePicker.test.js
@@ -2,20 +2,18 @@ import { JSDOM } from "jsdom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocked = vi.hoisted(() => ({
-  callAndroidBridge: vi.fn(),
+  callIOSBridge: vi.fn(),
 }));
 
-vi.mock("../../src/deps/clients/android/bridge.js", async () => {
-  const actual = await vi.importActual(
-    "../../src/deps/clients/android/bridge.js",
-  );
+vi.mock("../../src/deps/clients/ios/bridge.js", async () => {
+  const actual = await vi.importActual("../../src/deps/clients/ios/bridge.js");
   return {
     ...actual,
-    callAndroidBridge: mocked.callAndroidBridge,
+    callIOSBridge: mocked.callIOSBridge,
   };
 });
 
-import { createAndroidFilePicker } from "../../src/deps/clients/android/filePicker.js";
+import { createIOSFilePicker } from "../../src/deps/clients/ios/filePicker.js";
 
 const originalWindow = globalThis.window;
 const originalDocument = globalThis.document;
@@ -25,7 +23,7 @@ const originalFetch = globalThis.fetch;
 
 const installDom = () => {
   const dom = new JSDOM("<!doctype html><html><body></body></html>", {
-    url: "https://appassets.androidplatform.net/web/index.html",
+    url: "https://routevn.ios/ios/index.html",
   });
   globalThis.window = dom.window;
   globalThis.document = dom.window.document;
@@ -34,11 +32,11 @@ const installDom = () => {
   return dom;
 };
 
-describe("android file picker", () => {
+describe("ios file picker", () => {
   let dom;
 
   beforeEach(() => {
-    mocked.callAndroidBridge.mockReset();
+    mocked.callIOSBridge.mockReset();
     dom = installDom();
   });
 
@@ -70,28 +68,30 @@ describe("android file picker", () => {
         this.onchange?.({ target: this });
       });
 
-    const file = await createAndroidFilePicker().openFilePicker({
+    const file = await createIOSFilePicker().openFilePicker({
       multiple: false,
     });
 
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(file.name).toBe("hello.txt");
-    expect(document.getElementById("routevnAndroidFilePickerInput")).toBeNull();
+    expect(document.getElementById("routevnIOSFilePickerInput")).toBeNull();
   });
 
   it("cleans native picker request files after reading descriptors", async () => {
     const fetchedUrls = [];
     const deletedRequests = [];
+    let pickerPayload;
     globalThis.fetch = vi.fn(async (url) => {
       fetchedUrls.push(url);
       return new Response(new Blob(["hello"], { type: "text/plain" }), {
         status: 200,
       });
     });
-    mocked.callAndroidBridge.mockImplementation((method, payload) => {
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
       if (method === "openFilePicker") {
+        pickerPayload = payload;
         Promise.resolve().then(() => {
-          window.__routeVNAndroidFilePickerResult({
+          window.__routeVNIOSFilePickerResult({
             requestId: payload.requestId,
             files: [
               {
@@ -99,56 +99,62 @@ describe("android file picker", () => {
                 fileId: "file-0",
                 name: "hello.txt",
                 type: "text/plain",
-                url: `https://appassets.androidplatform.net/android-files/picker/${payload.requestId}/files/file-0`,
+                url: `routevn://app/ios-files/picker/${payload.requestId}/files/file-0`,
               },
             ],
           });
         });
-        return true;
+        return Promise.resolve(true);
       }
 
       if (method === "deletePickerRequest") {
         deletedRequests.push(payload.requestId);
-        return true;
+        return Promise.resolve(true);
       }
 
       throw new Error(`Unexpected bridge method: ${method}`);
     });
 
-    const file = await createAndroidFilePicker().openFilePicker({
+    const file = await createIOSFilePicker().openFilePicker({
       multiple: false,
+      accept: "image/*",
     });
 
     expect(file.name).toBe("hello.txt");
+    expect(pickerPayload).toEqual({
+      requestId: "picker-1",
+      multiple: false,
+      accept: "image/*",
+    });
     expect(fetchedUrls).toEqual([
-      "https://appassets.androidplatform.net/android-files/picker/picker-1/files/file-0",
+      "routevn://app/ios-files/picker/picker-1/files/file-0",
     ]);
     expect(deletedRequests).toEqual(["picker-1"]);
   });
 
   it("opens the native save picker when no bytes are supplied", async () => {
     let savePayload;
-    mocked.callAndroidBridge.mockImplementation((method, payload) => {
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
       if (method === "openSaveFilePicker") {
         savePayload = payload;
         Promise.resolve().then(() => {
-          window.__routeVNAndroidSaveFileResult({
+          window.__routeVNIOSSaveFileResult({
             requestId: payload.requestId,
-            uri: "content://exports/project_version.zip",
+            uri: "file:///exports/project_version.zip",
           });
         });
-        return true;
+        return Promise.resolve(true);
       }
 
       throw new Error(`Unexpected bridge method: ${method}`);
     });
 
-    const selectedUri = await createAndroidFilePicker().saveFilePicker({
+    const selectedUri = await createIOSFilePicker().saveFilePicker({
       defaultPath: "project_version.zip",
       mimeType: "application/zip",
     });
 
-    expect(selectedUri).toBe("content://exports/project_version.zip");
+    expect(selectedUri).toBe("file:///exports/project_version.zip");
     expect(savePayload).toEqual({
       requestId: "save-1",
       filename: "project_version.zip",
@@ -158,32 +164,34 @@ describe("android file picker", () => {
 
   it("opens the native folder picker with writable access when requested", async () => {
     let folderPayload;
-    mocked.callAndroidBridge.mockImplementation((method, payload) => {
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
       if (method === "openFolderPicker") {
         folderPayload = payload;
         Promise.resolve().then(() => {
-          window.__routeVNAndroidFolderPickerResult({
+          window.__routeVNIOSFolderPickerResult({
             requestId: payload.requestId,
             folder: {
-              uri: "content://exports",
+              uri: "routevn-folder://selected/folder-1",
               name: "Exports",
+              sourceUri: "file:///exports",
             },
           });
         });
-        return true;
+        return Promise.resolve(true);
       }
 
       throw new Error(`Unexpected bridge method: ${method}`);
     });
 
-    const folder = await createAndroidFilePicker().openFolderPicker({
+    const folder = await createIOSFilePicker().openFolderPicker({
       title: "Select Export Folder",
       writable: true,
     });
 
     expect(folder).toEqual({
-      uri: "content://exports",
+      uri: "routevn-folder://selected/folder-1",
       name: "Exports",
+      sourceUri: "file:///exports",
     });
     expect(folderPayload).toEqual({
       requestId: "folder-1",
@@ -192,43 +200,43 @@ describe("android file picker", () => {
     });
   });
 
-  it("writes supplied bytes to a selected Android save URI", async () => {
+  it("writes supplied bytes to a selected iOS save URI", async () => {
     let writePayload;
-    mocked.callAndroidBridge.mockImplementation((method, payload) => {
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
       if (method === "writeFileToUri") {
         writePayload = payload;
-        return payload.uri;
+        return Promise.resolve(payload.uri);
       }
 
       throw new Error(`Unexpected bridge method: ${method}`);
     });
 
-    const selectedUri = await createAndroidFilePicker().saveFilePicker({
-      uri: "content://exports/project_version.zip",
+    const selectedUri = await createIOSFilePicker().saveFilePicker({
+      uri: "file:///exports/project_version.zip",
       bytes: Uint8Array.from([1, 2, 3]),
       mimeType: "application/zip",
     });
 
-    expect(selectedUri).toBe("content://exports/project_version.zip");
+    expect(selectedUri).toBe("file:///exports/project_version.zip");
     expect(writePayload).toEqual({
-      uri: "content://exports/project_version.zip",
+      uri: "file:///exports/project_version.zip",
       mimeType: "application/zip",
       base64: "AQID",
     });
   });
 
-  it("writes supplied blobs to Android downloads", async () => {
+  it("writes supplied blobs to iOS downloads", async () => {
     let writePayload;
-    mocked.callAndroidBridge.mockImplementation((method, payload) => {
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
       if (method === "writeDownloadFile") {
         writePayload = payload;
-        return "file:///downloads/readme.txt";
+        return Promise.resolve("file:///downloads/readme.txt");
       }
 
       throw new Error(`Unexpected bridge method: ${method}`);
     });
 
-    const selectedUri = await createAndroidFilePicker().saveFilePicker(
+    const selectedUri = await createIOSFilePicker().saveFilePicker(
       new Blob(["hello"], { type: "text/plain" }),
       "readme.txt",
     );

--- a/tests/ios/projectServiceAdapters.test.js
+++ b/tests/ios/projectServiceAdapters.test.js
@@ -1,0 +1,214 @@
+import JSZip from "jszip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseBundle } from "../../src/deps/services/shared/projectExportService.js";
+
+const mocked = vi.hoisted(() => ({
+  callIOSBridge: vi.fn(),
+}));
+
+vi.mock("../../src/deps/clients/ios/bridge.js", async () => {
+  const actual = await vi.importActual("../../src/deps/clients/ios/bridge.js");
+  return {
+    ...actual,
+    callIOSBridge: mocked.callIOSBridge,
+  };
+});
+
+import { createIOSProjectServiceAdapters } from "../../src/deps/services/ios/projectServiceAdapters.js";
+
+const toBase64 = (bytes) => Buffer.from(bytes).toString("base64");
+
+const toExactArrayBuffer = (bytes) => {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+};
+
+describe("ios project service adapters", () => {
+  beforeEach(() => {
+    mocked.callIOSBridge.mockReset();
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prompts for distribution ZIP save location with the desktop ZIP name pattern", async () => {
+    const saveFilePicker = vi.fn(async () => "file:///exports/export.zip");
+    const { fileAdapter } = createIOSProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 1,
+    });
+
+    await expect(
+      fileAdapter.promptDistributionZipPath({
+        zipName: "project_version",
+        filePicker: { saveFilePicker },
+      }),
+    ).resolves.toBe("file:///exports/export.zip");
+
+    expect(saveFilePicker).toHaveBeenCalledWith({
+      title: "Save Distribution ZIP",
+      defaultPath: "project_version.zip",
+      filters: [{ name: "ZIP Archive", extensions: ["zip"] }],
+      mimeType: "application/zip",
+    });
+  });
+
+  it("delegates streamed ZIP exports to the native iOS bridge", async () => {
+    let nativePayload;
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
+      if (method === "createDistributionZipStreamedToUri") {
+        nativePayload = payload;
+        return Promise.resolve({
+          uri: "file:///exports/native.zip",
+          stats: {
+            zipBytes: 1234,
+          },
+        });
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
+    const { fileAdapter } = createIOSProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 1,
+    });
+
+    const savedPath = await fileAdapter.createDistributionZipStreamedToPath({
+      projectData: {
+        projectData: {
+          story: {
+            initialSceneId: "scene-1",
+          },
+        },
+      },
+      fileEntries: [{ fileId: "file-1", mimeType: "image/png" }],
+      outputPath: "routevn-folder://selected/export-folder",
+      staticFiles: {
+        indexHtml: "<!doctype html>",
+        mainJs: "console.log('routevn');",
+      },
+      getCurrentReference: () => ({
+        projectId: "project-1",
+      }),
+    });
+
+    expect(savedPath).toBe("file:///exports/native.zip");
+    expect(nativePayload).toEqual({
+      projectId: "project-1",
+      uri: "routevn-folder://selected/export-folder",
+      fileEntries: [{ id: "file-1", mimeType: "image/png" }],
+      instructionsJson: JSON.stringify({
+        projectData: {
+          story: {
+            initialSceneId: "scene-1",
+          },
+        },
+      }),
+      usePartFile: true,
+      indexHtml: "<!doctype html>",
+      mainJs: "console.log('routevn');",
+    });
+  });
+
+  it("falls back to a JavaScript ZIP written to the selected iOS file URI", async () => {
+    let savedPayload;
+    mocked.callIOSBridge.mockImplementation((method, payload) => {
+      if (method === "createDistributionZipStreamedToUri") {
+        return Promise.reject(new Error("Native ZIP unavailable"));
+      }
+
+      if (method === "readProjectFile") {
+        expect(payload).toEqual({
+          projectId: "project-1",
+          fileId: "file-1",
+        });
+        return Promise.resolve({
+          base64: toBase64(Uint8Array.from([1, 2, 3])),
+          mimeType: "image/png",
+        });
+      }
+
+      if (method === "writeFileToUri") {
+        savedPayload = payload;
+        return Promise.resolve("file:///exports/export.zip");
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
+    const { fileAdapter } = createIOSProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 1,
+    });
+
+    const savedPath = await fileAdapter.createDistributionZipStreamedToPath({
+      projectData: {
+        projectData: {
+          story: {
+            initialSceneId: "scene-1",
+          },
+        },
+      },
+      fileEntries: [{ fileId: "file-1", mimeType: "image/png" }],
+      outputPath: "file:///exports/export.zip",
+      staticFiles: {
+        indexHtml: "<!doctype html>",
+        mainJs: "console.log('routevn');",
+      },
+      getCurrentReference: () => ({
+        projectId: "project-1",
+      }),
+    });
+
+    expect(savedPath).toBe("file:///exports/export.zip");
+    expect(savedPayload.uri).toBe("file:///exports/export.zip");
+    expect(savedPayload.mimeType).toBe("application/zip");
+
+    const zipBytes = Buffer.from(savedPayload.base64, "base64");
+    const zip = await JSZip.loadAsync(zipBytes);
+    expect(await zip.file("index.html").async("string")).toBe(
+      "<!doctype html>",
+    );
+    expect(await zip.file("main.js").async("string")).toBe(
+      "console.log('routevn');",
+    );
+    const packageBytes = new Uint8Array(
+      await zip.file("package.bin").async("arraybuffer"),
+    );
+    const parsedBundle = await parseBundle(toExactArrayBuffer(packageBytes));
+    expect(parsedBundle.instructions.projectData.story.initialSceneId).toBe(
+      "scene-1",
+    );
+    expect(Array.from(parsedBundle.assets["file-1"].buffer)).toEqual([1, 2, 3]);
+    expect(parsedBundle.assets["file-1"].mime).toBe("image/png");
+  });
+
+  it("rejects endpoint-backed iOS collab sessions while disabled", async () => {
+    const { collabAdapter } = createIOSProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 1,
+    });
+
+    expect(() =>
+      collabAdapter.createTransport({
+        endpointUrl: "wss://api.example.invalid/sync",
+      }),
+    ).toThrow("iOS remote collaboration is disabled.");
+
+    await expect(
+      collabAdapter.createSessionForProject({
+        projectId: "project-1",
+        userId: "user-1",
+        clientId: "client-1",
+        endpointUrl: "wss://api.example.invalid/sync",
+        mode: "explicit",
+        getRepositoryByProject: vi.fn(),
+        getStoreByProject: vi.fn(),
+      }),
+    ).rejects.toThrow("iOS remote collaboration is disabled.");
+  });
+});

--- a/tests/ios/router.test.js
+++ b/tests/ios/router.test.js
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import IOSRouter from "../../src/deps/clients/ios/router.js";
+
+const ROUTER_STACK_STORAGE_KEY = "routevn.ios.router.stack.v1";
+
+const createStorageMock = () => {
+  const entries = new Map();
+
+  return {
+    getItem: vi.fn((key) => entries.get(key) ?? undefined),
+    setItem: vi.fn((key, value) => {
+      entries.set(key, value);
+    }),
+    removeItem: vi.fn((key) => {
+      entries.delete(key);
+    }),
+  };
+};
+
+const installStorage = (storage) => {
+  vi.stubGlobal("window", {
+    sessionStorage: storage,
+  });
+};
+
+describe("ios router", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("restores the route stack after a WebView reload", () => {
+    const storage = createStorageMock();
+    installStorage(storage);
+
+    const router = new IOSRouter({ initialPath: "/projects" });
+    router.redirect("/project", { p: "project-1" });
+    router.redirect("/project/images", {
+      p: "project-1",
+      folderId: "folder-1",
+    });
+
+    const reloadedRouter = new IOSRouter({ initialPath: "/projects" });
+
+    expect(reloadedRouter.getPathName()).toBe("/project/images");
+    expect(reloadedRouter.getPayload()).toEqual({
+      p: "project-1",
+      folderId: "folder-1",
+    });
+    expect(reloadedRouter.canGoBack()).toBe(true);
+    expect(reloadedRouter.stack).toEqual([
+      "/projects",
+      "/project?p=project-1",
+      "/project/images?p=project-1&folderId=folder-1",
+    ]);
+  });
+
+  it("updates the persisted stack when navigating back", () => {
+    const storage = createStorageMock();
+    installStorage(storage);
+
+    const router = new IOSRouter({ initialPath: "/projects" });
+    router.redirect("/project", { p: "project-1" });
+    router.redirect("/project/images", { p: "project-1" });
+
+    router.back();
+
+    const reloadedRouter = new IOSRouter({ initialPath: "/projects" });
+    expect(reloadedRouter.getPathName()).toBe("/project");
+    expect(reloadedRouter.getPayload()).toEqual({ p: "project-1" });
+    expect(reloadedRouter.stack).toEqual(["/projects", "/project?p=project-1"]);
+  });
+
+  it("ignores invalid persisted stacks", () => {
+    const storage = createStorageMock();
+    storage.setItem(ROUTER_STACK_STORAGE_KEY, JSON.stringify([]));
+    installStorage(storage);
+
+    const router = new IOSRouter({ initialPath: "/projects" });
+
+    expect(router.getPathName()).toBe("/projects");
+    expect(storage.removeItem).toHaveBeenCalledWith(ROUTER_STACK_STORAGE_KEY);
+  });
+});


### PR DESCRIPTION
## Summary
- add iOS adapter tests for router, file picker, project-service ZIP export, fallback writes, and disabled remote collaboration
- add Blob read fallback for Android/iOS mobile file-picker save paths
- add current roadmap status docs and clarify simulator-only iOS validation coverage

## Validation
- git diff --check
- bun run lint
- bunx vitest run tests/ios/router.test.js tests/ios/filePicker.test.js tests/ios/projectServiceAdapters.test.js tests/android/filePicker.test.js
- bun run test:smoke
- bash scripts/ios.sh run --smoke-test
- unzip -t on the simulator smoke export ZIP

No physical device validation was performed.