### PR TITLE
feat: use image selector for particle textures

### DIFF
--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -797,7 +797,7 @@ particlesPage:
   addParticleButton: "Add Particle"
   addParticleTitle: "Add Particle"
   appearanceTab: "Appearance"
-  backgroundImageLabel: "Background Image"
+  backgroundImageLabel: "Preview background image"
   basicsHelpText: "Pick a texture image and adjust the main emitter fields. Preset values were applied before opening this form."
   basicsTab: "Basics"
   burstCountDescription: "How many particles spawn each time a burst is emitted."

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -797,7 +797,7 @@ particlesPage:
   addParticleButton: "パーティクルを追加"
   addParticleTitle: "パーティクルを追加"
   appearanceTab: "外観"
-  backgroundImageLabel: "背景画像"
+  backgroundImageLabel: "プレビュー背景画像"
   basicsHelpText: "テクスチャ画像を選び、主要なエミッター項目を調整します。プリセット値はこのフォームを開く前に適用されています。"
   basicsTab: "基本"
   burstCountDescription: "バーストが発生するたびに生成されるパーティクル数です。"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -797,7 +797,7 @@ particlesPage:
   addParticleButton: "添加粒子"
   addParticleTitle: "添加粒子"
   appearanceTab: "外观"
-  backgroundImageLabel: "背景图像"
+  backgroundImageLabel: "预览背景图像"
   basicsHelpText: "选择纹理图像并调整主要发射器字段。预设值已在打开此表单前应用。"
   basicsTab: "基本"
   burstCountDescription: "每次发射一组粒子时生成的粒子数量。"

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -1087,6 +1087,12 @@ export const handleDialogPreviewBackgroundImageClick = (deps) => {
   render();
 };
 
