### PR TITLE
Prevent dropped files from replacing the Tauri view

### DIFF
--- a/src/deps/clients/tauri/fileDropNavigation.js
+++ b/src/deps/clients/tauri/fileDropNavigation.js
@@ -1,0 +1,47 @@
+const FILE_DRAG_TYPE = "Files";
+const LISTENER_OPTIONS = { capture: true };
+
+const containsFiles = (event) => {
+  const dataTransfer = event.dataTransfer;
+  const types = Array.from(dataTransfer?.types ?? []);
+  if (types.includes(FILE_DRAG_TYPE)) {
+    return true;
+  }
+
+  const items = Array.from(dataTransfer?.items ?? []);
+  if (items.some((item) => item.kind === "file")) {
+    return true;
+  }
+
+  return (dataTransfer?.files?.length ?? 0) > 0;
+};
+
+export const setupFileDropNavigationGuard = ({ target = window } = {}) => {
+  const preventFileDropNavigation = (event) => {
+    if (!containsFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+  };
+
+  target.addEventListener(
+    "dragover",
+    preventFileDropNavigation,
+    LISTENER_OPTIONS,
+  );
+  target.addEventListener("drop", preventFileDropNavigation, LISTENER_OPTIONS);
+
+  return () => {
+    target.removeEventListener(
+      "dragover",
+      preventFileDropNavigation,
+      LISTENER_OPTIONS,
+    );
+    target.removeEventListener(
+      "drop",
+      preventFileDropNavigation,
+      LISTENER_OPTIONS,
+    );
+  };
+};

--- a/src/pages/images/images.handlers.js
+++ b/src/pages/images/images.handlers.js
@@ -669,58 +669,6 @@ export const handleFilesDropRejected = (deps, payload) => {
   showInvalidFormatToast(appService, copy);
 };
 
-export const handleFormExtraEvent = async (deps) => {
-  const { appService, projectService, store } = deps;
-  const copy = selectCopy(deps);
-  const selectedItem = store.selectSelectedItem();
-  if (!selectedItem) {
-    return;
-  }
-
-  const result = await pickAndUploadImage({ appService, projectService, copy });
-  if (result.cancelled) {
-    return;
-  }
-
-  if (result.errorType === "pick-failed") {
-    showResourcePageError({
-      appService,
-      errorOrResult: result.error,
-      fallbackMessage: copy.failedSelectFile,
-    });
-    return;
-  }
-
-  if (result.errorType === "validation-failed") {
-    return;
-  }
-
-  if (result.errorType === "upload-failed") {
-    appService.showAlert({
-      message: copy.failedUploadImage,
-      title: copy.errorTitle,
-    });
-    return;
-  }
-
-  const { uploadResult } = result;
-  const updateAttempt = await runResourcePageMutation({
-    appService,
-    fallbackMessage: copy.failedUpdateImage,
-    action: () =>
-      projectService.updateImage({
-        imageId: selectedItem.id,
-        fileRecords: uploadResult.fileRecords,
-        data: buildImageResourcePatchFromUploadResult(uploadResult),
-      }),
-  });
-  if (!updateAttempt.ok) {
-    return;
-  }
-
-  await handleDataChanged(deps);
-};
-
 export const handleImageItemPreview = (deps, payload) => {
   const { itemId, source } = payload._event.detail;
   openImagePreviewById({

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -240,7 +240,7 @@ template:
                                   - rvn-detail-view#detailView key=${selectedDetailId} w=f h=1fg :fields=${detailFields}:
                                       - $if selectedItemId:
                                           - $if selectedPreviewFileId:
-                                              - 'div.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
+                                              - 'div#detailImagePreview.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
                                                   - rvn-file-image fileId=${selectedPreviewFileId} w=f h=f: null
                                           - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null
                             $else:

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -150,10 +150,6 @@ refs:
     eventListeners:
       click:
         handler: handleEditDialogImageClick
-  detailImage:
-    eventListeners:
-      click:
-        handler: handleFormExtraEvent
   detailHeader:
     eventListeners:
       click:
@@ -213,7 +209,8 @@ styles:
     box-shadow: 0 0 0 1px var(--border)
     border-radius: 6px
     overflow: hidden
-    cursor: pointer
+    cursor: default
+    pointer-events: none
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f w=f style="min-width: 0; min-height: 0;"':
@@ -243,7 +240,7 @@ template:
                                   - rvn-detail-view#detailView key=${selectedDetailId} w=f h=1fg :fields=${detailFields}:
                                       - $if selectedItemId:
                                           - $if selectedPreviewFileId:
-                                              - 'div#detailImage.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
+                                              - 'div.imageDetailPreviewFrame.imagePreviewTransparencyGrid slot="image-file-id"':
                                                   - rvn-file-image fileId=${selectedPreviewFileId} w=f h=f: null
                                           - rtgl-tag-select#detailTagSelect key=${selectedItemId} slot="image-tags" w=f :options=${tagFilterOptions} :selectedValues=${selectedItemTagIds} :draftSelectedValues=${detailTagDraftValues} :open=${isDetailTagSelectOpen} :addOption=${detailTagAddOption} :placeholder=${addTagPlaceholder}: null
                             $else:

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -7,6 +7,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 // Infra - Tauri
 import { createDb } from "./deps/clients/tauri/db";
 import { createTauriFilePicker } from "./deps/clients/tauri/filePicker";
+import { setupFileDropNavigationGuard } from "./deps/clients/tauri/fileDropNavigation";
 import createUpdater from "./deps/clients/tauri/updater";
 import { setupCloseListener } from "./deps/clients/tauri/windowClose";
 
@@ -24,6 +25,7 @@ import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectComp
 import { registerPrimitives } from "./primitives/registerPrimitives";
 
 registerPrimitives();
+setupFileDropNavigationGuard();
 
 const rawDistribution = import.meta.env?.VITE_ROUTEVN_DISTRIBUTION;
 const distribution = rawDistribution === "steam" ? rawDistribution : "direct";

--- a/tests/tauri/fileDropNavigation.test.js
+++ b/tests/tauri/fileDropNavigation.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupFileDropNavigationGuard } from "../../src/deps/clients/tauri/fileDropNavigation.js";
+
+const createTarget = () => {
+  const listeners = new Map();
+  return {
+    listeners,
+    addEventListener: vi.fn((eventName, listener) => {
+      listeners.set(eventName, listener);
+    }),
+    removeEventListener: vi.fn((eventName) => {
+      listeners.delete(eventName);
+    }),
+  };
+};
+
+describe("Tauri file drop navigation guard", () => {
+  it.each([
+    { types: ["Files"] },
+    { items: [{ kind: "file" }] },
+    { files: [{ name: "hero.png" }] },
+  ])("prevents browser navigation for file drags", (dataTransfer) => {
+    const target = createTarget();
+    setupFileDropNavigationGuard({ target });
+    const dragOverEvent = {
+      dataTransfer,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+    const dropEvent = {
+      dataTransfer,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    target.listeners.get("dragover")(dragOverEvent);
+    target.listeners.get("drop")(dropEvent);
+
+    expect(dragOverEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dropEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dragOverEvent.stopPropagation).not.toHaveBeenCalled();
+    expect(dropEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("leaves non-file drag behavior unchanged", () => {
+    const target = createTarget();
+    setupFileDropNavigationGuard({ target });
+    const event = {
+      dataTransfer: {
+        types: ["text/plain"],
+        items: [{ kind: "string" }],
+      },
+      preventDefault: vi.fn(),
+    };
+
+    target.listeners.get("dragover")(event);
+    target.listeners.get("drop")(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("registers capture listeners and removes them during cleanup", () => {
+    const target = createTarget();
+    const cleanup = setupFileDropNavigationGuard({ target });
+
+    expect(target.addEventListener).toHaveBeenCalledWith(
+      "dragover",
+      expect.any(Function),
+      { capture: true },
+    );
+    expect(target.addEventListener).toHaveBeenCalledWith(
+      "drop",
+      expect.any(Function),
+      { capture: true },
+    );
+
+    cleanup();
+
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      "dragover",
+      expect.any(Function),
+      { capture: true },
+    );
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      "drop",
+      expect.any(Function),
+      { capture: true },
+    );
+  });
+});

--- a/vt/specs/project/images.yaml
+++ b/vt/specs/project/images.yaml
@@ -137,12 +137,12 @@ steps:
       - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return deepQuery(document, '#fileExplorerDetailKeyboardScope')?.tabIndex; })()"
     value: -1
   - action: screenshot
-  - action: select
-    selector: "#detailImage"
-    steps:
-      - action: click
-  - action: wait
-    ms: 200
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const preview = deepQuery(document, '#detailImagePreview'); return preview ? getComputedStyle(preview).pointerEvents : undefined; })()"
+    value: none
   - action: keypress
     key: j
   - action: wait


### PR DESCRIPTION
## Summary

- make the image detail preview display-only
- prevent external file drops from navigating the Tauri WebView
- preserve existing upload zones and internal drag interactions
- add focused coverage for file detection, propagation, and cleanup
- update the images VT workflow to assert the preview is non-interactive

## Testing

- `bunx vitest run tests/tauri/fileDropNavigation.test.js tests/images/images.handlers.test.js`
- `bun run lint`
- `bunx prettier --check vt/specs/project/images.yaml`
- `git diff --check`