### PR TITLE
Fix macOS notarization for nested player template

### DIFF
--- a/docs/macos-player-export-plan.md
+++ b/docs/macos-player-export-plan.md
@@ -125,9 +125,12 @@ bundled universal player template ZIP
 ```
 
 The shipped template should itself be stored as an archive rather than as a
-nested `.app` resource inside RouteVN Creator. This avoids nested application
-signing problems and preserves the template's bundle layout and executable
-permissions.
+nested `.app` resource inside RouteVN Creator. This preserves the template's
+bundle layout and executable permissions, but it does not exempt the nested app
+from notarization checks. The public Creator release pipeline must sign the app
+inside the template archive with Developer ID, hardened runtime, and a secure
+timestamp before bundling it because Apple's notary service expands nested
+containers.
 
 Proposed resource path:
 
@@ -239,8 +242,9 @@ Only the outer `.app` directory and user-visible bundle metadata are renamed.
 Signing must be explicit rather than relying on `codesign --deep` to discover
 work. Sign known nested code from the deepest level outward, sign the top-level
 application last with the ad-hoc identity, and verify with
-`codesign --verify --strict --verbose=2`. The exporter must remove or
-replace stale template signatures as part of this process. Template
+`codesign --verify --strict --verbose=2`. The exporter must remove stale
+template signatures before customization, not merely overwrite them, so no
+Developer ID certificate payload remains in unused signature space. Template
 entitlements, if any are introduced, must be reviewed and applied deliberately;
 they must not be inherited accidentally from an unrelated Creator build.
 

--- a/docs/platform/13-macos-player-export.md
+++ b/docs/platform/13-macos-player-export.md
@@ -30,6 +30,14 @@ containment, and archives the template with `ditto`. The exact archive is
 produced locally and committed as a regular Git file. CI does not build or
 publish the macOS player template.
 
+The public Creator release pipeline expands that source archive into a
+temporary directory, signs its nested code and app with the maintainer's
+Developer ID identity, hardened runtime, and a secure timestamp, and verifies
+both architecture slices. It then writes an ignored release-only archive under
+`.artifacts/` and overrides the Tauri resource source while preserving the
+runtime path above. Apple notarization inspects code inside nested archives, so
+signing only the outer Creator app is insufficient.
+
 The template executable name stays stable. Export changes only the outer app
 directory, top-level bundle metadata, resources, and signature.
 
@@ -79,13 +87,16 @@ The native exporter:
    project icon, and package bytes
 2. expands exactly `RouteVNPlayerTemplate.app` with `ditto`
 3. rejects unsafe or escaping symlinks and non-universal Mach-O files
-4. writes the encrypted standalone package resource
-5. stamps top-level plist metadata and installs the ICNS icon
-6. signs nested native code deepest-first and the application last
-7. verifies the strict signature, metadata, architectures, permissions, and
+4. removes all template code signatures before changing the application
+5. writes the encrypted standalone package resource
+6. stamps top-level plist metadata and installs the ICNS icon
+7. ad-hoc signs nested native code deepest-first and the application last
+8. verifies every architecture is exclusively ad-hoc signed and contains no
+   retained Developer ID certificate payload
+9. verifies the strict signature, metadata, architectures, permissions, and
    symlinks
-8. creates a sibling `.part` archive with `ditto`, expands and validates it,
-   then atomically renames it to the selected destination
+10. creates a sibling `.part` archive with `ditto`, expands and validates it,
+    then atomically renames it to the selected destination
 
 Icon assembly first builds the standard iconset and uses `iconutil`. A direct
 system `sips` ICNS conversion is retained as a compatibility fallback for
@@ -110,6 +121,7 @@ messages.
 ## Canonical Implementation Areas
 
 - template build: `scripts/build-macos-player-template.js`
+- release signing: `scripts/prepare-macos-player-template-release.js`
 - native exporter: `src-tauri/src/export_macos.rs`
 - shared payload: `crates/routevn-packager/src/payload.rs`
 - shared player shell:

--- a/docs/runbooks/macos-signing-and-notarization.md
+++ b/docs/runbooks/macos-signing-and-notarization.md
@@ -66,15 +66,31 @@ That command uses [`scripts/tauri-build-mac.sh`](../../scripts/tauri-build-mac.s
 The script does this:
 
 1. Loads local values from `.env`
-2. Builds the Tauri frontend bundle
-3. Builds the macOS app bundle
-4. Signs the `.app`
-5. Lets Tauri notarize and staple the `.app`
-6. Builds the final `.dmg`
-7. Signs the `.dmg`
-8. Submits the `.dmg` with `xcrun notarytool`
-9. Staples the notarization ticket to the `.dmg`
-10. Validates the stapled `.dmg`
+2. Expands the bundled macOS player template
+3. Signs its nested code and app with the configured Developer ID identity,
+   hardened runtime, and a secure timestamp
+4. Verifies both universal slices and writes an ignored release-only template
+   archive under `.artifacts/`
+5. Builds the Tauri frontend bundle
+6. Builds the macOS app bundle with the signed player template
+7. Signs the `.app`
+8. Lets Tauri notarize and staple the `.app`
+9. Builds the final `.dmg`
+10. Signs the `.dmg`
+11. Submits the `.dmg` with `xcrun notarytool`
+12. Staples the notarization ticket to the `.dmg`
+13. Validates the stapled `.dmg`
+
+The committed player template remains the source used by local export. Release
+signing writes a separate archive so secure timestamps do not dirty the Git
+worktree. The release-only Tauri config replaces the source resource with that
+signed archive at the same runtime resource path.
+
+When a user exports a player, Creator removes the release template's signatures
+before changing any content, ad-hoc signs the completed player, and rejects the
+export if any architecture retains a Developer ID authority, team identifier,
+or certificate payload. The maintainer's Developer ID signature is only an
+input required to notarize Creator; it is not passed through to user exports.
 
 ## Final Artifact
 
@@ -123,6 +139,13 @@ Expected results:
 
 - The `.dmg` was never submitted to notarization, or the stapling step failed.
 - Re-run `bun run tauri:build:mac` after confirming `.env` has all Apple values.
+
+`Archive contains critical validation errors` for `routevn-shell`
+
+- The nested player template in an older build was not Developer ID signed.
+- `bun run tauri:build:mac` now prepares and verifies a signed release-only
+  template automatically. Do not call `tauri build` directly for a public
+  macOS release.
 
 ## Security Rules
 

--- a/scripts/prepare-macos-player-template-release.js
+++ b/scripts/prepare-macos-player-template-release.js
@@ -1,0 +1,313 @@
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const sourceArchivePath = path.join(
+  rootDir,
+  "src-tauri/assets/player-templates/macos/RouteVNPlayerTemplate.app.zip",
+);
+const releaseArchivePath = path.join(
+  rootDir,
+  ".artifacts/macos-player-template/RouteVNPlayerTemplate.app.zip",
+);
+const templateAppName = "RouteVNPlayerTemplate.app";
+const signingIdentity = process.env.APPLE_SIGNING_IDENTITY?.trim();
+const signingTeamId = process.env.APPLE_TEAM_ID?.trim();
+
+const run = (command, commandArgs, options = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      cwd: rootDir,
+      env: process.env,
+      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${commandArgs.join(" ")} failed with exit code ${code}${
+            stderr.trim() ? `: ${stderr.trim()}` : ""
+          }`,
+        ),
+      );
+    });
+  });
+
+const isMachoFile = async (filePath) => {
+  const bytes = await readFile(filePath);
+  if (bytes.byteLength < 4) {
+    return false;
+  }
+  const magic = bytes.subarray(0, 4).toString("hex");
+  return new Set([
+    "feedface",
+    "cefaedfe",
+    "feedfacf",
+    "cffaedfe",
+    "cafebabe",
+    "bebafeca",
+    "cafebabf",
+    "bfbafeca",
+  ]).has(magic);
+};
+
+const walk = async (directory, visit) => {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    await visit(entryPath, entry);
+    if (entry.isDirectory()) {
+      await walk(entryPath, visit);
+    }
+  }
+};
+
+const validateSymlinks = async (applicationPath) => {
+  const applicationRealPath = await realpath(applicationPath);
+  await walk(applicationPath, async (entryPath, entry) => {
+    if (!entry.isSymbolicLink()) {
+      return;
+    }
+    const resolved = await realpath(entryPath);
+    if (
+      resolved !== applicationRealPath &&
+      !resolved.startsWith(`${applicationRealPath}${path.sep}`)
+    ) {
+      throw new Error(`Template symlink escapes the app bundle: ${entryPath}`);
+    }
+  });
+};
+
+const readMainExecutablePath = async (applicationPath) => {
+  const infoPath = path.join(applicationPath, "Contents/Info.plist");
+  const result = await run(
+    "/usr/bin/plutil",
+    ["-extract", "CFBundleExecutable", "raw", "-o", "-", infoPath],
+    { capture: true },
+  );
+  return path.join(applicationPath, "Contents/MacOS", result.stdout.trim());
+};
+
+const validateUniversalApplication = async (applicationPath) => {
+  await validateSymlinks(applicationPath);
+  const machoFiles = [];
+  await walk(applicationPath, async (entryPath, entry) => {
+    if (entry.isFile() && (await isMachoFile(entryPath))) {
+      machoFiles.push(entryPath);
+    }
+  });
+  if (machoFiles.length === 0) {
+    throw new Error("The macOS player template contains no Mach-O files.");
+  }
+  for (const machoFile of machoFiles) {
+    const result = await run("/usr/bin/lipo", ["-archs", machoFile], {
+      capture: true,
+    });
+    const architectures = new Set(result.stdout.trim().split(/\s+/u));
+    if (!architectures.has("arm64") || !architectures.has("x86_64")) {
+      throw new Error(`Mach-O is not universal: ${machoFile}`);
+    }
+  }
+
+  const executablePath = await readMainExecutablePath(applicationPath);
+  const executableMode = (await lstat(executablePath)).mode;
+  if ((executableMode & 0o111) === 0) {
+    throw new Error("The macOS player template executable bit is missing.");
+  }
+};
+
+const requireSingleApplication = async (directory) => {
+  const entries = await readdir(directory, { withFileTypes: true });
+  if (
+    entries.length !== 1 ||
+    !entries[0].isDirectory() ||
+    path.extname(entries[0].name) !== ".app"
+  ) {
+    throw new Error(
+      "The macOS player template archive must contain exactly one app bundle.",
+    );
+  }
+  const applicationPath = path.join(directory, entries[0].name);
+  if (path.basename(applicationPath) !== templateAppName) {
+    throw new Error(`Template archive root must be ${templateAppName}.`);
+  }
+  return applicationPath;
+};
+
+const isCodeBundle = (entryPath) =>
+  new Set([".app", ".appex", ".bundle", ".framework", ".plugin", ".xpc"]).has(
+    path.extname(entryPath),
+  );
+
+const signCode = (codePath) =>
+  run("/usr/bin/codesign", [
+    "--force",
+    "--options",
+    "runtime",
+    "--timestamp",
+    "--sign",
+    signingIdentity,
+    codePath,
+  ]);
+
+const signApplicationInsideOut = async (applicationPath) => {
+  const mainExecutablePath = await readMainExecutablePath(applicationPath);
+  const machoFiles = [];
+  const nestedBundles = [];
+  await walk(applicationPath, async (entryPath, entry) => {
+    if (
+      entry.isFile() &&
+      entryPath !== mainExecutablePath &&
+      (await isMachoFile(entryPath))
+    ) {
+      machoFiles.push(entryPath);
+    }
+    if (
+      entry.isDirectory() &&
+      entryPath !== applicationPath &&
+      isCodeBundle(entryPath)
+    ) {
+      nestedBundles.push(entryPath);
+    }
+  });
+
+  const deepestFirst = (left, right) =>
+    right.split(path.sep).length - left.split(path.sep).length;
+  machoFiles.sort(deepestFirst);
+  nestedBundles.sort(deepestFirst);
+  for (const machoFile of machoFiles) {
+    await signCode(machoFile);
+  }
+  for (const nestedBundle of nestedBundles) {
+    await signCode(nestedBundle);
+  }
+  await signCode(applicationPath);
+};
+
+const verifyDistributionSignature = async (applicationPath) => {
+  await run("/usr/bin/codesign", [
+    "--verify",
+    "--all-architectures",
+    "--deep",
+    "--strict",
+    "--verbose=4",
+    applicationPath,
+  ]);
+
+  const mainExecutablePath = await readMainExecutablePath(applicationPath);
+  for (const architecture of ["x86_64", "arm64"]) {
+    const result = await run(
+      "/usr/bin/codesign",
+      ["-dvvv", "--arch", architecture, mainExecutablePath],
+      { capture: true },
+    );
+    const details = `${result.stdout}\n${result.stderr}`;
+    if (!details.includes("Authority=Developer ID Application:")) {
+      throw new Error(
+        `The ${architecture} player template slice is not signed with a Developer ID Application certificate.`,
+      );
+    }
+    if (!details.includes("Timestamp=")) {
+      throw new Error(
+        `The ${architecture} player template slice has no secure timestamp.`,
+      );
+    }
+    if (!/flags=.*\([^\n]*\bruntime\b[^\n]*\)/u.test(details)) {
+      throw new Error(
+        `The ${architecture} player template slice does not enable the hardened runtime.`,
+      );
+    }
+    if (signingTeamId && !details.includes(`TeamIdentifier=${signingTeamId}`)) {
+      throw new Error(
+        `The ${architecture} player template slice is not signed by team ${signingTeamId}.`,
+      );
+    }
+  }
+};
+
+if (process.platform !== "darwin") {
+  throw new Error("The macOS release player template must be signed on macOS.");
+}
+if (!signingIdentity) {
+  throw new Error(
+    "APPLE_SIGNING_IDENTITY is required to prepare the macOS release player template.",
+  );
+}
+
+const tempDirectory = await mkdtemp(
+  path.join(os.tmpdir(), "routevn-macos-release-template-"),
+);
+try {
+  const sourceDirectory = path.join(tempDirectory, "source");
+  await mkdir(sourceDirectory);
+  await run("/usr/bin/ditto", [
+    "-x",
+    "-k",
+    "--noqtn",
+    sourceArchivePath,
+    sourceDirectory,
+  ]);
+  const sourceApplication = await requireSingleApplication(sourceDirectory);
+  await validateUniversalApplication(sourceApplication);
+  await signApplicationInsideOut(sourceApplication);
+  await verifyDistributionSignature(sourceApplication);
+
+  await mkdir(path.dirname(releaseArchivePath), { recursive: true });
+  const partPath = `${releaseArchivePath}.part`;
+  await rm(partPath, { force: true });
+  await run("/usr/bin/ditto", [
+    "-c",
+    "-k",
+    "--keepParent",
+    "--norsrc",
+    "--noextattr",
+    "--noqtn",
+    "--noacl",
+    sourceApplication,
+    partPath,
+  ]);
+
+  const verificationDirectory = path.join(tempDirectory, "verify");
+  await mkdir(verificationDirectory);
+  await run("/usr/bin/ditto", [
+    "-x",
+    "-k",
+    "--noqtn",
+    partPath,
+    verificationDirectory,
+  ]);
+  const verifiedApplication = await requireSingleApplication(
+    verificationDirectory,
+  );
+  await validateUniversalApplication(verifiedApplication);
+  await verifyDistributionSignature(verifiedApplication);
+  await rename(partPath, releaseArchivePath);
+} finally {
+  await rm(tempDirectory, { recursive: true, force: true });
+}
+
+console.log(`Signed macOS release player template: ${releaseArchivePath}`);

