### PR TITLE
Clarify speaker sprite field

### DIFF
--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -775,6 +775,24 @@ export const handleCharacterSpriteBoxClick = (deps) => {
   render();
 };
 
+export const handleSpeakerSpriteTooltipMouseEnter = (deps, payload) => {
+  const { store, render } = deps;
+  const rect = payload._event.currentTarget.getBoundingClientRect();
+
+  store.showSpeakerSpriteTooltip({
+    x: rect.left + rect.width / 2,
+    y: rect.top - 8,
+  });
+  render();
+};
+
+export const handleSpeakerSpriteTooltipMouseLeave = (deps) => {
+  const { store, render } = deps;
+
+  store.hideSpeakerSpriteTooltip();
+  render();
+};
+
 export const handleCharacterSpriteGroupBoxClick = (deps, payload) => {
   const { store, render } = deps;
   const spriteGroupId = payload?._event?.currentTarget?.dataset?.spriteGroupId;

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -31,6 +31,9 @@ const ANIMATION_MODE_OPTIONS = [
 const DEFAULT_TEXT_SPEED = 75;
 const DEFAULT_SPRITE_GROUP_ID = "base";
 const DEFAULT_SPRITE_GROUP_NAME = "Sprite";
+const SPEAKER_SPRITE_LABEL = "Speaker sprite";
+const SPEAKER_SPRITE_TOOLTIP =
+  "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action";
 const UNGROUPED_CHARACTER_GROUP_ID = "__ungrouped_dialogue_characters__";
 const UNGROUPED_SPRITE_GROUP_ID = "__ungrouped_dialogue_sprites__";
 const UNGROUPED_GROUP_LABEL = "Ungrouped";
@@ -339,6 +342,11 @@ export const createInitialState = () => ({
   fullImagePreviewAtlas: undefined,
   fullImagePreviewAnimation: undefined,
   fullImagePreviewKey: undefined,
+  speakerSpriteTooltip: {
+    open: false,
+    x: 0,
+    y: 0,
+  },
 
   defaultValues: {
     mode: "adv",
@@ -410,11 +418,6 @@ export const createInitialState = () => ({
       {
         type: "slot",
         slot: "characterSprite",
-        label: "Speaker sprite",
-        tooltip: {
-          content:
-            "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
-        },
       },
       {
         name: "customizeTextSpeed",
@@ -655,6 +658,16 @@ export const hideFullImagePreview = ({ state }) => {
   state.fullImagePreviewAtlas = undefined;
   state.fullImagePreviewAnimation = undefined;
   state.fullImagePreviewKey = undefined;
+};
+
+export const showSpeakerSpriteTooltip = ({ state }, { x, y } = {}) => {
+  state.speakerSpriteTooltip.open = true;
+  state.speakerSpriteTooltip.x = x;
+  state.speakerSpriteTooltip.y = y;
+};
+
+export const hideSpeakerSpriteTooltip = ({ state }) => {
+  state.speakerSpriteTooltip.open = false;
 };
 
 export const setSelectedMode = ({ state }, { mode } = {}) => {
@@ -1118,6 +1131,12 @@ export const selectViewData = ({ state, props, i18n }) => {
     clearButtonLabel: localizeCommandLineText("Clear", copy),
     animationLabel: localizeCommandLineText("Animation", copy),
     spriteGroupsLabel: localizeCommandLineText("Sprite Groups", copy),
+    speakerSpriteLabel: localizeCommandLineText(SPEAKER_SPRITE_LABEL, copy),
+    speakerSpriteTooltip: state.speakerSpriteTooltip,
+    speakerSpriteTooltipContent: localizeCommandLineText(
+      SPEAKER_SPRITE_TOOLTIP,
+      copy,
+    ),
     submitButtonLabel: localizeCommandLineText("Submit", copy),
     selectButtonLabel: localizeCommandLineText("Select", copy),
     fullImagePreviewVisible: state.fullImagePreviewVisible,

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -410,7 +410,11 @@ export const createInitialState = () => ({
       {
         type: "slot",
         slot: "characterSprite",
-        label: "Character Sprite",
+        label: "Speaker sprite",
+        tooltip: {
+          content:
+            "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
+        },
       },
       {
         name: "customizeTextSpeed",

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -11,6 +11,16 @@ refs:
     eventListeners:
       click:
         handler: handleCharacterSpriteBoxClick
+  speakerSpriteTooltip:
+    eventListeners:
+      mouseenter:
+        handler: handleSpeakerSpriteTooltipMouseEnter
+      mouseleave:
+        handler: handleSpeakerSpriteTooltipMouseLeave
+      focus:
+        handler: handleSpeakerSpriteTooltipMouseEnter
+      blur:
+        handler: handleSpeakerSpriteTooltipMouseLeave
   clearCharacterSpriteButton:
     eventListeners:
       click:
@@ -70,6 +80,29 @@ refs:
     eventListeners:
       click:
         handler: handleSubmitClick
+styles:
+  ".commandLineDialogueBoxTooltipTrigger":
+    align-items: center
+    appearance: none
+    background: transparent
+    border: "1px solid var(--muted-foreground)"
+    border-radius: 50%
+    box-sizing: border-box
+    color: var(--muted-foreground)
+    cursor: help
+    display: flex
+    font-family: inherit
+    font-size: 11px
+    font-weight: 600
+    height: 16px
+    justify-content: center
+    line-height: 1
+    margin: 0
+    padding: 0
+    width: 16px
+  ".commandLineDialogueBoxTooltipTrigger:focus-visible":
+    outline: "2px solid var(--ring)"
+    outline-offset: 2px
 template:
   - rtgl-view w=f h=f p=lg:
       - $if mode == 'current':
@@ -77,6 +110,9 @@ template:
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f:
                   - rtgl-view slot=characterSprite g=md w=f:
+                      - rtgl-view d=h g=md av=c:
+                          - rtgl-text: ${speakerSpriteLabel}
+                          - 'button#speakerSpriteTooltip.commandLineDialogueBoxTooltipTrigger type=button aria-label="${speakerSpriteTooltipContent}"': "?"
                       - rtgl-view d=h g=md av=t pv=md br=md w=f:
                           - rtgl-view#characterSpriteBox cur=pointer bw=xs bc=bo h-bc=ac br=sm:
                               - rtgl-view p=md g=md br=md:
@@ -167,3 +203,4 @@ template:
                       - 'rvn-spritesheet-preview key=${fullImagePreviewKey} previewKey=${fullImagePreviewKey} fileId=${fullImagePreviewFileId} :atlas=${fullImagePreviewAtlas} :animation=${fullImagePreviewAnimation} w=80% h=80% emptyLabel="${noPreviewLabel}"': null
                     $else:
                       - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null
+  - rtgl-tooltip ?open=${speakerSpriteTooltip.open} x=${speakerSpriteTooltip.x} y=${speakerSpriteTooltip.y} place="t" content="${speakerSpriteTooltipContent}": null

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -1873,6 +1873,8 @@ commandLinePage:
   "Sound Effects": "Sound Effects"
   "Speaker": "Speaker"
   "Speaker Name": "Speaker Name"
+  "Speaker sprite": "Speaker sprite"
+  speakerSpriteTooltip: "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action"
   "Sprite Animation": "Sprite Animation"
   "Sprite Groups": "Sprite Groups"
   "Sprite Selection": "Sprite Selection"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -1873,6 +1873,8 @@ commandLinePage:
   "Sound Effects": "効果音"
   "Speaker": "話者"
   "Speaker Name": "話者名"
+  "Speaker sprite": "話者スプライト"
+  speakerSpriteTooltip: "会話ボックスの上に表示される話者の顔です。全身の立ち絵には「キャラクター」アクションを使用してください。"
   "Sprite Animation": "立ち絵アニメーション"
   "Sprite Groups": "立ち絵グループ"
   "Sprite Selection": "立ち絵選択"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -1873,6 +1873,8 @@ commandLinePage:
   "Sound Effects": "音效"
   "Speaker": "说话者"
   "Speaker Name": "说话者名称"
+  "Speaker sprite": "说话者立绘"
+  speakerSpriteTooltip: "显示在对话框上方的说话者面部图像。全身立绘请使用“角色”动作。"
   "Sprite Animation": "立绘动画"
   "Sprite Groups": "立绘组"
   "Sprite Selection": "立绘选择"

--- a/src/internal/ui/sceneEditor/commandLineCopy.js
+++ b/src/internal/ui/sceneEditor/commandLineCopy.js
@@ -32,6 +32,8 @@ const COMMAND_LINE_COPY_KEYS = Object.freeze({
   "Search...": "searchPlaceholder",
   "Select a scene before adding voice audio.": "selectSceneBeforeVoiceAudio",
   "Select a voice audio file first.": "selectVoiceAudioFirst",
+  "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action":
+    "speakerSpriteTooltip",
   Spritesheet: "spritesheetLabel",
   Spritesheets: "spritesheetsLabel",
   "The default branch must be the last branch.": "defaultBranchMustBeLast",

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   handleAfterMount,
@@ -5,6 +6,8 @@ import {
   handleButtonSelectClick,
   handleCharacterItemClick,
   handleFormChange,
+  handleSpeakerSpriteTooltipMouseEnter,
+  handleSpeakerSpriteTooltipMouseLeave,
   handleSpriteGroupTabClick,
   handleSpriteItemClick,
   handleSubmitClick,
@@ -13,6 +16,7 @@ import {
   clearCharacterSprite,
   clearTempSelectedSpriteIds,
   createInitialState,
+  hideSpeakerSpriteTooltip,
   setAppendDialogue,
   setCharacterSpriteEnabled,
   setCharacterName,
@@ -34,7 +38,16 @@ import {
   setTempSelectedSpriteIds,
   setCustomizeTextSpeed,
   setTextSpeed,
+  selectDialogueBuildState,
+  selectDialogueFormChangeState,
+  selectDialogueFormState,
+  selectMode,
+  selectSelectedSpriteGroupId,
+  selectSpriteCharacterId,
+  selectSpriteSelectionConfirmState,
+  selectSpriteSelectionState,
   showFullImagePreview,
+  showSpeakerSpriteTooltip,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
 
 const layouts = [
@@ -109,6 +122,16 @@ const animations = {
 
 const createStore = (state) => ({
   getState: () => state,
+  selectDialogueBuildState: () => selectDialogueBuildState({ state }),
+  selectDialogueFormChangeState: () => selectDialogueFormChangeState({ state }),
+  selectDialogueFormState: () => selectDialogueFormState({ state }),
+  selectMode: () => selectMode({ state }),
+  selectSelectedSpriteGroupId: () =>
+    selectSelectedSpriteGroupId({ state, props: { characters } }),
+  selectSpriteCharacterId: () => selectSpriteCharacterId({ state }),
+  selectSpriteSelectionConfirmState: () =>
+    selectSpriteSelectionConfirmState({ state }),
+  selectSpriteSelectionState: () => selectSpriteSelectionState({ state }),
   setSelectedMode: (payload) => setSelectedMode({ state }, payload),
   setSelectedResource: (payload) => setSelectedResource({ state }, payload),
   setSelectedCharacterId: (payload) =>
@@ -133,14 +156,17 @@ const createStore = (state) => ({
   setSearchQuery: (payload) => setSearchQuery({ state }, payload),
   setMode: (payload) => setMode({ state }, payload),
   showFullImagePreview: (payload) => showFullImagePreview({ state }, payload),
+  showSpeakerSpriteTooltip: (payload) =>
+    showSpeakerSpriteTooltip({ state }, payload),
+  hideSpeakerSpriteTooltip: (payload) =>
+    hideSpeakerSpriteTooltip({ state }, payload),
   setSpriteAnimationMode: (payload) =>
     setSpriteAnimationMode({ state }, payload),
   setSpriteAnimationId: (payload) => setSpriteAnimationId({ state }, payload),
   setAppendDialogue: (payload) => setAppendDialogue({ state }, payload),
   setPersistCharacter: (payload) => setPersistCharacter({ state }, payload),
   setClearPage: (payload) => setClearPage({ state }, payload),
-  setCustomizeTextSpeed: (payload) =>
-    setCustomizeTextSpeed({ state }, payload),
+  setCustomizeTextSpeed: (payload) => setCustomizeTextSpeed({ state }, payload),
   setTextSpeed: (payload) => setTextSpeed({ state }, payload),
 });
 
@@ -152,6 +178,58 @@ const createFormRefs = () => ({
 });
 
 describe("commandLineDialogueBox.handlers", () => {
+  it("renders an accessible speaker sprite tooltip trigger", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain(
+      "button#speakerSpriteTooltip.commandLineDialogueBoxTooltipTrigger",
+    );
+    expect(view).toContain(
+      'aria-label="${speakerSpriteTooltipContent}"\': "?"',
+    );
+    expect(view).toContain("handler: handleSpeakerSpriteTooltipMouseEnter");
+    expect(view).toContain("handler: handleSpeakerSpriteTooltipMouseLeave");
+    expect(view).toContain("rtgl-tooltip ?open=${speakerSpriteTooltip.open}");
+  });
+
+  it("shows and hides the speaker sprite tooltip", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const deps = {
+      store: createStore(state),
+      render,
+    };
+
+    handleSpeakerSpriteTooltipMouseEnter(deps, {
+      _event: {
+        currentTarget: {
+          getBoundingClientRect: () => ({
+            left: 100,
+            top: 80,
+            width: 16,
+          }),
+        },
+      },
+    });
+
+    expect(state.speakerSpriteTooltip).toEqual({
+      open: true,
+      x: 108,
+      y: 72,
+    });
+
+    handleSpeakerSpriteTooltipMouseLeave(deps);
+
+    expect(state.speakerSpriteTooltip.open).toBe(false);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
   it("hydrates persistCharacter and custom character name from props into the form state", () => {
     const state = createInitialState();
     const reset = vi.fn();

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
@@ -15,6 +15,10 @@ import {
   setCustomizeTextSpeed,
   setTextSpeed,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const selectTestViewData = ({ state, props }) =>
+  selectViewData({ state, props, i18n: EN_I18N });
 
 const isFieldVisible = ({ field, values }) => {
   const rendered = parseAndRender(
@@ -60,7 +64,7 @@ describe("commandLineDialogueBox.store", () => {
       },
     );
 
-    const viewData = selectViewData({
+    const viewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -114,8 +118,12 @@ describe("commandLineDialogueBox.store", () => {
     expect(
       viewData.form.fields.find((field) => field.slot === "characterSprite"),
     ).toMatchObject({
-      label: "Character Sprite",
+      label: "Speaker sprite",
       type: "slot",
+      tooltip: {
+        content:
+          "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
+      },
     });
     expect(
       viewData.form.fields.find((field) => field.name === "append"),
@@ -143,7 +151,7 @@ describe("commandLineDialogueBox.store", () => {
   it("uses one layout label for every dialogue mode", () => {
     const state = createInitialState();
 
-    const viewData = selectViewData({
+    const viewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -164,7 +172,7 @@ describe("commandLineDialogueBox.store", () => {
     });
 
     state.selectedMode = "nvl";
-    const nvlViewData = selectViewData({
+    const nvlViewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -195,7 +203,7 @@ describe("commandLineDialogueBox.store", () => {
       },
     );
 
-    const viewData = selectViewData({
+    const viewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -223,7 +231,7 @@ describe("commandLineDialogueBox.store", () => {
   it("exposes optional text speed controls with no override by default", () => {
     const state = createInitialState();
 
-    const viewData = selectViewData({
+    const viewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -293,7 +301,9 @@ describe("commandLineDialogueBox.store", () => {
     setTextSpeed({ state }, { textSpeed: 150 });
 
     expect(state.textSpeed).toBe(100);
-    expect(selectViewData({ state, props: { layouts: [], characters: [] } }))
+    expect(
+      selectTestViewData({ state, props: { layouts: [], characters: [] } }),
+    )
       .toMatchObject({
         defaultValues: {
           customizeTextSpeed: true,
@@ -304,7 +314,7 @@ describe("commandLineDialogueBox.store", () => {
 
   it("shows persistCharacter only for selected characters or enabled custom naming", () => {
     const state = createInitialState();
-    const viewData = selectViewData({
+    const viewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -410,7 +420,7 @@ describe("commandLineDialogueBox.store", () => {
       },
     );
 
-    const viewData = selectViewData({
+    const viewData = selectTestViewData({
       state,
       props: {
         layouts: [
@@ -476,8 +486,12 @@ describe("commandLineDialogueBox.store", () => {
     expect(
       viewData.form.fields.find((field) => field.slot === "characterSprite"),
     ).toMatchObject({
-      label: "Character Sprite",
+      label: "Speaker sprite",
       type: "slot",
+      tooltip: {
+        content:
+          "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
+      },
     });
     expect(viewData.hasSpriteCharacter).toBe(true);
     expect(viewData.characterSpriteEnabled).toBe(true);

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { parseAndRender } from "jempl";
 import {
   createInitialState,
+  hideSpeakerSpriteTooltip,
   setAppendDialogue,
   setCharacterName,
   setCustomCharacterName,
@@ -14,6 +15,7 @@ import {
   setSpriteTransformId,
   setCustomizeTextSpeed,
   setTextSpeed,
+  showSpeakerSpriteTooltip,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
 import { EN_I18N } from "../support/i18n.js";
 
@@ -117,13 +119,19 @@ describe("commandLineDialogueBox.store", () => {
     });
     expect(
       viewData.form.fields.find((field) => field.slot === "characterSprite"),
-    ).toMatchObject({
-      label: "Speaker sprite",
+    ).toEqual({
+      slot: "characterSprite",
       type: "slot",
-      tooltip: {
-        content:
-          "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
+    });
+    expect(viewData).toMatchObject({
+      speakerSpriteLabel: "Speaker sprite",
+      speakerSpriteTooltip: {
+        open: false,
+        x: 0,
+        y: 0,
       },
+      speakerSpriteTooltipContent:
+        "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
     });
     expect(
       viewData.form.fields.find((field) => field.name === "append"),
@@ -303,13 +311,12 @@ describe("commandLineDialogueBox.store", () => {
     expect(state.textSpeed).toBe(100);
     expect(
       selectTestViewData({ state, props: { layouts: [], characters: [] } }),
-    )
-      .toMatchObject({
-        defaultValues: {
-          customizeTextSpeed: true,
-          textSpeed: 100,
-        },
-      });
+    ).toMatchObject({
+      defaultValues: {
+        customizeTextSpeed: true,
+        textSpeed: 100,
+      },
+    });
   });
 
   it("shows persistCharacter only for selected characters or enabled custom naming", () => {
@@ -485,13 +492,9 @@ describe("commandLineDialogueBox.store", () => {
 
     expect(
       viewData.form.fields.find((field) => field.slot === "characterSprite"),
-    ).toMatchObject({
-      label: "Speaker sprite",
+    ).toEqual({
+      slot: "characterSprite",
       type: "slot",
-      tooltip: {
-        content:
-          "Speaker's face that appears on top of the dialogue box. For body sprites use the Characters action",
-      },
     });
     expect(viewData.hasSpriteCharacter).toBe(true);
     expect(viewData.characterSpriteEnabled).toBe(true);
@@ -535,5 +538,21 @@ describe("commandLineDialogueBox.store", () => {
 
     expect(state.spriteAnimationMode).toBe("transition");
     expect(state.spriteAnimationId).toBe("");
+  });
+
+  it("tracks the speaker sprite tooltip position and visibility", () => {
+    const state = createInitialState();
+
+    showSpeakerSpriteTooltip({ state }, { x: 120, y: 64 });
+
+    expect(state.speakerSpriteTooltip).toEqual({
+      open: true,
+      x: 120,
+      y: 64,
+    });
+
+    hideSpeakerSpriteTooltip({ state });
+
+    expect(state.speakerSpriteTooltip.open).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- rename Character Sprite to Speaker sprite in dialogue commands
- explain that the field is for the face shown above the dialogue box
- localize the new label and tooltip in English, Japanese, and Simplified Chinese
- update component store coverage

## Validation

- bunx vitest run tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
- bun run lint
- Rettangoli i18n catalog validation