### PR TITLE
Fix mobile safe area offsets

### DIFF
--- a/src/internal/ui/mobileSafeAreaInsets.js
+++ b/src/internal/ui/mobileSafeAreaInsets.js
@@ -1,0 +1,18 @@
+export const MOBILE_SAFE_AREA_INSET_TOP_VAR =
+  "--rvn-mobile-safe-area-inset-top";
+export const MOBILE_SAFE_AREA_INSET_BOTTOM_VAR =
+  "--rvn-mobile-safe-area-inset-bottom";
+
+export const MOBILE_SAFE_AREA_INSET_TOP_VALUE =
+  "var(--rvn-mobile-safe-area-inset-top, 0px)";
+export const MOBILE_SAFE_AREA_INSET_BOTTOM_VALUE =
+  "var(--rvn-mobile-safe-area-inset-bottom, 0px)";
+
+export const configureMobileSafeAreaInsets = ({
+  top = "0px",
+  bottom = "0px",
+} = {}) => {
+  const style = globalThis.document?.documentElement?.style;
+  style?.setProperty(MOBILE_SAFE_AREA_INSET_TOP_VAR, top);
+  style?.setProperty(MOBILE_SAFE_AREA_INSET_BOTTOM_VAR, bottom);
+};

--- a/src/internal/ui/resourcePages/mobileResourcePage.js
+++ b/src/internal/ui/resourcePages/mobileResourcePage.js
@@ -1,8 +1,9 @@
+import { MOBILE_SAFE_AREA_INSET_BOTTOM_VALUE } from "../mobileSafeAreaInsets.js";
+
 export const isTouchUiConfig = (uiConfig) =>
   uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
 
