### PR TITLE
fix: resolve partial presentation previews

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -734,6 +734,7 @@ export const handleTabClick = (deps, payload) => {
   });
 
   render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleSearchInput = (deps, payload) => {

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -174,33 +174,14 @@ const resolveBackgroundPreviewAction = ({ actions, presentationState }) => {
     return effectiveBackground;
   }
 
-  const previewBackground = { ...actionBackground };
-  const hasAppearanceOnlyChange =
-    Object.hasOwn(actionBackground, "opacity") ||
-    Object.hasOwn(actionBackground, "blur");
-  if (
-    hasAppearanceOnlyChange &&
-    !previewBackground.resourceId &&
-    effectiveBackground?.resourceId
-  ) {
-    previewBackground.resourceId = effectiveBackground.resourceId;
-    previewBackground.animationName = effectiveBackground.animationName;
-  }
-  if (
-    hasAppearanceOnlyChange &&
-    !previewBackground.colorId &&
-    effectiveBackground?.colorId
-  ) {
-    previewBackground.colorId = effectiveBackground.colorId;
-  }
-  if (!previewBackground.resourceId && actionBackground.colorId) {
-    previewBackground.resourceId = effectiveBackground?.resourceId;
-  }
-  if (!previewBackground.colorId && actionBackground.resourceId) {
-    previewBackground.colorId = effectiveBackground?.colorId;
+  if (!effectiveBackground) {
+    return actionBackground;
   }
 
-  return previewBackground;
+  return {
+    ...effectiveBackground,
+    ...actionBackground,
+  };
 };
 
 export const selectViewData = ({ state, props, props: attrs, i18n }) => {
@@ -1172,10 +1153,10 @@ export const selectActionsData = ({ props, state, copy }) => {
   }
 
   // Visual
-  const visualAction = isPlainObject(actions.visual)
-    ? actions.visual
-    : isPlainObject(presentationState.visual)
-      ? presentationState.visual
+  const visualAction = isPlainObject(presentationState.visual)
+    ? presentationState.visual
+    : isPlainObject(actions.visual)
+      ? actions.visual
       : undefined;
   if (Array.isArray(visualAction?.items)) {
     actionsObject.visual = visualAction;

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -10,6 +10,7 @@ import {
   handleResourceItemClick,
   handleSpritesheetSelected,
   handleSubmitClick,
+  handleTabClick,
 } from "../../src/components/commandLineBackground/commandLineBackground.handlers.js";
 import {
   createInitialState,
@@ -1028,6 +1029,59 @@ describe("commandLineBackground.handlers", () => {
         animationName: "wind",
       },
     });
+  });
+
+  it("restores the selected background preview when a tab change clears the temporary resource", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+
+    setRepositoryCollections(state);
+    setMode({ state }, { mode: "gallery" });
+    setSelectedResource(
+      { state },
+      {
+        resourceId: "bg-school",
+        resourceType: "image",
+      },
+    );
+
+    handleSpritesheetSelected(
+      { store, render, dispatchEvent },
+      {
+        _event: {
+          detail: {
+            resourceId: "bg-spritesheet",
+            animationName: "wind",
+          },
+        },
+      },
+    );
+    dispatchEvent.mockClear();
+    render.mockClear();
+
+    handleTabClick(
+      { store, render, dispatchEvent },
+      {
+        _event: {
+          detail: {
+            id: "image",
+          },
+        },
+      },
+    );
+
+    expect(selectTempSelectedResource({ state })).toBeNull();
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      presentationState: {
+        background: {
+          resourceId: "bg-school",
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it("submits playback continuity inside background animations", () => {

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -778,6 +778,134 @@ describe("systemActions.store", () => {
     });
   });
 
+  it("uses effective presentation resources for partial background and visual actions", () => {
+    const state = createInitialState();
+    const atlas = {
+      frames: {
+        "storm-0": {
+          frame: { x: 0, y: 0, w: 64, h: 64 },
+        },
+      },
+    };
+    const animation = {
+      frames: ["storm-0"],
+      fps: 12,
+    };
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          spritesheets: {
+            items: {
+              "weather-sheet": {
+                id: "weather-sheet",
+                type: "spritesheet",
+                name: "Weather",
+                fileId: "file-weather-sheet",
+                jsonData: atlas,
+                animations: { storm: animation },
+              },
+            },
+            tree: [{ id: "weather-sheet" }],
+          },
+        },
+      },
+    );
+
+    const partialAnimationResult = selectActionsData({
+      state,
+      props: {
+        actions: {
+          background: {
+            animationName: "storm",
+          },
+          visual: {
+            items: [
+              {
+                id: "weather-visual",
+                opacity: 0.5,
+              },
+            ],
+          },
+        },
+        presentationState: {
+          background: {
+            resourceId: "weather-sheet",
+            animationName: "storm",
+          },
+          visual: {
+            items: [
+              {
+                id: "weather-visual",
+                resourceId: "weather-sheet",
+                resourceType: "spritesheet",
+                animationName: "storm",
+                opacity: 0.5,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(partialAnimationResult.actions.background).toEqual({
+      resourceId: "weather-sheet",
+      animationName: "storm",
+    });
+    expect(partialAnimationResult.preview.background).toMatchObject({
+      id: "weather-sheet",
+      type: "spritesheet",
+      animationName: "storm",
+      spritesheetAnimation: animation,
+    });
+    expect(partialAnimationResult.actions.visual.items[0]).toEqual({
+      id: "weather-visual",
+      resourceId: "weather-sheet",
+      resourceType: "spritesheet",
+      animationName: "storm",
+      opacity: 0.5,
+    });
+    expect(partialAnimationResult.preview.visual.items[0]).toMatchObject({
+      id: "weather-visual",
+      resourceId: "weather-sheet",
+      resourceType: "spritesheet",
+      animationName: "storm",
+      spritesheetAnimation: animation,
+    });
+
+    const colorOnlyResult = selectActionsData({
+      state,
+      props: {
+        actions: {
+          background: {
+            colorId: "storm-tint",
+          },
+        },
+        presentationState: {
+          background: {
+            resourceId: "weather-sheet",
+            animationName: "storm",
+            colorId: "storm-tint",
+          },
+        },
+      },
+    });
+
+    expect(colorOnlyResult.actions.background).toEqual({
+      resourceId: "weather-sheet",
+      animationName: "storm",
+      colorId: "storm-tint",
+    });
+    expect(colorOnlyResult.preview.background).toMatchObject({
+      id: "weather-sheet",
+      type: "spritesheet",
+      animationName: "storm",
+      spritesheetAnimation: animation,
+      colorId: "storm-tint",
+    });
+  });
+
   it("includes custom character name and persist character labels in dialogue preview when a character is selected", () => {
     const state = createInitialState();
 


### PR DESCRIPTION
## Summary
- resolve partial background actions against the effective presentation state so inherited resources, spritesheet animations, and color overlays remain previewable
- prefer effective visual presentation items for opacity- and transform-only patches
- redispatch the selected background preview when changing tabs clears a temporary gallery resource
- add regression coverage for all three review findings

## Related
- follow-up to #945

## Testing
- `bun run lint`
- `bunx vitest run tests/commandLineBackground/commandLineBackground.handlers.test.js tests/commandLineBackground/commandLineBackground.store.test.js tests/commandLineVisual/commandLineVisual.handlers.test.js tests/commandLineVisual/commandLineVisual.store.test.js tests/systemActions/systemActions.store.test.js tests/systemActions/systemActions.view.test.js` (90 tests)
- `bun run test:smoke`