--- a/scripts/tauri-build-mac-steam.sh
+++ b/scripts/tauri-build-mac-steam.sh
@@ -41,9 +41,11 @@ fi
 
 export VITE_ROUTEVN_DISTRIBUTION=steam
 
+node scripts/prepare-macos-player-template-release.js
 bun run build:tauri
 tauri build \
   --config src-tauri/tauri.steam.conf.json \
+  --config src-tauri/tauri.macos-release.conf.json \
   --target universal-apple-darwin \
   --bundles app
 

--- a/scripts/tauri-build-mac.sh
+++ b/scripts/tauri-build-mac.sh
@@ -65,8 +65,13 @@ else
   echo "Set APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID in .env."
 fi
 
+node scripts/prepare-macos-player-template-release.js
 bun run build:tauri
-tauri build --config src-tauri/tauri.prod.conf.json --target universal-apple-darwin --bundles app,dmg
+tauri build \
+  --config src-tauri/tauri.prod.conf.json \
+  --config src-tauri/tauri.macos-release.conf.json \
+  --target universal-apple-darwin \
+  --bundles app,dmg
 
 MACOS_BUNDLE_DIR="src-tauri/target/universal-apple-darwin/release/bundle/macos"
 DMG_DIR="src-tauri/target/universal-apple-darwin/release/bundle/dmg"

