### PR TITLE
Fix WebKit IME composition commits in scene editor

### DIFF
--- a/docs/notes/macos-tauri-lexical-selection.md
+++ b/docs/notes/macos-tauri-lexical-selection.md
@@ -115,9 +115,10 @@ caret.
 
 The primitive handles this final commit before the general composing-event
 early return. It resolves only the event's committed text, prevents the native
-DOM mutation, maps the event target range to a line selection, and calls
-`insertPlainText` so the DOM, Lexical state, and serialized scene lines advance
-together. Ongoing composition events remain browser-managed.
+DOM mutation, maps the event target range to a line selection, clears Lexical's
+composition key, and calls `insertPlainText` so the DOM, Lexical state,
+serialized scene lines, and caret advance together. Ongoing composition events
+remain browser-managed.
 
 Regression coverage must include both the `insertFromComposition` commit and a
 following ordinary Space insertion. Checking only that the Chinese text appears

--- a/docs/notes/macos-tauri-lexical-selection.md
+++ b/docs/notes/macos-tauri-lexical-selection.md
@@ -1,10 +1,13 @@
-# macOS Tauri Lexical Selection Notes
+# Tauri WebKit Lexical Selection and IME Notes
 
 ## Symptoms
 
 In the scene document Lexical editor on macOS Tauri, the editor can be focused
 and receive keyboard events while printable typing or Enter-based line splitting
 does not visibly update the document.
+
+On Linux and macOS, Chinese IME commits could also appear at the caret and then
+disappear when the user pressed Space or entered another ordinary character.
 
 Observed selection/focus behavior:
 
@@ -96,3 +99,26 @@ as the source of truth before selection-sensitive text edits:
   before native selection paints; double-click selects the trailing word and a
   third click selects the full line content, while regular word selection and
   final-line selection stay native
+- final `insertFromComposition` commits are prevented from mutating only the
+  contenteditable DOM and are inserted through Lexical at the native target
+  range instead
+
+## IME Composition Commits
+
+WebKitGTK and macOS WebKit can emit a final, cancelable `beforeinput` event with
+`inputType: "insertFromComposition"`, the committed text in `data`, and
+`isComposing: true`. In the failing path, WebKit inserted that text into the
+contenteditable DOM and advanced the native caret, but Lexical's editor state
+did not change. The next controlled `insertText` operation reconciled the DOM
+from stale Lexical state, which removed every untracked IME commit before the
+caret.
+
+The primitive handles this final commit before the general composing-event
+early return. It resolves only the event's committed text, prevents the native
+DOM mutation, maps the event target range to a line selection, and calls
+`insertPlainText` so the DOM, Lexical state, and serialized scene lines advance
+together. Ongoing composition events remain browser-managed.
+
+Regression coverage must include both the `insertFromComposition` commit and a
+following ordinary Space insertion. Checking only that the Chinese text appears
+in the DOM does not catch the stale-state failure.

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -8,6 +8,7 @@ import {
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  $setCompositionKey,
   COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_HIGH,
   KEY_ENTER_COMMAND,
@@ -4673,7 +4674,8 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     // Linux and macOS WebKit can apply an IME commit to the contenteditable
     // DOM without updating Lexical's editor state. The next controlled input
     // then reconciles from stale state and removes the committed characters.
-    // Commit through Lexical using the native target range as the caret source.
+    // End Lexical composition before inserting so its range selection advances
+    // past the committed text instead of retaining composing-node semantics.
     if (inputType === "insertFromComposition") {
       const inputText = this.resolveBeforeInputText(event, {
         allowKeyFallback: false,
@@ -4687,11 +4689,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       event.stopPropagation?.();
       event.stopImmediatePropagation?.();
       const nativeSelection = this.getInputLineSelectionContext(event);
-      if (nativeSelection) {
-        this.insertPlainText(inputText, { nativeSelection });
-      } else {
-        this.insertPlainText(inputText);
-      }
+      this.insertPlainText(inputText, {
+        nativeSelection,
+        endComposition: true,
+      });
       return;
     }
 
@@ -6266,13 +6267,17 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     });
   }
 
