### PR TITLE
fix: scope mobile explorer top inset to iOS

### DIFF
--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -179,7 +179,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -293,7 +293,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -201,7 +201,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -156,7 +156,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -184,7 +184,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -151,7 +151,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -250,7 +250,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -108,7 +108,7 @@ template:
                       - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                           - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileNodeExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${nodeExplorerTitle}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -154,7 +154,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -182,7 +182,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -175,7 +175,7 @@ template:
           - 'rtgl-view pos=abs z=200 style="right: 8px; top: 8px;"':
               - 'rtgl-button#mobileFileExplorerOpenButton sq pre=hamburger v=ol title="${title}" aria-label="${title}"': null
       - $if showMobileFileExplorer:
-          - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+          - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
               - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
                   - rtgl-text w=1fg s=md: ${filesLabel}
                   - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -181,7 +181,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -177,7 +177,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -174,7 +174,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -209,7 +209,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -112,7 +112,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -171,7 +171,7 @@ template:
                               - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                                   - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
   - $if showMobileFileExplorer:
-      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
+      - 'rtgl-view pos=fix edge=f z=1250 bgc=bg d=v style="min-width: 0; min-height: 0; padding-top: var(--rvn-mobile-overlay-top-inset, 0px); padding-bottom: env(safe-area-inset-bottom); box-sizing: border-box;"':
           - rtgl-view h=48 w=f d=h av=c ph=md bgc=bg bwb=xs g=md:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null

--- a/static/ios/index.html
+++ b/static/ios/index.html
@@ -21,6 +21,7 @@
       }
 
       body {
+        --rvn-mobile-overlay-top-inset: env(safe-area-inset-top);
         --rvn-app-viewport-height: calc(
           100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)
         );

--- a/tests/images/images.view.test.js
+++ b/tests/images/images.view.test.js
@@ -89,7 +89,7 @@ describe("images view", () => {
     );
 
     expect(mobileExplorerBranch).toContain(
-      "padding-top: env(safe-area-inset-top)",
+      "padding-top: var(--rvn-mobile-overlay-top-inset, 0px)",
     );
     expect(mobileExplorerBranch).toContain(
       "padding-bottom: env(safe-area-inset-bottom)",

--- a/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
+++ b/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
@@ -49,6 +49,22 @@ const mobileFileExplorerPages = [
 ];
 
 describe("mobile file explorer navbar", () => {
+  it("enables the overlay top inset only in the iOS shell", () => {
+    const iosEntry = readFileSync(
+      new URL("../../static/ios/index.html", import.meta.url),
+      "utf8",
+    );
+    const androidEntry = readFileSync(
+      new URL("../../static/android/index.html", import.meta.url),
+      "utf8",
+    );
+
+    expect(iosEntry).toContain(
+      "--rvn-mobile-overlay-top-inset: env(safe-area-inset-top)",
+    );
+    expect(androidEntry).not.toContain("--rvn-mobile-overlay-top-inset");
+  });
+
   it.each(mobileFileExplorerPages)(
     "matches the images navbar style for %s",
     (_name, relativePath, explorerCondition) => {
@@ -64,7 +80,9 @@ describe("mobile file explorer navbar", () => {
       expect(view).toContain(
         "rtgl-button#mobileFileExplorerClose sq pre=x v=ol",
       );
-      expect(view).toContain("padding-top: env(safe-area-inset-top)");
+      expect(view).toContain(
+        "padding-top: var(--rvn-mobile-overlay-top-inset, 0px)",
+      );
       expect(view).toContain("padding-bottom: env(safe-area-inset-bottom)");
       expect(view).not.toContain(
         "rtgl-view h=56 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -15,7 +15,9 @@ describe("scenes view", () => {
     expect(scenesView).toContain(
       "rtgl-button#mobileFileExplorerClose sq pre=x v=ol",
     );
-    expect(scenesView).toContain("padding-top: env(safe-area-inset-top)");
+    expect(scenesView).toContain(
+      "padding-top: var(--rvn-mobile-overlay-top-inset, 0px)",
+    );
   });
 
   it("uses a popover for desktop scene creation and a dialog form for mobile", () => {


### PR DESCRIPTION
## Summary

- define the mobile overlay top inset only in the iOS shell
- use a `0px` fallback for Android and touch web across all 17 resource/explorer overlays
- preserve existing bottom safe-area handling
- extend shared view coverage for the platform-specific inset contract

## Validation

- `bun run lint`
- `bun run test:smoke`
- `bunx vitest run tests/resourcePages/mobileFileExplorerNavbar.view.test.js tests/images/images.view.test.js tests/scenes/scenes.view.test.js` (31 tests)
- rebuilt Android watch mode and verified the opened Sounds explorer starts directly below the Android status bar