### PR TITLE
fix: update graphics and stabilize Windows chrome icons

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
         "route-engine-js": "1.29.0",
-        "route-graphics": "1.25.1",
+        "route-graphics": "1.27.1",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
         "snabbdom-to-html": "7.1.0",
@@ -130,6 +130,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -461,6 +463,12 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "@wasm-audio-decoders/common": ["@wasm-audio-decoders/common@9.0.7", "", { "dependencies": { "@eshaz/web-worker": "1.2.2", "simple-yenc": "^1.0.4" } }, "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag=="],
+
+    "@wasm-audio-decoders/ogg-vorbis": ["@wasm-audio-decoders/ogg-vorbis@0.1.20", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "codec-parser": "2.5.0" } }, "sha512-zaQPasU5usRjUDXtXOHYED5tfkR4QMXd+EH3Nrz1+4+M5pCsdD+s9YxJqb0oqnTyRu/KUujOmu5Z/m/NT47vwg=="],
+
+    "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
+
     "@webgpu/types": ["@webgpu/types@0.1.70", "", {}, "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
@@ -514,6 +522,8 @@
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
+
+    "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
@@ -743,6 +753,8 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
@@ -750,6 +762,8 @@
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
     "oxc-parser": ["oxc-parser@0.112.0", "", { "dependencies": { "@oxc-project/types": "^0.112.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.112.0", "@oxc-parser/binding-android-arm64": "0.112.0", "@oxc-parser/binding-darwin-arm64": "0.112.0", "@oxc-parser/binding-darwin-x64": "0.112.0", "@oxc-parser/binding-freebsd-x64": "0.112.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.112.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.112.0", "@oxc-parser/binding-linux-arm64-gnu": "0.112.0", "@oxc-parser/binding-linux-arm64-musl": "0.112.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.112.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.112.0", "@oxc-parser/binding-linux-riscv64-musl": "0.112.0", "@oxc-parser/binding-linux-s390x-gnu": "0.112.0", "@oxc-parser/binding-linux-x64-gnu": "0.112.0", "@oxc-parser/binding-linux-x64-musl": "0.112.0", "@oxc-parser/binding-openharmony-arm64": "0.112.0", "@oxc-parser/binding-wasm32-wasi": "0.112.0", "@oxc-parser/binding-win32-arm64-msvc": "0.112.0", "@oxc-parser/binding-win32-ia32-msvc": "0.112.0", "@oxc-parser/binding-win32-x64-msvc": "0.112.0" } }, "sha512-7rQ3QdJwobMQLMZwQaPuPYMEF2fDRZwf51lZ//V+bA37nejjKW5ifMHbbCwvA889Y4RLhT+/wLJpPRhAoBaZYw=="],
 
@@ -823,7 +837,7 @@
 
     "route-engine-js": ["route-engine-js@1.29.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1", "unicode-segmenter": "^0.17.0" } }, "sha512-iVA7p6ftPPLqIkzNOphA+GdyXsRtaivg2tpPk3t7RvfSGsjr16pECXtRr6t3r9JJgQnqsXIXcJOSm40PyT9xlw=="],
 
-    "route-graphics": ["route-graphics@1.25.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-bRd+OR+j2+Q+IS76kP8YT8gmGCdkhG9gI+z/HOygIm0AwwZbzEOkYVnKHk3OiZxqeCvR0+GyMEVgNqPktiPC1Q=="],
+    "route-graphics": ["route-graphics@1.27.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "@wasm-audio-decoders/ogg-vorbis": "^0.1.20", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "ogg-opus-decoder": "^1.7.3", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-x+MaSZubf0tvURE/XuvtqTO1Bc4hj+m1sJwtO3F2r392Rx9WHseEXX5nLt1gh9bkxFqv7pqzZycWND8iO56X+w=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
@@ -862,6 +876,8 @@
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
     "route-engine-js": "1.29.0",
-    "route-graphics": "1.25.1",
+    "route-graphics": "1.27.1",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",
     "snabbdom-to-html": "7.1.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.8.2"
+version = "1.9.1"
 dependencies = [
  "log",
  "plist",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.8.2"
+version = "1.9.1"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/static/public/windowChrome.js
+++ b/static/public/windowChrome.js
@@ -48,7 +48,7 @@
       overflow: hidden;
       border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.1));
       background: #202020;
