### PR TITLE
fix(scene-editor): reactivate selected line on click

### DIFF
--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -3371,7 +3371,6 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return false;
     }
 
-    const previousSelectedLineId = this.state.selectedLineId;
     const cursorPosition = this.getLineOffsetFromPointerEvent(
       event,
       lineElement,
@@ -3386,13 +3385,11 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.awaitingCharacterShortcut = false;
     this.clearDeleteShortcutState();
     this.scheduleRender();
-    if (previousSelectedLineId !== lineId) {
-      this.dispatchSelectedLineChanged(lineId, {
-        cursorPosition: cursorPosition >= 0 ? cursorPosition : undefined,
-        isCollapsed: true,
-        mode: "text-editor",
-      });
-    }
+    this.dispatchSelectedLineChanged(lineId, {
+      cursorPosition: cursorPosition >= 0 ? cursorPosition : undefined,
+      isCollapsed: true,
+      mode: "text-editor",
+    });
     return true;
   }
 

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -3294,6 +3294,17 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       return;
     }
 
+    const shouldActivateReferenceLine = this.state.mode === "block";
+    const referenceLineElement = shouldActivateReferenceLine
+      ? this.getLineElementFromEvent(event)
+      : undefined;
+    const referenceLineId = shouldActivateReferenceLine
+      ? this.getLineIdFromLineElement(referenceLineElement)
+      : undefined;
+    const referenceCursorPosition = referenceLineId
+      ? this.getLineOffsetFromPointerEvent(event, referenceLineElement)
+      : undefined;
+
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation?.();
@@ -3302,6 +3313,15 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     this.setMode("text-editor");
     this.focus({ preventScroll: true });
     this.selectReferenceByNodeKey(referenceSnapshot.nodeKey);
+    if (referenceLineId) {
+      this.state.selectedLineId = referenceLineId;
+      this.dispatchSelectedLineChanged(referenceLineId, {
+        cursorPosition:
+          referenceCursorPosition >= 0 ? referenceCursorPosition : undefined,
+        isCollapsed: false,
+        mode: "text-editor",
+      });
+    }
     requestAnimationFrame(() => {
       if (!this.isConnected) {
         return;

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1881,6 +1881,9 @@ describe("lexical scene document editor line editing", () => {
         selectedLineId: "line-1",
         selectionActive: false,
       };
+      editorElement.markPointerDownInsideEditor = vi.fn();
+      editorElement.getReferenceSnapshotFromContextEvent = vi.fn();
+      editorElement.suppressNativeLineBoundaryDoubleClick = vi.fn(() => false);
       editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
       editorElement.getLineIdFromLineElement = vi.fn(() => "line-1");
       editorElement.getLineOffsetFromPointerEvent = vi.fn(() => 3);
@@ -1894,11 +1897,11 @@ describe("lexical scene document editor line editing", () => {
       editorElement.scheduleRender = vi.fn();
       editorElement.dispatchSelectedLineChanged = vi.fn();
 
-      const didEnter = editorElement.enterTextModeFromBlockModePointer({
+      editorElement.handleNativeMouseDown({
+        button: 0,
         target: lineElement,
       });
 
-      expect(didEnter).toBe(true);
       expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
         "line-1",
         {
@@ -1908,6 +1911,67 @@ describe("lexical scene document editor line editing", () => {
         },
       );
     } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("reports activation when an inactive editor clicks a reference on its already-selected line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    const animationFrames = installAnimationFrameQueue();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        selectionActive: false,
+      };
+      editorElement.markPointerDownInsideEditor = vi.fn();
+      editorElement.getReferenceSnapshotFromContextEvent = vi.fn(() => ({
+        nodeKey: "reference-1",
+      }));
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-1");
+      editorElement.getLineOffsetFromPointerEvent = vi.fn(() => 3);
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.setMode = vi.fn((mode) => {
+        editorElement.state.mode = mode;
+      });
+      editorElement.focus = vi.fn();
+      editorElement.selectReferenceByNodeKey = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      const event = {
+        button: 0,
+        target: lineElement,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        stopImmediatePropagation: vi.fn(),
+      };
+
+      editorElement.handleNativeMouseDown(event);
+
+      expect(editorElement.selectReferenceByNodeKey).toHaveBeenCalledWith(
+        "reference-1",
+      );
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-1",
+        {
+          cursorPosition: 3,
+          isCollapsed: false,
+          mode: "text-editor",
+        },
+      );
+    } finally {
+      animationFrames.restore();
       restoreDomGlobals();
     }
   });

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -1864,6 +1864,54 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it("reports activation when an inactive editor clicks its already-selected line", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      const lineElement = document.createElement("p");
+
+      editorElement.state = {
+        mode: "block",
+        selectedLineId: "line-1",
+        selectionActive: false,
+      };
+      editorElement.getLineElementFromEvent = vi.fn(() => lineElement);
+      editorElement.getLineIdFromLineElement = vi.fn(() => "line-1");
+      editorElement.getLineOffsetFromPointerEvent = vi.fn(() => 3);
+      editorElement.clearSelectedReferenceNodeKey = vi.fn();
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.closeMentionMenu = vi.fn();
+      editorElement.applyModeState = vi.fn((mode) => {
+        editorElement.state.mode = mode;
+      });
+      editorElement.clearDeleteShortcutState = vi.fn();
+      editorElement.scheduleRender = vi.fn();
+      editorElement.dispatchSelectedLineChanged = vi.fn();
+
+      const didEnter = editorElement.enterTextModeFromBlockModePointer({
+        target: lineElement,
+      });
+
+      expect(didEnter).toBe(true);
+      expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+        "line-1",
+        {
+          cursorPosition: 3,
+          isCollapsed: true,
+          mode: "text-editor",
+        },
+      );
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
   it("enters block mode for the clicked line from the left gutter", async () => {
     const restoreDomGlobals = installDomGlobals();
 


### PR DESCRIPTION
## Summary
- always report selected-line activation when block mode enters text mode
- activate inactive sections when their already-selected line is clicked through plain text or a reference chip
- preserve pointer cursor details and reference selection state in the activation event
- cover both behaviors through the complete native mouse event path

## Testing
- `bunx vitest run tests/sceneEditor/lexicalLineEditing.test.js` (111 tests)
- `bun run lint`
- pre-push `oxlint` and Prettier checks