### PR TITLE
Fix mobile resource dialogs

### DIFF
--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -622,6 +622,7 @@ animationEditorPage:
   softnessLabel: "Softness"
   stepSampleLabel: "Step"
   targetImageLabel: "Target Image"
+  timelineLabel: "Timeline"
   translateXPropertyLabel: "Translate X"
   translateXPropertyTooltip: "Uses viewport-width units. 1 moves by one full screen width, -1 moves by one full screen width to the left."
   translateYPropertyLabel: "Translate Y"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -622,6 +622,7 @@ animationEditorPage:
   softnessLabel: "ソフトネス"
   stepSampleLabel: "ステップ"
   targetImageLabel: "対象画像"
+  timelineLabel: "タイムライン"
   translateXPropertyLabel: "移動X"
   translateXPropertyTooltip: "画面幅単位を使います。1で画面幅1つ分右へ、-1で画面幅1つ分左へ移動します。"
   translateYPropertyLabel: "移動Y"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -622,6 +622,7 @@ animationEditorPage:
   softnessLabel: "柔化"
   stepSampleLabel: "阶梯"
   targetImageLabel: "目标图像"
+  timelineLabel: "时间线"
   translateXPropertyLabel: "平移 X"
   translateXPropertyTooltip: "使用视口宽度单位。1 表示向右移动一个完整屏幕宽度，-1 表示向左移动一个完整屏幕宽度。"
   translateYPropertyLabel: "平移 Y"

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -827,6 +827,19 @@ export const handleAddPropertiesClick = (deps, payload) => {
   const side = payload._event.currentTarget?.dataset?.side;
 
   if (!side && store.selectDialogType() === "transition") {
+    if (store.selectIsTouchMode()) {
+      store.setPopover({
+        mode: "addProperty",
+        x: payload._event.clientX,
+        y: payload._event.clientY,
+        payload: {
+          side: store.selectDefaultAddPropertySide(),
+        },
+      });
+      render();
+      return;
+    }
+
     store.setPopover({
       mode: "addPropertySideMenu",
       x: payload._event.clientX,
@@ -879,10 +892,17 @@ export const handleAddPropertyFormSubmit = (deps, payload) => {
     popover,
     payload,
   });
-  const { property, useInitialValue, tweenMode, duration, easing } =
-    mergedValues;
+  const {
+    property,
+    useInitialValue,
+    tweenMode,
+    duration,
+    easing,
+    side: submittedSide,
+  } = mergedValues;
+  const targetSide = submittedSide ?? side;
   const defaultInitialValue = store.selectDefaultInitialValue({ property });
-  const useAutoTween = side === "update" && tweenMode === "auto";
+  const useAutoTween = targetSide === "update" && tweenMode === "auto";
   const submittedInitialValue = hasOwnFormValue(trackedValues, "initialValue")
     ? trackedValues.initialValue
     : defaultInitialValue;
@@ -896,7 +916,7 @@ export const handleAddPropertyFormSubmit = (deps, payload) => {
       : undefined;
 
   store.addProperty({
-    side,
+    side: targetSide,
     property,
     initialValue: finalInitialValue,
     tweenMode,
@@ -1279,6 +1299,20 @@ const isPreviewImageSelectorTarget = (target) => {
 export const handleAddPropertyFormChange = (deps, payload) => {
   const { render, store } = deps;
   const { name, value } = payload._event.detail ?? {};
+  if (name === "side") {
+    const currentFormValues = store.selectPopover().formValues ?? {};
+    store.updatePopoverFormValues({
+      formValues: {
+        ...currentFormValues,
+        side: value,
+        property: undefined,
+        initialValue: undefined,
+      },
+    });
+    render();
+    return;
+  }
+
   if (name === "property") {
     const currentFormValues = store.selectPopover().formValues ?? {};
     const initialValue = store.selectDefaultInitialValue({

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -236,6 +236,7 @@ const STATIC_LABEL_COPY_KEYS = Object.freeze({
   Single: "singleMaskKind",
   Softness: "softnessLabel",
   Step: "stepSampleLabel",
+  Timeline: "timelineLabel",
   "Tween Mode": "tweenModeLabel",
   "The final value of the property at the end of the animation":
     "keyframeValueTooltip",
@@ -852,7 +853,7 @@ const createUpdateKeyframeForm = (
 const createAddPropertyForm = (
   availableProperties,
   propertyFieldConfig,
-  { side, property } = {},
+  { side, property, sideOptions = [] } = {},
   copy = {},
 ) => {
   const isUpdateSide = side === "update";
@@ -871,15 +872,26 @@ const createAddPropertyForm = (
       ? 'tweenMode != "auto" && useInitialValue == true'
       : "useInitialValue == true";
   }
-  const fields = [
-    {
-      name: "property",
-      type: "select",
-      label: "Property",
-      options: availableProperties,
+  const fields = [];
+
+  if (sideOptions.length > 0) {
+    fields.push({
+      name: "side",
+      type: "segmented-control",
+      label: "Timeline",
+      noClear: true,
+      options: sideOptions,
       required: true,
-    },
-  ];
+    });
+  }
+
+  fields.push({
+    name: "property",
+    type: "select",
+    label: "Property",
+    options: availableProperties,
+    required: true,
+  });
 
   if (isUpdateSide) {
     fields.push({
@@ -1391,6 +1403,21 @@ export const selectDefaultInitialValue = ({ state }, { property } = {}) => {
   }
 
   return getDefaultInitialValues(state)[property] ?? 0;
+};
+
+export const selectDefaultAddPropertySide = ({ state }) => {
+  if (state.dialogType !== "transition") {
+    return "update";
+  }
+
+  const propertyFieldConfig = getLocalizedPropertyFieldConfig(state);
+  const previousOptions = getAvailableProperties(
+    state,
+    "prev",
+    propertyFieldConfig,
+  );
+
+  return previousOptions.length > 0 ? "prev" : "next";
 };
 
 const resolveDialogSide = (state, side) => {
@@ -2573,14 +2600,6 @@ export const selectViewData = ({ state, i18n }) => {
     nextProperties,
     mask: getEffectiveTransitionMask(state),
   });
-  const addPropertySide =
-    state.popover.payload?.side ??
-    (dialogType === "transition" ? "prev" : "update");
-  const addPropertyOptions = getAvailableProperties(
-    state,
-    addPropertySide,
-    propertyFieldConfig,
-  );
   const updateTimelineDefaultValues = createTimelineDefaultValues(
     UPDATE_PROPERTY_KEYS,
     propertyFieldConfig,
@@ -2602,6 +2621,23 @@ export const selectViewData = ({ state, i18n }) => {
   const nextAddPropertyOptions = getAvailableProperties(
     state,
     "next",
+    propertyFieldConfig,
+  );
+  const transitionAddPropertySideOptions =
+    createTransitionAddPropertySideMenuItems({
+      previousAvailable: previousAddPropertyOptions.length > 0,
+      nextAvailable: nextAddPropertyOptions.length > 0,
+      copy,
+    });
+  const defaultTransitionAddPropertySide =
+    previousAddPropertyOptions.length > 0 ? "prev" : "next";
+  const addPropertySide =
+    state.popover.formValues.side ??
+    state.popover.payload?.side ??
+    (dialogType === "transition" ? defaultTransitionAddPropertySide : "update");
+  const addPropertyOptions = getAvailableProperties(
+    state,
+    addPropertySide,
     propertyFieldConfig,
   );
   const transitionMaskPanel = buildTransitionMaskPanelData(state, copy);
@@ -2646,6 +2682,10 @@ export const selectViewData = ({ state, i18n }) => {
   let editInitialValueDefaultValues = {};
   let editInitialValueContext = {};
   let addPropertySelectedProperty = addPropertyOptions[0]?.value;
+
+  if (dialogType === "transition") {
+    addPropertyFormDefaultValues.side = addPropertySide;
+  }
 
   if (state.popover.mode === "addProperty") {
     addPropertySelectedProperty =
@@ -2731,6 +2771,19 @@ export const selectViewData = ({ state, i18n }) => {
     };
   }
 
+  const showAddPropertyPopover =
+    !state.isTouchMode && state.popover.mode === "addProperty";
+  const showAddKeyframePopover =
+    !state.isTouchMode && state.popover.mode === "addKeyframe";
+  const showEditKeyframePopover =
+    !state.isTouchMode && state.popover.mode === "editKeyframe";
+  const showAddPropertyDialog =
+    state.isTouchMode && state.popover.mode === "addProperty";
+  const showAddKeyframeDialog =
+    state.isTouchMode && state.popover.mode === "addKeyframe";
+  const showEditKeyframeDialog =
+    state.isTouchMode && state.popover.mode === "editKeyframe";
+
   return {
     resourceCategory: ANIMATION_RESOURCE_CATEGORY,
     selectedResourceId: ANIMATION_SELECTED_RESOURCE_ID,
@@ -2758,6 +2811,10 @@ export const selectViewData = ({ state, i18n }) => {
       {
         side: addPropertySide,
         property: addPropertySelectedProperty,
+        sideOptions:
+          state.isTouchMode && dialogType === "transition"
+            ? transitionAddPropertySideOptions
+            : [],
       },
       copy,
     ),
@@ -2796,20 +2853,14 @@ export const selectViewData = ({ state, i18n }) => {
     transitionAddPropertyButtonVisible:
       previousAddPropertyOptions.length > 0 ||
       nextAddPropertyOptions.length > 0,
-    addPropertySideMenuItems: createTransitionAddPropertySideMenuItems({
-      previousAvailable: previousAddPropertyOptions.length > 0,
-      nextAvailable: nextAddPropertyOptions.length > 0,
-      copy,
-    }),
+    addPropertySideMenuItems: transitionAddPropertySideOptions,
     popover: {
       ...state.popover,
-      popoverIsOpen: [
-        "addProperty",
-        "addKeyframe",
-        "editKeyframe",
-        "editAuto",
-        "editInitialValue",
-      ].includes(state.popover.mode),
+      popoverIsOpen:
+        ["editAuto", "editInitialValue"].includes(state.popover.mode) ||
+        showAddPropertyPopover ||
+        showAddKeyframePopover ||
+        showEditKeyframePopover,
       maskDialogIsOpen: ["editMask", "addMask"].includes(state.popover.mode),
       dropdownMenuIsOpen: ["keyframeMenu", "propertyNameMenu"].includes(
         state.popover.mode,
@@ -2827,6 +2878,12 @@ export const selectViewData = ({ state, i18n }) => {
     showRightPanel: !state.isTouchMode,
     showMobileTweenActions: state.isTouchMode,
     showMobileMaskButton: state.isTouchMode && dialogType === "transition",
+    showAddPropertyPopover,
+    showAddKeyframePopover,
+    showEditKeyframePopover,
+    showAddPropertyDialog,
+    showAddKeyframeDialog,
+    showEditKeyframeDialog,
     addButton: copy.addButton ?? "Add",
     addMaskButton: copy.addMaskButton ?? "Add Mask",
     addMaskTitle: copy.addMaskTitle ?? "Add Mask",

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -95,6 +95,18 @@ refs:
     eventListeners:
       close:
         handler: handleClosePopover
+  addPropertyDialog:
+    eventListeners:
+      close:
+        handler: handleClosePopover
+  addKeyframeDialog:
+    eventListeners:
+      close:
+        handler: handleClosePopover
+  editKeyframeDialog:
+    eventListeners:
+      close:
+        handler: handleClosePopover
   maskDialog:
     eventListeners:
       close:
@@ -414,13 +426,13 @@ template:
                                       - 'rtgl-view#previewImageButton${i} data-target=${item.target} w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
                                           - rtgl-text c=mu-fg s=sm: ${selectImageLabel}
   - rtgl-popover#addPropertyPopover ?open=${popover.popoverIsOpen} x=${popover.x} y=${popover.y}:
-      - $if popover.mode == 'addProperty':
+      - $if showAddPropertyPopover:
           - rtgl-view slot=content:
               - rtgl-form#addPropertyForm key=${addPropertyFormKey} :form=${addPropertyForm} :context=${addPropertyContext} :defaultValues=${addPropertyFormDefaultValues}: null
-      - $if popover.mode == 'addKeyframe':
+      - $if showAddKeyframePopover:
           - rtgl-view slot=content:
               - rtgl-form#addKeyframeForm :form=${addKeyframeForm} :defaultValues=${addKeyframeDefaultValues}: null
-      - $if popover.mode == 'editKeyframe':
+      - $if showEditKeyframePopover:
           - rtgl-view slot=content:
               - rtgl-form#editKeyframeForm :form=${updateKeyframeForm} :defaultValues=${editKeyframeDefaultValues}: null
       - $if popover.mode == 'editAuto':
@@ -429,6 +441,15 @@ template:
       - $if popover.mode == 'editInitialValue':
           - rtgl-view slot=content:
               - rtgl-form#editInitialValueForm :form=${editInitialValueForm} :defaultValues=${editInitialValueDefaultValues} :context=${editInitialValueContext}: null
+  - $if showAddPropertyDialog:
+      - rtgl-dialog#addPropertyDialog ?open=${showAddPropertyDialog} s=sm:
+          - rtgl-form#addPropertyForm key=${addPropertyFormKey} slot=content :form=${addPropertyForm} :context=${addPropertyContext} :defaultValues=${addPropertyFormDefaultValues} w=f: null
+  - $if showAddKeyframeDialog:
+      - rtgl-dialog#addKeyframeDialog ?open=${showAddKeyframeDialog} s=sm:
+          - rtgl-form#addKeyframeForm slot=content :form=${addKeyframeForm} :defaultValues=${addKeyframeDefaultValues} w=f: null
+  - $if showEditKeyframeDialog:
+      - rtgl-dialog#editKeyframeDialog ?open=${showEditKeyframeDialog} s=sm:
+          - rtgl-form#editKeyframeForm slot=content :form=${updateKeyframeForm} :defaultValues=${editKeyframeDefaultValues} w=f: null
   - rtgl-dialog#maskDialog ?open=${popover.maskDialogIsOpen} s=sm:
       - $if popover.mode == 'editMask' || popover.mode == 'addMask':
           - 'rtgl-view slot=content d=v w=f g=md style="max-width: calc(100vw - 32px);"':

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -594,6 +594,8 @@ export const selectViewData = ({ state, i18n }) => {
     selectedItemDescription,
     isWaitingForTransform: state.isWaitingForTransform,
     showSceneForm: state.showSceneForm,
+    showSceneFormPopover: state.showSceneForm && !state.isTouchMode,
+    showSceneFormDialog: state.showSceneForm && state.isTouchMode,
     sceneFormKey,
     sceneFormPosition: state.sceneFormPosition,
     sceneFormData: sceneFormDefaultValues,

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -39,6 +39,10 @@ refs:
     eventListeners:
       close:
         handler: handleSceneFormClose
+  sceneFormDialog:
+    eventListeners:
+      close:
+        handler: handleSceneFormClose
   editDialog:
     eventListeners:
       close:
@@ -156,8 +160,12 @@ template:
                             $else:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
-      - rtgl-popover#sceneFormPopover ?open=${showSceneForm} x=${sceneFormPosition.x} y=${sceneFormPosition.y} md-place=center md-overlay:
-          - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=320: null
+      - $if showSceneFormPopover:
+          - rtgl-popover#sceneFormPopover ?open=${showSceneFormPopover} x=${sceneFormPosition.x} y=${sceneFormPosition.y}:
+              - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=320: null
+      - $if showSceneFormDialog:
+          - rtgl-dialog#sceneFormDialog ?open=${showSceneFormDialog} s=sm:
+              - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=f: null
       - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
           - rtgl-view slot=content g=md:
               - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} w=f: null

--- a/src/pages/textStyles/textStyles.store.js
+++ b/src/pages/textStyles/textStyles.store.js
@@ -1135,6 +1135,7 @@ export const selectViewData = ({ state, i18n }) => {
     isDialogOpen: state.isDialogOpen,
     dialogForm: dialogForm,
     dialogDefaultValues,
+    showDialogPreviewCanvas: !state.isTouchMode,
     formKey: `${state.selectedItemId}-${state.isDialogOpen || state.isAddFontDialogOpen}`,
     ...buildTagViewData({
       state,

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -195,18 +195,24 @@ template:
                       - rtgl-tag-select#detailTagSelect slot="text-style-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} placeholder="${addTagPlaceholder}": null
   - rtgl-dialog#folderNameDialog ?open=${isFolderNameDialogOpen} s=sm:
       - rtgl-form#folderNameForm key=${folderNameDialogItemId} slot=content :defaultValues=${folderNameDialogDefaultValues} :form=${folderNameForm} w=f: null
-  - rtgl-dialog#addTypographyDialog ?open=${isDialogOpen}:
+  - $if showDialogPreviewCanvas:
       - $if isDialogOpen:
-          - rtgl-view slot=content d=h g=md w=800:
-              - rtgl-view w=1fg:
+          - rtgl-dialog#addTypographyDialog ?open=${isDialogOpen}:
+              - rtgl-view slot=content d=h g=md w=800:
+                  - rtgl-view w=1fg:
+                      - rtgl-form#textStyleForm key=${formKey} :defaultValues=${dialogDefaultValues} :form=${dialogForm} w=f: null
+                  - rtgl-view w=1fg p=md d=v g=md:
+                      - rtgl-text s=lg fw=b: ${previewLabel}
+                      - 'rtgl-view w=f style="aspect-ratio: 16 / 9; min-width: 0; overflow: hidden;"':
+                          - rvn-font-preview h=f fontFamily=${previewFontFamily} previewText="${previewText}" fileId=${previewFontFileId} fontSize=${previewFontSize} lineHeight=${previewLineHeight} color=${previewColor} strokeColor=${previewStrokeColor} strokeWidth=${previewStrokeWidth} fontWeight=${previewFontWeight} width=f padding=8 showBorder=true: null
+                      - rtgl-view d=v g=sm w=f:
+                          - rtgl-text: ${previewTextLabel}
+                          - rtgl-input#previewTextInput key=${formKey} w=f value="${previewTextInputValue}": null
+    $else:
+      - $if isDialogOpen:
+          - rtgl-dialog#addTypographyDialog ?open=${isDialogOpen} s=md:
+              - rtgl-view slot=content g=md:
                   - rtgl-form#textStyleForm key=${formKey} :defaultValues=${dialogDefaultValues} :form=${dialogForm} w=f: null
-              - rtgl-view w=1fg p=md d=v g=md:
-                  - rtgl-text s=lg fw=b: ${previewLabel}
-                  - 'rtgl-view w=f style="aspect-ratio: 16 / 9; min-width: 0; overflow: hidden;"':
-                      - rvn-font-preview h=f fontFamily=${previewFontFamily} previewText="${previewText}" fileId=${previewFontFileId} fontSize=${previewFontSize} lineHeight=${previewLineHeight} color=${previewColor} strokeColor=${previewStrokeColor} strokeWidth=${previewStrokeWidth} fontWeight=${previewFontWeight} width=f padding=8 showBorder=true: null
-                  - rtgl-view d=v g=sm w=f:
-                      - rtgl-text: ${previewTextLabel}
-                      - rtgl-input#previewTextInput key=${formKey} w=f value="${previewTextInputValue}": null
   - rtgl-dialog#addColorDialog ?open=${isAddColorDialogOpen} s=sm:
       - $if isAddColorDialogOpen:
           - rtgl-form#addColorForm slot=content :defaultValues=${addColorDefaultValues} :form=${addColorForm} w=f: null

--- a/tests/animationEditor/animationEditor.handlers.test.js
+++ b/tests/animationEditor/animationEditor.handlers.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleAddMaskClick,
   handleAddKeyframeFormSubmit,
+  handleAddPropertiesClick,
   handleAddPropertyFormChange,
   handleAddPropertyFormSubmit,
   handleConfirmMaskImageSelection,
@@ -13,6 +14,7 @@ import {
   handleRulerTimeLeave,
   handleSavePreviewClick,
 } from "../../src/pages/animationEditor/animationEditor.handlers.js";
+import { EN_I18N } from "../support/i18n.js";
 
 describe("animationEditor.handlers", () => {
   const createIdleAutosaveMocks = () => ({
@@ -74,6 +76,75 @@ describe("animationEditor.handlers", () => {
       mode: "editMask",
       x: 120,
       y: 160,
+      payload: {},
+    });
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("opens the add-property dialog directly for touch transition animations", () => {
+    const store = {
+      selectDialogType: vi.fn(() => "transition"),
+      selectIsTouchMode: vi.fn(() => true),
+      selectDefaultAddPropertySide: vi.fn(() => "next"),
+      setPopover: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertiesClick(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          clientX: 24,
+          clientY: 48,
+          currentTarget: {
+            dataset: {},
+          },
+        },
+      },
+    );
+
+    expect(store.setPopover).toHaveBeenCalledWith({
+      mode: "addProperty",
+      x: 24,
+      y: 48,
+      payload: {
+        side: "next",
+      },
+    });
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("keeps the transition add-property side menu on desktop", () => {
+    const store = {
+      selectDialogType: vi.fn(() => "transition"),
+      selectIsTouchMode: vi.fn(() => false),
+      setPopover: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertiesClick(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          clientX: 24,
+          clientY: 48,
+          currentTarget: {
+            dataset: {},
+          },
+        },
+      },
+    );
+
+    expect(store.setPopover).toHaveBeenCalledWith({
+      mode: "addPropertySideMenu",
+      x: 24,
+      y: 48,
       payload: {},
     });
     expect(render).toHaveBeenCalled();
@@ -280,6 +351,46 @@ describe("animationEditor.handlers", () => {
         initialValue: 1,
         property: "scaleX",
         useInitialValue: true,
+      },
+    });
+    expect(render).toHaveBeenCalled();
+  });
+
+  it("resets add-property choices when the mobile transition side changes", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        formValues: {
+          side: "prev",
+          property: "x",
+          useInitialValue: true,
+          initialValue: 12,
+        },
+      })),
+      updatePopoverFormValues: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertyFormChange(
+      {
+        store,
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            name: "side",
+            value: "next",
+          },
+        },
+      },
+    );
+
+    expect(store.updatePopoverFormValues).toHaveBeenCalledWith({
+      formValues: {
+        side: "next",
+        property: undefined,
+        useInitialValue: true,
+        initialValue: undefined,
       },
     });
     expect(render).toHaveBeenCalled();
@@ -783,6 +894,7 @@ describe("animationEditor.handlers", () => {
         animations: [],
       })),
       selectPreviewData: vi.fn(() => previewData),
+      selectIsTouchMode: vi.fn(() => false),
       setItems: vi.fn(),
     };
     const projectService = {
@@ -809,6 +921,7 @@ describe("animationEditor.handlers", () => {
 
     await handleSavePreviewClick({
       appService,
+      i18n: EN_I18N,
       projectService,
       render,
       store,

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -20,16 +20,18 @@ import {
   setProjectResolution,
   setTransitionMaskChannel,
   setTransitionMaskImage,
+  setUiConfig,
   startPendingTransitionMask,
   updatePopoverFormValues,
 } from "../../src/pages/animationEditor/animationEditor.store.js";
+import { EN_I18N } from "../support/i18n.js";
 
 describe("animationEditor.store", () => {
   it("does not show Mask in the transition Add menu", () => {
     const state = createInitialState();
     openDialog({ state }, { dialogType: "transition" });
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.transitionAddPropertyButtonVisible).toBe(true);
     expect(viewData.addPropertySideMenuItems).not.toContainEqual({
@@ -52,7 +54,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.popover.popoverIsOpen).toBe(false);
     expect(viewData.popover.maskDialogIsOpen).toBe(true);
@@ -72,7 +74,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.transitionMaskPanel.enabled).toBe(false);
     expect(viewData.maskEditorPanel.enabled).toBe(true);
@@ -92,11 +94,147 @@ describe("animationEditor.store", () => {
     openDialog({ state }, { dialogType: "transition" });
     enableTransitionMask({ state });
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(state.transitionMask.channel).toBe("red");
     expect(viewData.transitionMaskPanel.channelValue).toBe("red");
     expect(viewData.transitionMaskPanel.channelLabel).toBe("Greyscale");
+  });
+
+  it("uses popovers on desktop and dialogs on touch for add-property and keyframe forms", () => {
+    const state = createInitialState();
+
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "update",
+        },
+      },
+    );
+
+    let viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.popover.popoverIsOpen).toBe(true);
+    expect(viewData.showAddPropertyPopover).toBe(true);
+    expect(viewData.showAddPropertyDialog).toBe(false);
+    expect(viewData.showAddKeyframePopover).toBe(false);
+    expect(viewData.showAddKeyframeDialog).toBe(false);
+    expect(viewData.showEditKeyframePopover).toBe(false);
+    expect(viewData.showEditKeyframeDialog).toBe(false);
+
+    setPopover(
+      { state },
+      {
+        mode: "addKeyframe",
+        payload: {
+          side: "update",
+          property: "x",
+          index: 0,
+        },
+      },
+    );
+
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.popover.popoverIsOpen).toBe(true);
+    expect(viewData.showAddPropertyPopover).toBe(false);
+    expect(viewData.showAddPropertyDialog).toBe(false);
+    expect(viewData.showAddKeyframePopover).toBe(true);
+    expect(viewData.showAddKeyframeDialog).toBe(false);
+    expect(viewData.showEditKeyframePopover).toBe(false);
+    expect(viewData.showEditKeyframeDialog).toBe(false);
+
+    setPopover(
+      { state },
+      {
+        mode: "editKeyframe",
+        payload: {
+          side: "update",
+          property: "x",
+          index: 0,
+        },
+      },
+    );
+
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.popover.popoverIsOpen).toBe(true);
+    expect(viewData.showAddPropertyPopover).toBe(false);
+    expect(viewData.showAddPropertyDialog).toBe(false);
+    expect(viewData.showAddKeyframePopover).toBe(false);
+    expect(viewData.showAddKeyframeDialog).toBe(false);
+    expect(viewData.showEditKeyframePopover).toBe(true);
+    expect(viewData.showEditKeyframeDialog).toBe(false);
+
+    setUiConfig(
+      { state },
+      {
+        uiConfig: {
+          id: "touch",
+          inputMode: "touch",
+        },
+      },
+    );
+
+    setPopover(
+      { state },
+      {
+        mode: "addProperty",
+        payload: {
+          side: "update",
+        },
+      },
+    );
+
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.popover.popoverIsOpen).toBe(false);
+    expect(viewData.showAddPropertyPopover).toBe(false);
+    expect(viewData.showAddPropertyDialog).toBe(true);
+    expect(viewData.showAddKeyframePopover).toBe(false);
+    expect(viewData.showAddKeyframeDialog).toBe(false);
+    expect(viewData.showEditKeyframePopover).toBe(false);
+    expect(viewData.showEditKeyframeDialog).toBe(false);
+
+    setPopover(
+      { state },
+      {
+        mode: "addKeyframe",
+        payload: {
+          side: "update",
+          property: "x",
+          index: 0,
+        },
+      },
+    );
+
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.popover.popoverIsOpen).toBe(false);
+    expect(viewData.showAddPropertyPopover).toBe(false);
+    expect(viewData.showAddPropertyDialog).toBe(false);
+    expect(viewData.showAddKeyframePopover).toBe(false);
+    expect(viewData.showAddKeyframeDialog).toBe(true);
+    expect(viewData.showEditKeyframePopover).toBe(false);
+    expect(viewData.showEditKeyframeDialog).toBe(false);
+
+    setPopover(
+      { state },
+      {
+        mode: "editKeyframe",
+        payload: {
+          side: "update",
+          property: "x",
+          index: 0,
+        },
+      },
+    );
+
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.popover.popoverIsOpen).toBe(false);
+    expect(viewData.showAddPropertyPopover).toBe(false);
+    expect(viewData.showAddPropertyDialog).toBe(false);
+    expect(viewData.showAddKeyframePopover).toBe(false);
+    expect(viewData.showAddKeyframeDialog).toBe(false);
+    expect(viewData.showEditKeyframePopover).toBe(false);
+    expect(viewData.showEditKeyframeDialog).toBe(true);
   });
 
   it("normalizes removed mask channels to greyscale red", () => {
@@ -130,9 +268,10 @@ describe("animationEditor.store", () => {
         },
       },
     );
-    const xField = selectViewData({ state }).addKeyframeForm.fields.find(
-      (field) => field.name === "value",
-    );
+    const xField = selectViewData({
+      state,
+      i18n: EN_I18N,
+    }).addKeyframeForm.fields.find((field) => field.name === "value");
 
     setPopover(
       { state },
@@ -143,9 +282,10 @@ describe("animationEditor.store", () => {
         },
       },
     );
-    const yField = selectViewData({ state }).addKeyframeForm.fields.find(
-      (field) => field.name === "value",
-    );
+    const yField = selectViewData({
+      state,
+      i18n: EN_I18N,
+    }).addKeyframeForm.fields.find((field) => field.name === "value");
 
     expect(xField).toMatchObject({
       min: -1920,
@@ -172,7 +312,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    let viewData = selectViewData({ state });
+    let viewData = selectViewData({ state, i18n: EN_I18N });
     const propertyField = viewData.addPropertyForm.fields.find(
       (field) => field.name === "property",
     );
@@ -198,7 +338,7 @@ describe("animationEditor.store", () => {
         },
       },
     );
-    viewData = selectViewData({ state });
+    viewData = selectViewData({ state, i18n: EN_I18N });
     expect(
       viewData.addPropertyForm.fields.find(
         (field) => field.name === "initialValue",
@@ -218,7 +358,7 @@ describe("animationEditor.store", () => {
         },
       },
     );
-    viewData = selectViewData({ state });
+    viewData = selectViewData({ state, i18n: EN_I18N });
     expect(
       viewData.addPropertyForm.fields.find(
         (field) => field.name === "initialValue",
@@ -244,7 +384,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     const propertyField = viewData.addPropertyForm.fields.find(
       (field) => field.name === "property",
     );
@@ -313,7 +453,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     const propertyField = viewData.addPropertyForm.fields.find(
       (field) => field.name === "property",
     );
@@ -355,7 +495,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     const addPropertyForm = viewData.addPropertyForm;
     const initialValueFields = addPropertyForm.fields.filter(
       (field) => field.name === "initialValue",
@@ -394,9 +534,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({
-      state,
-    });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     const initialValueFields = viewData.addPropertyForm.fields.filter(
       (field) => field.name === "initialValue",
     );
@@ -453,7 +591,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.transitionMaskPanel.singleImage).toMatchObject({
       imageId: "mask",
@@ -510,7 +648,7 @@ describe("animationEditor.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.previewPanel.items).toEqual([
       expect.objectContaining({

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("animationEditor view", () => {
-  it("uses a bordered navbar icon for the back action", () => {
+  it("uses an outline navbar icon button for the back action", () => {
     const view = readFileSync(
       new URL(
         "../../src/pages/animationEditor/animationEditor.view.yaml",
@@ -11,12 +11,32 @@ describe("animationEditor view", () => {
       "utf8",
     );
 
-    expect(view).toContain(
-      "rtgl-view#backButton w=36 h=36 bw=xs br=md ah=c av=c cur=pointer bgc=bg bc=bo",
-    );
-    expect(view).toContain("rtgl-svg svg=chevronLeft wh=16 c=mu-fg");
+    expect(view).toContain("rtgl-button#backButton sq pre=chevronLeft v=ol");
     expect(view).not.toContain(
       'rtgl-button#backButton sq pre="chevronLeft" v="gh"',
     );
+  });
+
+  it("uses dialogs on touch for add-property and keyframe forms", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/pages/animationEditor/animationEditor.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain("$if showAddPropertyPopover");
+    expect(view).toContain("$if showAddKeyframePopover");
+    expect(view).toContain("$if showEditKeyframePopover");
+    expect(view).toContain("rtgl-dialog#addPropertyDialog");
+    expect(view).toContain("rtgl-dialog#addKeyframeDialog");
+    expect(view).toContain("rtgl-dialog#editKeyframeDialog");
+    expect(view).toContain("?open=${showAddPropertyDialog}");
+    expect(view).toContain("?open=${showAddKeyframeDialog}");
+    expect(view).toContain("?open=${showEditKeyframeDialog}");
+    expect(view).not.toContain("$if popover.mode == 'addProperty'");
+    expect(view).not.toContain("$if popover.mode == 'addKeyframe'");
+    expect(view).not.toContain("$if popover.mode == 'editKeyframe'");
   });
 });

--- a/tests/scenes/scenes.store.test.js
+++ b/tests/scenes/scenes.store.test.js
@@ -5,6 +5,7 @@ import {
   openMobileFileExplorer,
   selectIsMobileFileExplorerOpen,
   selectViewData,
+  setShowSceneForm,
   setTouchMinimapReady,
   setUiConfig,
   setWhiteboardConnectionsReady,
@@ -65,5 +66,29 @@ describe("scenes.store mobile layout", () => {
     expect(viewData.showWhiteboardMinimapInTouchMode).toBe(false);
     expect(viewData.whiteboardMinimapPlacement).toBe("bottom-left");
     expect(viewData.whiteboardMinimapHeightScale).toBe(1);
+  });
+
+  it("uses a popover on desktop and a dialog on touch for scene creation", () => {
+    const state = createInitialState();
+
+    setShowSceneForm({ state }, { show: true });
+
+    const desktopViewData = selectViewData({ state, i18n: EN_I18N });
+    expect(desktopViewData.showSceneFormPopover).toBe(true);
+    expect(desktopViewData.showSceneFormDialog).toBe(false);
+
+    setUiConfig(
+      { state },
+      {
+        uiConfig: {
+          id: "touch",
+          inputMode: "touch",
+        },
+      },
+    );
+
+    const touchViewData = selectViewData({ state, i18n: EN_I18N });
+    expect(touchViewData.showSceneFormPopover).toBe(false);
+    expect(touchViewData.showSceneFormDialog).toBe(true);
   });
 });

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -18,14 +18,20 @@ describe("scenes view", () => {
     expect(scenesView).toContain("padding-top: env(safe-area-inset-top)");
   });
 
-  it("centers the create scene popover as an overlay on mobile", () => {
+  it("uses a popover for desktop scene creation and a dialog form for mobile", () => {
     const scenesView = readFileSync(
       new URL("../../src/pages/scenes/scenes.view.yaml", import.meta.url),
       "utf8",
     );
 
     expect(scenesView).toContain(
-      "rtgl-popover#sceneFormPopover ?open=${showSceneForm} x=${sceneFormPosition.x} y=${sceneFormPosition.y} md-place=center md-overlay",
+      "rtgl-popover#sceneFormPopover ?open=${showSceneFormPopover} x=${sceneFormPosition.x} y=${sceneFormPosition.y}",
+    );
+    expect(scenesView).toContain(
+      "rtgl-dialog#sceneFormDialog ?open=${showSceneFormDialog} s=sm",
+    );
+    expect(scenesView).toContain(
+      "rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=f",
     );
   });
 

--- a/tests/textStyles/textStyles.store.test.js
+++ b/tests/textStyles/textStyles.store.test.js
@@ -3,6 +3,7 @@ import {
   createInitialState,
   selectViewData,
   setItems,
+  setUiConfig,
 } from "../../src/pages/textStyles/textStyles.store.js";
 import { EN_I18N } from "../support/i18n.js";
 
@@ -69,5 +70,27 @@ describe("textStyles.store", () => {
       type: "item",
       value: "edit-item",
     });
+  });
+
+  it("hides the text style dialog preview canvas in touch mode", () => {
+    const state = createInitialState();
+
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).showDialogPreviewCanvas,
+    ).toBe(true);
+
+    setUiConfig(
+      { state },
+      {
+        uiConfig: {
+          id: "touch",
+          inputMode: "touch",
+        },
+      },
+    );
+
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).showDialogPreviewCanvas,
+    ).toBe(false);
   });
 });

--- a/tests/textStyles/textStyles.view.test.js
+++ b/tests/textStyles/textStyles.view.test.js
@@ -34,4 +34,44 @@ describe("textStyles view", () => {
     expect(textStylesView).toContain("handler: handleMobileDetailEditClick");
     expect(textStylesView).toContain("handler: handleTextStyleItemEdit");
   });
+
+  it("hides the add/edit preview canvas in the mobile dialog branch", () => {
+    const textStylesView = readFileSync(
+      new URL(
+        "../../src/pages/textStyles/textStyles.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    const desktopPreviewStart = textStylesView.indexOf(
+      "$if showDialogPreviewCanvas",
+    );
+    const mobileBranchStart = textStylesView.indexOf(
+      "$else:",
+      desktopPreviewStart,
+    );
+    const dialogEnd = textStylesView.indexOf(
+      "rtgl-dialog#addColorDialog",
+      mobileBranchStart,
+    );
+    const desktopBranch = textStylesView.slice(
+      desktopPreviewStart,
+      mobileBranchStart,
+    );
+    const mobileBranch = textStylesView.slice(mobileBranchStart, dialogEnd);
+
+    expect(desktopBranch).toContain("rvn-font-preview");
+    expect(desktopBranch).toContain("previewTextInput");
+    expect(mobileBranch).toContain("$if isDialogOpen");
+    expect(mobileBranch).toContain("rtgl-form#textStyleForm");
+    expect(mobileBranch).toContain(
+      "rtgl-dialog#addTypographyDialog ?open=${isDialogOpen} s=md",
+    );
+    expect(mobileBranch).toContain("rtgl-view slot=content g=md");
+    expect(mobileBranch).not.toContain("rvn-font-preview");
+    expect(mobileBranch).not.toContain("previewTextInput");
+    expect(mobileBranch).not.toContain("100vw");
+    expect(mobileBranch).not.toContain("calc(100vw");
+  });
 });


### PR DESCRIPTION
Summary
- Use mobile dialogs for scene creation and animation editor keyframe/property forms.
- Hide the Text Styles preview canvas on mobile and align its dialog lifecycle/width with existing resource edit dialogs.
- Add coverage for mobile dialog store/view behavior.

Validation
- bunx vitest run tests/scenes/scenes.store.test.js tests/scenes/scenes.view.test.js tests/animationEditor/animationEditor.store.test.js tests/animationEditor/animationEditor.view.test.js tests/animationEditor/animationEditor.handlers.test.js tests/textStyles/textStyles.store.test.js tests/textStyles/textStyles.view.test.js tests/textStyles/textStyleResourcesView.test.js tests/textStyles/textStyles.handlers.test.js tests/textStyles/textStyles.fileExplorer.test.js
- bun run lint
- git diff --check