### PR TITLE
chore: bump to 1.9.0 and hide native exports

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/pages/versions/versions.view.yaml
+++ b/src/pages/versions/versions.view.yaml
@@ -15,18 +15,6 @@ refs:
     eventListeners:
       click:
         handler: handleDownloadZipClick
-  detailWindowsExeBtn:
-    eventListeners:
-      click:
-        handler: handleDownloadWindowsExecutableClick
-  detailWindowsInstallerBtn:
-    eventListeners:
-      click:
-        handler: handleDownloadWindowsInstallerClick
-  detailMacosApplicationBtn:
-    eventListeners:
-      click:
-        handler: handleDownloadMacosApplicationClick
   detailHeader:
     eventListeners:
       click:
@@ -90,12 +78,6 @@ template:
                               - rvn-detail-view#detailView key=${selectedItemId} w=f h=1fg :fields=${detailFields}:
                                   - rtgl-view slot=actions d=v g=sm w=f:
                                       - rtgl-button#detailDownloadBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWebButton}
-                                      - $if canExportWindowsExecutable:
-                                          - rtgl-button#detailWindowsExeBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsExecutableButton}
-                                      - $if canExportWindowsInstaller:
-                                          - rtgl-button#detailWindowsInstallerBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsInstallerButton}
-                                      - $if canExportMacosApplication:
-                                          - rtgl-button#detailMacosApplicationBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportMacosApplicationButton}
                         $else:
                           - rtgl-view wh=f av=c ah=c bgc=mu-fg:
                               - rtgl-text s=md c=mu-fg: ${noSelectionLabel}
@@ -109,12 +91,6 @@ template:
                   - rvn-detail-view#mobileDetailView key=${selectedItemId} w=f :fields=${mobileDetailFields} :fillHeight=${mobileDetailFillHeight}:
                       - rtgl-view slot=actions d=v g=sm w=f:
                           - rtgl-button#detailDownloadBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWebButton}
-                          - $if canExportWindowsExecutable:
-                              - rtgl-button#detailWindowsExeBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsExecutableButton}
-                          - $if canExportWindowsInstaller:
-                              - rtgl-button#detailWindowsInstallerBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportWindowsInstallerButton}
-                          - $if canExportMacosApplication:
-                              - rtgl-button#detailMacosApplicationBtn data-version-id="${selectedItemId}" v=se s=sm pre=download w=f: ${exportMacosApplicationButton}
   - rtgl-dialog#versionDialog ?open=${isVersionDialogOpen} s=md:
       - rtgl-view slot=content w=f:
           - rtgl-form#versionForm :form=${versionForm} w=f: null

--- a/tests/versions/versions.view.test.js
+++ b/tests/versions/versions.view.test.js
@@ -7,27 +7,15 @@ const versionsView = readFileSync(
 );
 
 describe("versions view export actions", () => {
-  it("renders gated Windows installer actions in desktop and mobile details", () => {
-    expect(versionsView.match(/\$if canExportWindowsInstaller:/g)).toHaveLength(
-      2,
-    );
-    expect(
-      versionsView.match(/rtgl-button#detailWindowsInstallerBtn/g),
-    ).toHaveLength(2);
-    expect(
-      versionsView.match(/\$\{exportWindowsInstallerButton\}/g),
-    ).toHaveLength(2);
+  it("hides Windows export actions from all detail layouts", () => {
+    expect(versionsView).not.toContain("detailWindowsExeBtn");
+    expect(versionsView).not.toContain("detailWindowsInstallerBtn");
+    expect(versionsView).not.toContain("canExportWindowsExecutable");
+    expect(versionsView).not.toContain("canExportWindowsInstaller");
   });
 
-  it("renders gated macOS application actions in desktop and mobile details", () => {
-    expect(versionsView.match(/\$if canExportMacosApplication:/g)).toHaveLength(
-      2,
-    );
-    expect(
-      versionsView.match(/rtgl-button#detailMacosApplicationBtn/g),
-    ).toHaveLength(2);
-    expect(
-      versionsView.match(/\$\{exportMacosApplicationButton\}/g),
-    ).toHaveLength(2);
+  it("hides macOS export actions from all detail layouts", () => {
+    expect(versionsView).not.toContain("detailMacosApplicationBtn");
+    expect(versionsView).not.toContain("canExportMacosApplication");
   });
 });

--- a/vt/specs/project/versions.yaml
+++ b/vt/specs/project/versions.yaml
@@ -106,7 +106,7 @@ steps:
     state: visible
     timeoutMs: 10000
   - action: waitFor
-    selector: "#detailMacosApplicationBtn"
+    selector: "#detailDownloadBtn"
     state: visible
     timeoutMs: 5000
   - action: wait


### PR DESCRIPTION
## Summary

- bump the Tauri app version to 1.9.0
- hide Windows executable, Windows installer, and macOS application exports from desktop and mobile Versions detail layouts
- update the Versions view regression coverage and VT workflow for the hidden native export actions

## Testing

- `bun run lint`
- `bunx prettier --check src-tauri/tauri.conf.json tests/versions/versions.view.test.js vt/specs/project/versions.yaml`
- `bunx vitest run tests/versions` (22 tests passed)
- parsed `src-tauri/tauri.conf.json` as JSON
- `git diff --check`
