### PR TITLE
fix(layout): apply font weights to legacy text

### DIFF
--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -1217,7 +1217,14 @@ const getTextNodeContent = (node, context = {}) => {
     return `\${choice.items[${context.choiceItemIndex}].content}`;
   }
 
-  return TEXT_CONTENT_BY_TYPE[node.type] ?? node.text ?? "";
+  const referencedContent = TEXT_CONTENT_BY_TYPE[node.type];
+  if (referencedContent !== undefined) {
+    return referencedContent;
+  }
+
+  // The renderer's legacy string path drops fontWeight. Keep old persisted
+  // text nodes compatible by projecting them through the rich-text path.
+  return toRouteGraphicsLayoutTextContent([{ text: node.text ?? "" }]);
 };
 
 const toTextRevealingSegments = (content) => {

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -2193,7 +2193,7 @@
               "textStyle": {
                 "align": "left"
               },
-              "textStyleId": "5rwEfyx2GBEi",
+              "textStyleId": "e2WbW3vcPZR9",
               "hoverTextStyleId": "saV5A4pkvHRb",
               "click": {
                 "payload": {

--- a/tests/project/layout.richText.test.js
+++ b/tests/project/layout.richText.test.js
@@ -1,8 +1,18 @@
+import { readFileSync } from "node:fs";
 import { parseAndRender } from "jempl";
 import { describe, expect, it } from "vitest";
-import { buildLayoutElements } from "../../src/internal/project/layout.js";
+import {
+  buildLayoutElements,
+  buildLayoutRenderElements,
+} from "../../src/internal/project/layout.js";
 
 const emptyCollection = { items: {}, tree: [] };
+const defaultRepository = JSON.parse(
+  readFileSync(
+    new URL("../../static/templates/default/repository.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 describe("layout rich text projection", () => {
   it("projects layout text references as variable template segments", () => {
@@ -41,7 +51,7 @@ describe("layout rich text projection", () => {
     ).toEqual([{ text: "Hello " }, { text: "Aki" }, { text: "!" }]);
   });
 
-  it("keeps legacy text-only layout elements unchanged", () => {
+  it("projects legacy text-only layout elements through rich text rendering", () => {
     const { elements } = buildLayoutElements(
       [
         {
@@ -57,6 +67,46 @@ describe("layout rich text projection", () => {
       { layoutId: "layout-1" },
     );
 
-    expect(elements[0].content).toBe("Hello");
+    expect(elements[0].content).toEqual([{ text: "Hello" }]);
+  });
+
+  it("preserves the default menu font weights for legacy text", () => {
+    const cases = [
+      {
+        layoutId: "ob6i5RdAgrcK",
+        itemId: "7YoNNxFhJ6Je",
+        text: "Back",
+      },
+      {
+        layoutId: "fKr5fa67MQWh",
+        itemId: "icn4dknq2kyp",
+        text: "Load",
+      },
+      {
+        layoutId: "ob6i5RdAgrcK",
+        itemId: "PFLWNXpZDXXU",
+        text: "Options",
+      },
+    ];
+
+    for (const { layoutId, itemId, text } of cases) {
+      const layout = defaultRepository.layouts.items[layoutId];
+      const item = layout.elements.items[itemId];
+      const [element] = buildLayoutRenderElements(
+        [item],
+        defaultRepository.images,
+        defaultRepository.textStyles,
+        defaultRepository.colors,
+        defaultRepository.fonts,
+        {
+          layoutId: layout.id,
+          layoutSchemaVersion: layout.layoutSchemaVersion,
+        },
+      );
+
+      expect(element.content).toEqual([{ text }]);
+      expect(element.textStyle.fontWeight).toBe("700");
+      expect(element.hover.textStyle.fontWeight).toBe("400");
+    }
   });
 });


### PR DESCRIPTION
## Summary

- project legacy text-only layout nodes through the rich-text renderer so `fontWeight` reaches Pixi
- use the Menu Item text style for the default Load menu entry
- cover Back, Load, and Options font weights from the default repository template

## Testing

- `bunx vitest run tests/project/layout*.test.js tests/project/defaultTemplateIdFormat.test.js tests/layoutEditor/layoutEditorPreview.test.js` (54 passed)
- `node scripts/test-route-engine-project-data.js`
- Prettier, oxlint, and `git diff --check`
- headless Chrome verification with the real Route Graphics/Pixi runtime: projected text rendered at weight 700 while the legacy string control rendered as normal