### PR TITLE
fix(scene-editor): render initial line selection

### DIFF
--- a/src/internal/ui/sceneEditor/runtime.js
+++ b/src/internal/ui/sceneEditor/runtime.js
@@ -1431,7 +1431,7 @@ export const initializeSceneEditorPage = async (deps) => {
     store.setSelectedSectionId({
       selectedSectionId: entrySelection.sectionId,
     });
-    store.setSelectedLineId({ selectedLineId: undefined });
+    store.setSelectedLineId({ selectedLineId: entrySelection.lineId });
     const nextPayload = {
       ...appService.getPayload(),
       s: sceneId,
@@ -1442,7 +1442,11 @@ export const initializeSceneEditorPage = async (deps) => {
     } else {
       delete nextPayload.sectionId;
     }
-    delete nextPayload.lineId;
+    if (entrySelection.lineId) {
+      nextPayload.lineId = entrySelection.lineId;
+    } else {
+      delete nextPayload.lineId;
+    }
     appService.setPayload?.(nextPayload);
   }
 

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -872,7 +872,7 @@ export const syncSceneEditorRoutePayload = async (
     store.setSelectedSectionId({
       selectedSectionId: entrySelection.sectionId,
     });
-    store.setSelectedLineId({ selectedLineId: undefined });
+    store.setSelectedLineId({ selectedLineId: entrySelection.lineId });
 
     const nextPayload = {
       ...appService.getPayload(),
@@ -885,7 +885,11 @@ export const syncSceneEditorRoutePayload = async (
     } else {
       delete nextPayload.sectionId;
     }
-    delete nextPayload.lineId;
+    if (entrySelection.lineId) {
+      nextPayload.lineId = entrySelection.lineId;
+    } else {
+      delete nextPayload.lineId;
+    }
     appService.setPayload?.(nextPayload);
 
     reconcileCurrentEditorSession(deps);

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -365,11 +365,12 @@ describe("sceneEditorLexical.handlers route payload sync", () => {
     });
     expect(sceneId).toBe("scene-2");
     expect(selectedSectionId).toBe("new-section");
-    expect(selectedLineId).toBeUndefined();
+    expect(selectedLineId).toBe("new-line");
     expect(appService.setPayload).toHaveBeenCalledWith({
       p: "project-1",
       s: "scene-2",
       sectionId: "new-section",
+      lineId: "new-line",
     });
     expect(deps.subject.dispatch).toHaveBeenCalledWith(
       "sceneEditor.renderCanvas",

--- a/vt/specs/project/scenes.yaml
+++ b/vt/specs/project/scenes.yaml
@@ -207,6 +207,10 @@ steps:
     value: /project/scene-editor
   - action: wait
     ms: 1600
+  - action: waitFor
+    selector: 'rvn-lexical-scene-document-editor .editor-paragraph[data-selected="true"][data-mode="block"]'
+    state: visible
+    timeoutMs: 5000
   - action: assert
     type: text
     selector: "#sceneTextStats"


### PR DESCRIPTION
## Summary

- restore the initial selected line block when opening or switching scenes
- keep the route lineId synchronized with the resolved entry selection
- add unit and visual-test regression coverage

## Validation

- bunx vitest run tests/sceneEditor/runtime.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/sceneEditor.store.test.js
- bunx oxlint src/internal/ui/sceneEditor/runtime.js src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js tests/sceneEditor/sceneEditorLexical.handlers.test.js
- bunx prettier --check src/internal/ui/sceneEditor/runtime.js src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js tests/sceneEditor/sceneEditorLexical.handlers.test.js vt/specs/project/scenes.yaml
- Chromium verified the first paragraph is selected before pointer interaction