### PR TITLE
fix(project): patch legacy default menu styles

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -823,6 +823,17 @@ For the current full contract, see
 row value contract is in
 `docs/platform/12-windows-player-runtime-key-value-contract.md`.
 
+### Exceptional Project Content Patches
+
+Project content patches are narrowly scoped repairs for specific data written
+by a released RouteVN Creator template. They are not a general schema migration
+layer and must not bypass creator-model commands.
+
+The current marker, exact legacy-value predicates, no-op rules, remote-sync
+gate, failure semantics, implementation map, and checklist for any future patch
+are defined in `docs/platform/14-project-content-patches.md`. Treat that file as
+the required contract when touching content-patch behavior.
+
 ## Current Canonical Patterns
 
 These are the current patterns we want new work to align with. They are more

--- a/docs/platform/07-persisted-key-catalog.md
+++ b/docs/platform/07-persisted-key-catalog.md
@@ -147,6 +147,8 @@ Current keys:
   - currently used by the web collab path
 - `contentPatch.defaultMenuTextStyles-1-9-1`
   - boolean completion marker for the one-time default menu text-style repair
+  - full execution and collaboration-safety contract:
+    `14-project-content-patches.md`
 
 Important ownership rule:
 

--- a/docs/platform/07-persisted-key-catalog.md
+++ b/docs/platform/07-persisted-key-catalog.md
@@ -145,6 +145,8 @@ Current keys:
 - `collab.lastCommittedId:<projectId>`
   - committed remote cursor watermark
   - currently used by the web collab path
+- `contentPatch.defaultMenuTextStyles-1-9-1`
+  - boolean completion marker for the one-time default menu text-style repair
 
 Important ownership rule:
 

