### PR TITLE
fix: defer audio channel children until decoded

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "log",
  "plist",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.9.1"
+version = "1.9.2"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.8.2" date="2026-07-09"/>
+    <release version="1.9.2" date="2026-07-16"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -812,17 +812,31 @@ export const createGraphicsService = async ({
 
     audioElements.forEach((audioElement) => {
       const key = audioElement?.src;
-      if (typeof key !== "string" || !key) {
-        renderableAudio.push(audioElement);
+      if (typeof key === "string" && key) {
+        if (AudioAsset.getAsset?.(key)) {
+          renderableAudio.push(audioElement);
+          return;
+        }
+
+        missingAudioKeys.push(key);
         return;
       }
 
-      if (AudioAsset.getAsset?.(key)) {
-        renderableAudio.push(audioElement);
+      if (Array.isArray(audioElement?.children)) {
+        const splitChildren = splitRenderableAudio(audioElement.children);
+        missingAudioKeys.push(...splitChildren.missingAudioKeys);
+        renderableAudio.push(
+          splitChildren.missingAudioKeys.length > 0
+            ? {
+                ...audioElement,
+                children: splitChildren.renderableAudio,
+              }
+            : audioElement,
+        );
         return;
       }
 
-      missingAudioKeys.push(key);
+      renderableAudio.push(audioElement);
     });
 
     return {

--- a/tests/graphicsService/graphicsService.test.js
+++ b/tests/graphicsService/graphicsService.test.js
@@ -842,7 +842,7 @@ describe("graphicsService", () => {
     expect(routeGraphicsInstance.loadAssets).not.toHaveBeenCalled();
   });
 
-  it("waits for destination audio before rendering an animated engine state", async () => {
+  it("waits for destination channel audio before rendering an animated engine state", async () => {
     const bgmBuffer = new ArrayBuffer(8);
     const decodedAudioKeys = new Set();
     let resolveAudioLoad;
@@ -876,10 +876,17 @@ describe("graphicsService", () => {
       elements: [{ id: "story", type: "container", children: [] }],
       audio: [
         {
-          id: "bgm",
-          type: "sound",
-          src: "destination-bgm",
-          loop: true,
+          id: "channel:bgm",
+          type: "audio-channel",
+          volume: 100,
+          children: [
+            {
+              id: "bgm:default",
+              type: "sound",
+              src: "destination-bgm",
+              loop: true,
+            },
+          ],
         },
       ],
       animations: [
@@ -942,6 +949,118 @@ describe("graphicsService", () => {
     });
     expect(routeGraphicsInstance.render).toHaveBeenCalledWith(renderState);
     expect(selectRenderState).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds destination channel audio after rendering a static engine state", async () => {
+    const bgmBuffer = new ArrayBuffer(8);
+    const decodedAudioKeys = new Set();
+    let resolveAudioLoad;
+    const bufferManager = {
+      has: vi.fn(() => true),
+      load: vi.fn(async () => {}),
+      getBufferMap: vi.fn(() => ({
+        "destination-bgm": {
+          buffer: bgmBuffer,
+          type: "audio/mpeg",
+        },
+      })),
+      clear: vi.fn(),
+    };
+    createAssetBufferManagerMock.mockReturnValue(bufferManager);
+    audioAssetApi.getAsset = vi.fn((key) =>
+      decodedAudioKeys.has(key) ? { key } : undefined,
+    );
+    audioAssetApi.load = vi.fn(
+      (key) =>
+        new Promise((resolve) => {
+          resolveAudioLoad = () => {
+            decodedAudioKeys.add(key);
+            resolve({ key });
+          };
+        }),
+    );
+
+    const renderState = {
+      id: "render-static",
+      elements: [{ id: "story", type: "container", children: [] }],
+      audio: [
+        {
+          id: "channel:bgm",
+          type: "audio-channel",
+          volume: 100,
+          children: [
+            {
+              id: "bgm:default",
+              type: "sound",
+              src: "destination-bgm",
+              loop: true,
+            },
+          ],
+        },
+      ],
+      animations: [],
+    };
+    const selectRenderState = vi.fn(() => renderState);
+    createRouteEngineMock.mockReturnValue({
+      init: vi.fn(),
+      selectRenderState,
+      selectPresentationState: vi.fn(() => undefined),
+      selectPresentationChanges: vi.fn(() => undefined),
+      selectSectionLineChanges: vi.fn(() => []),
+      handleActions: vi.fn(),
+    });
+
+    const { createGraphicsService } = await import(
+      "../../src/deps/services/graphicsService.js"
+    );
+    const service = await createGraphicsService({
+      subject: {
+        dispatch: vi.fn(),
+      },
+    });
+
+    await service.init({
+      canvas: {
+        children: [],
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+      width: 1920,
+      height: 1080,
+    });
+    service.initRouteEngine({
+      screen: { width: 1920, height: 1080 },
+      story: { scenes: {} },
+      resources: {},
+    });
+    routeGraphicsInstance.render.mockClear();
+
+    service.engineRenderCurrentState();
+
+    await vi.waitFor(() => {
+      expect(audioAssetApi.load).toHaveBeenCalledWith(
+        "destination-bgm",
+        bgmBuffer,
+      );
+    });
+    expect(routeGraphicsInstance.render).toHaveBeenCalledTimes(1);
+    expect(routeGraphicsInstance.render).toHaveBeenLastCalledWith({
+      ...renderState,
+      audio: [
+        {
+          ...renderState.audio[0],
+          children: [],
+        },
+      ],
+    });
+
+    resolveAudioLoad();
+
+    await vi.waitFor(() => {
+      expect(routeGraphicsInstance.render).toHaveBeenCalledTimes(2);
+    });
+    expect(routeGraphicsInstance.render).toHaveBeenLastCalledWith(renderState);
+    expect(selectRenderState).toHaveBeenCalledTimes(2);
   });
 
   it("does not render a stale deferred state when newer audio is not yet decodable", async () => {
@@ -1095,10 +1214,17 @@ describe("graphicsService", () => {
       elements: [{ id: "story", type: "container", children: [] }],
       audio: [
         {
-          id: "bgm",
-          type: "sound",
-          src: "rejected-bgm",
-          loop: true,
+          id: "channel:bgm",
+          type: "audio-channel",
+          volume: 100,
+          children: [
+            {
+              id: "bgm:default",
+              type: "sound",
+              src: "rejected-bgm",
+              loop: true,
+            },
+          ],
         },
       ],
       animations: [
@@ -1152,7 +1278,12 @@ describe("graphicsService", () => {
       await vi.waitFor(() => {
         expect(routeGraphicsInstance.render).toHaveBeenCalledWith({
           ...renderState,
-          audio: [],
+          audio: [
+            {
+              ...renderState.audio[0],
+              children: [],
+            },
+          ],
         });
       });
       expect(consoleError).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- recursively split renderable audio inside `audio-channel` nodes so undecoded child sounds never reach Route Graphics
- wait for destination channel audio before animated section transitions and re-add decoded children after static transitions
- preserve channel structure while stripping children whose decode failed
- bump Creator desktop and Linux release metadata to 1.9.2

## Testing
- `bun run lint`
- `bun run build:web`
- `bun run test:smoke`
- `bun run test:integration`
- `bunx vitest run tests/graphicsService/graphicsService.test.js` (24 tests)
- Route Engine: `bunx vitest run spec/RouteEngine.audioChannels.test.js spec/RouteEngine.voice.test.js spec/RouteEngine.sfx.test.js` (9 tests)
- Route Graphics: `bunx vitest run spec/audio/audioStage.spec.js spec/audio/renderAudio.spec.js` (36 tests)
- `bun run tauri:validate:linux-packaging`
- `cargo metadata --manifest-path src-tauri/Cargo.toml --locked --no-deps --format-version 1`