### PR TITLE
fix(layout): allow deleting final text character

### DIFF
--- a/src/primitives/lexicalLayoutTextEditor.js
+++ b/src/primitives/lexicalLayoutTextEditor.js
@@ -1984,6 +1984,85 @@ export class LexicalLayoutTextEditorElement extends HTMLElement {
     return this.handleReferenceDelete(event);
   }
 
+  handleFinalPlainTextDelete(event) {
+    const direction = this.getReferenceDeleteDirection(event);
+    if (
+      direction === 0 ||
+      event.isComposing ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.altKey
+    ) {
+      return false;
+    }
+
+    const content = normalizeLayoutTextContent(this.state.content);
+    const item = content[0];
+    if (
+      content.length !== 1 ||
+      getLayoutTextReferenceResourceId(item) ||
+      Array.from(item.text ?? "").length !== 1
+    ) {
+      return false;
+    }
+
+    const textLength = (item.text ?? "").length;
+    const nativeSelection = this.getNativeSelectionTextRange();
+    let shouldDelete = nativeSelection
+      ? (!nativeSelection.collapsed &&
+          nativeSelection.start === 0 &&
+          nativeSelection.end === textLength) ||
+        (nativeSelection.collapsed &&
+          ((direction < 0 && nativeSelection.start === textLength) ||
+            (direction > 0 && nativeSelection.start === 0)))
+      : false;
+
+    if (!nativeSelection) {
+      shouldDelete = this.editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+
+        if (!selection.isCollapsed()) {
+          return true;
+        }
+
+        const { anchor } = selection;
+        if (anchor.type === "text") {
+          return direction < 0
+            ? anchor.offset === textLength
+            : anchor.offset === 0;
+        }
+
+        return direction < 0 ? anchor.offset > 0 : anchor.offset === 0;
+      });
+    }
+
+    if (!shouldDelete) {
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation?.();
+    event.stopImmediatePropagation?.();
+    this.editor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode(""));
+        root.clear();
+        root.append(paragraph);
+        paragraph.selectStart();
+      },
+      { discrete: true },
+    );
+    this.state.content = normalizeLayoutTextContent([]);
+    this.clearSelectedReferenceNodeKey();
+    this.closeMentionMenu("final-plain-text-delete");
+    return true;
+  }
+
   handleEditorFocus() {
     this.isEditorFocused = true;
   }
