### PR TITLE
feat(layout-editor): add anchor grid selector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@lexical/selection": "0.22.0",
         "@lexical/utils": "0.22.0",
         "@rettangoli/fe": "1.2.2",
-        "@rettangoli/ui": "1.10.1",
+        "@rettangoli/ui": "1.11.0",
         "@rettangoli/vt": "1.0.5",
         "@routevn/creator-model": "1.10.0",
         "@tauri-apps/api": "2.11.0",
@@ -50,6 +50,7 @@
     },
   },
   "overrides": {
+    "@rettangoli/fe": "1.2.2",
     "@tauri-apps/api": "2.11.0",
     "liquidjs": "10.27.0",
     "picomatch": "4.0.5",
@@ -314,7 +315,7 @@
 
     "@rettangoli/sites": ["@rettangoli/sites@1.2.0", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-taGLXClBbCL0Qbj7fFIZ0wW54yHNlKb43cJFZR1Poer2pxvo5GCnShvqZEvUfkPBqp/PKyvLfiOwMxGkbJxqyg=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.10.1", "", { "dependencies": { "@rettangoli/fe": "1.2.0", "jempl": "1.0.1" } }, "sha512-j/8JqUh2gV9cBLep6oeWpXItn/IQEKLvYu7HBjDSMECpCe/Zp4no5tOrH8t95q19JZeZb81yn4ASujwBlA04qA=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.11.0", "", { "dependencies": { "@rettangoli/fe": "1.2.3", "jempl": "1.0.1" } }, "sha512-sIVOsU0xm4/PgrUP7GmgYrxU0+qA2F/YSRCxdlBd0D9WKhw/fY9V/YjK63B1WtGr6fJ+moI+weAReVkcaQjmvg=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.5", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-YpZH5xQYj+x5Qy6gn+FUnMTUIQELrZkTA4qN8/U4n/1B4gpNHHPltJK/kVltZQVYVG0Tj676ZIKCMGN0ZAHdzg=="],
 
@@ -1084,8 +1085,6 @@
 
     "@rettangoli/sites/yahtml": ["yahtml@0.0.4", "", {}, "sha512-9QuyogoLkvpq1ETyiETeHtcFVqUUI0pl3RjgfJ8mlpeAvkP8f1risDDJ0s9rZ8H8TwAA9hegw3mzr2eTsdRT3g=="],
 
-    "@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.2.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-VvLpS19/sIcjJfDgsTbv+UE4gIIGzAlViXV8VAzxiNaJrZVRQ5QayVMrA2D73pQjW7+bEQgjRdMqyJFYA7ml2w=="],
-
     "@rettangoli/ui/jempl": ["jempl@1.0.1", "", {}, "sha512-aeOlPrZV1KVhwtMYidkH1vGLlLrCTZ8fk3LlDxLGyTFsZUMHDtvSuqmrCimJL0u2LZFg1rtoE4/1NzGjwmIoUw=="],
 
     "@rettangoli/vt/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
@@ -1134,21 +1133,15 @@
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "@rettangoli/ui/@rettangoli/fe/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
-
     "@vitest/ui/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.0.16", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "rtgl/@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.1.3", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-/fia9Ir5x5NU7fjfXtuioCwbc4ELj939pM+/vB9R7bOAPVKosKTspyOuYqMrstysfT84xfLEcPidBrI5OY/l0g=="],
 
     "rtgl/@rettangoli/ui/jempl": ["jempl@1.0.1", "", {}, "sha512-aeOlPrZV1KVhwtMYidkH1vGLlLrCTZ8fk3LlDxLGyTFsZUMHDtvSuqmrCimJL0u2LZFg1rtoE4/1NzGjwmIoUw=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "vitest/vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
-    "rtgl/@rettangoli/ui/@rettangoli/fe/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@lexical/selection": "0.22.0",
     "@lexical/utils": "0.22.0",
     "@rettangoli/fe": "1.2.2",
-    "@rettangoli/ui": "1.10.1",
+    "@rettangoli/ui": "1.11.0",
     "@rettangoli/vt": "1.0.5",
     "@routevn/creator-model": "1.10.0",
     "@tauri-apps/api": "2.11.0",
@@ -113,6 +113,7 @@
     "vitest": "3.2.4"
   },
   "overrides": {
+    "@rettangoli/fe": "1.2.2",
     "@tauri-apps/api": "2.11.0",
     "liquidjs": "10.27.0",
     "picomatch": "4.0.5",

--- a/src/components/layout-anchor-grid/layout-anchor-grid.handlers.js
+++ b/src/components/layout-anchor-grid/layout-anchor-grid.handlers.js
@@ -1,0 +1,78 @@
+const emitAnchorChange = (deps, index) => {
+  const { dispatchEvent, props } = deps;
+  const option = props.options?.[index];
+  if (!option) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("value-change", {
+      bubbles: true,
+      composed: true,
+      detail: {
+        item: option,
+        value: option.value,
+      },
+    }),
+  );
+};
+
+const getKeyboardTargetIndex = (index, key, optionCount) => {
+  const lastIndex = optionCount - 1;
+  const column = index % 3;
+  const row = Math.floor(index / 3);
+
+  if (key === "ArrowLeft") {
+    return column > 0 ? index - 1 : index;
+  }
+  if (key === "ArrowRight") {
+    return column < 2 && index < lastIndex ? index + 1 : index;
+  }
+  if (key === "ArrowUp") {
+    return row > 0 ? index - 3 : index;
+  }
+  if (key === "ArrowDown") {
+    return index + 3 <= lastIndex ? index + 3 : index;
+  }
+  if (key === "Home") {
+    return 0;
+  }
+  if (key === "End") {
+    return lastIndex;
+  }
+
+  return undefined;
+};
+
+export const handleAnchorCellClick = (deps, payload = {}) => {
+  const { _event } = payload;
+  if (_event.currentTarget.getAttribute("aria-checked") === "true") {
+    return;
+  }
+
+  emitAnchorChange(deps, Number(_event.currentTarget.dataset.anchorIndex));
+};
+
+export const handleAnchorCellKeyDown = (deps, payload = {}) => {
+  const { props, refs } = deps;
+  const { _event } = payload;
+  const currentIndex = Number(_event.currentTarget.dataset.anchorIndex);
+  const targetIndex = getKeyboardTargetIndex(
+    currentIndex,
+    _event.key,
+    props.options?.length ?? 0,
+  );
+  if (targetIndex === undefined) {
+    return;
+  }
+
+  _event.preventDefault();
+  if (targetIndex === currentIndex) {
+    return;
+  }
+
+  refs.anchorGrid
+    .querySelector(`[data-anchor-index="${targetIndex}"]`)
+    ?.focus();
+  emitAnchorChange(deps, targetIndex);
+};

