### PR TITLE
fix(scene-editor): discard canceled background previews

### DIFF
--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -1084,6 +1084,7 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
     preserveAnimationPlayback = false,
     skipAnimations = true,
     skipCanvasPaint = false,
+    syncCommittedSectionChanges = false,
   } = payload;
   const perfEnabled = isDebugEnabled(SCENE_EDITOR_PERF_SCOPE);
   const timingEnabled = shouldMeasureSceneEditorTiming();
@@ -1136,6 +1137,9 @@ export const renderSceneEditorState = async (deps, payload = {}) => {
   const presentationStateDurationMs = shouldMeasure
     ? getDebugDurationMs(presentationStateStartedAt)
     : undefined;
+  if (syncCommittedSectionChanges) {
+    await updateSceneEditorSectionChanges(deps);
+  }
   const temporaryPresentationState = selectTemporaryPresentationState(store);
   const temporaryPresentationStateStartedAt = shouldMeasure ? getDebugNow() : 0;
   let renderProjectData = await prepareTemporaryPresentationProjectData(
@@ -1631,14 +1635,12 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
   void preloadDirectTransitionScenes(deps, projectData, sceneIdsToLoad);
 
   const renderSceneStateStartedAt = shouldMeasure ? getDebugNow() : 0;
-  await renderSceneEditorState(deps, payload);
+  await renderSceneEditorState(deps, {
+    ...payload,
+    syncCommittedSectionChanges: true,
+  });
   const renderSceneStateDurationMs = shouldMeasure
     ? getDebugDurationMs(renderSceneStateStartedAt)
-    : undefined;
-  const sectionChangesStartedAt = shouldMeasure ? getDebugNow() : 0;
-  await updateSceneEditorSectionChanges(deps);
-  const sectionChangesDurationMs = shouldMeasure
-    ? getDebugDurationMs(sectionChangesStartedAt)
     : undefined;
 
   let uiRenderDurationMs = 0;
@@ -1667,7 +1669,6 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
       projectDataDurationMs,
       sceneAssetLoadDurationMs,
       renderSceneStateDurationMs,
-      sectionChangesDurationMs,
       uiRenderDurationMs,
       sceneIdsToLoad,
     });
@@ -1686,7 +1687,6 @@ export const renderSceneEditorCanvas = async (deps, payload) => {
       projectDataDurationMs,
       sceneAssetLoadDurationMs,
       renderSceneStateDurationMs,
-      sectionChangesDurationMs,
       uiRenderDurationMs,
       sceneIdsToLoad,
     });

--- a/tests/sceneEditor/runtime.test.js
+++ b/tests/sceneEditor/runtime.test.js
@@ -394,6 +394,90 @@ describe("renderSceneEditorState", () => {
     ).toBe("temporary");
   });
 
+  it("keeps section presentation changes based on committed data during temporary background previews", async () => {
+    const projectData = createProjectData();
+    projectData.resources.colors = {
+      "background-committed": {
+        id: "background-committed",
+        hex: "#111111",
+      },
+      "background-temporary": {
+        id: "background-temporary",
+        hex: "#eeeeee",
+      },
+    };
+    projectData.story.scenes["scene-1"].sections[
+      "section-1"
+    ].lines[1].actions.background = {
+      colorId: "background-committed",
+    };
+    const graphicsService = createGraphicsService();
+    let temporaryPresentationState = {
+      background: {
+        colorId: "background-temporary",
+      },
+    };
+    const store = {
+      selectIsScenePageLoading: () => false,
+      selectPreviewScene: () => ({
+        previewVisible: false,
+      }),
+      selectSceneId: () => "scene-1",
+      selectSelectedSectionId: () => "section-1",
+      selectSelectedLineId: () => "line-2",
+      selectProjectData: () => projectData,
+      selectTemporaryPresentationState: () => temporaryPresentationState,
+      selectScene: () => ({
+        sections: [{ id: "section-1" }],
+      }),
+      selectIsMuted: () => false,
+      setPresentationState: ({ presentationState }) => {
+        store.presentationState = presentationState;
+      },
+      setSectionLineChanges: ({ changes }) => {
+        store.sectionLineChanges = changes;
+      },
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      graphicsService,
+      refs: {
+        previewCanvasHost: {
+          getCanvasRoot: () => ({
+            isConnected: true,
+          }),
+        },
+      },
+    };
+
+    await renderSceneEditorCanvas(deps, {
+      skipAnimations: true,
+    });
+
+    const selectedLineChange = store.sectionLineChanges.lines.find(
+      (line) => line.id === "line-2",
+    );
+    expect(selectedLineChange.presentationState.background.colorId).toBe(
+      "background-committed",
+    );
+    expect(
+      graphicsService.engineSelectPresentationState()?.background?.colorId,
+    ).toBe("background-temporary");
+
+    temporaryPresentationState = {};
+    await renderSceneEditorCanvas(deps, {
+      skipAnimations: true,
+    });
+
+    expect(store.presentationState.background.colorId).toBe(
+      "background-committed",
+    );
+    expect(
+      graphicsService.engineSelectPresentationState()?.background?.colorId,
+    ).toBe("background-committed");
+  });
+
   it("can warm route-engine state without drawing the canvas", async () => {
     const projectData = createProjectData();
     const graphicsService = createGraphicsService();


### PR DESCRIPTION
## Summary
- derive section presentation changes from committed project data before applying temporary scene previews
- keep live background previews isolated from the bottom-right presentation state
- add Route Engine regression coverage for previewing and canceling a background change

## Testing
- bunx vitest run tests/sceneEditor/runtime.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/sceneEditor.store.test.js tests/commandLineBackground/commandLineBackground.handlers.test.js
- pre-push hook: oxlint
- pre-push hook: prettier --check src