### PR TITLE
fix: hide deleted dialogue presentation state

### DIFF
--- a/src/components/systemActions/systemActions.handlers.js
+++ b/src/components/systemActions/systemActions.handlers.js
@@ -19,6 +19,14 @@ const normalizeActionsObject = (value) => {
   return normalizeLineActions(toPlainObject(value));
 };
 
+const syncActions = (store, value) => {
+  const actions = toPlainObject(value);
+  store.setAuthoredDialogueWasCleared({
+    authoredDialogueWasCleared: actions.dialogue?.clear === true,
+  });
+  store.updateActions(normalizeActionsObject(actions));
+};
+
 const mergeActions = (currentActions, nextPartialActions) => {
   return {
     ...toPlainObject(currentActions),
@@ -60,12 +68,9 @@ const syncRepositoryState = (deps) => {
 export const open = (deps, payload) => {
   const { store, render } = deps;
   const { mode, actions } = payload;
-  const nextActions =
-    actions !== undefined
-      ? normalizeActionsObject(actions)
-      : normalizeActionsObject(deps.props?.actions);
+  const nextActions = actions !== undefined ? actions : deps.props?.actions;
 
-  store.updateActions(nextActions);
+  syncActions(store, nextActions);
   store.showActionsDialog();
   store.setMode({ mode });
   render();
@@ -80,7 +85,7 @@ export const handleAfterMount = async (deps) => {
 export const handleBeforeMount = (deps) => {
   const { props, render, store, uiConfig } = deps;
   store.setUiConfig({ uiConfig });
-  store.updateActions(normalizeActionsObject(props.actions));
+  syncActions(store, props.actions);
   store.setRepositoryState({
     repositoryState: deps.projectService.getRepositoryState(),
   });
@@ -91,7 +96,7 @@ export const handleOnUpdate = (deps, changes) => {
   const { render, store } = deps;
   const { newProps } = changes;
   syncRepositoryState(deps);
-  store.updateActions(normalizeActionsObject(newProps.actions));
+  syncActions(store, newProps.actions);
 
   if (
     !isBooleanPropEnabled(newProps?.suppressDialogClose) &&
@@ -292,6 +297,11 @@ export const handleCommandLineSubmit = (deps, payload) => {
     mergeActions(store.selectAction(), submittedActions),
   );
 
+  if (Object.hasOwn(submittedActions, "dialogue")) {
+    store.setAuthoredDialogueWasCleared({
+      authoredDialogueWasCleared: submittedActions.dialogue?.clear === true,
+    });
+  }
   store.updateActions(nextActions);
   dispatchEvent(
     new CustomEvent("actions-change", {

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -472,6 +472,15 @@ const resolveDialogueActionForPreview = ({
   return authoredDialogue ?? presentationDialogue;
 };
 
+const isDisplayablePresentationDialogue = (dialogue, layoutsItems) => {
+  if (dialogue?.clear === true) {
+    return false;
+  }
+
+  const layoutId = dialogue?.ui?.resourceId ?? dialogue?.gui?.resourceId;
+  return Boolean(layoutsItems?.[layoutId]?.name);
+};
+
 const findSectionReference = (sceneItems = {}, sectionId) => {
   if (typeof sectionId !== "string" || sectionId.length === 0) {
     return {};
@@ -946,7 +955,12 @@ export const selectActionsData = ({ props, state, copy }) => {
     props,
   });
 
-  if (dialogueAction) {
+  const shouldShowDialogue =
+    dialogueAction &&
+    (props.actionType !== "presentation" ||
+      isDisplayablePresentationDialogue(dialogueAction, layoutsItems));
+
+  if (shouldShowDialogue) {
     actionsObject.dialogue = dialogueAction;
     const authoredDialogue = isPlainObject(actions.dialogue)
       ? actions.dialogue

--- a/src/components/systemActions/systemActions.store.js
+++ b/src/components/systemActions/systemActions.store.js
@@ -23,6 +23,7 @@ import {
 export const createInitialState = () => ({
   mode: "actions",
   actions: {},
+  authoredDialogueWasCleared: false,
   isTouchMode: false,
   isActionsDialogOpen: false,
   suppressDialogClose: false,
@@ -189,6 +190,8 @@ export const selectViewData = ({ state, props, props: attrs, i18n }) => {
   const displayActions = selectDisplayActions({ state });
   const actionProps = { ...props };
   actionProps.actions = selectAction({ state });
+  actionProps.authoredDialogueWasCleared =
+    state.authoredDialogueWasCleared === true;
   const { actions: actionsObject, preview } = selectActionsData({
     props: actionProps,
     state,
@@ -356,6 +359,13 @@ export const updateActions = ({ state }, payload = {}) => {
   if (previousVoiceResourceId !== nextVoiceResourceId) {
     closeAudioPlayer({ state });
   }
+};
+
+export const setAuthoredDialogueWasCleared = (
+  { state },
+  { authoredDialogueWasCleared } = {},
+) => {
+  state.authoredDialogueWasCleared = authoredDialogueWasCleared === true;
 };
 
 export const showActionsDialog = ({ state }, _payload = {}) => {
@@ -954,9 +964,14 @@ export const selectActionsData = ({ props, state, copy }) => {
     presentationState,
     props,
   });
+  const authoredDialogueWasCleared =
+    props.actionType === "presentation" &&
+    (props.authoredDialogueWasCleared === true ||
+      props.actions?.dialogue?.clear === true);
 
   const shouldShowDialogue =
     dialogueAction &&
+    !authoredDialogueWasCleared &&
     (props.actionType !== "presentation" ||
       isDisplayablePresentationDialogue(dialogueAction, layoutsItems));
 

--- a/src/internal/project/engineActions.js
+++ b/src/internal/project/engineActions.js
@@ -90,10 +90,10 @@ const normalizeDialogueAction = (dialogue = {}) => {
     normalizedDialogue.content = [{ text: normalizedDialogue.content }];
   }
 
-  const hasNonClearFields = Object.keys(normalizedDialogue).some(
-    (key) => key !== "clear",
+  const hasPresentationFields = Object.keys(normalizedDialogue).some(
+    (key) => key !== "clear" && key !== "content",
   );
-  if (normalizedDialogue.clear === true && hasNonClearFields) {
+  if (normalizedDialogue.clear === true && hasPresentationFields) {
     delete normalizedDialogue.clear;
   }
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -3000,7 +3000,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
     const selectedLine = store.selectSelectedLine();
 
     if (actionsType && selectedLineId && selectedSectionId) {
-      // Special handling for dialogue - keep content, remove only layoutId and characterId
+      // Keep editable content while clearing the dialogue presentation.
       if (actionsType === "dialogue") {
         const currentDialogue = selectedLine?.actions?.dialogue;
         if (currentDialogue) {
@@ -3009,7 +3009,7 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
             async () => {
               await projectService.updateLineDialogueAction({
                 lineId: selectedLineId,
-                dialogue: {},
+                dialogue: { clear: true },
                 preserve: ["dialogue.content"],
               });
             },
@@ -3616,9 +3616,7 @@ export const handleSystemActionsActionDelete = async (deps, payload) => {
   // For inherited actions (visual, character, background), we set a "clear" value
   // to override inherited state. For non-inherited actions, we delete the key.
   const newActions = structuredClone(selectedLine.actions || {});
-  if (actionType === "dialogue") {
-    newActions.dialogue = { clear: true };
-  } else if (actionType === "visual") {
+  if (actionType === "visual") {
     // Clear visual by setting empty items array
     newActions.visual = { items: [] };
   } else if (actionType === "character") {
@@ -3639,6 +3637,15 @@ export const handleSystemActionsActionDelete = async (deps, payload) => {
   await runSceneEditorPersistence(
     deps,
     async () => {
+      if (actionType === "dialogue") {
+        await projectService.updateLineDialogueAction({
+          lineId: selectedLine.id,
+          dialogue: { clear: true },
+          preserve: ["dialogue.content"],
+        });
+        return;
+      }
+
       await projectService.updateLineActions({
         lineId: selectedLine.id,
         data: newActions,

--- a/tests/project/engineActions.test.js
+++ b/tests/project/engineActions.test.js
@@ -16,7 +16,23 @@ describe("normalizeLineActions", () => {
     });
   });
 
-  it("removes stale dialogue clear when dialogue data is present", () => {
+  it("keeps dialogue clear while editable content is present", () => {
+    expect(
+      normalizeLineActions({
+        dialogue: {
+          clear: true,
+          content: [{ text: "Keep writing" }],
+        },
+      }),
+    ).toEqual({
+      dialogue: {
+        clear: true,
+        content: [{ text: "Keep writing" }],
+      },
+    });
+  });
+
+  it("removes stale dialogue clear when presentation data is present", () => {
     expect(
       normalizeLineActions({
         dialogue: {

--- a/tests/project/projection.test.js
+++ b/tests/project/projection.test.js
@@ -5,6 +5,7 @@ import {
   collectUsedResourcesForExport,
   constructProjectData,
   getSectionPresentation,
+  projectRepositoryStateToDomainState,
 } from "../../src/internal/project/projection.js";
 
 const createTreeCollection = (items = {}, tree = []) => ({
@@ -75,6 +76,52 @@ const selectRouteEngineRenderState = (projectData) => {
 
   return engine.selectRenderState();
 };
+
+describe("projectRepositoryStateToDomainState", () => {
+  it("keeps dialogue cleared when its editable content is preserved", () => {
+    const state = projectRepositoryStateToDomainState({
+      repositoryState: {
+        scenes: createTreeCollection(
+          {
+            "scene-1": {
+              id: "scene-1",
+              type: "scene",
+              sections: createTreeCollection(
+                {
+                  "section-1": {
+                    id: "section-1",
+                    lines: createTreeCollection(
+                      {
+                        "line-1": {
+                          id: "line-1",
+                          actions: {
+                            dialogue: {
+                              clear: true,
+                              content: [{ text: "Keep writing" }],
+                            },
+                          },
+                        },
+                      },
+                      [{ id: "line-1" }],
+                    ),
+                  },
+                },
+                [{ id: "section-1" }],
+              ),
+            },
+          },
+          [{ id: "scene-1" }],
+        ),
+      },
+      projectId: "project-1",
+    });
+
+    expect(state.lines["line-1"].actions.dialogue).toEqual({
+      clear: true,
+      content: [{ text: "Keep writing" }],
+    });
+  });
+});
 
 describe("constructProjectData", () => {
   it("counts conditional branch targets when determining section presentation", () => {

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -15,6 +15,7 @@ import {
   handlePreviewClick,
   handleSectionMoveSceneFormActionClick,
   handleSelectedLineChanged,
+  handleSystemActionsActionDelete,
   handleSystemActionsDialogOpen,
   handleTemporaryPresentationStateChange,
   scrollEntrySelectionIntoView,
@@ -1327,6 +1328,130 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       lineId: "line-1",
       dialogue: {
         characterId: "character-2",
+      },
+      preserve: ["dialogue.content"],
+    });
+  });
+
+  it("preserves dialogue content behind a clear marker when deleting from presentation state", async () => {
+    const saveError = new Error("stop after assertion");
+    const updateLineDialogueAction = vi.fn(async () => {
+      throw saveError;
+    });
+    const store = {
+      selectSelectedLine: vi.fn(() => ({
+        id: "line-1",
+        actions: {
+          dialogue: {
+            ui: {
+              resourceId: "dialogue-layout",
+            },
+            content: [{ text: "Keep writing" }],
+          },
+        },
+      })),
+      selectDraftSection: vi.fn(() => undefined),
+    };
+
+    await expect(
+      handleSystemActionsActionDelete(
+        {
+          store,
+          render: vi.fn(),
+          i18n: {
+            resourcePages: {},
+            scenesPage: {},
+            sceneEditorPage: {},
+            commandLinePage: {},
+          },
+          subject: {
+            dispatch: vi.fn(),
+          },
+          projectService: {
+            updateLineDialogueAction,
+          },
+        },
+        {
+          _event: {
+            detail: {
+              actionType: "dialogue",
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("stop after assertion");
+
+    expect(updateLineDialogueAction).toHaveBeenCalledWith({
+      lineId: "line-1",
+      dialogue: {
+        clear: true,
+      },
+      preserve: ["dialogue.content"],
+    });
+  });
+
+  it("preserves dialogue content behind a clear marker when deleting from the line menu", async () => {
+    const saveError = new Error("stop after assertion");
+    const updateLineDialogueAction = vi.fn(async () => {
+      throw saveError;
+    });
+    const store = {
+      selectDropdownMenu: vi.fn(() => ({
+        actionsType: "dialogue",
+        lineId: "line-1",
+      })),
+      selectSceneId: vi.fn(() => "scene-1"),
+      hideDropdownMenu: vi.fn(),
+      selectSelectedLineId: vi.fn(() => "line-1"),
+      selectSelectedSectionId: vi.fn(() => "section-1"),
+      selectSelectedLine: vi.fn(() => ({
+        id: "line-1",
+        actions: {
+          dialogue: {
+            ui: {
+              resourceId: "dialogue-layout",
+            },
+            content: [{ text: "Keep writing" }],
+          },
+        },
+      })),
+      selectDraftSection: vi.fn(() => undefined),
+    };
+
+    await expect(
+      handleDropdownMenuClickItem(
+        {
+          store,
+          render: vi.fn(),
+          i18n: {
+            resourcePages: {},
+            scenesPage: {},
+            sceneEditorPage: {},
+            commandLinePage: {},
+          },
+          subject: {
+            dispatch: vi.fn(),
+          },
+          projectService: {
+            updateLineDialogueAction,
+          },
+        },
+        {
+          _event: {
+            detail: {
+              item: {
+                value: "delete-actions",
+              },
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("stop after assertion");
+
+    expect(updateLineDialogueAction).toHaveBeenCalledWith({
+      lineId: "line-1",
+      dialogue: {
+        clear: true,
       },
       preserve: ["dialogue.content"],
     });

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -917,6 +917,7 @@ describe("systemActions.handlers", () => {
     expect(state.authoredDialogueWasCleared).toBe(true);
     expect(selectAction({ state })).toEqual({
       dialogue: {
+        clear: true,
         content: [{ text: "Keep writing" }],
       },
     });

--- a/tests/systemActions/systemActions.handlers.test.js
+++ b/tests/systemActions/systemActions.handlers.test.js
@@ -5,6 +5,7 @@ import {
   openAudioPlayer,
   selectVoicePreview,
   selectAction,
+  setAuthoredDialogueWasCleared,
   setRepositoryState,
   updateActions,
 } from "../../src/components/systemActions/systemActions.store.js";
@@ -150,6 +151,8 @@ describe("systemActions.handlers", () => {
     const deps = {
       store: {
         selectAction: () => selectAction({ state }),
+        setAuthoredDialogueWasCleared: (payload) =>
+          setAuthoredDialogueWasCleared({ state }, payload),
         updateActions: (payload) => updateActions({ state }, payload),
         hideActionsDialog: () => {},
       },
@@ -195,6 +198,8 @@ describe("systemActions.handlers", () => {
     const deps = {
       store: {
         selectAction: () => selectAction({ state }),
+        setAuthoredDialogueWasCleared: (payload) =>
+          setAuthoredDialogueWasCleared({ state }, payload),
         updateActions: (payload) => updateActions({ state }, payload),
         hideActionsDialog: () => {},
       },
@@ -235,9 +240,16 @@ describe("systemActions.handlers", () => {
     const state = createInitialState();
     const dispatchedEvents = [];
 
+    setAuthoredDialogueWasCleared(
+      { state },
+      { authoredDialogueWasCleared: true },
+    );
+
     const deps = {
       store: {
         selectAction: () => selectAction({ state }),
+        setAuthoredDialogueWasCleared: (payload) =>
+          setAuthoredDialogueWasCleared({ state }, payload),
         updateActions: (payload) => updateActions({ state }, payload),
         hideActionsDialog: () => {},
       },
@@ -269,6 +281,7 @@ describe("systemActions.handlers", () => {
     });
 
     expect(dispatchedEvents).toHaveLength(1);
+    expect(state.authoredDialogueWasCleared).toBe(false);
     expect(dispatchedEvents[0].detail).toEqual({
       dialogue: {
         mode: "adv",
@@ -814,6 +827,8 @@ describe("systemActions.handlers", () => {
       },
       store: {
         updateActions: (payload) => updateActions({ state }, payload),
+        setAuthoredDialogueWasCleared: (payload) =>
+          setAuthoredDialogueWasCleared({ state }, payload),
         showActionsDialog: () => {},
         setMode: () => {},
       },
@@ -844,6 +859,8 @@ describe("systemActions.handlers", () => {
       },
       store: {
         updateActions: (payload) => updateActions({ state }, payload),
+        setAuthoredDialogueWasCleared: (payload) =>
+          setAuthoredDialogueWasCleared({ state }, payload),
         showActionsDialog: () => {},
         setMode: () => {},
       },
@@ -870,6 +887,37 @@ describe("systemActions.handlers", () => {
       updateVariable: {
         id: "updateVariable1",
         operations: [],
+      },
+    });
+  });
+
+  it("keeps an authored dialogue clear marker when syncing editable content", () => {
+    const state = createInitialState();
+    const deps = {
+      props: {
+        actions: {
+          dialogue: {
+            clear: true,
+            content: [{ text: "Keep writing" }],
+          },
+        },
+      },
+      store: {
+        updateActions: (payload) => updateActions({ state }, payload),
+        setAuthoredDialogueWasCleared: (payload) =>
+          setAuthoredDialogueWasCleared({ state }, payload),
+        showActionsDialog: () => {},
+        setMode: () => {},
+      },
+      render: () => {},
+    };
+
+    open(deps, { mode: "actions" });
+
+    expect(state.authoredDialogueWasCleared).toBe(true);
+    expect(selectAction({ state })).toEqual({
+      dialogue: {
+        content: [{ text: "Keep writing" }],
       },
     });
   });
@@ -1062,6 +1110,8 @@ describe("systemActions.handlers", () => {
         store: {
           setRepositoryState: (payload) =>
             setRepositoryState({ state }, payload),
+          setAuthoredDialogueWasCleared: (payload) =>
+            setAuthoredDialogueWasCleared({ state }, payload),
           updateActions: (payload) => updateActions({ state }, payload),
         },
         render,

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -5,6 +5,7 @@ import {
   openAudioPlayer,
   selectActionsData,
   selectViewData as selectViewDataBase,
+  setAuthoredDialogueWasCleared,
   setUiConfig,
   setRepositoryState,
   updateActions,
@@ -1102,6 +1103,62 @@ describe("systemActions.store", () => {
         presentationState: {
           dialogue: {
             clear: true,
+          },
+        },
+      },
+    });
+
+    expect(actions.dialogue).toBeUndefined();
+    expect(preview.dialogue).toBeUndefined();
+  });
+
+  it("keeps cleared dialogue hidden after its content is edited", () => {
+    const state = createInitialState();
+
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          layouts: {
+            items: {
+              "dialogue-layout": {
+                id: "dialogue-layout",
+                type: "layout",
+                name: "Main Dialogue",
+                layoutType: "dialogue-adv",
+              },
+            },
+            tree: [{ id: "dialogue-layout" }],
+          },
+        },
+      },
+    );
+
+    updateActions(
+      { state },
+      {
+        dialogue: {
+          content: [{ text: "Edited after deletion" }],
+        },
+      },
+    );
+    setAuthoredDialogueWasCleared(
+      { state },
+      { authoredDialogueWasCleared: true },
+    );
+
+    const { actions, preview } = selectViewData({
+      state,
+      props: {
+        actionType: "presentation",
+        actions: {},
+        presentationState: {
+          dialogue: {
+            ui: {
+              resourceId: "dialogue-layout",
+            },
+            mode: "adv",
+            content: [{ text: "Edited after deletion" }],
           },
         },
       },

--- a/tests/systemActions/systemActions.store.test.js
+++ b/tests/systemActions/systemActions.store.test.js
@@ -1087,6 +1087,51 @@ describe("systemActions.store", () => {
     });
   });
 
+  it("omits cleared dialogue from the presentation state preview", () => {
+    const state = createInitialState();
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actionType: "presentation",
+        actions: {
+          dialogue: {
+            clear: true,
+          },
+        },
+        presentationState: {
+          dialogue: {
+            clear: true,
+          },
+        },
+      },
+    });
+
+    expect(actions.dialogue).toBeUndefined();
+    expect(preview.dialogue).toBeUndefined();
+  });
+
+  it("omits layout-less dialogue from the presentation state preview", () => {
+    const state = createInitialState();
+
+    const { actions, preview } = selectActionsData({
+      state,
+      props: {
+        actionType: "presentation",
+        actions: {},
+        presentationState: {
+          dialogue: {
+            mode: "adv",
+            content: [{ text: "Deleted dialogue" }],
+          },
+        },
+      },
+    });
+
+    expect(actions.dialogue).toBeUndefined();
+    expect(preview.dialogue).toBeUndefined();
+  });
+
   it("renders dialogue editor props from current component action state", () => {
     const state = createInitialState();
 


### PR DESCRIPTION
## Summary

- omit cleared dialogue and dialogue without a resolvable layout from the scene editor presentation-state list
- preserve dialogue text behind a clear marker when deleting from either presentation state or the line menu
- keep the clear marker through repository projection and subsequent text edits, while real dialogue presentation metadata still restores the dialogue normally
- preserve normal dialogue action previews outside the deleted presentation case

## Validation

- project normalization, projection, and system-actions store suites (57 passed)
- focused system-actions handler regressions (2 passed)
- focused scene-editor deletion regressions (2 passed)
- targeted Prettier and oxlint checks passed
- pre-push full source oxlint and Prettier checks passed
- Chromium right-click check confirmed Delete emits the dialogue event, hides the item, and keeps it hidden after content editing

## Known unrelated test failures

The full system-actions handler test file still has two existing test-harness failures caused by missing `resourcePages` i18n catalogs. The directly affected tests above pass.