--- a/docs/platform/14-project-content-patches.md
+++ b/docs/platform/14-project-content-patches.md
@@ -1,0 +1,181 @@
+# Project Content Patches
+
+Date baseline: July 16, 2026.
+
+## Status
+
+Project content patches are an exceptional repair mechanism for correcting
+specific user-project data written by a released RouteVN Creator template.
+
+They are not:
+
+- project format migrations
+- creator-model schema migrations or command upcasters
+- a replacement for fixing the default project template
+- permission to rewrite user-authored data that merely resembles old defaults
+
+The normal compatibility policy remains unchanged. Schema and project-format
+changes must use the compatibility strategy described in
+`10-model-compatibility-and-upgrades.md`.
+
+## Current Patch
+
+RouteVN Creator 1.9.1 introduced one grouped content patch for two default menu
+text-style defects.
+
+Completion marker:
+
+```text
+contentPatch.defaultMenuTextStyles-1-9-1 = true
+```
+
+The marker is stored in the project-specific DB `app` key-value store. One key
+covers both repairs.
+
+The repairs are:
+
+| Repair                    | Target identity                               | Required legacy value                                                                 | Partial update                        |
+| ------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------- |
+| Selected menu text weight | text style `saV5A4pkvHRb`                     | `fontWeight` is exactly `"400"`                                                       | set `fontWeight` to `"700"`           |
+| Load menu text style      | layout `fKr5fa67MQWh`, element `icn4dknq2kyp` | `textStyleId` is exactly `"5rwEfyx2GBEi"` and destination style `e2WbW3vcPZR9` exists | set `textStyleId` to `"e2WbW3vcPZR9"` |
+
+Identity is determined only by the fixed repository ids. Display names and the
+visible `Load` text are not patch selectors.
+
+The corrected values also live in `static/templates/default/repository.json`
+so newly created projects do not depend on the repair.
+
+## Execution Contract
+
+The grouped patch follows this order:
+
+1. Read `contentPatch.defaultMenuTextStyles-1-9-1` from the project KV store.
+2. If the value is exactly `true`, stop without inspecting or changing project
+   content.
+3. Read the current repository state.
+4. Run each repair independently and only when its target ids exist and its
+   current value exactly matches the documented legacy value.
+5. Submit repository changes through the existing creator-model commands.
+6. After both repairs either succeed or resolve as no-ops, write the marker as
+   `true`.
+
+Missing ids, missing destination resources, already-correct values, and
+user-customized values are successful no-ops. They are never recreated,
+renamed, or overwritten.
+
+The marker is still written after successful no-op evaluation. This makes the
+repair a one-time decision: if a missing default id is imported later, or a
+user later changes a value back to its legacy value, this patch must not run
+again.
+
+If a submitted update fails or throws, the marker is not written. If the first
+repair succeeds and the second fails, a retry is safe because the first repair
+will see its new value and become a no-op. If the marker write itself fails, a
+retry is also safe for the same reason.
+
+An in-memory per-project promise prevents duplicate execution by concurrent
+repository-ensure calls in one application instance. The persisted marker is
+the cross-restart completion record.
+
+## Persistence And Commands
+
+The patch must use existing repository commands:
+
+- `textStyle.update` with only `fontWeight`
+- `layout.element.update` with only `textStyleId` and `replace: false`
+
+It must not mutate projected repository state directly and must not introduce a
+patch-specific creator-model command. Command submission preserves normal
+repository persistence, collaboration, validation, and projection behavior.
+
+The marker belongs in the project-specific `store.app` area because it is
+app-owned repair bookkeeping. It must not be stored in:
+
+- `projectInfo`, whose fields have a separate ownership contract
+- global `userConfig`, which does not travel with the project DB
+- `creatorVersion`, which is a project-format compatibility gate
+- `layoutSchemaVersion`, which describes layout structure rather than content
+- a hidden user-visible repository resource
+
+The marker is local to one project DB and is not synchronized as repository
+content. Another device or project copy can therefore evaluate the same patch.
+Exact legacy-value predicates and idempotent partial assignments remain
+mandatory even when a marker exists.
+
+## Collaboration Safety
+
+Local and native projects may evaluate the patch after repository hydration.
+
+Web projects that can synchronize with a remote authority have a stricter
+contract. A remote project must not evaluate or mark the patch during ordinary
+repository ensure because its IndexedDB projection can be stale.
+
+Remote evaluation is allowed only after all of the following are true:
+
+1. the initial remote `syncNow()` completed successfully
+2. queued committed commands finished applying to the repository projection
+3. any uncommitted local events were replayed and synchronized
+4. the second apply queue drain completed
+5. no projection gap is stored
+
+The web collaboration session exposes this as
+`hasCompletedInitialRemoteSync()`. The connection runtime calls
+`projectService.ensureProjectContentPatches()` only when that method returns
+`true`.
+
+If transport attachment fails, initial synchronization fails, or a projection
+gap exists, the patch is not evaluated and the marker remains absent. Project
+open may continue with its existing offline or compatibility behavior, but the
+repair must wait for a later authoritative synchronization opportunity.
+
+This prevents a stale local value from overwriting a newer server-side user
+customization. It does not add compare-and-swap semantics to ordinary
+collaboration commands; a truly simultaneous edit after synchronization still
+uses the platform's normal last-writer behavior.
+
+## Rules For Future Content Patches
+
+Do not turn this implementation into a general migration registry by default.
+A future content patch requires an explicit review of all of these points:
+
+1. The defect was written into user projects by a released application or
+   template.
+2. Targets have stable ids; names or visible copy are not sufficient.
+3. Every mutation has an exact legacy-value predicate that protects user
+   customization.
+4. Updates are the smallest possible partial creator-model commands.
+5. Missing targets and unexpected values are documented no-ops.
+6. A new, unique project-KV key identifies the patch group. Do not reuse or
+   change the meaning of an existing key.
+7. The marker is written only after the full group succeeds.
+8. Remote web execution is gated by authoritative synchronization and
+   projection readiness.
+9. The current default template is fixed separately.
+10. Tests cover applied, already marked, missing, customized, failed-command,
+    local-project, successful-sync, and failed-sync behavior.
+11. The new persisted key is added to `07-persisted-key-catalog.md`.
+
+Do not remove a shipped patch merely because new projects contain corrected
+defaults. Old project databases can remain unopened for long periods and still
+need the repair when they return.
+
+## Implementation And Test Mapping
+
+Implementation:
+
+- shared patch predicates, commands, marker, and explicit entry point:
+  `src/deps/services/shared/projectServiceCore.js`
+- web local-project classification:
+  `src/deps/services/web/collabBootstrapService.js`
+- web initial-sync readiness and projection-gap check:
+  `src/deps/services/web/projectServiceAdapters.js`
+- post-sync invocation:
+  `src/deps/services/web/collab/connectionRuntime.js`
+- corrected defaults: `static/templates/default/repository.json`
+
+Primary regression coverage:
+
+- `tests/projectService/projectServiceCore.releaseRuntime.test.js`
+- `tests/web/projectServiceAdapters.test.js`
+- `tests/collab/connectionRuntime.test.js`
+- `tests/project/layout.richText.test.js`

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -65,6 +65,7 @@ Bundle implementation points:
 9. `11-windows-player-runtime-persistence.md`
 10. `12-windows-player-runtime-key-value-contract.md`
 11. `13-macos-player-export.md`
