### PR TITLE
fix: restore web startup flow and dialog Escape priority

### DIFF
--- a/scripts/build-macos-player-template.js
+++ b/scripts/build-macos-player-template.js
@@ -10,7 +10,6 @@ import {
   rename,
   rm,
   stat,
-  writeFile,
 } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import os from "node:os";
@@ -18,10 +17,12 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { NATIVE_PLAYER_INDEX_HTML } from "../src/deps/services/shared/projectExportService.js";
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
+const playerIndexPath = path.join(
+  rootDir,
+  "scripts/player-templates/macos/index.html",
+);
 const shellDir = path.join(rootDir, "crates/routevn-packager/tauri-shell");
 const shellDistDir = path.join(shellDir, "dist");
 const templateDir = path.join(
@@ -91,6 +92,7 @@ const stagePlayerFrontend = async () => {
     "static/bundle/player-runtime-persistence-host.js",
   );
   if (
+    !(await pathExists(playerIndexPath)) ||
     !(await pathExists(bundleMainJsPath)) ||
     !(await pathExists(persistenceHostPath))
   ) {
@@ -100,10 +102,7 @@ const stagePlayerFrontend = async () => {
   }
 
   await mkdir(shellDistDir, { recursive: true });
-  await writeFile(
-    path.join(shellDistDir, "index.html"),
-    NATIVE_PLAYER_INDEX_HTML,
-  );
+  await copyFile(playerIndexPath, path.join(shellDistDir, "index.html"));
   await copyFile(bundleMainJsPath, path.join(shellDistDir, "main.js"));
   await copyFile(
     persistenceHostPath,

--- a/scripts/build-windows-player-template.js
+++ b/scripts/build-windows-player-template.js
@@ -1,12 +1,14 @@
-import { copyFile, mkdir, stat, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { WINDOWS_PLAYER_INDEX_HTML } from "../src/deps/services/shared/projectExportService.js";
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
+const playerIndexPath = path.join(
+  rootDir,
+  "scripts/player-templates/windows/index.html",
+);
 const shellDir = path.join(rootDir, "crates/routevn-packager/tauri-shell");
 const shellDistDir = path.join(shellDir, "dist");
 const creatorTemplateDir = path.join(
@@ -106,6 +108,7 @@ const stagePlayerFrontend = async () => {
   const windowChromePath = path.join(rootDir, "static/public/windowChrome.js");
 
   if (
+    !(await pathExists(playerIndexPath)) ||
     !(await pathExists(bundleMainJsPath)) ||
     !(await pathExists(persistenceHostPath)) ||
     !(await pathExists(windowChromePath))
@@ -116,10 +119,7 @@ const stagePlayerFrontend = async () => {
   }
 
   await mkdir(shellDistDir, { recursive: true });
-  await writeFile(
-    path.join(shellDistDir, "index.html"),
-    WINDOWS_PLAYER_INDEX_HTML,
-  );
+  await copyFile(playerIndexPath, path.join(shellDistDir, "index.html"));
   await copyFile(bundleMainJsPath, path.join(shellDistDir, "main.js"));
   await copyFile(
     persistenceHostPath,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -18,6 +18,7 @@ import {
 } from "../src/internal/runtime/graphicsEngineRuntime.js";
 import { resolveBundleAssetMimeType } from "../src/internal/bundleRuntimeAssets.js";
 import { createBundleRangeReader as createPackageBinRangeReader } from "../src/deps/services/shared/projectExportService.js";
+import { waitForPlayerStart } from "./playerStartGate.js";
 
 const MAX_DIAGNOSTIC_EVENTS = 24;
 const MAX_DIAGNOSTIC_TEXT_LENGTH = 12_000;
@@ -914,6 +915,10 @@ const bootstrap = async () => {
   try {
     const preloadedData = await preloadBundleData();
     const engineRuntime = await prepareEngine(preloadedData);
+    await waitForPlayerStart({
+      loadingElement: document.getElementById("loading"),
+      startMode: document.body?.dataset.playerStart,
+    });
     engineRuntime.startEngine();
     await engineRuntime.waitForFirstRender();
     hideLoadingOverlay();

--- a/scripts/player-templates/macos/index.html
+++ b/scripts/player-templates/macos/index.html
@@ -1,0 +1,281 @@
+<html>
+  <head>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #000;
+      }
+
+      body {
+        display: grid;
+        place-items: center;
+      }
+
+      #canvas {
+        --project-screen-width: 16;
+        --project-screen-height: 9;
+        width: min(
+          100vw,
+          calc(
+            var(--rvn-app-viewport-height, 100vh) *
+              var(--project-screen-width) / var(--project-screen-height)
+          )
+        );
+        aspect-ratio: var(--project-screen-width) / var(--project-screen-height);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      #canvas canvas {
+        width: 100% !important;
+        height: 100% !important;
+        display: block;
+      }
+
+      #loading {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        box-sizing: border-box;
+        padding: 24px;
+        color: #fff;
+        background: #000;
+        z-index: 10;
+        user-select: none;
+      }
+
+      #loading.error {
+        cursor: default;
+        text-align: left;
+        user-select: text;
+      }
+
+      #loading.hidden {
+        display: none;
+      }
+
+      #loading .loading-error {
+        width: min(760px, calc(100vw - 32px));
+      }
+
+      #loading .loading-error-title {
+        margin: 0 0 8px;
+        font: 700 24px/1.2 sans-serif;
+      }
+
+      #loading .loading-error-summary {
+        margin: 0 0 16px;
+        color: #f1f5f9;
+        font: 500 15px/1.45 sans-serif;
+      }
+
+      #loading .loading-error-details {
+        box-sizing: border-box;
+        width: 100%;
+        max-height: min(58vh, 520px);
+        margin: 0;
+        overflow: auto;
+        padding: 12px;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        background: #0f172a;
+        color: #e2e8f0;
+        font:
+          12px/1.45 ui-monospace,
+          SFMono-Regular,
+          Consolas,
+          monospace;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body data-player-start="automatic">
+    <div id="loading"></div>
+    <div id="canvas"></div>
+  </body>
+  <script>
+    (() => {
+      const originalFetch = window.fetch.bind(window);
+      const embeddedPackageChunkSize = 1024 * 1024;
+
+      const getHeaderValue = (headers, name) => {
+        if (!headers) {
+          return "";
+        }
+
+        const normalizedName = name.toLowerCase();
+
+        if (typeof headers.get === "function") {
+          return headers.get(name) || headers.get(normalizedName) || "";
+        }
+
+        if (Array.isArray(headers)) {
+          const entry = headers.find(
+            ([key]) => String(key).toLowerCase() === normalizedName,
+          );
+          return entry?.[1] || "";
+        }
+
+        if (typeof headers === "object") {
+          const entry = Object.entries(headers).find(
+            ([key]) => String(key).toLowerCase() === normalizedName,
+          );
+          return entry?.[1] || "";
+        }
+
+        return "";
+      };
+
+      const getRangeHeader = (input, init) => {
+        return (
+          getHeaderValue(init?.headers, "range") ||
+          getHeaderValue(input?.headers, "range")
+        );
+      };
+
+      const parseRangeHeader = (rangeHeader, totalLength) => {
+        if (!rangeHeader) {
+          return undefined;
+        }
+
+        const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+        if (!match || totalLength === 0) {
+          return { invalid: true };
+        }
+
+        let start;
+        let end;
+
+        if (match[1] === "") {
+          const suffixLength = Number(match[2]);
+          if (!Number.isFinite(suffixLength) || suffixLength <= 0) {
+            return { invalid: true };
+          }
+          start = Math.max(totalLength - suffixLength, 0);
+          end = totalLength - 1;
+        } else {
+          start = Number(match[1]);
+          end = match[2] === "" ? totalLength - 1 : Number(match[2]);
+        }
+
+        if (
+          !Number.isSafeInteger(start) ||
+          !Number.isSafeInteger(end) ||
+          start < 0 ||
+          end < start ||
+          start >= totalLength
+        ) {
+          return { invalid: true };
+        }
+
+        return {
+          start,
+          end: Math.min(end, totalLength - 1),
+        };
+      };
+
+      const createEmbeddedPackageResponse = async ({ invoke, rangeHeader }) => {
+        const info = await invoke("get_embedded_package_info");
+        const totalLength = Number(info?.byteLength || 0);
+        if (!rangeHeader) {
+          return new Response(null, {
+            status: 416,
+            headers: {
+              "accept-ranges": "bytes",
+              "content-range": "bytes */" + totalLength,
+            },
+          });
+        }
+
+        const parsedRange = parseRangeHeader(rangeHeader, totalLength);
+
+        if (parsedRange?.invalid) {
+          return new Response(null, {
+            status: 416,
+            headers: {
+              "accept-ranges": "bytes",
+              "content-range": "bytes */" + totalLength,
+            },
+          });
+        }
+
+        const start = parsedRange?.start ?? 0;
+        const end = parsedRange?.end ?? totalLength - 1;
+        const contentLength = Math.max(end - start + 1, 0);
+        let cursor = start;
+
+        const stream = new ReadableStream({
+          async pull(controller) {
+            if (cursor > end || contentLength === 0) {
+              controller.close();
+              return;
+            }
+
+            const length = Math.min(embeddedPackageChunkSize, end - cursor + 1);
+            const bytes = await invoke("read_embedded_package_range", {
+              offset: cursor,
+              length,
+            });
+            const normalizedBytes =
+              bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+
+            if (normalizedBytes.byteLength === 0) {
+              controller.close();
+              return;
+            }
+
+            cursor += normalizedBytes.byteLength;
+            controller.enqueue(normalizedBytes);
+          },
+        });
+
+        const headers = {
+          "accept-ranges": "bytes",
+          "content-length": String(contentLength),
+          "content-type": "application/octet-stream",
+        };
+        if (parsedRange) {
+          headers["content-range"] =
+            "bytes " + start + "-" + end + "/" + totalLength;
+        }
+
+        return new Response(stream, {
+          status: parsedRange ? 206 : 200,
+          headers,
+        });
+      };
+
+      window.fetch = async (input, init) => {
+        const rawUrl = typeof input === "string" ? input : input?.url;
+
+        if (rawUrl) {
+          try {
+            const resolvedUrl = new URL(rawUrl, window.location.href);
+            const invoke = window.__TAURI__?.core?.invoke;
+
+            if (resolvedUrl.pathname.endsWith("/package.bin") && invoke) {
+              try {
+                return await createEmbeddedPackageResponse({
+                  invoke,
+                  rangeHeader: getRangeHeader(input, init),
+                });
+              } catch (error) {
+                console.warn("Falling back to package.bin fetch.", error);
+              }
+            }
+          } catch {}
+        }
+
+        return originalFetch(input, init);
+      };
+    })();
+  </script>
+  <script src="./player-runtime-persistence-host.js"></script>
+  <script src="./main.js" type="module"></script>
+</html>

--- a/scripts/player-templates/windows/index.html
+++ b/scripts/player-templates/windows/index.html
@@ -1,0 +1,282 @@
+<html>
+  <head>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #000;
+      }
+
+      body {
+        display: grid;
+        place-items: center;
+      }
+
+      #canvas {
+        --project-screen-width: 16;
+        --project-screen-height: 9;
+        width: min(
+          100vw,
+          calc(
+            var(--rvn-app-viewport-height, 100vh) *
+              var(--project-screen-width) / var(--project-screen-height)
+          )
+        );
+        aspect-ratio: var(--project-screen-width) / var(--project-screen-height);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      #canvas canvas {
+        width: 100% !important;
+        height: 100% !important;
+        display: block;
+      }
+
+      #loading {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        box-sizing: border-box;
+        padding: 24px;
+        color: #fff;
+        background: #000;
+        z-index: 10;
+        user-select: none;
+      }
+
+      #loading.error {
+        cursor: default;
+        text-align: left;
+        user-select: text;
+      }
+
+      #loading.hidden {
+        display: none;
+      }
+
+      #loading .loading-error {
+        width: min(760px, calc(100vw - 32px));
+      }
+
+      #loading .loading-error-title {
+        margin: 0 0 8px;
+        font: 700 24px/1.2 sans-serif;
+      }
+
+      #loading .loading-error-summary {
+        margin: 0 0 16px;
+        color: #f1f5f9;
+        font: 500 15px/1.45 sans-serif;
+      }
+
+      #loading .loading-error-details {
+        box-sizing: border-box;
+        width: 100%;
+        max-height: min(58vh, 520px);
+        margin: 0;
+        overflow: auto;
+        padding: 12px;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        background: #0f172a;
+        color: #e2e8f0;
+        font:
+          12px/1.45 ui-monospace,
+          SFMono-Regular,
+          Consolas,
+          monospace;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body data-player-start="automatic">
+    <div id="loading"></div>
+    <div id="canvas"></div>
+  </body>
+  <script>
+    (() => {
+      const originalFetch = window.fetch.bind(window);
+      const embeddedPackageChunkSize = 1024 * 1024;
+
+      const getHeaderValue = (headers, name) => {
+        if (!headers) {
+          return "";
+        }
+
+        const normalizedName = name.toLowerCase();
+
+        if (typeof headers.get === "function") {
+          return headers.get(name) || headers.get(normalizedName) || "";
+        }
+
+        if (Array.isArray(headers)) {
+          const entry = headers.find(
+            ([key]) => String(key).toLowerCase() === normalizedName,
+          );
+          return entry?.[1] || "";
+        }
+
+        if (typeof headers === "object") {
+          const entry = Object.entries(headers).find(
+            ([key]) => String(key).toLowerCase() === normalizedName,
+          );
+          return entry?.[1] || "";
+        }
+
+        return "";
+      };
+
+      const getRangeHeader = (input, init) => {
+        return (
+          getHeaderValue(init?.headers, "range") ||
+          getHeaderValue(input?.headers, "range")
+        );
+      };
+
+      const parseRangeHeader = (rangeHeader, totalLength) => {
+        if (!rangeHeader) {
+          return undefined;
+        }
+
+        const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+        if (!match || totalLength === 0) {
+          return { invalid: true };
+        }
+
+        let start;
+        let end;
+
+        if (match[1] === "") {
+          const suffixLength = Number(match[2]);
+          if (!Number.isFinite(suffixLength) || suffixLength <= 0) {
+            return { invalid: true };
+          }
+          start = Math.max(totalLength - suffixLength, 0);
+          end = totalLength - 1;
+        } else {
+          start = Number(match[1]);
+          end = match[2] === "" ? totalLength - 1 : Number(match[2]);
+        }
+
+        if (
+          !Number.isSafeInteger(start) ||
+          !Number.isSafeInteger(end) ||
+          start < 0 ||
+          end < start ||
+          start >= totalLength
+        ) {
+          return { invalid: true };
+        }
+
+        return {
+          start,
+          end: Math.min(end, totalLength - 1),
+        };
+      };
+
+      const createEmbeddedPackageResponse = async ({ invoke, rangeHeader }) => {
+        const info = await invoke("get_embedded_package_info");
+        const totalLength = Number(info?.byteLength || 0);
+        if (!rangeHeader) {
+          return new Response(null, {
+            status: 416,
+            headers: {
+              "accept-ranges": "bytes",
+              "content-range": "bytes */" + totalLength,
+            },
+          });
+        }
+
+        const parsedRange = parseRangeHeader(rangeHeader, totalLength);
+
+        if (parsedRange?.invalid) {
+          return new Response(null, {
+            status: 416,
+            headers: {
+              "accept-ranges": "bytes",
+              "content-range": "bytes */" + totalLength,
+            },
+          });
+        }
+
+        const start = parsedRange?.start ?? 0;
+        const end = parsedRange?.end ?? totalLength - 1;
+        const contentLength = Math.max(end - start + 1, 0);
+        let cursor = start;
+
+        const stream = new ReadableStream({
+          async pull(controller) {
+            if (cursor > end || contentLength === 0) {
+              controller.close();
+              return;
+            }
+
+            const length = Math.min(embeddedPackageChunkSize, end - cursor + 1);
+            const bytes = await invoke("read_embedded_package_range", {
+              offset: cursor,
+              length,
+            });
+            const normalizedBytes =
+              bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+
+            if (normalizedBytes.byteLength === 0) {
+              controller.close();
+              return;
+            }
+
+            cursor += normalizedBytes.byteLength;
+            controller.enqueue(normalizedBytes);
+          },
+        });
+
+        const headers = {
+          "accept-ranges": "bytes",
+          "content-length": String(contentLength),
+          "content-type": "application/octet-stream",
+        };
+        if (parsedRange) {
+          headers["content-range"] =
+            "bytes " + start + "-" + end + "/" + totalLength;
+        }
+
+        return new Response(stream, {
+          status: parsedRange ? 206 : 200,
+          headers,
+        });
+      };
+
+      window.fetch = async (input, init) => {
+        const rawUrl = typeof input === "string" ? input : input?.url;
+
+        if (rawUrl) {
+          try {
+            const resolvedUrl = new URL(rawUrl, window.location.href);
+            const invoke = window.__TAURI__?.core?.invoke;
+
+            if (resolvedUrl.pathname.endsWith("/package.bin") && invoke) {
+              try {
+                return await createEmbeddedPackageResponse({
+                  invoke,
+                  rangeHeader: getRangeHeader(input, init),
+                });
+              } catch (error) {
+                console.warn("Falling back to package.bin fetch.", error);
+              }
+            }
+          } catch {}
+        }
+
+        return originalFetch(input, init);
+      };
+    })();
+  </script>
+  <script src="./windowChrome.js" defer></script>
+  <script src="./player-runtime-persistence-host.js"></script>
+  <script src="./main.js" type="module"></script>
+</html>