--- a/src/components/layout-anchor-grid/layout-anchor-grid.schema.yaml
+++ b/src/components/layout-anchor-grid/layout-anchor-grid.schema.yaml
@@ -1,0 +1,25 @@
+componentName: rvn-layout-anchor-grid
+description: Selects one of nine anchor positions in a three-by-three grid.
+propsSchema:
+  type: object
+  properties:
+    value:
+      type: object
+      description: Selected anchor coordinates.
+      properties:
+        x:
+          type: number
+        y:
+          type: number
+    options:
+      type: array
+      description: Localized anchor position options.
+      items:
+        type: object
+    label:
+      type: string
+      description: Accessible label for the anchor grid.
+      default: Anchor
+events:
+  value-change:
+    type: object

--- a/src/components/layout-anchor-grid/layout-anchor-grid.store.js
+++ b/src/components/layout-anchor-grid/layout-anchor-grid.store.js
@@ -1,0 +1,23 @@
+const anchorsMatch = (left, right) =>
+  left?.x === right?.x && left?.y === right?.y;
+
+export const createInitialState = () => ({});
+
+export const selectViewData = ({ props }) => {
+  const options = props.options ?? [];
+  const selectedIndex = options.findIndex((option) =>
+    anchorsMatch(option.value, props.value),
+  );
+  const tabbableIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+  return {
+    label: props.label ?? "Anchor",
+    cells: options.map((option, index) => ({
+      index,
+      isSelected: index === selectedIndex,
+      label: option.label,
+      tabIndex: index === tabbableIndex ? 0 : -1,
+      value: option.value,
+    })),
+  };
+};

--- a/src/components/layout-anchor-grid/layout-anchor-grid.view.yaml
+++ b/src/components/layout-anchor-grid/layout-anchor-grid.view.yaml
@@ -1,0 +1,54 @@
+refs:
+  anchorCell*:
+    eventListeners:
+      click:
+        handler: handleAnchorCellClick
+      keydown:
+        handler: handleAnchorCellKeyDown
+styles:
+  ".layoutAnchorGrid":
+    display: grid
+    grid-template-columns: "repeat(3, 36px)"
+    gap: 4px
+    width: max-content
+  ".layoutAnchorGridCell":
+    align-items: center
+    appearance: none
+    background: var(--muted)
+    border: "1px solid var(--border)"
+    border-radius: var(--border-radius-md)
+    box-sizing: border-box
+    color: var(--muted-foreground)
+    cursor: pointer
+    display: flex
+    height: 36px
+    justify-content: center
+    margin: 0
+    padding: 0
+    transition: "background-color 120ms ease, border-color 120ms ease, color 120ms ease"
+    width: 36px
+  ".layoutAnchorGridCell:hover":
+    background: var(--accent)
+    border-color: var(--foreground)
+    color: var(--accent-foreground)
+  ".layoutAnchorGridCell[data-selected='true']":
+    background: var(--accent)
+    border-color: var(--foreground)
+    color: var(--accent-foreground)
+  ".layoutAnchorGridCell:focus-visible":
+    outline: "2px solid var(--ring)"
+    outline-offset: 2px
+  ".layoutAnchorGridDot":
+    background: currentColor
+    border-radius: 50%
+    height: 7px
+    transition: "height 120ms ease, width 120ms ease"
+    width: 7px
+  ".layoutAnchorGridCell[data-selected='true'] .layoutAnchorGridDot":
+    height: 11px
+    width: 11px
+template:
+  - 'div#anchorGrid.layoutAnchorGrid role=radiogroup aria-label="${label}"':
+      - $for cell, i in cells:
+          - 'button#anchorCell${i}.layoutAnchorGridCell key=${cell.index} type=button role=radio aria-label="${cell.label}" aria-checked="${cell.isSelected}" tabindex=${cell.tabIndex} title="${cell.label}" data-anchor-index=${cell.index} data-selected="${cell.isSelected}"':
+              - span.layoutAnchorGridDot aria-hidden=true: null

--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -196,6 +196,7 @@ layoutSections:
   - "$when": "supportsChildInteractionInheritance"
     id: childInteraction
     label: Child Interaction
+    tooltip: Inherit child event from parent
     "$if canAddChildInteractionInheritance":
       labelAction: plus
     items:

--- a/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.constants.yaml
@@ -105,7 +105,7 @@ layoutSections:
             value: "${values.opacity}"
             popoverForm: *opacityPopoverForm
       - "$when": "supportsAnchor"