+12. `14-project-content-patches.md`
 
 ## Implementation Mapping
 

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -32,6 +32,7 @@ export const createProjectServiceCore = ({
   storageAdapter,
   fileAdapter,
   collabAdapter,
+  shouldApplyProjectContentPatchesOnEnsure = () => true,
 }) => {
   const repositoryService = createProjectRepositoryService({
     router,
@@ -217,10 +218,23 @@ export const createProjectServiceCore = ({
     }
   };
 
+  const ensureProjectContentPatches = async () => {
+    const repository = await repositoryService.ensureRepository();
+    await ensureLayoutSchemaVersion(repository);
+    await ensureDefaultMenuTextStylesPatch(repository);
+    return repository;
+  };
+
   const ensureRepository = async (options = {}) => {
     const repository = await repositoryService.ensureRepository(options);
     await ensureLayoutSchemaVersion(repository);
-    await ensureDefaultMenuTextStylesPatch(repository);
+    const shouldApplyContentPatches =
+      await shouldApplyProjectContentPatchesOnEnsure({
+        projectId: getCurrentProjectId(),
+      });
+    if (shouldApplyContentPatches) {
+      await ensureDefaultMenuTextStylesPatch(repository);
+    }
     return repository;
   };
 
@@ -364,6 +378,7 @@ export const createProjectServiceCore = ({
     releaseCurrentRepository: repositoryService.releaseCurrentRepository,
     releaseProjectRuntime,
     ensureRepository,
+    ensureProjectContentPatches,
     ensureProjectCompatibleById:
       repositoryService.ensureProjectCompatibleByProjectId,
     subscribeProjectState(listener, options) {

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -13,6 +13,14 @@ import {
   normalizeLayoutSchemaVersion,
 } from "../../../internal/project/layout.js";
 
+const DEFAULT_MENU_TEXT_STYLES_PATCH_KEY =
+  "contentPatch.defaultMenuTextStyles-1-9-1";
+const MENU_ITEM_TEXT_STYLE_ID = "e2WbW3vcPZR9";
+const MENU_ITEM_SELECTED_TEXT_STYLE_ID = "saV5A4pkvHRb";
+const MENU_PAGE_LAYOUT_ID = "fKr5fa67MQWh";
+const LOAD_MENU_ELEMENT_ID = "icn4dknq2kyp";
+const LEGACY_DIALOGUE_CONTENT_TEXT_STYLE_ID = "5rwEfyx2GBEi";
+
 export const createProjectServiceCore = ({
   router,
   db,
@@ -79,6 +87,8 @@ export const createProjectServiceCore = ({
   const getCurrentProjectId = () =>
     repositoryService.getEnsuredProjectId() || router.getPayload()?.p;
 
+  const defaultMenuTextStylesPatchByProject = new Map();
+
   const getRepositoryState = () => {
     const repository = repositoryService.getCachedRepository();
     return repository.getState();
@@ -122,9 +132,95 @@ export const createProjectServiceCore = ({
     }
   };
 
+  const patchDefaultMenuItemSelectedTextStyle = async (repositoryState) => {
+    const selectedTextStyle =
+      repositoryState?.textStyles?.items?.[MENU_ITEM_SELECTED_TEXT_STYLE_ID];
+    if (selectedTextStyle?.fontWeight !== "400") {
+      return;
+    }
+
+    const result = await collabService.commandApi.updateTextStyle({
+      textStyleId: MENU_ITEM_SELECTED_TEXT_STYLE_ID,
+      data: {
+        fontWeight: "700",
+      },
+    });
+    if (result?.valid === false) {
+      throw new Error(
+        result.error?.message ||
+          "Failed to patch the default selected menu text style.",
+      );
+    }
+  };
+
+  const patchDefaultMenuLoadTextStyle = async (repositoryState) => {
+    const menuItemTextStyle =
+      repositoryState?.textStyles?.items?.[MENU_ITEM_TEXT_STYLE_ID];
+    const menuPage = repositoryState?.layouts?.items?.[MENU_PAGE_LAYOUT_ID];
+    const loadMenuElement = menuPage?.elements?.items?.[LOAD_MENU_ELEMENT_ID];
+
+    if (
+      !menuItemTextStyle ||
+      loadMenuElement?.textStyleId !== LEGACY_DIALOGUE_CONTENT_TEXT_STYLE_ID
+    ) {
+      return;
+    }
+
+    const result = await collabService.commandApi.updateLayoutElement({
+      layoutId: MENU_PAGE_LAYOUT_ID,
+      elementId: LOAD_MENU_ELEMENT_ID,
+      data: {
+        textStyleId: MENU_ITEM_TEXT_STYLE_ID,
+      },
+      replace: false,
+    });
+    if (result?.valid === false) {
+      throw new Error(
+        result.error?.message || "Failed to patch the default Load menu text.",
+      );
+    }
+  };
+
+  const applyDefaultMenuTextStylesPatch = async (repository) => {
+    if (typeof repository?.getState !== "function") {
+      return;
+    }
+
+    const store = repositoryService.getCachedStore();
+    const isApplied = await store.app.get(DEFAULT_MENU_TEXT_STYLES_PATCH_KEY);
+    if (isApplied === true) {
+      return;
+    }
+
+    const repositoryState = repository.getState();
+    await patchDefaultMenuItemSelectedTextStyle(repositoryState);
+    await patchDefaultMenuLoadTextStyle(repositoryState);
+    await store.app.set(DEFAULT_MENU_TEXT_STYLES_PATCH_KEY, true);
+  };
+
+  const ensureDefaultMenuTextStylesPatch = async (repository) => {
+    const projectId = getCurrentProjectId();
+    const existingPatch = defaultMenuTextStylesPatchByProject.get(projectId);
+    if (existingPatch) {
+      return existingPatch;
+    }
+
+    const patch = applyDefaultMenuTextStylesPatch(repository);
+    defaultMenuTextStylesPatchByProject.set(projectId, patch);
+
+    try {
+      await patch;
+    } finally {
+      if (defaultMenuTextStylesPatchByProject.get(projectId) === patch) {
+        defaultMenuTextStylesPatchByProject.delete(projectId);
+      }
+    }
+  };
+
   const ensureRepository = async (options = {}) => {
     const repository = await repositoryService.ensureRepository(options);
     await ensureLayoutSchemaVersion(repository);
+    await ensureDefaultMenuTextStylesPatch(repository);
     return repository;
   };
 

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -13,6 +13,9 @@ import {
   normalizeLayoutSchemaVersion,
 } from "../../../internal/project/layout.js";
 
+// Exceptional shipped-data repair. Keep its marker, legacy predicates,
+// collaboration gate, and lifecycle aligned with
+// docs/platform/14-project-content-patches.md.
 const DEFAULT_MENU_TEXT_STYLES_PATCH_KEY =
   "contentPatch.defaultMenuTextStyles-1-9-1";
 const MENU_ITEM_TEXT_STYLE_ID = "e2WbW3vcPZR9";

--- a/src/deps/services/web/collab/connectionRuntime.js
+++ b/src/deps/services/web/collab/connectionRuntime.js
@@ -43,7 +43,7 @@ const loadLocalProjectEntries = async ({ db } = {}) => {
   }
 };
 
-const isLocalProjectId = async ({ db, projectId } = {}) => {
+export const isLocalProjectId = async ({ db, projectId } = {}) => {
   if (!projectId) {
     return false;
   }
@@ -162,6 +162,26 @@ export const createCollabConnectionRuntime = ({
     return params.get("p");
   };
 
+  const ensureProjectContentPatches = async ({ projectId, reason } = {}) => {
+    if (!projectId || getCollabProjectId() !== projectId) {
+      return;
+    }
+
+    try {
+      await projectService.ensureProjectContentPatches();
+      collabDebugLog("info", "project content patches completed", {
+        projectId,
+        reason,
+      });
+    } catch (error) {
+      collabDebugLog("warn", "project content patches failed", {
+        projectId,
+        reason,
+        error: error?.message || "unknown",
+      });
+    }
+  };
+
   const connectCollabDebugSession = async ({
     endpointUrl = collabRuntime.endpointUrl || DEFAULT_WEB_COLLAB_ENDPOINT,
     userId = collabRuntime.userId || "web-debug-user",
@@ -195,6 +215,12 @@ export const createCollabConnectionRuntime = ({
           userId,
           clientId: resolvedClientId,
         });
+        if (session?.hasCompletedInitialRemoteSync?.() === true) {
+          await ensureProjectContentPatches({
+            projectId,
+            reason: "initial_remote_sync",
+          });
+        }
         collabRuntime.endpointUrl = candidateEndpointUrl;
         collabRuntime.userId = userId;
         collabRuntime.clientId = resolvedClientId;
@@ -363,6 +389,10 @@ export const createCollabConnectionRuntime = ({
         mode: autoConnectMode,
         projectId: projectId || undefined,
         isLocalProject: localProject,
+      });
+      await ensureProjectContentPatches({
+        projectId,
+        reason: "local_project",
       });
       return;
     }

--- a/src/deps/services/web/collabBootstrapService.js
+++ b/src/deps/services/web/collabBootstrapService.js
@@ -2,6 +2,7 @@ import { createProjectService } from "./projectService.js";
 import {
   createCollabDebugLogger,
   createCollabConnectionRuntime,
+  isLocalProjectId,
   resolveCollabDebugEnabled,
 } from "./collab/connectionRuntime.js";
 import { createRemoteEventBridge } from "./collab/remoteEventBridge.js";
@@ -32,6 +33,8 @@ export const createWebProjectServiceWithCollab = async ({
     onRemoteEvent,
     db,
     creatorVersion,
+    shouldApplyProjectContentPatchesOnEnsure: ({ projectId }) =>
+      isLocalProjectId({ db, projectId }),
   });
 
   const collabConnectionRuntime = createCollabConnectionRuntime({

--- a/src/deps/services/web/projectService.js
+++ b/src/deps/services/web/projectService.js
@@ -10,6 +10,7 @@ export const createProjectService = ({
   onRemoteEvent,
   db,
   creatorVersion,
+  shouldApplyProjectContentPatchesOnEnsure = () => false,
 }) => {
   const collabLog = (level, message, meta = {}) => {
     if (!ENABLE_VERBOSE_COLLAB_LOGS && level !== "warn" && level !== "error") {
@@ -43,5 +44,6 @@ export const createProjectService = ({
     storageAdapter,
     fileAdapter,
     collabAdapter,
+    shouldApplyProjectContentPatchesOnEnsure,
   });
 };

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -25,6 +25,7 @@ import {
 } from "./projectServiceCollabRuntime.js";
 import {
   clearProjectionGap,
+  loadProjectionGap,
   saveProjectionGap,
 } from "../shared/collab/projectionGapState.js";
 import { loadRepositoryEventsFromClientStore } from "../shared/collab/clientStoreHistory.js";
@@ -408,6 +409,7 @@ export const createWebProjectServiceAdapters = ({
       const clientStore = await getCollabClientStore(projectId);
       await ensureCommittedIdLoaded(projectId, getStoreByProject);
       const projectionTracker = createCommittedCommandProjectionTracker();
+      let initialRemoteSyncCompleted = false;
       const collabSession = createProjectCollabService({
         projectId: resolvedProjectId,
         token,
@@ -608,6 +610,8 @@ export const createWebProjectServiceAdapters = ({
             }
           }),
       });
+      collabSession.hasCompletedInitialRemoteSync = () =>
+        initialRemoteSyncCompleted;
 
       await collabSession.start();
       collabLog("info", "session started", {
@@ -695,6 +699,8 @@ export const createWebProjectServiceAdapters = ({
             });
           }
 
+          const projectionGap = await loadProjectionGap(adapter);
+          initialRemoteSyncCompleted = !projectionGap;
           const syncDurationMs = Date.now() - syncStartedAt;
           collabLog("info", "initial remote sync completed", {
             projectId: resolvedProjectId,

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -409,6 +409,9 @@ export const createWebProjectServiceAdapters = ({
       const clientStore = await getCollabClientStore(projectId);
       await ensureCommittedIdLoaded(projectId, getStoreByProject);
       const projectionTracker = createCommittedCommandProjectionTracker();
+      // Content patches may trust web repository state only after the initial
+      // remote sync is fully projected with no stored projection gap. See
+      // docs/platform/14-project-content-patches.md.
       let initialRemoteSyncCompleted = false;
       const collabSession = createProjectCollabService({
         projectId: resolvedProjectId,

--- a/static/templates/default/repository.json
+++ b/static/templates/default/repository.json
@@ -1159,7 +1159,7 @@
         "colorId": "2mssudbGwHNF",
         "strokeColorId": "VH2N5yPHTbaW",
         "fontId": "7m7oC7i8JTEE",
-        "fontWeight": "400",
+        "fontWeight": "700",
         "previewText": "",
         "strokeWidth": 4
       },

--- a/tests/collab/connectionRuntime.test.js
+++ b/tests/collab/connectionRuntime.test.js
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveCollabDebugEnabled } from "../../src/deps/services/web/collab/connectionRuntime.js";
+import {
+  createCollabConnectionRuntime,
+  resolveCollabDebugEnabled,
+} from "../../src/deps/services/web/collab/connectionRuntime.js";
 
 const originalLocalStorage = globalThis.localStorage;
 
@@ -20,5 +23,84 @@ describe("collab connection runtime debug flag", () => {
   it("respects the explicit enabled override", () => {
     expect(resolveCollabDebugEnabled({ enabled: true })).toBe(true);
     expect(resolveCollabDebugEnabled({ enabled: false })).toBe(false);
+  });
+});
+
+const createConnectionRuntimeTestContext = ({
+  initialRemoteSyncCompleted = false,
+  projectEntries = [],
+} = {}) => {
+  const session = {
+    hasCompletedInitialRemoteSync: vi.fn(() => initialRemoteSyncCompleted),
+  };
+  const projectService = {
+    createCollabSession: vi.fn(async () => session),
+    ensureProjectContentPatches: vi.fn(async () => {}),
+    getCollabSession: vi.fn(() => undefined),
+    getCollabSessionMode: vi.fn(() => undefined),
+    stopCollabSession: vi.fn(async () => {}),
+  };
+  const runtime = createCollabConnectionRuntime({
+    projectService,
+    router: {
+      getPayload: () => ({ p: "project-1" }),
+    },
+    db: {
+      get: vi.fn(async () => projectEntries),
+    },
+    collabDebugLog: vi.fn(),
+  });
+
+  return {
+    projectService,
+    runtime,
+  };
+};
+
+describe("collab connection runtime project content patches", () => {
+  it("applies project content patches after initial remote sync completes", async () => {
+    const { projectService, runtime } = createConnectionRuntimeTestContext({
+      initialRemoteSyncCompleted: true,
+    });
+
+    await runtime.connectCollabDebugSession({
+      endpointUrl: "ws://localhost:1234/sync",
+      userId: "user-1",
+      clientId: "client-1",
+      token: "token-1",
+    });
+
+    expect(projectService.ensureProjectContentPatches).toHaveBeenCalledTimes(1);
+    expect(
+      projectService.createCollabSession.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      projectService.ensureProjectContentPatches.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not apply project content patches when initial remote sync fails", async () => {
+    const { projectService, runtime } = createConnectionRuntimeTestContext({
+      initialRemoteSyncCompleted: false,
+    });
+
+    await runtime.connectCollabDebugSession({
+      endpointUrl: "ws://localhost:1234/sync",
+      userId: "user-1",
+      clientId: "client-1",
+      token: "token-1",
+    });
+
+    expect(projectService.ensureProjectContentPatches).not.toHaveBeenCalled();
+  });
+
+  it("applies project content patches directly for local projects", async () => {
+    const { projectService, runtime } = createConnectionRuntimeTestContext({
+      projectEntries: [{ id: "project-1" }],
+    });
+
+    await runtime.bootCollabAutoConnect();
+
+    expect(projectService.createCollabSession).not.toHaveBeenCalled();
+    expect(projectService.ensureProjectContentPatches).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/project/layout.richText.test.js
+++ b/tests/project/layout.richText.test.js
@@ -106,7 +106,7 @@ describe("layout rich text projection", () => {
 
       expect(element.content).toEqual([{ text }]);
       expect(element.textStyle.fontWeight).toBe("700");
-      expect(element.hover.textStyle.fontWeight).toBe("400");
+      expect(element.hover.textStyle.fontWeight).toBe("700");
     }
   });
 });

--- a/tests/projectService/projectServiceCore.releaseRuntime.test.js
+++ b/tests/projectService/projectServiceCore.releaseRuntime.test.js
@@ -27,10 +27,18 @@ const mocked = vi.hoisted(() => ({
     updateCurrentProjectInfo: vi.fn(),
     updateProjectInfoByProjectId: vi.fn(),
   },
+  projectStore: {
+    app: {
+      get: vi.fn(),
+      set: vi.fn(),
+    },
+  },
   collabService: {
     stopCollabSession: vi.fn(),
     commandApi: {
       upgradeLayoutSchemaVersion: vi.fn(),
+      updateTextStyle: vi.fn(),
+      updateLayoutElement: vi.fn(),
       deleteSceneItem: vi.fn(),
     },
     addVersionToProject: vi.fn(),
@@ -98,14 +106,25 @@ describe("projectServiceCore releaseProjectRuntime", () => {
     mocked.importImageFile.mockReset();
     mocked.repositoryService.getEnsuredProjectId.mockReset();
     mocked.repositoryService.ensureRepository.mockReset();
+    mocked.repositoryService.getCachedStore.mockReset();
     mocked.repositoryService.getCachedRepository.mockReset();
     mocked.repositoryService.releaseCurrentRepository.mockReset();
     mocked.repositoryService.releaseRepositoryByProjectId.mockReset();
     mocked.collabService.stopCollabSession.mockReset();
     mocked.collabService.commandApi.upgradeLayoutSchemaVersion.mockReset();
+    mocked.collabService.commandApi.updateTextStyle.mockReset();
+    mocked.collabService.commandApi.updateLayoutElement.mockReset();
     mocked.collabService.commandApi.deleteSceneItem.mockReset();
+    mocked.projectStore.app.get.mockReset();
+    mocked.projectStore.app.set.mockReset();
     mocked.checkProjectResourceUsage.mockReset();
     mocked.checkSceneDeleteUsage.mockReset();
+
+    mocked.repositoryService.getCachedStore.mockReturnValue(
+      mocked.projectStore,
+    );
+    mocked.projectStore.app.get.mockResolvedValue(undefined);
+    mocked.projectStore.app.set.mockResolvedValue(undefined);
   });
 
   it("stops the ensured collab session before releasing that project runtime", async () => {
@@ -360,6 +379,308 @@ describe("projectServiceCore releaseProjectRuntime", () => {
       layoutIds: ["layout-old"],
       targetSchemaVersion: 2,
     });
+  });
+
+  it("patches legacy default menu text styles before recording completion", async () => {
+    const repository = {
+      getState: vi.fn(() => ({
+        textStyles: {
+          items: {
+            saV5A4pkvHRb: {
+              id: "saV5A4pkvHRb",
+              type: "textStyle",
+              fontWeight: "400",
+            },
+            e2WbW3vcPZR9: {
+              id: "e2WbW3vcPZR9",
+              type: "textStyle",
+            },
+          },
+        },
+        layouts: {
+          items: {
+            fKr5fa67MQWh: {
+              id: "fKr5fa67MQWh",
+              type: "layout",
+              layoutSchemaVersion: 2,
+              elements: {
+                items: {
+                  icn4dknq2kyp: {
+                    id: "icn4dknq2kyp",
+                    type: "text",
+                    textStyleId: "5rwEfyx2GBEi",
+                  },
+                },
+              },
+            },
+          },
+        },
+      })),
+    };
+    mocked.repositoryService.ensureRepository.mockResolvedValue(repository);
+    mocked.collabService.commandApi.updateTextStyle.mockResolvedValue({
+      valid: true,
+    });
+    mocked.collabService.commandApi.updateLayoutElement.mockResolvedValue({
+      valid: true,
+    });
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-1" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+    });
+
+    await expect(projectService.ensureRepository()).resolves.toBe(repository);
+
+    expect(mocked.projectStore.app.get).toHaveBeenCalledWith(
+      "contentPatch.defaultMenuTextStyles-1-9-1",
+    );
+    expect(
+      mocked.collabService.commandApi.updateTextStyle,
+    ).toHaveBeenCalledWith({
+      textStyleId: "saV5A4pkvHRb",
+      data: {
+        fontWeight: "700",
+      },
+    });
+    expect(
+      mocked.collabService.commandApi.updateLayoutElement,
+    ).toHaveBeenCalledWith({
+      layoutId: "fKr5fa67MQWh",
+      elementId: "icn4dknq2kyp",
+      data: {
+        textStyleId: "e2WbW3vcPZR9",
+      },
+      replace: false,
+    });
+    expect(mocked.projectStore.app.set).toHaveBeenCalledWith(
+      "contentPatch.defaultMenuTextStyles-1-9-1",
+      true,
+    );
+    expect(
+      mocked.collabService.commandApi.updateTextStyle.mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(mocked.projectStore.app.set.mock.invocationCallOrder[0]);
+    expect(
+      mocked.collabService.commandApi.updateLayoutElement.mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(mocked.projectStore.app.set.mock.invocationCallOrder[0]);
+  });
+
+  it("skips the default menu text-style patch when already completed", async () => {
+    const repository = {
+      getState: vi.fn(() => ({
+        layouts: {
+          items: {},
+        },
+      })),
+    };
+    mocked.repositoryService.ensureRepository.mockResolvedValue(repository);
+    mocked.projectStore.app.get.mockResolvedValue(true);
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-1" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+    });
+
+    await projectService.ensureRepository();
+
+    expect(
+      mocked.collabService.commandApi.updateTextStyle,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocked.collabService.commandApi.updateLayoutElement,
+    ).not.toHaveBeenCalled();
+    expect(mocked.projectStore.app.set).not.toHaveBeenCalled();
+  });
+
+  it("does not patch default menu values that no longer match the legacy values", async () => {
+    const repository = {
+      getState: vi.fn(() => ({
+        textStyles: {
+          items: {
+            saV5A4pkvHRb: {
+              id: "saV5A4pkvHRb",
+              type: "textStyle",
+              fontWeight: "500",
+            },
+            e2WbW3vcPZR9: {
+              id: "e2WbW3vcPZR9",
+              type: "textStyle",
+            },
+          },
+        },
+        layouts: {
+          items: {
+            fKr5fa67MQWh: {
+              id: "fKr5fa67MQWh",
+              type: "layout",
+              layoutSchemaVersion: 2,
+              elements: {
+                items: {
+                  icn4dknq2kyp: {
+                    id: "icn4dknq2kyp",
+                    type: "text",
+                    textStyleId: "custom-text-style",
+                  },
+                },
+              },
+            },
+          },
+        },
+      })),
+    };
+    mocked.repositoryService.ensureRepository.mockResolvedValue(repository);
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-1" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+    });
+
+    await projectService.ensureRepository();
+
+    expect(
+      mocked.collabService.commandApi.updateTextStyle,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocked.collabService.commandApi.updateLayoutElement,
+    ).not.toHaveBeenCalled();
+    expect(mocked.projectStore.app.set).toHaveBeenCalledWith(
+      "contentPatch.defaultMenuTextStyles-1-9-1",
+      true,
+    );
+  });
+
+  it("records completion without updates when the default menu ids are absent", async () => {
+    const repository = {
+      getState: vi.fn(() => ({
+        textStyles: {
+          items: {},
+        },
+        layouts: {
+          items: {},
+        },
+      })),
+    };
+    mocked.repositoryService.ensureRepository.mockResolvedValue(repository);
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-1" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+    });
+
+    await projectService.ensureRepository();
+
+    expect(
+      mocked.collabService.commandApi.updateTextStyle,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocked.collabService.commandApi.updateLayoutElement,
+    ).not.toHaveBeenCalled();
+    expect(mocked.projectStore.app.set).toHaveBeenCalledWith(
+      "contentPatch.defaultMenuTextStyles-1-9-1",
+      true,
+    );
+  });
+
+  it("does not record completion when a default menu patch update fails", async () => {
+    const repository = {
+      getState: vi.fn(() => ({
+        textStyles: {
+          items: {
+            saV5A4pkvHRb: {
+              id: "saV5A4pkvHRb",
+              type: "textStyle",
+              fontWeight: "400",
+            },
+          },
+        },
+        layouts: {
+          items: {},
+        },
+      })),
+    };
+    mocked.repositoryService.ensureRepository.mockResolvedValue(repository);
+    mocked.collabService.commandApi.updateTextStyle.mockResolvedValue({
+      valid: false,
+      error: {
+        message: "Text style patch failed.",
+      },
+    });
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-1" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+    });
+
+    await expect(projectService.ensureRepository()).rejects.toThrow(
+      "Text style patch failed.",
+    );
+
+    expect(mocked.projectStore.app.set).not.toHaveBeenCalled();
+    expect(
+      mocked.collabService.commandApi.updateLayoutElement,
+    ).not.toHaveBeenCalled();
   });
 
   it("loads historical repository state through the ensured repository contract", async () => {

--- a/tests/projectService/projectServiceCore.releaseRuntime.test.js
+++ b/tests/projectService/projectServiceCore.releaseRuntime.test.js
@@ -518,6 +518,53 @@ describe("projectServiceCore releaseProjectRuntime", () => {
     expect(mocked.projectStore.app.set).not.toHaveBeenCalled();
   });
 
+  it("defers automatic content patches until the platform marks the project ready", async () => {
+    const repository = {
+      getState: vi.fn(() => ({
+        textStyles: {
+          items: {},
+        },
+        layouts: {
+          items: {},
+        },
+      })),
+    };
+    mocked.repositoryService.ensureRepository.mockResolvedValue(repository);
+
+    const projectService = createProjectServiceCore({
+      router: {
+        getPayload: () => ({ p: "project-1" }),
+      },
+      db: {},
+      filePicker: {},
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      creatorVersion: 1,
+      storageAdapter: {
+        initializeProject: vi.fn(),
+      },
+      fileAdapter: {},
+      collabAdapter: {},
+      shouldApplyProjectContentPatchesOnEnsure: () => false,
+    });
+
+    await projectService.ensureRepository();
+
+    expect(mocked.projectStore.app.get).not.toHaveBeenCalled();
+    expect(mocked.projectStore.app.set).not.toHaveBeenCalled();
+
+    await projectService.ensureProjectContentPatches();
+
+    expect(mocked.projectStore.app.get).toHaveBeenCalledWith(
+      "contentPatch.defaultMenuTextStyles-1-9-1",
+    );
+    expect(mocked.projectStore.app.set).toHaveBeenCalledWith(
+      "contentPatch.defaultMenuTextStyles-1-9-1",
+      true,
+    );
+  });
+
   it("does not patch default menu values that no longer match the legacy values", async () => {
     const repository = {
       getState: vi.fn(() => ({

--- a/tests/web/projectServiceAdapters.test.js
+++ b/tests/web/projectServiceAdapters.test.js
@@ -145,7 +145,7 @@ describe("web project service adapters", () => {
       creatorVersion: 2,
     });
 
-    await collabAdapter.createSessionForProject({
+    const createdSession = await collabAdapter.createSessionForProject({
       projectId: "project-1",
       token: "token-1",
       userId: "user-1",
@@ -164,6 +164,47 @@ describe("web project service adapters", () => {
     expect(session.submitEvent).toHaveBeenCalledTimes(1);
     expect(session.flushDrafts).toHaveBeenCalledTimes(1);
     expect(session.syncNow).toHaveBeenCalledTimes(2);
+    expect(createdSession.hasCompletedInitialRemoteSync()).toBe(true);
+  });
+
+  it("does not mark initial remote sync complete when synchronization fails", async () => {
+    const repository = {
+      getState: vi.fn(() => structuredClone(initialProjectData)),
+    };
+    const adapter = {
+      listCommittedAfter: vi.fn(async () => []),
+      listDraftsOrdered: vi.fn(async () => []),
+      getCursor: vi.fn(async () => 0),
+      app: {
+        get: vi.fn(async () => undefined),
+        set: vi.fn(async () => {}),
+      },
+    };
+    const session = createSessionMock();
+    session.syncNow.mockRejectedValue(new Error("sync failed"));
+    mocked.createProjectCollabService.mockReturnValue(session);
+
+    const { collabAdapter } = createWebProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+
+    const createdSession = await collabAdapter.createSessionForProject({
+      projectId: "project-1",
+      token: "token-1",
+      userId: "user-1",
+      clientId: "client-1",
+      endpointUrl: "ws://localhost:1234",
+      mode: "explicit",
+      getRepositoryByProject: async () => repository,
+      getStoreByProject: async () => adapter,
+      getProjectInfoByProjectId: async () => ({
+        name: "Project 1",
+        description: "",
+      }),
+    });
+
+    expect(createdSession.hasCompletedInitialRemoteSync()).toBe(false);
   });
 
   it("rejects distribution ZIP export outside the Tauri app", async () => {
@@ -172,9 +213,9 @@ describe("web project service adapters", () => {
       creatorVersion: 2,
     });
 
-    await expect(
-      fileAdapter.promptDistributionZipPath(),
-    ).rejects.toThrow("Distribution ZIP export is only supported");
+    await expect(fileAdapter.promptDistributionZipPath()).rejects.toThrow(
+      "Distribution ZIP export is only supported",
+    );
     await expect(fileAdapter.createDistributionZipStreamed()).rejects.toThrow(
       "Distribution ZIP export is only supported",
     );


### PR DESCRIPTION
## Summary

- patch legacy selected-menu font weight and Load text style during project open
- guard both partial updates by exact legacy values and record completion in the project KV store
- update the default repository template, persisted-key documentation, and regression coverage

## Validation

- bun run lint
- bun run test
- bunx vitest run tests/projectService/projectServiceCore.releaseRuntime.test.js
- bun test tests/project/layout.richText.test.js