### PR TITLE
feat: improve resource workflows and animation timelines

### DIFF
--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -1422,7 +1422,10 @@ export const handleItemContextMenu = (deps, payload) => {
     folderContextMenuItems,
     itemContextMenuItems,
   });
+  store.clearPendingDrag();
+  store.setSelectedItemId({ itemId });
   render();
+  emitItemClick({ dispatchEvent: deps.dispatchEvent, item });
 };
 
 export const handleItemClick = (deps, payload) => {

--- a/src/components/catalogResourcesView/catalogResourcesView.handlers.js
+++ b/src/components/catalogResourcesView/catalogResourcesView.handlers.js
@@ -30,7 +30,7 @@ const resolvePopoverButtonPosition = (element) => {
   const rect = element.getBoundingClientRect();
 
   return {
-    x: Math.round(rect.left),
+    x: Math.round(rect.right),
     y: Math.round(rect.bottom),
   };
 };
@@ -531,6 +531,13 @@ export const handleItemContextMenu = (deps, payload) => {
 
   if (parseBooleanProp(props.mobileLayout)) {
     dispatchEvent(
+      new CustomEvent("item-click", {
+        detail: { itemId, source: "context-menu" },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    dispatchEvent(
       new CustomEvent("item-dblclick", {
         detail: {
           itemId,
@@ -549,6 +556,13 @@ export const handleItemContextMenu = (deps, payload) => {
     y: payload._event.clientY,
   });
   render();
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: { itemId, source: "context-menu" },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 };
 
 export const handleZoomChange = (deps, payload) => {

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -199,12 +199,12 @@ template:
                                                           - rvn-keyframe-timeline w=f ?showRuler=true ?showTracks=false timelineDuration=${item.transitionTimelineDuration}: null
                                                           - rtgl-view d=v w=f g=xs:
                                                               - rtgl-text s=xs c=mu-fg: Out
-                                                              - rvn-keyframe-timeline w=f ?showTotalDuration=false ?showRuler=false timelineDuration=${item.transitionTimelineDuration} :properties=${item.prevProperties}: null
+                                                              - rvn-keyframe-timeline w=f ?showTotalDuration=false ?showRuler=false timelineDuration=${item.transitionTimelineDuration} :properties=${item.prevProperties} :defaultValues=${item.timelineDefaultValues}: null
                                                           - rtgl-view d=v w=f g=xs:
                                                               - rtgl-text s=xs c=mu-fg: In
-                                                              - rvn-keyframe-timeline w=f ?showTotalDuration=false ?showRuler=false timelineDuration=${item.transitionTimelineDuration} :properties=${item.nextProperties}: null
+                                                              - rvn-keyframe-timeline w=f ?showTotalDuration=false ?showRuler=false timelineDuration=${item.transitionTimelineDuration} :properties=${item.nextProperties} :defaultValues=${item.timelineDefaultValues}: null
                                                     $else:
-                                                      - rvn-keyframe-timeline w=f ?showRuler=true :properties=${item.updateProperties}: null
+                                                      - rvn-keyframe-timeline w=f ?showRuler=true :properties=${item.updateProperties} :defaultValues=${item.timelineDefaultValues}: null
                                             $else:
                                               - rtgl-view w=${item.catalogTextWidth} h=152 d=v ah=c av=c br=md p=md g=sm:
                                                   - rtgl-text s=md ellipsis w=f: ${item.name}

--- a/src/components/catalogResourcesView/catalogResourcesView.view.yaml
+++ b/src/components/catalogResourcesView/catalogResourcesView.view.yaml
@@ -223,7 +223,7 @@ template:
                   - rtgl-text s=lg c=mu-fg: No data
           - $if groups.length > 0:
               - 'rtgl-view w=f h="${scrollBottomPadding}" style="flex-shrink: 0;"': null
-  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=bs content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
+  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=be content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
       - $if showFilterPopoverSearch:
           - rtgl-text s=md: Filter
           - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} w=f: null
@@ -240,7 +240,7 @@ template:
           - rtgl-button#tagFilterClear v=se s=sm ?disabled=${tagFilterPopover.clearDisabled}: Clear
           - rtgl-button#tagFilterApply v=pr s=sm: Save
   - $if showZoomControls:
-      - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
+      - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=be content-w=260 content-g=sm content-ph=md content-pv=md:
           - rtgl-text s=md: Zoom
           - rtgl-view d=h av=c g=sm w=f:
               - rtgl-button#zoomOut sq v=ol: '-'

--- a/src/components/charactersResourcesView/charactersResourcesView.handlers.js
+++ b/src/components/charactersResourcesView/charactersResourcesView.handlers.js
@@ -383,6 +383,13 @@ export const handleItemContextMenu = (deps, payload) => {
 
   if (parseBooleanProp(props.mobileLayout)) {
     dispatchEvent(
+      new CustomEvent("item-click", {
+        detail: { itemId, source: "context-menu" },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    dispatchEvent(
       new CustomEvent("item-dblclick", {
         detail: {
           itemId,
@@ -401,6 +408,13 @@ export const handleItemContextMenu = (deps, payload) => {
     y: payload._event.clientY,
   });
   render();
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: { itemId, source: "context-menu" },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 };
 
 export const handleCloseContextMenu = (deps) => {

--- a/src/components/charactersResourcesView/charactersResourcesView.view.yaml
+++ b/src/components/charactersResourcesView/charactersResourcesView.view.yaml
@@ -118,7 +118,7 @@ template:
                   - rtgl-text s=lg c=mu-fg: No data
           - $if groups.length > 0:
               - 'rtgl-view w=f h="${scrollBottomPadding}" style="flex-shrink: 0;"': null
-  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=bs content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
+  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=be content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
       - $if showFilterPopoverSearch:
           - rtgl-text s=md: Filter
           - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} w=f: null

--- a/src/components/groupVariablesView/groupVariablesView.handlers.js
+++ b/src/components/groupVariablesView/groupVariablesView.handlers.js
@@ -746,6 +746,7 @@ export const handleRowContextMenu = (deps, payload) => {
 
   store.showContextMenu({ itemId, x, y });
   render();
+  handleRowClick(deps, payload);
 };
 
 export const handleContextMenuClickItem = (deps, payload) => {

--- a/src/components/groupVariablesView/groupVariablesView.view.yaml
+++ b/src/components/groupVariablesView/groupVariablesView.view.yaml
@@ -204,7 +204,7 @@ template:
       - rtgl-popover#enumValuePopover ?open=${enumValuePopover.isOpen} x=${enumValuePopover.x} y=${enumValuePopover.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
           - rtgl-form#enumValueForm key=${enumValuePopover.key} :defaultValues=${enumValueDefaultValues} :form=${enumValueForm} w=f: null
       - rtgl-dropdown-menu#enumValueMenu :items=${enumValueMenu.items} ?open=${enumValueMenu.isOpen} x=${enumValueMenu.x} y=${enumValueMenu.y}: null
-  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=bs content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
+  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=be content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
       - $if showFilterPopoverSearch:
           - rtgl-text s=md: ${filterLabel}
           - rtgl-input#searchInput s=sm placeholder="${searchPlaceholder}" value=${searchQuery} w=f: null

--- a/src/components/keyframeTimeline/keyframeTimeline.easing.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.easing.js
@@ -1,0 +1,287 @@
+const CURVE_WIDTH = 100;
+const CURVE_HEIGHT = 20;
+const CURVE_PADDING = 1;
+const CURVE_SAMPLE_COUNT = 36;
+
+const EASING_MODES = Object.freeze(["In", "Out", "InOut"]);
+const EASING_FAMILIES = Object.freeze([
+  "Quad",
+  "Cubic",
+  "Quart",
+  "Quint",
+  "Sine",
+  "Expo",
+  "Circ",
+  "Back",
+  "Bounce",
+  "Elastic",
+]);
+
+export const SUPPORTED_EASING_CURVE_NAMES = Object.freeze([
+  "linear",
+  ...EASING_FAMILIES.flatMap((family) =>
+    EASING_MODES.map((mode) => `ease${mode}${family}`),
+  ),
+]);
+
+const easeOutBounce = (progress) => {
+  const coefficient = 7.5625;
+  const divisor = 2.75;
+
+  if (progress < 1 / divisor) {
+    return coefficient * progress ** 2;
+  }
+
+  if (progress < 2 / divisor) {
+    const offsetProgress = progress - 1.5 / divisor;
+    return coefficient * offsetProgress ** 2 + 0.75;
+  }
+
+  if (progress < 2.5 / divisor) {
+    const offsetProgress = progress - 2.25 / divisor;
+    return coefficient * offsetProgress ** 2 + 0.9375;
+  }
+
+  const offsetProgress = progress - 2.625 / divisor;
+  return coefficient * offsetProgress ** 2 + 0.984375;
+};
+
+const easeInBack = (progress) => {
+  const overshoot = 1.70158;
+  return (overshoot + 1) * progress ** 3 - overshoot * progress ** 2;
+};
+
+const easeInOutBack = (progress) => {
+  const overshoot = 1.70158 * 1.525;
+
+  if (progress < 0.5) {
+    return (
+      ((2 * progress) ** 2 * ((overshoot + 1) * 2 * progress - overshoot)) / 2
+    );
+  }
+
+  return (
+    ((2 * progress - 2) ** 2 *
+      ((overshoot + 1) * (progress * 2 - 2) + overshoot) +
+      2) /
+    2
+  );
+};
+
+const easeInElastic = (progress) => {
+  if (progress === 0 || progress === 1) {
+    return progress;
+  }
+
+  const period = (2 * Math.PI) / 3;
+  return (
+    -(2 ** (10 * progress - 10)) * Math.sin((10 * progress - 10.75) * period)
+  );
+};
+
+const easeOutElastic = (progress) => {
+  if (progress === 0 || progress === 1) {
+    return progress;
+  }
+
+  const period = (2 * Math.PI) / 3;
+  return 2 ** (-10 * progress) * Math.sin((10 * progress - 0.75) * period) + 1;
+};
+
+const easeInOutElastic = (progress) => {
+  if (progress === 0 || progress === 1) {
+    return progress;
+  }
+
+  const period = (2 * Math.PI) / 4.5;
+  if (progress < 0.5) {
+    return (
+      -(
+        2 ** (20 * progress - 10) *
+        Math.sin((20 * progress - 11.125) * period)
+      ) / 2
+    );
+  }
+
+  return (
+    (2 ** (-20 * progress + 10) * Math.sin((20 * progress - 11.125) * period)) /
+      2 +
+    1
+  );
+};
+
+const EASE_IN_BY_FAMILY = Object.freeze({
+  Quad: (progress) => progress ** 2,
+  Cubic: (progress) => progress ** 3,
+  Quart: (progress) => progress ** 4,
+  Quint: (progress) => progress ** 5,
+  Sine: (progress) => 1 - Math.cos((progress * Math.PI) / 2),
+  Expo: (progress) => (progress === 0 ? 0 : 2 ** (10 * progress - 10)),
+  Circ: (progress) => 1 - Math.sqrt(1 - progress ** 2),
+  Back: easeInBack,
+  Bounce: (progress) => 1 - easeOutBounce(1 - progress),
+  Elastic: easeInElastic,
+});
+
+const resolveEasingFunction = (easingName) => {
+  if (easingName === "linear") {
+    return (progress) => progress;
+  }
+
+  const match = /^ease(InOut|In|Out)([A-Za-z]+)$/.exec(easingName ?? "");
+  if (!match) {
+    return (progress) => progress;
+  }
+
+  const [, mode, family] = match;
+  if (family === "Elastic") {
+    if (mode === "In") return easeInElastic;
+    if (mode === "Out") return easeOutElastic;
+    return easeInOutElastic;
+  }
+
+  if (family === "Back" && mode === "InOut") {
+    return easeInOutBack;
+  }
+
+  if (family === "Bounce" && mode === "Out") {
+    return easeOutBounce;
+  }
+
+  const easeIn = EASE_IN_BY_FAMILY[family];
+  if (!easeIn) {
+    return (progress) => progress;
+  }
+
+  if (mode === "In") {
+    return easeIn;
+  }
+
+  if (mode === "Out") {
+    return (progress) => 1 - easeIn(1 - progress);
+  }
+
+  return (progress) => {
+    if (progress < 0.5) {
+      return easeIn(progress * 2) / 2;
+    }
+
+    return 1 - easeIn((1 - progress) * 2) / 2;
+  };
+};
+
+const createEasingSamples = (easingName) => {
+  const easing = resolveEasingFunction(easingName);
+  const samples = Array.from(
+    { length: CURVE_SAMPLE_COUNT + 1 },
+    (_, sampleIndex) => {
+      const progress = sampleIndex / CURVE_SAMPLE_COUNT;
+      const value = easing(progress);
+      return {
+        progress,
+        value: Number.isFinite(value) ? value : progress,
+      };
+    },
+  );
+  samples[0].value = 0;
+  samples[samples.length - 1].value = 1;
+  return samples;
+};
+
+const EASING_SAMPLES = Object.freeze(
+  Object.fromEntries(
+    SUPPORTED_EASING_CURVE_NAMES.map((easingName) => [
+      easingName,
+      createEasingSamples(easingName),
+    ]),
+  ),
+);
+
+const resolveNumber = (value, fallback) => {
+  const numberValue = Number.parseFloat(value);
+  return Number.isFinite(numberValue) ? numberValue : fallback;
+};
+
+const resolveInitialValue = ({ initialValue, defaultValue } = {}) => {
+  return resolveNumber(initialValue, resolveNumber(defaultValue, 0));
+};
+
+const resolveTargetValue = ({ keyframe, startValue } = {}) => {
+  const keyframeValue = resolveNumber(keyframe?.value, 0);
+  return keyframe?.relative ? startValue + keyframeValue : keyframeValue;
+};
+
+const createValuePointPath = ({ points, timelineDuration } = {}) => {
+  const values = points.map((point) => point.value);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const hasValueRange = maxValue !== minValue;
+  const valueRange = hasValueRange ? maxValue - minValue : 1;
+  const drawableHeight = CURVE_HEIGHT - CURVE_PADDING * 2;
+
+  return points
+    .map(({ timeMs, value }, pointIndex) => {
+      const x = (timeMs / timelineDuration) * CURVE_WIDTH;
+      const normalizedValue = hasValueRange
+        ? (value - minValue) / valueRange
+        : 0.5;
+      const y = CURVE_PADDING + (1 - normalizedValue) * drawableHeight;
+      const command = pointIndex === 0 ? "M" : "L";
+      return `${command}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+};
+
+export const createKeyframeValueCurvePath = ({
+  defaultValue,
+  initialValue,
+  keyframes = [],
+  timelineDuration,
+} = {}) => {
+  if (keyframes.length === 0) {
+    return "";
+  }
+
+  const points = [];
+  let elapsedTimeMs = 0;
+  let startValue = resolveInitialValue({ initialValue, defaultValue });
+
+  keyframes.forEach((keyframe, keyframeIndex) => {
+    const duration = resolveNumber(keyframe.duration, 1000) || 1000;
+    const targetValue = resolveTargetValue({ keyframe, startValue });
+    const easingSamples =
+      EASING_SAMPLES[keyframe.easing ?? "linear"] ?? EASING_SAMPLES.linear;
+
+    easingSamples.forEach(({ progress, value: easedProgress }, sampleIndex) => {
+      if (keyframeIndex > 0 && sampleIndex === 0) {
+        return;
+      }
+
+      points.push({
+        timeMs: elapsedTimeMs + progress * duration,
+        value: startValue + (targetValue - startValue) * easedProgress,
+      });
+    });
+
+    elapsedTimeMs += duration;
+    startValue = targetValue;
+  });
+
+  const resolvedTimelineDuration =
+    Number(timelineDuration) > 0 ? Number(timelineDuration) : elapsedTimeMs;
+  if (resolvedTimelineDuration <= 0) {
+    return "";
+  }
+
+  if (resolvedTimelineDuration > elapsedTimeMs) {
+    points.push({
+      timeMs: resolvedTimelineDuration,
+      value: startValue,
+    });
+  }
+
+  return createValuePointPath({
+    points,
+    timelineDuration: resolvedTimelineDuration,
+  });
+};

--- a/src/components/keyframeTimeline/keyframeTimeline.store.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.store.js
@@ -1,3 +1,5 @@
+import { createKeyframeValueCurvePath } from "./keyframeTimeline.easing.js";
+
 export const createInitialState = () => ({
   hoverTarget: undefined,
   hoverIndicatorLeftPercent: undefined,
@@ -281,6 +283,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
 
       nextProperty.auto = {
         ...property.auto,
+        easingLabel: formatEasingLabel(property.auto.easing),
         label: `Auto ${propertyDuration}ms ${formatEasingLabel(property.auto.easing)}`,
         widthPercent: autoWidthPercent.toFixed(2),
       };
@@ -305,6 +308,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       };
 
       if (resolvedTimelineDuration > 0) {
+        const propertyConfig = props.properties?.[property.name] ?? {};
         const propertyTotalDuration = property.keyframes.reduce(
           (sum, keyframe) => sum + (parseFloat(keyframe.duration) || 1000),
           0,
@@ -330,9 +334,17 @@ export const selectViewData = ({ state, props, props: attrs }) => {
           }
           return {
             ...keyframe,
+            easing: keyframe.easing ?? "linear",
+            easingLabel: formatEasingLabel(keyframe.easing ?? "linear"),
             value: displayValue,
             widthPercent: widthPercent.toFixed(2),
           };
+        });
+        nextProperty.valueCurvePath = createKeyframeValueCurvePath({
+          defaultValue: props.defaultValues?.[property.name],
+          initialValue: propertyConfig.initialValue,
+          keyframes: property.keyframes,
+          timelineDuration: resolvedTimelineDuration,
         });
         nextProperty.propertyWidthPercent = propertyWidthPercent.toFixed(2);
         nextProperty.fillerWidthPercent = (100 - propertyWidthPercent).toFixed(

--- a/src/components/keyframeTimeline/keyframeTimeline.view.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.view.yaml
@@ -55,6 +55,9 @@ template:
                           - 'rtgl-view#track${pIndex} data-property=${property.name} data-track-mode=${property.trackMode} d=h w=f h=24 bgc=mu br=sm g=xs pos=rel style="min-width: 0; overflow: hidden; cursor: ${property.trackCursor};"':
                               - $if trackIndicatorVisible:
                                   - 'rtgl-view pos=abs bgc=fg op="0.5" style="${hoverIndicatorTrackStyle}"': null
+                              - $if property.valueCurvePath:
+                                  - 'svg data-value-curve=${property.name} aria-hidden=true viewBox="0 0 100 20" preserveAspectRatio="none" style="position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; opacity: 0.72; z-index: 1;"':
+                                      - 'path d="${property.valueCurvePath}" fill="none" stroke="var(--accent-foreground)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"': null
                               - $if property.hoverTarget:
                                   - 'rtgl-view pos=abs bgc=pr br=sm op="0.14" style="top: 0; bottom: 0; left: ${property.hoverTarget.zoneLeft}px; width: ${property.hoverTarget.zoneWidth}px; pointer-events: none; z-index: 2;"': null
                                   - $if property.hoverTarget.mode == 'empty':
@@ -65,15 +68,15 @@ template:
                                       - 'rtgl-view pos=abs bgc=pr br=f w=16 h=16 ah=c av=c style="top: 50%; left: ${property.hoverTarget.chipLeft}px; transform: translate(-50%, -50%); pointer-events: none; z-index: 4;"':
                                           - rtgl-text s=xs c=bg: +
                               - $if property.auto:
-                                  - 'rtgl-view d=h p=xs h=f bgc=ac br=sm ah=c av=c style="width: ${property.auto.widthPercent}%"':
-                                      - rtgl-text s=xs: ${property.auto.label}
+                                  - 'rtgl-view d=h p=xs h=f bgc=ac br=sm ah=c av=c pos=rel title="${property.auto.easingLabel}" style="width: ${property.auto.widthPercent}%; overflow: hidden;"':
+                                      - 'rtgl-text s=xs c=ac-fg style="position: relative; z-index: 1;"': ${property.auto.label}
                                   - $if property.fillerWidthPercent && property.fillerWidthPercent > 0:
                                       - 'rtgl-view d=h h=f style="width: ${property.fillerWidthPercent}%"': null
                                 $else:
                                   - $if property.keyframes && property.keyframes.length > 0:
                                       - $for keyframe, j in property.keyframes:
-                                          - 'rtgl-view#keyframe${pIndex}x${j} data-keyframe=true data-property=${property.name} data-index=${j} d=h p=xs h=f bgc=ac br=sm ah=e av=e mr=xs cur=pointer style="width: ${keyframe.widthPercent}%"':
-                                              - rtgl-text s=xs: ${keyframe.value}
+                                          - 'rtgl-view#keyframe${pIndex}x${j} data-keyframe=true data-property=${property.name} data-index=${j} d=h p=xs h=f bgc=ac br=sm ah=e av=e cur=pointer pos=rel title="${keyframe.easingLabel}" style="width: ${keyframe.widthPercent}%; overflow: hidden;"':
+                                              - 'rtgl-text s=xs c=ac-fg style="position: relative; z-index: 1;"': ${keyframe.value}
                                       - $if property.fillerWidthPercent && property.fillerWidthPercent > 0:
                                           - 'rtgl-view d=h h=f style="width: ${property.fillerWidthPercent}%"': null
                                     $else:

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -1086,6 +1086,13 @@ export const handleItemContextMenu = (deps, payload) => {
 
   if (parseBooleanProp(props.mobileLayout)) {
     dispatchEvent(
+      new CustomEvent("item-click", {
+        detail: { itemId, source: "context-menu" },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    dispatchEvent(
       new CustomEvent("item-dblclick", {
         detail: {
           itemId,
@@ -1104,6 +1111,13 @@ export const handleItemContextMenu = (deps, payload) => {
     y: payload._event.clientY,
   });
   render();
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: { itemId, source: "context-menu" },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 };
 
 export const handleCloseContextMenu = (deps) => {

--- a/src/components/textStyleResourcesView/textStyleResourcesView.handlers.js
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.handlers.js
@@ -30,7 +30,7 @@ const resolvePopoverButtonPosition = (element) => {
   const rect = element.getBoundingClientRect();
 
   return {
-    x: Math.round(rect.left),
+    x: Math.round(rect.right),
     y: Math.round(rect.bottom),
   };
 };
@@ -513,6 +513,13 @@ export const handleItemContextMenu = (deps, payload) => {
 
   if (parseBooleanProp(props.mobileLayout)) {
     dispatchEvent(
+      new CustomEvent("item-click", {
+        detail: { itemId, source: "context-menu" },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    dispatchEvent(
       new CustomEvent("item-dblclick", {
         detail: {
           itemId,
@@ -531,6 +538,13 @@ export const handleItemContextMenu = (deps, payload) => {
     y: payload._event.clientY,
   });
   render();
+  dispatchEvent(
+    new CustomEvent("item-click", {
+      detail: { itemId, source: "context-menu" },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 };
 
 export const handleZoomChange = (deps, payload) => {

--- a/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
+++ b/src/components/textStyleResourcesView/textStyleResourcesView.view.yaml
@@ -137,7 +137,7 @@ template:
                   - rtgl-text s=lg c=mu-fg: No data
           - $if groups.length > 0:
               - 'rtgl-view w=f h="${scrollBottomPadding}" style="flex-shrink: 0;"': null
-  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=bs content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
+  - rtgl-popover#tagFilterPopover ?open=${tagFilterPopover.isOpen} x=${tagFilterPopover.position.x} y=${tagFilterPopover.position.y} place=be content-w=320 content-g=sm content-sv=true content-ph=md content-pv=md:
       - $if showFilterPopoverSearch:
           - rtgl-text s=md: Filter
           - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} w=f: null
@@ -154,7 +154,7 @@ template:
           - rtgl-button#tagFilterClear v=se s=sm ?disabled=${tagFilterPopover.clearDisabled}: Clear
           - rtgl-button#tagFilterApply v=pr s=sm: Save
   - $if showZoomControls:
-      - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=bs content-w=260 content-g=sm content-ph=md content-pv=md:
+      - rtgl-popover#zoomPopover ?open=${zoomPopover.isOpen} x=${zoomPopover.position.x} y=${zoomPopover.position.y} place=be content-w=260 content-g=sm content-ph=md content-pv=md:
           - rtgl-text s=md: Zoom
           - rtgl-view d=h av=c g=sm w=f:
               - rtgl-button#zoomOut sq v=ol: '-'

--- a/src/deps/clients/router.js
+++ b/src/deps/clients/router.js
@@ -125,6 +125,13 @@ export default class WebRouter {
     return {};
   };
 
+  subscribePopState = (listener) => {
+    window.addEventListener("popstate", listener);
+    return () => {
+      window.removeEventListener("popstate", listener);
+    };
+  };
+
   redirect = (path, payload, options = {}) => {
     this.clearPendingPayload();
     const finalPath = createPathWithPayload(path, payload);

--- a/src/deps/clients/router.js
+++ b/src/deps/clients/router.js
@@ -20,6 +20,18 @@ const getCurrentPathWithSearch = () => {
   return `${window.location.pathname}${window.location.search}`;
 };
 
+const HISTORY_INDEX_STATE_KEY = "__rvnHistoryIndex";
+
+const getHistoryIndex = (state) => {
+  const value = state?.[HISTORY_INDEX_STATE_KEY];
+  return Number.isInteger(value) ? value : undefined;
+};
+
+const withHistoryIndex = (state, historyIndex) => ({
+  ...state,
+  [HISTORY_INDEX_STATE_KEY]: historyIndex,
+});
+
 export default class WebRouter {
   // _routes;
   routerType = "web";
@@ -28,6 +40,10 @@ export default class WebRouter {
   pendingPayloadSourcePath = undefined;
   pendingPayloadTimerId = undefined;
   lastPayloadReplaceAt = 0;
+  currentHistoryIndex = 0;
+  renderedHistoryIndex = 0;
+  historyTrackingInitialized = false;
+  suppressedPopStateCount = 0;
 
   getPathName = () => {
     return window.location.pathname;
@@ -66,7 +82,10 @@ export default class WebRouter {
       return;
     }
 
-    window.history.replaceState(this.getHistoryState(), "", finalPath);
+    const historyState = this.historyTrackingInitialized
+      ? withHistoryIndex(this.getHistoryState(), this.currentHistoryIndex)
+      : this.getHistoryState();
+    window.history.replaceState(historyState, "", finalPath);
     this.lastPayloadReplaceAt = Date.now();
   };
 
@@ -120,33 +139,91 @@ export default class WebRouter {
   getHistoryState = () => {
     const state = window.history.state;
     if (state && typeof state === "object") {
-      return { ...state };
+      const publicState = { ...state };
+      delete publicState[HISTORY_INDEX_STATE_KEY];
+      return publicState;
     }
     return {};
   };
 
+  initializeHistoryTracking = () => {
+    if (this.historyTrackingInitialized) {
+      return;
+    }
+
+    const historyIndex = getHistoryIndex(window.history.state) ?? 0;
+    this.currentHistoryIndex = historyIndex;
+    this.renderedHistoryIndex = historyIndex;
+    this.historyTrackingInitialized = true;
+    window.history.replaceState(
+      withHistoryIndex(this.getHistoryState(), historyIndex),
+      "",
+      getCurrentPathWithSearch(),
+    );
+  };
+
   subscribePopState = (listener) => {
-    window.addEventListener("popstate", listener);
+    this.initializeHistoryTracking();
+    const handlePopState = (event) => {
+      const destinationHistoryIndex = getHistoryIndex(event.state);
+      if (destinationHistoryIndex !== undefined) {
+        this.currentHistoryIndex = destinationHistoryIndex;
+      }
+
+      if (this.suppressedPopStateCount > 0) {
+        this.suppressedPopStateCount -= 1;
+        return;
+      }
+
+      listener(event);
+    };
+    window.addEventListener("popstate", handlePopState);
     return () => {
-      window.removeEventListener("popstate", listener);
+      window.removeEventListener("popstate", handlePopState);
     };
   };
 
   redirect = (path, payload, options = {}) => {
     this.clearPendingPayload();
     const finalPath = createPathWithPayload(path, payload);
-    window.history.pushState(options.state ?? {}, "", finalPath);
+    if (this.historyTrackingInitialized) {
+      this.currentHistoryIndex += 1;
+      this.renderedHistoryIndex = this.currentHistoryIndex;
+    }
+    const historyState = this.historyTrackingInitialized
+      ? withHistoryIndex(options.state, this.currentHistoryIndex)
+      : (options.state ?? {});
+    window.history.pushState(historyState, "", finalPath);
   };
 
   replace = (path, payload, options = {}) => {
     this.clearPendingPayload();
     const finalPath = createPathWithPayload(path, payload);
-    window.history.replaceState(options.state ?? {}, "", finalPath);
+    const historyState = this.historyTrackingInitialized
+      ? withHistoryIndex(options.state, this.currentHistoryIndex)
+      : (options.state ?? {});
+    window.history.replaceState(historyState, "", finalPath);
+    this.renderedHistoryIndex = this.currentHistoryIndex;
   };
 
   back = () => {
     this.clearPendingPayload();
     window.history.back();
+  };
+
+  restoreAfterFailedPop = () => {
+    this.clearPendingPayload();
+    const restoreDelta = this.renderedHistoryIndex - this.currentHistoryIndex;
+    if (restoreDelta === 0) {
+      return;
+    }
+
+    this.suppressedPopStateCount += 1;
+    window.history.go(restoreDelta);
+  };
+
+  acceptCurrentHistoryEntry = () => {
+    this.renderedHistoryIndex = this.currentHistoryIndex;
   };
 
   get stack() {

--- a/src/deps/services/shared/appShellService.js
+++ b/src/deps/services/shared/appShellService.js
@@ -181,7 +181,25 @@ export const createAppShellService = ({
       if (target) {
         await prepareNavigation(target);
       }
-      return router.back();
+      const didGoBack = router.back();
+      if (didGoBack === true) {
+        subject.dispatch("app.route.request", {
+          path: router.getPathName(),
+          payload: router.getPayload(),
+          historyState: router.getHistoryState?.() ?? {},
+          navigationPrepared: true,
+          shouldUpdateHistory: false,
+        });
+      }
+      return didGoBack;
+    },
+
+    restoreAfterFailedHistoryPop() {
+      router.restoreAfterFailedPop?.();
+    },
+
+    acceptCurrentHistoryEntry() {
+      router.acceptCurrentHistoryEntry?.();
     },
 
     canGoBack() {

--- a/src/internal/ui/fileExplorerKeyboardScope.js
+++ b/src/internal/ui/fileExplorerKeyboardScope.js
@@ -163,7 +163,7 @@ export const createFileExplorerKeyboardScopeHandlers = ({
       return;
     }
 
-    if (isBackShortcut && typeof onBackKey === "function") {
+    if (isBackShortcut && !event.repeat && typeof onBackKey === "function") {
       event.preventDefault();
       event.stopPropagation();
       onBackKey({ deps, event });

--- a/src/internal/ui/fileExplorerKeyboardScope.js
+++ b/src/internal/ui/fileExplorerKeyboardScope.js
@@ -109,6 +109,7 @@ export const createFileExplorerKeyboardScopeHandlers = ({
   fileExplorerRefName = "fileExplorer",
   keyboardScopeRefName = "fileExplorerKeyboardScope",
   isNavigationBlocked = () => false,
+  onBackKey,
   onEnterKey,
   onEditKey,
   resolveSelectedItemId = ({ selectedExplorerItem }) => {
@@ -150,12 +151,22 @@ export const createFileExplorerKeyboardScopeHandlers = ({
       return;
     }
 
+    const isBackShortcut =
+      event.shiftKey && String(event.key ?? "").toLowerCase() === "h";
+
     if (isTextEntryKeyEvent(event)) {
       return;
     }
 
     const jumpDirection = resolveJumpDirection(event);
     if (event.altKey || event.metaKey || (event.ctrlKey && !jumpDirection)) {
+      return;
+    }
+
+    if (isBackShortcut && typeof onBackKey === "function") {
+      event.preventDefault();
+      event.stopPropagation();
+      onBackKey({ deps, event });
       return;
     }
 

--- a/src/internal/ui/resourcePages/catalog/createCatalogPageHandlers.js
+++ b/src/internal/ui/resourcePages/catalog/createCatalogPageHandlers.js
@@ -17,6 +17,7 @@ export const createCatalogPageHandlers = ({
   selectData = (repositoryState) =>
     repositoryState?.[resourceType] ?? EMPTY_TREE,
   onProjectStateChanged = () => {},
+  onEditKey,
   createExplorerHandlers = ({ refresh }) =>
     createResourceFileExplorerHandlers({
       resourceType,
@@ -147,11 +148,32 @@ export const createCatalogPageHandlers = ({
 
   const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
     createExplorerHandlers({ refresh: refreshData, copy: resolveCopy });
+  const handleEditKey = ({ deps, selectedItemId, selectedExplorerItem }) => {
+    const selectedStoreItemId = deps.store.selectSelectedItemId();
+    const isFolder =
+      selectedStoreItemId === selectedItemId
+        ? false
+        : (selectedExplorerItem?.isFolder ??
+          deps.store.selectSelectedFolderId?.() === selectedItemId);
+
+    if (isFolder) {
+      openFolderNameDialogWithValues({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    onEditKey?.({ deps, selectedItemId, selectedExplorerItem });
+  };
   const {
     focusKeyboardScope,
     handleKeyboardScopeClick: handleFileExplorerKeyboardScopeClick,
     handleKeyboardScopeKeyDown: handleBaseFileExplorerKeyboardScopeKeyDown,
-  } = createFileExplorerKeyboardScopeHandlers();
+  } = createFileExplorerKeyboardScopeHandlers({
+    onEditKey: handleEditKey,
+    resolveSelectedItemId: ({ deps, selectedExplorerItem }) =>
+      deps.store.selectSelectedItemId() ??
+      selectedExplorerItem?.itemId ??
+      deps.store.selectSelectedFolderId?.(),
+  });
 
   const handleFileExplorerKeyboardScopeKeyDown = (deps, payload) => {
     if (handleResourceZoomShortcutKeyDown(deps, payload)) {

--- a/src/internal/ui/resourcePages/catalog/createCatalogPageStore.js
+++ b/src/internal/ui/resourcePages/catalog/createCatalogPageStore.js
@@ -407,7 +407,7 @@ export const createCatalogPageStore = ({
         return {
           ...group,
           children: filteredChildren.map((item) =>
-            buildCatalogItem(item, { copy }),
+            buildCatalogItem(item, { copy, state }),
           ),
           hasChildFolders: folderIdsWithChildFolders.has(group.id),
           hasChildren: filteredChildren.length > 0,

--- a/src/internal/ui/tagFilterPopover.handlers.js
+++ b/src/internal/ui/tagFilterPopover.handlers.js
@@ -1,4 +1,4 @@
-const resolveTagFilterButtonPosition = (element, { alignEnd = false } = {}) => {
+const resolveTagFilterButtonPosition = (element, { alignEnd = true } = {}) => {
   if (!element?.getBoundingClientRect) {
     return {
       x: 0,
@@ -17,7 +17,7 @@ const resolveTagFilterButtonPosition = (element, { alignEnd = false } = {}) => {
 export const openTagFilterPopoverFromButton = (
   deps,
   payload,
-  { alignEnd = false } = {},
+  { alignEnd = true } = {},
 ) => {
   const { refs, props, store, render } = deps;
   payload?._event?.stopPropagation?.();

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -539,6 +539,9 @@ const {
 } = createCatalogPageHandlers({
   resourceType: "animations",
   copy: ({ i18n }) => selectAnimationsPageCopy(i18n),
+  onEditKey: ({ deps, selectedItemId }) => {
+    openEditDialogWithValues({ deps, itemId: selectedItemId });
+  },
   selectData: (repositoryState) => {
     const tagsData = getTagsCollection(
       repositoryState,

--- a/src/pages/animations/animations.store.js
+++ b/src/pages/animations/animations.store.js
@@ -11,6 +11,10 @@ import {
   formatAnimationDurationLabel,
   toAnimationDisplayItem,
 } from "../../internal/animationDisplay.js";
+import {
+  createDefaultInitialValuesByProperty,
+  createPropertyFieldConfig,
+} from "../../internal/animationPreview.js";
 import { matchesTagAwareSearch } from "../../internal/resourceTags.js";
 import { selectAnimationsPageCopy } from "./support/animationsPageCopy.js";
 
@@ -254,11 +258,14 @@ const createAnimationCenterItemContextMenuItems = (copy = {}) => [
   },
 ];
 
-const buildCatalogItem = (item, { copy = {} } = {}) => {
+const buildCatalogItem = (item, { copy = {}, state } = {}) => {
   const displayItem = toAnimationDisplayItem(item);
   return {
     ...displayItem,
     animationTypeLabel: getAnimationTypeLabel(displayItem.animationType, copy),
+    timelineDefaultValues: createDefaultInitialValuesByProperty(
+      createPropertyFieldConfig(state.projectResolution),
+    ),
   };
 };
 

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -739,6 +739,12 @@ const subscriptions = (deps) => {
 
   return [
     subject.pipe(
+      filter(({ action }) => action === "routePop"),
+      tap(() => {
+        void handleWindowPop(deps);
+      }),
+    ),
+    subject.pipe(
       filter(
         ({ action }) => action === "redirect" || action === "app.route.request",
       ),

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -566,18 +566,14 @@ export const handleAfterMount = (deps) => {
     });
 };
 
-export const handleWindowPop = async (deps) => {
-  const { appService, store, subject } = deps;
+export const handleWindowPop = async (
+  deps,
+  { shouldContinue = () => true } = {},
+) => {
+  const { appService, subject } = deps;
   const copy = selectAppCopy(deps.i18n);
   const destinationPath = appService.getPath();
   const destinationPayload = appService.getPayload();
-  const destinationHistoryState = appService.getHistoryState();
-  const sourcePath = store.selectCurrentRoute();
-  const sourcePayload = store.selectCurrentRoutePayload();
-
-  appService.replace(sourcePath, sourcePayload, {
-    state: destinationHistoryState,
-  });
 
   try {
     await appService.prepareNavigation({
@@ -585,7 +581,12 @@ export const handleWindowPop = async (deps) => {
       payload: destinationPayload,
     });
   } catch (error) {
+    if (!shouldContinue()) {
+      return;
+    }
+
     console.error("Failed to prepare back navigation:", error);
+    appService.restoreAfterFailedHistoryPop();
     appService.showToast({
       title: copy.errorTitle ?? "Error",
       message: copy.navigationFailed ?? "Could not navigate. Please try again.",
@@ -594,9 +595,11 @@ export const handleWindowPop = async (deps) => {
     return;
   }
 
-  appService.replace(destinationPath, destinationPayload, {
-    state: destinationHistoryState,
-  });
+  if (!shouldContinue()) {
+    return;
+  }
+
+  appService.acceptCurrentHistoryEntry();
   subject.dispatch("app.route.request", {
     path: destinationPath,
     payload: destinationPayload,
@@ -695,6 +698,7 @@ export const handleMobileSheetClose = (deps) => {
 const subscriptions = (deps) => {
   const { appService, subject } = deps;
   const runRouteTransition = createRouteTransitionRunner(deps);
+  let navigationRequestSequence = 0;
   const projectKeyDown$ = fromEvent(window, "keydown", { capture: true }).pipe(
     filter(() => isProjectRoute(appService.getPath())),
     filter((event) => !event.defaultPrevented),
@@ -741,7 +745,10 @@ const subscriptions = (deps) => {
     subject.pipe(
       filter(({ action }) => action === "routePop"),
       tap(() => {
-        void handleWindowPop(deps);
+        const requestSequence = ++navigationRequestSequence;
+        void handleWindowPop(deps, {
+          shouldContinue: () => requestSequence === navigationRequestSequence,
+        });
       }),
     ),
     subject.pipe(
@@ -749,6 +756,7 @@ const subscriptions = (deps) => {
         ({ action }) => action === "redirect" || action === "app.route.request",
       ),
       tap(({ action, payload }) => {
+        navigationRequestSequence += 1;
         const shouldUpdateHistory = action === "redirect";
         const path = shouldUpdateHistory ? payload.path : payload?.path;
         const nextPayload = shouldUpdateHistory

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -15,9 +15,6 @@ refs:
     eventListeners:
       close:
         handler: handleMobileSheetClose
-subscriptions:
-  - from: routePop
-    handler: handleWindowPop
 template:
   - 'rtgl-view d=${appShellDirection} w=f h=f style="min-width: 0; min-height: 0; height: var(--rvn-app-viewport-height, 100vh); max-height: var(--rvn-app-viewport-height, 100vh); overflow: hidden;"':
       - $if showSidebar:

--- a/src/pages/characterSprites/characterSprites.handlers.js
+++ b/src/pages/characterSprites/characterSprites.handlers.js
@@ -207,6 +207,9 @@ const {
   handleKeyboardScopeKeyDown: handleBaseFileExplorerKeyboardScopeKeyDown,
 } = createFileExplorerKeyboardScopeHandlers({
   isNavigationBlocked: ({ deps }) => deps.store.selectFullImagePreviewVisible(),
+  onBackKey: ({ deps }) => {
+    void deps.appService.back();
+  },
   onEnterKey: ({ deps, selectedItemId }) => {
     const item = deps.store.selectSpriteItemById({ itemId: selectedItemId });
     if (item?.type === "spritesheet") {
@@ -219,6 +222,20 @@ const {
     }
 
     openSpritePreviewById({ deps, itemId: selectedItemId, syncExplorer: true });
+  },
+  onEditKey: ({ deps, selectedItemId, selectedExplorerItem }) => {
+    if (selectedExplorerItem?.isFolder) {
+      openFolderNameDialogForFolder({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    const item = deps.store.selectSpriteItemById({ itemId: selectedItemId });
+    if (item?.type === "spritesheet") {
+      openSpritesheetEditDialogForItem({ deps, itemId: selectedItemId });
+      return;
+    }
+
+    openEditDialogForSprite({ deps, itemId: selectedItemId });
   },
   resolveSelectedItemId: ({ deps, selectedExplorerItem }) => {
     return selectedExplorerItem?.isFolder

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -270,6 +270,18 @@ const readSpriteGroupTarget = (payload) =>
 const readSpriteGroupIndex = (payload) =>
   Number.parseInt(payload?._event?.currentTarget?.dataset?.index ?? "", 10);
 
+const navigateToCharacterSprites = ({ deps, characterId } = {}) => {
+  const { appService, render } = deps;
+  const { p } = appService.getPayload();
+
+  appService.navigate("/project/character-sprites", {
+    characterId,
+    p,
+  });
+
+  render();
+};
+
 const { handleFileExplorerAction, handleFileExplorerTargetChanged } =
   createResourceFileExplorerHandlers({
     resourceType: "characters",
@@ -280,7 +292,26 @@ const {
   focusKeyboardScope: focusFileExplorerKeyboardScope,
   handleKeyboardScopeClick: handleFileExplorerKeyboardScopeClick,
   handleKeyboardScopeKeyDown: handleFileExplorerKeyboardScopeKeyDown,
-} = createFileExplorerKeyboardScopeHandlers();
+} = createFileExplorerKeyboardScopeHandlers({
+  onBackKey: ({ deps }) => {
+    void deps.appService.back();
+  },
+  onEnterKey: ({ deps, selectedItemId }) => {
+    navigateToCharacterSprites({ deps, characterId: selectedItemId });
+  },
+  onEditKey: ({ deps, selectedItemId, selectedExplorerItem }) => {
+    if (selectedExplorerItem?.isFolder) {
+      openFolderNameDialogWithValues({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    openEditDialogWithValues({ deps, itemId: selectedItemId });
+  },
+  resolveSelectedItemId: ({ deps, selectedExplorerItem }) =>
+    selectedExplorerItem?.isFolder
+      ? undefined
+      : (selectedExplorerItem?.itemId ?? deps.store.selectSelectedItemId()),
+});
 
 export {
   handleFileExplorerAction,
@@ -319,14 +350,14 @@ export const handleFileExplorerSelectionChanged = async (deps, payload) => {
   focusFileExplorerKeyboardScope(deps);
 };
 
-export const handleCharacterItemClick = async (deps, payload) => {
+export const handleCharacterItemClick = (deps, payload) => {
   const { store, render, refs } = deps;
   const { itemId } = payload._event.detail;
   if (!itemId) {
     return;
   }
 
-  store.setSelectedItemId({ itemId: itemId });
+  store.setSelectedItemId({ itemId });
 
   const { fileExplorer } = refs;
   fileExplorer?.selectItem?.({ itemId });
@@ -512,17 +543,8 @@ export const handleCharacterCreated = async (deps, payload) => {
 };
 
 export const handleSpritesButtonClick = (deps, payload) => {
-  const { appService, render } = deps;
   const { itemId } = payload._event.detail;
-  const { p } = appService.getPayload();
-
-  // Navigate to character sprites page
-  appService.navigate("/project/character-sprites", {
-    characterId: itemId,
-    p: p,
-  });
-
-  render();
+  navigateToCharacterSprites({ deps, characterId: itemId });
 };
 
 export const handleSearchInput = (deps, payload) => {

--- a/src/pages/colors/colors.handlers.js
+++ b/src/pages/colors/colors.handlers.js
@@ -74,6 +74,9 @@ const {
 } = createCatalogPageHandlers({
   resourceType: "colors",
   copy: ({ i18n }) => selectColorsPageCopy(i18n),
+  onEditKey: ({ deps, selectedItemId }) => {
+    openEditDialogWithValues({ deps, itemId: selectedItemId });
+  },
   selectData: (repositoryState) => {
     const tagsData = getTagsCollection(repositoryState, COLOR_TAG_SCOPE_KEY);
 

--- a/src/pages/controls/controls.handlers.js
+++ b/src/pages/controls/controls.handlers.js
@@ -67,6 +67,9 @@ const {
 } = createCatalogPageHandlers({
   resourceType: "controls",
   copy: selectCopy,
+  onEditKey: ({ deps, selectedItemId }) => {
+    openEditDialogWithValues({ deps, itemId: selectedItemId });
+  },
   selectData: (repositoryState) => {
     const tagsData = getTagsCollection(repositoryState, CONTROL_TAG_SCOPE_KEY);
 

--- a/src/pages/layouts/layouts.handlers.js
+++ b/src/pages/layouts/layouts.handlers.js
@@ -116,6 +116,9 @@ const {
 } = createCatalogPageHandlers({
   resourceType: "layouts",
   copy: ({ i18n }) => selectLayoutsPageCopy(i18n),
+  onEditKey: ({ deps, selectedItemId }) => {
+    openEditDialogWithValues({ deps, itemId: selectedItemId });
+  },
   selectData: (repositoryState) => {
     const tagsData = getTagsCollection(repositoryState, LAYOUT_TAG_SCOPE_KEY);
 

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -621,6 +621,21 @@ const {
 } = createCatalogPageHandlers({
   resourceType: "particles",
   copy: ({ i18n }) => selectParticlesPageCopy(i18n),
+  onEditKey: ({ deps, selectedItemId }) => {
+    const itemData = deps.store.selectParticleItemById({
+      itemId: selectedItemId,
+    });
+    if (!itemData) {
+      return;
+    }
+
+    void openParticleDialog({
+      deps,
+      editMode: true,
+      itemId: selectedItemId,
+      itemData,
+    });
+  },
   selectData: (repositoryState) => {
     const tagsData = getTagsCollection(repositoryState, PARTICLE_TAG_SCOPE_KEY);
 

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -881,6 +881,18 @@ const {
   handleKeyboardScopeKeyDown: handleFileExplorerKeyboardScopeKeyDown,
 } = createFileExplorerKeyboardScopeHandlers({
   fileExplorerRefName: "fileexplorer",
+  onEditKey: ({ deps, selectedItemId, selectedExplorerItem }) => {
+    if (selectedExplorerItem?.isFolder) {
+      openFolderEditDialogWithValues({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    openEditDialogWithValues({ deps, sceneId: selectedItemId });
+  },
+  resolveSelectedItemId: ({ deps, selectedExplorerItem }) =>
+    selectedExplorerItem?.isFolder
+      ? undefined
+      : (selectedExplorerItem?.itemId ?? deps.store.selectSelectedItemId()),
 });
 
 export {

--- a/src/pages/spritesheets/spritesheets.handlers.js
+++ b/src/pages/spritesheets/spritesheets.handlers.js
@@ -486,7 +486,20 @@ const {
   focusKeyboardScope: focusFileExplorerKeyboardScope,
   handleKeyboardScopeClick: handleFileExplorerKeyboardScopeClick,
   handleKeyboardScopeKeyDown: handleBaseFileExplorerKeyboardScopeKeyDown,
-} = createFileExplorerKeyboardScopeHandlers();
+} = createFileExplorerKeyboardScopeHandlers({
+  onEditKey: ({ deps, selectedItemId, selectedExplorerItem }) => {
+    if (selectedExplorerItem?.isFolder) {
+      openFolderNameDialogForFolder({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    openEditDialogForItem({ deps, itemId: selectedItemId });
+  },
+  resolveSelectedItemId: ({ deps, selectedExplorerItem }) =>
+    selectedExplorerItem?.isFolder
+      ? undefined
+      : (selectedExplorerItem?.itemId ?? deps.store.selectSelectedItemId()),
+});
 
 export {
   handleFileExplorerAction,

--- a/src/pages/textStyles/textStyles.handlers.js
+++ b/src/pages/textStyles/textStyles.handlers.js
@@ -109,7 +109,20 @@ const {
   focusKeyboardScope: focusFileExplorerKeyboardScope,
   handleKeyboardScopeClick: handleFileExplorerKeyboardScopeClick,
   handleKeyboardScopeKeyDown: handleBaseFileExplorerKeyboardScopeKeyDown,
-} = createFileExplorerKeyboardScopeHandlers();
+} = createFileExplorerKeyboardScopeHandlers({
+  onEditKey: ({ deps, selectedItemId, selectedExplorerItem }) => {
+    if (selectedExplorerItem?.isFolder) {
+      openFolderNameDialogWithValues({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    openEditDialogWithValues({ deps, itemId: selectedItemId });
+  },
+  resolveSelectedItemId: ({ deps, selectedExplorerItem }) =>
+    selectedExplorerItem?.isFolder
+      ? undefined
+      : (selectedExplorerItem?.itemId ?? deps.store.selectSelectedItemId()),
+});
 
 const {
   openCreateTagDialogForMode,

--- a/src/pages/transforms/transforms.handlers.js
+++ b/src/pages/transforms/transforms.handlers.js
@@ -797,6 +797,9 @@ const {
 } = createCatalogPageHandlers({
   resourceType: "transforms",
   copy: ({ i18n }) => selectTransformsPageCopy(i18n),
+  onEditKey: ({ deps, selectedItemId }) => {
+    void openTransformEditDialog({ deps, itemId: selectedItemId });
+  },
   selectData: (repositoryState) => {
     const tagsData = getTagsCollection(
       repositoryState,

--- a/src/pages/variables/variables.handlers.js
+++ b/src/pages/variables/variables.handlers.js
@@ -153,6 +153,18 @@ const {
   handleKeyboardScopeKeyDown: handleFileExplorerKeyboardScopeKeyDown,
 } = createFileExplorerKeyboardScopeHandlers({
   fileExplorerRefName: "fileexplorer",
+  onEditKey: ({ deps, selectedItemId, selectedExplorerItem }) => {
+    if (selectedExplorerItem?.isFolder) {
+      openFolderNameDialogWithValues({ deps, folderId: selectedItemId });
+      return;
+    }
+
+    openVariableEditDialog({ deps, itemId: selectedItemId });
+  },
+  resolveSelectedItemId: ({ deps, selectedExplorerItem }) =>
+    selectedExplorerItem?.isFolder
+      ? undefined
+      : (selectedExplorerItem?.itemId ?? deps.store.selectSelectedItemId()),
 });
 
 const {

--- a/src/setup.android.js
+++ b/src/setup.android.js
@@ -89,19 +89,6 @@ window.routeVNNativeBack = () => {
   nativeBackInFlight = true;
   void appService
     .back()
-    .then((didGoBack) => {
-      if (!didGoBack) {
-        return;
-      }
-
-      subject.dispatch("app.route.request", {
-        path: router.getPathName(),
-        payload: router.getPayload(),
-        historyState: router.getHistoryState(),
-        navigationPrepared: true,
-        shouldUpdateHistory: false,
-      });
-    })
     .catch((error) => {
       console.error("Failed to prepare Android back navigation:", error);
       const copy = appService.getAppCopy();

--- a/src/setup.ios.js
+++ b/src/setup.ios.js
@@ -101,19 +101,6 @@ window.routeVNNativeBack = () => {
   nativeBackInFlight = true;
   void appService
     .back()
-    .then((didGoBack) => {
-      if (!didGoBack) {
-        return;
-      }
-
-      subject.dispatch("app.route.request", {
-        path: router.getPathName(),
-        payload: router.getPayload(),
-        historyState: router.getHistoryState(),
-        navigationPrepared: true,
-        shouldUpdateHistory: false,
-      });
-    })
     .catch((error) => {
       console.error("Failed to prepare iOS back navigation:", error);
       const copy = appService.getAppCopy();

--- a/src/setup.tauri.js
+++ b/src/setup.tauri.js
@@ -56,6 +56,7 @@ const updater = updatesEnabled
 
 // Create subject for inter-component communication
 const subject = new Subject();
+router.subscribePopState(subject.dispatchCall("routePop"));
 
 const projectMediaOrigin =
   (await invoke("get_project_media_server_origin").catch(() => undefined)) ??

--- a/src/setup.web.js
+++ b/src/setup.web.js
@@ -71,6 +71,7 @@ const updater = {
 
 // Create subject for inter-component communication
 const subject = new Subject();
+router.subscribePopState(subject.dispatchCall("routePop"));
 installVtBridge({ subject, router });
 const collabConfig = {
   endpointUrl: "ws://127.0.0.1:8787/sync",

--- a/tests/animations/animations.store.test.js
+++ b/tests/animations/animations.store.test.js
@@ -7,6 +7,7 @@ import {
   setAnimationPreviewVisible,
   setImagesData,
   setItems,
+  setProjectResolution,
   setSelectedItemId,
 } from "../../src/pages/animations/animations.store.js";
 import { EN_I18N } from "../support/i18n.js";
@@ -142,5 +143,49 @@ describe("animations.store", () => {
     expect(imageFolderField.options).toEqual([
       { value: "folder-image", label: "Image Folder" },
     ]);
+  });
+
+  it("supplies resolution-aware defaults to catalog timelines", () => {
+    const state = createInitialState();
+    setProjectResolution(
+      { state },
+      { projectResolution: { width: 1280, height: 720 } },
+    );
+    setItems(
+      { state },
+      {
+        data: {
+          items: {
+            fade: {
+              id: "fade",
+              type: "animation",
+              name: "Fade",
+              animation: {
+                type: "update",
+                tween: {
+                  alpha: {
+                    keyframes: [{ duration: 1000, value: 0 }],
+                  },
+                },
+              },
+            },
+          },
+          tree: [{ id: "fade" }],
+        },
+      },
+    );
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+    const animationItem = viewData.catalogGroups
+      .flatMap((group) => group.children)
+      .find((item) => item.id === "fade");
+
+    expect(animationItem.timelineDefaultValues).toMatchObject({
+      alpha: 1,
+      scaleX: 1,
+      scaleY: 1,
+      x: 640,
+      y: 360,
+    });
   });
 });

--- a/tests/animations/animations.view.test.js
+++ b/tests/animations/animations.view.test.js
@@ -2,6 +2,19 @@ import { readFileSync } from "fs";
 import { describe, expect, it } from "vitest";
 
 describe("animations view", () => {
+  it("passes property defaults to every catalog timeline with curves", () => {
+    const catalogView = readFileSync(
+      new URL(
+        "../../src/components/catalogResourcesView/catalogResourcesView.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(
+      catalogView.match(/:defaultValues=\$\{item\.timelineDefaultValues\}/g),
+    ).toHaveLength(3);
+  });
+
   it("uses edit, duplicate, and delete icons in the mobile detail sheet", () => {
     const animationsView = readFileSync(
       new URL(

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -93,22 +93,17 @@ describe("app route transitions", () => {
     expect(appService.prepareNavigation).not.toHaveBeenCalled();
   });
 
-  it("prepares browser back navigation in the rendered route context", async () => {
-    let currentPath = "/projects";
-    let currentPayload = {};
+  it("prepares browser back navigation without rewriting the popped entry", async () => {
+    const currentPath = "/projects";
+    const currentPayload = {};
     const calls = [];
     const appService = {
       getPath: vi.fn(() => currentPath),
       getPayload: vi.fn(() => ({ ...currentPayload })),
-      getHistoryState: vi.fn(() => ({ entry: "destination" })),
-      replace: vi.fn((path, payload) => {
-        currentPath = path;
-        currentPayload = { ...payload };
-        calls.push(`replace:${path}:${payload?.p ?? "none"}`);
-      }),
       prepareNavigation: vi.fn(async () => {
         calls.push(`prepare:${currentPath}:${currentPayload.p}`);
       }),
+      acceptCurrentHistoryEntry: vi.fn(),
       showToast: vi.fn(),
     };
     const subject = {
@@ -128,18 +123,72 @@ describe("app route transitions", () => {
 
     await handleWindowPop(deps);
 
-    expect(calls).toEqual([
-      "replace:/project/scene-editor:project-1",
-      "prepare:/project/scene-editor:project-1",
-      "replace:/projects:none",
-      "dispatch",
-    ]);
+    expect(calls).toEqual(["prepare:/projects:undefined", "dispatch"]);
     expect(subject.dispatch).toHaveBeenCalledWith("app.route.request", {
       path: "/projects",
       payload: {},
       navigationPrepared: true,
       shouldUpdateHistory: false,
     });
+  });
+
+  it("restores browser history after current pop preparation fails", async () => {
+    const error = new Error("draft flush failed");
+    const appService = {
+      getPath: vi.fn(() => "/projects"),
+      getPayload: vi.fn(() => ({})),
+      prepareNavigation: vi.fn(async () => {
+        throw error;
+      }),
+      restoreAfterFailedHistoryPop: vi.fn(),
+      showToast: vi.fn(),
+    };
+    const subject = {
+      dispatch: vi.fn(),
+    };
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await handleWindowPop({ appService, i18n: {}, subject });
+
+    expect(appService.restoreAfterFailedHistoryPop).toHaveBeenCalledOnce();
+    expect(appService.showToast).toHaveBeenCalledWith({
+      title: "Error",
+      message: "Could not navigate. Please try again.",
+      status: "error",
+    });
+    expect(subject.dispatch).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("discards stale pop preparation completions", async () => {
+    let finishPreparation;
+    let isCurrent = true;
+    const appService = {
+      getPath: vi.fn(() => "/projects"),
+      getPayload: vi.fn(() => ({})),
+      prepareNavigation: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishPreparation = resolve;
+          }),
+      ),
+      showToast: vi.fn(),
+    };
+    const subject = {
+      dispatch: vi.fn(),
+    };
+    const transition = handleWindowPop(
+      { appService, i18n: {}, subject },
+      { shouldContinue: () => isCurrent },
+    );
+
+    isCurrent = false;
+    finishPreparation();
+    await transition;
+
+    expect(subject.dispatch).not.toHaveBeenCalled();
   });
 
   it("routes popstate subject actions through the app transition", async () => {
@@ -164,6 +213,7 @@ describe("app route transitions", () => {
       getPlatform: vi.fn(() => "web"),
       prepareNavigation: vi.fn(async () => {}),
       refreshCurrentProjectEntry: vi.fn(async () => {}),
+      acceptCurrentHistoryEntry: vi.fn(),
       replace: vi.fn((path, payload) => {
         currentPath = path;
         currentPayload = { ...payload };

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -1,6 +1,7 @@
 import { JSDOM } from "jsdom";
 import { NEVER } from "rxjs";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import Subject from "../../src/deps/subject.js";
 import {
   createRouteTransitionRunner,
   handleBeforeMount,
@@ -139,6 +140,83 @@ describe("app route transitions", () => {
       navigationPrepared: true,
       shouldUpdateHistory: false,
     });
+  });
+
+  it("routes popstate subject actions through the app transition", async () => {
+    const dom = new JSDOM("<!doctype html><body></body>");
+    vi.stubGlobal("window", dom.window);
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("Element", dom.window.Element);
+
+    let currentPath = "/project/character-sprites";
+    let currentPayload = {
+      characterId: "character-1",
+      p: "project-1",
+    };
+    let renderedRoute = currentPath;
+    let renderedPayload = { ...currentPayload };
+    const subject = new Subject();
+    const appService = {
+      getCurrentProjectId: vi.fn(() => currentPayload.p ?? ""),
+      getHistoryState: vi.fn(() => ({})),
+      getPath: vi.fn(() => currentPath),
+      getPayload: vi.fn(() => ({ ...currentPayload })),
+      getPlatform: vi.fn(() => "web"),
+      prepareNavigation: vi.fn(async () => {}),
+      refreshCurrentProjectEntry: vi.fn(async () => {}),
+      replace: vi.fn((path, payload) => {
+        currentPath = path;
+        currentPayload = { ...payload };
+      }),
+      setAppCopyProvider: vi.fn(),
+    };
+    const store = {
+      closeMobileSheet: vi.fn(),
+      selectCurrentRoute: vi.fn(() => renderedRoute),
+      selectCurrentRoutePayload: vi.fn(() => ({ ...renderedPayload })),
+      setCurrentRoute: vi.fn(({ route, payload }) => {
+        renderedRoute = route;
+        renderedPayload = { ...payload };
+      }),
+      setPlatform: vi.fn(),
+      setRepositoryLoading: vi.fn(),
+      setUiConfig: vi.fn(),
+    };
+    const deps = {
+      appService,
+      i18n: {},
+      projectService: {
+        ensureRepository: vi.fn(async () => {}),
+        getEnsuredProjectId: vi.fn(() => "project-1"),
+      },
+      render: vi.fn(),
+      store,
+      subject,
+      uiConfig: {},
+    };
+    const cleanup = handleBeforeMount(deps);
+    await vi.waitFor(() =>
+      expect(store.setCurrentRoute).toHaveBeenCalledWith({
+        route: "/project/character-sprites",
+        payload: {
+          characterId: "character-1",
+          p: "project-1",
+        },
+      }),
+    );
+
+    currentPath = "/project/characters";
+    currentPayload = { p: "project-1" };
+    subject.dispatch("routePop");
+
+    await vi.waitFor(() =>
+      expect(store.setCurrentRoute).toHaveBeenCalledWith({
+        route: "/project/characters",
+        payload: { p: "project-1" },
+      }),
+    );
+
+    cleanup();
   });
 });
 

--- a/tests/appService/appShellService.test.js
+++ b/tests/appService/appShellService.test.js
@@ -87,6 +87,23 @@ describe("appShellService", () => {
 
     expect(deps.router.getBackTarget).toHaveBeenCalledOnce();
     expect(deps.router.back).toHaveBeenCalledOnce();
+    expect(deps.subject.dispatch).toHaveBeenCalledWith("app.route.request", {
+      path: "/projects",
+      payload: { p: "project-1" },
+      historyState: {},
+      navigationPrepared: true,
+      shouldUpdateHistory: false,
+    });
+  });
+
+  it("leaves web history route updates to popstate", async () => {
+    const deps = createDeps();
+    deps.router.back.mockReturnValue(undefined);
+    const service = createAppShellService(deps);
+
+    await expect(service.back()).resolves.toBeUndefined();
+
+    expect(deps.subject.dispatch).not.toHaveBeenCalled();
   });
 
   it("forwards alert dialogs through showAlert", async () => {

--- a/tests/appService/router.test.js
+++ b/tests/appService/router.test.js
@@ -14,7 +14,9 @@ const createWindowMock = () => {
   };
 
   return {
+    addEventListener: vi.fn(),
     location,
+    removeEventListener: vi.fn(),
     history: {
       replaceState: vi.fn((_state, _title, path) => {
         setLocationFromPath(location, path);
@@ -41,6 +43,27 @@ describe("web router payload updates", () => {
     router.setPayload({ p: "project-1" });
 
     expect(windowMock.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it("subscribes the app shell to browser history changes", () => {
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+    const listener = vi.fn();
+
+    const unsubscribe = router.subscribePopState(listener);
+
+    expect(windowMock.addEventListener).toHaveBeenCalledWith(
+      "popstate",
+      listener,
+    );
+
+    unsubscribe();
+
+    expect(windowMock.removeEventListener).toHaveBeenCalledWith(
+      "popstate",
+      listener,
+    );
   });
 
   it("coalesces throttled payload writes and exposes the pending payload", () => {

--- a/tests/appService/router.test.js
+++ b/tests/appService/router.test.js
@@ -12,20 +12,25 @@ const createWindowMock = () => {
     pathname: "/project/scene-editor",
     search: "?p=project-1",
   };
+  const history = {
+    state: {},
+    replaceState: vi.fn((state, _title, path) => {
+      history.state = state;
+      setLocationFromPath(location, path);
+    }),
+    pushState: vi.fn((state, _title, path) => {
+      history.state = state;
+      setLocationFromPath(location, path);
+    }),
+    back: vi.fn(),
+    go: vi.fn(),
+  };
 
   return {
     addEventListener: vi.fn(),
     location,
     removeEventListener: vi.fn(),
-    history: {
-      replaceState: vi.fn((_state, _title, path) => {
-        setLocationFromPath(location, path);
-      }),
-      pushState: vi.fn((_state, _title, path) => {
-        setLocationFromPath(location, path);
-      }),
-      back: vi.fn(),
-    },
+    history,
   };
 };
 
@@ -52,18 +57,63 @@ describe("web router payload updates", () => {
     const listener = vi.fn();
 
     const unsubscribe = router.subscribePopState(listener);
+    const popStateHandler = windowMock.addEventListener.mock.calls[0][1];
 
     expect(windowMock.addEventListener).toHaveBeenCalledWith(
       "popstate",
-      listener,
+      popStateHandler,
     );
+
+    popStateHandler({ type: "popstate" });
+    expect(listener).toHaveBeenCalledWith({ type: "popstate" });
 
     unsubscribe();
 
     expect(windowMock.removeEventListener).toHaveBeenCalledWith(
       "popstate",
-      listener,
+      popStateHandler,
     );
+  });
+
+  it("restores a failed pop without dispatching another route pop", () => {
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+    const listener = vi.fn();
+    router.subscribePopState(listener);
+    const popStateHandler = windowMock.addEventListener.mock.calls[0][1];
+    const destinationState = { ...windowMock.history.state };
+    router.redirect("/projects", {});
+    popStateHandler({ state: destinationState, type: "popstate" });
+    listener.mockClear();
+
+    router.restoreAfterFailedPop();
+    popStateHandler({ state: windowMock.history.state, type: "popstate" });
+
+    expect(windowMock.history.go).toHaveBeenCalledWith(1);
+    expect(listener).not.toHaveBeenCalled();
+
+    popStateHandler({ type: "popstate" });
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it("restores across multiple pending pop entries", () => {
+    const windowMock = createWindowMock();
+    vi.stubGlobal("window", windowMock);
+    const router = new WebRouter();
+    router.subscribePopState(vi.fn());
+    const popStateHandler = windowMock.addEventListener.mock.calls[0][1];
+    const oldestState = { ...windowMock.history.state };
+    router.redirect("/project/characters", { p: "project-1" });
+    router.redirect("/project/character-sprites", {
+      characterId: "character-1",
+      p: "project-1",
+    });
+
+    popStateHandler({ state: oldestState, type: "popstate" });
+    router.restoreAfterFailedPop();
+
+    expect(windowMock.history.go).toHaveBeenCalledWith(2);
   });
 
   it("coalesces throttled payload writes and exposes the pending payload", () => {

--- a/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
@@ -706,5 +706,12 @@ describe("baseFileExplorer handlers", () => {
     handleItemContextMenu(desktopDeps, { _event: mouseContextMenuEvent });
 
     expect(desktopDeps.store.selectDropdownMenuItemId()).toBe("item-1");
+    expect(desktopDeps.store.selectSelectedItemId()).toBe("item-1");
+    expect(desktopDeps.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "item-click",
+        detail: expect.objectContaining({ itemId: "item-1" }),
+      }),
+    );
   });
 });

--- a/tests/catalogResourcesView/catalogResourcesView.handlers.test.js
+++ b/tests/catalogResourcesView/catalogResourcesView.handlers.test.js
@@ -113,6 +113,45 @@ describe("catalogResourcesView.handlers", () => {
     expect(render).not.toHaveBeenCalled();
   });
 
+  it("selects the item when opening its desktop context menu", () => {
+    const dispatchEvent = vi.fn();
+    const showContextMenu = vi.fn();
+    const render = vi.fn();
+
+    handleItemContextMenu(
+      {
+        props: {
+          mobileLayout: false,
+        },
+        dispatchEvent,
+        store: {
+          showContextMenu,
+        },
+        render,
+      },
+      {
+        _event: {
+          ...createItemEvent("color-1"),
+          preventDefault: vi.fn(),
+          clientX: 10,
+          clientY: 20,
+        },
+      },
+    );
+
+    expect(showContextMenu).toHaveBeenCalledWith({
+      itemId: "color-1",
+      x: 10,
+      y: 20,
+    });
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "item-click",
+        detail: { itemId: "color-1", source: "context-menu" },
+      }),
+    );
+  });
+
   it("uses the mobile column default instead of restoring desktop column counts", () => {
     const getUserConfig = vi.fn((key) =>
       key === "groupControlsView.itemsPerRow" ? 8 : undefined,

--- a/tests/characterSprites/characterSprites.handlers.test.js
+++ b/tests/characterSprites/characterSprites.handlers.test.js
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { EN_I18N } from "../support/i18n.js";
 import {
   handleEditDialogImageClick,
+  handleFileExplorerKeyboardScopeKeyDown,
   handleUploadClick,
   handlePreviewCanvasModeClick,
   handlePreviewFitModeClick,
@@ -57,6 +58,27 @@ const createEvent = (key, overrides = {}) => ({
   preventDefault: vi.fn(),
   stopPropagation: vi.fn(),
   ...overrides,
+});
+
+describe("characterSprites keyboard navigation", () => {
+  it("goes back one browser-history entry with Shift+H", () => {
+    const deps = {
+      appService: {
+        back: vi.fn(() => Promise.resolve(true)),
+      },
+      store: {
+        selectFullImagePreviewVisible: vi.fn(() => false),
+      },
+      refs: {},
+    };
+    const event = createEvent("H", { shiftKey: true });
+
+    handleFileExplorerKeyboardScopeKeyDown(deps, { _event: event });
+
+    expect(deps.appService.back).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("characterSprites preview handlers", () => {

--- a/tests/characters/characters.handlers.test.js
+++ b/tests/characters/characters.handlers.test.js
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { EN_I18N } from "../support/i18n.js";
 import {
   handleAddCharacterClick,
+  handleCharacterItemClick,
   handleCloseDialog,
   handleDialogFormActionClick,
   handleEditFormAction,
+  handleFileExplorerKeyboardScopeKeyDown,
   handleSpriteGroupAddClick,
   handleSpriteGroupCardClick,
   handleSpriteGroupDropdownMenuItemClick,
@@ -30,6 +32,156 @@ const createDeps = () => {
     },
   };
 };
+
+describe("characters item selection", () => {
+  it("selects a character without opening its sprites page", () => {
+    const deps = {
+      appService: {
+        navigate: vi.fn(),
+      },
+      store: {
+        setSelectedItemId: vi.fn(),
+      },
+      refs: {
+        fileExplorer: {
+          selectItem: vi.fn(),
+        },
+      },
+      render: vi.fn(),
+    };
+
+    handleCharacterItemClick(deps, {
+      _event: {
+        detail: {
+          itemId: "character-1",
+        },
+      },
+    });
+
+    expect(deps.store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: "character-1",
+    });
+    expect(deps.refs.fileExplorer.selectItem).toHaveBeenCalledWith({
+      itemId: "character-1",
+    });
+    expect(deps.appService.navigate).not.toHaveBeenCalled();
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the selected character's sprites page with Enter", () => {
+    const deps = {
+      appService: {
+        getPayload: vi.fn(() => ({ p: "project-1" })),
+        navigate: vi.fn(),
+      },
+      refs: {
+        fileExplorer: {
+          getSelectedItem: vi.fn(() => ({
+            isFolder: false,
+            itemId: "character-1",
+          })),
+        },
+      },
+      render: vi.fn(),
+    };
+    const event = {
+      key: "Enter",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleFileExplorerKeyboardScopeKeyDown(deps, { _event: event });
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(deps.appService.navigate).toHaveBeenCalledWith(
+      "/project/character-sprites",
+      {
+        characterId: "character-1",
+        p: "project-1",
+      },
+    );
+  });
+
+  it("opens the selected character edit dialog when e is pressed", () => {
+    const character = {
+      id: "character-1",
+      name: "Hero",
+      description: "Main character",
+      spriteGroups: [],
+      tagIds: [],
+    };
+    const deps = {
+      store: {
+        selectSelectedItemId: vi.fn(() => "character-1"),
+        selectCharacterItemById: vi.fn(() => character),
+        setSelectedItemId: vi.fn(),
+        openEditDialog: vi.fn(),
+      },
+      refs: {
+        fileExplorer: {
+          getSelectedItem: vi.fn(() => ({
+            isFolder: false,
+            itemId: "character-1",
+          })),
+          selectItem: vi.fn(),
+        },
+        editForm: {
+          reset: vi.fn(),
+          setValues: vi.fn(),
+        },
+      },
+      render: vi.fn(),
+    };
+    const event = {
+      key: "e",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleFileExplorerKeyboardScopeKeyDown(deps, { _event: event });
+
+    expect(deps.store.openEditDialog).toHaveBeenCalledWith({
+      itemId: "character-1",
+      spriteGroups: [],
+    });
+    expect(deps.refs.editForm.setValues).toHaveBeenCalledWith({
+      values: {
+        name: "Hero",
+        nameVariableId: "",
+        description: "Main character",
+        shortcut: "",
+        tagIds: [],
+      },
+    });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("goes back one browser-history entry with Shift+H", () => {
+    const deps = {
+      appService: {
+        back: vi.fn(() => Promise.resolve(true)),
+      },
+      refs: {},
+    };
+    const event = {
+      altKey: false,
+      ctrlKey: false,
+      key: "H",
+      metaKey: false,
+      shiftKey: true,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleFileExplorerKeyboardScopeKeyDown(deps, { _event: event });
+
+    expect(deps.appService.back).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("characters add dialog form reset", () => {
   it("resets the add form each time the add dialog opens", () => {

--- a/tests/characters/charactersResourcesView.handlers.test.js
+++ b/tests/characters/charactersResourcesView.handlers.test.js
@@ -98,6 +98,47 @@ describe("charactersResourcesView.handlers", () => {
     expect(render).not.toHaveBeenCalled();
   });
 
+  it("selects the item when opening its desktop context menu", () => {
+    const dispatchEvent = vi.fn();
+    const showContextMenu = vi.fn();
+
+    handleItemContextMenu(
+      {
+        props: {
+          mobileLayout: false,
+        },
+        dispatchEvent,
+        store: {
+          showContextMenu,
+        },
+        render: vi.fn(),
+      },
+      {
+        _event: {
+          ...createItemEvent("character-1"),
+          preventDefault: vi.fn(),
+          clientX: 10,
+          clientY: 20,
+        },
+      },
+    );
+
+    expect(showContextMenu).toHaveBeenCalledWith({
+      itemId: "character-1",
+      x: 10,
+      y: 20,
+    });
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "item-click",
+        detail: {
+          itemId: "character-1",
+          source: "context-menu",
+        },
+      }),
+    );
+  });
+
   it("progressively renders character cards after the first batch", () => {
     const frameCallbacks = [];
     vi.stubGlobal(

--- a/tests/internal/createCatalogPageHandlers.test.js
+++ b/tests/internal/createCatalogPageHandlers.test.js
@@ -19,6 +19,7 @@ describe("createCatalogPageHandlers", () => {
     });
     const deps = {
       store: {
+        selectSelectedItemId: vi.fn(() => undefined),
         setSelectedItemId: vi.fn(),
       },
       refs: {
@@ -64,5 +65,48 @@ describe("createCatalogPageHandlers", () => {
     handlers.handleAfterMount(deps);
 
     expect(deps.refs.fileExplorerKeyboardScope.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the page edit handler for the selected catalog item", () => {
+    const onEditKey = vi.fn();
+    const handlers = createCatalogPageHandlers({
+      resourceType: "colors",
+      onEditKey,
+    });
+    const deps = {
+      store: {
+        selectSelectedItemId: vi.fn(() => "color-1"),
+        selectSelectedFolderId: vi.fn(() => undefined),
+      },
+      refs: {
+        fileExplorer: {
+          getSelectedItem: vi.fn(() => ({
+            itemId: "color-1",
+            isFolder: false,
+          })),
+        },
+      },
+    };
+    const event = {
+      key: "e",
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handlers.handleFileExplorerKeyboardScopeKeyDown(deps, { _event: event });
+
+    expect(onEditKey).toHaveBeenCalledWith({
+      deps,
+      selectedItemId: "color-1",
+      selectedExplorerItem: {
+        itemId: "color-1",
+        isFolder: false,
+      },
+    });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/internal/fileExplorerKeyboardScope.test.js
+++ b/tests/internal/fileExplorerKeyboardScope.test.js
@@ -321,6 +321,22 @@ describe("fileExplorerKeyboardScope", () => {
     expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
+  it("runs the back handler when Shift+H is pressed", () => {
+    const onBackKey = vi.fn();
+    const deps = createDeps();
+    const { handleKeyboardScopeKeyDown } =
+      createFileExplorerKeyboardScopeHandlers({ onBackKey });
+    const event = createKeyEvent("H", { shiftKey: true });
+
+    handleKeyboardScopeKeyDown(deps, {
+      _event: event,
+    });
+
+    expect(onBackKey).toHaveBeenCalledWith({ deps, event });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
   it("runs the edit handler for the selected explorer item when e is pressed", () => {
     const onEditKey = vi.fn();
     const fileExplorer = {

--- a/tests/internal/fileExplorerKeyboardScope.test.js
+++ b/tests/internal/fileExplorerKeyboardScope.test.js
@@ -337,6 +337,22 @@ describe("fileExplorerKeyboardScope", () => {
     expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores repeated Shift+H keydowns", () => {
+    const onBackKey = vi.fn();
+    const deps = createDeps();
+    const { handleKeyboardScopeKeyDown } =
+      createFileExplorerKeyboardScopeHandlers({ onBackKey });
+    const event = createKeyEvent("H", { repeat: true, shiftKey: true });
+
+    handleKeyboardScopeKeyDown(deps, {
+      _event: event,
+    });
+
+    expect(onBackKey).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
   it("runs the edit handler for the selected explorer item when e is pressed", () => {
     const onEditKey = vi.fn();
     const fileExplorer = {

--- a/tests/keyframeTimeline/keyframeTimeline.store.test.js
+++ b/tests/keyframeTimeline/keyframeTimeline.store.test.js
@@ -1,0 +1,188 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  SUPPORTED_EASING_CURVE_NAMES,
+  createKeyframeValueCurvePath,
+} from "../../src/components/keyframeTimeline/keyframeTimeline.easing.js";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/components/keyframeTimeline/keyframeTimeline.store.js";
+
+describe("keyframeTimeline easing curves", () => {
+  const readPathPoints = (path) => {
+    return Array.from(path.matchAll(/[ML]([\d.-]+),([\d.-]+)/g)).map(
+      (match) => ({
+        x: Number(match[1]),
+        y: Number(match[2]),
+      }),
+    );
+  };
+
+  const createPath = ({
+    easing = "linear",
+    endValue,
+    initialValue,
+    relative = false,
+  } = {}) => {
+    return createKeyframeValueCurvePath({
+      initialValue,
+      keyframes: [
+        {
+          duration: 1000,
+          easing,
+          relative,
+          value: endValue,
+        },
+      ],
+      timelineDuration: 1000,
+    });
+  };
+
+  it("creates finite paths for every supported easing", () => {
+    const paths = SUPPORTED_EASING_CURVE_NAMES.map((easingName) =>
+      createPath({
+        easing: easingName,
+        endValue: 1,
+        initialValue: 0,
+      }),
+    );
+
+    paths.forEach((path) => {
+      expect(path).toMatch(/^M0\.00,/);
+      expect(path).not.toMatch(/NaN|Infinity/);
+      expect(path.match(/ L/g)).toHaveLength(36);
+    });
+    expect(
+      createPath({
+        easing: "easeOutBounce",
+        endValue: 1,
+        initialValue: 0,
+      }),
+    ).not.toBe(createPath({ easing: "linear", endValue: 1, initialValue: 0 }));
+    expect(
+      createPath({ easing: "unsupported", endValue: 1, initialValue: 0 }),
+    ).toBe(createPath({ easing: "linear", endValue: 1, initialValue: 0 }));
+  });
+
+  it("draws increasing, decreasing, and unchanged values differently", () => {
+    const increasingPoints = readPathPoints(
+      createPath({ initialValue: 0, endValue: 1 }),
+    );
+    const decreasingPoints = readPathPoints(
+      createPath({ initialValue: 1, endValue: 0 }),
+    );
+    const unchangedPoints = readPathPoints(
+      createPath({ initialValue: 0, endValue: 0 }),
+    );
+
+    expect(increasingPoints[0].y).toBeGreaterThan(increasingPoints.at(-1).y);
+    expect(decreasingPoints[0].y).toBeLessThan(decreasingPoints.at(-1).y);
+    expect(new Set(unchangedPoints.map((point) => point.y))).toEqual(
+      new Set([10]),
+    );
+
+    const defaultValuePoints = readPathPoints(
+      createKeyframeValueCurvePath({
+        defaultValue: 1,
+        keyframes: [{ duration: 1000, easing: "linear", value: 0 }],
+        timelineDuration: 1000,
+      }),
+    );
+    expect(defaultValuePoints[0].y).toBeLessThan(defaultValuePoints.at(-1).y);
+  });
+
+  it("accumulates relative values and keeps one value scale across segments", () => {
+    const points = readPathPoints(
+      createKeyframeValueCurvePath({
+        initialValue: 0,
+        keyframes: [
+          { duration: 500, easing: "linear", value: 1 },
+          {
+            duration: 500,
+            easing: "linear",
+            relative: true,
+            value: -1,
+          },
+        ],
+        timelineDuration: 1000,
+      }),
+    );
+
+    expect(points[0]).toEqual({ x: 0, y: 19 });
+    expect(points[36]).toEqual({ x: 50, y: 1 });
+    expect(points.at(-1)).toEqual({ x: 100, y: 19 });
+  });
+
+  it("adds one property value path and easing labels to keyframe tracks", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [
+              {
+                duration: 500,
+                easing: "easeOutBounce",
+                value: 100,
+              },
+              {
+                duration: 500,
+                value: 200,
+              },
+            ],
+          },
+          alpha: {
+            auto: {
+              duration: 1000,
+              easing: "easeInOutElastic",
+            },
+          },
+        },
+      },
+    });
+
+    const keyframeProperty = viewData.selectedProperties[0];
+    expect(keyframeProperty.keyframes[0]).toMatchObject({
+      easing: "easeOutBounce",
+      easingLabel: "Ease Out Bounce",
+    });
+    expect(keyframeProperty.keyframes[1]).toMatchObject({
+      easing: "linear",
+      easingLabel: "Linear",
+    });
+    expect(keyframeProperty.valueCurvePath).toBe(
+      createKeyframeValueCurvePath({
+        initialValue: 0,
+        keyframes: [
+          { duration: 500, easing: "easeOutBounce", value: 100 },
+          { duration: 500, value: 200 },
+        ],
+        timelineDuration: 1000,
+      }),
+    );
+
+    const autoProperty = viewData.selectedProperties[1];
+    expect(autoProperty.auto).toMatchObject({
+      easing: "easeInOutElastic",
+      easingLabel: "Ease In Out Elastic",
+    });
+    expect(autoProperty.valueCurvePath).toBeUndefined();
+  });
+
+  it("renders decorative SVG paths without replacing keyframe click targets", () => {
+    const view = readFileSync(
+      "src/components/keyframeTimeline/keyframeTimeline.view.yaml",
+      "utf8",
+    );
+
+    expect(view).toContain("data-keyframe=true");
+    expect(view).toContain("data-value-curve=${property.name}");
+    expect(view).toContain('d="${property.valueCurvePath}"');
+    expect(view).toContain("pointer-events: none");
+    expect(view.match(/data-keyframe=true[^\n]+/g)).toEqual([
+      expect.not.stringContaining("mr=xs"),
+    ]);
+  });
+});

--- a/tests/mediaResourcesView/mediaResourcesView.handlers.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.handlers.test.js
@@ -161,13 +161,14 @@ describe("mediaResourcesView.handlers", () => {
   it("keeps the context menu on desktop contextmenu gestures", () => {
     const showContextMenu = vi.fn();
     const render = vi.fn();
+    const dispatchEvent = vi.fn();
 
     handleItemContextMenu(
       {
         props: {
           mobileLayout: false,
         },
-        dispatchEvent: vi.fn(),
+        dispatchEvent,
         store: {
           showContextMenu,
         },
@@ -193,6 +194,12 @@ describe("mediaResourcesView.handlers", () => {
       y: 20,
     });
     expect(render).toHaveBeenCalled();
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "item-click",
+        detail: { itemId: "image-1", source: "context-menu" },
+      }),
+    );
   });
 
   it("clamps restored mobile column counts to six", () => {

--- a/tests/mediaResourcesView/mediaResourcesView.view.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.view.test.js
@@ -16,7 +16,7 @@ describe("mediaResourcesView view", () => {
     );
   });
 
-  it("places filter and zoom popovers below and left-aligned to their buttons", () => {
+  it("places filter and zoom popovers below and right-aligned to their buttons", () => {
     const view = readFileSync(
       new URL(
         "../../src/components/mediaResourcesView/mediaResourcesView.view.yaml",

--- a/tests/resourcePages/resourcePopoverPlacement.test.js
+++ b/tests/resourcePages/resourcePopoverPlacement.test.js
@@ -1,0 +1,138 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleTagFilterButtonClick as handleCatalogFilterClick,
+  handleZoomButtonClick as handleCatalogZoomClick,
+} from "../../src/components/catalogResourcesView/catalogResourcesView.handlers.js";
+import { handleTagFilterButtonClick as handleCharactersFilterClick } from "../../src/components/charactersResourcesView/charactersResourcesView.handlers.js";
+import { handleTagFilterButtonClick as handleVariablesFilterClick } from "../../src/components/groupVariablesView/groupVariablesView.handlers.js";
+import {
+  handleTagFilterButtonClick as handleMediaFilterClick,
+  handleZoomButtonClick as handleMediaZoomClick,
+} from "../../src/components/mediaResourcesView/mediaResourcesView.handlers.js";
+import {
+  handleTagFilterButtonClick as handleTextStyleFilterClick,
+  handleZoomButtonClick as handleTextStyleZoomClick,
+} from "../../src/components/textStyleResourcesView/textStyleResourcesView.handlers.js";
+
+const popoverHandlers = [
+  [
+    "media filter",
+    handleMediaFilterClick,
+    "tagFilterButton",
+    "openTagFilterPopover",
+  ],
+  ["media zoom", handleMediaZoomClick, "zoomButton", "openZoomPopover"],
+  [
+    "catalog filter",
+    handleCatalogFilterClick,
+    "tagFilterButton",
+    "openTagFilterPopover",
+  ],
+  ["catalog zoom", handleCatalogZoomClick, "zoomButton", "openZoomPopover"],
+  [
+    "text style filter",
+    handleTextStyleFilterClick,
+    "tagFilterButton",
+    "openTagFilterPopover",
+  ],
+  [
+    "text style zoom",
+    handleTextStyleZoomClick,
+    "zoomButton",
+    "openZoomPopover",
+  ],
+  [
+    "characters filter",
+    handleCharactersFilterClick,
+    "tagFilterButton",
+    "openTagFilterPopover",
+  ],
+  [
+    "variables filter",
+    handleVariablesFilterClick,
+    "tagFilterButton",
+    "openTagFilterPopover",
+  ],
+];
+
+const resourcePopoverViews = [
+  [
+    "mediaResourcesView/mediaResourcesView.view.yaml",
+    ["tagFilterPopover", "zoomPopover"],
+  ],
+  [
+    "catalogResourcesView/catalogResourcesView.view.yaml",
+    ["tagFilterPopover", "zoomPopover"],
+  ],
+  [
+    "textStyleResourcesView/textStyleResourcesView.view.yaml",
+    ["tagFilterPopover", "zoomPopover"],
+  ],
+  [
+    "charactersResourcesView/charactersResourcesView.view.yaml",
+    ["tagFilterPopover"],
+  ],
+  ["groupVariablesView/groupVariablesView.view.yaml", ["tagFilterPopover"]],
+];
+
+describe("resource popover placement", () => {
+  it.each(popoverHandlers)(
+    "anchors %s to the button's right edge",
+    (_name, handler, refName, storeMethod) => {
+      const openPopover = vi.fn();
+      const stopPropagation = vi.fn();
+      const deps = {
+        props: {
+          selectedTagFilterValues: [],
+        },
+        refs: {
+          [refName]: {
+            getBoundingClientRect: () => ({
+              left: 900,
+              right: 940,
+              bottom: 48,
+            }),
+          },
+        },
+        store: {
+          [storeMethod]: openPopover,
+        },
+        render: vi.fn(),
+      };
+
+      handler(deps, {
+        _event: {
+          stopPropagation,
+        },
+      });
+
+      expect(openPopover).toHaveBeenCalledWith(
+        expect.objectContaining({
+          position: { x: 940, y: 48 },
+        }),
+      );
+      expect(stopPropagation).toHaveBeenCalledOnce();
+      expect(deps.render).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(resourcePopoverViews)(
+    "uses bottom-end placement in %s",
+    (relativePath, popoverIds) => {
+      const view = readFileSync(
+        new URL(`../../src/components/${relativePath}`, import.meta.url),
+        "utf8",
+      );
+      const lines = view.split("\n");
+
+      for (const popoverId of popoverIds) {
+        const popoverLine = lines.find((line) =>
+          line.includes(`rtgl-popover#${popoverId}`),
+        );
+
+        expect(popoverLine).toContain("place=be");
+      }
+    },
+  );
+});

--- a/tests/scenes/scenes.handlers.test.js
+++ b/tests/scenes/scenes.handlers.test.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   handleAfterMount,
+  handleFileExplorerKeyboardScopeKeyDown,
   handleFileExplorerSelectionChanged,
   handleMobileFileExplorerClose,
   handleMobileFileExplorerOpen,
@@ -296,6 +297,58 @@ describe("scenes.handlers config keys", () => {
       durationMs: 160,
     });
     expect(deps.render).toHaveBeenCalled();
+  });
+
+  it("opens the selected scene edit dialog when e is pressed", () => {
+    const deps = createDeps();
+    deps.store.selectSelectedItemId.mockReturnValue("scene-1");
+    deps.store.selectScenesData = vi.fn(() => ({
+      items: {
+        "scene-1": {
+          id: "scene-1",
+          type: "scene",
+          name: "Opening",
+          description: "The opening scene",
+        },
+      },
+      tree: [{ id: "scene-1" }],
+    }));
+    deps.store.openEditDialog = vi.fn();
+    deps.refs.fileexplorer.getSelectedItem = vi.fn(() => ({
+      itemId: "scene-1",
+      isFolder: false,
+    }));
+    deps.refs.editForm = {
+      reset: vi.fn(),
+      setValues: vi.fn(),
+    };
+    const event = {
+      key: "e",
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleFileExplorerKeyboardScopeKeyDown(deps, { _event: event });
+
+    expect(deps.store.openEditDialog).toHaveBeenCalledWith({
+      itemId: "scene-1",
+      itemType: "scene",
+      defaultValues: {
+        name: "Opening",
+        description: "The opening scene",
+      },
+    });
+    expect(deps.refs.editForm.setValues).toHaveBeenCalledWith({
+      values: {
+        name: "Opening",
+        description: "The opening scene",
+      },
+    });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
   it("closes the mobile file explorer after selecting a scene", () => {

--- a/tests/textStyles/textStyleResourcesView.test.js
+++ b/tests/textStyles/textStyleResourcesView.test.js
@@ -128,6 +128,48 @@ describe("textStyleResourcesView", () => {
     expect(render).not.toHaveBeenCalled();
   });
 
+  it("selects the item when opening its desktop context menu", () => {
+    const dispatchEvent = vi.fn();
+    const showContextMenu = vi.fn();
+
+    handleItemContextMenu(
+      {
+        props: {
+          mobileLayout: false,
+        },
+        dispatchEvent,
+        store: {
+          showContextMenu,
+        },
+        render: vi.fn(),
+      },
+      {
+        _event: {
+          currentTarget: {
+            getAttribute: vi.fn((name) =>
+              name === "data-item-id" ? "text-style-1" : undefined,
+            ),
+          },
+          preventDefault: vi.fn(),
+          clientX: 10,
+          clientY: 20,
+        },
+      },
+    );
+
+    expect(showContextMenu).toHaveBeenCalledWith({
+      itemId: "text-style-1",
+      x: 10,
+      y: 20,
+    });
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "item-click",
+        detail: { itemId: "text-style-1", source: "context-menu" },
+      }),
+    );
+  });
+
   it("uses provided item context menu items for text style cards", () => {
     const state = createInitialState();
     const props = {

--- a/tests/variables/groupVariablesView.handlers.test.js
+++ b/tests/variables/groupVariablesView.handlers.test.js
@@ -95,6 +95,45 @@ describe("groupVariablesView.handlers", () => {
     expect(store.showContextMenu).not.toHaveBeenCalled();
   });
 
+  it("selects the row when opening its desktop context menu", () => {
+    const dispatchEvent = vi.fn();
+    const showContextMenu = vi.fn();
+
+    handleRowContextMenu(
+      {
+        props: {
+          mobileLayout: false,
+        },
+        dispatchEvent,
+        store: {
+          showContextMenu,
+        },
+        render: vi.fn(),
+      },
+      {
+        _event: {
+          ...createRowEvent("variable-1"),
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+          clientX: 10,
+          clientY: 20,
+        },
+      },
+    );
+
+    expect(showContextMenu).toHaveBeenCalledWith({
+      itemId: "variable-1",
+      x: 10,
+      y: 20,
+    });
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "variable-item-click",
+        detail: { itemId: "variable-1" },
+      }),
+    );
+  });
+
   it("ignores placeholder row events with empty data ids", () => {
     const dispatchEvent = vi.fn();
 

--- a/vt/specs/project/character-sprites.yaml
+++ b/vt/specs/project/character-sprites.yaml
@@ -232,4 +232,21 @@ steps:
   - action: wait
     ms: 350
   - action: screenshot
+  - action: keypress
+    key: Escape
+  - action: select
+    selector: "#fileExplorerKeyboardScope"
+    steps:
+      - action: focus
+  - action: keypress
+    key: Shift+H
+  - action: wait
+    ms: 1000
+  - action: assert
+    type: url
+    value: /project/characters
+  - action: waitFor
+    selector: rvn-characters
+    state: attached
+    timeoutMs: 10000
 ---

--- a/vt/specs/project/colors.yaml
+++ b/vt/specs/project/colors.yaml
@@ -105,9 +105,11 @@ steps:
   - action: wait
     ms: 250
   - action: select
-    selector: "#detailHeader"
+    selector: "#fileExplorerKeyboardScope"
     steps:
-      - action: click
+      - action: focus
+  - action: keypress
+    key: e
   - action: waitFor
     selector: "#editDialog[open]"
     state: attached

--- a/vt/specs/project/images.yaml
+++ b/vt/specs/project/images.yaml
@@ -147,6 +147,23 @@ steps:
     key: j
   - action: wait
     ms: 300
+  - action: select
+    selector: "rvn-media-resources-view#groupview #itemRef0x0"
+    steps:
+      - action: rclick
+  - action: waitFor
+    selector: "rvn-media-resources-view#groupview #contextMenu[open]"
+    state: attached
+    timeoutMs: 5000
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return deepQuery(document, '#detailHeader')?.textContent?.trim(); })()"
+    value: options_black_bg
+  - action: click
+    x: 12
+    y: 12
   - action: screenshot
   - action: select
     selector: "rvn-media-resources-view#groupview #itemRef0x0"
@@ -242,8 +259,9 @@ steps:
   - action: wait
     ms: 400
   - action: screenshot
-  - action: keypress
-    key: Escape
+  - action: click
+    x: 12
+    y: 12
   - action: waitFor
     selector: "#editDialog"
     state: hidden

--- a/vt/specs/project/scenes.yaml
+++ b/vt/specs/project/scenes.yaml
@@ -140,6 +140,22 @@ steps:
     ms: 350
   - action: screenshot
   - action: select
+    selector: "#fileExplorerDetailKeyboardScope"
+    steps:
+      - action: focus
+  - action: keypress
+    key: e
+  - action: waitFor
+    selector: "#editDialog[open]"
+    state: attached
+    timeoutMs: 5000
+  - action: keypress
+    key: Escape
+  - action: waitFor
+    selector: "#editDialog"
+    state: hidden
+    timeoutMs: 10000
+  - action: select
     selector: "#sectionsListToggle"
     steps:
       - action: click
@@ -194,7 +210,7 @@ steps:
   - action: assert
     type: text
     selector: "#sceneTextStats"
-    value: "0 characters"
+    value: "0 lines 0 words"
   - action: screenshot
   - action: select
     selector: "#systemActions #addActionButton"


### PR DESCRIPTION
## Summary
- improve resource-page selection and editing workflows by selecting context-menu targets, enabling `e` editing across catalog/resource pages, and aligning filter/zoom popovers to their controls
- keep character cards single-click selectable, open the selected character sprites with Enter, support Shift+H history navigation, and restore web/Tauri routes from browser `popstate`
- add animation keyframe easing/value curve rendering with easing labels and focused coverage
- expand VT coverage for character sprites, colors, images, and scenes

## Testing
- `bun run lint`
- focused Vitest suites: 159 tests passed
- history-routing regression suites rerun after cleanup: 72 tests passed
- pre-push hook: Oxlint and Prettier checks passed

## Notes
- `bun run build:web` was not run during PR preparation