### PR TITLE
fix: simplify particle image selector actions

### DIFF
--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -880,6 +880,7 @@ particlesPage:
   scaleMinLabel: "Scale Min"
   seedDescription: "Use a fixed random seed to make the effect replay consistently."
   seedLabel: "Seed"
+  selectButton: "Select"
   selectImageOption: "Select image"
   selectValidTextureImage: "Select a valid particle texture image."
   selectorLabel: "selector"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -880,6 +880,7 @@ particlesPage:
   scaleMinLabel: "スケール 最小"
   seedDescription: "固定ランダムシードを使い、エフェクトを毎回同じように再生します。"
   seedLabel: "シード"
+  selectButton: "選択"
   selectImageOption: "画像を選択"
   selectValidTextureImage: "有効なパーティクル用テクスチャ画像を選択してください。"
   selectorLabel: "セレクター"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -880,6 +880,7 @@ particlesPage:
   scaleMinLabel: "缩放最小值"
   seedDescription: "使用固定随机种子，让效果每次都能一致重放。"
   seedLabel: "种子"
+  selectButton: "选择"
   selectImageOption: "选择图像"
   selectValidTextureImage: "请选择有效的粒子纹理图像。"
   selectorLabel: "选择器"

--- a/src/pages/particles/particles.handlers.js
+++ b/src/pages/particles/particles.handlers.js
@@ -1208,12 +1208,6 @@ export const handleConfirmPreviewImageSelection = async (deps) => {
   await applySelectedDialogImage(deps, imageSelectorDialog.selectedImageId);
 };
 
-export const handleCancelPreviewImageSelection = (deps) => {
-  const { render, store } = deps;
-  store.hidePreviewImageSelectorDialog();
-  render();
-};
-
 export const handleClosePreviewImageSelectorDialog = (deps) => {
   const { render, store } = deps;
   store.hidePreviewImageSelectorDialog();

--- a/src/pages/particles/particles.store.js
+++ b/src/pages/particles/particles.store.js
@@ -259,8 +259,7 @@ const {
       addTagPlaceholder: copy.addTagPlaceholder ?? "Add tag",
       backgroundImageLabel:
         copy.backgroundImageLabel ?? "Preview background image",
-      cancelButton: copy.cancelButton ?? "Cancel",
-      confirmButton: copy.confirmButton ?? "OK",
+      selectButton: copy.selectButton ?? "Select",
       deleteButton: copy.deleteButton ?? "Delete",
       filesLabel: copy.filesLabel ?? "Files",
       noSelectionLabel: copy.noSelectionLabel ?? "No selection",

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -141,10 +141,6 @@ refs:
     eventListeners:
       click:
         handler: handleConfirmPreviewImageSelection
-  cancelPreviewImageSelection:
-    eventListeners:
-      click:
-        handler: handleCancelPreviewImageSelection
   detailCanvas: {}
   dialogCanvas: {}
 template:
@@ -265,5 +261,4 @@ template:
                   - 'rtgl-view#imageSelectorKeyboardScope tabindex=-1 w=1fg h=f style="min-width: 0; min-height: 0; outline: none;"':
                       - rvn-image-selector#imageSelector selectedImageId=${previewImageSelectorDialog.selectedImageId}: null
               - rtgl-view d=h g=sm w=f ah=e:
-                  - rtgl-button#cancelPreviewImageSelection variant=se: ${cancelButton}
-                  - rtgl-button#confirmPreviewImageSelection variant=pr: ${confirmButton}
+                  - rtgl-button#confirmPreviewImageSelection variant=pr: ${selectButton}


### PR DESCRIPTION
## Summary
- remove the Cancel button from the particle image-selector dialog
- rename the remaining OK action to Select
- remove unused handler/view copy and localize the new label

## Testing
- `bunx vitest run tests/particles/particles.imageSelector.test.js tests/layoutEditor/mobileImageSelectorFileExplorer.test.js`
- `bun run lint`
- `build:web` not run per request