### PR TITLE
chore: update route-graphics to 1.24.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
         "route-engine-js": "1.26.1",
-        "route-graphics": "1.24.1",
+        "route-graphics": "1.24.2",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
         "snabbdom-to-html": "7.1.0",
@@ -823,7 +823,7 @@
 
     "route-engine-js": ["route-engine-js@1.26.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1" } }, "sha512-azxqZKV8jxh+6WBm8tiLuW2hCNTjzKsS/a3EBJ5yuzToC+fIVyXz0KaQaGbXFBZu4Ha778d5dQlpwR2ZsZaUuA=="],
 
-    "route-graphics": ["route-graphics@1.24.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-GgWzKJsbV9KMBG2K70eFHc5mIQ4Vz7+2/OZzrSGLquQdu+b1o+6RaQXBhnOtEqO4F6szvd5WL/UOa2khrmQi+Q=="],
+    "route-graphics": ["route-graphics@1.24.2", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-HQw1oqw4R09OyUVHPlbvB6cu2XjvYhrBb2NB0eWS56yQe4GYPfIFPp3p7BL6FeHkpIOuhXSEtDymrhhzS6U0CQ=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
     "route-engine-js": "1.26.1",
-    "route-graphics": "1.24.1",
+    "route-graphics": "1.24.2",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",
     "snabbdom-to-html": "7.1.0",


### PR DESCRIPTION
## Summary
- update route-graphics from 1.24.1 to 1.24.2
- refresh bun.lock to the published npm package integrity for 1.24.2

## Testing
- `bun install --frozen-lockfile --lockfile-only`
- `npm view route-graphics version dist-tags --json` confirmed latest is 1.24.2