### PR TITLE
fix: sync sidebar selection and prepare 1.9.4

### DIFF
--- a/crates/routevn-packager/tauri-shell/src-tauri/tauri.conf.json
+++ b/crates/routevn-packager/tauri-shell/src-tauri/tauri.conf.json
@@ -11,8 +11,8 @@
     "windows": [
       {
         "title": "",
-        "width": 800,
-        "height": 600,
+        "width": 1600,
+        "height": 930,
         "resizable": true,
         "fullscreen": false,
         "decorations": true,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "log",
  "plist",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.9.3"
+version = "1.9.4"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.9.3" date="2026-07-16"/>
+    <release version="1.9.4" date="2026-07-16"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",
@@ -13,6 +13,8 @@
     "windows": [
       {
         "title": "RouteVN Creator",
+        "width": 1600,
+        "height": 930,
         "resizable": true,
         "fullscreen": false,
         "decorations": true,

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -5,6 +5,8 @@
     "windows": [
       {
         "title": "RouteVN Creator",
+        "width": 1600,
+        "height": 930,
         "resizable": true,
         "fullscreen": false,
         "decorations": true,

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -21,7 +21,7 @@ subscriptions:
 template:
   - 'rtgl-view d=${appShellDirection} w=f h=f style="min-width: 0; min-height: 0; height: var(--rvn-app-viewport-height, 100vh); max-height: var(--rvn-app-viewport-height, 100vh); overflow: hidden;"':
       - $if showSidebar:
-          - rvn-sidebar: []
+          - rvn-sidebar :currentRoute=${currentRoute}: []
       - 'rtgl-view style="width: ${contentWidth}; height: ${contentHeight}; min-width: 0; min-height: 0; overflow: hidden; box-sizing: border-box; flex-shrink: 1;"':
           - $if isRepositoryLoading:
               - rtgl-view w=f h=f d=v ah=c av=c g=sm:

--- a/src/pages/sidebar/sidebar.handlers.js
+++ b/src/pages/sidebar/sidebar.handlers.js
@@ -1,8 +1,5 @@
 import { filter, tap } from "rxjs";
-import {
-  createNavigationTiming,
-  markNavigationTiming,
-} from "../../internal/navigationTiming.js";
+import { createNavigationTiming } from "../../internal/navigationTiming.js";
 
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
@@ -74,21 +71,12 @@ export const handleProjectImageUpdate = async (deps) => {
 };
 
 const subscriptions = (deps) => {
-  const { subject, render } = deps;
+  const { subject } = deps;
   return [
     subject.pipe(
       filter(({ action }) => action === "project-image-update"),
       tap(({ payload }) => {
         deps.handlers.handleProjectImageUpdate(deps, payload);
-      }),
-    ),
-    subject.pipe(
-      filter(({ action }) => action === "redirect"),
-      tap(({ payload }) => {
-        // Small delay to ensure route has changed
-        markNavigationTiming(payload?.timing, "sidebar.redirect.render.start");
-        render();
-        markNavigationTiming(payload?.timing, "sidebar.redirect.render.end");
       }),
     ),
   ];

--- a/src/pages/sidebar/sidebar.schema.yaml
+++ b/src/pages/sidebar/sidebar.schema.yaml
@@ -1,4 +1,6 @@
 componentName: rvn-sidebar
 propsSchema:
   type: object
-  properties: {}
+  properties:
+    currentRoute:
+      type: string

--- a/src/pages/sidebar/sidebar.store.js
+++ b/src/pages/sidebar/sidebar.store.js
@@ -90,10 +90,9 @@ export const setProjectImageUrl = ({ state }, { imageUrl } = {}) => {
   state.header.image.src = imageUrl;
 };
 
-export const selectViewData = ({ state, i18n }) => {
+export const selectViewData = ({ state, props = {}, i18n }) => {
   const copy = selectSidebarCopy(i18n);
-  const currentPath =
-    typeof window !== "undefined" ? window.location.pathname : "";
+  const currentPath = props.currentRoute ?? "";
 
   // Find the matching item based on path
   const findMatchingItem = () => {

--- a/tests/app/app.view.test.js
+++ b/tests/app/app.view.test.js
@@ -2,6 +2,15 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("app view", () => {
+  it("passes the committed route to the sidebar", () => {
+    const appView = readFileSync(
+      new URL("../../src/pages/app/app.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    expect(appView).toContain("rvn-sidebar :currentRoute=${currentRoute}");
+  });
+
   it("prevents mobile tab tap feedback from rendering over the sheet", () => {
     const appView = readFileSync(
       new URL("../../src/pages/app/app.view.yaml", import.meta.url),

--- a/tests/sidebar/sidebar.handlers.test.js
+++ b/tests/sidebar/sidebar.handlers.test.js
@@ -1,6 +1,8 @@
+import { Subject } from "rxjs";
 import { describe, expect, it, vi } from "vitest";
 import {
   handleAfterMount,
+  handleBeforeMount,
   handleItemClick,
   handleProjectImageUpdate,
 } from "../../src/pages/sidebar/sidebar.handlers.js";
@@ -73,25 +75,45 @@ describe("sidebar.handlers", () => {
     expect(deps.subject.dispatch).toHaveBeenCalledWith("redirect", {
       path: "/project/images",
       payload: { p: "project-1" },
+      historyMode: "replace",
       timing: undefined,
     });
   });
 
-  it("selects sidebar groups by item id for nested resource routes", () => {
-    const originalWindow = globalThis.window;
+  it("selects sidebar groups from consecutive committed route props", () => {
+    const state = createInitialState();
 
-    globalThis.window = {
-      location: {
-        pathname: "/project/images",
-      },
+    expect(
+      selectViewData({
+        state,
+        props: { currentRoute: "/project/images" },
+      }).selectedItemId,
+    ).toBe("assets");
+    expect(
+      selectViewData({
+        state,
+        props: { currentRoute: "/project/scenes" },
+      }).selectedItemId,
+    ).toBe("scenes");
+    expect(
+      selectViewData({
+        state,
+        props: { currentRoute: "/project/about" },
+      }).selectedItemId,
+    ).toBe("settings");
+  });
+
+  it("does not render from a redirect request before the route is committed", () => {
+    const deps = createDeps();
+    deps.subject = new Subject();
+    deps.handlers = {
+      handleProjectImageUpdate: vi.fn(),
     };
 
-    try {
-      const viewData = selectViewData({ state: createInitialState() });
+    const cleanup = handleBeforeMount(deps);
+    deps.subject.next({ action: "redirect" });
 
-      expect(viewData.selectedItemId).toBe("assets");
-    } finally {
-      globalThis.window = originalWindow;
-    }
+    expect(deps.render).not.toHaveBeenCalled();
+    cleanup();
   });
 });

--- a/tests/windowChrome/windowChrome.test.js
+++ b/tests/windowChrome/windowChrome.test.js
@@ -25,6 +25,12 @@ const windowsPlayerIndexHtml = readFileSync(
   ),
   "utf8",
 );
+const tauriConfig = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../../src-tauri/tauri.conf.json", import.meta.url)),
+    "utf8",
+  ),
+);
 const tauriWindowsConfig = JSON.parse(
   readFileSync(
     fileURLToPath(
@@ -311,6 +317,15 @@ describe("standalone window chrome", () => {
     expect(defaultCapability.permissions).not.toContain(
       "core:window:allow-toggle-maximize",
     );
+  });
+
+  it("uses the same default size for Creator and exported player windows", () => {
+    for (const config of [tauriConfig, tauriWindowsConfig, playerShellConfig]) {
+      expect(config.app.windows[0]).toMatchObject({
+        width: 1600,
+        height: 930,
+      });
+    }
   });
 
   it("keeps the exported player native frame until custom chrome activates", () => {


### PR DESCRIPTION
## Summary
- derive sidebar selection from the committed app route instead of rendering on the earlier redirect event
- set Creator and exported player default window sizes to 1600 × 930
- align Tauri, Cargo, lockfile, and Linux AppStream metadata at version 1.9.4
- add regression coverage for sidebar route timing and aligned window dimensions

## Testing
- bun run lint
- bun prettier --check tests/app/app.view.test.js tests/sidebar/sidebar.handlers.test.js tests/windowChrome/windowChrome.test.js src-tauri/tauri.conf.json src-tauri/tauri.windows.conf.json crates/routevn-packager/tauri-shell/src-tauri/tauri.conf.json
- bunx vitest run tests/sidebar/sidebar.handlers.test.js tests/app/app.view.test.js tests/app/app.store.test.js tests/app/app.handlers.test.js tests/windowChrome/windowChrome.test.js
- bun scripts/validate-linux-packaging.js
- cargo metadata --format-version 1 --no-deps --locked