--- a/src-tauri/assets/player-templates/macos/README.md
+++ b/src-tauri/assets/player-templates/macos/README.md
@@ -26,3 +26,11 @@ player archive.
 
 The template is built locally and committed as a regular Git artifact. CI does
 not build or publish it.
+
+Public Creator builds do not bundle this archive directly. Running
+`bun run tauri:build:mac` automatically expands it, Developer-ID-signs the
+template with hardened runtime and a secure timestamp, verifies both universal
+slices, and writes a release-only copy under `.artifacts/`. Exported player apps
+have that release signature removed before customization, then are ad-hoc signed
+and checked for retained Developer ID certificate data. Users therefore receive
+neither an active RouteVN Developer ID signature nor its certificate payload.

--- a/src-tauri/src/export_macos.rs
+++ b/src-tauri/src/export_macos.rs
@@ -194,6 +194,7 @@ mod macos {
         }
         validate_bundle_symlinks(&template_app_path)?;
         validate_universal_macho_files(&template_app_path)?;
+        strip_application_signatures_inside_out(&template_app_path)?;
 
         let application_name = sanitize_application_name(&metadata.title)?;
         let application_path = extract_directory.join(format!("{application_name}.app"));
@@ -580,7 +581,9 @@ mod macos {
         Ok(())
     }
 
