### PR TITLE
fix(scene-editor): preserve conditional branch keyboard flow

### DIFF
--- a/src/components/commandLineConditional/commandLineConditional.handlers.js
+++ b/src/components/commandLineConditional/commandLineConditional.handlers.js
@@ -415,12 +415,14 @@ export const handleBranchMenuButtonClick = (deps, payload) => {
 };
 
 export const handleBranchMenuButtonKeyDown = (deps, payload) => {
+  const key = payload._event.key;
   const directionByKey = {
     ArrowUp: "up",
     ArrowDown: "down",
   };
-  const direction = directionByKey[payload._event.key];
-  if (!direction) {
+  const direction = directionByKey[key];
+  const shouldDelete = key === "Delete";
+  if (!direction && !shouldDelete) {
     return;
   }
 
@@ -429,7 +431,11 @@ export const handleBranchMenuButtonKeyDown = (deps, payload) => {
   const { store, render } = deps;
   const branchId = payload._event.currentTarget.dataset.branchId;
 
-  store.moveBranch({ branchId, direction });
+  if (shouldDelete) {
+    store.deleteBranch({ branchId });
+  } else {
+    store.moveBranch({ branchId, direction });
+  }
   render();
 };
 

--- a/src/components/commandLineConditional/commandLineConditional.store.js
+++ b/src/components/commandLineConditional/commandLineConditional.store.js
@@ -469,7 +469,7 @@ export const selectViewData = ({ state, props, i18n }) => {
     return {
       ...branch,
       index,
-      menuKeyShortcuts: "",
+      menuKeyShortcuts: "Delete",
       summary: getBranchSummary(branch, state.variablesData, copy),
       actionsSummary:
         branchActionCount > 0
@@ -491,6 +491,7 @@ export const selectViewData = ({ state, props, i18n }) => {
     if (index < conditionBranchItems.length - 1) {
       menuKeyShortcuts.push("ArrowDown");
     }
+    menuKeyShortcuts.push("Delete");
 
     return {
       ...createBranchViewData(branch, index),

--- a/src/components/commandLineConditional/commandLineConditional.view.yaml
+++ b/src/components/commandLineConditional/commandLineConditional.view.yaml
@@ -98,12 +98,12 @@ template:
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md mt=md w=f:
                   - rtgl-text s=sm c=mu-fg: ${branchesLabel}
-                  - $for branch, i in branches:
-                      - rtgl-view#conditionalBranch${i} data-branch-id=${branch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
+                  - $for branch in branches:
+                      - rtgl-view#conditionalBranch${branch.id} data-branch-id=${branch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
                           - rtgl-view d=v w=1fg:
                               - rtgl-text s=sm: ${branch.summary}
                               - rtgl-text s=xs c=mu-fg: ${branch.actionsSummary}
-                          - 'rtgl-button#branchMenuButton${i} data-branch-id=${branch.id} sq s=sm v=gh pre=ellipsis title="${branchMenuButtonLabel}" aria-label="${branchMenuButtonLabel}" aria-haspopup=menu aria-keyshortcuts="${branch.menuKeyShortcuts}"': null
+                          - 'rtgl-button#branchMenuButton${branch.id} data-branch-id=${branch.id} sq s=sm v=gh pre=ellipsis title="${branchMenuButtonLabel}" aria-label="${branchMenuButtonLabel}" aria-haspopup=menu aria-keyshortcuts="${branch.menuKeyShortcuts}"': null
                   - rtgl-button#addBranchButton v=ol w=f mt=md: ${addBranchButton}
                   - rtgl-text s=sm c=mu-fg mt=md: ${defaultBranchLabel}
                   - $if hasDefaultBranch:
@@ -111,7 +111,7 @@ template:
                           - rtgl-view d=v w=1fg:
                               - rtgl-text s=sm: ${defaultBranch.summary}
                               - rtgl-text s=xs c=mu-fg: ${defaultBranch.actionsSummary}
-                          - 'rtgl-button#branchMenuButtonDefault data-branch-id=${defaultBranch.id} sq s=sm v=gh pre=ellipsis title="${branchMenuButtonLabel}" aria-label="${branchMenuButtonLabel}" aria-haspopup=menu': null
+                          - 'rtgl-button#branchMenuButtonDefault data-branch-id=${defaultBranch.id} sq s=sm v=gh pre=ellipsis title="${branchMenuButtonLabel}" aria-label="${branchMenuButtonLabel}" aria-haspopup=menu aria-keyshortcuts="${defaultBranch.menuKeyShortcuts}"': null
                   - $if !hasDefaultBranch:
                       - rtgl-button#addDefaultButton v=ol w=f: ${addDefaultBranchButton}
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':

--- a/tests/commandLineConditional/commandLineConditional.handlers.test.js
+++ b/tests/commandLineConditional/commandLineConditional.handlers.test.js
@@ -873,12 +873,11 @@ describe("commandLineConditional.handlers", () => {
     expect(render).toHaveBeenCalledOnce();
   });
 
-  it("opens and operates the branch menu from its keyboard trigger", () => {
+  it("opens the branch menu from its button", () => {
     const state = createInitialState();
     const store = createStore(state);
     const render = vi.fn();
     const stopPropagation = vi.fn();
-    const preventDefault = vi.fn();
     const createConditionBranch = (id) => ({
       id,
       when: {
@@ -916,25 +915,111 @@ describe("commandLineConditional.handlers", () => {
       branchId: "branch-2",
       position: { x: 320, y: 240 },
     });
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("repeatedly moves and deletes the same branch with keyboard shortcuts", () => {
+    const state = createInitialState();
+    const store = createStore(state);
+    const render = vi.fn();
+    const stopPropagation = vi.fn();
+    const preventDefault = vi.fn();
+    const createConditionBranch = (id) => ({
+      id,
+      when: {
+        eq: [{ var: "variables.trust" }, id],
+      },
+      actions: {},
+    });
+
+    setBranches(
+      { state },
+      {
+        branches: [
+          createConditionBranch("branch-1"),
+          createConditionBranch("branch-2"),
+          createConditionBranch("branch-3"),
+        ],
+      },
+    );
+    const currentTarget = {
+      dataset: { branchId: "branch-3" },
+    };
+    const pressShortcut = (key) => {
+      handleBranchMenuButtonKeyDown(
+        { store, render },
+        {
+          _event: {
+            key,
+            currentTarget,
+            preventDefault,
+            stopPropagation,
+          },
+        },
+      );
+    };
+
+    pressShortcut("ArrowUp");
+    pressShortcut("ArrowUp");
+
+    expect(state.branches.map((branch) => branch.id)).toEqual([
+      "branch-3",
+      "branch-1",
+      "branch-2",
+    ]);
+
+    pressShortcut("Delete");
+
+    expect(state.branches.map((branch) => branch.id)).toEqual([
+      "branch-1",
+      "branch-2",
+    ]);
+    expect(preventDefault).toHaveBeenCalledTimes(3);
+    expect(stopPropagation).toHaveBeenCalledTimes(3);
+    expect(render).toHaveBeenCalledTimes(3);
+  });
+
+  it("deletes the default branch with its keyboard shortcut", () => {
+    const state = createInitialState();
+    const store = createStore(state);
+    const render = vi.fn();
+    const stopPropagation = vi.fn();
+    const preventDefault = vi.fn();
+
+    setBranches(
+      { state },
+      {
+        branches: [
+          {
+            id: "branch-1",
+            when: {
+              eq: [{ var: "variables.trust" }, 70],
+            },
+            actions: {},
+          },
+          { id: "branch-default", actions: {} },
+        ],
+      },
+    );
 
     handleBranchMenuButtonKeyDown(
       { store, render },
       {
         _event: {
-          key: "ArrowUp",
-          currentTarget,
+          key: "Delete",
+          currentTarget: {
+            dataset: { branchId: "branch-default" },
+          },
           preventDefault,
           stopPropagation,
         },
       },
     );
 
-    expect(state.branches.map((branch) => branch.id)).toEqual([
-      "branch-2",
-      "branch-1",
-    ]);
+    expect(state.branches.map((branch) => branch.id)).toEqual(["branch-1"]);
     expect(preventDefault).toHaveBeenCalledOnce();
-    expect(stopPropagation).toHaveBeenCalledTimes(2);
-    expect(render).toHaveBeenCalledTimes(2);
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledOnce();
   });
 });

--- a/tests/commandLineConditional/commandLineConditional.store.test.js
+++ b/tests/commandLineConditional/commandLineConditional.store.test.js
@@ -391,11 +391,11 @@ describe("commandLineConditional.store", () => {
 
     const viewData = selectViewData({ state, i18n: EN_I18N });
     expect(viewData.branches.map((branch) => branch.menuKeyShortcuts)).toEqual([
-      "ArrowDown",
-      "ArrowUp ArrowDown",
-      "ArrowUp",
+      "ArrowDown Delete",
+      "ArrowUp ArrowDown Delete",
+      "ArrowUp Delete",
     ]);
-    expect(viewData.defaultBranch.menuKeyShortcuts).toBe("");
+    expect(viewData.defaultBranch.menuKeyShortcuts).toBe("Delete");
 
     showDropdownMenu(
       { state },

--- a/tests/commandLineConditional/commandLineConditional.view.test.js
+++ b/tests/commandLineConditional/commandLineConditional.view.test.js
@@ -24,8 +24,14 @@ describe("commandLineConditional view", () => {
     expect(view).toContain("handler: handleRemoveOneOfValueClick");
     expect(view).toContain("handler: handleBranchMenuButtonClick");
     expect(view).toContain("handler: handleBranchMenuButtonKeyDown");
-    expect(view).toContain("rtgl-button#branchMenuButton${i}");
+    expect(view).toContain("rtgl-view#conditionalBranch${branch.id}");
+    expect(view).toContain("rtgl-button#branchMenuButton${branch.id}");
+    expect(view).not.toContain("rtgl-view#conditionalBranch${i}");
+    expect(view).not.toContain("rtgl-button#branchMenuButton${i}");
     expect(view).toContain("aria-haspopup=menu");
     expect(view).toContain('aria-keyshortcuts="${branch.menuKeyShortcuts}"');
+    expect(view).toContain(
+      'aria-keyshortcuts="${defaultBranch.menuKeyShortcuts}"',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- preserve focus on the same conditional branch through repeated keyboard reorders
- expose Delete as a direct keyboard shortcut for conditional and default branches
- add regression coverage for stable branch identities, repeated movement, and deletion

Follow-up to #978.

## Validation

- bunx vitest run tests/commandLineConditional/commandLineConditional.handlers.test.js tests/commandLineConditional/commandLineConditional.store.test.js tests/commandLineConditional/commandLineConditional.view.test.js
- bunx oxlint src/components/commandLineConditional/commandLineConditional.handlers.js src/components/commandLineConditional/commandLineConditional.store.js tests/commandLineConditional/commandLineConditional.handlers.test.js tests/commandLineConditional/commandLineConditional.store.test.js tests/commandLineConditional/commandLineConditional.view.test.js
- bunx prettier --check on all six changed files
- Chromium verified focus remains on the same branch after two ArrowUp renders and Delete removes the default branch