-  insertPlainText(text, { nativeSelection } = {}) {
+  insertPlainText(text, { nativeSelection, endComposition = false } = {}) {
     const nextText = String(text ?? "").replace(/\r\n?/g, "\n");
     const resolvedNativeSelection =
       nativeSelection ?? this.getNativeLineSelectionContext();
 
     this.editor.update(
       () => {
+        if (endComposition) {
+          $setCompositionKey(null);
+        }
+
         if (resolvedNativeSelection?.lineId) {
           const lineKey = this.lineKeyById.get(resolvedNativeSelection.lineId);
           const lineNode = lineKey ? $getNodeByKey(lineKey) : undefined;

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -4665,7 +4665,37 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
-    if (event.defaultPrevented || event.isComposing || this.isComposing) {
+    if (event.defaultPrevented) {
+      this.clearPendingTextInputFallback();
+      return;
+    }
+
+    // Linux and macOS WebKit can apply an IME commit to the contenteditable
+    // DOM without updating Lexical's editor state. The next controlled input
+    // then reconciles from stale state and removes the committed characters.
+    // Commit through Lexical using the native target range as the caret source.
+    if (inputType === "insertFromComposition") {
+      const inputText = this.resolveBeforeInputText(event, {
+        allowKeyFallback: false,
+      });
+      if (inputText === undefined) {
+        return;
+      }
+
+      this.clearSelectedReferenceNodeKey();
+      event.preventDefault();
+      event.stopPropagation?.();
+      event.stopImmediatePropagation?.();
+      const nativeSelection = this.getInputLineSelectionContext(event);
+      if (nativeSelection) {
+        this.insertPlainText(inputText, { nativeSelection });
+      } else {
+        this.insertPlainText(inputText);
+      }
+      return;
+    }
+
+    if (event.isComposing || this.isComposing) {
       this.clearPendingTextInputFallback();
       return;
     }

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -3,6 +3,7 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $setCompositionKey,
   $setSelection,
   createEditor,
 } from "lexical";
@@ -4574,6 +4575,7 @@ describe("lexical scene document editor line editing", () => {
         1,
       );
       expect(insertPlainText).toHaveBeenCalledWith("发", {
+        endComposition: true,
         nativeSelection,
       });
     } finally {
@@ -4630,16 +4632,21 @@ describe("lexical scene document editor line editing", () => {
           const root = $getRoot();
           const line = $createParagraphNode();
 
-          line.append($createTextNode("ab"));
+          const textNode = $createTextNode("ab");
+          line.append(textNode);
           root.append(line);
           lineKey = line.getKey();
           editorElement.lineMetaByKey.set(lineKey, {
             id: "line-1",
           });
           editorElement.lineKeyById.set("line-1", lineKey);
+          textNode.select(1, 1);
+          $setCompositionKey(textNode.getKey());
         },
         { discrete: true },
       );
+
+      expect(editor.isComposing()).toBe(true);
 
       const compositionRange = document.createRange();
       const initialTextNode =
@@ -4658,21 +4665,27 @@ describe("lexical scene document editor line editing", () => {
         stopImmediatePropagation: vi.fn(),
       });
 
-      const spaceRange = document.createRange();
-      const committedTextNode =
-        editor.getElementByKey(lineKey).firstChild.firstChild;
-      spaceRange.setStart(committedTextNode, 2);
-      spaceRange.collapse(true);
+      const committedState = editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        return {
+          text: $getRoot().getFirstChild().getTextContent(),
+          anchorOffset: selection?.anchor.offset,
+          focusOffset: selection?.focus.offset,
+        };
+      });
+      expect(editor.isComposing()).toBe(false);
+      expect(committedState).toEqual({
+        text: "a发b",
+        anchorOffset: 2,
+        focusOffset: 2,
+      });
 
-      editorElement.handleNativeBeforeInput({
-        inputType: "insertText",
-        data: " ",
-        isComposing: false,
-        defaultPrevented: false,
-        getTargetRanges: () => [spaceRange],
-        preventDefault: vi.fn(),
-        stopPropagation: vi.fn(),
-        stopImmediatePropagation: vi.fn(),
+      editorElement.insertPlainText(" ", {
+        nativeSelection: {
+          lineId: "line-1",
+          start: committedState.anchorOffset,
+          end: committedState.focusOffset,
+        },
       });
 
       const result = editor.getEditorState().read(() => {

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -4527,6 +4527,163 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("commits WebKit insertFromComposition text through Lexical", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const preventDefault = vi.fn();
+      const stopPropagation = vi.fn();
+      const stopImmediatePropagation = vi.fn();
+      const insertPlainText = vi.fn();
+      const nativeSelection = {
+        lineId: "line-1",
+        start: 9,
+        end: 9,
+      };
+
+      editorElement.state = {
+        mode: "text-editor",
+      };
+      editorElement.isComposing = true;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.clearPendingTextInputFallback = vi.fn();
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.getInputLineSelectionContext = vi.fn(() => nativeSelection);
+      editorElement.insertPlainText = insertPlainText;
+
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertFromComposition",
+        data: "发",
+        isComposing: true,
+        defaultPrevented: false,
+        preventDefault,
+        stopPropagation,
+        stopImmediatePropagation,
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(stopPropagation).toHaveBeenCalledTimes(1);
+      expect(stopImmediatePropagation).toHaveBeenCalledTimes(1);
+      expect(editorElement.clearSelectedReferenceNodeKey).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(insertPlainText).toHaveBeenCalledWith("发", {
+        nativeSelection,
+      });
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("preserves a WebKit composition commit when the next input is Space", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editor = createEditor({
+        namespace: "lexical-webkit-composition-commit-test",
+        theme: {
+          paragraph: "editor-paragraph",
+        },
+        onError: (error) => {
+          throw error;
+        },
+      });
+      const rootElement = document.createElement("div");
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      let lineKey;
+
+      document.body.append(rootElement);
+      editor.setRootElement(rootElement);
+      editorElement.editor = editor;
+      editorElement.refs = {
+        editor: rootElement,
+      };
+      editorElement.state = {
+        selectedLineId: "line-1",
+        lines: [],
+        mentionTargets: [],
+        mentionMenu: {
+          isOpen: false,
+        },
+        mode: "text-editor",
+      };
+      editorElement.pendingTextInputFallback = undefined;
+      editorElement.lastCommittedTextInputFallback = undefined;
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.lineMetaByKey = new Map();
+      editorElement.lineKeyById = new Map();
+
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const line = $createParagraphNode();
+
+          line.append($createTextNode("ab"));
+          root.append(line);
+          lineKey = line.getKey();
+          editorElement.lineMetaByKey.set(lineKey, {
+            id: "line-1",
+          });
+          editorElement.lineKeyById.set("line-1", lineKey);
+        },
+        { discrete: true },
+      );
+
+      const compositionRange = document.createRange();
+      const initialTextNode =
+        editor.getElementByKey(lineKey).firstChild.firstChild;
+      compositionRange.setStart(initialTextNode, 1);
+      compositionRange.collapse(true);
+
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertFromComposition",
+        data: "发",
+        isComposing: true,
+        defaultPrevented: false,
+        getTargetRanges: () => [compositionRange],
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      });
+
+      const spaceRange = document.createRange();
+      const committedTextNode =
+        editor.getElementByKey(lineKey).firstChild.firstChild;
+      spaceRange.setStart(committedTextNode, 2);
+      spaceRange.collapse(true);
+
+      editorElement.handleNativeBeforeInput({
+        inputType: "insertText",
+        data: " ",
+        isComposing: false,
+        defaultPrevented: false,
+        getTargetRanges: () => [spaceRange],
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      });
+
+      const result = editor.getEditorState().read(() => {
+        return $getRoot().getFirstChild().getTextContent();
+      });
+      expect(result).toBe("a发 b");
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("uses printable keydown text when beforeinput insertText has no data", async () => {
     const restoreDomGlobals = installDomGlobals();
 


### PR DESCRIPTION
## Summary

- route final WebKit insertFromComposition commits through Lexical using the native target range
- keep ongoing composition events browser-managed
- add regression coverage for a Chinese IME commit followed by Space
- document the DOM and Lexical state divergence; remove temporary diagnostics

## Root cause

On Linux and macOS WebKit, the committed IME text could be applied to the contenteditable DOM without entering Lexical editor state. The next controlled insertion reconciled from stale state and removed the committed Chinese characters before the caret.

## Validation

- bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js (109 tests passed)
- bun run lint
- manually verified by the reporter