-export const MOBILE_RESOURCE_SCROLL_BOTTOM_PADDING =
-  "calc(96px + env(safe-area-inset-bottom))";
+export const MOBILE_RESOURCE_SCROLL_BOTTOM_PADDING = `calc(96px + ${MOBILE_SAFE_AREA_INSET_BOTTOM_VALUE})`;
 
 export const resolveResourceScrollBottomPadding = ({
   mobileLayout,

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -179,7 +179,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -515,6 +515,7 @@ export const handleBeforeMount = (deps) => {
 
   appService.setAppCopyProvider?.(() => selectAppCopy(deps.i18n));
   store.setUiConfig({ uiConfig });
+  store.setPlatform({ platform: appService.getPlatform() });
   subject.dispatch("app.route.request", {
     path: initialPath,
     payload: appService.getPayload(),

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -1,5 +1,6 @@
 export const createInitialState = () => ({
   currentRoute: "/projects",
+  platform: "web",
   isTouchMode: false,
   isMobileSheetOpen: false,
   mobileSheetVariant: undefined,
@@ -12,7 +13,8 @@ export const createInitialState = () => ({
 const SIDEBAR_WIDTH_PX = 64;
 const MOBILE_TAB_BAR_HEIGHT_PX = 64;
 const HELP_BUTTON_BOTTOM_OFFSET_PX = 24;
-const HELP_BUTTON_TOUCH_EXTRA_BOTTOM_OFFSET_PX = 40;
+const HELP_BUTTON_IOS_TOUCH_EXTRA_BOTTOM_OFFSET_PX = 40;
+const HELP_BUTTON_ANDROID_TOUCH_EXTRA_BOTTOM_OFFSET_PX = -8;
 const MOBILE_TAB_BAR_ACTIVE_COLOR = "white";
 const MOBILE_TAB_BAR_INACTIVE_COLOR = "mu-fg";
 
@@ -167,6 +169,10 @@ export const setUiConfig = ({ state }, { uiConfig } = {}) => {
     uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
 };
 
+export const setPlatform = ({ state }, { platform } = {}) => {
+  state.platform = platform ?? "web";
+};
+
 export const setCurrentRoute = ({ state }, { route } = {}) => {
   state.currentRoute = route;
 };
@@ -241,6 +247,26 @@ const selectRepositoryLoadingProgressPercent = ({ state }) => {
   return Math.min(100, Math.max(0, Math.round((current / total) * 100)));
 };
 
+const selectHelpButtonBottom = ({ state }) => {
+  if (!state.isTouchMode) {
+    return `${HELP_BUTTON_BOTTOM_OFFSET_PX}px`;
+  }
+
+  if (state.platform === "ios") {
+    return `calc(${
+      MOBILE_TAB_BAR_HEIGHT_PX +
+      HELP_BUTTON_BOTTOM_OFFSET_PX +
+      HELP_BUTTON_IOS_TOUCH_EXTRA_BOTTOM_OFFSET_PX
+    }px + var(--rvn-mobile-safe-area-inset-bottom, 0px))`;
+  }
+
+  return `${
+    MOBILE_TAB_BAR_HEIGHT_PX +
+    HELP_BUTTON_BOTTOM_OFFSET_PX +
+    HELP_BUTTON_ANDROID_TOUCH_EXTRA_BOTTOM_OFFSET_PX
+  }px`;
+};
+
 export const selectViewData = ({ state, i18n }) => {
   const copy = selectAppCopy(i18n);
   const showSidebar = selectShowSidebar({ state });
@@ -265,13 +291,7 @@ export const selectViewData = ({ state, i18n }) => {
     contentHeight: showMobileTabBar
       ? `calc(var(--rvn-app-viewport-height, 100vh) - ${MOBILE_TAB_BAR_HEIGHT_PX}px)`
       : "100%",
-    helpButtonBottom: state.isTouchMode
-      ? `${
-          MOBILE_TAB_BAR_HEIGHT_PX +
-          HELP_BUTTON_BOTTOM_OFFSET_PX +
-          HELP_BUTTON_TOUCH_EXTRA_BOTTOM_OFFSET_PX
-        }px`
-      : `${HELP_BUTTON_BOTTOM_OFFSET_PX}px`,
+    helpButtonBottom: selectHelpButtonBottom({ state }),
     repositoryLoadingProgressPercent,
     repositoryLoadingProgressWidth: `${repositoryLoadingProgressPercent}%`,
     hasRepositoryLoadingProgress,

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -293,7 +293,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -201,7 +201,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -156,7 +156,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -184,7 +184,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -151,7 +151,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -250,7 +250,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -108,7 +108,7 @@ template:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileNodeExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${nodeExplorerTitle}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -154,7 +154,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -182,7 +182,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -1696,7 +1696,7 @@ const selectMobileSceneEditorBottomInset = ({ state }) => {
     return "0px";
   }
 
-  return `calc(${MOBILE_TAB_BAR_HEIGHT_PX}px + env(safe-area-inset-bottom))`;
+  return `calc(${MOBILE_TAB_BAR_HEIGHT_PX}px + var(--rvn-mobile-safe-area-inset-bottom, 0px))`;
 };
 
 const selectSystemActionsDialogPanelWidth = ({ state }) => {

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -175,7 +175,7 @@ template:
           - 'rtgl-view pos=abs z=200 style="right: 8px; top: 8px;"':
               - 'rtgl-button#mobileFileExplorerOpenButton sq pre=hamburger v=ol title="${title}" aria-label="${title}"': null
       - $if showMobileFileExplorer:
-          - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+          - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
               - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
                   - rtgl-text w=1fg s=md: ${filesLabel}
                   - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/sounds/sounds.store.js
+++ b/src/pages/sounds/sounds.store.js
@@ -181,7 +181,7 @@ const {
       audioPlayerLeft: state.isTouchMode ? 0 : state.audioPlayerLeft,
       audioPlayerRight: state.isTouchMode ? 0 : state.audioPlayerRight,
       audioPlayerBottom: state.isTouchMode
-        ? "calc(64px + env(safe-area-inset-bottom))"
+        ? "calc(64px + var(--rvn-mobile-safe-area-inset-bottom, 0px))"
         : "0px",
       mobileDeleteDialogOpen: state.mobileDeleteDialogOpen,
       mobileDeleteDialogTitle: copy.deleteTitle,

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -181,7 +181,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -177,7 +177,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -174,7 +174,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -209,7 +209,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -112,7 +112,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -171,7 +171,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-safe-area-inset-top, 0px); padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/setup.android.js
+++ b/src/setup.android.js
@@ -13,6 +13,7 @@ import { createAudioService } from "./deps/services/audioService.js";
 import Subject from "./deps/subject.js";
 import { createGraphicsService } from "./deps/services/graphicsService.js";
 import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
+import { configureMobileSafeAreaInsets } from "./internal/ui/mobileSafeAreaInsets.js";
 import { registerPrimitives } from "./primitives/registerPrimitives.js";
 import tauriConfig from "../src-tauri/tauri.conf.json";
 
@@ -25,6 +26,7 @@ const uiConfig = {
 };
 document.documentElement.dataset.rvnUiVersion = uiConfig.id;
 document.documentElement.dataset.rvnInputMode = uiConfig.inputMode;
+configureMobileSafeAreaInsets();
 
 const readAndroidEnv = (key, fallback) => {
   const value = window.env?.[key];

--- a/src/setup.ios.js
+++ b/src/setup.ios.js
@@ -16,6 +16,7 @@ import { createGraphicsService } from "./deps/services/graphicsService.js";
 import { createBundleInstructions } from "./deps/services/shared/projectExportService.js";
 import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
 import { DEFAULT_PROJECT_RESOLUTION } from "./internal/projectResolution.js";
+import { configureMobileSafeAreaInsets } from "./internal/ui/mobileSafeAreaInsets.js";
 import { registerPrimitives } from "./primitives/registerPrimitives.js";
 import tauriConfig from "../src-tauri/tauri.conf.json";
 
@@ -28,6 +29,10 @@ const uiConfig = {
 };
 document.documentElement.dataset.rvnUiVersion = uiConfig.id;
 document.documentElement.dataset.rvnInputMode = uiConfig.inputMode;
+configureMobileSafeAreaInsets({
+  top: "env(safe-area-inset-top)",
+  bottom: "env(safe-area-inset-bottom)",
+});
 
 const readIOSEnv = (key, fallback) => {
   const value = window.env?.[key];

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -21,9 +21,11 @@ import Subject from "./deps/subject";
 import Router from "./deps/clients/router";
 import { createGraphicsService } from "./deps/services/graphicsService";
 import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
+import { configureMobileSafeAreaInsets } from "./internal/ui/mobileSafeAreaInsets.js";
 import { registerPrimitives } from "./primitives/registerPrimitives";
 
 registerPrimitives();
+configureMobileSafeAreaInsets();
 
 const rawDistribution = import.meta.env?.VITE_ROUTEVN_DISTRIBUTION;
 const distribution = rawDistribution === "steam" ? rawDistribution : "direct";

--- a/src/setup.web.js
+++ b/src/setup.web.js
@@ -18,6 +18,7 @@ import Subject from "./deps/subject.js";
 import Router from "./deps/clients/router.js";
 import { createGraphicsService } from "./deps/services/graphicsService.js";
 import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
+import { configureMobileSafeAreaInsets } from "./internal/ui/mobileSafeAreaInsets.js";
 import { registerPrimitives } from "./primitives/registerPrimitives.js";
 import tauriConfig from "../src-tauri/tauri.conf.json";
 
@@ -46,6 +47,7 @@ const activeUiVersion = isTouchPrimaryDevice() ? "touch" : "normal";
 const uiConfig = uiVersions[activeUiVersion];
 document.documentElement.dataset.rvnUiVersion = uiConfig.id;
 document.documentElement.dataset.rvnInputMode = uiConfig.inputMode;
+configureMobileSafeAreaInsets();
 
 // Initialize app database using web adapter
 const appDb = createDb({ path: "app" });

--- a/tests/app/app.store.test.js
+++ b/tests/app/app.store.test.js
@@ -3,9 +3,11 @@ import {
   createInitialState,
   openMobileSheet,
   selectViewData,
+  setPlatform,
   setRepositoryLoading,
   setRepositoryLoadingPhase,
   setRepositoryLoadingProgress,
+  setUiConfig,
 } from "../../src/pages/app/app.store.js";
 
 const selectMobileTab = ({ state, tabId }) => {
@@ -167,5 +169,33 @@ describe("app.store mobile tab active state", () => {
 
     expect(selectMobileTab({ state, tabId: "release" }).color).toBe("white");
     expect(selectMobileTab({ state, tabId: "assets" }).color).toBe("mu-fg");
+  });
+});
+
+describe("app.store help button position", () => {
+  it("keeps the desktop help button near the bottom edge", () => {
+    const state = createInitialState();
+
+    expect(selectViewData({ state }).helpButtonBottom).toBe("24px");
+  });
+
+  it("places the Android touch help button below the iOS-safe position", () => {
+    const state = createInitialState();
+
+    setUiConfig({ state }, { uiConfig: { id: "touch" } });
+    setPlatform({ state }, { platform: "android" });
+
+    expect(selectViewData({ state }).helpButtonBottom).toBe("80px");
+  });
+
+  it("keeps the iOS touch help button above the tab bar safe area", () => {
+    const state = createInitialState();
+
+    setUiConfig({ state }, { uiConfig: { id: "touch" } });
+    setPlatform({ state }, { platform: "ios" });
+
+    expect(selectViewData({ state }).helpButtonBottom).toBe(
+      "calc(128px + var(--rvn-mobile-safe-area-inset-bottom, 0px))",
+    );
   });
 });

--- a/tests/images/images.view.test.js
+++ b/tests/images/images.view.test.js
@@ -70,7 +70,7 @@ describe("images view", () => {
     expect(mobileExplorerBranch).toContain("bottom-empty-space-height=80vh");
   });
 
-  it("keeps the mobile file explorer clear of iOS safe areas", () => {
+  it("uses platform-controlled safe-area variables for the mobile file explorer", () => {
     const imagesView = readFileSync(
       new URL("../../src/pages/images/images.view.yaml", import.meta.url),
       "utf8",
@@ -89,11 +89,13 @@ describe("images view", () => {
     );
 
     expect(mobileExplorerBranch).toContain(
-      "padding-top: env(safe-area-inset-top)",
+      "padding-top: var(--rvn-mobile-safe-area-inset-top, 0px)",
     );
     expect(mobileExplorerBranch).toContain(
-      "padding-bottom: env(safe-area-inset-bottom)",
+      "padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px)",
     );
+    expect(mobileExplorerBranch).not.toContain("env(safe-area-inset-top)");
+    expect(mobileExplorerBranch).not.toContain("env(safe-area-inset-bottom)");
   });
 
   it("keeps the mobile file explorer header aligned with the image grid header height", () => {

--- a/tests/layoutEditor/layoutEditor.view.test.js
+++ b/tests/layoutEditor/layoutEditor.view.test.js
@@ -2,6 +2,25 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("layoutEditor.view", () => {
+  it("uses platform-controlled safe-area variables for the mobile node explorer shell", () => {
+    const layoutEditorView = readFileSync(
+      new URL(
+        "../../src/pages/layoutEditor/layoutEditor.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(layoutEditorView).toContain(
+      "padding-top: var(--rvn-mobile-safe-area-inset-top, 0px)",
+    );
+    expect(layoutEditorView).toContain(
+      "padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px)",
+    );
+    expect(layoutEditorView).not.toContain("env(safe-area-inset-top)");
+    expect(layoutEditorView).not.toContain("env(safe-area-inset-bottom)");
+  });
+
   it("keeps the mobile preview mounted while node detail is visible", () => {
     const layoutEditorView = readFileSync(
       new URL(

--- a/tests/mobileSafeAreaInsets/mobileSafeAreaInsets.test.js
+++ b/tests/mobileSafeAreaInsets/mobileSafeAreaInsets.test.js
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  configureMobileSafeAreaInsets,
+  MOBILE_SAFE_AREA_INSET_BOTTOM_VAR,
+  MOBILE_SAFE_AREA_INSET_TOP_VAR,
+} from "../../src/internal/ui/mobileSafeAreaInsets.js";
+
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "document",
+);
+
+const installDocumentStyle = () => {
+  const setProperty = vi.fn();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      documentElement: {
+        style: {
+          setProperty,
+        },
+      },
+    },
+  });
+  return setProperty;
+};
+
+afterEach(() => {
+  if (originalDocumentDescriptor) {
+    Object.defineProperty(globalThis, "document", originalDocumentDescriptor);
+    return;
+  }
+
+  delete globalThis.document;
+});
+
+describe("mobile safe area insets", () => {
+  it("defaults mobile safe-area variables to zero", () => {
+    const setProperty = installDocumentStyle();
+
+    configureMobileSafeAreaInsets();
+
+    expect(setProperty).toHaveBeenCalledWith(
+      MOBILE_SAFE_AREA_INSET_TOP_VAR,
+      "0px",
+    );
+    expect(setProperty).toHaveBeenCalledWith(
+      MOBILE_SAFE_AREA_INSET_BOTTOM_VAR,
+      "0px",
+    );
+  });
+
+  it("allows iOS setup to provide native safe-area env values", () => {
+    const setProperty = installDocumentStyle();
+
+    configureMobileSafeAreaInsets({
+      top: "env(safe-area-inset-top)",
+      bottom: "env(safe-area-inset-bottom)",
+    });
+
+    expect(setProperty).toHaveBeenCalledWith(
+      MOBILE_SAFE_AREA_INSET_TOP_VAR,
+      "env(safe-area-inset-top)",
+    );
+    expect(setProperty).toHaveBeenCalledWith(
+      MOBILE_SAFE_AREA_INSET_BOTTOM_VAR,
+      "env(safe-area-inset-bottom)",
+    );
+  });
+});

--- a/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
+++ b/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
@@ -64,8 +64,14 @@ describe("mobile file explorer navbar", () => {
       expect(view).toContain(
         "rtgl-button#mobileFileExplorerClose sq pre=x v=ol",
       );
-      expect(view).toContain("padding-top: env(safe-area-inset-top)");
-      expect(view).toContain("padding-bottom: env(safe-area-inset-bottom)");
+      expect(view).toContain(
+        "padding-top: var(--rvn-mobile-safe-area-inset-top, 0px)",
+      );
+      expect(view).toContain(
+        "padding-bottom: var(--rvn-mobile-safe-area-inset-bottom, 0px)",
+      );
+      expect(view).not.toContain("env(safe-area-inset-top)");
+      expect(view).not.toContain("env(safe-area-inset-bottom)");
       expect(view).not.toContain(
         "rtgl-view h=56 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",
       );

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -15,7 +15,10 @@ describe("scenes view", () => {
     expect(scenesView).toContain(
       "rtgl-button#mobileFileExplorerClose sq pre=x v=ol",
     );
-    expect(scenesView).toContain("padding-top: env(safe-area-inset-top)");
+    expect(scenesView).toContain(
+      "padding-top: var(--rvn-mobile-safe-area-inset-top, 0px)",
+    );
+    expect(scenesView).not.toContain("env(safe-area-inset-top)");
   });
 
   it("uses a popover for desktop scene creation and a dialog form for mobile", () => {

--- a/tests/sounds/sounds.store.test.js
+++ b/tests/sounds/sounds.store.test.js
@@ -82,7 +82,7 @@ describe("sounds store audio player layout", () => {
     expect(selectViewData(context).audioPlayerLeft).toBe(0);
     expect(selectViewData(context).audioPlayerRight).toBe(0);
     expect(selectViewData(context).audioPlayerBottom).toBe(
-      "calc(64px + env(safe-area-inset-bottom))",
+      "calc(64px + var(--rvn-mobile-safe-area-inset-bottom, 0px))",
     );
   });
 });


### PR DESCRIPTION
## Summary
- add platform-configured mobile safe-area CSS variables
- use iOS safe-area env values only from iOS setup; keep Android/web/desktop at 0px
- update mobile file explorer overlays, mobile bottom padding, audio player inset, scene editor inset, and floating help button positioning to use the shared variables

## Testing
- bunx vitest run tests/mobileSafeAreaInsets/mobileSafeAreaInsets.test.js tests/resourcePages/mobileFileExplorerNavbar.view.test.js tests/images/images.view.test.js tests/scenes/scenes.view.test.js tests/layoutEditor/layoutEditor.view.test.js tests/layoutEditor/layoutEditor.store.test.js tests/app/app.store.test.js tests/sounds/sounds.store.test.js tests/mediaResourcesView/mediaResourcesView.store.test.js
- bun run lint
- git diff --check
- rebuilt Android bundle with ./node_modules/.bin/rtgl fe build -s src/setup.android.js
- verified on Vivo Android device: safe-area CSS vars are 0px and Images file explorer no longer has the iOS Dynamic Island top gap