@@ -1998,7 +2077,10 @@ export class LexicalLayoutTextEditorElement extends HTMLElement {
       event.inputType === "deleteContentBackward" ||
       event.inputType === "deleteContentForward"
     ) {
-      if (this.handleReferenceDelete(event)) {
+      if (
+        this.handleReferenceDelete(event) ||
+        this.handleFinalPlainTextDelete(event)
+      ) {
         return;
       }
     }
@@ -2061,7 +2143,10 @@ export class LexicalLayoutTextEditorElement extends HTMLElement {
       return;
     }
 
-    if (this.handleReferenceDelete(event)) {
+    if (
+      this.handleReferenceDelete(event) ||
+      this.handleFinalPlainTextDelete(event)
+    ) {
       return;
     }
 

--- a/src/primitives/lexicalLayoutTextEditor.js
+++ b/src/primitives/lexicalLayoutTextEditor.js
@@ -70,6 +70,16 @@ const createClosedMentionMenuState = () => ({
 
 const TYPED_SLASH_MENTION_TRIGGER_WINDOW_MS = 1000;
 const isSlashText = (value) => String(value ?? "") === "/";
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+const isSingleGrapheme = (value) => {
+  const segments = graphemeSegmenter
+    .segment(String(value ?? ""))
+    [Symbol.iterator]();
+  return !segments.next().done && segments.next().done;
+};
 
 const getMentionTriggerMatchFromBeforeCaret = ({
   beforeCaret,
@@ -2001,7 +2011,7 @@ export class LexicalLayoutTextEditorElement extends HTMLElement {
     if (
       content.length !== 1 ||
       getLayoutTextReferenceResourceId(item) ||
-      Array.from(item.text ?? "").length !== 1
+      !isSingleGrapheme(item.text)
     ) {
       return false;
     }

--- a/tests/layoutEditor/lexicalLayoutTextEditor.test.js
+++ b/tests/layoutEditor/lexicalLayoutTextEditor.test.js
@@ -343,59 +343,62 @@ describe("lexical layout text editor", () => {
     }
   });
 
-  it("deletes the final plain-text character on Backspace", async () => {
-    const { editorElement, rootElement, dispose } =
-      await createTextEditorHarness();
+  it.each(["x", "👨‍👩‍👧‍👦", "e\u0301"])(
+    "deletes the final plain-text grapheme %s on Backspace",
+    async (contentText) => {
+      const { editorElement, rootElement, dispose } =
+        await createTextEditorHarness();
 
-    try {
-      editorElement.state.content = [{ text: "x" }];
-      editorElement.editor.update(
-        () => {
-          const root = $getRoot();
-          const paragraph = $createParagraphNode();
-          const textNode = $createTextNode("x");
+      try {
+        editorElement.state.content = [{ text: contentText }];
+        editorElement.editor.update(
+          () => {
+            const root = $getRoot();
+            const paragraph = $createParagraphNode();
+            const textNode = $createTextNode(contentText);
 
-          paragraph.append(textNode);
-          root.clear();
-          root.append(paragraph);
-          textNode.selectEnd();
-        },
-        { discrete: true },
-      );
+            paragraph.append(textNode);
+            root.clear();
+            root.append(paragraph);
+            textNode.selectEnd();
+          },
+          { discrete: true },
+        );
 
-      const textNode = rootElement.firstChild.firstChild;
-      const range = document.createRange();
-      range.setStart(textNode, 1);
-      range.collapse(true);
-      window.getSelection().removeAllRanges();
-      window.getSelection().addRange(range);
+        const textNode = rootElement.firstChild.firstChild.firstChild;
+        const range = document.createRange();
+        range.setStart(textNode, contentText.length);
+        range.collapse(true);
+        window.getSelection().removeAllRanges();
+        window.getSelection().addRange(range);
 
-      const event = {
-        key: "Backspace",
-        isComposing: false,
-        ctrlKey: false,
-        metaKey: false,
-        altKey: false,
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn(),
-        stopImmediatePropagation: vi.fn(),
-      };
-      editorElement.handleEditorKeyDown(event);
+        const event = {
+          key: "Backspace",
+          isComposing: false,
+          ctrlKey: false,
+          metaKey: false,
+          altKey: false,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+          stopImmediatePropagation: vi.fn(),
+        };
+        editorElement.handleEditorKeyDown(event);
 
-      expect(event.preventDefault).toHaveBeenCalledTimes(1);
-      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
-      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
-      expect(rootElement.textContent).toBe("");
-      expect(editorElement.getContent()).toEqual([{ text: "" }]);
-      expect(
-        editorElement.editor.getEditorState().read(() => {
-          return $getRoot().getTextContent();
-        }),
-      ).toBe("");
-    } finally {
-      dispose();
-    }
-  });
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+        expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+        expect(rootElement.textContent).toBe("");
+        expect(editorElement.getContent()).toEqual([{ text: "" }]);
+        expect(
+          editorElement.editor.getEditorState().read(() => {
+            return $getRoot().getTextContent();
+          }),
+        ).toBe("");
+      } finally {
+        dispose();
+      }
+    },
+  );
 
   it("deletes the final plain-text character on beforeinput", async () => {
     const { editorElement, rootElement, dispose } =

--- a/tests/layoutEditor/lexicalLayoutTextEditor.test.js
+++ b/tests/layoutEditor/lexicalLayoutTextEditor.test.js
@@ -343,6 +343,109 @@ describe("lexical layout text editor", () => {
     }
   });
 
+  it("deletes the final plain-text character on Backspace", async () => {
+    const { editorElement, rootElement, dispose } =
+      await createTextEditorHarness();
+
+    try {
+      editorElement.state.content = [{ text: "x" }];
+      editorElement.editor.update(
+        () => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          const textNode = $createTextNode("x");
+
+          paragraph.append(textNode);
+          root.clear();
+          root.append(paragraph);
+          textNode.selectEnd();
+        },
+        { discrete: true },
+      );
+
+      const textNode = rootElement.firstChild.firstChild;
+      const range = document.createRange();
+      range.setStart(textNode, 1);
+      range.collapse(true);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+
+      const event = {
+        key: "Backspace",
+        isComposing: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+      editorElement.handleEditorKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(rootElement.textContent).toBe("");
+      expect(editorElement.getContent()).toEqual([{ text: "" }]);
+      expect(
+        editorElement.editor.getEditorState().read(() => {
+          return $getRoot().getTextContent();
+        }),
+      ).toBe("");
+    } finally {
+      dispose();
+    }
+  });
+
+  it("deletes the final plain-text character on beforeinput", async () => {
+    const { editorElement, rootElement, dispose } =
+      await createTextEditorHarness();
+
+    try {
+      editorElement.state.content = [{ text: "x" }];
+      editorElement.editor.update(
+        () => {
+          const root = $getRoot();
+          const paragraph = $createParagraphNode();
+          const textNode = $createTextNode("x");
+
+          paragraph.append(textNode);
+          root.clear();
+          root.append(paragraph);
+          textNode.selectEnd();
+        },
+        { discrete: true },
+      );
+
+      const textNode = rootElement.firstChild.firstChild;
+      const range = document.createRange();
+      range.setStart(textNode, 1);
+      range.collapse(true);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+
+      const event = {
+        inputType: "deleteContentBackward",
+        isComposing: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+      editorElement.handleEditorBeforeInput(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(rootElement.textContent).toBe("");
+      expect(editorElement.getContent()).toEqual([{ text: "" }]);
+    } finally {
+      dispose();
+    }
+  });
+
   it("selects a variable chip before Backspace removes it", async () => {
     const [
       { $createMentionNode },


### PR DESCRIPTION
Summary:
- handle deletion of the final plain-text character in the layout text content editor
- cover both keydown and beforeinput deletion paths
- add regression coverage for the empty-content result

Validation:
- bun run lint
- bunx vitest run tests/layoutEditor/lexicalLayoutTextEditor.test.js
- bun run build:web