### PR TITLE
fix(layout-editor): badge special element icons

### DIFF
--- a/src/components/baseFileExplorer/baseFileExplorer.schema.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.schema.yaml
@@ -11,8 +11,8 @@ propsSchema:
             type: string
           id:
             type: string
-          trailingSvg:
-            type: string
+          iconCornerBadge:
+            type: boolean
           contextMenuItems:
             type: array
           level:

--- a/src/components/baseFileExplorer/baseFileExplorer.view.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.view.yaml
@@ -64,13 +64,13 @@ template:
                             $else:
                               - rtgl-view d=h av=c ah=c w=16 h=16 min-w=16: null
                           - 'rtgl-view d=h g=md av=c w=1fg style="min-width: 0; overflow: hidden;"':
-                              - rtgl-view d=h av=c ah=c w=16 h=16 min-w=16:
+                              - rtgl-view d=h av=c ah=c w=16 h=16 min-w=16 pos=rel:
                                   - rtgl-svg svg=${item.svg} wh=16: null
+                                  - $if item.iconCornerBadge:
+                                      - 'svg.iconCornerBadge aria-hidden=true viewBox="0 0 9 9" style="position: absolute; right: -1px; bottom: -1px; width: 9px; height: 9px; overflow: visible; pointer-events: none;"':
+                                          - 'polygon points="9 0, 9 9, 0 9" fill="var(--foreground)" stroke="var(--background)" stroke-width="1.5" stroke-linejoin="round"': null
                               - 'rtgl-view w=1fg style="min-width: 0; overflow: hidden;"':
                                   - 'rtgl-text s=sm ellipsis=true w=f style="min-width: 0;"': ${item.name}
-                              - $if item.trailingSvg:
-                                  - rtgl-view d=h av=c ah=c w=14 h=14 min-w=14:
-                                      - rtgl-svg svg=${item.trailingSvg} wh=12 c=mu-fg: null
                   - 'div#container style="width: 100%; height: ${bottomEmptySpaceHeight}; min-height: ${bottomEmptySpaceHeight}; flex: 0 0 ${bottomEmptySpaceHeight}; pointer-events: none;"': null
           - $if targetDragIndex != -2 && targetDropPosition != 'inside':
               - 'rtgl-view pos=abs bgc=fg h=2 style="top: ${targetDragPosition}px; left: ${targetDragLeftOffset}px; width: calc(100% - ${targetDragLeftOffset}px); z-index: 1000;"': null

--- a/src/pages/layoutEditor/support/layoutEditorViewData.js
+++ b/src/pages/layoutEditor/support/layoutEditorViewData.js
@@ -142,7 +142,7 @@ export const toLayoutEditorExplorerItems = (
         canReceiveChildren === true
           ? toContainerContextMenuItems(contextMenuItems, item)
           : leafItemContextMenuItems,
-      trailingSvg: hasPreviewDependencies ? "component" : undefined,
+      iconCornerBadge: hasPreviewDependencies,
       dragOptions: {
         ...item.dragOptions,
         canReceiveChildren,

--- a/tests/baseFileExplorer/baseFileExplorer.view.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.view.test.js
@@ -38,4 +38,15 @@ describe("baseFileExplorer view", () => {
     expect(view).toContain("touch-action: ${item.touchAction};");
     expect(view).toContain("data-file-explorer-arrow=true");
   });
+
+  it("renders special-item badges in the bottom-right corner of the item icon", () => {
+    const view = readView();
+
+    expect(view).toContain("$if item.iconCornerBadge");
+    expect(view).toContain("svg.iconCornerBadge");
+    expect(view).toContain('viewBox="0 0 9 9"');
+    expect(view).toContain('points="9 0, 9 9, 0 9"');
+    expect(view).toContain('stroke="var(--background)"');
+    expect(view).not.toContain("item.trailingSvg");
+  });
 });

--- a/tests/layoutEditor/layoutEditor.store.test.js
+++ b/tests/layoutEditor/layoutEditor.store.test.js
@@ -177,7 +177,7 @@ describe("layoutEditor.store", () => {
     expect(emptyMenuLabels).not.toContain("Text (Choice Content)");
   });
 
-  it("adds the component badge to special layout editor items", () => {
+  it("adds an icon corner badge to special layout editor items", () => {
     const state = createInitialState();
 
     syncRepositoryState(
@@ -199,8 +199,16 @@ describe("layoutEditor.store", () => {
               type: "text",
               name: "Text",
             },
+            "choice-container": {
+              type: "container-ref-choice-item",
+              name: "Choice Item",
+            },
           },
-          tree: [{ id: "text-bound" }, { id: "text-free" }],
+          tree: [
+            { id: "text-bound" },
+            { id: "text-free" },
+            { id: "choice-container" },
+          ],
         },
       },
     );
@@ -212,11 +220,17 @@ describe("layoutEditor.store", () => {
     });
 
     expect(
-      viewData.flatItems.find((item) => item.id === "text-bound")?.trailingSvg,
-    ).toBe("component");
+      viewData.flatItems.find((item) => item.id === "text-bound")
+        ?.iconCornerBadge,
+    ).toBe(true);
     expect(
-      viewData.flatItems.find((item) => item.id === "text-free")?.trailingSvg,
-    ).toBeUndefined();
+      viewData.flatItems.find((item) => item.id === "text-free")
+        ?.iconCornerBadge,
+    ).toBe(false);
+    expect(
+      viewData.flatItems.find((item) => item.id === "choice-container")
+        ?.iconCornerBadge,
+    ).toBe(true);
   });
 
   it("keeps child creation actions only on container items", () => {


### PR DESCRIPTION
## Summary
- remove the trailing diamond from preview-dependent layout editor elements
- add a visible bottom-right triangle badge to each special element base icon
- cover text and non-text special elements in explorer tests

## Testing
- bun run lint
- bunx vitest run tests/baseFileExplorer/baseFileExplorer.view.test.js tests/layoutEditor/layoutEditor.store.test.js tests/layoutEditor/layoutEditorViewData.test.js
- bun run build:web
- isolated browser render confirmed 9x9 badges are visible at normal display density