### PR TITLE
fix: restore layout action values and Windows version exports

### DIFF
--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.handlers.js
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.handlers.js
@@ -3,6 +3,16 @@ import {
   createRuntimeActionSubmitDetail,
 } from "../../internal/runtimeActions.js";
 
+const syncFormValues = (deps) => {
+  const { refs, store } = deps;
+  const { mode, action } = store.selectSubmitData();
+
+  refs.form.reset();
+  refs.form.setValues({
+    values: createRuntimeActionDefaultValues(mode, action),
+  });
+};
+
 export const handleBeforeMount = (deps) => {
   const { props, store } = deps;
   store.setMode({ mode: props?.mode });
@@ -10,6 +20,10 @@ export const handleBeforeMount = (deps) => {
   store.setFormValues({
     values: undefined,
   });
+};
+
+export const handleAfterMount = (deps) => {
+  syncFormValues(deps);
 };
 
 export const handleOnUpdate = (deps, payload) => {
@@ -22,6 +36,7 @@ export const handleOnUpdate = (deps, payload) => {
     values: undefined,
   });
   render();
+  syncFormValues(deps);
 };
 
 export const handleFormChange = (deps, payload) => {

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -239,6 +239,7 @@ export const selectViewData = ({ state, props, props: attrs, i18n }) => {
     dropdownMenu: localizeCommandLineDropdownMenu(state.dropdownMenu, copy),
     displayActions,
     actions: actionsObject,
+    runtimeAction: actionsObject[state.mode] ?? {},
     preview,
     playingSound: state.playingSound,
     showAudioPlayer: state.showAudioPlayer,

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -310,5 +310,5 @@ template:
                 $elif mode == "conditional":
                   - rvn-command-line-conditional#commandLineConditional :conditional=${actions.conditional} :hiddenModes=${hiddenModes}: null
                 $elif isRuntimeActionMode:
-                  - rvn-command-line-runtime-action#commandLineRuntimeAction :mode=${mode} :action=${actions[mode]}: null
+                  - rvn-command-line-runtime-action#commandLineRuntimeAction :mode=${mode} :action=${runtimeAction}: null
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/internal/runtimeActions.js
+++ b/src/internal/runtimeActions.js
@@ -21,7 +21,6 @@ const createValueActionDefinition = ({
   min,
   step,
   description,
-  placeholder,
 } = {}) => {
   const field = getRuntimeFieldItem(runtimeId);
 
@@ -34,7 +33,6 @@ const createValueActionDefinition = ({
     description: description ?? field?.description,
     defaultValue: field?.default,
     valueLabel: "Value",
-    placeholder,
     min,
     step,
   };
@@ -140,7 +138,6 @@ export const RUNTIME_ACTION_DEFINITIONS = Object.freeze({
     icon: "settings",
     runtimeId: "menuPage",
     inputType: "text",
-    placeholder: "menu-page-id",
   }),
   setMenuEntryPoint: createValueActionDefinition({
     mode: "setMenuEntryPoint",
@@ -148,7 +145,6 @@ export const RUNTIME_ACTION_DEFINITIONS = Object.freeze({
     icon: "settings",
     runtimeId: "menuEntryPoint",
     inputType: "text",
-    placeholder: "entry-point",
   }),
 });
 
@@ -235,7 +231,6 @@ const createFixedValueField = (definition) => {
     description: definition.description,
     min: definition.min,
     step: definition.step,
-    placeholder: definition.placeholder,
   };
 };
 

--- a/src/pages/versions/versions.view.yaml
+++ b/src/pages/versions/versions.view.yaml
@@ -86,6 +86,8 @@ template:
                               - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                                   - rtgl-view slot=actions d=v g=sm w=f:
                                       - rtgl-button#detailDownloadBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWebButton}
+                                      - $if canExportWindowsExecutable:
+                                          - rtgl-button#detailWindowsExeBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsExecutableButton}
                         $else:
                           - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                               - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
@@ -99,6 +101,8 @@ template:
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-view slot=actions d=v g=sm w=f:
                           - rtgl-button#detailDownloadBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWebButton}
+                          - $if canExportWindowsExecutable:
+                              - rtgl-button#detailWindowsExeBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsExecutableButton}
   - rtgl-dialog#versionDialog ?open=${isVersionDialogOpen} s=md:
       - rtgl-view slot=content w=f:
           - rtgl-form#versionForm :form=${versionForm} w=f: null

--- a/src/pages/versions/versions.view.yaml
+++ b/src/pages/versions/versions.view.yaml
@@ -88,6 +88,8 @@ template:
                                       - rtgl-button#detailDownloadBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWebButton}
                                       - $if canExportWindowsExecutable:
                                           - rtgl-button#detailWindowsExeBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsExecutableButton}
+                                      - $if canExportWindowsInstaller:
+                                          - rtgl-button#detailWindowsInstallerBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsInstallerButton}
                         $else:
                           - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                               - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
@@ -103,6 +105,8 @@ template:
                           - rtgl-button#detailDownloadBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWebButton}
                           - $if canExportWindowsExecutable:
                               - rtgl-button#detailWindowsExeBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsExecutableButton}
+                          - $if canExportWindowsInstaller:
+                              - rtgl-button#detailWindowsInstallerBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsInstallerButton}
   - rtgl-dialog#versionDialog ?open=${isVersionDialogOpen} s=md:
       - rtgl-view slot=content w=f:
           - rtgl-form#versionForm :form=${versionForm} w=f: null

--- a/tests/commandLineRuntimeAction/commandLineRuntimeAction.handlers.test.js
+++ b/tests/commandLineRuntimeAction/commandLineRuntimeAction.handlers.test.js
@@ -1,15 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createInitialState,
+  selectSubmitData,
   setAction,
   setFormValues,
   setMode,
 } from "../../src/components/commandLineRuntimeAction/commandLineRuntimeAction.store.js";
 import {
+  handleAfterMount,
   handleFormChange,
   handleBeforeMount,
+  handleOnUpdate,
   handleSubmitClick,
 } from "../../src/components/commandLineRuntimeAction/commandLineRuntimeAction.handlers.js";
+
+const createStore = (state) => ({
+  setMode: (payload) => setMode({ state }, payload),
+  setAction: (payload) => setAction({ state }, payload),
+  setFormValues: (payload) => setFormValues({ state }, payload),
+  selectSubmitData: () => selectSubmitData({ state }),
+});
 
 describe("commandLineRuntimeAction.handlers", () => {
   it("initializes scene-editor-facing runtime actions from props on mount", () => {
@@ -44,6 +54,71 @@ describe("commandLineRuntimeAction.handlers", () => {
       value: 80,
     });
     expect(state.formValues).toEqual({});
+  });
+
+  it.each([
+    ["setMenuPage", "settings"],
+    ["setMenuEntryPoint", "pause-menu"],
+  ])("hydrates the existing %s value into the mounted form", (mode, value) => {
+    const state = createInitialState();
+    const store = createStore(state);
+    const form = {
+      reset: vi.fn(),
+      setValues: vi.fn(),
+    };
+
+    handleBeforeMount({
+      props: {
+        mode,
+        action: { value },
+      },
+      store,
+    });
+    handleAfterMount({
+      refs: { form },
+      store,
+    });
+
+    expect(form.reset).toHaveBeenCalledOnce();
+    expect(form.setValues).toHaveBeenCalledWith({
+      values: {
+        valueSource: "fixed",
+        value,
+      },
+    });
+  });
+
+  it("rehydrates the form when an existing runtime action is opened in place", () => {
+    const state = createInitialState();
+    const store = createStore(state);
+    const form = {
+      reset: vi.fn(),
+      setValues: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleOnUpdate(
+      {
+        refs: { form },
+        store,
+        render,
+      },
+      {
+        newProps: {
+          mode: "setMenuEntryPoint",
+          action: { value: "pause-menu" },
+        },
+      },
+    );
+
+    expect(render).toHaveBeenCalledOnce();
+    expect(form.reset).toHaveBeenCalledOnce();
+    expect(form.setValues).toHaveBeenCalledWith({
+      values: {
+        valueSource: "fixed",
+        value: "pause-menu",
+      },
+    });
   });
 
   it("stores form values on change so conditional fields can rerender", () => {
@@ -95,7 +170,7 @@ describe("commandLineRuntimeAction.handlers", () => {
     handleSubmitClick(
       {
         store: {
-          getState: () => state,
+          selectSubmitData: () => selectSubmitData({ state }),
         },
         dispatchEvent,
       },
@@ -135,7 +210,7 @@ describe("commandLineRuntimeAction.handlers", () => {
     handleSubmitClick(
       {
         store: {
-          getState: () => state,
+          selectSubmitData: () => selectSubmitData({ state }),
         },
         dispatchEvent,
       },

--- a/tests/internal/runtimeActions.test.js
+++ b/tests/internal/runtimeActions.test.js
@@ -8,6 +8,31 @@ import {
 } from "../../src/internal/runtimeActions.js";
 
 describe("runtimeActions", () => {
+  it.each(["setMenuPage", "setMenuEntryPoint"])(
+    "does not add placeholder text to %s",
+    (mode) => {
+      const valueField = createRuntimeActionForm(mode).fields.find(
+        (field) => field.name === "value",
+      );
+
+      expect(valueField).not.toHaveProperty("placeholder");
+    },
+  );
+
+  it.each([
+    ["setMenuPage", "settings"],
+    ["setMenuEntryPoint", "pause-menu"],
+  ])("uses the existing %s value as the form default", (mode, value) => {
+    expect(
+      createRuntimeActionDefaultValues(mode, {
+        value,
+      }),
+    ).toEqual({
+      valueSource: "fixed",
+      value,
+    });
+  });
+
   it("shows a value source segmented control for runtime value actions", () => {
     expect(createRuntimeActionForm("setMusicVolume")).toMatchObject({
       fields: [

--- a/tests/systemActions/systemActions.runtimeAction.test.js
+++ b/tests/systemActions/systemActions.runtimeAction.test.js
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setMode,
+  updateActions,
+} from "../../src/components/systemActions/systemActions.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("systemActions runtime action editor", () => {
+  it.each([
+    ["setMenuPage", "options"],
+    ["setMenuEntryPoint", "story"],
+  ])("selects the existing %s action for the editor", (mode, value) => {
+    const state = createInitialState();
+
+    updateActions(
+      { state },
+      {
+        [mode]: { value },
+      },
+    );
+    setMode({ state }, { mode });
+
+    expect(
+      selectViewData({
+        state,
+        props: {},
+        i18n: EN_I18N,
+      }).runtimeAction,
+    ).toEqual({ value });
+  });
+
+  it("passes the selected action through a direct template binding", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/systemActions/systemActions.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain(":action=${runtimeAction}");
+    expect(view).not.toContain(":action=${actions[mode]}");
+  });
+});

--- a/tests/versions/versions.view.test.js
+++ b/tests/versions/versions.view.test.js
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const versionsView = readFileSync(
+  new URL("../../src/pages/versions/versions.view.yaml", import.meta.url),
+  "utf8",
+);
+
+describe("versions view export actions", () => {
+  it("renders gated Windows installer actions in desktop and mobile details", () => {
+    expect(versionsView.match(/\$if canExportWindowsInstaller:/g)).toHaveLength(
+      2,
+    );
+    expect(
+      versionsView.match(/rtgl-button#detailWindowsInstallerBtn/g),
+    ).toHaveLength(2);
+    expect(
+      versionsView.match(/\$\{exportWindowsInstallerButton\}/g),
+    ).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- remove placeholder text from Set Current Menu Page and Set Menu Entry Point
- pass the selected runtime action through a direct view binding so existing values populate when editing
- rehydrate runtime action forms on mount and prop updates
- expose Windows EXE export and the gated Windows installer export in desktop and mobile Versions detail views
- add regression coverage for both menu actions, their parent editor binding, and both installer button locations

## Testing
- bunx vitest run tests/versions/versions.view.test.js tests/versions/versions.store.test.js tests/versions/versions.handlers.test.js
- bunx vitest run tests/systemActions/systemActions.runtimeAction.test.js tests/internal/runtimeActions.test.js tests/commandLineRuntimeAction/commandLineRuntimeAction.handlers.test.js
- bun run lint