### PR TITLE
chore: update Rettangoli UI to 1.12.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@lexical/selection": "0.22.0",
         "@lexical/utils": "0.22.0",
         "@rettangoli/fe": "1.2.3",
-        "@rettangoli/ui": "1.11.1",
+        "@rettangoli/ui": "1.12.0",
         "@rettangoli/vt": "1.0.5",
         "@routevn/creator-model": "1.10.2",
         "@tauri-apps/api": "2.11.0",
@@ -314,7 +314,7 @@
 
     "@rettangoli/sites": ["@rettangoli/sites@1.2.0", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-taGLXClBbCL0Qbj7fFIZ0wW54yHNlKb43cJFZR1Poer2pxvo5GCnShvqZEvUfkPBqp/PKyvLfiOwMxGkbJxqyg=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.11.1", "", { "dependencies": { "@rettangoli/fe": "1.2.3", "jempl": "1.0.1" } }, "sha512-8fEOobEt8gJG0QTYOle0SbEXFNeJqMB0Uw4kUrzzx3i7ODr4HGvw194lZ3qYxoZxritRAfjgGOa+FYVGFJCVLw=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.12.0", "", { "dependencies": { "@rettangoli/fe": "1.2.3", "jempl": "1.0.1" } }, "sha512-ztGq9VmuMu7l9VUASrWm3+1zZMnK9fTm5ce3xNEtyOZB3TqBdFxEa7T7Bjj+WAZFvMMLDKRs/sQWPf8UjrqyCg=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.5", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-YpZH5xQYj+x5Qy6gn+FUnMTUIQELrZkTA4qN8/U4n/1B4gpNHHPltJK/kVltZQVYVG0Tj676ZIKCMGN0ZAHdzg=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@lexical/selection": "0.22.0",
     "@lexical/utils": "0.22.0",
     "@rettangoli/fe": "1.2.3",
-    "@rettangoli/ui": "1.11.1",
+    "@rettangoli/ui": "1.12.0",
     "@rettangoli/vt": "1.0.5",
     "@routevn/creator-model": "1.10.2",
     "@tauri-apps/api": "2.11.0",


### PR DESCRIPTION
## Summary
- update @rettangoli/ui from 1.11.1 to 1.12.0
- refresh the Bun lockfile resolution

## Testing
- bun install --frozen-lockfile
- bun run lint
- bun run test:smoke