### PR TITLE
fix: restore particle image picker keyboard access

### DIFF
--- a/src/components/imageSelector/imageSelector.handlers.js
+++ b/src/components/imageSelector/imageSelector.handlers.js
@@ -30,10 +30,7 @@ export const handleOnUpdate = (deps, payload) => {
 
 export const handleImageItemClick = (deps, payload) => {
   const { store, render, dispatchEvent } = deps;
-
-  const id =
-    payload._event.currentTarget?.dataset?.itemId ||
-    payload._event.currentTarget?.id?.replace("imageItem", "");
+  const id = payload._event.currentTarget.dataset.itemId;
 
   store.setSelectedImageId({
     imageId: id,
@@ -48,6 +45,47 @@ export const handleImageItemClick = (deps, payload) => {
   );
 
   render();
+};
+
+const focusImageItem = (deps, currentTarget, targetIndex) => {
+  const imageItems = Array.from(
+    deps.refs.container.querySelectorAll('[role="option"]'),
+  );
+  if (imageItems.length === 0) {
+    return;
+  }
+
+  const currentIndex = imageItems.indexOf(currentTarget);
+  const normalizedTargetIndex = Math.max(
+    0,
+    Math.min(imageItems.length - 1, targetIndex(currentIndex, imageItems)),
+  );
+  imageItems[normalizedTargetIndex].focus();
+};
+
+export const handleImageItemKeyDown = (deps, payload) => {
+  const { _event } = payload;
+  if (_event.key === "Enter" || _event.key === " ") {
+    _event.preventDefault();
+    handleImageItemClick(deps, payload);
+    return;
+  }
+
+  const focusTargets = {
+    ArrowDown: (currentIndex) => currentIndex + 1,
+    ArrowLeft: (currentIndex) => currentIndex - 1,
+    ArrowRight: (currentIndex) => currentIndex + 1,
+    ArrowUp: (currentIndex) => currentIndex - 1,
+    End: (_currentIndex, imageItems) => imageItems.length - 1,
+    Home: () => 0,
+  };
+  const targetIndex = focusTargets[_event.key];
+  if (!targetIndex) {
+    return;
+  }
+
+  _event.preventDefault();
+  focusImageItem(deps, _event.currentTarget, targetIndex);
 };
 
 export const handleImageItemDoubleClick = () => {};

--- a/src/components/imageSelector/imageSelector.store.js
+++ b/src/components/imageSelector/imageSelector.store.js
@@ -31,7 +31,7 @@ const matchesSearch = (item, searchQuery) => {
   return name.includes(searchQuery) || description.includes(searchQuery);
 };
 
-export const selectViewData = ({ state, props = {} }) => {
+export const selectViewData = ({ state, props = {}, i18n = {} }) => {
   const images = state.images ?? { items: {}, tree: [] };
   const selectedImageId = state.selectedImageId;
   const searchQuery = (props.searchQuery ?? "").toLowerCase().trim();
@@ -51,6 +51,7 @@ export const selectViewData = ({ state, props = {} }) => {
 
           return {
             ...child,
+            isSelected,
             itemBorderColor,
             itemHoverBorderColor,
             imageCardStyle,
@@ -69,6 +70,7 @@ export const selectViewData = ({ state, props = {} }) => {
 
   return {
     groups,
+    imageSelectorLabel: i18n.imagesPage?.title ?? "Images",
     selectedImageId,
   };
 };

--- a/src/components/imageSelector/imageSelector.view.yaml
+++ b/src/components/imageSelector/imageSelector.view.yaml
@@ -6,6 +6,8 @@ refs:
         handler: handleImageItemClick
       dblclick:
         handler: handleImageItemDoubleClick
+      keydown:
+        handler: handleImageItemKeyDown
 styles:
   ".imageSelectorThumbnailTransparencyGrid":
     background-color: "#eef2f7"
@@ -14,7 +16,7 @@ styles:
     background-repeat: repeat
     background-size: 12px 12px
 template:
-  - 'rtgl-view#container h=1fg sv g=lg style="outline: none;"':
+  - 'rtgl-view#container role=listbox aria-label="${imageSelectorLabel}" h=1fg sv g=lg style="outline: none;"':
       - $for group, i in groups:
           - 'rtgl-view#groupRef${i} data-group-id=${group.id} mb=sm w=f bgc=bg style="position: sticky; top: 0"':
               - rtgl-view d=h av=c g=md:
@@ -22,7 +24,7 @@ template:
                   - rtgl-text: ${group.fullLabel}
           - rtgl-view d=h w=f wrap g=md:
               - $for item, j in group.children:
-                  - rtgl-view#imageItemRef${i}x${j} data-item-id=${item.id} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md cur=pointer key=${item.id}:
+                  - 'rtgl-view#imageItemRef${i}x${j} role=option tabindex=0 aria-selected="${item.isSelected}" data-item-id=${item.id} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md cur=pointer key=${item.id}':
                       - 'rtgl-view br=md w=200 pos=rel overflow=hidden style="${item.imageCardStyle}"':
                           - 'div.imageSelectorThumbnailTransparencyGrid style="display: block; width: 100%; aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                               - rvn-file-image w=f h=f imageId=${item.id} source="thumbnail": null

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -1093,6 +1093,16 @@ export const handleDialogTextureImageClick = (deps) => {
   render();
 };
 
+export const handleDialogTextureImageKeyDown = (deps, payload) => {
+  const { _event } = payload;
+  if (_event.key !== "Enter" && _event.key !== " ") {
+    return;
+  }
+
+  _event.preventDefault();
+  handleDialogTextureImageClick(deps);
+};
+
 export const handleDialogPreviewBackgroundImageContextMenu = async (
   deps,
   payload,

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -115,6 +115,8 @@ refs:
     eventListeners:
       click:
         handler: handleDialogTextureImageClick
+      keydown:
+        handler: handleDialogTextureImageKeyDown
   previewImageSelectorDialog:
     eventListeners:
       close:
@@ -225,13 +227,13 @@ template:
                                       - rtgl-text s=sm c=mu-fg: ${textureImageDescription}
                                   - 'rtgl-view h=8 style="flex-shrink: 0;"': null
                                   - $if dialogTextureImage:
-                                      - 'rtgl-view#dialogTextureImageButton cur=pointer bw=xs bc=${dialogTextureImage.itemBorderColor} h-bc=${dialogTextureImage.itemHoverBorderColor} br=md w=160 overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
+                                      - 'rtgl-view#dialogTextureImageButton role=button tabindex=0 aria-haspopup=dialog aria-label="${textureImageLabel}" cur=pointer bw=xs bc=${dialogTextureImage.itemBorderColor} h-bc=${dialogTextureImage.itemHoverBorderColor} br=md w=160 overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
                                           - 'rtgl-view w=f style="aspect-ratio: ${dialogTextureImage.previewAspectRatio}; overflow: hidden;"':
                                               - rvn-file-image w=f h=f fileId=${dialogTextureImage.previewFileId}: null
                                           - rtgl-view w=f p=md:
                                               - rtgl-text s=xs c=mu-fg ellipsis w=f: ${dialogTextureImage.name}
                                     $else:
-                                      - 'rtgl-view#dialogTextureImageButton w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
+                                      - 'rtgl-view#dialogTextureImageButton role=button tabindex=0 aria-haspopup=dialog aria-label="${textureImageLabel}" w=160 h=90 av=c ah=c bgc=bg bc=bo bw=xs br=md cur=pointer style="max-width: 100%; box-sizing: border-box;"':
                                           - rtgl-text c=mu-fg s=sm: ${selectImageLabel}
               - 'rtgl-view w=6fg lg-w=f d=v av=c g=md h=f style="min-width: 0; min-height: 0; overflow-y: auto;"':
                   - 'rtgl-view w=f pos=rel br=md bw=xs bc=bo style="aspect-ratio: ${dialogPreviewAspectRatio}; overflow: hidden; background: #000;"':

--- a/tests/imageSelector/imageSelector.handlers.test.js
+++ b/tests/imageSelector/imageSelector.handlers.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleImageItemClick,
   handleImageItemDoubleClick,
+  handleImageItemKeyDown,
 } from "../../src/components/imageSelector/imageSelector.handlers.js";
 
 const createPayload = (imageId) => ({
@@ -54,5 +55,68 @@ describe("imageSelector.handlers", () => {
     );
 
     expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it.each(["Enter", " "])("selects images with the %s key", (key) => {
+    const dispatchEvent = vi.fn();
+    const preventDefault = vi.fn();
+    const render = vi.fn();
+    const setSelectedImageId = vi.fn();
+    const payload = createPayload("image-1");
+    payload._event.key = key;
+    payload._event.preventDefault = preventDefault;
+
+    handleImageItemKeyDown(
+      {
+        dispatchEvent,
+        render,
+        store: {
+          setSelectedImageId,
+        },
+      },
+      payload,
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(setSelectedImageId).toHaveBeenCalledWith({
+      imageId: "image-1",
+    });
+    expect(dispatchEvent.mock.calls[0][0]).toMatchObject({
+      type: "image-selected",
+      detail: {
+        imageId: "image-1",
+      },
+    });
+  });
+
+  it("moves focus between image options with arrow keys", () => {
+    const previousItem = { focus: vi.fn() };
+    const currentItem = { focus: vi.fn() };
+    const nextItem = { focus: vi.fn() };
+    const preventDefault = vi.fn();
+
+    handleImageItemKeyDown(
+      {
+        refs: {
+          container: {
+            querySelectorAll: vi.fn(() => [
+              previousItem,
+              currentItem,
+              nextItem,
+            ]),
+          },
+        },
+      },
+      {
+        _event: {
+          currentTarget: currentItem,
+          key: "ArrowRight",
+          preventDefault,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(nextItem.focus).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/particles/particles.imageSelector.test.js
+++ b/tests/particles/particles.imageSelector.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createInitialState,
   selectPreviewImageSelectorDialog,
@@ -12,6 +12,7 @@ import {
   createParticleCreateSetupForm,
   createParticleForm,
 } from "../../src/pages/particles/support/particleForm.js";
+import { handleDialogTextureImageKeyDown } from "../../src/pages/particles/particles.handlers.js";
 import { EN_I18N } from "../support/i18n.js";
 
 const IMAGE_ID = "image-one";
@@ -86,4 +87,32 @@ describe("particle texture image selector", () => {
 
     expect(state.dialogFormValues.textureImageId).toBe(IMAGE_ID);
   });
+
+  it.each(["Enter", " "])(
+    "opens the texture image selector with the %s key",
+    (key) => {
+      const preventDefault = vi.fn();
+      const render = vi.fn();
+      const showTextureImageSelectorDialog = vi.fn();
+
+      handleDialogTextureImageKeyDown(
+        {
+          render,
+          store: {
+            showTextureImageSelectorDialog,
+          },
+        },
+        {
+          _event: {
+            key,
+            preventDefault,
+          },
+        },
+      );
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(showTextureImageSelectorDialog).toHaveBeenCalledTimes(1);
+      expect(render).toHaveBeenCalledTimes(1);
+    },
+  );
 });

--- a/vt/specs/project/particles.yaml
+++ b/vt/specs/project/particles.yaml
@@ -82,21 +82,33 @@ steps:
     ms: 700
   - action: screenshot
   - action: waitFor
-    selector: "#particleDialog rtgl-select#field1 [data-testid='select-button']"
+    selector: "#dialogTextureImageButton"
     state: visible
     timeoutMs: 5000
   - action: select
-    selector: "#particleDialog rtgl-select#field1 [data-testid='select-button']"
+    selector: "#dialogTextureImageButton"
     steps:
       - action: click
   - action: waitFor
-    selector: "#particleDialog rtgl-select#field1 #option1"
+    selector: "#previewImageSelectorDialog[open]"
+    state: visible
+    timeoutMs: 5000
+  - action: waitFor
+    selector: "#previewImageSelectorDialog [role='option'][data-item-id]"
     state: visible
     timeoutMs: 5000
   - action: select
-    selector: "#particleDialog rtgl-select#field1 #option1"
+    selector: "#previewImageSelectorDialog [role='option'][data-item-id]"
     steps:
       - action: click
+  - action: select
+    selector: "#confirmPreviewImageSelection"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#previewImageSelectorDialog"
+    state: hidden
+    timeoutMs: 5000
   - action: wait
     ms: 300
   - action: screenshot


### PR DESCRIPTION
## Summary
- make the particle texture trigger keyboard-focusable and operable with Enter or Space
- add listbox/option semantics, keyboard selection, and arrow/Home/End navigation to the shared image selector
- update the particles VT workflow to select the texture through the new dialog

Follow-up to #972.

## Testing
- `bunx vitest run tests/imageSelector/imageSelector.handlers.test.js tests/particles/particles.imageSelector.test.js tests/layoutEditor/mobileImageSelectorFileExplorer.test.js`
- `bun run lint`
- VT spec YAML parse validation
- `build:web` and VT generation not run per request