--- a/scripts/playerStartGate.js
+++ b/scripts/playerStartGate.js
@@ -1,0 +1,22 @@
+export const waitForPlayerStart = async ({
+  loadingElement,
+  startMode,
+} = {}) => {
+  if (startMode !== "click" || !loadingElement) {
+    return;
+  }
+
+  loadingElement.textContent = "Click to start";
+  loadingElement.classList.add("ready");
+
+  await new Promise((resolve) => {
+    const handleClick = () => {
+      loadingElement.removeEventListener("click", handleClick);
+      resolve();
+    };
+
+    loadingElement.addEventListener("click", handleClick);
+  });
+
+  loadingElement.classList.remove("ready");
+};

--- a/scripts/test-export-bundle-pipeline.js
+++ b/scripts/test-export-bundle-pipeline.js
@@ -310,7 +310,8 @@ try {
         const { bundle } = await createBundleResult(projectData, files);
         const zip = new JSZip();
         zip.file("package.bin", bundle);
-        if (staticFiles.indexHtml) zip.file("index.html", staticFiles.indexHtml);
+        if (staticFiles.indexHtml)
+          zip.file("index.html", staticFiles.indexHtml);
         if (staticFiles.mainJs) zip.file("main.js", staticFiles.mainJs);
 
         const zipBlob = await zip.generateAsync({
@@ -365,6 +366,9 @@ try {
   const indexHtml = await zip.file("index.html").async("string");
   assert.ok(!indexHtml.includes("/@vite/client"));
   assert.ok(!indexHtml.includes("player-runtime-persistence-host.js"));
+  assert.ok(indexHtml.includes('<body data-player-start="click">'));
+  assert.ok(indexHtml.includes('<div id="loading">Loading...</div>'));
+  assert.ok(indexHtml.includes("#loading.ready"));
 
   const packageBin = await zip.file("package.bin").async("arraybuffer");
   const parsed = await parseBundle(packageBin);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "log",
  "plist",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.9.2"
+version = "1.9.3"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.9.2" date="2026-07-16"/>
+    <release version="1.9.3" date="2026-07-16"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/deps/services/shared/projectExportService.js
+++ b/src/deps/services/shared/projectExportService.js
@@ -56,8 +56,14 @@ export const BUNDLE_PLAYER_INDEX_HTML = `<html>
         padding: 24px;
         color: #fff;
         background: #000;
+        font: 600 24px/1.2 sans-serif;
+        letter-spacing: 0.02em;
         z-index: 10;
         user-select: none;
+      }
+
+      #loading.ready {
+        cursor: pointer;
       }
 
       #loading.error {
@@ -101,8 +107,8 @@ export const BUNDLE_PLAYER_INDEX_HTML = `<html>
       }
     </style>
   </head>
-  <body>
-    <div id="loading"></div>
+  <body data-player-start="click">
+    <div id="loading">Loading...</div>
     <div id="canvas"></div>
   </body>
   <script>
@@ -288,14 +294,6 @@ export const BUNDLE_PLAYER_INDEX_HTML = `<html>
   <script src="./main.js" type="module"></script>
 </html>
 `;
-export const NATIVE_PLAYER_INDEX_HTML = BUNDLE_PLAYER_INDEX_HTML.replace(
-  '  <script src="./main.js" type="module"></script>',
-  '  <script src="./player-runtime-persistence-host.js"></script>\n  <script src="./main.js" type="module"></script>',
-);
-export const WINDOWS_PLAYER_INDEX_HTML = NATIVE_PLAYER_INDEX_HTML.replace(
-  '  <script src="./player-runtime-persistence-host.js"></script>',
-  '  <script src="./windowChrome.js" defer></script>\n  <script src="./player-runtime-persistence-host.js"></script>',
-);
 const BUNDLE_MANIFEST_CHUNKING = Object.freeze({
   algorithm: "none",
   mode: "whole-file-only",

--- a/static/bundle/index.html
+++ b/static/bundle/index.html
@@ -58,7 +58,7 @@
       }
     </style>
   </head>
-  <body>
+  <body data-player-start="click">
     <div id="loading">Loading...</div>
     <div id="canvas"></div>
   </body>

--- a/static/public/windowChrome.js
+++ b/static/public/windowChrome.js
@@ -8,6 +8,7 @@
   const WINDOW_STATE_POLL_INTERVAL_MS = 500;
   const APP_ICON_MENU_DELAY_MS = 500;
   const DEFAULT_APP_TITLE = "RouteVN Creator";
+  const OPEN_DIALOG_SELECTOR = "dialog[open], rtgl-dialog[open]";
   const DEFAULT_APP_ICON =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAIN0lEQVR42p1XC0xU2Rn+GIb3+/1QnkVGQERW6sYHgkqw291VoglUbbqljUItmLpsmkjItiVKUkkwG900XYJuqkaz2SWLqVRXo+vaWmU3ojayDIXlzSLv1/CYAabnO/bcnQHbmp7kZu7cc8853/m+7/z/f/UArHiJ5uDgAEdHRywuLsrrRU2v18Nqtcp+/r7UvP8LgFp4fn5ee+bv74+wsDD4+PjIxYaGhtDd3Y25uTk7MLZj/i8AXHhhYUHeR0dHY9++fUhJSYFOp8PY2BhMJpPsc3d3h5ubGyYmJnD//n3U1tZienpavkcm/hsb/xGAk5MTLBYLXF1dUVlZiYSEBFy9ehX19fVoaWlZNqmLiwvWrFmDrKwsrF27Frdu3UJNTc2yjbwUALV4amoqzpw5g8uXL+P06dPL2KE8bEt9wZ0fOXJEgi4qKpJz8dmLvLMMgNKOOykvL8eBAwfQ3t5uZ0Lb3at79vPiQkr77du349ChQ9i/f78cx/6lzNkBUCiJ/OzZs8jOzsbk5KSk12w2v7SzlSQ0ZU5ODnbv3o38/PwXSuEort8uHVxdXY2SkhLpbMrBxRVAesLDwwNeXl7SfNwtDcjJbQ3HhZydnfH06VNkZGRgxYoVePjwoWTYTi5bTTmYTm9sbMSTJ080L/j6+iIiIkJefn5+cmIuwD61IMEQoG1jP1tpaSn27NkjgROw8o4dA0qf4uJinDp1SlJPpLGxsRLcwMAARkZG5HMesdnZWUkxx/F3ZmZG84GtVIrB4OBgpKWlyWNqy4JOLc4Hq1atkov09fVpLqcMPT09Ejl3qBZRF5n4Wf5PZZzg/VKnK0NeuHABmzdvtnumMaDo37Fjhwwwjx8/Xub4FHG2DatXo6OjQ0rA52onrsID71W8K//rXdzgInwyNjqqscHnU1NTSE9Pl79dXV1akNIYYAsNDZWd6myrY8n2WtY2nCh9Gw46R0kp+5XGkVHReDZmwsEDufh92TvIytyqmdb2qN6+fRtbt9r36W1fCAgIwKhAbnuu5SIOOhji4zA2NICigp+jtaMbg4ODeCUlGV4e7tiYtg4BPq6IiooUOSIIs5YFVJ/9UM6r5GW7d+8edu7cqZ2SZQA8PT3lxOoFogwKDsFvjr2Dva/twKBIOslJibAKFkaGh+HoYEWgvx8+qq1D1Z8/w+iECb4+3ti0caOci3R7e3tLg3Ij/f39Un8eyd7eXglOr+gm1TzPNGBubi46Ozvx4MED7M15E4Febig7UYlJ0zRWx8Xgrbw9WLcmkTxifGwczv4rMDptwdfGFvgLFiOiY+VxJQAGJPpJMUuJmTMIgBvUK6MEBQVptHDwsWPH0NzcDOPXTbh5vxEff1Inj6CnCEAJQo43ct7A3PgEnJ0c8YuiYrR2dqNLgOZi60QOefTokRZfyIICwMDESHv9+vXnoVsZkPmd55stMTERN27cwLlz5xAeEYkPPqjGq99fj3mLGeGhIUhaHc8oIwbr4OTsAutQB35X8kv8+ldFOJT/FvJ2vy7etWheordUY14JDAzUzKlXAMLDwzX9GSwuXbok7w0xkcCPf4Ty4xVwc/dAzs5tiImOxPzsnKDw+dgFIaGH3gHvvl0IswhQFqtISP82HjWnDGwM44wX6r+UXgEICQnRACgmJIVikdHuFgTozXj/RCnCBANWMZByjYsCJFDsjjtZED62mufhLCa3mBfkO7b+Umxs2rRJ+6/FAXUEGQWVbqo1f9OJb7p6EGv4HkKDAyW1nJS7YGzXiXflhPLIiZ9FqwjNZnnZHmcVltevX28HSANAo7Cksg1MisK7f2/AvDCgxbKg9Y+MjsFVgOj7th8dAqCeiYuJxt0V3T29mBQnYGnhQnMnJSXZ1ZsaAOqj0q4tapOQo+ZSLf5Q8yc4h4Zp8X5CAJqcMsHdzVXI4AezSEhuQYFoN7ai8v1qKZ1tJGVjCqfUimkeQ7v8GRMTowEgXWxDQ8OwCFqPlJbjj1XvwcXPF3ovT0THxsDL0wPeYlJPwZ6zrw8e/u0BMt7MhbG1XSiyqBUmKvkwh3Detra25fUAgwb1kbsW1a7BYJD3TE4hIkawFZaUYnt2Dq7Xf4YJIYGjmFwnrt7ePlz88AJ+UlCM7t5v4S2AmUzPjUyfMBKyMYWzNTQ0fGdQBYARimUTG9Mv67nx8XH5nFWuarfv3pO1wd4fZiE0LFxSbDQ2IzUpQeaLmUUHGbBUo+7MrpSYErBSZoBTOUKvEsXNmzdRVVUlCwdWQwcPHpSSEAAHM3rt2rULU2Jn02ODyHj1FTQ+/ofIUzr8YFs6Mremo6GpDb4hEfi09hMtFTO8Z2ZmylzA8cwHthWyjjd0Khe6du0aKioqtGSUl5enSUKABQUF4p2/4KkwWr9pEVGGJGzLykZyahrqv/gSfQPDaGv9J+JEYcPFWcoVFhbKmpDlHOPLypUr5b0yoVYVK1SsCZkyjUajBBYZGSl1ZJw4fPiwTFY01qw45wzf6Vs2Y05o+/ndvyIlOVnIJVK0MKW/oJ5SnD9/XlL+otLfriLi4vwQYSnOGo96cYGNIrWyRC8rK8OwSMH8LtTrHWXgCQkJlu8xAhni4/HVV1/KLMeEw9BOOen8eNHHOENv2aZ/eeLE4lbSvWXLFmlCfoYpnUjhhg0bcOXKFekDIue7BMygRbYoj4tYZEawcOfOHQme8YSO53fk0aNHJQPMAQR/8eJF1NXVfVeucUJSSq2Ygp89eya/egmAmYuBIy4uTtaCKjjRUJREVcRkgQBoWn43Ejjf4XXy5Ek0NTVJ8FFRUTh+/Lhkht8eDPn/AqpkTtjZKDHOAAAAAElFTkSuQmCC";
 
@@ -600,6 +601,13 @@
         return;
       }
       if (event.key === "Escape" && (state.fullscreen || state.maximized)) {
+        const isFromOpenDialog = event
+          .composedPath()
+          .some((target) => target?.matches?.(OPEN_DIALOG_SELECTOR));
+        if (isFromOpenDialog) {
+          return;
+        }
+
         event.preventDefault();
         runWindowAction("Restore window", toggleExpandedWindow);
       }

--- a/tests/services/playerStartGate.test.js
+++ b/tests/services/playerStartGate.test.js
@@ -1,0 +1,44 @@
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+import { waitForPlayerStart } from "../../scripts/playerStartGate.js";
+
+describe("player start gate", () => {
+  it("waits for a click before starting the web player", async () => {
+    const dom = new JSDOM('<div id="loading">Loading...</div>');
+    const loadingElement = dom.window.document.querySelector("#loading");
+    let didStart = false;
+
+    const startPromise = waitForPlayerStart({
+      loadingElement,
+      startMode: "click",
+    }).then(() => {
+      didStart = true;
+    });
+
+    await Promise.resolve();
+    expect(didStart).toBe(false);
+    expect(loadingElement.textContent).toBe("Click to start");
+    expect(loadingElement.classList.contains("ready")).toBe(true);
+
+    loadingElement.click();
+    await startPromise;
+
+    expect(loadingElement.textContent).toBe("Click to start");
+    expect(loadingElement.classList.contains("ready")).toBe(false);
+    dom.window.close();
+  });
+
+  it("starts native players without showing or waiting on the gate", async () => {
+    const dom = new JSDOM('<div id="loading"></div>');
+    const loadingElement = dom.window.document.querySelector("#loading");
+
+    await waitForPlayerStart({
+      loadingElement,
+      startMode: "automatic",
+    });
+
+    expect(loadingElement.textContent).toBe("");
+    expect(loadingElement.classList.contains("ready")).toBe(false);
+    dom.window.close();
+  });
+});

--- a/tests/services/projectExportService.test.js
+++ b/tests/services/projectExportService.test.js
@@ -1,10 +1,10 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BUNDLE_FORMAT_VERSION_V4,
   BUNDLE_HEADER_SIZE,
   BUNDLE_PLAYER_INDEX_HTML,
-  NATIVE_PLAYER_INDEX_HTML,
-  WINDOWS_PLAYER_INDEX_HTML,
   createBundleInstructions,
   createBundleResult,
   createProjectExportService,
@@ -13,6 +13,21 @@ import {
 } from "../../src/deps/services/shared/projectExportService.js";
 
 const originalFetch = globalThis.fetch;
+const readRepositoryFile = (relativeUrl) =>
+  readFileSync(fileURLToPath(new URL(relativeUrl, import.meta.url)), "utf8");
+const webPlayerIndexHtml = readRepositoryFile("../../static/bundle/index.html");
+const macosPlayerIndexHtml = readRepositoryFile(
+  "../../scripts/player-templates/macos/index.html",
+);
+const windowsPlayerIndexHtml = readRepositoryFile(
+  "../../scripts/player-templates/windows/index.html",
+);
+const macosPlayerBuildScript = readRepositoryFile(
+  "../../scripts/build-macos-player-template.js",
+);
+const windowsPlayerBuildScript = readRepositoryFile(
+  "../../scripts/build-windows-player-template.js",
+);
 
 describe("projectExportService", () => {
   afterEach(() => {
@@ -24,25 +39,57 @@ describe("projectExportService", () => {
     expect(BUNDLE_PLAYER_INDEX_HTML).not.toContain(
       "player-runtime-persistence-host.js",
     );
-    expect(NATIVE_PLAYER_INDEX_HTML).not.toContain("windowChrome.js");
-    expect(NATIVE_PLAYER_INDEX_HTML).toContain(
+    expect(macosPlayerIndexHtml).not.toContain("windowChrome.js");
+    expect(macosPlayerIndexHtml).toContain(
       '<script src="./player-runtime-persistence-host.js"></script>',
     );
     expect(
-      NATIVE_PLAYER_INDEX_HTML.indexOf("player-runtime-persistence-host.js"),
-    ).toBeLessThan(NATIVE_PLAYER_INDEX_HTML.indexOf("./main.js"));
-    expect(WINDOWS_PLAYER_INDEX_HTML).toContain(
+      macosPlayerIndexHtml.indexOf("player-runtime-persistence-host.js"),
+    ).toBeLessThan(macosPlayerIndexHtml.indexOf("./main.js"));
+    expect(windowsPlayerIndexHtml).toContain(
       '<script src="./windowChrome.js" defer></script>',
     );
-    expect(WINDOWS_PLAYER_INDEX_HTML).toContain(
+    expect(windowsPlayerIndexHtml).toContain(
       '<script src="./player-runtime-persistence-host.js"></script>',
     );
-    expect(WINDOWS_PLAYER_INDEX_HTML.indexOf("windowChrome.js")).toBeLessThan(
-      WINDOWS_PLAYER_INDEX_HTML.indexOf("player-runtime-persistence-host.js"),
+    expect(windowsPlayerIndexHtml.indexOf("windowChrome.js")).toBeLessThan(
+      windowsPlayerIndexHtml.indexOf("player-runtime-persistence-host.js"),
     );
     expect(
-      WINDOWS_PLAYER_INDEX_HTML.indexOf("player-runtime-persistence-host.js"),
-    ).toBeLessThan(WINDOWS_PLAYER_INDEX_HTML.indexOf("./main.js"));
+      windowsPlayerIndexHtml.indexOf("player-runtime-persistence-host.js"),
+    ).toBeLessThan(windowsPlayerIndexHtml.indexOf("./main.js"));
+    expect(
+      windowsPlayerIndexHtml.replace(
+        '  <script src="./windowChrome.js" defer></script>\n',
+        "",
+      ),
+    ).toBe(macosPlayerIndexHtml);
+  });
+
+  it("stages dedicated desktop index documents instead of deriving the web document", () => {
+    expect(macosPlayerBuildScript).toContain(
+      '"scripts/player-templates/macos/index.html"',
+    );
+    expect(windowsPlayerBuildScript).toContain(
+      '"scripts/player-templates/windows/index.html"',
+    );
+    expect(macosPlayerBuildScript).not.toContain("BUNDLE_PLAYER_INDEX_HTML");
+    expect(windowsPlayerBuildScript).not.toContain("BUNDLE_PLAYER_INDEX_HTML");
+  });
+
+  it("keeps the loading and click-to-start surface only in the web player HTML", () => {
+    for (const html of [BUNDLE_PLAYER_INDEX_HTML, webPlayerIndexHtml]) {
+      expect(html).toContain('<body data-player-start="click">');
+      expect(html).toContain('<div id="loading">Loading...</div>');
+      expect(html).toContain("#loading.ready");
+    }
+
+    for (const html of [macosPlayerIndexHtml, windowsPlayerIndexHtml]) {
+      expect(html).toContain('<body data-player-start="automatic">');
+      expect(html).toContain('<div id="loading"></div>');
+      expect(html).not.toContain('<div id="loading">Loading...</div>');
+      expect(html).not.toContain("#loading.ready");
+    }
   });
 
   it("sizes the player canvas within custom window chrome", () => {

--- a/tests/windowChrome/windowChrome.test.js
+++ b/tests/windowChrome/windowChrome.test.js
@@ -2,7 +2,6 @@ import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { JSDOM } from "jsdom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WINDOWS_PLAYER_INDEX_HTML } from "../../src/deps/services/shared/projectExportService.js";
 
 const windowChromeSource = readFileSync(
   fileURLToPath(
@@ -15,6 +14,15 @@ const staticDirectory = fileURLToPath(
 );
 const testPermissionsHtml = readFileSync(
   fileURLToPath(new URL("../../static/test-permissions.html", import.meta.url)),
+  "utf8",
+);
+const windowsPlayerIndexHtml = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../../scripts/player-templates/windows/index.html",
+      import.meta.url,
+    ),
+  ),
   "utf8",
 );
 const tauriWindowsConfig = JSON.parse(
@@ -272,11 +280,14 @@ describe("standalone window chrome", () => {
   });
 
   it("is staged and loaded by the exported Windows player shell", () => {
-    expect(WINDOWS_PLAYER_INDEX_HTML).toContain(
+    expect(windowsPlayerIndexHtml).toContain(
       '<script src="./windowChrome.js" defer></script>',
     );
-    expect(WINDOWS_PLAYER_INDEX_HTML.indexOf("windowChrome.js")).toBeLessThan(
-      WINDOWS_PLAYER_INDEX_HTML.indexOf("./main.js"),
+    expect(windowsPlayerIndexHtml.indexOf("windowChrome.js")).toBeLessThan(
+      windowsPlayerIndexHtml.indexOf("./main.js"),
+    );
+    expect(playerBuildScript).toContain(
+      '"scripts/player-templates/windows/index.html"',
     );
     expect(playerBuildScript).toContain('"static/public/windowChrome.js"');
     expect(playerBuildScript).toContain(
@@ -818,6 +829,43 @@ describe("standalone window chrome", () => {
     );
     await flushTasks();
 
+    expect(harness.appWindow.setFullscreen).toHaveBeenCalledOnce();
+    expect(fullscreenButton.getAttribute("aria-pressed")).toBe("true");
+    expect(document.documentElement.dataset.rvnWindowFullscreen).toBe("true");
+  });
+
+  it("leaves Escape to an open dialog without exiting fullscreen", async () => {
+    const harness = createWindowHarness();
+    await flushTasks();
+
+    const { document } = harness.dom.window;
+    const chrome = document.querySelector("#rvn-window-chrome");
+    const fullscreenButton = chrome.querySelector(
+      '[data-window-action="fullscreen"]',
+    );
+    const dialog = document.createElement("rtgl-dialog");
+    const dialogButton = document.createElement("button");
+    dialog.setAttribute("open", "");
+    dialog.append(dialogButton);
+    document.body.append(dialog);
+
+    harness.dom.window.dispatchEvent(
+      new harness.dom.window.KeyboardEvent("keydown", { key: "F11" }),
+    );
+    await flushTasks();
+    expect(harness.appWindow.setFullscreen).toHaveBeenCalledOnce();
+    expect(harness.appWindow.setFullscreen).toHaveBeenLastCalledWith(true);
+
+    const escapeEvent = new harness.dom.window.KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "Escape",
+    });
+    dialogButton.dispatchEvent(escapeEvent);
+    await flushTasks();
+
+    expect(escapeEvent.defaultPrevented).toBe(false);
     expect(harness.appWindow.setFullscreen).toHaveBeenCalledOnce();
     expect(fullscreenButton.getAttribute("aria-pressed")).toBe("true");
     expect(document.documentElement.dataset.rvnWindowFullscreen).toBe("true");


### PR DESCRIPTION
## Summary
- restore the Loading and Click to start gate for web exports while keeping desktop players automatic
- stage dedicated macOS and Windows player index documents instead of deriving them from the web export template
- keep Windows fullscreen active when Escape is closing an open dialog
- bump Tauri, Cargo, lockfile, and Linux AppStream release metadata to 1.9.3

## Testing
- bun run build:web
- bunx vitest run tests/services/playerStartGate.test.js tests/services/projectExportService.test.js tests/windowChrome/windowChrome.test.js
- node scripts/test-export-bundle-pipeline.js
- node scripts/build-windows-player-template.js --prepare-only
- node scripts/build-macos-player-template.js --prepare-only
- cargo metadata --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml
- Linux AppStream XML parsed with saxes
- bun run lint
- pre-push lint and formatting hooks