-        type: select
+        type: anchor-grid
         label: Anchor
         name: anchor
         value: "${values.anchor}"

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -1800,6 +1800,7 @@ export const handleConditionalOverrideAddAttributeClick = (deps, payload) => {
   store.openConditionalOverrideAttributeDialog({
     editingIndex: index,
     fieldName: undefined,
+    selectedAnchor: { x: 0, y: 0 },
   });
   render();
 };
@@ -1816,12 +1817,30 @@ export const handleConditionalOverrideAttributeClick = (deps, payload) => {
     Number.isInteger(index) && CONDITIONAL_OVERRIDE_IMAGE_FIELDS.has(fieldName)
       ? rules[index]?.set?.[fieldName]
       : undefined;
+  const selectedRule = Number.isInteger(index) ? rules[index] : undefined;
+  const selectedAnchor = {
+    x: Number.isFinite(selectedRule?.set?.anchorX)
+      ? selectedRule.set.anchorX
+      : 0,
+    y: Number.isFinite(selectedRule?.set?.anchorY)
+      ? selectedRule.set.anchorY
+      : 0,
+  };
 
   store.openConditionalOverrideAttributeDialog({
     editingIndex: Number.isInteger(index) && index >= 0 ? index : undefined,
     fieldName,
     selectedImageId,
+    selectedAnchor,
   });
+  render();
+};
+
+export const handleConditionalOverrideAnchorChange = (deps, payload) => {
+  const { render, store } = deps;
+  const { value } = payload._event.detail;
+
+  store.setConditionalOverrideAttributeDialogAnchor({ anchor: value });
   render();
 };
 
@@ -1999,12 +2018,18 @@ export const handleConditionalOverrideAttributeFormAction = (deps, payload) => {
   }
 
   const nextRules = [...rules];
