### PR TITLE
feat: support packaged Windows player export

### DIFF
--- a/crates/routevn-packager/src/windows_resources.rs
+++ b/crates/routevn-packager/src/windows_resources.rs
@@ -19,10 +19,21 @@ const CODEPAGE_UNICODE: u32 = 1200;
 const RT_ICON: u16 = 3;
 const RT_GROUP_ICON: u16 = 14;
 const RT_VERSION: u16 = 16;
+const RT_MANIFEST: u16 = 24;
 const RESOURCE_ICON_ID: u16 = 1;
 const RESOURCE_VERSION_ID: u16 = 1;
+const RESOURCE_MANIFEST_ID: u16 = 1;
 const MAX_WINDOWS_ICON_SIZE: u32 = 256;
 const MIN_WINDOWS_ICON_SIZE: u32 = 64;
+const WINDOWS_COMMON_CONTROLS_MANIFEST: &[u8] = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>
+"#;
 
 #[derive(Clone, Copy, Debug)]
 pub struct WindowsResourceMetadata<'a> {
@@ -423,11 +434,16 @@ fn build_resource_section(
             bytes: version_info,
             code_page: CODEPAGE_UNICODE,
         },
+        ResourceData {
+            bytes: WINDOWS_COMMON_CONTROLS_MANIFEST.to_vec(),
+            code_page: 0,
+        },
     ];
     let tree = ResourceNode::Directory(vec![
         type_resource_entry(RT_ICON, RESOURCE_ICON_ID, 0),
         type_resource_entry(RT_GROUP_ICON, RESOURCE_ICON_ID, 1),
         type_resource_entry(RT_VERSION, RESOURCE_VERSION_ID, 2),
+        type_resource_entry(RT_MANIFEST, RESOURCE_MANIFEST_ID, 3),
     ]);
     let mut bytes = Vec::new();
     let mut data_entry_patches = Vec::new();
