### PR TITLE
fix: refine mobile layout and navigation

### DIFF
--- a/.github/workflows/windows-player-template.yaml
+++ b/.github/workflows/windows-player-template.yaml
@@ -1,18 +1,6 @@
 name: Windows Player Template
 
 on:
-  pull_request:
-    paths:
-      - "crates/routevn-packager/**"
-      - "docker/windows-player-template/**"
-      - "scripts/build-windows-player-template.js"
-      - "scripts/build-windows-player-template-docker.sh"
-      - "scripts/main.js"
-      - "src/deps/services/shared/projectExportService.js"
-      - "package.json"
-      - "bun.lock"
-      - "rust-toolchain.toml"
-      - ".github/workflows/windows-player-template.yaml"
   workflow_dispatch:
 
 jobs:

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@lexical/selection": "0.22.0",
         "@lexical/utils": "0.22.0",
         "@rettangoli/fe": "1.2.0",
-        "@rettangoli/ui": "1.8.2",
+        "@rettangoli/ui": "1.9.1",
         "@rettangoli/vt": "1.0.5",
         "@routevn/creator-model": "1.9.0",
         "@tauri-apps/api": "2.11.0",
@@ -313,7 +313,7 @@
 
     "@rettangoli/sites": ["@rettangoli/sites@1.2.0", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-taGLXClBbCL0Qbj7fFIZ0wW54yHNlKb43cJFZR1Poer2pxvo5GCnShvqZEvUfkPBqp/PKyvLfiOwMxGkbJxqyg=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.8.2", "", { "dependencies": { "@rettangoli/fe": "1.2.0", "jempl": "1.0.1" } }, "sha512-M/5R+E3FkQn0R9mmKQeDe1JzXTZYce8UfUlu9YfRtmLrKTKG4QWL569Wu3S0NKfIdCZxSusD02jlqW2bJsZJjQ=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.9.1", "", { "dependencies": { "@rettangoli/fe": "1.2.0", "jempl": "1.0.1" } }, "sha512-3sRGwb78+LIIk2ecwjaVTSg+mc0wEDche2lAowgiMB+0ztVotsRiVMJ+FSQhLNiUtJ4MKwvy+3wPlz9d7+eUow=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.5", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-YpZH5xQYj+x5Qy6gn+FUnMTUIQELrZkTA4qN8/U4n/1B4gpNHHPltJK/kVltZQVYVG0Tj676ZIKCMGN0ZAHdzg=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@lexical/selection": "0.22.0",
     "@lexical/utils": "0.22.0",
     "@rettangoli/fe": "1.2.0",
-    "@rettangoli/ui": "1.8.2",
+    "@rettangoli/ui": "1.9.1",
     "@rettangoli/vt": "1.0.5",
     "@routevn/creator-model": "1.9.0",
     "@tauri-apps/api": "2.11.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,14 @@ set -e
 
 BUILD_TYPE=${1:-web}
 SETUP_FILE="src/setup.${BUILD_TYPE}.js"
-RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.7.5")
+RETTANGOLI_VERSION=$(node -e '
+const version = require("./package.json").dependencies?.["@rettangoli/ui"];
+if (!version) {
+  console.error("Error: @rettangoli/ui is missing from package.json dependencies.");
+  process.exit(1);
+}
+process.stdout.write(version);
+')
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 

--- a/scripts/watch-android.sh
+++ b/scripts/watch-android.sh
@@ -3,7 +3,14 @@
 set -e
 
 PORT="3001"
-RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.9.1")
+RETTANGOLI_VERSION=$(node -e '
+const version = require("./package.json").dependencies?.["@rettangoli/ui"];
+if (!version) {
+  console.error("Error: @rettangoli/ui is missing from package.json dependencies.");
+  process.exit(1);
+}
+process.stdout.write(version);
+')
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 

--- a/scripts/watch-android.sh
+++ b/scripts/watch-android.sh
@@ -3,7 +3,7 @@
 set -e
 
 PORT="3001"
-RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.8.2")
+RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.9.1")
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 

--- a/scripts/watch-ios.sh
+++ b/scripts/watch-ios.sh
@@ -3,7 +3,14 @@
 set -e
 
 PORT="3001"
-RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.9.1")
+RETTANGOLI_VERSION=$(node -e '
+const version = require("./package.json").dependencies?.["@rettangoli/ui"];
+if (!version) {
+  console.error("Error: @rettangoli/ui is missing from package.json dependencies.");
+  process.exit(1);
+}
+process.stdout.write(version);
+')
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 

--- a/scripts/watch-ios.sh
+++ b/scripts/watch-ios.sh
@@ -3,7 +3,7 @@
 set -e
 
 PORT="3001"
-RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.8.2")
+RETTANGOLI_VERSION=$(node -p "require('./package.json').dependencies['@rettangoli/ui']" 2>/dev/null || echo "1.9.1")
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#^}"
 RETTANGOLI_VERSION="${RETTANGOLI_VERSION#~}"
 

--- a/src/components/whiteboard/whiteboard.schema.yaml
+++ b/src/components/whiteboard/whiteboard.schema.yaml
@@ -29,6 +29,8 @@ propsSchema:
       type: string
     minimapHeightScale:
       type: number
+    minimapTopInset:
+      type: number
 methods:
   properties:
     ensureItemVisible:

--- a/src/components/whiteboard/whiteboard.store.js
+++ b/src/components/whiteboard/whiteboard.store.js
@@ -52,14 +52,14 @@ const parseBooleanProp = (value, fallback = false) => {
   return value === true || value === "true";
 };
 
-const resolveMinimapContainerStyle = (placement) => {
+const resolveMinimapContainerStyle = (placement, topInset) => {
   const baseStyle = "overflow: hidden;";
   if (placement === "top-right") {
-    return ["right: 20px", "top: 20px", baseStyle].join("; ");
+    return ["right: 20px", `top: ${topInset}px`, baseStyle].join("; ");
   }
 
   if (placement === "top-left") {
-    return ["left: 20px", "top: 20px", baseStyle].join("; ");
+    return ["left: 20px", `top: ${topInset}px`, baseStyle].join("; ");
   }
 
   return ["left: 20px", "bottom: 20px", baseStyle].join("; ");
@@ -68,6 +68,11 @@ const resolveMinimapContainerStyle = (placement) => {
 const resolveMinimapHeightScale = (value) => {
   const numericValue = Number(value);
   return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 1;
+};
+
+const resolveMinimapTopInset = (value) => {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue >= 0 ? numericValue : 20;
 };
 
 export const createInitialState = () => ({
@@ -866,6 +871,7 @@ export const selectViewData = ({ state, props }) => {
   const minimapHeightScale = resolveMinimapHeightScale(
     props.minimapHeightScale,
   );
+  const minimapTopInset = resolveMinimapTopInset(props.minimapTopInset);
   const showMinimap = showTouchMinimap || showDesktopMinimap;
 
   return {
@@ -881,7 +887,10 @@ export const selectViewData = ({ state, props }) => {
           },
         )
       : undefined,
-    minimapContainerStyle: resolveMinimapContainerStyle(minimapPlacement),
+    minimapContainerStyle: resolveMinimapContainerStyle(
+      minimapPlacement,
+      minimapTopInset,
+    ),
     arrowsList,
     selectedItemId: props.selectedItemId,
     isPanMode: state.isPinnedPanMode || state.isKeyboardPanMode,

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -514,6 +514,7 @@ export const handleBeforeMount = (deps) => {
   const initialPath = currentPath === "/" ? "/projects" : currentPath;
 
   appService.setAppCopyProvider?.(() => selectAppCopy(deps.i18n));
+  store.setPlatform({ platform: appService.getPlatform() });
   store.setUiConfig({ uiConfig });
   subject.dispatch("app.route.request", {
     path: initialPath,

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -1,4 +1,5 @@
 export const createInitialState = () => ({
+  platform: "web",
   currentRoute: "/projects",
   isTouchMode: false,
   isMobileSheetOpen: false,
@@ -12,7 +13,8 @@ export const createInitialState = () => ({
 const SIDEBAR_WIDTH_PX = 64;
 const MOBILE_TAB_BAR_HEIGHT_PX = 64;
 const HELP_BUTTON_BOTTOM_OFFSET_PX = 24;
-const HELP_BUTTON_TOUCH_EXTRA_BOTTOM_OFFSET_PX = 40;
+const HELP_BUTTON_TOUCH_BOTTOM_OFFSET_PX = 28;
+const HELP_BUTTON_IOS_EXTRA_BOTTOM_OFFSET_PX = 36;
 const MOBILE_TAB_BAR_ACTIVE_COLOR = "white";
 const MOBILE_TAB_BAR_INACTIVE_COLOR = "mu-fg";
 
@@ -167,6 +169,10 @@ export const setUiConfig = ({ state }, { uiConfig } = {}) => {
     uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
 };
 
+export const setPlatform = ({ state }, { platform } = {}) => {
+  state.platform = platform ?? "web";
+};
+
 export const setCurrentRoute = ({ state }, { route } = {}) => {
   state.currentRoute = route;
 };
@@ -268,8 +274,10 @@ export const selectViewData = ({ state, i18n }) => {
     helpButtonBottom: state.isTouchMode
       ? `${
           MOBILE_TAB_BAR_HEIGHT_PX +
-          HELP_BUTTON_BOTTOM_OFFSET_PX +
-          HELP_BUTTON_TOUCH_EXTRA_BOTTOM_OFFSET_PX
+          HELP_BUTTON_TOUCH_BOTTOM_OFFSET_PX +
+          (state.platform === "ios"
+            ? HELP_BUTTON_IOS_EXTRA_BOTTOM_OFFSET_PX
+            : 0)
         }px`
       : `${HELP_BUTTON_BOTTOM_OFFSET_PX}px`,
     repositoryLoadingProgressPercent,

--- a/src/pages/project/project.handlers.js
+++ b/src/pages/project/project.handlers.js
@@ -303,6 +303,7 @@ export const handleEditIconCropDialogConfirm = async (deps) => {
 export const handleBackToProjects = async (deps) => {
   const { appService } = deps;
   appService.navigate("/projects", undefined, {
+    historyMode: "replace",
     historyState: { preserveProjectsEntryOnProjectOpen: true },
   });
 };

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -629,6 +629,7 @@ export const selectViewData = ({ state, i18n }) => {
       state.isTouchMode && state.isTouchMinimapReady,
     whiteboardMinimapPlacement: state.isTouchMode ? "top-left" : "bottom-left",
     whiteboardMinimapHeightScale: state.isTouchMode ? 2 / 3 : 1,
+    whiteboardMinimapTopInset: state.isTouchMode ? 8 : undefined,
     filesLabel: copy.filesLabel ?? "Files",
     title: copy.title ?? "Scenes",
     previewButton: copy.previewMenuItem ?? "Preview",

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -117,7 +117,7 @@ template:
                       - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
           - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
-                  - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId} :isTouchMode=${isTouchMode} :showArrows=${showWhiteboardConnections} :showMinimapInTouchMode=${showWhiteboardMinimapInTouchMode} :minimapPlacement=${whiteboardMinimapPlacement} :minimapHeightScale=${whiteboardMinimapHeightScale}: null
+                  - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId} :isTouchMode=${isTouchMode} :showArrows=${showWhiteboardConnections} :showMinimapInTouchMode=${showWhiteboardMinimapInTouchMode} :minimapPlacement=${whiteboardMinimapPlacement} :minimapHeightScale=${whiteboardMinimapHeightScale} :minimapTopInset=${whiteboardMinimapTopInset}: null
           - $if showDetailPanel:
               - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
                   - rtgl-view wh=f slot="content":

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -14,7 +14,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/ios/index.html
+++ b/static/ios/index.html
@@ -42,7 +42,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.8.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.9.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/tests/app/app.store.test.js
+++ b/tests/app/app.store.test.js
@@ -3,9 +3,11 @@ import {
   createInitialState,
   openMobileSheet,
   selectViewData,
+  setPlatform,
   setRepositoryLoading,
   setRepositoryLoadingPhase,
   setRepositoryLoadingProgress,
+  setUiConfig,
 } from "../../src/pages/app/app.store.js";
 
 const selectMobileTab = ({ state, tabId }) => {
@@ -167,5 +169,28 @@ describe("app.store mobile tab active state", () => {
 
     expect(selectMobileTab({ state, tabId: "release" }).color).toBe("white");
     expect(selectMobileTab({ state, tabId: "assets" }).color).toBe("mu-fg");
+  });
+});
+
+describe("app.store floating help button", () => {
+  it("uses platform-specific touch offsets", () => {
+    const androidState = createInitialState();
+    setPlatform({ state: androidState }, { platform: "android" });
+    setUiConfig(
+      { state: androidState },
+      { uiConfig: { id: "touch", inputMode: "touch" } },
+    );
+
+    const iosState = createInitialState();
+    setPlatform({ state: iosState }, { platform: "ios" });
+    setUiConfig(
+      { state: iosState },
+      { uiConfig: { id: "touch", inputMode: "touch" } },
+    );
+
+    expect(selectViewData({ state: androidState }).helpButtonBottom).toBe(
+      "92px",
+    );
+    expect(selectViewData({ state: iosState }).helpButtonBottom).toBe("128px");
   });
 });

--- a/tests/projectPage/projectPage.handlers.test.js
+++ b/tests/projectPage/projectPage.handlers.test.js
@@ -32,6 +32,7 @@ describe("project page handlers", () => {
     expect(enterEvent.preventDefault).toHaveBeenCalledTimes(1);
     expect(spaceEvent.preventDefault).toHaveBeenCalledTimes(1);
     const expectedOptions = {
+      historyMode: "replace",
       historyState: { preserveProjectsEntryOnProjectOpen: true },
     };
     expect(deps.appService.navigate).toHaveBeenNthCalledWith(

--- a/tests/scenes/scenes.store.test.js
+++ b/tests/scenes/scenes.store.test.js
@@ -38,6 +38,7 @@ describe("scenes.store mobile layout", () => {
     expect(viewData.showWhiteboardConnections).toBe(false);
     expect(viewData.whiteboardMinimapPlacement).toBe("top-left");
     expect(viewData.whiteboardMinimapHeightScale).toBe(2 / 3);
+    expect(viewData.whiteboardMinimapTopInset).toBe(8);
 
     setTouchMinimapReady({ state }, { isReady: true });
     setWhiteboardConnectionsReady({ state }, { isReady: true });
@@ -66,6 +67,7 @@ describe("scenes.store mobile layout", () => {
     expect(viewData.showWhiteboardMinimapInTouchMode).toBe(false);
     expect(viewData.whiteboardMinimapPlacement).toBe("bottom-left");
     expect(viewData.whiteboardMinimapHeightScale).toBe(1);
+    expect(viewData.whiteboardMinimapTopInset).toBeUndefined();
   });
 
   it("uses a popover on desktop and a dialog on touch for scene creation", () => {

--- a/tests/whiteboard/whiteboard.store.test.js
+++ b/tests/whiteboard/whiteboard.store.test.js
@@ -199,12 +199,13 @@ describe("whiteboard minimap viewport drag", () => {
         showMinimapInTouchMode: true,
         minimapPlacement: "top-left",
         minimapHeightScale: 2 / 3,
+        minimapTopInset: 8,
       },
     });
 
     expect(forcedTouchViewData.showMinimap).toBe(true);
     expect(forcedTouchViewData.minimapContainerStyle).toContain("left: 20px");
-    expect(forcedTouchViewData.minimapContainerStyle).toContain("top: 20px");
+    expect(forcedTouchViewData.minimapContainerStyle).toContain("top: 8px");
   });
 });
 


### PR DESCRIPTION
## Summary

- update `@rettangoli/ui` and runtime entry points to 1.9.1
- fail build and mobile watch scripts immediately when `@rettangoli/ui` is missing from `package.json`
- align the touch scene-map minimap with the mobile explorer button
- apply platform-specific floating help-button offsets while preserving the iOS position
- replace history when returning from a project to the projects list
- make the Windows Player Template workflow manual-only instead of running on pull requests

## Validation

- `bun run lint`
- `bun run test:smoke`
- `bunx vitest run tests/app/app.store.test.js tests/projectPage/projectPage.handlers.test.js tests/scenes/scenes.store.test.js tests/scenes/scenes.view.test.js tests/whiteboard/whiteboard.store.test.js` (29 tests)
- `bash -n scripts/build.sh scripts/watch-android.sh scripts/watch-ios.sh`
- workflow validation for `.github/workflows/windows-player-template.yaml`
- verified the strict dependency lookup success and failure branches
- verified the scene-map alignment, Rettangoli UI 1.9.1 load, and floating help-button position on the attached Android device in watch mode

## Additional check

- `bun run check:contracts` is not clean: the current checker reports 3,643 repository-wide registry and YAHTML diagnostics, including unknown Rettangoli primitives across unchanged pages.