+  const attributeValues = { ...values };
+  attributeValues.selectedImageId = dialog.selectedImageId;
+  if (values.fieldName === "anchor") {
+    attributeValues.anchor = dialog.selectedAnchor;
+  }
+
   nextRules[editingIndex] = {
     ...nextRules[editingIndex],
-    set: buildConditionalOverrideSetUpdate(nextRules[editingIndex]?.set, {
-      ...values,
-      selectedImageId: dialog.selectedImageId,
-    }),
+    set: buildConditionalOverrideSetUpdate(
+      nextRules[editingIndex]?.set,
+      attributeValues,
+    ),
   };
 
   applyPanelValueUpdate(deps, {

--- a/src/components/layoutEditPanel/layoutEditPanel.handlers.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.handlers.js
@@ -1376,6 +1376,25 @@ export const handleSectionActionClick = async (deps, payload) => {
   }
 };
 
+export const handleSectionTooltipMouseEnter = (deps, payload) => {
+  const { render, store } = deps;
+  const target = payload._event.currentTarget;
+  const rect = target.getBoundingClientRect();
+
+  store.showSectionTooltip({
+    x: rect.left + rect.width / 2,
+    y: rect.top - 8,
+    content: target.dataset.tooltip,
+  });
+  render();
+};
+
+export const handleSectionTooltipMouseLeave = (deps) => {
+  const { render, store } = deps;
+  store.hideSectionTooltip();
+  render();
+};
+
 export const handleFormActions = (deps, payload) => {
   const { store } = deps;
   const { _event } = payload;

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -692,6 +692,12 @@ const resetSelectionUiState = (state) => {
     targetName: undefined,
     items: [],
   };
+  state.sectionTooltip = {
+    open: false,
+    x: 0,
+    y: 0,
+    content: "",
+  };
   state.saveLoadPaginationDialog = {
     open: false,
     key: 0,
@@ -901,6 +907,17 @@ export const hideContextMenu = ({ state }, _payload = {}) => {
   state.dropdownMenu.y = 0;
   state.dropdownMenu.targetName = undefined;
   state.dropdownMenu.items = [];
+};
+
+export const showSectionTooltip = ({ state }, { x, y, content } = {}) => {
+  state.sectionTooltip.open = true;
+  state.sectionTooltip.x = x;
+  state.sectionTooltip.y = y;
+  state.sectionTooltip.content = content;
+};
+
+export const hideSectionTooltip = ({ state }, _payload = {}) => {
+  state.sectionTooltip.open = false;
 };
 
 export const openSaveLoadPaginationDialog = ({ state }, _payload = {}) => {
@@ -1763,6 +1780,7 @@ export const selectViewData = ({ state, props, constants, i18n }) => {
     popover: state.popover,
     visibilityConditionDialog: state.visibilityConditionDialog,
     dropdownMenu: state.dropdownMenu,
+    sectionTooltip: state.sectionTooltip,
     visibilityConditionDialogDefaults,
     visibilityConditionDialogForm: createVisibilityConditionForm({
       targetOptions: visibilityConditionTargetOptions,

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -22,6 +22,7 @@ import {
 import {
   createChildInteractionDialogDefaults,
   createChildInteractionForm,
+  createConditionalOverrideAnchorOptions,
   createConditionalOverrideAttributeDefaults,
   createConditionalOverrideAttributeForm,
   createConditionalOverrideAttributeImagePreview,
@@ -730,6 +731,7 @@ const resetSelectionUiState = (state) => {
     editingIndex: undefined,
     fieldName: undefined,
     selectedImageId: undefined,
+    selectedAnchor: undefined,
     validationErrors: {},
   };
   state.selectedElementMetrics = undefined;
@@ -1047,13 +1049,14 @@ export const setConditionalOverrideConditionDialogSelectedVariableType = (
 
 export const openConditionalOverrideAttributeDialog = (
   { state },
-  { editingIndex, fieldName, selectedImageId } = {},
+  { editingIndex, fieldName, selectedImageId, selectedAnchor } = {},
 ) => {
   state.conditionalOverrideAttributeDialog.open = true;
   state.conditionalOverrideAttributeDialog.key += 1;
   state.conditionalOverrideAttributeDialog.editingIndex = editingIndex;
   state.conditionalOverrideAttributeDialog.fieldName = fieldName;
   state.conditionalOverrideAttributeDialog.selectedImageId = selectedImageId;
+  state.conditionalOverrideAttributeDialog.selectedAnchor = selectedAnchor;
   state.conditionalOverrideAttributeDialog.validationErrors = {};
 };
 
@@ -1065,6 +1068,7 @@ export const closeConditionalOverrideAttributeDialog = (
   state.conditionalOverrideAttributeDialog.editingIndex = undefined;
   state.conditionalOverrideAttributeDialog.fieldName = undefined;
   state.conditionalOverrideAttributeDialog.selectedImageId = undefined;
+  state.conditionalOverrideAttributeDialog.selectedAnchor = undefined;
   state.conditionalOverrideAttributeDialog.validationErrors = {};
 };
 
@@ -1075,6 +1079,13 @@ export const setConditionalOverrideAttributeDialogImage = (
   state.conditionalOverrideAttributeDialog.selectedImageId = imageId;
   delete state.conditionalOverrideAttributeDialog.validationErrors
     .selectedImageId;
+};
+
+export const setConditionalOverrideAttributeDialogAnchor = (
+  { state },
+  { anchor } = {},
+) => {
+  state.conditionalOverrideAttributeDialog.selectedAnchor = anchor;
 };
 
 export const setConditionalOverrideAttributeDialogValidationErrors = (
@@ -1685,6 +1696,8 @@ export const selectViewData = ({ state, props, constants, i18n }) => {
       state.conditionalOverrideAttributeDialog.fieldName,
       conditionalOverrideAttributeOptions,
     );
+  const conditionalOverrideAnchorOptions =
+    createConditionalOverrideAnchorOptions(copy);
   const conditionalOverrideAttributeImagePreview =
     createConditionalOverrideAttributeImagePreview(
       state.imagesData,
@@ -1813,6 +1826,11 @@ export const selectViewData = ({ state, props, constants, i18n }) => {
     },
     conditionalOverrideAttributeDialog:
       state.conditionalOverrideAttributeDialog,
+    conditionalOverrideAnchorLabel: copy.anchorLabel ?? "Anchor",
+    conditionalOverrideAnchorOptions,
+    conditionalOverrideAnchorValue:
+      state.conditionalOverrideAttributeDialog.selectedAnchor ??
+      conditionalOverrideAnchorOptions[0].value,
     conditionalOverrideAttributeImagePreview,
     conditionalOverrideAttributeDefaults,
     conditionalOverrideAttributeForm: createConditionalOverrideAttributeForm({

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -125,6 +125,10 @@ refs:
     eventListeners:
       form-action:
         handler: handleConditionalOverrideAttributeFormAction
+  conditionalOverrideAnchor:
+    eventListeners:
+      value-change:
+        handler: handleConditionalOverrideAnchorChange
   conditionalOverrideAttributeImage:
     eventListeners:
       click:
@@ -300,6 +304,11 @@ template:
                           - rtgl-text s=xs w=65: ${item.label}
                           - 'rtgl-view style="width: calc(100% - 65px);"':
                               - rtgl-select#selectItem${i}x${j} data-name=${item.name} w=f no-clear :selectedValue=${item.value} :options=${item.options}: null
+                    $elif item.type == 'anchor-grid':
+                      - rtgl-view d=h w=f:
+                          - 'rtgl-text s=xs w=65 style="padding-top: 4px;"': ${item.label}
+                          - 'rtgl-view style="width: calc(100% - 65px);"':
+                              - 'rvn-layout-anchor-grid#selectItem${i}x${j} data-name=${item.name} label="${item.label}" :value=${item.value} :options=${item.options}': null
                     $elif item.type == 'segmented-control':
                       - rtgl-view d=h av=c w=f:
                           - rtgl-text s=xs w=65: ${item.label}
@@ -442,6 +451,7 @@ template:
       - $if conditionalOverrideAttributeDialog.open:
           - rtgl-view slot=content g=md:
               - rtgl-form#conditionalOverrideAttributeForm key=${conditionalOverrideAttributeDialog.key} :form=${conditionalOverrideAttributeForm} :defaultValues=${conditionalOverrideAttributeDefaults} :context=${conditionalOverrideAttributeDialogContext} w=f:
+                  - 'rvn-layout-anchor-grid#conditionalOverrideAnchor slot=conditional-override-anchor label="${conditionalOverrideAnchorLabel}" :value=${conditionalOverrideAnchorValue} :options=${conditionalOverrideAnchorOptions}': null
                   - rtgl-view slot=conditional-override-image d=v w=f:
                       - $if conditionalOverrideAttributeImagePreview:
                           - 'rtgl-view#conditionalOverrideAttributeImage role=button tabindex=0 aria-haspopup=dialog aria-label="${imageLabel}" cur=pointer bw=xs bc=${conditionalOverrideAttributeImagePreview.itemBorderColor} h-bc=${conditionalOverrideAttributeImagePreview.itemHoverBorderColor} br=md w=160 overflow=hidden style="max-width: 100%; box-sizing: border-box;"':

--- a/src/components/layoutEditPanel/layoutEditPanel.view.yaml
+++ b/src/components/layoutEditPanel/layoutEditPanel.view.yaml
@@ -163,6 +163,16 @@ refs:
     eventListeners:
       click:
         handler: handleSectionActionClick
+  sectionTooltip*:
+    eventListeners:
+      mouseenter:
+        handler: handleSectionTooltipMouseEnter
+      mouseleave:
+        handler: handleSectionTooltipMouseLeave
+      focus:
+        handler: handleSectionTooltipMouseEnter
+      blur:
+        handler: handleSectionTooltipMouseLeave
   systemActions:
     eventListeners:
       actions-change:
@@ -273,18 +283,40 @@ styles:
     cursor: pointer
     user-select: none
     "-webkit-user-select": none
+  ".layoutEditPanelSectionTooltipTrigger":
+    align-items: center
+    appearance: none
+    background: transparent
+    border: "1px solid var(--muted-foreground)"
+    border-radius: 50%
+    box-sizing: border-box
+    color: var(--muted-foreground)
+    cursor: help
+    display: flex
+    font-family: inherit
+    font-size: 11px
+    font-weight: 600
+    height: 16px
+    justify-content: center
+    line-height: 1
+    margin: 0
+    padding: 0
+    width: 16px
+  ".layoutEditPanelSectionTooltipTrigger:focus-visible":
+    outline: "2px solid var(--ring)"
+    outline-offset: 2px
 template:
   - $for section, i in config.sections:
       - $if i > 0:
           - rtgl-view h=1 w=f bgc=mu mv=lg: null
       - rtgl-view key=${section.viewKey} w=f g=md ph=md:
-          - $if section.labelAction:
-              - rtgl-view d=h w=f av=c:
-                  - rtgl-text s=sm: ${section.label}
+          - rtgl-view d=h w=f av=c g=sm:
+              - rtgl-text s=sm: ${section.label}
+              - $if section.tooltip:
+                  - 'button#sectionTooltip${i}.layoutEditPanelSectionTooltipTrigger type=button aria-label="${section.tooltip}" data-tooltip="${section.tooltip}"': "?"
+              - $if section.labelAction:
                   - rtgl-view w=1fg: null
                   - rtgl-button#sectionAction${i} data-id=${section.id} pre=${section.labelAction} sq s=sm v=gh: null
-            $else:
-              - rtgl-text s=sm: ${section.label}
           - $for item, j in section.items:
               - rtgl-view key=${item.viewKey} w=f:
                   - $if item.type == 'group':
@@ -409,6 +441,7 @@ template:
       - $if visibilityConditionDialog.open:
           - rtgl-view slot=content g=md:
               - rtgl-form#visibilityConditionForm key=${visibilityConditionDialog.key} :form=${visibilityConditionDialogForm} :defaultValues=${visibilityConditionDialogDefaults} :context=${visibilityConditionDialogContext} w=f: null
+  - rtgl-tooltip ?open=${sectionTooltip.open} x=${sectionTooltip.x} y=${sectionTooltip.y} place="t" content="${sectionTooltip.content}": null
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} ?open=${dropdownMenu.isOpen} x=${dropdownMenu.x} y=${dropdownMenu.y}: null
   - rtgl-dialog#saveLoadPaginationDialog ?open=${saveLoadPaginationDialog.open} s=md:
       - $if saveLoadPaginationDialog.open:

--- a/src/components/layoutEditPanel/support/layoutEditPanelConditionalOverrides.js
+++ b/src/components/layoutEditPanel/support/layoutEditPanelConditionalOverrides.js
@@ -94,6 +94,13 @@ const normalizeOpacity = (value) => {
 };
 
 const normalizeAnchorValue = (value) => {
+  if (Number.isFinite(value?.x) && Number.isFinite(value?.y)) {
+    return {
+      anchorX: value.x,
+      anchorY: value.y,
+    };
+  }
+
   const option = ANCHOR_OPTIONS.find((item) => item.value === value);
   if (!option) {
     return undefined;
@@ -420,6 +427,13 @@ export const getConditionalOverrideAttributeOptions = ({
   }));
 };
 
+export const createConditionalOverrideAnchorOptions = (copy = {}) => {
+  return ANCHOR_OPTIONS.map(({ value, x, y }) => ({
+    label: getAnchorOptionLabel(value, copy),
+    value: { x, y },
+  }));
+};
+
 export const createConditionalOverrideAttributeDefaults = (
   rule,
   fieldName,
@@ -521,15 +535,9 @@ export const createConditionalOverrideAttributeForm = ({
       },
       {
         $when: "fieldName == 'anchor'",
-        name: "anchor",
-        type: "select",
+        type: "slot",
+        slot: "conditional-override-anchor",
         label: copy.anchorLabel ?? "Anchor",
-        required: true,
-        clearable: false,
-        options: ANCHOR_OPTIONS.map(({ value }) => ({
-          label: getAnchorOptionLabel(value, copy),
-          value,
-        })),
       },
       {
         $when: "fieldName == 'textStyle.align'",

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -14,7 +14,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/ios/index.html
+++ b/static/ios/index.html
@@ -43,7 +43,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/tests/layoutAnchorGrid/layoutAnchorGrid.handlers.test.js
+++ b/tests/layoutAnchorGrid/layoutAnchorGrid.handlers.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAnchorCellClick,
+  handleAnchorCellKeyDown,
+} from "../../src/components/layout-anchor-grid/layout-anchor-grid.handlers.js";
+
+const OPTIONS = [
+  { label: "Top Left", value: { x: 0, y: 0 } },
+  { label: "Top Center", value: { x: 0.5, y: 0 } },
+  { label: "Top Right", value: { x: 1, y: 0 } },
+  { label: "Center Left", value: { x: 0, y: 0.5 } },
+  { label: "Center", value: { x: 0.5, y: 0.5 } },
+  { label: "Center Right", value: { x: 1, y: 0.5 } },
+  { label: "Bottom Left", value: { x: 0, y: 1 } },
+  { label: "Bottom Center", value: { x: 0.5, y: 1 } },
+  { label: "Bottom Right", value: { x: 1, y: 1 } },
+];
+
+const createDeps = () => {
+  const focusedCell = {
+    focus: vi.fn(),
+  };
+  return {
+    deps: {
+      dispatchEvent: vi.fn(),
+      props: {
+        options: OPTIONS,
+      },
+      refs: {
+        anchorGrid: {
+          querySelector: vi.fn(() => focusedCell),
+        },
+      },
+    },
+    focusedCell,
+  };
+};
+
+describe("layoutAnchorGrid handlers", () => {
+  it("emits the selected option when a cell is clicked", () => {
+    const { deps } = createDeps();
+
+    handleAnchorCellClick(deps, {
+      _event: {
+        currentTarget: {
+          dataset: { anchorIndex: "8" },
+          getAttribute: vi.fn(() => "false"),
+        },
+      },
+    });
+
+    const event = deps.dispatchEvent.mock.calls[0][0];
+    expect(event.type).toBe("value-change");
+    expect(event.detail).toEqual({
+      item: OPTIONS[8],
+      value: { x: 1, y: 1 },
+    });
+  });
+
+  it("moves and selects by row with arrow keys", () => {
+    const { deps, focusedCell } = createDeps();
+    const preventDefault = vi.fn();
+
+    handleAnchorCellKeyDown(deps, {
+      _event: {
+        currentTarget: {
+          dataset: { anchorIndex: "1" },
+        },
+        key: "ArrowDown",
+        preventDefault,
+      },
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(deps.refs.anchorGrid.querySelector).toHaveBeenCalledWith(
+      '[data-anchor-index="4"]',
+    );
+    expect(focusedCell.focus).toHaveBeenCalled();
+    expect(deps.dispatchEvent.mock.calls[0][0].detail.value).toEqual({
+      x: 0.5,
+      y: 0.5,
+    });
+  });
+
+  it("does not emit when the selected cell is clicked again", () => {
+    const { deps } = createDeps();
+
+    handleAnchorCellClick(deps, {
+      _event: {
+        currentTarget: {
+          dataset: { anchorIndex: "4" },
+          getAttribute: vi.fn(() => "true"),
+        },
+      },
+    });
+
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/layoutAnchorGrid/layoutAnchorGrid.store.test.js
+++ b/tests/layoutAnchorGrid/layoutAnchorGrid.store.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { selectViewData } from "../../src/components/layout-anchor-grid/layout-anchor-grid.store.js";
+
+const OPTIONS = [
+  { label: "Top Left", value: { x: 0, y: 0 } },
+  { label: "Top Center", value: { x: 0.5, y: 0 } },
+  { label: "Top Right", value: { x: 1, y: 0 } },
+  { label: "Center Left", value: { x: 0, y: 0.5 } },
+  { label: "Center", value: { x: 0.5, y: 0.5 } },
+  { label: "Center Right", value: { x: 1, y: 0.5 } },
+  { label: "Bottom Left", value: { x: 0, y: 1 } },
+  { label: "Bottom Center", value: { x: 0.5, y: 1 } },
+  { label: "Bottom Right", value: { x: 1, y: 1 } },
+];
+
+describe("layoutAnchorGrid store", () => {
+  it("selects the matching anchor cell and makes it tabbable", () => {
+    const viewData = selectViewData({
+      props: {
+        label: "Anchor",
+        options: OPTIONS,
+        value: { x: 0.5, y: 1 },
+      },
+    });
+
+    expect(viewData.cells).toHaveLength(9);
+    expect(viewData.cells[7]).toMatchObject({
+      isSelected: true,
+      label: "Bottom Center",
+      tabIndex: 0,
+      value: { x: 0.5, y: 1 },
+    });
+    expect(viewData.cells.filter((cell) => cell.tabIndex === 0)).toHaveLength(
+      1,
+    );
+  });
+
+  it("makes the first cell tabbable when the value is not recognized", () => {
+    const viewData = selectViewData({
+      props: {
+        options: OPTIONS,
+        value: { x: 0.25, y: 0.25 },
+      },
+    });
+
+    expect(viewData.cells[0].tabIndex).toBe(0);
+    expect(viewData.cells.some((cell) => cell.isSelected)).toBe(false);
+  });
+});

--- a/tests/layoutAnchorGrid/layoutAnchorGrid.view.test.js
+++ b/tests/layoutAnchorGrid/layoutAnchorGrid.view.test.js
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+const readView = () =>
+  readFileSync(
+    new URL(
+      "../../src/components/layout-anchor-grid/layout-anchor-grid.view.yaml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+describe("layoutAnchorGrid view", () => {
+  it("renders an accessible three-by-three radio grid", () => {
+    const view = readView();
+
+    expect(() => yaml.load(view)).not.toThrow();
+    expect(view).toContain('role=radiogroup aria-label="${label}"');
+    expect(view).toContain('grid-template-columns: "repeat(3, 36px)"');
+    expect(view).toContain("button#anchorCell${i}.layoutAnchorGridCell");
+    expect(view).toContain("role=radio");
+    expect(view).toContain('aria-checked="${cell.isSelected}"');
+    expect(view).toContain("tabindex=${cell.tabIndex}");
+    expect(view).toContain(".layoutAnchorGridCell[data-selected='true']");
+  });
+});

--- a/tests/layoutEditPanel/layoutEditPanel.anchorGrid.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.anchorGrid.test.js
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setValues,
+} from "../../src/components/layoutEditPanel/layoutEditPanel.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const EMPTY_TREE = { items: {}, tree: [] };
+const LAYOUT_EDIT_PANEL_CONSTANTS = yaml.load(
+  readFileSync(
+    new URL(
+      "../../src/components/layoutEditPanel/layoutEditPanel.constants.yaml",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+
+const getAnchorItem = (itemType) => {
+  const state = createInitialState();
+  setValues(
+    { state },
+    {
+      values: {
+        type: itemType,
+        name: "Element",
+        anchorX: 0.5,
+        anchorY: 1,
+      },
+    },
+  );
+
+  const viewData = selectViewData({
+    state,
+    props: {
+      itemType,
+      layoutType: "general",
+      resourceType: "layouts",
+      layoutsData: EMPTY_TREE,
+      charactersData: EMPTY_TREE,
+      isInsideSaveLoadSlot: false,
+      isInsideDirectedContainer: false,
+    },
+    constants: LAYOUT_EDIT_PANEL_CONSTANTS,
+    i18n: EN_I18N,
+  });
+
+  return viewData.config.sections
+    .flatMap((section) => section.items)
+    .find((item) => item.name === "anchor");
+};
+
+describe("layoutEditPanel anchor grid", () => {
+  it("uses the nine-cell grid for text anchors", () => {
+    expect(getAnchorItem("text-revealing-ref-dialogue-content")).toMatchObject({
+      type: "anchor-grid",
+      label: "Anchor",
+      value: {
+        x: 0.5,
+        y: 1,
+      },
+      options: expect.arrayContaining([
+        {
+          label: "Bottom Center",
+          value: {
+            x: 0.5,
+            y: 1,
+          },
+        },
+      ]),
+    });
+  });
+
+  it.each([
+    "container",
+    "fragment-ref",
+    "sprite",
+    "particle",
+    "spritesheet-animation",
+    "input",
+  ])("uses the nine-cell grid for %s anchors", (itemType) => {
+    expect(getAnchorItem(itemType)).toMatchObject({
+      type: "anchor-grid",
+      name: "anchor",
+    });
+  });
+});

--- a/tests/layoutEditPanel/layoutEditPanel.childInteractionTooltip.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.childInteractionTooltip.test.js
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleSectionTooltipMouseEnter,
+  handleSectionTooltipMouseLeave,
+} from "../../src/components/layoutEditPanel/layoutEditPanel.handlers.js";
+import {
+  createInitialState,
+  selectViewData,
+  setValues,
+} from "../../src/components/layoutEditPanel/layoutEditPanel.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const EMPTY_TREE = { items: {}, tree: [] };
+const LAYOUT_EDIT_PANEL_CONSTANTS = yaml.load(
+  readFileSync(
+    new URL(
+      "../../src/components/layoutEditPanel/layoutEditPanel.constants.yaml",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+
+describe("layoutEditPanel child interaction tooltip", () => {
+  it("adds help text to the Child Interaction section", () => {
+    const state = createInitialState();
+    setValues(
+      { state },
+      {
+        values: {
+          type: "container",
+          name: "Container",
+        },
+      },
+    );
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        itemType: "container",
+        layoutType: "general",
+        resourceType: "layouts",
+        layoutsData: EMPTY_TREE,
+        charactersData: EMPTY_TREE,
+        isInsideSaveLoadSlot: false,
+        isInsideDirectedContainer: false,
+      },
+      constants: LAYOUT_EDIT_PANEL_CONSTANTS,
+      i18n: EN_I18N,
+    });
+    const section = viewData.config.sections.find(
+      (item) => item.id === "childInteraction",
+    );
+
+    expect(section).toMatchObject({
+      label: "Child Interaction",
+      tooltip: "Inherit child event from parent",
+    });
+  });
+
+  it("renders a circular question-mark trigger and tooltip", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/layoutEditPanel/layoutEditPanel.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain(
+      "button#sectionTooltip${i}.layoutEditPanelSectionTooltipTrigger",
+    );
+    expect(view).toContain('data-tooltip="${section.tooltip}"\': "?"');
+    expect(view).toContain("handler: handleSectionTooltipMouseEnter");
+    expect(view).toContain("handler: handleSectionTooltipMouseLeave");
+    expect(view).toContain("rtgl-tooltip ?open=${sectionTooltip.open}");
+  });
+
+  it("shows the tooltip above the help trigger and hides it on leave", () => {
+    const store = {
+      showSectionTooltip: vi.fn(),
+      hideSectionTooltip: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleSectionTooltipMouseEnter(
+      { store, render },
+      {
+        _event: {
+          currentTarget: {
+            dataset: { tooltip: "Inherit child event from parent" },
+            getBoundingClientRect: () => ({ left: 20, top: 40, width: 16 }),
+          },
+        },
+      },
+    );
+
+    expect(store.showSectionTooltip).toHaveBeenCalledWith({
+      x: 28,
+      y: 32,
+      content: "Inherit child event from parent",
+    });
+
+    handleSectionTooltipMouseLeave({ store, render });
+
+    expect(store.hideSectionTooltip).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/layoutEditPanel/layoutEditPanel.conditionalOverrides.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.conditionalOverrides.test.js
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
+  handleConditionalOverrideAnchorChange,
+  handleConditionalOverrideAttributeClick,
   handleConditionalOverrideAttributeFormAction,
   handleConditionalOverrideAttributeImageClick,
   handleConditionalOverrideAttributeImageKeyDown,
@@ -8,6 +10,10 @@ import {
   handleConditionalOverrideDeleteClick,
   handleImageSelectorSubmit,
 } from "../../src/components/layoutEditPanel/layoutEditPanel.handlers.js";
+import {
+  createConditionalOverrideAnchorOptions,
+  createConditionalOverrideAttributeForm,
+} from "../../src/components/layoutEditPanel/support/layoutEditPanelConditionalOverrides.js";
 import { EN_I18N } from "../support/i18n.js";
 
 const RULES = [
@@ -53,6 +59,96 @@ const createPayload = (index = 0) => ({
 });
 
 describe("layoutEditPanel conditional overrides", () => {
+  it("uses the nine-cell selector for conditional anchor overrides", () => {
+    const form = createConditionalOverrideAttributeForm({
+      attributeOptions: [{ label: "Anchor", value: "anchor" }],
+      textStyleOptions: [],
+      submitLabel: "Save",
+      copy: {},
+    });
+    const anchorField = form.fields.find(
+      (field) => field.$when === "fieldName == 'anchor'",
+    );
+    const options = createConditionalOverrideAnchorOptions({});
+    const view = readFileSync(
+      new URL(
+        "../../src/components/layoutEditPanel/layoutEditPanel.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(anchorField).toEqual({
+      $when: "fieldName == 'anchor'",
+      type: "slot",
+      slot: "conditional-override-anchor",
+      label: "Anchor",
+    });
+    expect(options).toHaveLength(9);
+    expect(options[4]).toEqual({
+      label: "Center",
+      value: { x: 0.5, y: 0.5 },
+    });
+    expect(view).toContain(
+      "rvn-layout-anchor-grid#conditionalOverrideAnchor slot=conditional-override-anchor",
+    );
+  });
+
+  it("tracks the selected conditional anchor", () => {
+    const store = {
+      setConditionalOverrideAttributeDialogAnchor: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleConditionalOverrideAnchorChange(
+      { store, render },
+      {
+        _event: {
+          detail: { value: { x: 1, y: 0.5 } },
+        },
+      },
+    );
+
+    expect(
+      store.setConditionalOverrideAttributeDialogAnchor,
+    ).toHaveBeenCalledWith({ anchor: { x: 1, y: 0.5 } });
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("prefills the grid when editing a conditional anchor", () => {
+    const store = {
+      selectValues: vi.fn(() => ({
+        conditionalOverrides: [
+          {
+            when: { target: "variables['enabled']", op: "eq", value: true },
+            set: { anchorX: 0.5, anchorY: 1 },
+          },
+        ],
+      })),
+      openConditionalOverrideAttributeDialog: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleConditionalOverrideAttributeClick(
+      { store, render },
+      {
+        _event: {
+          currentTarget: {
+            dataset: { index: "0", fieldName: "anchor" },
+          },
+        },
+      },
+    );
+
+    expect(store.openConditionalOverrideAttributeDialog).toHaveBeenCalledWith({
+      editingIndex: 0,
+      fieldName: "anchor",
+      selectedImageId: undefined,
+      selectedAnchor: { x: 0.5, y: 1 },
+    });
+    expect(render).toHaveBeenCalledOnce();
+  });
+
   it("uses a border-only card hover and a full-width add attribute button", () => {
     const view = readFileSync(
       new URL(
@@ -311,6 +407,52 @@ describe("layoutEditPanel conditional overrides", () => {
 
     expect(values.conditionalOverrides[0].set).toEqual({
       imageId: "image-selected",
+    });
+    expect(
+      store.closeConditionalOverrideAttributeDialog,
+    ).toHaveBeenCalledOnce();
+  });
+
+  it("saves the selected grid cell as a conditional anchor", () => {
+    const values = {
+      conditionalOverrides: [
+        {
+          when: { target: "variables['enabled']", op: "eq", value: true },
+          set: { visible: true },
+        },
+      ],
+    };
+    const store = {
+      selectConditionalOverrideAttributeDialog: vi.fn(() => ({
+        editingIndex: 0,
+        selectedAnchor: { x: 0.5, y: 1 },
+      })),
+      selectValues: vi.fn(() => values),
+      updateValueProperty: vi.fn(({ name, value }) => {
+        values[name] = value;
+      }),
+      closeConditionalOverrideAttributeDialog: vi.fn(),
+    };
+    const deps = {
+      store,
+      render: vi.fn(),
+      dispatchEvent: vi.fn(),
+      i18n: EN_I18N,
+    };
+
+    handleConditionalOverrideAttributeFormAction(deps, {
+      _event: {
+        detail: {
+          actionId: "submit",
+          values: { fieldName: "anchor" },
+        },
+      },
+    });
+
+    expect(values.conditionalOverrides[0].set).toEqual({
+      visible: true,
+      anchorX: 0.5,
+      anchorY: 1,
     });
     expect(
       store.closeConditionalOverrideAttributeDialog,

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -6,7 +6,7 @@
     <title>VT E2E Runner</title>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.10.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module">
       const VT_RESET_KEY = "routevn.vt.indexeddb-reset-done";
 


### PR DESCRIPTION
## Summary
- replace layout-editor anchor dropdowns with an accessible nine-cell grid selector
- apply the grid to every anchor-capable layout element, including containers and fragments
- use the same selector for conditional anchor overrides while preserving anchor coordinate persistence
- add a circular question-mark tooltip to the Child Interaction section
- upgrade Rettangoli UI to 1.11.0 and align all watch and VT HTML entry points

## Testing
- `bunx vitest run tests/layoutEditPanel/layoutEditPanel.childInteractionTooltip.test.js tests/layoutAnchorGrid tests/layoutEditPanel/layoutEditPanel.anchorGrid.test.js tests/layoutEditPanel/layoutEditPanel.conditionalOverrides.test.js tests/layoutEditPanel/layoutEditPanel.emptySections.test.js`
- `bunx rtgl check --dir src/components/layout-anchor-grid`
- `bun run lint`
- `bun run build:web`