-      color: var(--foreground, #f5f5f5);
+      color: #f5f5f5;
       font-family: Roboto, "Segoe UI Variable", "Segoe UI", sans-serif;
       font-size: 12px;
       line-height: 1;
@@ -86,7 +86,7 @@
     #${WINDOW_CHROME_ID}[data-focused="false"] {
       color: color-mix(
         in srgb,
-        var(--foreground, #f5f5f5) 62%,
+        #f5f5f5 62%,
         transparent
       );
     }
@@ -187,7 +187,7 @@
       transition-duration: 0ms;
       background-color: color-mix(
         in srgb,
-        var(--foreground, #f5f5f5) 18%,
+        #f5f5f5 18%,
         transparent
       );
     }
@@ -288,7 +288,7 @@
         aria-label="Minimize"
       >
         <svg viewBox="0 0 12 12" aria-hidden="true">
-          <path d="M1.5 6h9" />
+          <path d="M1.5 6.5h9" />
         </svg>
       </button>
       <button

--- a/tests/windowChrome/windowChrome.test.js
+++ b/tests/windowChrome/windowChrome.test.js
@@ -499,16 +499,28 @@ describe("standalone window chrome", () => {
     expect(document.documentElement.dataset.rvnWindowMaximized).toBe("false");
   });
 
-  it("uses centered Windows-style window control icons", async () => {
+  it("uses centered, theme-independent Windows-style window control icons", async () => {
     const harness = createWindowHarness();
     await flushTasks();
 
-    const chrome =
-      harness.dom.window.document.querySelector("#rvn-window-chrome");
-    const controlIconRule = [
-      ...harness.dom.window.document.querySelector("#rvn-window-chrome-styles")
-        .sheet.cssRules,
-    ].find(
+    const { document } = harness.dom.window;
+    const chrome = document.querySelector("#rvn-window-chrome");
+    const rules = [
+      ...document.querySelector("#rvn-window-chrome-styles").sheet.cssRules,
+    ];
+    const chromeRule = rules.find(
+      (rule) => rule.selectorText === "#rvn-window-chrome",
+    );
+    const unfocusedChromeRule = rules.find(
+      (rule) =>
+        rule.selectorText === '#rvn-window-chrome[data-focused="false"]',
+    );
+    const controlActiveRule = rules.find(
+      (rule) =>
+        rule.selectorText ===
+        "#rvn-window-chrome .rvn-window-chrome-control:active",
+    );
+    const controlIconRule = rules.find(
       (rule) =>
         rule.selectorText ===
         "#rvn-window-chrome .rvn-window-chrome-control svg",
@@ -528,8 +540,18 @@ describe("standalone window chrome", () => {
     );
 
     expect(appMenuButton.hasAttribute("data-tauri-drag-region")).toBe(false);
+    expect(chromeRule.style.getPropertyValue("color")).toBe("#f5f5f5");
+    expect(unfocusedChromeRule.style.getPropertyValue("color")).not.toContain(
+      "--foreground",
+    );
+    expect(
+      controlActiveRule.style.getPropertyValue("background-color"),
+    ).not.toContain("--foreground");
+    expect(controlIconRule.style.getPropertyValue("stroke")).toBe(
+      "currentColor",
+    );
     expect(controlIconRule.style.getPropertyValue("stroke-width")).toBe("1");
-    expect(minimizePath.getAttribute("d")).toBe("M1.5 6h9");
+    expect(minimizePath.getAttribute("d")).toBe("M1.5 6.5h9");
     expect(
       ["x", "y", "width", "height", "rx"].map((attribute) =>
         enterFullscreenRect.getAttribute(attribute),


### PR DESCRIPTION
## Summary
- update `route-graphics` from 1.25.1 to 1.27.1 and bump RouteVN Creator to 1.9.1
- align the Tauri configuration, Rust manifest, and Cargo lockfile package version
- keep Windows custom-title-bar icon colors independent from the app theme
- pixel-align the minimize glyph so its one-pixel stroke renders at full opacity
- add regression coverage for theme-independent chrome colors and icon geometry

## Testing
- `bun run lint`
- `bun run build:web`
- `bunx vitest run tests/windowChrome/windowChrome.test.js`
- `cargo metadata --manifest-path src-tauri/Cargo.toml --locked --no-deps --format-version 1`