+export const handleDialogTextureImageClick = (deps) => {
+  const { render, store } = deps;
+  store.showTextureImageSelectorDialog();
+  render();
+};
+
 export const handleDialogPreviewBackgroundImageContextMenu = async (
   deps,
   payload,
@@ -1128,6 +1134,30 @@ const applyDialogPreviewBackgroundImage = async (deps, imageId) => {
   await renderCurrentDialogPreview(deps);
 };
 
+const applyDialogTextureImage = async (deps, imageId) => {
+  const { refs, render, store } = deps;
+  store.setDialogTextureImage({
+    imageId,
+  });
+  store.hidePreviewImageSelectorDialog();
+  render();
+  refs.particleForm.setValues({
+    values: store.selectDialogFormValues(),
+  });
+  await renderCurrentDialogPreview(deps);
+};
+
+const applySelectedDialogImage = async (deps, imageId) => {
+  const { store } = deps;
+  const imageSelectorDialog = store.selectPreviewImageSelectorDialog();
+  if (imageSelectorDialog.target === "texture") {
+    await applyDialogTextureImage(deps, imageId);
+    return;
+  }
+
+  await applyDialogPreviewBackgroundImage(deps, imageId);
+};
+
 export const handlePreviewImageSelected = (deps, payload) => {
   const { render, store } = deps;
   store.setPreviewImageSelectorSelectedImageId({
@@ -1142,7 +1172,7 @@ export const handlePreviewImageDoubleClick = async (deps, payload) => {
     return;
   }
 
-  await applyDialogPreviewBackgroundImage(deps, imageId);
+  await applySelectedDialogImage(deps, imageId);
 };
 
 export const handlePreviewImageFileExplorerClickItem = (deps, payload) => {
@@ -1165,10 +1195,7 @@ export {
 export const handleConfirmPreviewImageSelection = async (deps) => {
   const { store } = deps;
   const imageSelectorDialog = store.selectPreviewImageSelectorDialog();
-  await applyDialogPreviewBackgroundImage(
-    deps,
-    imageSelectorDialog.selectedImageId,
-  );
+  await applySelectedDialogImage(deps, imageSelectorDialog.selectedImageId);
 };
 
 export const handleCancelPreviewImageSelection = (deps) => {

--- a/src/pages/particles/particles.store.js
+++ b/src/pages/particles/particles.store.js
@@ -23,7 +23,6 @@ import {
 } from "./support/particleForm.js";
 import { DEFAULT_PARTICLE_PRESET_ID } from "./support/particlePresets.js";
 import { formatParticleAspectRatio } from "./support/particlePreview.js";
-import { toParticleTextureImageOptions } from "../../internal/particles.js";
 import { selectParticlesPageCopy } from "./support/particlesPageCopy.js";
 
 const EMPTY_TREE = {
@@ -42,8 +41,12 @@ const CREATE_TAG_DEFAULT_VALUES = Object.freeze({
 
 const createInitialPreviewImageSelectorDialogState = () => ({
   open: false,
+  target: undefined,
   selectedImageId: undefined,
 });
+
+const PREVIEW_BACKGROUND_IMAGE_TARGET = "preview-background";
+const TEXTURE_IMAGE_TARGET = "texture";
 
 const getImageItems = (state) => state.imagesData?.items ?? {};
 
@@ -62,8 +65,7 @@ const resolveImageAspectRatio = (item) => {
   return `${Math.max(1, Math.round(width))} / ${Math.max(1, Math.round(height))}`;
 };
 
-const buildDialogPreviewBackgroundImage = (state) => {
-  const imageId = state.dialogPreviewBackgroundImageId;
+const buildDialogImageCard = (state, imageId) => {
   const imageItem = getImageItemById(state, imageId);
 
   if (!imageId || !imageItem?.fileId) {
@@ -78,6 +80,10 @@ const buildDialogPreviewBackgroundImage = (state) => {
     itemBorderColor: "bo",
     itemHoverBorderColor: "ac",
   };
+};
+
+const buildDialogPreviewBackgroundImage = (state) => {
+  return buildDialogImageCard(state, state.dialogPreviewBackgroundImageId);
 };
 
 const createTagForm = (copy = {}) => ({
@@ -104,27 +110,23 @@ const createTagForm = (copy = {}) => ({
 
 const createDialogForm = ({
   editMode = false,
-  imagesData = EMPTY_TREE,
   tagsData = createEmptyTagCollection(),
   activeTab = DEFAULT_PARTICLE_FORM_TAB,
   dialogStep = PARTICLE_EDITOR_STEP,
   copy = {},
 } = {}) => {
-  const imageOptions = toParticleTextureImageOptions(imagesData);
   const tagOptions = buildTagFilterOptions({
     tagsCollection: tagsData,
   });
 
   if (!editMode && dialogStep === CREATE_PARTICLE_SETUP_STEP) {
     return createParticleCreateSetupForm({
-      imageOptions,
       copy,
     });
   }
 
   return createParticleForm({
     editMode,
-    imageOptions,
     tagOptions,
     activeTab,
     copy,
@@ -230,7 +232,6 @@ const {
       particleFormKey: `particle-form-${state.dialogStep}-${state.dialogFormTab}`,
       particleForm: createDialogForm({
         editMode: state.editMode,
-        imagesData: state.imagesData,
         tagsData: state.tagsData,
         activeTab: state.dialogFormTab,
         dialogStep: state.dialogStep,
@@ -239,6 +240,10 @@ const {
       dialogFormValues: state.dialogFormValues,
       dialogPreviewAspectRatio: state.dialogPreviewAspectRatio,
       dialogPreviewBackgroundImage: buildDialogPreviewBackgroundImage(state),
+      dialogTextureImage: buildDialogImageCard(
+        state,
+        state.dialogFormValues.textureImageId,
+      ),
       previewImageSelectorDialog: state.previewImageSelectorDialog,
       showImageSelectorFileExplorer: !state.isTouchMode,
       imageFolderItems: toFlatItems(state.imagesData).filter(
@@ -252,7 +257,8 @@ const {
       createTagForm: createTagForm(copy),
       selectedItem,
       addTagPlaceholder: copy.addTagPlaceholder ?? "Add tag",
-      backgroundImageLabel: copy.backgroundImageLabel ?? "Background Image",
+      backgroundImageLabel:
+        copy.backgroundImageLabel ?? "Preview background image",
       cancelButton: copy.cancelButton ?? "Cancel",
       confirmButton: copy.confirmButton ?? "OK",
       deleteButton: copy.deleteButton ?? "Delete",
@@ -261,6 +267,13 @@ const {
       previewButton: copy.previewMenuItem ?? "Preview",
       removeMenuItem: copy.removeMenuItem ?? "Remove",
       selectImageLabel: copy.selectImageOption ?? "Select image",
+      textureImageDescription:
+        state.dialogStep === CREATE_PARTICLE_SETUP_STEP
+          ? (copy.setupTextureImageDescription ??
+            "Choose the image used for each spawned particle.")
+          : (copy.textureImageDescription ??
+            "Choose the image used to draw each particle sprite."),
+      textureImageLabel: copy.textureImageLabel ?? "Texture Image",
     };
   },
 });
@@ -349,7 +362,6 @@ export const setTagsData = ({ state }, { tagsData } = {}) => {
   );
   state.particleForm = createDialogForm({
     editMode: state.editMode,
-    imagesData: state.imagesData,
     tagsData: state.tagsData,
     activeTab: state.dialogFormTab,
     dialogStep: state.dialogStep,
@@ -489,7 +501,6 @@ const setDialogState = (state, options = {}) => {
   });
   state.particleForm = createDialogForm({
     editMode,
-    imagesData: state.imagesData,
     tagsData: state.tagsData,
     activeTab: state.dialogFormTab,
     dialogStep: state.dialogStep,
@@ -531,7 +542,6 @@ export const closeParticleDialog = ({ state }, _payload = {}) => {
   state.previewImageSelectorDialog =
     createInitialPreviewImageSelectorDialogState();
   state.particleForm = createDialogForm({
-    imagesData: state.imagesData,
     tagsData: state.tagsData,
     activeTab: state.dialogFormTab,
     dialogStep: state.dialogStep,
@@ -573,7 +583,6 @@ export const setImagesData = ({ state }, { imagesData } = {}) => {
   }
   state.particleForm = createDialogForm({
     editMode: state.editMode,
-    imagesData: state.imagesData,
     tagsData: state.tagsData,
     activeTab: state.dialogFormTab,
     dialogStep: state.dialogStep,
@@ -588,7 +597,6 @@ export const setDialogFormTab = ({ state }, { tab } = {}) => {
   state.dialogFormTab = tab ?? DEFAULT_PARTICLE_FORM_TAB;
   state.particleForm = createDialogForm({
     editMode: state.editMode,
-    imagesData: state.imagesData,
     tagsData: state.tagsData,
     activeTab: state.dialogFormTab,
     dialogStep: state.dialogStep,
@@ -599,7 +607,6 @@ export const setDialogStep = ({ state }, { step } = {}) => {
   state.dialogStep = step ?? CREATE_PARTICLE_SETUP_STEP;
   state.particleForm = createDialogForm({
     editMode: state.editMode,
-    imagesData: state.imagesData,
     tagsData: state.tagsData,
     activeTab: state.dialogFormTab,
     dialogStep: state.dialogStep,
@@ -634,8 +641,18 @@ export const clearDialogPreviewBackgroundImage = ({ state }, _payload = {}) => {
 
 export const showPreviewImageSelectorDialog = ({ state }, _payload = {}) => {
   state.previewImageSelectorDialog.open = true;
+  state.previewImageSelectorDialog.target = PREVIEW_BACKGROUND_IMAGE_TARGET;
   state.previewImageSelectorDialog.selectedImageId =
     state.dialogPreviewBackgroundImageId;
+};
+
+export const showTextureImageSelectorDialog = ({ state }, _payload = {}) => {
+  const imageId = state.dialogFormValues.textureImageId;
+  state.previewImageSelectorDialog.open = true;
+  state.previewImageSelectorDialog.target = TEXTURE_IMAGE_TARGET;
+  state.previewImageSelectorDialog.selectedImageId = imageId
+    ? imageId
+    : undefined;
 };
 
 export const hidePreviewImageSelectorDialog = ({ state }, _payload = {}) => {
@@ -648,6 +665,10 @@ export const setPreviewImageSelectorSelectedImageId = (
   { imageId } = {},
 ) => {
   state.previewImageSelectorDialog.selectedImageId = imageId ?? undefined;
+};
+
+export const setDialogTextureImage = ({ state }, { imageId } = {}) => {
+  state.dialogFormValues.textureImageId = imageId ?? "";
 };
 
 export const selectTargetGroupId = ({ state }) => state.targetGroupId;

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -111,6 +111,10 @@ refs:
         handler: handleDialogPreviewBackgroundImageClick
       contextmenu:
         handler: handleDialogPreviewBackgroundImageContextMenu
+  dialogTextureImageButton:
+    eventListeners:
+      click:
+        handler: handleDialogTextureImageClick
   previewImageSelectorDialog:
     eventListeners:
       close:
@@ -215,13 +219,28 @@ template:
                           - rtgl-form#particleForm key=${particleFormKey} :defaultValues=${dialogFormValues} :form=${particleForm} w=f:
                               - $if showParticleFormTabs:
                                   - rtgl-tabs#tabs slot=particle-form-tabs selected-tab=${selectedParticleFormTab} :items=${particleFormTabs}: null
+                              - rtgl-view slot=particle-texture-image d=v w=f:
+                                  - rtgl-view d=v w=f g=xs:
+                                      - rtgl-text: ${textureImageLabel}
+                                      - rtgl-text s=sm c=mu-fg: ${textureImageDescription}
+                                  - 'rtgl-view h=8 style="flex-shrink: 0;"': null
+                                  - $if dialogTextureImage:
+                                      - 'rtgl-view#dialogTextureImageButton cur=pointer bw=xs bc=${dialogTextureImage.itemBorderColor} h-bc=${dialogTextureImage.itemHoverBorderColor} br=md w=160 overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
+                                          - 'rtgl-view w=f style="aspect-ratio: ${dialogTextureImage.previewAspectRatio}; overflow: hidden;"':
+                                              - rvn-file-image w=f h=f fileId=${dialogTextureImage.previewFileId}: null
+                                          - rtgl-view w=f p=md:
+                                              - rtgl-text s=xs c=mu-fg ellipsis w=f: ${dialogTextureImage.name}
+                                    $else:
+                                      - 'rtgl-view#dialogTextureImageButton w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
+                                          - rtgl-text c=mu-fg s=sm: ${selectImageLabel}
               - 'rtgl-view w=6fg lg-w=f d=v av=c g=md h=f style="min-width: 0; min-height: 0; overflow-y: auto;"':
                   - 'rtgl-view w=f pos=rel br=md bw=xs bc=bo style="aspect-ratio: ${dialogPreviewAspectRatio}; overflow: hidden; background: #000;"':
                       - rtgl-view pos=abs cor=full:
                           - 'div#dialogCanvas style="width: 100%; height: 100%; display: flex; overflow: hidden;"': null
                   - $if !isPreviewOnlyDialog:
-                      - rtgl-view d=v w=f g=xs:
+                      - rtgl-view d=v w=f:
                           - rtgl-text s=sm c=mu-fg: ${backgroundImageLabel}
+                          - 'rtgl-view h=8 style="flex-shrink: 0;"': null
                           - rtgl-view d=h wrap g=sm w=f av=c:
                               - $if dialogPreviewBackgroundImage:
                                   - 'rtgl-view#dialogPreviewBackgroundImageButton cur=pointer bw=xs bc=${dialogPreviewBackgroundImage.itemBorderColor} h-bc=${dialogPreviewBackgroundImage.itemHoverBorderColor} br=md w=160 style="max-width: 100%; box-sizing: border-box;"':

--- a/src/pages/particles/support/particleForm.js
+++ b/src/pages/particles/support/particleForm.js
@@ -60,18 +60,6 @@ const createParticleTagField = (copy = {}, tagOptions = []) => ({
   required: false,
 });
 
-const resolveTextureImageOptions = (imageOptions = [], copy = {}) => [
-  {
-    id: "",
-    label:
-      imageOptions.length > 0
-        ? (copy.selectImageOption ?? "Select image")
-        : (copy.noImagesAvailableOption ?? "No images available"),
-    value: "",
-  },
-  ...imageOptions,
-];
-
 const toTextValue = (value) => {
   if (value === undefined || value === null) {
     return "";
@@ -383,10 +371,7 @@ const withFieldTooltips = (fields = []) =>
     };
   });
 
-export const createParticleCreateSetupForm = ({
-  imageOptions = [],
-  copy = {},
-} = {}) => ({
+export const createParticleCreateSetupForm = ({ copy = {} } = {}) => ({
   title: copy.createParticleTitle ?? "Create Particle",
   description:
     copy.createSetupDescription ??
@@ -404,25 +389,12 @@ export const createParticleCreateSetupForm = ({
       options: createParticlePresetOptions(copy),
     },
     {
-      name: "textureImageId",
-      type: "select",
-      label: copy.textureImageLabel ?? "Texture Image",
-      description:
-        copy.setupTextureImageDescription ??
-        "Choose the image used for each spawned particle.",
-      options: resolveTextureImageOptions(imageOptions, copy),
-      required: true,
-      clearable: false,
+      type: "slot",
+      slot: "particle-texture-image",
     },
   ]),
   actions: {
     buttons: [
-      {
-        id: "cancel",
-        variant: "se",
-        label: copy.cancelButton ?? "Cancel",
-        align: "left",
-      },
       {
         id: "submit",
         variant: "pr",
@@ -453,11 +425,7 @@ const PARTICLE_FORM_TAB_IDS = new Set(
   PARTICLE_FORM_TABS.map((item) => item.id),
 );
 
-const createParticleFieldsByTab = ({
-  imageOptions = [],
-  tagOptions = [],
-  copy = {},
-} = {}) => {
+const createParticleFieldsByTab = ({ tagOptions = [], copy = {} } = {}) => {
   const fieldsByTab = {
     basics: [
       {
@@ -807,14 +775,8 @@ const createParticleFieldsByTab = ({
     ],
     appearance: [
       {
-        name: "textureImageId",
-        type: "select",
-        label: copy.textureImageLabel ?? "Texture Image",
-        description:
-          copy.textureImageDescription ??
-          "Choose the image used to draw each particle sprite.",
-        options: resolveTextureImageOptions(imageOptions, copy),
-        required: true,
+        type: "slot",
+        slot: "particle-texture-image",
       },
       {
         name: "scaleMin",
@@ -851,7 +813,6 @@ const createParticleFieldsByTab = ({
 
 export const createParticleForm = ({
   editMode = false,
-  imageOptions = [],
   tagOptions = [],
   activeTab = "basics",
   copy = {},
@@ -865,7 +826,6 @@ export const createParticleForm = ({
       slot: "particle-form-tabs",
     },
     ...createParticleFieldsByTab({
-      imageOptions,
       tagOptions,
       copy,
     })[PARTICLE_FORM_TAB_IDS.has(activeTab) ? activeTab : "basics"],

--- a/tests/particles/particles.imageSelector.test.js
+++ b/tests/particles/particles.imageSelector.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectPreviewImageSelectorDialog,
+  selectViewData,
+  setDialogFormValues,
+  setDialogTextureImage,
+  setImagesData,
+  showTextureImageSelectorDialog,
+} from "../../src/pages/particles/particles.store.js";
+import {
+  createParticleCreateSetupForm,
+  createParticleForm,
+} from "../../src/pages/particles/support/particleForm.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const IMAGE_ID = "image-one";
+
+const createImagesData = () => ({
+  items: {
+    [IMAGE_ID]: {
+      id: IMAGE_ID,
+      type: "image",
+      name: "Image One",
+      fileId: "file-one",
+      thumbnailFileId: "thumbnail-one",
+      width: 64,
+      height: 32,
+    },
+  },
+  tree: [],
+});
+
+describe("particle texture image selector", () => {
+  it("uses the image selector slot in setup and appearance forms", () => {
+    const setupForm = createParticleCreateSetupForm();
+    const appearanceForm = createParticleForm({ activeTab: "appearance" });
+
+    expect(setupForm.fields).toContainEqual({
+      type: "slot",
+      slot: "particle-texture-image",
+    });
+    expect(appearanceForm.fields).toContainEqual({
+      type: "slot",
+      slot: "particle-texture-image",
+    });
+    expect(
+      setupForm.fields.find((field) => field.name === "textureImageId"),
+    ).toBeUndefined();
+    expect(
+      appearanceForm.fields.find((field) => field.name === "textureImageId"),
+    ).toBeUndefined();
+    expect(setupForm.actions.buttons.map((button) => button.id)).toEqual([
+      "submit",
+    ]);
+  });
+
+  it("opens with the current texture selected and builds its image card", () => {
+    const state = createInitialState();
+    setImagesData({ state }, { imagesData: createImagesData() });
+    setDialogFormValues({ state }, { values: { textureImageId: IMAGE_ID } });
+
+    showTextureImageSelectorDialog({ state });
+
+    expect(selectPreviewImageSelectorDialog({ state })).toEqual({
+      open: true,
+      target: "texture",
+      selectedImageId: IMAGE_ID,
+    });
+    expect(selectViewData({ state, i18n: EN_I18N }).dialogTextureImage).toEqual(
+      {
+        imageId: IMAGE_ID,
+        previewFileId: "thumbnail-one",
+        previewAspectRatio: "64 / 32",
+        name: "Image One",
+        itemBorderColor: "bo",
+        itemHoverBorderColor: "ac",
+      },
+    );
+  });
+
+  it("stores a texture selected from the image selector", () => {
+    const state = createInitialState();
+
+    setDialogTextureImage({ state }, { imageId: IMAGE_ID });
+
+    expect(state.dialogFormValues.textureImageId).toBe(IMAGE_ID);
+  });
+});


### PR DESCRIPTION
## Summary
- replace particle texture dropdowns in setup and Appearance with the shared image-selector dialog
- show the selected texture as a flush image card and refine preview-background spacing and copy
- remove the initial Create Particle Cancel action and add focused selector coverage

## Testing
- `bunx vitest run tests/particles/particles.imageSelector.test.js tests/layoutEditor/mobileImageSelectorFileExplorer.test.js`
- `bun run lint`
- `build:web` not run per request