-    fn sign_application_inside_out(application_path: &Path) -> Result<(), String> {
+    fn collect_nested_code_paths(
+        application_path: &Path,
+    ) -> Result<(Vec<PathBuf>, Vec<PathBuf>), String> {
         let main_executable = read_main_executable_path(application_path)?;
         let mut macho_files = Vec::new();
         let mut nested_bundles = Vec::new();
@@ -593,12 +596,38 @@ mod macos {
             }
             Ok(())
         })?;
-
         macho_files.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+        nested_bundles.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+        Ok((macho_files, nested_bundles))
+    }
+
+    fn strip_application_signatures_inside_out(application_path: &Path) -> Result<(), String> {
+        let (macho_files, nested_bundles) = collect_nested_code_paths(application_path)?;
+        for path in macho_files {
+            remove_signature(&path)?;
+        }
+        for path in nested_bundles {
+            remove_signature(&path)?;
+        }
+        remove_signature(application_path)
+    }
+
+    fn remove_signature(path: &Path) -> Result<(), String> {
+        run_tool(
+            "/usr/bin/codesign",
+            [
+                OsString::from("--remove-signature"),
+                path.as_os_str().to_os_string(),
+            ],
+            "remove the macOS player template signature",
+        )
+    }
+
+    fn sign_application_inside_out(application_path: &Path) -> Result<(), String> {
+        let (macho_files, nested_bundles) = collect_nested_code_paths(application_path)?;
         for path in macho_files {
             codesign(&path)?;
         }
-        nested_bundles.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
         for path in nested_bundles {
             codesign(&path)?;
         }
@@ -643,12 +672,76 @@ mod macos {
             "/usr/bin/codesign",
             [
                 OsString::from("--verify"),
+                OsString::from("--all-architectures"),
                 OsString::from("--strict"),
                 OsString::from("--verbose=2"),
                 application_path.as_os_str().to_os_string(),
             ],
             "verify the macOS application signature",
-        )
+        )?;
+        verify_ad_hoc_signatures(application_path)
+    }
+
+    fn verify_ad_hoc_signatures(application_path: &Path) -> Result<(), String> {
+        const DEVELOPER_ID_MARKER: &[u8] = b"Developer ID Application:";
+
+        let mut macho_files = Vec::new();
+        visit_paths(application_path, &mut |path, file_type| {
+            if file_type.is_file() && is_macho_file(path)? {
+                macho_files.push(path.to_path_buf());
+            }
+            Ok(())
+        })?;
+
+        for path in macho_files {
+            let bytes = fs::read(&path).map_err(|error| {
+                format!(
+                    "Failed to inspect the exported macOS player signature {}: {error}",
+                    path.display()
+                )
+            })?;
+            if bytes
+                .windows(DEVELOPER_ID_MARKER.len())
+                .any(|window| window == DEVELOPER_ID_MARKER)
+            {
+                return Err(format!(
+                    "The exported macOS player retains Developer ID signature data: {}.",
+                    path.display()
+                ));
+            }
+
+            for architecture in ["x86_64", "arm64"] {
+                let output = run_tool_output(
+                    "/usr/bin/codesign",
+                    [
+                        OsString::from("-dvvv"),
+                        OsString::from("--arch"),
+                        OsString::from(architecture),
+                        path.as_os_str().to_os_string(),
+                    ],
+                    "inspect the exported macOS player signature",
+                )?;
+                let details = format!(
+                    "{}\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                let is_ad_hoc = details.lines().any(|line| line.trim() == "Signature=adhoc");
+                let has_no_team = details
+                    .lines()
+                    .any(|line| line.trim() == "TeamIdentifier=not set");
+                let has_authority = details
+                    .lines()
+                    .any(|line| line.trim_start().starts_with("Authority="));
+                if !is_ad_hoc || !has_no_team || has_authority {
+                    return Err(format!(
+                        "The exported macOS player is not exclusively ad-hoc signed for {architecture}: {}.",
+                        path.display()
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     fn verify_info_plist(
@@ -809,7 +902,7 @@ mod macos {
 
     #[cfg(test)]
     mod tests {
-        use std::path::Path;
+        use std::path::{Path, PathBuf};
 
         use super::{
             MacosApplicationMetadata, export_macos_application_sync,
@@ -867,8 +960,12 @@ mod macos {
         #[test]
         fn exports_and_verifies_a_real_universal_application_archive() {
             let manifest_directory = Path::new(env!("CARGO_MANIFEST_DIR"));
-            let template_path = manifest_directory
-                .join("assets/player-templates/macos/RouteVNPlayerTemplate.app.zip");
+            let template_path = std::env::var_os("ROUTEVN_MACOS_TEST_TEMPLATE_PATH")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    manifest_directory
+                        .join("assets/player-templates/macos/RouteVNPlayerTemplate.app.zip")
+                });
             assert!(template_path.is_file());
             let temp = tempfile::tempdir().unwrap();
             let output_path = temp.path().join("Acceptance Game.app.zip");

--- a/src-tauri/tauri.macos-release.conf.json
+++ b/src-tauri/tauri.macos-release.conf.json
@@ -1,0 +1,8 @@
+{
+  "bundle": {
+    "resources": {
+      "assets/player-templates/macos/RouteVNPlayerTemplate.app.zip": null,
+      "../.artifacts/macos-player-template/RouteVNPlayerTemplate.app.zip": "player-templates/macos/RouteVNPlayerTemplate.app.zip"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- prepare a release-only Developer ID signed copy of the universal macOS player template before Creator bundling
- use a Tauri release config override so the committed editable template remains unchanged
- strip the release signature before user export, then ad-hoc sign and verify both architectures
- reject exported Mach-O files that retain a Developer ID authority, team identifier, or certificate payload
- document the release and user-export signing boundaries

## Validation

- bun run lint
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- Prettier, Oxlint, ShellCheck, Node syntax, Bash syntax, and git diff checks
- real Developer ID template signing with hardened runtime and secure timestamp on x86_64 and arm64
- universal Tauri app bundle confirmed to contain the generated signed template byte-for-byte
- signed-template export acceptance test passed, including launch and runtime persistence
- exported x86_64 and arm64 slices verified as ad-hoc with no team identifier or retained Developer ID certificate payload

The full notarization submission was not repeated to avoid creating an unnecessary Apple notarization job; the exact nested artifact that previously failed now passes local strict Developer ID verification.