@@ -842,8 +858,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        WindowsResourceMetadata, WindowsResourceStampRequest, parse_windows_version_parts,
-        stamp_windows_resources,
+        WINDOWS_COMMON_CONTROLS_MANIFEST, WindowsResourceMetadata, WindowsResourceStampRequest,
+        parse_windows_version_parts, stamp_windows_resources,
     };
 
     const PNG_64: &[u8] = &[
@@ -899,6 +915,11 @@ mod tests {
         assert!(resource_size > 0);
         assert!(outcome.resource_bytes > 0);
         assert!(stamped.windows(PNG_64.len()).any(|window| window == PNG_64));
+        assert!(
+            stamped
+                .windows(WINDOWS_COMMON_CONTROLS_MANIFEST.len())
+                .any(|window| window == WINDOWS_COMMON_CONTROLS_MANIFEST)
+        );
         let title_marker = utf16le("My Game");
         assert!(
             stamped

--- a/crates/routevn-packager/tauri-shell/src-tauri/Cargo.lock
+++ b/crates/routevn-packager/tauri-shell/src-tauri/Cargo.lock
@@ -355,6 +355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +1853,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2240,16 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2960,6 +2989,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
@@ -3926,6 +3961,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",

--- a/crates/routevn-packager/tauri-shell/src-tauri/Cargo.toml
+++ b/crates/routevn-packager/tauri-shell/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ writeable = { version = "=0.6.3", features = ["alloc"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "=2.11.2", features = [] }
+tauri = { version = "=2.11.2", features = ["image-png"] }
 tauri-plugin-log = "=2.7.1"
 routevn-packager = { path = "../.." }
 

--- a/crates/routevn-packager/tauri-shell/src-tauri/capabilities/default.json
+++ b/crates/routevn-packager/tauri-shell/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-set-title",
-    "core:window:allow-set-icon"
+    "core:window:allow-set-icon",
+    "core:window:allow-show"
   ]
 }

--- a/crates/routevn-packager/tauri-shell/src-tauri/capabilities/default.json
+++ b/crates/routevn-packager/tauri-shell/src-tauri/capabilities/default.json
@@ -2,10 +2,10 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "windows": [
-    "main"
-  ],
+  "windows": ["main"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "core:window:allow-set-title",
+    "core:window:allow-set-icon"
   ]
 }

--- a/crates/routevn-packager/tauri-shell/src-tauri/tauri.conf.json
+++ b/crates/routevn-packager/tauri-shell/src-tauri/tauri.conf.json
@@ -10,11 +10,12 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "title": "RouteVN",
+        "title": "",
         "width": 800,
         "height": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "visible": false
       }
     ],
     "security": {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -107,6 +107,14 @@ const recordDiagnosticStep = (message, details) => {
   console.info("[RouteVN player]", message, details ?? "");
 };
 
+document.addEventListener(
+  "contextmenu",
+  (event) => {
+    event.preventDefault();
+  },
+  { capture: true },
+);
+
 const formatDiagnosticEvents = () =>
   diagnosticEvents
     .map((event) => {
@@ -134,33 +142,52 @@ const getBundleProjectTitle = (bundleMetadata) => {
 const hasTauriCurrentWindow = () =>
   !!globalThis.window?.__TAURI_INTERNALS__?.metadata?.currentWindow;
 
-const setNativeWindowTitle = (title) => {
+const setNativeWindowTitle = async (title) => {
   if (!hasTauriCurrentWindow()) {
-    return;
+    return false;
   }
 
-  void getCurrentWindow()
-    .setTitle(title)
-    .then(() => {
-      recordDiagnosticStep("Set native window title", { title });
-    })
-    .catch((error) => {
-      console.warn("Failed to set native window title.", error);
-      recordDiagnosticStep("Failed to set native window title", {
-        title,
-        error: formatErrorForDiagnostics(error),
-      });
+  try {
+    await getCurrentWindow().setTitle(title);
+    recordDiagnosticStep("Set native window title", { title });
+    return true;
+  } catch (error) {
+    console.warn("Failed to set native window title.", error);
+    recordDiagnosticStep("Failed to set native window title", {
+      title,
+      error: formatErrorForDiagnostics(error),
     });
+    return false;
+  }
 };
 
-const setBundleDocumentTitle = (bundleMetadata) => {
+const setBundleDocumentTitle = async (bundleMetadata) => {
   const title = getBundleProjectTitle(bundleMetadata);
   if (!title) {
-    return;
+    return false;
   }
 
   document.title = title;
-  setNativeWindowTitle(title);
+  return setNativeWindowTitle(title);
+};
+
+const showNativeWindow = async ({ reason } = {}) => {
+  if (!hasTauriCurrentWindow()) {
+    return false;
+  }
+
+  try {
+    await getCurrentWindow().show();
+    recordDiagnosticStep("Showed native window", { reason });
+    return true;
+  } catch (error) {
+    console.warn("Failed to show native window.", error);
+    recordDiagnosticStep("Failed to show native window", {
+      reason,
+      error: formatErrorForDiagnostics(error),
+    });
+    return false;
+  }
 };
 
 const setBundleFavicon = ({ url, type }) => {
@@ -222,7 +249,7 @@ const readBundleAssetObjectUrl = async ({ bundleReader, assetId }) => {
 const loadBundleFavicon = async ({ bundleMetadata, bundleReader }) => {
   const iconFileId = bundleMetadata?.project?.iconFileId;
   if (!iconFileId || !bundleReader.hasAsset(iconFileId)) {
-    return;
+    return false;
   }
 
   recordDiagnosticStep("Loading project favicon", { assetId: iconFileId });
@@ -252,12 +279,14 @@ const loadBundleFavicon = async ({ bundleMetadata, bundleReader }) => {
       size: favicon.size,
       nativeIcon: didSetNativeIcon,
     });
+    return didSetNativeIcon;
   } catch (error) {
     console.warn("Failed to load project favicon.", error);
     recordDiagnosticStep("Failed to load project favicon", {
       assetId: iconFileId,
       error: formatErrorForDiagnostics(error),
     });
+    return false;
   }
 };
 
@@ -535,11 +564,13 @@ const preloadBundleData = async () => {
   const jsonData = {
     ...vnbundleInstructions.projectData,
   };
-  setBundleDocumentTitle(vnbundleInstructions.bundleMetadata);
-  void loadBundleFavicon({
-    bundleMetadata: vnbundleInstructions.bundleMetadata,
-    bundleReader,
-  });
+  await Promise.all([
+    setBundleDocumentTitle(vnbundleInstructions.bundleMetadata),
+    loadBundleFavicon({
+      bundleMetadata: vnbundleInstructions.bundleMetadata,
+      bundleReader,
+    }),
+  ]);
 
   return {
     jsonData,
@@ -792,9 +823,6 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
     });
 
   canvasContainer?.appendChild(routeGraphics.canvas);
-  canvasContainer?.addEventListener("contextmenu", (e) => {
-    e.preventDefault();
-  });
 
   engine = createRouteEngine({ handlePendingEffects: effectsHandler });
   const preloadSaveSlotImagesResult = await preloadRuntimeSaveSlotImages(
@@ -851,12 +879,14 @@ const bootstrap = async () => {
     engineRuntime.startEngine();
     await engineRuntime.waitForFirstRender();
     hideLoadingOverlay();
+    await showNativeWindow({ reason: "first-render" });
   } catch (error) {
     console.error("Failed to start bundle player:", error);
     setLoadingError({
       summary: "The player could not finish startup.",
       error,
     });
+    await showNativeWindow({ reason: "startup-error" });
   }
 };
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -131,15 +131,25 @@ const getBundleProjectTitle = (bundleMetadata) => {
   return "";
 };
 
+const hasTauriCurrentWindow = () =>
+  !!globalThis.window?.__TAURI_INTERNALS__?.metadata?.currentWindow;
+
 const setNativeWindowTitle = (title) => {
-  if (!globalThis.window?.__TAURI_INTERNALS__?.metadata?.currentWindow) {
+  if (!hasTauriCurrentWindow()) {
     return;
   }
 
   void getCurrentWindow()
     .setTitle(title)
+    .then(() => {
+      recordDiagnosticStep("Set native window title", { title });
+    })
     .catch((error) => {
       console.warn("Failed to set native window title.", error);
+      recordDiagnosticStep("Failed to set native window title", {
+        title,
+        error: formatErrorForDiagnostics(error),
+      });
     });
 };
 
@@ -173,6 +183,19 @@ const setBundleFavicon = ({ url, type }) => {
   link.href = url;
 };
 
+const setNativeWindowIcon = async ({ assetId, bytes }) => {
+  if (!hasTauriCurrentWindow()) {
+    return false;
+  }
+
+  await getCurrentWindow().setIcon(bytes);
+  recordDiagnosticStep("Set native window icon", {
+    assetId,
+    size: bytes.byteLength,
+  });
+  return true;
+};
+
 const readBundleAssetObjectUrl = async ({ bundleReader, assetId }) => {
   const metadata = await bundleReader.readAsset(assetId);
   if (metadata?.encoding === "diced-image") {
@@ -180,6 +203,8 @@ const readBundleAssetObjectUrl = async ({ bundleReader, assetId }) => {
   }
 
   const content = metadata.buffer;
+  const bytes =
+    content instanceof Uint8Array ? content.slice() : new Uint8Array(content);
   const fileType = await fileTypeFromBuffer(content);
   const type = resolveBundleAssetMimeType({
     bundleMime: metadata.mime,
@@ -190,6 +215,7 @@ const readBundleAssetObjectUrl = async ({ bundleReader, assetId }) => {
     url: URL.createObjectURL(new Blob([content], { type })),
     type,
     size: content.byteLength,
+    bytes,
   };
 };
 
@@ -209,10 +235,22 @@ const loadBundleFavicon = async ({ bundleMetadata, bundleReader }) => {
       url: favicon.url,
       type: favicon.type,
     });
+    const didSetNativeIcon = await setNativeWindowIcon({
+      assetId: iconFileId,
+      bytes: favicon.bytes,
+    }).catch((error) => {
+      console.warn("Failed to set native window icon.", error);
+      recordDiagnosticStep("Failed to set native window icon", {
+        assetId: iconFileId,
+        error: formatErrorForDiagnostics(error),
+      });
+      return false;
+    });
     recordDiagnosticStep("Loaded project favicon", {
       assetId: iconFileId,
       type: favicon.type,
       size: favicon.size,
+      nativeIcon: didSetNativeIcon,
     });
   } catch (error) {
     console.warn("Failed to load project favicon.", error);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,5 @@
 import { fileTypeFromBuffer } from "file-type";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import createRouteEngine, {
   createEffectsHandler,
   createIndexedDbPersistence,
@@ -17,6 +18,210 @@ import {
 } from "../src/internal/runtime/graphicsEngineRuntime.js";
 import { resolveBundleAssetMimeType } from "../src/internal/bundleRuntimeAssets.js";
 import { createBundleRangeReader as createPackageBinRangeReader } from "../src/deps/services/shared/projectExportService.js";
+
+const MAX_DIAGNOSTIC_EVENTS = 24;
+const MAX_DIAGNOSTIC_TEXT_LENGTH = 12_000;
+const diagnosticEvents = [];
+
+const truncateDiagnosticText = (value) => {
+  if (value.length <= MAX_DIAGNOSTIC_TEXT_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_DIAGNOSTIC_TEXT_LENGTH)}\n... truncated ...`;
+};
+
+const stringifyDiagnosticValue = (value) => {
+  if (value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return formatErrorForDiagnostics(value);
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const formatErrorForDiagnostics = (error) => {
+  if (!error) {
+    return "";
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  const lines = [];
+  const name = typeof error.name === "string" ? error.name : "";
+  const message =
+    typeof error.message === "string" && error.message.length > 0
+      ? error.message
+      : String(error);
+
+  lines.push(name && name !== "Error" ? `${name}: ${message}` : message);
+
+  if (error.details !== undefined) {
+    lines.push(`Details: ${stringifyDiagnosticValue(error.details)}`);
+  }
+
+  if (error.stack) {
+    lines.push(`Stack: ${error.stack}`);
+  }
+
+  if (error.cause) {
+    lines.push(`Cause: ${formatErrorForDiagnostics(error.cause)}`);
+  }
+
+  return lines.filter(Boolean).join("\n");
+};
+
+const createRuntimeError = (message, cause, details) => {
+  const error = new Error(message);
+  error.cause = cause;
+  if (details !== undefined) {
+    error.details = details;
+  }
+  return error;
+};
+
+const recordDiagnosticStep = (message, details) => {
+  const entry = {
+    time: new Date().toISOString(),
+    message,
+    details,
+  };
+  diagnosticEvents.push(entry);
+  if (diagnosticEvents.length > MAX_DIAGNOSTIC_EVENTS) {
+    diagnosticEvents.shift();
+  }
+
+  console.info("[RouteVN player]", message, details ?? "");
+};
+
+const formatDiagnosticEvents = () =>
+  diagnosticEvents
+    .map((event) => {
+      const details = stringifyDiagnosticValue(event.details);
+      return details
+        ? `[${event.time}] ${event.message}\n${details}`
+        : `[${event.time}] ${event.message}`;
+    })
+    .join("\n\n");
+
+const getBundleProjectTitle = (bundleMetadata) => {
+  const title = bundleMetadata?.project?.title?.trim?.();
+  if (title) {
+    return title;
+  }
+
+  const name = bundleMetadata?.project?.name?.trim?.();
+  if (name) {
+    return name;
+  }
+
+  return "";
+};
+
+const setNativeWindowTitle = (title) => {
+  if (!globalThis.window?.__TAURI_INTERNALS__?.metadata?.currentWindow) {
+    return;
+  }
+
+  void getCurrentWindow()
+    .setTitle(title)
+    .catch((error) => {
+      console.warn("Failed to set native window title.", error);
+    });
+};
+
+const setBundleDocumentTitle = (bundleMetadata) => {
+  const title = getBundleProjectTitle(bundleMetadata);
+  if (!title) {
+    return;
+  }
+
+  document.title = title;
+  setNativeWindowTitle(title);
+};
+
+const setBundleFavicon = ({ url, type }) => {
+  const head = document.head;
+  if (!head || !url) {
+    return;
+  }
+
+  let link = document.querySelector(
+    'link[rel="icon"][data-routevn-bundle-icon="true"]',
+  );
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "icon";
+    link.dataset.routevnBundleIcon = "true";
+    head.appendChild(link);
+  }
+
+  link.type = type ?? "image/png";
+  link.href = url;
+};
+
+const readBundleAssetObjectUrl = async ({ bundleReader, assetId }) => {
+  const metadata = await bundleReader.readAsset(assetId);
+  if (metadata?.encoding === "diced-image") {
+    throw new Error("Diced image assets are not supported as favicon images.");
+  }
+
+  const content = metadata.buffer;
+  const fileType = await fileTypeFromBuffer(content);
+  const type = resolveBundleAssetMimeType({
+    bundleMime: metadata.mime,
+    detectedMime: fileType?.mime,
+  });
+
+  return {
+    url: URL.createObjectURL(new Blob([content], { type })),
+    type,
+    size: content.byteLength,
+  };
+};
+
+const loadBundleFavicon = async ({ bundleMetadata, bundleReader }) => {
+  const iconFileId = bundleMetadata?.project?.iconFileId;
+  if (!iconFileId || !bundleReader.hasAsset(iconFileId)) {
+    return;
+  }
+
+  recordDiagnosticStep("Loading project favicon", { assetId: iconFileId });
+  try {
+    const favicon = await readBundleAssetObjectUrl({
+      bundleReader,
+      assetId: iconFileId,
+    });
+    setBundleFavicon({
+      url: favicon.url,
+      type: favicon.type,
+    });
+    recordDiagnosticStep("Loaded project favicon", {
+      assetId: iconFileId,
+      type: favicon.type,
+      size: favicon.size,
+    });
+  } catch (error) {
+    console.warn("Failed to load project favicon.", error);
+    recordDiagnosticStep("Failed to load project favicon", {
+      assetId: iconFileId,
+      error: formatErrorForDiagnostics(error),
+    });
+  }
+};
 
 const collectBundleAssetIds = ({ value, hasAsset, result = new Set() }) => {
   if (typeof value === "string") {
@@ -49,59 +254,95 @@ const createBundleAssetLoader = ({ bundleReader, routeGraphics }) => {
   const assetLoadPromises = new Map();
   const dicedAtlasPixelCache = new Map();
 
-  const shouldBufferAsset = (mimeType = "") => {
-    return (
-      mimeType.startsWith("audio/") ||
-      mimeType.startsWith("font/") ||
-      [
-        "application/font-woff",
-        "application/font-woff2",
-        "application/x-font-ttf",
-        "application/x-font-otf",
-      ].includes(mimeType)
+  const createAssetBuffer = (content) => {
+    if (content instanceof ArrayBuffer) {
+      return content.slice(0);
+    }
+
+    return content.buffer.slice(
+      content.byteOffset,
+      content.byteOffset + content.byteLength,
     );
   };
 
   const createRuntimeAsset = async (assetId) => {
-    const metadata = await bundleReader.readAsset(assetId);
+    recordDiagnosticStep("Reading bundle asset", { assetId });
+    let metadata;
+    try {
+      metadata = await bundleReader.readAsset(assetId);
+    } catch (error) {
+      throw createRuntimeError(
+        `Failed to read bundle asset "${assetId}".`,
+        error,
+        { assetId },
+      );
+    }
 
     if (metadata?.encoding === "diced-image") {
       let atlas;
       if (!dicedAtlasPixelCache.has(metadata.atlasId)) {
-        atlas = await bundleReader.readAtlas(metadata.atlasId);
+        recordDiagnosticStep("Reading diced image atlas", {
+          assetId,
+          atlasId: metadata.atlasId,
+        });
+        try {
+          atlas = await bundleReader.readAtlas(metadata.atlasId);
+        } catch (error) {
+          throw createRuntimeError(
+            `Failed to read diced atlas "${metadata.atlasId}" for asset "${assetId}".`,
+            error,
+            { assetId, atlasId: metadata.atlasId },
+          );
+        }
       }
 
-      return createRuntimeAssetFromDicedImage({
-        asset: metadata,
-        atlases: atlas
-          ? {
-              [metadata.atlasId]: atlas,
-            }
-          : {},
-        atlasCache: dicedAtlasPixelCache,
-      });
+      try {
+        return await createRuntimeAssetFromDicedImage({
+          asset: metadata,
+          atlases: atlas
+            ? {
+                [metadata.atlasId]: atlas,
+              }
+            : {},
+          atlasCache: dicedAtlasPixelCache,
+        });
+      } catch (error) {
+        throw createRuntimeError(
+          `Failed to reconstruct diced image asset "${assetId}".`,
+          error,
+          {
+            assetId,
+            atlasId: metadata.atlasId,
+            width: metadata.width,
+            height: metadata.height,
+          },
+        );
+      }
     }
 
     const content = metadata.buffer;
-    const fileType = await fileTypeFromBuffer(content);
+    let fileType;
+    try {
+      fileType = await fileTypeFromBuffer(content);
+    } catch (error) {
+      throw createRuntimeError(
+        `Failed to inspect bundle asset "${assetId}".`,
+        error,
+        {
+          assetId,
+          mime: metadata.mime,
+          size: content?.byteLength,
+        },
+      );
+    }
     const detectedType = resolveBundleAssetMimeType({
       bundleMime: metadata.mime,
       detectedMime: fileType?.mime,
     });
-    if (shouldBufferAsset(detectedType)) {
-      return {
-        buffer: content.buffer.slice(
-          content.byteOffset,
-          content.byteOffset + content.byteLength,
-        ),
-        source: "buffer",
-        type: detectedType,
-      };
-    }
 
     return {
-      source: "url",
-      url: URL.createObjectURL(new Blob([content], { type: detectedType })),
+      buffer: createAssetBuffer(content),
+      source: "buffer",
       type: detectedType,
       size: content.byteLength,
     };
@@ -118,9 +359,31 @@ const createBundleAssetLoader = ({ bundleReader, routeGraphics }) => {
 
     const loadPromise = (async () => {
       const asset = await createRuntimeAsset(assetId);
-      await routeGraphics.loadAssets({
-        [assetId]: asset,
-      });
+      try {
+        const loadedAssets = await routeGraphics.loadAssets({
+          [assetId]: asset,
+        });
+        recordDiagnosticStep("Loaded route graphics asset", {
+          assetId,
+          source: asset?.source,
+          type: asset?.type,
+          size: asset?.size,
+          returnedAssetCount: Array.isArray(loadedAssets)
+            ? loadedAssets.length
+            : undefined,
+        });
+      } catch (error) {
+        throw createRuntimeError(
+          `Graphics engine failed to load asset "${assetId}".`,
+          error,
+          {
+            assetId,
+            source: asset?.source,
+            type: asset?.type,
+            size: asset?.size,
+          },
+        );
+      }
 
       loadedAssetIds.add(assetId);
     })().finally(() => {
@@ -159,44 +422,86 @@ const hideLoadingOverlay = () => {
   }
 };
 
-const setLoadingText = (text) => {
+const setLoadingError = ({
+  summary = "Failed to load",
+  error,
+  details,
+} = {}) => {
   const loadingElement = document.getElementById("loading");
-  if (loadingElement) {
-    loadingElement.textContent = text;
+  if (!loadingElement) {
+    return;
   }
-};
 
-const setLoadingReadyForClick = () => {
-  const loadingElement = document.getElementById("loading");
-  if (loadingElement) {
-    loadingElement.textContent = "Click to start";
-    loadingElement.classList.add("ready");
+  loadingElement.classList.remove("hidden");
+  loadingElement.classList.add("error");
+  loadingElement.textContent = "";
+
+  const panel = document.createElement("div");
+  panel.className = "loading-error";
+
+  const title = document.createElement("h1");
+  title.className = "loading-error-title";
+  title.textContent = "Failed to load";
+
+  const summaryElement = document.createElement("p");
+  summaryElement.className = "loading-error-summary";
+  summaryElement.textContent = summary;
+
+  const detailBlocks = [];
+  const detailsText = stringifyDiagnosticValue(details);
+  if (detailsText) {
+    detailBlocks.push(`Context:\n${detailsText}`);
   }
-};
 
-const waitForClickToStart = async () => {
-  const loadingElement = document.getElementById("loading");
-  if (!loadingElement) return;
+  const errorText = formatErrorForDiagnostics(error);
+  if (errorText) {
+    detailBlocks.push(`Error:\n${errorText}`);
+  }
 
-  await new Promise((resolve) => {
-    const handleClick = () => {
-      loadingElement.removeEventListener("click", handleClick);
-      loadingElement.classList.remove("ready");
-      resolve();
-    };
+  const recentSteps = formatDiagnosticEvents();
+  if (recentSteps) {
+    detailBlocks.push(`Recent steps:\n${recentSteps}`);
+  }
 
-    loadingElement.addEventListener("click", handleClick);
-  });
+  const detailsElement = document.createElement("pre");
+  detailsElement.className = "loading-error-details";
+  detailsElement.textContent = truncateDiagnosticText(
+    detailBlocks.filter(Boolean).join("\n\n"),
+  );
+
+  panel.append(title, summaryElement, detailsElement);
+  loadingElement.append(panel);
 };
 
 const preloadBundleData = async () => {
+  recordDiagnosticStep("Opening package bundle", { url: "./package.bin" });
   const bundleReader = await createPackageBinRangeReader({
     url: "./package.bin",
+  }).catch((error) => {
+    throw createRuntimeError("Failed to open package.bin.", error, {
+      url: "./package.bin",
+    });
   });
-  const vnbundleInstructions = await bundleReader.readInstructions();
+  recordDiagnosticStep("Reading bundle instructions", {
+    totalLength: bundleReader.totalLength,
+    assetCount: Object.keys(bundleReader.manifest?.assets ?? {}).length,
+    atlasCount: Object.keys(bundleReader.manifest?.atlases ?? {}).length,
+  });
+  const vnbundleInstructions = await bundleReader
+    .readInstructions()
+    .catch((error) => {
+      throw createRuntimeError("Failed to read bundle instructions.", error, {
+        totalLength: bundleReader.totalLength,
+      });
+    });
   const jsonData = {
     ...vnbundleInstructions.projectData,
   };
+  setBundleDocumentTitle(vnbundleInstructions.bundleMetadata);
+  void loadBundleFavicon({
+    bundleMetadata: vnbundleInstructions.bundleMetadata,
+    bundleReader,
+  });
 
   return {
     jsonData,
@@ -221,7 +526,13 @@ const createBundleNamespace = (bundleMetadata) => {
 };
 
 const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
-  const plugins = await loadGraphicsEnginePlugins();
+  recordDiagnosticStep("Preparing graphics runtime", {
+    assetCount: Object.keys(bundleReader.manifest?.assets ?? {}).length,
+    atlasCount: Object.keys(bundleReader.manifest?.atlases ?? {}).length,
+  });
+  const plugins = await loadGraphicsEnginePlugins().catch((error) => {
+    throw createRuntimeError("Failed to load graphics engine plugins.", error);
+  });
   const namespace = createBundleNamespace(bundleMetadata);
 
   // Create dedicated ticker for auto mode
@@ -231,11 +542,13 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
   const routeGraphics = createRouteGraphics();
   let engine;
   let resolveFirstRender;
-  let firstRenderResolved = false;
+  let rejectFirstRender;
+  let firstRenderSettled = false;
   let latestPreparedRenderState;
   let renderAssetLoadToken = 0;
-  const firstRenderPromise = new Promise((resolve) => {
+  const firstRenderPromise = new Promise((resolve, reject) => {
     resolveFirstRender = resolve;
+    rejectFirstRender = reject;
   });
   const bundleAssetLoader = createBundleAssetLoader({
     bundleReader,
@@ -269,17 +582,51 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
   }
 
   const markFirstRender = () => {
-    if (firstRenderResolved) {
+    if (firstRenderSettled) {
       return;
     }
 
-    firstRenderResolved = true;
+    firstRenderSettled = true;
     resolveFirstRender();
   };
 
+  const failFirstRender = (error) => {
+    if (firstRenderSettled) {
+      return false;
+    }
+
+    firstRenderSettled = true;
+    rejectFirstRender(error);
+    return true;
+  };
+
+  const handleRuntimeRenderFailure = (error, details) => {
+    const runtimeError = createRuntimeError(
+      "Failed to render runtime state.",
+      error,
+      details,
+    );
+    console.error("Failed to render runtime state:", runtimeError);
+
+    if (failFirstRender(runtimeError)) {
+      return;
+    }
+
+    setLoadingError({
+      summary: "The player failed while rendering the current scene.",
+      error: runtimeError,
+    });
+  };
+
   const renderPreparedState = (renderState) => {
-    routeGraphics.render(renderState);
-    markFirstRender();
+    try {
+      routeGraphics.render(renderState);
+      markFirstRender();
+    } catch (error) {
+      handleRuntimeRenderFailure(error, {
+        hasRenderState: !!renderState,
+      });
+    }
   };
 
   const renderEngineState = (renderState) => {
@@ -298,7 +645,9 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
 
     const loadToken = renderAssetLoadToken + 1;
     renderAssetLoadToken = loadToken;
-    setLoadingText("Loading assets...");
+    recordDiagnosticStep("Loading render assets", {
+      assetIds: missingAssetIds,
+    });
 
     void bundleAssetLoader
       .ensureAssetsLoaded(missingAssetIds)
@@ -310,11 +659,28 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
         renderPreparedState(latestPreparedRenderState);
       })
       .catch((error) => {
-        console.error("Failed to load runtime assets:", error);
-        setLoadingText("Failed to load");
+        const runtimeError = createRuntimeError(
+          "Failed to load runtime assets.",
+          error,
+          {
+            assetIds: missingAssetIds,
+            renderAssetLoadToken: loadToken,
+          },
+        );
+
+        console.error("Failed to load runtime assets:", runtimeError);
+        if (failFirstRender(runtimeError)) {
+          return;
+        }
+
+        setLoadingError({
+          summary: "Runtime asset loading failed after the player started.",
+          error: runtimeError,
+        });
       });
   };
 
+  recordDiagnosticStep("Loading runtime save data", { namespace });
   const persistence = createIndexedDbPersistence({ namespace });
   const {
     saveSlots,
@@ -322,7 +688,11 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
     globalAccountVariables,
     globalRuntime,
     accountViewedRegistry,
-  } = await persistence.load();
+  } = await persistence.load().catch((error) => {
+    throw createRuntimeError("Failed to load runtime save data.", error, {
+      namespace,
+    });
+  });
 
   const effectsHandler = createEffectsHandler({
     getEngine: () => engine,
@@ -365,12 +735,23 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
       },
     });
 
-  await routeGraphics.init({
+  recordDiagnosticStep("Initializing graphics engine", {
     width: screenWidth,
     height: screenHeight,
-    plugins,
-    eventHandler: routeGraphicsEventHandler,
   });
+  await routeGraphics
+    .init({
+      width: screenWidth,
+      height: screenHeight,
+      plugins,
+      eventHandler: routeGraphicsEventHandler,
+    })
+    .catch((error) => {
+      throw createRuntimeError("Failed to initialize graphics engine.", error, {
+        width: screenWidth,
+        height: screenHeight,
+      });
+    });
 
   canvasContainer?.appendChild(routeGraphics.canvas);
   canvasContainer?.addEventListener("contextmenu", (e) => {
@@ -381,7 +762,12 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
   const preloadSaveSlotImagesResult = await preloadRuntimeSaveSlotImages(
     routeGraphics,
     saveSlots,
-  );
+  ).catch((error) => {
+    throw createRuntimeError(
+      "Failed to preload saved thumbnail images.",
+      error,
+    );
+  });
 
   if (preloadSaveSlotImagesResult.failed > 0) {
     console.warn(
@@ -390,21 +776,28 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
   }
 
   const startEngine = () => {
-    engine.init({
-      namespace,
-      initialState: {
-        global: {
-          saveSlots,
-          variables: {
-            ...globalDeviceVariables,
-            ...globalAccountVariables,
+    recordDiagnosticStep("Starting route engine", { namespace });
+    try {
+      engine.init({
+        namespace,
+        initialState: {
+          global: {
+            saveSlots,
+            variables: {
+              ...globalDeviceVariables,
+              ...globalAccountVariables,
+            },
+            runtime: globalRuntime,
+            accountViewedRegistry,
           },
-          runtime: globalRuntime,
-          accountViewedRegistry,
+          projectData: jsonData,
         },
-        projectData: jsonData,
-      },
-    });
+      });
+    } catch (error) {
+      throw createRuntimeError("Failed to start route engine.", error, {
+        namespace,
+      });
+    }
   };
 
   return {
@@ -417,14 +810,15 @@ const bootstrap = async () => {
   try {
     const preloadedData = await preloadBundleData();
     const engineRuntime = await prepareEngine(preloadedData);
-    setLoadingReadyForClick();
-    await waitForClickToStart();
     engineRuntime.startEngine();
     await engineRuntime.waitForFirstRender();
     hideLoadingOverlay();
   } catch (error) {
     console.error("Failed to start bundle player:", error);
-    setLoadingText("Failed to load");
+    setLoadingError({
+      summary: "The player could not finish startup.",
+      error,
+    });
   }
 };
 

--- a/scripts/tauri-wsl-windows-runner.sh
+++ b/scripts/tauri-wsl-windows-runner.sh
@@ -92,13 +92,22 @@ else
   target_root="${manifest_dir}/target"
 fi
 
-exe_path="${target_root}/${target}/${profile_dir}/app.exe"
-if [[ ! -f "${exe_path}" ]]; then
-  exe_path="$(find "${target_root}/${target}/${profile_dir}" -maxdepth 1 -type f -name "*.exe" -print -quit)"
+profile_path="${target_root}/${target}/${profile_dir}"
+exe_path=""
+for candidate_name in routevn-creator.exe app.exe; do
+  candidate_path="${profile_path}/${candidate_name}"
+  if [[ -f "${candidate_path}" ]]; then
+    exe_path="${candidate_path}"
+    break
+  fi
+done
+
+if [[ -z "${exe_path}" ]]; then
+  exe_path="$(find "${profile_path}" -maxdepth 1 -type f -name "*.exe" -printf "%T@ %p\n" | sort -nr | awk 'NR == 1 { $1 = ""; sub(/^ /, ""); print }')"
 fi
 
 if [[ -z "${exe_path}" ]] || [[ ! -f "${exe_path}" ]]; then
-  echo "Could not find built Windows executable under ${target_root}/${target}/${profile_dir}" >&2
+  echo "Could not find built Windows executable under ${profile_path}" >&2
   exit 1
 fi
 

--- a/src/deps/services/shared/projectExportService.js
+++ b/src/deps/services/shared/projectExportService.js
@@ -51,25 +51,57 @@ export const BUNDLE_PLAYER_INDEX_HTML = `<html>
         inset: 0;
         display: grid;
         place-items: center;
+        box-sizing: border-box;
+        padding: 24px;
         color: #fff;
         background: #000;
-        font: 600 24px/1.2 sans-serif;
-        letter-spacing: 0.02em;
         z-index: 10;
         user-select: none;
       }
 
-      #loading.ready {
-        cursor: pointer;
+      #loading.error {
+        cursor: default;
+        text-align: left;
+        user-select: text;
       }
 
       #loading.hidden {
         display: none;
       }
+
+      #loading .loading-error {
+        width: min(760px, calc(100vw - 32px));
+      }
+
+      #loading .loading-error-title {
+        margin: 0 0 8px;
+        font: 700 24px/1.2 sans-serif;
+      }
+
+      #loading .loading-error-summary {
+        margin: 0 0 16px;
+        color: #f1f5f9;
+        font: 500 15px/1.45 sans-serif;
+      }
+
+      #loading .loading-error-details {
+        box-sizing: border-box;
+        width: 100%;
+        max-height: min(58vh, 520px);
+        margin: 0;
+        overflow: auto;
+        padding: 12px;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        background: #0f172a;
+        color: #e2e8f0;
+        font: 12px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace;
+        white-space: pre-wrap;
+      }
     </style>
   </head>
   <body>
-    <div id="loading">Loading...</div>
+    <div id="loading"></div>
     <div id="canvas"></div>
   </body>
   <script>
@@ -402,6 +434,8 @@ const buildChunkManifest = async (instructions, assets = {}) => {
 };
 
 export const createBundleInstructions = ({ projectData, bundler, project }) => {
+  const projectTitle = project?.title ?? project?.name ?? "";
+
   return {
     projectData,
     bundleMetadata: {
@@ -411,6 +445,8 @@ export const createBundleInstructions = ({ projectData, bundler, project }) => {
       },
       project: {
         namespace: project?.namespace ?? "",
+        title: projectTitle,
+        iconFileId: project?.iconFileId ?? "",
       },
     },
   };

--- a/src/internal/bundleRuntimeDicedImages.js
+++ b/src/internal/bundleRuntimeDicedImages.js
@@ -200,7 +200,7 @@ const decodeAtlasBufferToPixels = async ({ buffer, mime }) => {
   }
 };
 
-const encodePixelsToObjectUrl = async ({ width, height, pixels }) => {
+const encodePixelsToPngBuffer = async ({ width, height, pixels }) => {
   const canvas = createCanvas({ width, height });
   const context = canvas.getContext("2d");
   if (!context) {
@@ -225,7 +225,7 @@ const encodePixelsToObjectUrl = async ({ width, height, pixels }) => {
     });
   }
 
-  return URL.createObjectURL(blob);
+  return blob.arrayBuffer();
 };
 
 export const createRuntimeAssetFromDicedImage = async ({
@@ -263,15 +263,16 @@ export const createRuntimeAssetFromDicedImage = async ({
     indices: asset.indices,
     rect: asset.rect,
   });
-  const url = await encodePixelsToObjectUrl({
+  const buffer = await encodePixelsToPngBuffer({
     width: Number(asset.width ?? 0),
     height: Number(asset.height ?? 0),
     pixels,
   });
 
   return {
-    url,
+    buffer,
+    source: "buffer",
     type: "image/png",
-    size: pixels.byteLength,
+    size: buffer.byteLength,
   };
 };

--- a/src/pages/versions/versions.handlers.js
+++ b/src/pages/versions/versions.handlers.js
@@ -122,6 +122,70 @@ const getProjectExportTitle = ({ projectInfo } = {}) => {
   return projectInfo?.name?.trim?.();
 };
 
+const UNKNOWN_ERROR_MESSAGE =
+  "Unknown error. Check the developer console for details.";
+const WINDOWS_EXPORT_COMMAND_RESTART_MESSAGE =
+  "The running Tauri shell does not include Windows export commands. Restart the Tauri dev process so the native shell rebuilds.";
+
+const getErrorMessage = (error, fallback = UNKNOWN_ERROR_MESSAGE) => {
+  if (typeof error === "string") {
+    return error.trim() || fallback;
+  }
+
+  const message = error?.message;
+  if (typeof message === "string" && message.trim()) {
+    return message.trim();
+  }
+
+  try {
+    const serialized = JSON.stringify(error);
+    if (serialized && serialized !== "{}") {
+      return serialized;
+    }
+  } catch {}
+
+  return fallback;
+};
+
+const getWindowsExportErrorMessage = (error) => {
+  const message = getErrorMessage(error);
+  if (
+    /^Command export_windows_(portable_executable|installer_from_project) not found$/.test(
+      message,
+    )
+  ) {
+    return `${message}. ${WINDOWS_EXPORT_COMMAND_RESTART_MESSAGE}`;
+  }
+
+  return message;
+};
+
+const formatWindowsExportErrorCopy = ({ template, error }) =>
+  formatI18nCopy(template, {
+    message: getWindowsExportErrorMessage(error),
+  });
+
+const logWindowsExportError = ({
+  exportType,
+  error,
+  version,
+  versionId,
+  outputPath,
+  windowsFileVersion,
+  replay,
+} = {}) => {
+  console.error(`Version Windows ${exportType} export failed`, {
+    errorMessage: getWindowsExportErrorMessage(error),
+    versionId,
+    versionName: version?.name,
+    versionActionIndex: version?.actionIndex,
+    outputPath,
+    windowsFileVersion,
+    replay,
+    error,
+  });
+};
+
 const WINDOWS_VERSION_PART_BASE = 65536;
 const WINDOWS_VERSION_PART_MAX = 65535;
 const WINDOWS_VERSION_ACTION_INDEX_MAX =
@@ -196,6 +260,17 @@ const createVersionExportData = async ({
 
     return entry;
   });
+
+  if (
+    projectInfo.iconFileId &&
+    !fileEntries.some((entry) => entry.fileId === projectInfo.iconFileId)
+  ) {
+    fileEntries.push({
+      fileId: projectInfo.iconFileId,
+      mimeType: "image/png",
+    });
+  }
+
   const transformedData = createBundleInstructions({
     projectData: constructedProjectData,
     bundler: {
@@ -203,6 +278,8 @@ const createVersionExportData = async ({
     },
     project: {
       namespace: projectInfo.namespace,
+      title: getProjectExportTitle({ projectInfo }),
+      iconFileId: projectInfo.iconFileId,
     },
   });
 
@@ -421,7 +498,7 @@ export const handleDownloadZipClick = async (deps, payload) => {
     appService.showAlert({
       message: formatI18nCopy(
         copy.failedOpenSaveDialog ?? "Failed to open save dialog: {message}",
-        { message: error.message },
+        { message: getErrorMessage(error) },
       ),
       title: copy.errorTitle ?? "Error",
     });
@@ -486,10 +563,10 @@ export const handleDownloadZipClick = async (deps, payload) => {
 
     appService.showAlert({
       message: replay
-        ? `${formatReplayFailureMessage({ replay, copy })}\n${error.message}`
+        ? `${formatReplayFailureMessage({ replay, copy })}\n${getErrorMessage(error)}`
         : formatI18nCopy(
             copy.failedSaveZipFile ?? "Failed to save ZIP file: {message}",
-            { message: error.message },
+            { message: getErrorMessage(error) },
           ),
       title: copy.errorTitle ?? "Error",
     });
@@ -523,11 +600,12 @@ export const handleDownloadWindowsExecutableClick = async (deps, payload) => {
     windowsFileVersion = getWindowsFileVersion({ version });
   } catch (error) {
     appService.showAlert({
-      message: formatI18nCopy(
-        copy.failedSaveWindowsExecutable ??
+      message: formatWindowsExportErrorCopy({
+        template:
+          copy.failedSaveWindowsExecutable ??
           "Failed to save Windows executable: {message}",
-        { message: error.message },
-      ),
+        error,
+      }),
       title: copy.errorTitle ?? "Error",
     });
     return;
@@ -543,11 +621,19 @@ export const handleDownloadWindowsExecutableClick = async (deps, payload) => {
   try {
     outputPath = await projectService.promptWindowsExecutablePath(exeName);
   } catch (error) {
+    logWindowsExportError({
+      exportType: "executable save dialog",
+      error,
+      version,
+      versionId,
+      windowsFileVersion,
+    });
     appService.showAlert({
-      message: formatI18nCopy(
-        copy.failedOpenSaveDialog ?? "Failed to open save dialog: {message}",
-        { message: error.message },
-      ),
+      message: formatWindowsExportErrorCopy({
+        template:
+          copy.failedOpenSaveDialog ?? "Failed to open save dialog: {message}",
+        error,
+      }),
       title: copy.errorTitle ?? "Error",
     });
     return;
@@ -597,24 +683,25 @@ export const handleDownloadWindowsExecutableClick = async (deps, payload) => {
   } catch (error) {
     const replay = error?.details?.replay;
 
-    if (replay) {
-      console.error("Version Windows executable export history replay failed", {
-        versionId,
-        versionName: version?.name,
-        versionActionIndex: version?.actionIndex,
-        replay,
-        error,
-      });
-    }
+    logWindowsExportError({
+      exportType: "executable",
+      error,
+      version,
+      versionId,
+      outputPath,
+      windowsFileVersion,
+      replay,
+    });
 
     appService.showAlert({
       message: replay
-        ? `${formatReplayFailureMessage({ replay, copy })}\n${error.message}`
-        : formatI18nCopy(
-            copy.failedSaveWindowsExecutable ??
+        ? `${formatReplayFailureMessage({ replay, copy })}\n${getErrorMessage(error)}`
+        : formatWindowsExportErrorCopy({
+            template:
+              copy.failedSaveWindowsExecutable ??
               "Failed to save Windows executable: {message}",
-            { message: error.message },
-          ),
+            error,
+          }),
       title: copy.errorTitle ?? "Error",
     });
   }
@@ -647,11 +734,12 @@ export const handleDownloadWindowsInstallerClick = async (deps, payload) => {
     windowsFileVersion = getWindowsFileVersion({ version });
   } catch (error) {
     appService.showAlert({
-      message: formatI18nCopy(
-        copy.failedSaveWindowsInstaller ??
+      message: formatWindowsExportErrorCopy({
+        template:
+          copy.failedSaveWindowsInstaller ??
           "Failed to save Windows installer: {message}",
-        { message: error.message },
-      ),
+        error,
+      }),
       title: copy.errorTitle ?? "Error",
     });
     return;
@@ -667,11 +755,19 @@ export const handleDownloadWindowsInstallerClick = async (deps, payload) => {
   try {
     outputPath = await projectService.promptWindowsInstallerPath(installerName);
   } catch (error) {
+    logWindowsExportError({
+      exportType: "installer save dialog",
+      error,
+      version,
+      versionId,
+      windowsFileVersion,
+    });
     appService.showAlert({
-      message: formatI18nCopy(
-        copy.failedOpenSaveDialog ?? "Failed to open save dialog: {message}",
-        { message: error.message },
-      ),
+      message: formatWindowsExportErrorCopy({
+        template:
+          copy.failedOpenSaveDialog ?? "Failed to open save dialog: {message}",
+        error,
+      }),
       title: copy.errorTitle ?? "Error",
     });
     return;
@@ -720,24 +816,25 @@ export const handleDownloadWindowsInstallerClick = async (deps, payload) => {
   } catch (error) {
     const replay = error?.details?.replay;
 
-    if (replay) {
-      console.error("Version Windows installer export history replay failed", {
-        versionId,
-        versionName: version?.name,
-        versionActionIndex: version?.actionIndex,
-        replay,
-        error,
-      });
-    }
+    logWindowsExportError({
+      exportType: "installer",
+      error,
+      version,
+      versionId,
+      outputPath,
+      windowsFileVersion,
+      replay,
+    });
 
     appService.showAlert({
       message: replay
-        ? `${formatReplayFailureMessage({ replay, copy })}\n${error.message}`
-        : formatI18nCopy(
-            copy.failedSaveWindowsInstaller ??
+        ? `${formatReplayFailureMessage({ replay, copy })}\n${getErrorMessage(error)}`
+        : formatWindowsExportErrorCopy({
+            template:
+              copy.failedSaveWindowsInstaller ??
               "Failed to save Windows installer: {message}",
-            { message: error.message },
-          ),
+            error,
+          }),
       title: copy.errorTitle ?? "Error",
     });
   }

--- a/src/pages/versions/versions.store.js
+++ b/src/pages/versions/versions.store.js
@@ -233,9 +233,7 @@ export const selectViewData = ({ state, i18n }) => {
       copy.exportWindowsExecutableButton ?? "Export Windows EXE",
     exportWindowsInstallerButton:
       copy.exportWindowsInstallerButton ?? "Export Windows Installer",
-    canExportWindowsExecutable:
-      state.platform === "tauri" &&
-      state.windowsExportAvailability.portableExecutable,
+    canExportWindowsExecutable: state.platform === "tauri",
     canExportWindowsInstaller:
       state.platform === "tauri" && state.windowsExportAvailability.installer,
     noSelectionLabel: copy.noSelectionLabel ?? "No selection",

--- a/tests/services/projectExportService.test.js
+++ b/tests/services/projectExportService.test.js
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BUNDLE_FORMAT_VERSION_V4,
   BUNDLE_HEADER_SIZE,
+  createBundleInstructions,
   createBundleResult,
   createProjectExportService,
   normalizeExportFileEntries,
@@ -107,6 +108,23 @@ describe("projectExportService", () => {
       { id: "file-3", mimeType: "font/ttf" },
       { id: "file-4" },
     ]);
+  });
+
+  it("stores project title and icon metadata in bundle instructions", () => {
+    expect(
+      createBundleInstructions({
+        projectData: {},
+        project: {
+          namespace: "project-one",
+          title: "Project One",
+          iconFileId: "icon-1",
+        },
+      }).bundleMetadata.project,
+    ).toEqual({
+      namespace: "project-one",
+      title: "Project One",
+      iconFileId: "icon-1",
+    });
   });
 
   it("stores repeated raw assets once in bundle format v4", async () => {
@@ -365,5 +383,4 @@ describe("projectExportService", () => {
       "scene-1",
     );
   });
-
 });

--- a/tests/versions/versions.handlers.test.js
+++ b/tests/versions/versions.handlers.test.js
@@ -283,8 +283,19 @@ describe("versions.handleDownloadZipClick", () => {
       deps.projectService.createDistributionZipStreamed,
     ).toHaveBeenCalled();
     expect(
+      deps.projectService.createDistributionZipStreamed.mock.calls[0][0]
+        .bundleMetadata.project,
+    ).toMatchObject({
+      namespace: "project-one",
+      title: "Project One",
+      iconFileId: "icon-1",
+    });
+    expect(
       deps.projectService.createDistributionZipStreamed.mock.calls[0][1],
-    ).toEqual([{ fileId: "file-1", mimeType: "image/png" }]);
+    ).toEqual([
+      { fileId: "file-1", mimeType: "image/png" },
+      { fileId: "icon-1", mimeType: "image/png" },
+    ]);
   });
 
   it("drops invalid font mime metadata before export", async () => {
@@ -404,7 +415,10 @@ describe("versions.handleDownloadZipClick", () => {
     ).toHaveBeenCalled();
     expect(
       deps.projectService.createDistributionZipStreamed.mock.calls[0][1],
-    ).toEqual([{ fileId: "file-font-1" }]);
+    ).toEqual([
+      { fileId: "file-font-1" },
+      { fileId: "icon-1", mimeType: "image/png" },
+    ]);
   });
 });
 
@@ -509,5 +523,95 @@ describe("versions Windows export handlers", () => {
         ),
       }),
     );
+  });
+
+  it("shows and logs string errors from Windows EXE export", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const repository = {
+      loadState: vi.fn(async () => structuredClone(initialProjectData)),
+      loadEvents: vi.fn(async () => []),
+      getState: vi.fn(() => structuredClone(initialProjectData)),
+    };
+    const deps = createDeps({
+      repository,
+    });
+    deps.projectService.createWindowsPortableExecutableToPath = vi.fn(
+      async () => {
+        throw "native export failed";
+      },
+    );
+
+    try {
+      await handleDownloadWindowsExecutableClick(
+        deps,
+        createVersionClickPayload(),
+      );
+
+      expect(deps.appService.showAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("native export failed"),
+        }),
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        "Version Windows executable export failed",
+        expect.objectContaining({
+          error: "native export failed",
+          errorMessage: "native export failed",
+          outputPath: "/tmp/export.exe",
+          versionActionIndex: 3,
+          versionId: "version-1",
+          versionName: "Version 1",
+          windowsFileVersion: "1.0.0.3",
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("explains missing native Windows EXE export command errors", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const repository = {
+      loadState: vi.fn(async () => structuredClone(initialProjectData)),
+      loadEvents: vi.fn(async () => []),
+      getState: vi.fn(() => structuredClone(initialProjectData)),
+    };
+    const deps = createDeps({
+      repository,
+    });
+    deps.projectService.createWindowsPortableExecutableToPath = vi.fn(
+      async () => {
+        throw "Command export_windows_portable_executable not found";
+      },
+    );
+
+    try {
+      await handleDownloadWindowsExecutableClick(
+        deps,
+        createVersionClickPayload(),
+      );
+
+      expect(deps.appService.showAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            "Restart the Tauri dev process so the native shell rebuilds.",
+          ),
+        }),
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        "Version Windows executable export failed",
+        expect.objectContaining({
+          errorMessage: expect.stringContaining(
+            "Restart the Tauri dev process so the native shell rebuilds.",
+          ),
+        }),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/tests/versions/versions.store.test.js
+++ b/tests/versions/versions.store.test.js
@@ -3,8 +3,10 @@ import {
   createInitialState,
   selectViewData,
   setSelectedItemId,
+  setPlatform,
   setUiConfig,
   setVersions,
+  setWindowsExportAvailability,
 } from "../../src/pages/versions/versions.store.js";
 
 const version = {
@@ -56,5 +58,46 @@ describe("versions store mobile view data", () => {
     expect(viewData.showDetailPanel).toBe(true);
     expect(viewData.showMobileDetailSheet).toBe(false);
     expect(viewData.contentLeftPadding).toBe("sm");
+  });
+});
+
+describe("versions store export actions", () => {
+  it("shows Windows EXE export in Tauri without hiding it behind resource preflight", () => {
+    const state = createInitialState();
+
+    setPlatform({ state }, { platform: "tauri" });
+    setWindowsExportAvailability(
+      { state },
+      {
+        availability: {
+          portableExecutable: false,
+          installer: false,
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.canExportWindowsExecutable).toBe(true);
+    expect(viewData.canExportWindowsInstaller).toBe(false);
+  });
+
+  it("hides Windows exports in web runtime", () => {
+    const state = createInitialState();
+
+    setWindowsExportAvailability(
+      { state },
+      {
+        availability: {
+          portableExecutable: true,
+          installer: true,
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state });
+
+    expect(viewData.canExportWindowsExecutable).toBe(false);
+    expect(viewData.canExportWindowsInstaller).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- show Windows export actions from the Versions page in Tauri builds and improve Windows export errors/logging
- package Windows portable EXEs with project title/icon metadata, embedded runtime favicon/title support, and no click-to-start loading screen
- fix Windows player template/resource handling, including Common Controls manifest stamping and buffer-backed packaged asset loading
- rebuild the Windows player template executable

## Testing
- `bun run lint`
- `bunx vitest run tests/services/projectExportService.test.js tests/versions/versions.handlers.test.js tests/versions/versions.store.test.js tests/internal/bundleRuntimeDicedImages.test.js`
- `node scripts/test-export-bundle-pipeline.js`
- `bun prettier --check scripts/main.js src/deps/services/shared/projectExportService.js src/pages/versions/versions.handlers.js tests/services/projectExportService.test.js tests/versions/versions.handlers.test.js`
- `bun run build:bundle`
- `bun run player-template:build:win:docker`
- `cargo test --manifest-path crates/routevn-packager/Cargo.toml windows_resources`