### PR TITLE
feat(layout-editor): add canvas hover and selection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
         "route-engine-js": "1.29.2",
-        "route-graphics": "1.28.1",
+        "route-graphics": "1.29.0",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
         "snabbdom-to-html": "7.1.0",
@@ -894,7 +894,7 @@
 
     "route-engine-js": ["route-engine-js@1.29.2", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1", "unicode-segmenter": "^0.17.0" } }, "sha512-T4vMUlkpsk5zzcBDqa6irzCTd9+BN88r4K/hefRPQgn+ILmQHoAvFrbnBRlHb+cCPSVMyrY/J3AOeT7rFzFeGw=="],
 
-    "route-graphics": ["route-graphics@1.28.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "@wasm-audio-decoders/ogg-vorbis": "^0.1.20", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "ogg-opus-decoder": "^1.7.3", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-hZkbh4xV3Mcgsszjmp1uXEO9fuAwdxebUWFTIWdvfpkvmUGAye8aWQjMoAvlusYxnMEJ/IwOAdVpdbDu7Hj3xg=="],
+    "route-graphics": ["route-graphics@1.29.0", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "@wasm-audio-decoders/ogg-vorbis": "^0.1.20", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "ogg-opus-decoder": "^1.7.3", "pixi.js": "^8.7.1", "playwright": "^1.44.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-9YK8iAlUDLM0Zjncm3OfAfjR3zBuFqeSGUEsGeVaHU6O/hKsf+LHGa44szyhBHqXYC/z+VNABvnLuJCLZ5nf9g=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,12 +10,13 @@
 6. [Project Storage And Sync Redesign](./project-storage-and-sync-redesign.md)
 7. [Insieme 2.1.0 Hard Cutover Checklist](./insieme-2.1.0-hard-cutover-checklist.md)
 8. [Animation Editor Transition Mask Plan](./animation-editor-transition-mask-plan.md)
-9. [Resource Tags Spec](./resource-tags-spec.md)
-10. [Import Packages](./import-packages.md)
-11. [Observability Proposal](./observability.md)
-12. [Android Development](./android.md)
-13. [iOS Development](./ios.md)
-14. [macOS Player Export Plan](./macos-player-export-plan.md)
+9. [Layout Editor Canvas Hover And Selection Spec](./layout-editor-canvas-selection-spec.md)
+10. [Resource Tags Spec](./resource-tags-spec.md)
+11. [Import Packages](./import-packages.md)
+12. [Observability Proposal](./observability.md)
+13. [Android Development](./android.md)
+14. [iOS Development](./ios.md)
+15. [macOS Player Export Plan](./macos-player-export-plan.md)
 
 ## Runbooks
 

--- a/docs/layout-editor-canvas-selection-spec.md
+++ b/docs/layout-editor-canvas-selection-spec.md
@@ -1,6 +1,6 @@
 # Layout Editor Canvas Hover And Selection Specification
 
-Status: Proposed implementation specification
+Status: Implemented
 
 Last updated: 2026-07-21
 
@@ -66,8 +66,9 @@ The canvas interaction model establishes these rules:
    front of them.
 5. A right-click **Select layer** menu provides an explicit way to choose from
    layers underneath one pointer position.
-6. Hidden and locked layers do not participate in normal canvas selection.
-7. Clicking empty canvas space or pressing `Escape` clears selection.
+6. Hidden layers do not participate in normal canvas selection. Locked-element
+   behavior remains deferred until authored elements support locking.
+7. Clicking empty canvas space clears selection.
 
 The baseline does not prescribe every low-level hit-testing detail or define
 RouteVN concepts such as repeated preview instances and fragment references.
@@ -233,8 +234,11 @@ eligible occurrence behind it can then win.
 
 ## Hover Behavior
 
-Hover is a prediction of the target that a primary click with the current
-modifier keys would select.
+Hover normally predicts the target that a primary click with the current
+modifier keys would select. The selected-descendant suppression rule below is
+an intentional presentation exception: it avoids highlighting an ancestor
+while the pointer remains over its selected descendant, even though a normal
+click would select that ancestor.
 
 ### Normal hover
 
@@ -279,13 +283,13 @@ target immediately.
 - If they refer to different occurrences, keep the selection chrome and show
   the hover outline at the same time.
 - Clear hover when the pointer leaves the canvas, no candidate exists, a drag
-  starts, the canvas is disabled, or the component unmounts.
+  starts, or the component unmounts.
 
 Hover updates MUST be cheap. Pointer movement MUST NOT reload assets, query the
 repository, or recompile the layout. It MAY submit the cached render tree plus
 the hover rectangles through Route Graphics' element-diff render path. Hit
-testing SHOULD use an index rebuilt only when the resolved render tree changes,
-and visual updates SHOULD be limited to one animation-frame cadence.
+testing MUST query Route Graphics' live transformed render tree, and visual
+updates SHOULD be limited to one animation-frame cadence.
 
 ## Click Behavior
 
@@ -331,7 +335,8 @@ MUST NOT accidentally reset the depth and prevent repeated descent.
 - The white selection outline MUST be outside the occurrence and the gray
   outline MUST be inside it, without duplicating either color on both sides of
   the authored boundary.
-- Keep the stroke approximately two CSS pixels at every canvas scale.
+- Keep each outline approximately one CSS pixel at every canvas scale. Together,
+  the exterior white and interior gray bands span approximately two CSS pixels.
 - Show the existing white anchor marker with its one-CSS-pixel light-gray
   border and only the resize handles supported by the selected authored item.
 - Use no selection fill; authored content must remain visible and color-accurate.
@@ -351,8 +356,7 @@ A primary click inside the graphics canvas with no selectable candidate MUST:
 - remove hover and selection chrome
 
 The synthetic preview background counts as empty space. Clicking UI outside the
-design canvas does not implicitly clear canvas selection. `Escape` SHOULD also
-clear selection, unless a higher-priority dialog or input owns the key.
+design canvas does not implicitly clear canvas selection.
 
 ### Pointer gesture boundary
 
@@ -515,7 +519,8 @@ At all times:
 - there is at most one authored selected item
 - there is at most one hovered render occurrence
 - a selected occurrence, when present, maps to `selectedItemId`
-- hover resolution and click resolution use the same hit index and resolver
+- hover resolution and click resolution use the same live renderer hit results
+  and resolver
 - hover never mutates authored selection
 - selection never mutates project data
 - editor chrome never participates in content hit testing
@@ -523,8 +528,7 @@ At all times:
 
 ## Acceptance Scenarios
 
-The implementation is complete only when automated coverage proves all of the
-following:
+The following scenarios define the implemented behavior:
 
 1. A top-level image highlights on hover and selects on click.
 2. Hover and click over a child select its top-level container.
@@ -557,11 +561,12 @@ following:
 18. Selection handles and move/resize drags continue to work without selecting
     content behind the overlay.
 
-Pure resolver tests SHOULD cover hierarchy, paint order, visibility, clipping,
-selection-owner mapping, and occurrence fallback. Canvas integration tests
-SHOULD cover pointer/modifier sequences and synchronization. VT coverage SHOULD
-capture at least normal hover, deep hover, parent selection, deep selection,
-and overlap selection with stable pointer positions.
+Current unit and integration coverage verifies hierarchy resolution, paint-order
+handoff, selection-owner mapping, fragment boundaries, repeated occurrences,
+editor-chrome hit handling, pointer selection, and explorer/detail
+synchronization. Route Graphics owns coverage for live transformed bounds,
+clipping, text whitespace, sprite bounds, and renderer paint order. Dedicated VT
+coverage for canvas hover and selection remains future work.
 
 ## Implementation Boundaries
 
@@ -578,8 +583,9 @@ This specification fits the existing architecture as follows:
 - Route Graphics owns low-level transformed hit testing when the renderer must
   expose it; page handlers must not inspect Pixi or browser globals directly.
 
-The resolved render tree and hit index SHOULD be cached per successful canvas
-render. Pointer movement should query that cache and update editor chrome only.
+The resolved render elements and authored-occurrence metadata SHOULD be cached
+per successful canvas render. Pointer movement should query Route Graphics'
+live transformed render tree and update editor chrome only.
 The implementation MUST NOT add selection behavior by attaching authored
 runtime interaction payloads to every layout element, because doing so mixes
 editor intent with game-runtime behavior.

--- a/docs/layout-editor-canvas-selection-spec.md
+++ b/docs/layout-editor-canvas-selection-spec.md
@@ -1,0 +1,609 @@
+# Layout Editor Canvas Hover And Selection Specification
+
+Status: Proposed implementation specification
+
+Last updated: 2026-07-20
+
+## Purpose
+
+The layout editor canvas must let users discover and select authored layout
+elements directly, using interaction rules familiar from Figma.
+
+This document defines exactly:
+
+- which element is highlighted while the pointer hovers the canvas
+- which element is selected by a primary click
+- how nesting and containers change the result
+- how overlapping elements are ordered
+- how RouteVN-specific rendered output maps back to an authored element
+- how canvas selection synchronizes with the existing node explorer and detail
+  panel
+
+This is a behavior specification, not an implementation plan. The normative
+terms **MUST**, **MUST NOT**, **SHOULD**, and **MAY** describe requirements.
+
+## Scope
+
+The first implementation covers single selection in the layout editor's design
+canvas:
+
+- pointer hover
+- primary click or tap
+- double-click to descend through nested containers
+- deep select with `Command` on macOS or `Control` on Windows and Linux
+- selection clearing from empty canvas space
+- synchronization with the node explorer and detail panel
+
+The separate interactive Preview surface is not changed by this specification.
+
+The following Figma features are intentionally deferred:
+
+- multiple selection and `Shift`-click
+- selection marquee
+- a right-click **Select layer** menu
+- canvas keyboard traversal with `Enter`, `Shift+Enter`, `Tab`, and
+  `Shift+Tab`
+- locked elements
+- a user preference to disable hover highlighting
+- outline mode
+
+The node explorer remains the way to select an element behind another element
+until **Select layer** is implemented. It also remains the complete keyboard
+selection path.
+
+## Research Baseline
+
+Figma's documented behavior establishes these rules:
+
+1. An ordinary canvas click selects a parent by default when the visible object
+   is nested in a frame or group.
+2. Double-clicking descends one level of nesting. Repeating the action descends
+   again.
+3. Holding `Command` on macOS or `Control` on Windows performs a deep select.
+   Figma describes this as highlighting and selecting the deepest visible layer
+   under the pointer.
+4. Layer order controls visual overlap: layers drawn above other layers are in
+   front of them.
+5. A right-click **Select layer** menu is Figma's explicit way to choose from
+   layers underneath one pointer position.
+6. Hidden layers do not participate in Figma's normal canvas selection. Locked
+   layers are also skipped by normal left-click selection.
+7. Clicking empty canvas space or pressing `Escape` clears selection.
+
+Primary sources, accessed 2026-07-20:
+
+- [Select layers and objects](https://help.figma.com/hc/en-us/articles/360040449873-Select-layers-and-objects)
+- [The UX writer's guide to Figma](https://www.figma.com/best-practices/the-ux-writers-guide-to-figma/)
+- [Layers 101: Get started with layers](https://help.figma.com/hc/en-us/articles/26584819173271-Layers-101-Get-started-with-layers)
+- [Parent, child, and sibling relationships](https://help.figma.com/hc/en-us/articles/360039959014-Parent-child-and-sibling-relationships)
+- [Lock and unlock layers](https://help.figma.com/hc/en-us/articles/360041596573-Lock-and-unlock-layers)
+
+Figma's public documentation does not specify every low-level hit-testing
+detail, nor can it define RouteVN concepts such as repeated preview instances
+and fragment references. Those behaviors are explicit RouteVN product
+decisions below. They follow Figma's hierarchy and stacking model without
+pretending that the two document models are identical.
+
+## Terms
+
+### Authored item
+
+An item stored in the current layout's `elements.items` and shown in the node
+explorer. Selection is always expressed as the id of one authored item.
+
+### Render occurrence
+
+One concrete, parsed graphics element visible in the current canvas preview.
+One authored item can produce zero, one, or many render occurrences.
+
+Examples:
+
+- a normal rectangle produces one occurrence
+- a conditionally hidden item produces zero occurrences
+- a repeated save slot can produce several occurrences
+- a fragment reference produces a wrapper plus graphics compiled from another
+  layout
+
+### Selection owner
+
+The authored item that owns a render occurrence for editor selection. Renderer
+internals and compiled elements that are not independently editable map to an
+authored owner or have no owner.
+
+### Hit path
+
+The ordered authored hierarchy for the frontmost render occurrence under the
+pointer, from a top-level item to the deepest selectable descendant.
+
+For this hierarchy:
+
+```text
+Container A
+└── Container B
+    └── Text C
+```
+
+the hit path over the text is `[A, B, C]`.
+
+### Frontmost
+
+Closest to the user in actual rendered paint order. This term is about visual
+stacking, not hierarchy depth.
+
+### Top-level
+
+An authored item whose parent is the layout root. This term is about hierarchy,
+not visual stacking.
+
+## Selectable Surface
+
+The editor MUST build selection candidates from the same fully resolved and
+parsed render tree used to draw the canvas. It MUST NOT derive selection from
+the repository tree alone, because layout, conditions, fragments, repetition,
+anchors, scaling, rotation, and clipping can change the visible result.
+
+An occurrence participates in hit testing when all of the following are true:
+
+- it has a selection owner in the current layout
+- it is present after template and condition evaluation
+- neither its owner nor an authored ancestor has `hidden: true`
+- it has a non-empty rendered hit region, or it is an ancestor of a hit
+  descendant
+- the pointer lies inside the canvas and inside every clipping ancestor
+
+Hit regions use the occurrence's final transformed layout bounds:
+
+- anchors, scale, rotation, container transforms, and directed layout MUST be
+  applied
+- clipping MUST limit where an occurrence can be hit
+- a rotated item MUST be tested in its rotated geometry, not only its
+  axis-aligned bounding box
+- sprite transparency and text glyph gaps MUST NOT create click-through holes;
+  the full transformed layout bounds are the hit region
+- opacity, including zero opacity, does not make an occurrence hidden; an item
+  that still renders remains selectable by bounds
+- the selection outline, hover outline, anchor marker, and resize handles MUST
+  NOT become selection candidates
+
+For a container:
+
+- positive resolved width and height define a full rectangular hit region
+- if it has no positive resolved bounds, its effective hit region is the union
+  of its selectable descendants
+- an empty container with no positive bounds cannot be selected from the
+  canvas and remains selectable from the node explorer
+- hitting a descendant also puts every selectable authored container ancestor
+  on the hit path
+
+After a target is resolved, its highlight shows the occurrence's full
+transformed bounds, even when only part of those bounds was hittable because of
+clipping. The outer canvas still clips all editor chrome.
+
+## Selection-Owner Mapping
+
+The compile/render path MUST provide explicit selection metadata. Selection
+ownership MUST NOT be recovered by heuristically parsing rendered ids such as
+`-instance-0` or `fragment--child`.
+
+The mapping rules are:
+
+| Rendered content                                                                       | Selection owner                                             |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Normal layout element                                                                  | The authored item with the same semantic identity           |
+| Repeated container occurrence                                                          | The repeated container's authored source item               |
+| Descendant inside a repeated occurrence                                                | That descendant's authored source item                      |
+| Child compiled from a `fragment-ref`                                                   | The outermost `fragment-ref` authored in the current layout |
+| Slider bar, thumb, input internals, particle internals, or other plugin-owned graphics | The authored item that produced the control                 |
+| Synthetic preview background                                                           | None                                                        |
+| Hover/selection overlay and handles                                                    | None                                                        |
+
+Fragment content is atomic in the containing layout editor. Even deep select
+stops at the current layout's `fragment-ref`; editing the referenced layout's
+children requires opening that layout.
+
+For repeated content, the authored id and the occurrence identity are separate:
+
+- selecting any occurrence selects the one authored source item in the node
+  explorer and detail panel
+- the canvas remembers the clicked occurrence as transient UI state and keeps
+  the selection outline on that occurrence
+- edits apply to the authored source and therefore affect every occurrence
+- selecting the item from the node explorer, where there is no occurrence
+  context, uses the first currently rendered occurrence in deterministic render
+  order
+- if the remembered occurrence disappears after preview data changes, the
+  first remaining occurrence becomes primary; if none remain, selection stays
+  in the node explorer/detail panel but no canvas outline is shown
+
+## Hit Resolution And Stacking
+
+At a pointer position, the editor MUST resolve candidates in this order:
+
+1. Gather all selectable rendered occurrences whose hit region contains the
+   point.
+2. Order them from front to back using the graphics renderer's actual recursive
+   paint order and stacking contexts.
+3. Ignore candidates with no selection owner.
+4. Choose the first remaining occurrence as the frontmost occurrence.
+5. Map its render ancestry to a de-duplicated authored hit path.
+6. Apply the normal, deep, or double-click hierarchy rule to that one path.
+
+The current compiled paint order is authoritative. Code MUST NOT assume that
+raw object insertion order or node-explorer display order is always paint
+order. This matters because current layout schema versions transform tree order
+for normal stacking while directed containers preserve layout order.
+
+Normal and deep selection do not cycle through overlapping siblings. Repeated
+clicks at an unchanged position resolve the same frontmost branch. An element
+behind that branch is selected through the node explorer until the deferred
+**Select layer** menu exists.
+
+If the frontmost item is hidden, conditionally absent, clipped out at the
+pointer, or synthetic, it is removed before the winner is chosen. The next
+eligible occurrence behind it can then win.
+
+## Hover Behavior
+
+Hover is a prediction of the target that a primary click with the current
+modifier keys would select.
+
+### Normal hover
+
+With no deep-select modifier, hover highlights the first item in the frontmost
+hit path: the top-level authored item.
+
+Examples:
+
+- hovering a top-level image highlights the image
+- hovering text inside a top-level container highlights the top-level container
+- hovering a deeply nested child still highlights its top-level ancestor
+
+### Deep-select hover
+
+While `Command` on macOS or `Control` on Windows/Linux is held, hover highlights
+the last item in the same frontmost hit path: the deepest selectable authored
+item.
+
+Changing the modifier while the pointer is stationary MUST recompute the hover
+target immediately.
+
+### Hover presentation
+
+- Show a solid, one-CSS-pixel light-gray (`#b3b3b3`) outline around the
+  hovered occurrence with a one-CSS-pixel white outline visible outside it.
+- The white hover rectangle MUST be offset to the exterior of the occurrence;
+  it MUST NOT produce a second white line inside the gray outline.
+- Keep the stroke approximately one CSS pixel at every canvas scale; it MUST
+  NOT become nearly invisible when a high-resolution project is scaled down.
+- Do not show fill, anchor markers, resize handles, or a layer-name label.
+- Draw the hover outline above authored content and below selection handles.
+- When hover and selection chrome are both visible and overlap, the complete
+  hover outline MUST remain behind the complete selected outline, anchor, and
+  resize handles.
+- Hover MUST NOT change `selectedItemId`, the node explorer, the detail panel,
+  or repository state.
+- If hover and selection refer to the same occurrence, show only the stronger
+  selection chrome.
+- If the selected occurrence appears anywhere on the current normal-hover hit
+  path, do not highlight one of its ancestors while the pointer remains over
+  the selected occurrence.
+- If they refer to different occurrences, keep the selection chrome and show
+  the hover outline at the same time.
+- Clear hover when the pointer leaves the canvas, no candidate exists, a drag
+  starts, the canvas is disabled, or the component unmounts.
+
+Hover updates MUST be cheap. Pointer movement MUST NOT reload assets, query the
+repository, or recompile the layout. It MAY submit the cached render tree plus
+the hover rectangles through Route Graphics' element-diff render path. Hit
+testing SHOULD use an index rebuilt only when the resolved render tree changes,
+and visual updates SHOULD be limited to one animation-frame cadence.
+
+## Click Behavior
+
+### Primary click
+
+A primary click with no modifier selects the first item in the frontmost hit
+path: the top-level authored item.
+
+The final click target MUST equal the immediately preceding normal-hover target
+when neither canvas content nor pointer position changed.
+
+### Deep select
+
+`Command`-click on macOS or `Control`-click on Windows/Linux selects the last
+item in the frontmost hit path.
+
+The final target MUST equal the deep-select hover target shown while the
+modifier is held.
+
+### Double-click
+
+Double-click descends exactly one authored hierarchy level along the frontmost
+hit path.
+
+- With no selection on that path, the first click establishes the top-level
+  item and the completed double-click selects the next item in the path.
+- If an item on that path was already selected before the double-click gesture,
+  the completed double-click selects its immediate child on the path.
+- Repeated double-click gestures continue one level at a time.
+- At the deepest selectable item, another double-click leaves selection
+  unchanged.
+- A fragment boundary counts as the deepest level in the containing layout.
+
+The gesture recognizer MUST retain the selection that existed at the start of
+the double-click sequence. The ordinary click event emitted before `dblclick`
+MUST NOT accidentally reset the depth and prevent repeated descent.
+
+### Selection presentation
+
+- Show a persistent solid, one-CSS-pixel light-gray (`#b3b3b3`) outline
+  around the selected occurrence with a one-CSS-pixel white outline visible
+  outside it.
+- The white selection outline MUST be outside the occurrence and the gray
+  outline MUST be inside it, without duplicating either color on both sides of
+  the authored boundary.
+- Keep the stroke approximately two CSS pixels at every canvas scale.
+- Show the existing white anchor marker with its one-CSS-pixel light-gray
+  border and only the resize handles supported by the selected authored item.
+- Use no selection fill; authored content must remain visible and color-accurate.
+- Draw selection chrome above hover chrome and authored content.
+- Keep selection chrome visible after the pointer leaves the canvas.
+- When an authored item has no current render occurrence, keep explorer/detail
+  selection but show no canvas selection chrome.
+
+### Empty space and clearing
+
+A primary click inside the graphics canvas with no selectable candidate MUST:
+
+- clear the page's selected item
+- clear the node explorer selection
+- clear the detail panel selection
+- clear selected occurrence state
+- remove hover and selection chrome
+
+The synthetic preview background counts as empty space. Clicking UI outside the
+design canvas does not implicitly clear canvas selection. `Escape` SHOULD also
+clear selection, matching Figma, unless a higher-priority dialog or input owns
+the key.
+
+### Pointer gesture boundary
+
+- Only the primary button performs selection.
+- Right-click MUST NOT change selection before opening any context menu.
+- A resize handle or anchor marker owns its pointer gesture and MUST NOT cause
+  a hit test against content behind it.
+- The selected occurrence's full move surface owns a drag after movement
+  crosses the threshold. Before that threshold, its click and double-click
+  resolution MUST use the authored content hit path beneath the editor overlay
+  so nested selection remains possible.
+- Once movement crosses the editor's drag threshold, hover clears and the
+  existing move/resize contract takes precedence.
+- A press released after crossing the threshold is a drag, not an additional
+  click selection.
+
+## Containers And Nested Items
+
+Every RouteVN authored container type follows the same hierarchy behavior,
+including specialized container-reference types.
+
+For a hit path `[A, B, C]`:
+
+| Gesture                              | Result             |
+| ------------------------------------ | ------------------ |
+| Hover                                | `A` is highlighted |
+| Click                                | `A` is selected    |
+| First double-click from no selection | `B` is selected    |
+| Next double-click                    | `C` is selected    |
+| `Command`/`Control` hover            | `C` is highlighted |
+| `Command`/`Control` click            | `C` is selected    |
+
+Container direction does not change hierarchy selection. Horizontal and
+vertical containers still act as parents. Direction only affects resolved
+geometry and, where children overlap, actual paint order.
+
+## Overlap Examples
+
+Assume `Front` and `Back` overlap at the pointer.
+
+### Top-level siblings
+
+```text
+Layout root
+├── Front
+└── Back
+```
+
+If `Front` is visually in front, normal and deep hover/click select `Front`.
+They never cycle to `Back`.
+
+### Nested front branch
+
+```text
+Layout root
+├── Front container
+│   └── Front child
+└── Back item
+```
+
+If `Front child` is the frontmost occurrence at the pointer:
+
+- normal hover/click resolves `Front container`
+- deep hover/click resolves `Front child`
+- no gesture in this scope resolves `Back item`
+
+### Overlapping children in one container
+
+```text
+Container A
+├── Child Front
+└── Child Back
+```
+
+At the overlap:
+
+- normal hover/click resolves `Container A`
+- deep hover/click resolves `Child Front`
+- double-click from `Container A` resolves `Child Front`
+
+The renderer's real paint order determines which child is `Child Front`.
+
+## RouteVN Edge-Case Matrix
+
+| Scenario                                 | Normal hover/click                      | Deep hover/click                                           |
+| ---------------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
+| Top-level leaf                           | The leaf                                | The leaf                                                   |
+| Child nested under two containers        | Top-level container                     | Deepest child                                              |
+| Two overlapping top-level leaves         | Frontmost eligible leaf                 | Same frontmost eligible leaf                               |
+| Hidden front item over visible back item | Visible back item                       | Visible back item                                          |
+| Child clipped out at the pointer         | Next eligible hit behind it, or none    | Same                                                       |
+| Zero-opacity but rendered item           | The item or its top-level ancestor      | The item                                                   |
+| Empty positive-size container area       | The top-level container on that path    | Deepest container on that path                             |
+| Empty zero-size container                | No canvas target                        | No canvas target                                           |
+| Synthetic preview background             | No canvas target                        | No canvas target                                           |
+| Child rendered from a fragment           | Current layout's `fragment-ref`         | Same `fragment-ref`                                        |
+| Third occurrence of a repeated child     | Its top-level source ancestor           | Child's authored source id, with occurrence three retained |
+| Slider thumb or bar                      | Slider or its top-level source ancestor | Authored slider                                            |
+
+## Selection Synchronization
+
+The page's `selectedItemId` remains the canonical authored selection. Canvas
+selection MUST use the same page-level path as node-explorer selection.
+
+When the canvas selects an item, it MUST:
+
+1. dispatch one canonical selection event containing at least `itemId` and the
+   transient occurrence identity
+2. update page `selectedItemId`
+3. select and reveal that item in the node explorer
+4. synchronize the detail panel to the same item
+5. render the selection overlay around the chosen occurrence
+
+Selection MUST NOT submit a project command or otherwise persist data.
+
+Hover state and occurrence identity belong to the mounted canvas instance as
+plain UI state. They are not project semantics and MUST NOT be stored in the
+repository. Handlers MUST NOT keep them in module-scoped mutable state or on a
+`refs.__...Runtime` property.
+
+If the selected item is deleted, page selection and occurrence state MUST
+clear. If it remains authored but has no current occurrence because it is
+hidden or its condition is false, the node explorer and detail panel MAY remain
+selected while the canvas shows no selection outline.
+
+## Editor Versus Runtime Interactions
+
+Canvas selection is observational. It MUST NOT disable, replace, cancel, or
+stop propagation of Route Graphics interactions.
+
+While the pointer is interacting with the design canvas:
+
+- authored hover and click visuals continue to run
+- renderer-managed input, slider, scroll, sound, and pointer behavior continue
+  to run
+- the editor observes the same pointer gesture to update selection
+- selection and hover resolution MUST NOT call `preventDefault()` or
+  `stopPropagation()` on an authored-content gesture
+
+Selection and resize handles are the exception because they are explicit editor
+chrome and already own their move/resize gestures. Whether an authored action
+payload has a Route Engine consumer remains an existing canvas integration
+decision; canvas selection itself neither enables nor suppresses those actions.
+
+## Touch Behavior
+
+Touch has no hover state.
+
+- A single tap uses the normal primary-click rule.
+- The tapped item synchronizes with the mobile node explorer and detail view.
+- Deep selection by modifier and nested double-tap selection are not required
+  for the first touch implementation.
+- Nested or obscured items remain selectable through the node explorer on
+  touch devices.
+
+## Required State Invariants
+
+At all times:
+
+- there is at most one authored selected item
+- there is at most one hovered render occurrence
+- a selected occurrence, when present, maps to `selectedItemId`
+- hover resolution and click resolution use the same hit index and resolver
+- hover never mutates authored selection
+- selection never mutates project data
+- editor chrome never participates in content hit testing
+- selection observation does not suppress authored renderer interactions
+
+## Acceptance Scenarios
+
+The implementation is complete only when automated coverage proves all of the
+following:
+
+1. A top-level image highlights on hover and selects on click.
+2. Hover and click over a child select its top-level container.
+3. One double-click selects the next nested level and repeated double-clicks
+   continue one level at a time.
+4. `Command`/`Control` changes both stationary hover and click to the deepest
+   selectable item.
+5. Two overlapping siblings resolve the actual frontmost rendered sibling.
+6. Normal and deep clicks do not cycle to an obscured sibling.
+7. Hidden, conditionally absent, clipped-out, and synthetic elements are not
+   selected.
+8. Rotated, scaled, and anchored elements use their final transformed hit
+   regions.
+9. Transparent sprite pixels and text whitespace still hit the element's
+   bounds.
+10. A container is selected from its bounds and from hits on its descendants.
+11. Fragment content selects the current layout's fragment reference, including
+    with deep select.
+12. Clicking a repeated occurrence selects its authored source while preserving
+    that occurrence for the canvas outline.
+13. Node-explorer selection of a repeated source outlines the deterministic
+    first occurrence.
+14. Blank space clears the canvas, node explorer, and detail-panel selection.
+15. Selecting on the canvas reveals the same item in the node explorer and
+    opens the same detail content as explorer selection.
+16. Hover causes no repository read/write, asset load, or layout recompile; it
+    only updates cached Route Graphics elements through the renderer diff.
+17. Editor selection preserves authored hover/click visuals and existing
+    renderer-managed sounds, inputs, sliders, and scrolling.
+18. Selection handles and move/resize drags continue to work without selecting
+    content behind the overlay.
+
+Pure resolver tests SHOULD cover hierarchy, paint order, visibility, clipping,
+selection-owner mapping, and occurrence fallback. Canvas integration tests
+SHOULD cover pointer/modifier sequences and synchronization. VT coverage SHOULD
+capture at least normal hover, deep hover, parent selection, deep selection,
+and overlap selection with stable pointer positions.
+
+## Implementation Boundaries
+
+This specification fits the existing architecture as follows:
+
+- `layoutEditorCanvas` owns local pointer input, transient hover/occurrence
+  state, hit-testing integration, and editor chrome.
+- A pure selection resolver owns frontmost ordering, authored hit-path
+  construction, and normal/deep/double target resolution.
+- The layout compile/render path owns explicit occurrence-to-authored-item
+  metadata, including fragment and repetition boundaries.
+- The layout editor page owns canonical `selectedItemId`, node-explorer sync,
+  detail-panel sync, and deselection orchestration.
+- Route Graphics owns low-level transformed hit testing when the renderer must
+  expose it; page handlers must not inspect Pixi or browser globals directly.
+
+The resolved render tree and hit index SHOULD be cached per successful canvas
+render. Pointer movement should query that cache and update editor chrome only.
+The implementation MUST NOT add selection behavior by attaching authored
+runtime interaction payloads to every layout element, because doing so mixes
+editor intent with game-runtime behavior.
+
+## Deferred Figma Parity
+
+When a **Select layer** context menu is added, it should list unique selection
+owners under the pointer in front-to-back order, identify repeated occurrences,
+exclude hidden/absent content, and allow choosing an item behind the normal
+winner. Its exact menu behavior requires a separate specification because it
+also intersects the layout editor's existing create/edit context menu.
+
+Multiple selection and marquee selection also require a separate specification
+and a page selection model that can represent more than one authored id. They
+must not be partially introduced into this single-selection contract.

--- a/docs/layout-editor-canvas-selection-spec.md
+++ b/docs/layout-editor-canvas-selection-spec.md
@@ -284,6 +284,8 @@ target immediately.
   the hover outline at the same time.
 - Clear hover when the pointer leaves the canvas, no candidate exists, a drag
   starts, or the component unmounts.
+- After a full canvas render, restore the hover outline for an eligible
+  stationary pointer without requiring additional pointer movement.
 
 Hover updates MUST be cheap. Pointer movement MUST NOT reload assets, query the
 repository, or recompile the layout. It MAY submit the cached render tree plus
@@ -337,6 +339,8 @@ MUST NOT accidentally reset the depth and prevent repeated descent.
   the authored boundary.
 - Keep each outline approximately one CSS pixel at every canvas scale. Together,
   the exterior white and interior gray bands span approximately two CSS pixels.
+- When the canvas's CSS size changes, recompute renderer units per CSS pixel and
+  rebuild hover, selection, anchor, and resize chrome from cached render data.
 - Show the existing white anchor marker with its one-CSS-pixel light-gray
   border and only the resize handles supported by the selected authored item.
 - Use no selection fill; authored content must remain visible and color-accurate.

--- a/docs/layout-editor-canvas-selection-spec.md
+++ b/docs/layout-editor-canvas-selection-spec.md
@@ -341,8 +341,8 @@ MUST NOT accidentally reset the depth and prevent repeated descent.
   the exterior white and interior gray bands span approximately two CSS pixels.
 - When the canvas's CSS size changes, recompute renderer units per CSS pixel and
   rebuild hover, selection, anchor, and resize chrome from cached render data.
-- Show the existing white anchor marker with its one-CSS-pixel light-gray
-  border and only the resize handles supported by the selected authored item.
+- Show a circular white anchor marker with its one-CSS-pixel light-gray border
+  and only the resize handles supported by the selected authored item.
 - Use no selection fill; authored content must remain visible and color-accurate.
 - Draw selection chrome above hover chrome and authored content.
 - Keep selection chrome visible after the pointer leaves the canvas.

--- a/docs/layout-editor-canvas-selection-spec.md
+++ b/docs/layout-editor-canvas-selection-spec.md
@@ -2,12 +2,13 @@
 
 Status: Proposed implementation specification
 
-Last updated: 2026-07-20
+Last updated: 2026-07-21
 
 ## Purpose
 
 The layout editor canvas must let users discover and select authored layout
-elements directly, using interaction rules familiar from Figma.
+elements directly, using interaction rules familiar from layered graphics
+editors.
 
 This document defines exactly:
 
@@ -36,7 +37,7 @@ canvas:
 
 The separate interactive Preview surface is not changed by this specification.
 
-The following Figma features are intentionally deferred:
+The following advanced canvas features are intentionally deferred:
 
 - multiple selection and `Shift`-click
 - selection marquee
@@ -51,38 +52,26 @@ The node explorer remains the way to select an element behind another element
 until **Select layer** is implemented. It also remains the complete keyboard
 selection path.
 
-## Research Baseline
+## Interaction Baseline
 
-Figma's documented behavior establishes these rules:
+The canvas interaction model establishes these rules:
 
 1. An ordinary canvas click selects a parent by default when the visible object
    is nested in a frame or group.
 2. Double-clicking descends one level of nesting. Repeating the action descends
    again.
 3. Holding `Command` on macOS or `Control` on Windows performs a deep select.
-   Figma describes this as highlighting and selecting the deepest visible layer
-   under the pointer.
+   This highlights and selects the deepest visible layer under the pointer.
 4. Layer order controls visual overlap: layers drawn above other layers are in
    front of them.
-5. A right-click **Select layer** menu is Figma's explicit way to choose from
+5. A right-click **Select layer** menu provides an explicit way to choose from
    layers underneath one pointer position.
-6. Hidden layers do not participate in Figma's normal canvas selection. Locked
-   layers are also skipped by normal left-click selection.
+6. Hidden and locked layers do not participate in normal canvas selection.
 7. Clicking empty canvas space or pressing `Escape` clears selection.
 
-Primary sources, accessed 2026-07-20:
-
-- [Select layers and objects](https://help.figma.com/hc/en-us/articles/360040449873-Select-layers-and-objects)
-- [The UX writer's guide to Figma](https://www.figma.com/best-practices/the-ux-writers-guide-to-figma/)
-- [Layers 101: Get started with layers](https://help.figma.com/hc/en-us/articles/26584819173271-Layers-101-Get-started-with-layers)
-- [Parent, child, and sibling relationships](https://help.figma.com/hc/en-us/articles/360039959014-Parent-child-and-sibling-relationships)
-- [Lock and unlock layers](https://help.figma.com/hc/en-us/articles/360041596573-Lock-and-unlock-layers)
-
-Figma's public documentation does not specify every low-level hit-testing
-detail, nor can it define RouteVN concepts such as repeated preview instances
-and fragment references. Those behaviors are explicit RouteVN product
-decisions below. They follow Figma's hierarchy and stacking model without
-pretending that the two document models are identical.
+The baseline does not prescribe every low-level hit-testing detail or define
+RouteVN concepts such as repeated preview instances and fragment references.
+Those behaviors are explicit RouteVN product decisions below.
 
 ## Terms
 
@@ -363,8 +352,7 @@ A primary click inside the graphics canvas with no selectable candidate MUST:
 
 The synthetic preview background counts as empty space. Clicking UI outside the
 design canvas does not implicitly clear canvas selection. `Escape` SHOULD also
-clear selection, matching Figma, unless a higher-priority dialog or input owns
-the key.
+clear selection, unless a higher-priority dialog or input owns the key.
 
 ### Pointer gesture boundary
 
@@ -596,7 +584,7 @@ The implementation MUST NOT add selection behavior by attaching authored
 runtime interaction payloads to every layout element, because doing so mixes
 editor intent with game-runtime behavior.
 
-## Deferred Figma Parity
+## Deferred Canvas Features
 
 When a **Select layer** context menu is added, it should list unique selection
 owners under the pointer in front-to-back order, identify repeated occurrences,

--- a/docs/layout-editor-end-state-architecture.md
+++ b/docs/layout-editor-end-state-architecture.md
@@ -166,6 +166,9 @@ It must be pure and deterministic.
 - selection/overlay orchestration
 - editor-side persistence policy
 
+Canvas hover, hit testing, nesting, overlap, and selection behavior are defined
+in `docs/layout-editor-canvas-selection-spec.md`.
+
 It may depend on project semantics, but it must not redefine them.
 
 ### Client Right Panel UI

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
     "route-engine-js": "1.29.2",
-    "route-graphics": "1.28.1",
+    "route-graphics": "1.29.0",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",
     "snabbdom-to-html": "7.1.0",

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -11,9 +11,16 @@ import {
 import { captureCanvasThumbnailImage } from "../../internal/runtime/graphicsEngineRuntime.js";
 import {
   createLayoutEditorAssetReferences,
+  createLayoutEditorHoverOverlay,
   createLayoutEditorRenderedElements,
   loadLayoutEditorAssets,
 } from "./support/layoutEditorCanvasRender.js";
+import {
+  resolveLayoutEditorCanvasHitPath,
+  selectLayoutEditorCanvasHit,
+  selectLayoutEditorCanvasHover,
+  selectNextLayoutEditorCanvasHit,
+} from "./support/layoutEditorCanvasSelection.js";
 
 const KEYBOARD_SAVE_DELAY = 1000;
 
@@ -23,6 +30,7 @@ const KEYBOARD_UNITS = {
 };
 const MIN_RESIZE_DIMENSION = 1;
 const RESIZE_TARGET_PREFIX = "selected-border-resize-";
+const POINTER_DRAG_THRESHOLD = 4;
 
 const mountSubscriptions = (deps) => {
   const streams = subscriptions(deps) || [];
@@ -249,6 +257,192 @@ const getDragModeFromTargetId = (targetId) => {
   return "move";
 };
 
+const isDeepSelectModifierActive = (event = {}) => {
+  return event.metaKey === true || event.ctrlKey === true;
+};
+
+const toRendererPointerPosition = (deps, event = {}) => {
+  const canvasBounds = deps.refs.canvas.getBoundingClientRect();
+  if (canvasBounds.width <= 0 || canvasBounds.height <= 0) {
+    return undefined;
+  }
+
+  const { width, height } = requireCanvasResolution(deps.props);
+  const localX = event.clientX - canvasBounds.left;
+  const localY = event.clientY - canvasBounds.top;
+
+  if (
+    localX < 0 ||
+    localY < 0 ||
+    localX > canvasBounds.width ||
+    localY > canvasBounds.height
+  ) {
+    return undefined;
+  }
+
+  return {
+    x: (localX / canvasBounds.width) * width,
+    y: (localY / canvasBounds.height) * height,
+    clientX: event.clientX,
+    clientY: event.clientY,
+  };
+};
+
+const getCanvasUnitsPerCssPixel = (deps, props = deps.props) => {
+  const canvasBounds = deps.refs.canvas.getBoundingClientRect();
+  if (canvasBounds.width <= 0) {
+    return 1;
+  }
+
+  const { width } = requireCanvasResolution(props);
+  return width / canvasBounds.width;
+};
+
+const hitTestCanvasPosition = (deps, position) => {
+  if (!position) {
+    return {
+      blocked: false,
+      path: [],
+    };
+  }
+
+  const hits = deps.graphicsService.hitTestElementBounds({
+    x: position.x,
+    y: position.y,
+  });
+
+  return resolveLayoutEditorCanvasHitPath({
+    hits,
+    occurrencesById: deps.store.selectSelectionOccurrencesById(),
+  });
+};
+
+const areBoundsCornersEqual = (left, right) => {
+  const leftCorners = left?.corners ?? [];
+  const rightCorners = right?.corners ?? [];
+
+  return (
+    leftCorners.length === rightCorners.length &&
+    leftCorners.every((corner, index) => {
+      return (
+        corner.x === rightCorners[index]?.x &&
+        corner.y === rightCorners[index]?.y
+      );
+    })
+  );
+};
+
+const areCanvasSelectionsEqual = (left, right) => {
+  if (!left || !right) {
+    return left === right;
+  }
+
+  return (
+    left.itemId === right.itemId &&
+    left.occurrenceId === right.occurrenceId &&
+    areBoundsCornersEqual(left.bounds, right.bounds)
+  );
+};
+
+const renderCanvasHoverOverlay = (deps, selection) => {
+  const { elements, canvasUnitsPerCssPixel } =
+    deps.store.selectCanvasRenderState();
+  if (elements.length === 0) {
+    return;
+  }
+
+  const hoverElements = createLayoutEditorHoverOverlay({
+    bounds: selection?.bounds,
+    canvasUnitsPerCssPixel,
+  });
+  const selectionOverlayIndex = elements.findIndex(({ id }) => {
+    return id?.startsWith("selected-border");
+  });
+  const renderedElements =
+    selectionOverlayIndex < 0
+      ? [...elements, ...hoverElements]
+      : [
+          ...elements.slice(0, selectionOverlayIndex),
+          ...hoverElements,
+          ...elements.slice(selectionOverlayIndex),
+        ];
+  deps.graphicsService.render({
+    elements: renderedElements,
+    animations: [],
+  });
+};
+
+const clearCanvasHover = (deps) => {
+  if (!deps.store.selectHoveredSelection()) {
+    return;
+  }
+
+  deps.store.clearHoveredSelection();
+  renderCanvasHoverOverlay(deps);
+};
+
+const updateCanvasHover = (deps) => {
+  const position = deps.store.selectLastPointerPosition();
+  const pointerGesture = deps.store.selectPointerGesture();
+  if (!position || pointerGesture?.moved === true) {
+    clearCanvasHover(deps);
+    return;
+  }
+
+  const hitResolution = hitTestCanvasPosition(deps, position);
+  const selection = selectLayoutEditorCanvasHover(hitResolution, {
+    deepSelect: deps.store.selectDeepSelectActive(),
+    selectedOccurrenceId: deps.store.selectResolvedSelectedOccurrenceId(),
+  });
+  const currentSelection = deps.store.selectHoveredSelection();
+
+  if (areCanvasSelectionsEqual(currentSelection, selection)) {
+    return;
+  }
+
+  deps.store.setHoveredSelection({ selection });
+  renderCanvasHoverOverlay(deps, selection);
+};
+
+const scheduleCanvasHoverUpdate = (deps) => {
+  if (deps.store.selectHoverFrameId() !== undefined) {
+    return;
+  }
+
+  if (typeof globalThis.requestAnimationFrame !== "function") {
+    updateCanvasHover(deps);
+    return;
+  }
+
+  const frameId = globalThis.requestAnimationFrame(() => {
+    deps.store.setHoverFrameId({ frameId: undefined });
+    updateCanvasHover(deps);
+  });
+  deps.store.setHoverFrameId({ frameId });
+};
+
+const dispatchCanvasSelection = (deps, selection) => {
+  if (selection) {
+    deps.store.setSelectedOccurrence({
+      occurrenceId: selection.occurrenceId,
+      ownerItemId: selection.itemId,
+    });
+  } else {
+    deps.store.clearSelectedOccurrence();
+  }
+
+  deps.dispatchEvent(
+    new CustomEvent("selection-change", {
+      detail: {
+        itemId: selection?.itemId,
+        occurrenceId: selection?.occurrenceId,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
 export const applyCanvasItemKeyboardChange = ({
   item,
   key,
@@ -394,16 +588,24 @@ const renderLayoutEditorCanvas = async (
       layoutSchemaVersion: props.layoutState?.layoutSchemaVersion,
       elements: layoutData,
     };
-    const { elements, fileReferences, selectedElementMetrics } =
-      createLayoutEditorRenderedElements({
-        layoutState,
-        repositoryState,
-        previewData: props.previewData,
-        resolution: props.resolution,
-        selectedItemId: props.selectedItemId,
-        disableMoveDrag: props.disableMoveDrag === true,
-        graphicsService: deps.graphicsService,
-      });
+    const canvasUnitsPerCssPixel = getCanvasUnitsPerCssPixel(deps, props);
+    const {
+      elements,
+      fileReferences,
+      selectedElementMetrics,
+      occurrencesById,
+      occurrenceIdsByOwner,
+    } = createLayoutEditorRenderedElements({
+      layoutState,
+      repositoryState,
+      previewData: props.previewData,
+      resolution: props.resolution,
+      selectedItemId: props.selectedItemId,
+      selectedOccurrenceId: deps.store.selectSelectedOccurrenceId(),
+      disableMoveDrag: props.disableMoveDrag === true,
+      canvasUnitsPerCssPixel,
+      graphicsService: deps.graphicsService,
+    });
     if (finishStaleCanvasRender(deps, renderRequestId)) {
       return;
     }
@@ -467,6 +669,17 @@ const renderLayoutEditorCanvas = async (
       elements,
       animations: [],
     });
+    deps.store.setCanvasRenderState({
+      elements,
+      canvasUnitsPerCssPixel,
+    });
+    deps.store.setSelectionOccurrences({
+      occurrencesById,
+      occurrenceIdsByOwner,
+    });
+    if (deps.store.selectLastPointerPosition()) {
+      scheduleCanvasHoverUpdate(deps);
+    }
   } catch (error) {
     console.error("[layoutEditorCanvas] Failed to render canvas", error);
   }
@@ -486,6 +699,177 @@ const initCanvasGraphics = async (deps, props = deps.props) => {
 
 export const handleCaptureThumbnailImage = async (deps) => {
   return captureCanvasThumbnailImage(deps.graphicsService, deps.refs.canvas);
+};
+
+export const handleCanvasPointerMove = (deps, payload) => {
+  const event = payload._event;
+  const position = toRendererPointerPosition(deps, event);
+  const deepSelectActive = isDeepSelectModifierActive(event);
+  deps.store.setDeepSelectActive({ value: deepSelectActive });
+
+  if (!position) {
+    deps.store.clearLastPointerPosition();
+    clearCanvasHover(deps);
+    return;
+  }
+
+  deps.store.setLastPointerPosition({ position });
+  const pointerGesture = deps.store.selectPointerGesture();
+  if (
+    pointerGesture?.pointerId === event.pointerId &&
+    pointerGesture.moved !== true
+  ) {
+    const distance = Math.hypot(
+      position.clientX - pointerGesture.startClientX,
+      position.clientY - pointerGesture.startClientY,
+    );
+
+    if (distance >= POINTER_DRAG_THRESHOLD) {
+      deps.store.setPointerGesture({
+        gesture: {
+          ...pointerGesture,
+          moved: true,
+        },
+      });
+      clearCanvasHover(deps);
+      return;
+    }
+  }
+
+  scheduleCanvasHoverUpdate(deps);
+};
+
+export const handleCanvasPointerLeave = (deps) => {
+  deps.store.clearLastPointerPosition();
+  clearCanvasHover(deps);
+};
+
+export const handleCanvasPointerDown = (deps, payload) => {
+  const event = payload._event;
+  if (event.button !== 0 || event.isPrimary === false) {
+    return;
+  }
+
+  const position = toRendererPointerPosition(deps, event);
+  const hitResolution = hitTestCanvasPosition(deps, position);
+  deps.store.clearPendingClickGesture();
+
+  if (!position || hitResolution.blocked === true) {
+    deps.store.clearPointerGesture();
+    clearCanvasHover(deps);
+    return;
+  }
+
+  deps.store.setPointerGesture({
+    gesture: {
+      pointerId: event.pointerId,
+      startClientX: position.clientX,
+      startClientY: position.clientY,
+      hitResolution,
+      selectedItemIdAtStart: deps.props.selectedItemId,
+      moved: false,
+    },
+  });
+};
+
+export const handleCanvasPointerUp = (deps, payload) => {
+  const event = payload._event;
+  const pointerGesture = deps.store.selectPointerGesture();
+  if (!pointerGesture || pointerGesture.pointerId !== event.pointerId) {
+    return;
+  }
+
+  deps.store.clearPointerGesture();
+  if (pointerGesture.moved === true) {
+    deps.store.clearPendingClickGesture();
+    return;
+  }
+
+  deps.store.setPendingClickGesture({
+    gesture: {
+      hitResolution: pointerGesture.hitResolution,
+      selectedItemIdAtStart: pointerGesture.selectedItemIdAtStart,
+    },
+  });
+};
+
+export const handleCanvasPointerCancel = (deps) => {
+  deps.store.clearPointerGesture();
+  deps.store.clearPendingClickGesture();
+  clearCanvasHover(deps);
+};
+
+export const handleCanvasClick = (deps, payload) => {
+  const event = payload._event;
+  const clickGesture = deps.store.selectPendingClickGesture();
+  deps.store.clearPendingClickGesture();
+
+  if (!clickGesture) {
+    return;
+  }
+
+  const clickCount = event.detail ?? 1;
+  const currentSequence = deps.store.selectDoubleClickSequence();
+  if (clickCount > 1) {
+    deps.store.setDoubleClickSequence({
+      sequence: {
+        selectedItemIdAtStart:
+          currentSequence?.selectedItemIdAtStart ??
+          clickGesture.selectedItemIdAtStart,
+        hitResolution: clickGesture.hitResolution,
+      },
+    });
+    return;
+  }
+
+  deps.store.setDoubleClickSequence({
+    sequence: {
+      selectedItemIdAtStart: clickGesture.selectedItemIdAtStart,
+      hitResolution: clickGesture.hitResolution,
+    },
+  });
+  const selection = selectLayoutEditorCanvasHit(clickGesture.hitResolution, {
+    deepSelect: isDeepSelectModifierActive(event),
+  });
+  dispatchCanvasSelection(deps, selection);
+};
+
+export const handleCanvasDoubleClick = (deps) => {
+  const sequence = deps.store.selectDoubleClickSequence();
+  deps.store.clearDoubleClickSequence();
+  deps.store.clearPendingClickGesture();
+  if (!sequence) {
+    return;
+  }
+
+  const selection = selectNextLayoutEditorCanvasHit(sequence.hitResolution, {
+    selectedItemId: sequence.selectedItemIdAtStart,
+  });
+  dispatchCanvasSelection(deps, selection);
+};
+
+const handleCanvasModifierChange = (deps, event) => {
+  if (event.key !== "Meta" && event.key !== "Control") {
+    return;
+  }
+
+  const deepSelectActive = isDeepSelectModifierActive(event);
+  if (deps.store.selectDeepSelectActive() === deepSelectActive) {
+    return;
+  }
+
+  deps.store.setDeepSelectActive({ value: deepSelectActive });
+  if (deps.store.selectLastPointerPosition()) {
+    scheduleCanvasHoverUpdate(deps);
+  }
+};
+
+export const handleUseDefaultSelectionOccurrence = async (deps) => {
+  deps.store.clearSelectedOccurrence();
+  await renderLayoutEditorCanvas(deps, deps.props, {
+    updatedItem: deps.store.selectPendingUpdatedItem(),
+    reason: "default-selection-occurrence",
+  });
 };
 
 const handleKeyboardMove = async (deps, event) => {
@@ -546,6 +930,9 @@ const handleBorderDragStart = (deps, payload = {}) => {
   deps.store.startDragging({
     dragMode,
   });
+  deps.store.clearPointerGesture();
+  deps.store.clearPendingClickGesture();
+  clearCanvasHover(deps);
   deps.render();
 };
 
@@ -640,6 +1027,16 @@ const subscriptions = (deps) => {
         handleKeyboardMove(deps, event);
       }),
     ),
+    fromEvent(window, "keydown").pipe(
+      tap((event) => {
+        handleCanvasModifierChange(deps, event);
+      }),
+    ),
+    fromEvent(window, "keyup").pipe(
+      tap((event) => {
+        handleCanvasModifierChange(deps, event);
+      }),
+    ),
     subject.pipe(
       filter(({ action }) => action === "border-drag-start"),
       tap(({ payload }) => {
@@ -682,6 +1079,13 @@ export const handleBeforeMount = (deps) => {
   const cleanupSubscriptions = mountSubscriptions(deps);
 
   return () => {
+    const hoverFrameId = deps.store.selectHoverFrameId();
+    if (
+      hoverFrameId !== undefined &&
+      typeof globalThis.cancelAnimationFrame === "function"
+    ) {
+      globalThis.cancelAnimationFrame(hoverFrameId);
+    }
     cleanupSubscriptions?.();
     void deps.graphicsService.destroy();
   };
@@ -737,6 +1141,13 @@ export const handleOnUpdate = async (deps, changes) => {
 
   if (!deps.store.selectIsGraphicsReady()) {
     return;
+  }
+
+  if (
+    deps.store.selectSelectedOccurrenceOwnerId() &&
+    deps.store.selectSelectedOccurrenceOwnerId() !== newProps.selectedItemId
+  ) {
+    deps.store.clearSelectedOccurrence();
   }
 
   const pendingUpdatedItem = deps.store.selectPendingUpdatedItem();

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -13,6 +13,7 @@ import {
   createLayoutEditorAssetReferences,
   createLayoutEditorHoverOverlay,
   createLayoutEditorRenderedElements,
+  createLayoutEditorSelectionRenderState,
   loadLayoutEditorAssets,
 } from "./support/layoutEditorCanvasRender.js";
 import {
@@ -285,6 +286,7 @@ const toRendererPointerPosition = (deps, event = {}) => {
     y: (localY / canvasBounds.height) * height,
     clientX: event.clientX,
     clientY: event.clientY,
+    pointerType: event.pointerType,
   };
 };
 
@@ -384,7 +386,11 @@ const clearCanvasHover = (deps) => {
 const updateCanvasHover = (deps) => {
   const position = deps.store.selectLastPointerPosition();
   const pointerGesture = deps.store.selectPointerGesture();
-  if (!position || pointerGesture?.moved === true) {
+  if (
+    !position ||
+    position.pointerType === "touch" ||
+    pointerGesture?.moved === true
+  ) {
     clearCanvasHover(deps);
     return;
   }
@@ -421,7 +427,75 @@ const scheduleCanvasHoverUpdate = (deps) => {
   deps.store.setHoverFrameId({ frameId });
 };
 
+const dispatchSelectedElementMetrics = (deps, { itemId, metrics } = {}) => {
+  deps.dispatchEvent(
+    new CustomEvent("selected-element-metrics-change", {
+      detail: {
+        itemId,
+        metrics,
+      },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+const restoreCanvasHoverAfterRender = (deps) => {
+  deps.store.clearHoveredSelection();
+  const position = deps.store.selectLastPointerPosition();
+  if (position && position.pointerType !== "touch") {
+    scheduleCanvasHoverUpdate(deps);
+  }
+};
+
+const renderCachedCanvasChrome = (
+  deps,
+  { canvasUnitsPerCssPixel = getCanvasUnitsPerCssPixel(deps) } = {},
+) => {
+  const { baseElements, parsedElements } = deps.store.selectCanvasRenderState();
+  if (baseElements.length === 0 || parsedElements.length === 0) {
+    return false;
+  }
+
+  const { occurrencesById, occurrenceIdsByOwner } =
+    deps.store.selectSelectionOccurrenceState();
+  const { elements, selectedElementMetrics } =
+    createLayoutEditorSelectionRenderState({
+      baseElements,
+      parsedElements,
+      selectedItemId: deps.props.selectedItemId,
+      selectedOccurrenceId: deps.store.selectSelectedOccurrenceId(),
+      occurrencesById,
+      occurrenceIdsByOwner,
+      selectedItem:
+        deps.props.layoutState?.elements?.items?.[deps.props.selectedItemId],
+      disableMoveDrag: deps.props.disableMoveDrag === true,
+      canvasUnitsPerCssPixel,
+    });
+
+  deps.graphicsService.render({
+    elements,
+    animations: [],
+  });
+  deps.store.setCanvasRenderState({
+    elements,
+    baseElements,
+    parsedElements,
+    canvasUnitsPerCssPixel,
+  });
+  dispatchSelectedElementMetrics(deps, {
+    itemId: deps.props.selectedItemId,
+    metrics: selectedElementMetrics,
+  });
+  restoreCanvasHoverAfterRender(deps);
+  return true;
+};
+
 const dispatchCanvasSelection = (deps, selection) => {
+  const shouldRefreshSelectedOccurrence =
+    selection?.itemId === deps.props.selectedItemId &&
+    selection.occurrenceId !== deps.store.selectSelectedOccurrenceId();
+
   if (selection) {
     deps.store.setSelectedOccurrence({
       occurrenceId: selection.occurrenceId,
@@ -441,6 +515,10 @@ const dispatchCanvasSelection = (deps, selection) => {
       composed: true,
     }),
   );
+
+  if (shouldRefreshSelectedOccurrence) {
+    renderCachedCanvasChrome(deps);
+  }
 };
 
 export const applyCanvasItemKeyboardChange = ({
@@ -591,6 +669,8 @@ const renderLayoutEditorCanvas = async (
     const canvasUnitsPerCssPixel = getCanvasUnitsPerCssPixel(deps, props);
     const {
       elements,
+      baseElements,
+      parsedElements,
       fileReferences,
       selectedElementMetrics,
       occurrencesById,
@@ -610,15 +690,10 @@ const renderLayoutEditorCanvas = async (
       return;
     }
 
-    deps.dispatchEvent(
-      new CustomEvent("selected-element-metrics-change", {
-        detail: {
-          metrics: selectedElementMetrics,
-        },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    dispatchSelectedElementMetrics(deps, {
+      itemId: props.selectedItemId,
+      metrics: selectedElementMetrics,
+    });
 
     if (clearFirst) {
       deps.graphicsService.render({
@@ -671,15 +746,15 @@ const renderLayoutEditorCanvas = async (
     });
     deps.store.setCanvasRenderState({
       elements,
+      baseElements,
+      parsedElements,
       canvasUnitsPerCssPixel,
     });
     deps.store.setSelectionOccurrences({
       occurrencesById,
       occurrenceIdsByOwner,
     });
-    if (deps.store.selectLastPointerPosition()) {
-      scheduleCanvasHoverUpdate(deps);
-    }
+    restoreCanvasHoverAfterRender(deps);
   } catch (error) {
     console.error("[layoutEditorCanvas] Failed to render canvas", error);
   }
@@ -699,6 +774,22 @@ const initCanvasGraphics = async (deps, props = deps.props) => {
 
 export const handleCaptureThumbnailImage = async (deps) => {
   return captureCanvasThumbnailImage(deps.graphicsService, deps.refs.canvas);
+};
+
+export const handleCanvasResize = (deps) => {
+  if (!deps.store.selectIsGraphicsReady()) {
+    return false;
+  }
+
+  const { canvasUnitsPerCssPixel } = deps.store.selectCanvasRenderState();
+  const nextCanvasUnitsPerCssPixel = getCanvasUnitsPerCssPixel(deps);
+  if (canvasUnitsPerCssPixel === nextCanvasUnitsPerCssPixel) {
+    return false;
+  }
+
+  return renderCachedCanvasChrome(deps, {
+    canvasUnitsPerCssPixel: nextCanvasUnitsPerCssPixel,
+  });
 };
 
 export const handleCanvasPointerMove = (deps, payload) => {
@@ -734,6 +825,11 @@ export const handleCanvasPointerMove = (deps, payload) => {
       clearCanvasHover(deps);
       return;
     }
+  }
+
+  if (event.pointerType === "touch") {
+    clearCanvasHover(deps);
+    return;
   }
 
   scheduleCanvasHoverUpdate(deps);
@@ -1075,8 +1171,76 @@ const subscriptions = (deps) => {
   ];
 };
 
+const mountCanvasResizeObserver = (deps) => {
+  if (typeof globalThis.ResizeObserver !== "function") {
+    return () => {};
+  }
+
+  let observer;
+  let mountFrameId;
+  let mountTimerId;
+  let resizeFrameId;
+  let disposed = false;
+
+  const runResize = () => {
+    resizeFrameId = undefined;
+    if (!disposed) {
+      handleCanvasResize(deps);
+    }
+  };
+  const scheduleResize = () => {
+    if (resizeFrameId !== undefined) {
+      return;
+    }
+
+    if (typeof globalThis.requestAnimationFrame === "function") {
+      resizeFrameId = globalThis.requestAnimationFrame(runResize);
+      return;
+    }
+
+    runResize();
+  };
+  const mountObserver = () => {
+    mountFrameId = undefined;
+    mountTimerId = undefined;
+    if (disposed || !deps.refs.canvas) {
+      return;
+    }
+
+    observer = new globalThis.ResizeObserver(scheduleResize);
+    observer.observe(deps.refs.canvas);
+  };
+
+  if (typeof globalThis.requestAnimationFrame === "function") {
+    mountFrameId = globalThis.requestAnimationFrame(mountObserver);
+  } else {
+    mountTimerId = globalThis.setTimeout(mountObserver, 0);
+  }
+
+  return () => {
+    disposed = true;
+    observer?.disconnect();
+    if (
+      mountFrameId !== undefined &&
+      typeof globalThis.cancelAnimationFrame === "function"
+    ) {
+      globalThis.cancelAnimationFrame(mountFrameId);
+    }
+    if (mountTimerId !== undefined) {
+      globalThis.clearTimeout?.(mountTimerId);
+    }
+    if (
+      resizeFrameId !== undefined &&
+      typeof globalThis.cancelAnimationFrame === "function"
+    ) {
+      globalThis.cancelAnimationFrame(resizeFrameId);
+    }
+  };
+};
+
 export const handleBeforeMount = (deps) => {
   const cleanupSubscriptions = mountSubscriptions(deps);
+  const cleanupCanvasResizeObserver = mountCanvasResizeObserver(deps);
 
   return () => {
     const hoverFrameId = deps.store.selectHoverFrameId();
@@ -1086,6 +1250,7 @@ export const handleBeforeMount = (deps) => {
     ) {
       globalThis.cancelAnimationFrame(hoverFrameId);
     }
+    cleanupCanvasResizeObserver();
     cleanupSubscriptions?.();
     void deps.graphicsService.destroy();
   };

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.methods.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.methods.js
@@ -5,3 +5,7 @@ export function restartPreview() {
 export function captureThumbnailImage() {
   return this.transformedHandlers.handleCaptureThumbnailImage({});
 }
+
+export function useDefaultSelectionOccurrence() {
+  return this.transformedHandlers.handleUseDefaultSelectionOccurrence({});
+}

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.schema.yaml
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.schema.yaml
@@ -19,3 +19,18 @@ propsSchema:
       type: boolean
     disableInteraction:
       type: boolean
+methods:
+  type: object
+  properties:
+    restartPreview:
+      description: Restarts the interactive layout preview from its initial state.
+      params: []
+      returns: void
+    captureThumbnailImage:
+      description: Captures the current layout preview as an image.
+      params: []
+      returns: object
+    useDefaultSelectionOccurrence:
+      description: Uses the first rendered occurrence for the currently selected authored item.
+      params: []
+      returns: void

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.store.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.store.js
@@ -24,6 +24,8 @@ export const createInitialState = () => ({
   deepSelectActive: false,
   hoverFrameId: undefined,
   canvasRenderElements: [],
+  canvasBaseElements: [],
+  canvasParsedElements: [],
   canvasUnitsPerCssPixel: 1,
 });
 
@@ -163,9 +165,16 @@ export const setHoverFrameId = ({ state }, { frameId } = {}) => {
 
 export const setCanvasRenderState = (
   { state },
-  { elements = [], canvasUnitsPerCssPixel = 1 } = {},
+  {
+    elements = [],
+    baseElements = [],
+    parsedElements = [],
+    canvasUnitsPerCssPixel = 1,
+  } = {},
 ) => {
   state.canvasRenderElements = elements;
+  state.canvasBaseElements = baseElements;
+  state.canvasParsedElements = parsedElements;
   state.canvasUnitsPerCssPixel = canvasUnitsPerCssPixel;
 };
 
@@ -221,6 +230,13 @@ export const selectSelectionOccurrencesById = ({ state }) => {
   return state.selectionOccurrencesById;
 };
 
+export const selectSelectionOccurrenceState = ({ state }) => {
+  return {
+    occurrencesById: state.selectionOccurrencesById,
+    occurrenceIdsByOwner: state.selectionOccurrenceIdsByOwner,
+  };
+};
+
 export const selectHoveredSelection = ({ state }) => {
   return state.hoveredSelection;
 };
@@ -267,6 +283,8 @@ export const selectHoverFrameId = ({ state }) => {
 export const selectCanvasRenderState = ({ state }) => {
   return {
     elements: state.canvasRenderElements,
+    baseElements: state.canvasBaseElements,
+    parsedElements: state.canvasParsedElements,
     canvasUnitsPerCssPixel: state.canvasUnitsPerCssPixel,
   };
 };

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.store.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.store.js
@@ -12,6 +12,19 @@ export const createInitialState = () => ({
   pendingUpdatedItem: undefined,
   fileContentCacheById: {},
   activeRenderRequestId: undefined,
+  selectionOccurrencesById: {},
+  selectionOccurrenceIdsByOwner: {},
+  hoveredSelection: undefined,
+  selectedOccurrenceId: undefined,
+  selectedOccurrenceOwnerId: undefined,
+  pointerGesture: undefined,
+  pendingClickGesture: undefined,
+  doubleClickSequence: undefined,
+  lastPointerPosition: undefined,
+  deepSelectActive: false,
+  hoverFrameId: undefined,
+  canvasRenderElements: [],
+  canvasUnitsPerCssPixel: 1,
 });
 
 export const setGraphicsReady = ({ state }, { value = false } = {}) => {
@@ -70,6 +83,92 @@ export const setActiveRenderRequestId = ({ state }, { requestId } = {}) => {
   state.activeRenderRequestId = requestId;
 };
 
+export const setSelectionOccurrences = (
+  { state },
+  { occurrencesById = {}, occurrenceIdsByOwner = {} } = {},
+) => {
+  state.selectionOccurrencesById = occurrencesById;
+  state.selectionOccurrenceIdsByOwner = occurrenceIdsByOwner;
+
+  const selectedOccurrence = occurrencesById[state.selectedOccurrenceId];
+  if (
+    state.selectedOccurrenceId &&
+    selectedOccurrence?.ownerItemId !== state.selectedOccurrenceOwnerId
+  ) {
+    state.selectedOccurrenceId = undefined;
+    state.selectedOccurrenceOwnerId = undefined;
+  }
+};
+
+export const setHoveredSelection = ({ state }, { selection } = {}) => {
+  state.hoveredSelection = selection;
+};
+
+export const clearHoveredSelection = ({ state }, _payload = {}) => {
+  state.hoveredSelection = undefined;
+};
+
+export const setSelectedOccurrence = (
+  { state },
+  { occurrenceId, ownerItemId } = {},
+) => {
+  state.selectedOccurrenceId = occurrenceId;
+  state.selectedOccurrenceOwnerId = ownerItemId;
+};
+
+export const clearSelectedOccurrence = ({ state }, _payload = {}) => {
+  state.selectedOccurrenceId = undefined;
+  state.selectedOccurrenceOwnerId = undefined;
+};
+
+export const setPointerGesture = ({ state }, { gesture } = {}) => {
+  state.pointerGesture = gesture;
+};
+
+export const clearPointerGesture = ({ state }, _payload = {}) => {
+  state.pointerGesture = undefined;
+};
+
+export const setPendingClickGesture = ({ state }, { gesture } = {}) => {
+  state.pendingClickGesture = gesture;
+};
+
+export const clearPendingClickGesture = ({ state }, _payload = {}) => {
+  state.pendingClickGesture = undefined;
+};
+
+export const setDoubleClickSequence = ({ state }, { sequence } = {}) => {
+  state.doubleClickSequence = sequence;
+};
+
+export const clearDoubleClickSequence = ({ state }, _payload = {}) => {
+  state.doubleClickSequence = undefined;
+};
+
+export const setLastPointerPosition = ({ state }, { position } = {}) => {
+  state.lastPointerPosition = position;
+};
+
+export const clearLastPointerPosition = ({ state }, _payload = {}) => {
+  state.lastPointerPosition = undefined;
+};
+
+export const setDeepSelectActive = ({ state }, { value = false } = {}) => {
+  state.deepSelectActive = value === true;
+};
+
+export const setHoverFrameId = ({ state }, { frameId } = {}) => {
+  state.hoverFrameId = frameId;
+};
+
+export const setCanvasRenderState = (
+  { state },
+  { elements = [], canvasUnitsPerCssPixel = 1 } = {},
+) => {
+  state.canvasRenderElements = elements;
+  state.canvasUnitsPerCssPixel = canvasUnitsPerCssPixel;
+};
+
 export const cacheFileContent = ({ state }, { fileId, url } = {}) => {
   if (!fileId || !url) {
     return;
@@ -116,6 +215,60 @@ export const selectPendingUpdatedItem = ({ state }) => {
 
 export const selectActiveRenderRequestId = ({ state }) => {
   return state.activeRenderRequestId;
+};
+
+export const selectSelectionOccurrencesById = ({ state }) => {
+  return state.selectionOccurrencesById;
+};
+
+export const selectHoveredSelection = ({ state }) => {
+  return state.hoveredSelection;
+};
+
+export const selectSelectedOccurrenceId = ({ state }) => {
+  return state.selectedOccurrenceId;
+};
+
+export const selectSelectedOccurrenceOwnerId = ({ state }) => {
+  return state.selectedOccurrenceOwnerId;
+};
+
+export const selectResolvedSelectedOccurrenceId = ({ state, props }) => {
+  return (
+    state.selectedOccurrenceId ??
+    state.selectionOccurrenceIdsByOwner[props.selectedItemId]?.[0]
+  );
+};
+
+export const selectPointerGesture = ({ state }) => {
+  return state.pointerGesture;
+};
+
+export const selectPendingClickGesture = ({ state }) => {
+  return state.pendingClickGesture;
+};
+
+export const selectDoubleClickSequence = ({ state }) => {
+  return state.doubleClickSequence;
+};
+
+export const selectLastPointerPosition = ({ state }) => {
+  return state.lastPointerPosition;
+};
+
+export const selectDeepSelectActive = ({ state }) => {
+  return state.deepSelectActive;
+};
+
+export const selectHoverFrameId = ({ state }) => {
+  return state.hoverFrameId;
+};
+
+export const selectCanvasRenderState = ({ state }) => {
+  return {
+    elements: state.canvasRenderElements,
+    canvasUnitsPerCssPixel: state.canvasUnitsPerCssPixel,
+  };
 };
 
 export const selectViewData = ({ state, props }) => {

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.view.yaml
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.view.yaml
@@ -1,5 +1,20 @@
 refs:
-  canvas: {}
+  canvas:
+    eventListeners:
+      pointermove:
+        handler: handleCanvasPointerMove
+      pointerleave:
+        handler: handleCanvasPointerLeave
+      pointerdown:
+        handler: handleCanvasPointerDown
+      pointerup:
+        handler: handleCanvasPointerUp
+      pointercancel:
+        handler: handleCanvasPointerCancel
+      click:
+        handler: handleCanvasClick
+      dblclick:
+        handler: handleCanvasDoubleClick
 template:
   - 'rtgl-view w=f bgc=mu pos=rel bwb=xs style="margin-left: 1px; aspect-ratio: ${canvasAspectRatio};"':
       - rtgl-view pos=abs cor=full:

--- a/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
+++ b/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
@@ -6,10 +6,20 @@ import {
 } from "../../../internal/project/layout.js";
 import { getLayoutEditorItemResizeEdges } from "../../../internal/layoutEditorElementRegistry.js";
 import { toHierarchyStructure } from "../../../internal/project/tree.js";
+import {
+  createLayoutEditorSelectionElementMapper,
+  extractLayoutEditorSelectionOccurrences,
+} from "./layoutEditorCanvasSelection.js";
 
-const OVERLAY_BORDER = {
+const OVERLAY_INNER_COLOR = "#b3b3b3";
+const OVERLAY_INNER_BORDER = {
+  color: OVERLAY_INNER_COLOR,
+  width: 1,
+  alpha: 1,
+};
+const OVERLAY_OUTER_BORDER = {
   color: "#ffffff",
-  width: 2,
+  width: 1,
   alpha: 1,
 };
 const OVERLAY_FILL = {
@@ -21,7 +31,7 @@ const OVERLAY_ANCHOR_FILL = {
   alpha: 1,
 };
 const OVERLAY_ANCHOR_BORDER = {
-  color: "#111111",
+  color: OVERLAY_INNER_COLOR,
   width: 1,
   alpha: 1,
 };
@@ -290,38 +300,21 @@ const createLayoutEditorPreviewBackgroundElement = ({
   };
 };
 
-const isSelectableMatch = (elementId, selectedItemId) => {
-  if (typeof elementId !== "string" || typeof selectedItemId !== "string") {
-    return false;
-  }
-
-  if (elementId === selectedItemId) {
-    return true;
-  }
-
-  return elementId === `${selectedItemId}-instance-0`;
-};
-
 const collectMatchingPaths = (
   elements,
-  selectedItemId,
+  occurrenceId,
   parentPath = [],
   matchingPaths = [],
 ) => {
   toElementList(elements).forEach((element) => {
     const path = [...parentPath, element];
 
-    if (isSelectableMatch(element.id, selectedItemId)) {
+    if (element.id === occurrenceId) {
       matchingPaths.push(path);
     }
 
     if (Array.isArray(element.children) && element.children.length > 0) {
-      collectMatchingPaths(
-        element.children,
-        selectedItemId,
-        path,
-        matchingPaths,
-      );
+      collectMatchingPaths(element.children, occurrenceId, path, matchingPaths);
     }
   });
 
@@ -372,7 +365,6 @@ const buildOverlayRect = ({ element, overlayId, draggable }) => {
     width: element.width,
     height: element.height,
     fill: OVERLAY_FILL,
-    border: OVERLAY_BORDER,
   };
 
   if (draggable) {
@@ -395,48 +387,113 @@ const buildOverlayRect = ({ element, overlayId, draggable }) => {
   return overlayRect;
 };
 
-const buildOverlayAnchorMarker = ({ element, overlayId }) => {
+const buildOverlayOuterRect = ({
+  element,
+  overlayId,
+  canvasUnitsPerCssPixel,
+}) => {
+  if (!hasRenderableBounds(element)) {
+    return undefined;
+  }
+
+  const borderWidth = OVERLAY_OUTER_BORDER.width * canvasUnitsPerCssPixel;
+  const borderOffset = borderWidth / 2;
+
+  return {
+    id: `${overlayId}-outer`,
+    type: "rect",
+    x: -borderOffset,
+    y: -borderOffset,
+    width: element.width + borderWidth,
+    height: element.height + borderWidth,
+    fill: OVERLAY_FILL,
+    border: {
+      ...OVERLAY_OUTER_BORDER,
+      width: borderWidth,
+    },
+  };
+};
+
+const buildOverlayInnerRect = ({
+  element,
+  overlayId,
+  canvasUnitsPerCssPixel,
+}) => {
+  if (!hasRenderableBounds(element)) {
+    return undefined;
+  }
+
+  return {
+    id: `${overlayId}-inner`,
+    type: "rect",
+    x: canvasUnitsPerCssPixel / 2,
+    y: canvasUnitsPerCssPixel / 2,
+    width: Math.max(0, element.width - canvasUnitsPerCssPixel),
+    height: Math.max(0, element.height - canvasUnitsPerCssPixel),
+    fill: OVERLAY_FILL,
+    border: {
+      ...OVERLAY_INNER_BORDER,
+      width: OVERLAY_INNER_BORDER.width * canvasUnitsPerCssPixel,
+    },
+  };
+};
+
+const buildOverlayAnchorMarker = ({
+  element,
+  overlayId,
+  canvasUnitsPerCssPixel,
+}) => {
   if (!hasRenderableBounds(element)) {
     return undefined;
   }
 
   const { x: originX, y: originY } = getElementOrigin(element);
+  const anchorSize = OVERLAY_ANCHOR_SIZE * canvasUnitsPerCssPixel;
 
   return {
     id: `${overlayId}-anchor`,
     type: "rect",
-    x: originX - OVERLAY_ANCHOR_SIZE / 2,
-    y: originY - OVERLAY_ANCHOR_SIZE / 2,
-    width: OVERLAY_ANCHOR_SIZE,
-    height: OVERLAY_ANCHOR_SIZE,
+    x: originX - anchorSize / 2,
+    y: originY - anchorSize / 2,
+    width: anchorSize,
+    height: anchorSize,
     fill: OVERLAY_ANCHOR_FILL,
-    border: OVERLAY_ANCHOR_BORDER,
+    border: {
+      ...OVERLAY_ANCHOR_BORDER,
+      width: OVERLAY_ANCHOR_BORDER.width * canvasUnitsPerCssPixel,
+    },
   };
 };
 
-const buildOverlayResizeHandle = ({ element, overlayId, edge }) => {
+const buildOverlayResizeHandle = ({
+  element,
+  overlayId,
+  edge,
+  canvasUnitsPerCssPixel,
+}) => {
   if (!hasRenderableBounds(element)) {
     return undefined;
   }
 
   const vertical = edge === "left" || edge === "right";
+  const resizeHandleSize = OVERLAY_RESIZE_HANDLE_SIZE * canvasUnitsPerCssPixel;
   const resizeHandle = {
     id: `${overlayId}-resize-${edge}`,
     type: "rect",
     x:
       edge === "left"
-        ? -OVERLAY_RESIZE_HANDLE_SIZE / 2
+        ? -resizeHandleSize / 2
         : edge === "right"
-          ? element.width - OVERLAY_RESIZE_HANDLE_SIZE / 2
+          ? element.width - resizeHandleSize / 2
           : 0,
     y:
       edge === "top"
-        ? -OVERLAY_RESIZE_HANDLE_SIZE / 2
+        ? -resizeHandleSize / 2
         : edge === "bottom"
-          ? element.height - OVERLAY_RESIZE_HANDLE_SIZE / 2
+          ? element.height - resizeHandleSize / 2
           : 0,
-    width: vertical ? OVERLAY_RESIZE_HANDLE_SIZE : element.width,
-    height: vertical ? element.height : OVERLAY_RESIZE_HANDLE_SIZE,
+    width: vertical ? resizeHandleSize : element.width,
+    height: vertical ? element.height : resizeHandleSize,
     fill: OVERLAY_FILL,
     hover: {
       cursor: vertical ? "ew-resize" : "ns-resize",
@@ -457,11 +514,23 @@ const buildOverlayResizeHandle = ({ element, overlayId, edge }) => {
   return resizeHandle;
 };
 
-const buildOverlayResizeHandles = ({ element, overlayId, selectedItem }) => {
+const buildOverlayResizeHandles = ({
+  element,
+  overlayId,
+  selectedItem,
+  canvasUnitsPerCssPixel,
+}) => {
   const edges = getLayoutEditorItemResizeEdges(selectedItem ?? element);
 
   return edges
-    .map((edge) => buildOverlayResizeHandle({ element, overlayId, edge }))
+    .map((edge) =>
+      buildOverlayResizeHandle({
+        element,
+        overlayId,
+        edge,
+        canvasUnitsPerCssPixel,
+      }),
+    )
     .filter(Boolean);
 };
 
@@ -491,20 +560,37 @@ const buildOverlayElementContainer = ({ element, overlayId, children }) => {
   return overlayContainer;
 };
 
-const buildOverlayTree = ({ path, overlayId, draggable, selectedItem }) => {
+const buildOverlayTree = ({
+  path,
+  overlayId,
+  draggable,
+  selectedItem,
+  canvasUnitsPerCssPixel,
+}) => {
   const selectedElement = path[path.length - 1];
   const overlayRect = buildOverlayRect({
     element: selectedElement,
     overlayId,
     draggable,
   });
+  const overlayOuterRect = buildOverlayOuterRect({
+    element: selectedElement,
+    overlayId,
+    canvasUnitsPerCssPixel,
+  });
+  const overlayInnerRect = buildOverlayInnerRect({
+    element: selectedElement,
+    overlayId,
+    canvasUnitsPerCssPixel,
+  });
   const anchorMarker = buildOverlayAnchorMarker({
     element: selectedElement,
     overlayId,
+    canvasUnitsPerCssPixel,
   });
   let overlayTree;
 
-  if (!overlayRect || !anchorMarker) {
+  if (!overlayRect || !overlayOuterRect || !overlayInnerRect || !anchorMarker) {
     return undefined;
   }
 
@@ -512,11 +598,14 @@ const buildOverlayTree = ({ path, overlayId, draggable, selectedItem }) => {
     element: selectedElement,
     overlayId: `${overlayId}-group`,
     children: [
+      overlayOuterRect,
+      overlayInnerRect,
       overlayRect,
       ...buildOverlayResizeHandles({
         element: selectedElement,
         overlayId,
         selectedItem,
+        canvasUnitsPerCssPixel,
       }),
       anchorMarker,
     ],
@@ -535,27 +624,32 @@ const buildOverlayTree = ({ path, overlayId, draggable, selectedItem }) => {
   return overlayTree;
 };
 
-const selectPrimaryMatchingPath = (parsedElements, selectedItemId) => {
+const selectPrimaryMatchingPath = ({
+  parsedElements,
+  selectedItemId,
+  selectedOccurrenceId,
+  occurrencesById,
+  occurrenceIdsByOwner,
+}) => {
   if (!selectedItemId) {
     return undefined;
   }
 
+  const selectedOccurrence = occurrencesById[selectedOccurrenceId];
+  const occurrenceId =
+    selectedOccurrence?.ownerItemId === selectedItemId
+      ? selectedOccurrenceId
+      : occurrenceIdsByOwner[selectedItemId]?.[0];
   const matchingPaths = collectMatchingPaths(
     parsedElements,
-    selectedItemId,
+    occurrenceId,
   ).filter((path) => hasRenderableBounds(path[path.length - 1]));
 
   if (matchingPaths.length === 0) {
     return undefined;
   }
 
-  return (
-    matchingPaths.find(
-      (path) =>
-        path[path.length - 1]?.id === selectedItemId ||
-        path[path.length - 1]?.id === `${selectedItemId}-instance-0`,
-    ) ?? matchingPaths[0]
-  );
+  return matchingPaths[0];
 };
 
 const toSelectedElementMetrics = (path) => {
@@ -590,10 +684,20 @@ const resolveLayoutPreviewElements = ({ elements, previewData } = {}) => {
 export const createLayoutEditorSelectionOverlay = ({
   parsedElements,
   selectedItemId,
+  selectedOccurrenceId,
+  occurrencesById = {},
+  occurrenceIdsByOwner = {},
   selectedItem,
   disableMoveDrag = false,
+  canvasUnitsPerCssPixel = 1,
 } = {}) => {
-  const primaryPath = selectPrimaryMatchingPath(parsedElements, selectedItemId);
+  const primaryPath = selectPrimaryMatchingPath({
+    parsedElements,
+    selectedItemId,
+    selectedOccurrenceId,
+    occurrencesById,
+    occurrenceIdsByOwner,
+  });
   if (!primaryPath) {
     return [];
   }
@@ -603,6 +707,7 @@ export const createLayoutEditorSelectionOverlay = ({
     overlayId: "selected-border",
     draggable: disableMoveDrag !== true,
     selectedItem,
+    canvasUnitsPerCssPixel,
   });
 
   if (!primaryOverlay) {
@@ -610,6 +715,73 @@ export const createLayoutEditorSelectionOverlay = ({
   }
 
   return [primaryOverlay];
+};
+
+export const createLayoutEditorHoverOverlay = ({
+  bounds,
+  canvasUnitsPerCssPixel = 1,
+} = {}) => {
+  const corners = bounds?.corners ?? [];
+  if (corners.length !== 4) {
+    return [];
+  }
+
+  const [topLeft, topRight, , bottomLeft] = corners;
+  const width = Math.hypot(topRight.x - topLeft.x, topRight.y - topLeft.y);
+  const height = Math.hypot(bottomLeft.x - topLeft.x, bottomLeft.y - topLeft.y);
+  if (width <= 0 || height <= 0) {
+    return [];
+  }
+
+  const unitX = {
+    x: (topRight.x - topLeft.x) / width,
+    y: (topRight.y - topLeft.y) / width,
+  };
+  const unitY = {
+    x: (bottomLeft.x - topLeft.x) / height,
+    y: (bottomLeft.y - topLeft.y) / height,
+  };
+  const rotation = (Math.atan2(unitX.y, unitX.x) * 180) / Math.PI;
+  const halfStroke = canvasUnitsPerCssPixel / 2;
+  const toOffsetPoint = (distance) => ({
+    x: topLeft.x + unitX.x * distance + unitY.x * distance,
+    y: topLeft.y + unitX.y * distance + unitY.y * distance,
+  });
+  const outerPosition = toOffsetPoint(-halfStroke);
+  const innerPosition = toOffsetPoint(halfStroke);
+
+  return [
+    {
+      id: "hover-border-outer",
+      type: "rect",
+      x: outerPosition.x,
+      y: outerPosition.y,
+      width: width + canvasUnitsPerCssPixel,
+      height: height + canvasUnitsPerCssPixel,
+      rotation,
+      fill: OVERLAY_FILL,
+      border: {
+        color: "#ffffff",
+        width: canvasUnitsPerCssPixel,
+        alpha: 1,
+      },
+    },
+    {
+      id: "hover-border-inner",
+      type: "rect",
+      x: innerPosition.x,
+      y: innerPosition.y,
+      width: Math.max(0, width - canvasUnitsPerCssPixel),
+      height: Math.max(0, height - canvasUnitsPerCssPixel),
+      rotation,
+      fill: OVERLAY_FILL,
+      border: {
+        color: OVERLAY_INNER_COLOR,
+        width: canvasUnitsPerCssPixel,
+        alpha: 1,
+      },
+    },
+  ];
 };
 
 export const loadLayoutEditorAssets = async ({
@@ -724,6 +896,9 @@ export const createLayoutEditorRenderState = ({
       particlesData,
       spritesheetsData,
       layoutsData: repositoryState?.layouts?.items || {},
+      mapElement: createLayoutEditorSelectionElementMapper({
+        layoutId: layoutState?.id,
+      }),
     },
   );
 
@@ -752,6 +927,9 @@ const createLayoutEditorResolvedElements = ({
   const resolvedFinalElements = resolveLayoutReferences(finalElements, {
     resources,
   });
+  const selectionOccurrences = extractLayoutEditorSelectionOccurrences(
+    resolvedFinalElements,
+  );
   const previewBackgroundElement = createLayoutEditorPreviewBackgroundElement({
     previewData: normalizedPreviewData,
     repositoryState,
@@ -759,8 +937,10 @@ const createLayoutEditorResolvedElements = ({
   });
   return {
     renderedElements: previewBackgroundElement
-      ? [previewBackgroundElement, ...resolvedFinalElements]
-      : resolvedFinalElements,
+      ? [previewBackgroundElement, ...selectionOccurrences.elements]
+      : selectionOccurrences.elements,
+    occurrencesById: selectionOccurrences.occurrencesById,
+    occurrenceIdsByOwner: selectionOccurrences.occurrenceIdsByOwner,
   };
 };
 
@@ -790,32 +970,46 @@ export const createLayoutEditorRenderedElements = ({
   previewData,
   resolution,
   selectedItemId,
+  selectedOccurrenceId,
   disableMoveDrag,
+  canvasUnitsPerCssPixel,
   graphicsService,
 } = {}) => {
-  const { renderedElements } = createLayoutEditorResolvedElements({
-    layoutState,
-    repositoryState,
-    previewData,
-    resolution,
-  });
+  const { renderedElements, occurrencesById, occurrenceIdsByOwner } =
+    createLayoutEditorResolvedElements({
+      layoutState,
+      repositoryState,
+      previewData,
+      resolution,
+    });
   const parsedState = graphicsService.parse({
     elements: renderedElements,
   });
   const overlayElements = createLayoutEditorSelectionOverlay({
     parsedElements: parsedState.elements,
     selectedItemId,
+    selectedOccurrenceId,
+    occurrencesById,
+    occurrenceIdsByOwner,
     selectedItem: layoutState?.elements?.items?.[selectedItemId],
     disableMoveDrag,
+    canvasUnitsPerCssPixel,
   });
-  const selectedElementMetrics = toSelectedElementMetrics(
-    selectPrimaryMatchingPath(parsedState.elements, selectedItemId),
-  );
+  const primaryMatchingPath = selectPrimaryMatchingPath({
+    parsedElements: parsedState.elements,
+    selectedItemId,
+    selectedOccurrenceId,
+    occurrencesById,
+    occurrenceIdsByOwner,
+  });
+  const selectedElementMetrics = toSelectedElementMetrics(primaryMatchingPath);
   const fileReferences = extractFileIdsFromRenderState(renderedElements);
 
   return {
     elements: [...renderedElements, ...overlayElements],
     fileReferences,
     selectedElementMetrics,
+    occurrencesById,
+    occurrenceIdsByOwner,
   };
 };

--- a/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
+++ b/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
@@ -717,6 +717,41 @@ export const createLayoutEditorSelectionOverlay = ({
   return [primaryOverlay];
 };
 
+export const createLayoutEditorSelectionRenderState = ({
+  baseElements = [],
+  parsedElements = [],
+  selectedItemId,
+  selectedOccurrenceId,
+  occurrencesById = {},
+  occurrenceIdsByOwner = {},
+  selectedItem,
+  disableMoveDrag = false,
+  canvasUnitsPerCssPixel = 1,
+} = {}) => {
+  const overlayElements = createLayoutEditorSelectionOverlay({
+    parsedElements,
+    selectedItemId,
+    selectedOccurrenceId,
+    occurrencesById,
+    occurrenceIdsByOwner,
+    selectedItem,
+    disableMoveDrag,
+    canvasUnitsPerCssPixel,
+  });
+  const primaryMatchingPath = selectPrimaryMatchingPath({
+    parsedElements,
+    selectedItemId,
+    selectedOccurrenceId,
+    occurrencesById,
+    occurrenceIdsByOwner,
+  });
+
+  return {
+    elements: [...baseElements, ...overlayElements],
+    selectedElementMetrics: toSelectedElementMetrics(primaryMatchingPath),
+  };
+};
+
 export const createLayoutEditorHoverOverlay = ({
   bounds,
   canvasUnitsPerCssPixel = 1,
@@ -985,7 +1020,8 @@ export const createLayoutEditorRenderedElements = ({
   const parsedState = graphicsService.parse({
     elements: renderedElements,
   });
-  const overlayElements = createLayoutEditorSelectionOverlay({
+  const selectionRenderState = createLayoutEditorSelectionRenderState({
+    baseElements: renderedElements,
     parsedElements: parsedState.elements,
     selectedItemId,
     selectedOccurrenceId,
@@ -995,20 +1031,13 @@ export const createLayoutEditorRenderedElements = ({
     disableMoveDrag,
     canvasUnitsPerCssPixel,
   });
-  const primaryMatchingPath = selectPrimaryMatchingPath({
-    parsedElements: parsedState.elements,
-    selectedItemId,
-    selectedOccurrenceId,
-    occurrencesById,
-    occurrenceIdsByOwner,
-  });
-  const selectedElementMetrics = toSelectedElementMetrics(primaryMatchingPath);
   const fileReferences = extractFileIdsFromRenderState(renderedElements);
 
   return {
-    elements: [...renderedElements, ...overlayElements],
+    ...selectionRenderState,
+    baseElements: renderedElements,
+    parsedElements: parsedState.elements,
     fileReferences,
-    selectedElementMetrics,
     occurrencesById,
     occurrenceIdsByOwner,
   };

--- a/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
+++ b/src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js
@@ -26,14 +26,20 @@ const OVERLAY_FILL = {
   color: "#ffffff",
   alpha: 0.001,
 };
-const OVERLAY_ANCHOR_FILL = {
-  color: "#ffffff",
-  alpha: 1,
-};
-const OVERLAY_ANCHOR_BORDER = {
-  color: OVERLAY_INNER_COLOR,
-  width: 1,
-  alpha: 1,
+const OVERLAY_ANCHOR_CIRCLE_FILL = {
+  type: "radial-gradient",
+  innerCenter: { x: 0.5, y: 0.5 },
+  innerRadius: 0,
+  outerCenter: { x: 0.5, y: 0.5 },
+  outerRadius: 0.5,
+  coordinateSpace: "local",
+  stops: [
+    { offset: 0, color: "#ffffff" },
+    { offset: 0.75, color: "#ffffff" },
+    { offset: 0.75, color: OVERLAY_INNER_COLOR },
+    { offset: 1, color: OVERLAY_INNER_COLOR },
+    { offset: 1, color: "transparent" },
+  ],
 };
 const OVERLAY_ANCHOR_SIZE = 8;
 const OVERLAY_RESIZE_HANDLE_SIZE = 12;
@@ -457,11 +463,7 @@ const buildOverlayAnchorMarker = ({
     y: originY - anchorSize / 2,
     width: anchorSize,
     height: anchorSize,
-    fill: OVERLAY_ANCHOR_FILL,
-    border: {
-      ...OVERLAY_ANCHOR_BORDER,
-      width: OVERLAY_ANCHOR_BORDER.width * canvasUnitsPerCssPixel,
-    },
+    fill: OVERLAY_ANCHOR_CIRCLE_FILL,
   };
 };
 

--- a/src/components/layoutEditorCanvas/support/layoutEditorCanvasSelection.js
+++ b/src/components/layoutEditorCanvas/support/layoutEditorCanvasSelection.js
@@ -1,0 +1,209 @@
+export const LAYOUT_EDITOR_SELECTION_METADATA_KEY = "__layoutEditorSelection";
+
+const EDITOR_CHROME_ID_PREFIX = "selected-border";
+
+const toElementList = (elements) => {
+  if (Array.isArray(elements)) {
+    return elements.filter(Boolean);
+  }
+
+  return elements ? [elements] : [];
+};
+
+const toUniqueItemIds = (itemIds = []) => {
+  const seen = new Set();
+
+  return itemIds.filter((itemId) => {
+    if (!itemId || seen.has(itemId)) {
+      return false;
+    }
+
+    seen.add(itemId);
+    return true;
+  });
+};
+
+export const createLayoutEditorSelectionElementMapper = ({ layoutId } = {}) => {
+  return ({ element, ancestry = [] }) => {
+    const authoredPath = toUniqueItemIds(
+      ancestry
+        .filter((entry) => entry.layoutId === layoutId)
+        .map((entry) => entry.node?.id),
+    );
+    const ownerItemId = authoredPath.at(-1);
+
+    if (!ownerItemId) {
+      return element;
+    }
+
+    return {
+      ...element,
+      [LAYOUT_EDITOR_SELECTION_METADATA_KEY]: {
+        ownerItemId,
+        authoredPath,
+      },
+    };
+  };
+};
+
+export const extractLayoutEditorSelectionOccurrences = (elements) => {
+  const occurrencesById = {};
+  const occurrenceIdsByOwner = {};
+
+  const visit = (elementList) => {
+    return toElementList(elementList).map((element) => {
+      const nextElement = {
+        ...element,
+      };
+      const metadata = nextElement[LAYOUT_EDITOR_SELECTION_METADATA_KEY];
+      delete nextElement[LAYOUT_EDITOR_SELECTION_METADATA_KEY];
+
+      if (metadata?.ownerItemId && nextElement.id) {
+        const occurrence = {
+          occurrenceId: nextElement.id,
+          ownerItemId: metadata.ownerItemId,
+          authoredPath: toUniqueItemIds(metadata.authoredPath),
+        };
+        occurrencesById[nextElement.id] = occurrence;
+
+        const ownerOccurrences =
+          occurrenceIdsByOwner[metadata.ownerItemId] ?? [];
+        ownerOccurrences.push(nextElement.id);
+        occurrenceIdsByOwner[metadata.ownerItemId] = ownerOccurrences;
+      }
+
+      if (Array.isArray(nextElement.children)) {
+        nextElement.children = visit(nextElement.children);
+      }
+
+      return nextElement;
+    });
+  };
+
+  return {
+    elements: visit(elements),
+    occurrencesById,
+    occurrenceIdsByOwner,
+  };
+};
+
+const isBlockingEditorChromeHit = (hit) => {
+  const targetId = hit?.path?.at(-1)?.id;
+
+  return (
+    targetId === `${EDITOR_CHROME_ID_PREFIX}-anchor` ||
+    targetId?.startsWith(`${EDITOR_CHROME_ID_PREFIX}-resize-`)
+  );
+};
+
+const createAuthoredHitPath = ({ renderPath, occurrencesById }) => {
+  let deepestOccurrence;
+
+  for (let index = renderPath.length - 1; index >= 0; index -= 1) {
+    const occurrence = occurrencesById[renderPath[index].id];
+    if (occurrence) {
+      deepestOccurrence = occurrence;
+      break;
+    }
+  }
+
+  if (!deepestOccurrence) {
+    return [];
+  }
+
+  return deepestOccurrence.authoredPath.flatMap((itemId) => {
+    const renderEntry = renderPath.find((entry) => {
+      return occurrencesById[entry.id]?.ownerItemId === itemId;
+    });
+
+    if (!renderEntry) {
+      return [];
+    }
+
+    return [
+      {
+        itemId,
+        occurrenceId: renderEntry.id,
+        bounds: renderEntry.bounds,
+      },
+    ];
+  });
+};
+
+export const resolveLayoutEditorCanvasHitPath = ({
+  hits = [],
+  occurrencesById = {},
+} = {}) => {
+  if (isBlockingEditorChromeHit(hits[0])) {
+    return {
+      blocked: true,
+      path: [],
+    };
+  }
+
+  for (const hit of hits) {
+    const path = createAuthoredHitPath({
+      renderPath: hit.path ?? [],
+      occurrencesById,
+    });
+
+    if (path.length > 0) {
+      return {
+        blocked: false,
+        path,
+      };
+    }
+  }
+
+  return {
+    blocked: false,
+    path: [],
+  };
+};
+
+export const selectLayoutEditorCanvasHit = (
+  hitResolution,
+  { deepSelect = false } = {},
+) => {
+  if (hitResolution?.blocked === true || hitResolution?.path?.length === 0) {
+    return undefined;
+  }
+
+  return deepSelect ? hitResolution.path.at(-1) : hitResolution.path[0];
+};
+
+export const selectLayoutEditorCanvasHover = (
+  hitResolution,
+  { deepSelect = false, selectedOccurrenceId } = {},
+) => {
+  const selectedOccurrenceIsUnderPointer = hitResolution?.path?.some(
+    ({ occurrenceId }) => occurrenceId === selectedOccurrenceId,
+  );
+
+  if (!deepSelect && selectedOccurrenceIsUnderPointer) {
+    return undefined;
+  }
+
+  return selectLayoutEditorCanvasHit(hitResolution, { deepSelect });
+};
+
+export const selectNextLayoutEditorCanvasHit = (
+  hitResolution,
+  { selectedItemId } = {},
+) => {
+  if (hitResolution?.blocked === true || hitResolution?.path?.length === 0) {
+    return undefined;
+  }
+
+  const selectedIndex = hitResolution.path.findIndex(
+    ({ itemId }) => itemId === selectedItemId,
+  );
+
+  if (selectedIndex < 0) {
+    return hitResolution.path[1] ?? hitResolution.path[0];
+  }
+
+  return (
+    hitResolution.path[selectedIndex + 1] ?? hitResolution.path[selectedIndex]
+  );
+};

--- a/src/deps/services/graphicsService.js
+++ b/src/deps/services/graphicsService.js
@@ -2262,6 +2262,8 @@ export const createGraphicsService = async ({
       );
     },
     parse: (payload) => routeGraphics?.parse(payload),
+    hitTestElementBounds: (point) =>
+      routeGraphics?.hitTestElementBounds(point) ?? [],
     destroy: async () => {
       if (routeGraphicsInitPromise) {
         await routeGraphicsInitPromise.catch(() => {});

--- a/src/internal/project/layout.js
+++ b/src/internal/project/layout.js
@@ -855,7 +855,12 @@ const prefixElementIds = (elements, prefix) => {
   });
 };
 
-const resolveFragmentChildren = ({ node, imageItems, context }) => {
+const resolveFragmentChildren = ({
+  node,
+  imageItems,
+  context,
+  ancestry = [],
+}) => {
   const fragmentLayoutId = node.fragmentLayoutId;
   const fragmentStack = context.fragmentStack || [];
   if (
@@ -892,6 +897,7 @@ const resolveFragmentChildren = ({ node, imageItems, context }) => {
           node: child,
           imageItems,
           context: fragmentContext,
+          ancestry,
         }),
       )
       .filter(Boolean),
@@ -1680,7 +1686,7 @@ const applyContainerNode = ({ element, node }) => {
   };
 };
 
-const mapLayoutNode = ({ node, imageItems, context }) => {
+const mapLayoutNode = ({ node, imageItems, context, ancestry = [] }) => {
   if (node.hidden === true) {
     return undefined;
   }
@@ -1702,6 +1708,13 @@ const mapLayoutNode = ({ node, imageItems, context }) => {
             ),
           }
         : context;
+  const nodeAncestry = [
+    ...ancestry,
+    {
+      layoutId: nodeContext.layoutId,
+      node: effectiveNode,
+    },
+  ];
   let element = buildBaseElement(node, nodeContext);
 
   element = applyTextNode({
@@ -1747,6 +1760,7 @@ const mapLayoutNode = ({ node, imageItems, context }) => {
           node: effectiveNode,
           imageItems,
           context: childContext,
+          ancestry: nodeAncestry,
         })
       : effectiveNode.children?.length > 0
         ? effectiveNode.children
@@ -1755,6 +1769,7 @@ const mapLayoutNode = ({ node, imageItems, context }) => {
                 node: child,
                 imageItems,
                 context: childContext,
+                ancestry: nodeAncestry,
               }),
             )
             .filter(Boolean)
@@ -1766,6 +1781,14 @@ const mapLayoutNode = ({ node, imageItems, context }) => {
     if (REPEATING_CONTAINER_CONFIG[effectiveNode.type]) {
       element.children = updateChildrenIds(element.children, "i");
     }
+  }
+
+  if (typeof nodeContext.mapElement === "function") {
+    element = nodeContext.mapElement({
+      element,
+      node: effectiveNode,
+      ancestry: nodeAncestry,
+    });
   }
 
   return element;
@@ -1923,6 +1946,7 @@ export const buildLayoutElements = (
     spritesheetItems: options.spritesheetsData?.items || {},
     layoutsData: options.layoutsData,
     fragmentStack: options.fragmentStack ?? [],
+    mapElement: options.mapElement,
   };
 
   const orderedLayout = applyLayoutRenderOrder({

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -1830,11 +1830,11 @@ export const handleLayoutEditorCanvasUpdate = async (deps, payload) => {
 
 export const handleLayoutEditorCanvasMetricsChange = (deps, payload) => {
   const { refs, store } = deps;
-  const metrics = payload._event.detail?.metrics;
+  const { itemId, metrics } = payload._event.detail;
   const selectedItemId = store.selectSelectedItemId();
   const detailPanelSelectedItemId = store.selectDetailPanelSelectedItemId?.();
 
-  if (metrics?.id && selectedItemId && metrics.id !== selectedItemId) {
+  if (itemId !== selectedItemId) {
     return;
   }
 

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -632,13 +632,18 @@ const scheduleDetailPanelSelectionRender = (deps, { itemId } = {}) => {
 };
 
 export const handleFileExplorerItemClick = async (deps, payload) => {
-  const { store, render } = deps;
+  const { store, refs, render } = deps;
   const detail = payload._event.detail || {};
   const itemId = detail.id || detail.itemId || detail.item?.id;
   if (!itemId) {
     store.setSelectedItemId({ itemId: undefined });
+    store.setDetailPanelSelectedItemId({ itemId: undefined });
     render();
     return;
+  }
+
+  if (store.selectSelectedItemId() === itemId) {
+    void refs.layoutEditorCanvas?.useDefaultSelectionOccurrence?.();
   }
 
   store.setSelectedItemId({ itemId: itemId });
@@ -657,6 +662,31 @@ export const handleFileExplorerItemClick = async (deps, payload) => {
   });
 };
 
+export const handleLayoutEditorCanvasSelectionChange = (deps, payload) => {
+  const { store, refs, render } = deps;
+  const { itemId } = payload._event.detail;
+
+  if (!itemId) {
+    store.setSelectedItemId({ itemId: undefined });
+    store.setDetailPanelSelectedItemId({ itemId: undefined });
+    refs.fileExplorer?.clearSelection?.();
+    render();
+    return;
+  }
+
+  store.setSelectedItemId({ itemId });
+  refs.fileExplorer?.selectItem?.({ itemId });
+
+  if (store.selectIsTouchMode?.()) {
+    store.setDetailPanelSelectedItemId({ itemId });
+    render();
+    return;
+  }
+
+  render();
+  scheduleDetailPanelSelectionRender(deps, { itemId });
+};
+
 export const handleLayoutEditorCanvasBackgroundClick = (deps, payload) => {
   const { store, refs, render } = deps;
   const event = payload._event;
@@ -666,6 +696,7 @@ export const handleLayoutEditorCanvasBackgroundClick = (deps, payload) => {
   }
 
   store.setSelectedItemId({ itemId: undefined });
+  store.setDetailPanelSelectedItemId({ itemId: undefined });
   refs.fileExplorer?.clearSelection?.();
   render();
 };

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -48,6 +48,8 @@ refs:
         handler: handleLayoutEditPanelUpdateHandler
   layoutEditorCanvas:
     eventListeners:
+      selection-change:
+        handler: handleLayoutEditorCanvasSelectionChange
       selected-element-metrics-change:
         handler: handleLayoutEditorCanvasMetricsChange
       drag-update:

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -822,6 +822,7 @@ describe("layoutEditor.handleLayoutEditorCanvasMetricsChange", () => {
     handleLayoutEditorCanvasMetricsChange(deps, {
       _event: {
         detail: {
+          itemId: "selected-item",
           metrics: {
             id: "selected-item",
             width: 76,
@@ -841,6 +842,43 @@ describe("layoutEditor.handleLayoutEditorCanvasMetricsChange", () => {
     expect(
       deps.refs.layoutEditPanel.setSelectedElementMetrics,
     ).not.toHaveBeenCalled();
+  });
+
+  it("accepts metrics for a repeated occurrence of the selected authored item", () => {
+    const metrics = {
+      id: "selected-item-instance-2",
+      width: 76,
+      height: 54,
+    };
+    const deps = {
+      store: {
+        selectSelectedItemId: vi.fn(() => "selected-item"),
+        selectDetailPanelSelectedItemId: vi.fn(() => "selected-item"),
+        setSelectedElementMetrics: vi.fn(),
+      },
+      refs: {
+        layoutEditPanel: {
+          getSelectedElementMetrics: vi.fn(),
+          setSelectedElementMetrics: vi.fn(),
+        },
+      },
+    };
+
+    handleLayoutEditorCanvasMetricsChange(deps, {
+      _event: {
+        detail: {
+          itemId: "selected-item",
+          metrics,
+        },
+      },
+    });
+
+    expect(deps.store.setSelectedElementMetrics).toHaveBeenCalledWith({
+      metrics,
+    });
+    expect(
+      deps.refs.layoutEditPanel.setSelectedElementMetrics,
+    ).toHaveBeenCalledWith({ metrics });
   });
 });
 

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -8,6 +8,7 @@ import {
   handleLayoutEditorCanvasBackgroundClick,
   handleLayoutEditorCanvasDragUpdate,
   handleLayoutEditorCanvasMetricsChange,
+  handleLayoutEditorCanvasSelectionChange,
   handleLayoutEditPanelUpdateHandler,
   handlePreviewButtonClick,
   handleSaveButtonClick,
@@ -847,6 +848,7 @@ describe("layoutEditor.handleFileExplorerItemClick", () => {
   it("clears node selection after clicking empty explorer space", async () => {
     const store = {
       setSelectedItemId: vi.fn(),
+      setDetailPanelSelectedItemId: vi.fn(),
     };
     const render = vi.fn();
 
@@ -870,6 +872,7 @@ describe("layoutEditor.handleFileExplorerItemClick", () => {
   it("closes the mobile node explorer and reveals detail for the selected node", async () => {
     const store = {
       setSelectedItemId: vi.fn(),
+      selectSelectedItemId: vi.fn(() => undefined),
       selectIsTouchMode: vi.fn(() => true),
       selectIsMobileFileExplorerOpen: vi.fn(() => true),
       setDetailPanelSelectedItemId: vi.fn(),
@@ -878,7 +881,7 @@ describe("layoutEditor.handleFileExplorerItemClick", () => {
     const render = vi.fn();
 
     await handleFileExplorerItemClick(
-      { store, render },
+      { store, refs: {}, render },
       {
         _event: {
           detail: {
@@ -902,6 +905,7 @@ describe("layoutEditor.handleLayoutEditorCanvasBackgroundClick", () => {
     const background = {};
     const store = {
       setSelectedItemId: vi.fn(),
+      setDetailPanelSelectedItemId: vi.fn(),
     };
     const refs = {
       fileExplorer: {
@@ -951,6 +955,76 @@ describe("layoutEditor.handleLayoutEditorCanvasBackgroundClick", () => {
     expect(store.setSelectedItemId).not.toHaveBeenCalled();
     expect(refs.fileExplorer.clearSelection).not.toHaveBeenCalled();
     expect(render).not.toHaveBeenCalled();
+  });
+});
+
+describe("layoutEditor.handleLayoutEditorCanvasSelectionChange", () => {
+  it("synchronizes canvas selection with explorer and touch detail", () => {
+    const store = {
+      setSelectedItemId: vi.fn(),
+      selectIsTouchMode: vi.fn(() => true),
+      setDetailPanelSelectedItemId: vi.fn(),
+    };
+    const refs = {
+      fileExplorer: {
+        selectItem: vi.fn(),
+      },
+    };
+    const render = vi.fn();
+
+    handleLayoutEditorCanvasSelectionChange(
+      { store, refs, render },
+      {
+        _event: {
+          detail: {
+            itemId: "node-1",
+            occurrenceId: "node-1-instance-2",
+          },
+        },
+      },
+    );
+
+    expect(store.setSelectedItemId).toHaveBeenCalledWith({ itemId: "node-1" });
+    expect(refs.fileExplorer.selectItem).toHaveBeenCalledWith({
+      itemId: "node-1",
+    });
+    expect(store.setDetailPanelSelectedItemId).toHaveBeenCalledWith({
+      itemId: "node-1",
+    });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears all canonical selection surfaces for an empty canvas hit", () => {
+    const store = {
+      setSelectedItemId: vi.fn(),
+      setDetailPanelSelectedItemId: vi.fn(),
+    };
+    const refs = {
+      fileExplorer: {
+        clearSelection: vi.fn(),
+      },
+    };
+    const render = vi.fn();
+
+    handleLayoutEditorCanvasSelectionChange(
+      { store, refs, render },
+      {
+        _event: {
+          detail: {
+            itemId: undefined,
+          },
+        },
+      },
+    );
+
+    expect(store.setSelectedItemId).toHaveBeenCalledWith({
+      itemId: undefined,
+    });
+    expect(store.setDetailPanelSelectedItemId).toHaveBeenCalledWith({
+      itemId: undefined,
+    });
+    expect(refs.fileExplorer.clearSelection).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
+++ b/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
@@ -168,7 +168,7 @@ const runClick = (deps, { clickCount = 1, metaKey = false } = {}) => {
 };
 
 describe("layoutEditorCanvas pointer selection", () => {
-  it("renders hover with Route Graphics rects and a one-CSS-pixel black line", () => {
+  it("renders hover with Route Graphics rects and a one-CSS-pixel light-gray line", () => {
     const deps = createDeps();
 
     handleCanvasPointerMove(deps, {

--- a/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
+++ b/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
@@ -1,12 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { Subject } from "rxjs";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  handleBeforeMount,
   handleCanvasClick,
   handleCanvasDoubleClick,
   handleCanvasPointerDown,
   handleCanvasPointerMove,
   handleCanvasPointerUp,
+  handleCanvasResize,
+  handleOnUpdate,
 } from "../../src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js";
 import * as canvasStore from "../../src/components/layoutEditorCanvas/layoutEditorCanvas.store.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 const bounds = (x, y, width, height) => ({
   x,
@@ -46,14 +54,26 @@ const createStore = (props) => {
 
   return {
     state,
+    setGraphicsReady: bindAction(canvasStore.setGraphicsReady),
+    selectIsGraphicsReady: bindSelector(canvasStore.selectIsGraphicsReady),
+    setActiveRenderRequestId: bindAction(canvasStore.setActiveRenderRequestId),
+    selectActiveRenderRequestId: bindSelector(
+      canvasStore.selectActiveRenderRequestId,
+    ),
     setSelectionOccurrences: bindAction(canvasStore.setSelectionOccurrences),
     selectSelectionOccurrencesById: bindSelector(
       canvasStore.selectSelectionOccurrencesById,
+    ),
+    selectSelectionOccurrenceState: bindSelector(
+      canvasStore.selectSelectionOccurrenceState,
     ),
     selectHoveredSelection: bindSelector(canvasStore.selectHoveredSelection),
     setHoveredSelection: bindAction(canvasStore.setHoveredSelection),
     clearHoveredSelection: bindAction(canvasStore.clearHoveredSelection),
     setSelectedOccurrence: bindAction(canvasStore.setSelectedOccurrence),
+    selectSelectedOccurrenceId: bindSelector(
+      canvasStore.selectSelectedOccurrenceId,
+    ),
     clearSelectedOccurrence: bindAction(canvasStore.clearSelectedOccurrence),
     setPointerGesture: bindAction(canvasStore.setPointerGesture),
     selectPointerGesture: bindSelector(canvasStore.selectPointerGesture),
@@ -82,6 +102,17 @@ const createStore = (props) => {
     selectHoverFrameId: bindSelector(canvasStore.selectHoverFrameId),
     setCanvasRenderState: bindAction(canvasStore.setCanvasRenderState),
     selectCanvasRenderState: bindSelector(canvasStore.selectCanvasRenderState),
+    selectPendingUpdatedItem: bindSelector(
+      canvasStore.selectPendingUpdatedItem,
+    ),
+    clearPendingUpdatedItem: bindAction(canvasStore.clearPendingUpdatedItem),
+    selectSelectedOccurrenceOwnerId: bindSelector(
+      canvasStore.selectSelectedOccurrenceOwnerId,
+    ),
+    cacheFileContent: bindAction(canvasStore.cacheFileContent),
+    selectCachedFileContent: bindSelector(canvasStore.selectCachedFileContent),
+    clearCachedFileContent: bindAction(canvasStore.clearCachedFileContent),
+    clearFileContentCache: bindAction(canvasStore.clearFileContentCache),
   };
 };
 
@@ -92,8 +123,60 @@ const createDeps = ({ selectedItemId } = {}) => {
       width: 100,
       height: 100,
     },
+    layoutState: {
+      id: "layout-main",
+      layoutType: "general",
+      elements: {
+        items: {
+          parent: {
+            type: "container",
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+          },
+          child: {
+            type: "rect",
+            x: 20,
+            y: 20,
+            width: 40,
+            height: 40,
+          },
+        },
+        tree: [{ id: "parent", children: [{ id: "child" }] }],
+      },
+    },
+    previewData: {},
   };
   const store = createStore(props);
+  const canvasBounds = {
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+  };
+  const baseElements = [{ id: "base", type: "rect", width: 100, height: 100 }];
+  const parsedElements = [
+    {
+      id: "parent",
+      type: "container",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      children: [
+        {
+          id: "child",
+          type: "rect",
+          x: 20,
+          y: 20,
+          width: 40,
+          height: 40,
+        },
+      ],
+    },
+  ];
+  store.setGraphicsReady({ value: true });
   store.setSelectionOccurrences({
     occurrencesById: {
       parent: {
@@ -121,6 +204,8 @@ const createDeps = ({ selectedItemId } = {}) => {
         children: [],
       },
     ],
+    baseElements,
+    parsedElements,
     canvasUnitsPerCssPixel: 2,
   });
 
@@ -129,18 +214,28 @@ const createDeps = ({ selectedItemId } = {}) => {
     store,
     refs: {
       canvas: {
-        getBoundingClientRect: () => ({
-          left: 0,
-          top: 0,
-          width: 100,
-          height: 100,
-        }),
+        getBoundingClientRect: () => canvasBounds,
       },
     },
     graphicsService: {
       hitTestElementBounds: vi.fn(createNestedContentHits),
       render: vi.fn(),
+      parse: vi.fn(({ elements }) => ({ elements })),
+      waitUntilReady: vi.fn(),
+      hasLoadedAsset: vi.fn(() => true),
+      loadAssets: vi.fn(),
     },
+    projectService: {
+      ensureRepository: vi.fn(),
+      getRepositoryState: vi.fn(() => ({
+        layouts: { items: {} },
+        images: { items: {} },
+        textStyles: { items: {} },
+        colors: { items: {} },
+        fonts: { items: {} },
+      })),
+    },
+    canvasBounds,
     dispatchEvent: vi.fn(),
     render: vi.fn(),
   };
@@ -195,6 +290,39 @@ describe("layoutEditorCanvas pointer selection", () => {
     });
   });
 
+  it("tracks touch movement without rendering hover chrome", () => {
+    const deps = createDeps();
+    const pointerEvent = {
+      button: 0,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 30,
+      clientY: 30,
+      metaKey: false,
+      ctrlKey: false,
+    };
+
+    handleCanvasPointerDown(deps, { _event: pointerEvent });
+    handleCanvasPointerMove(deps, {
+      _event: {
+        ...pointerEvent,
+        clientX: 31,
+      },
+    });
+
+    expect(deps.store.selectLastPointerPosition()).toMatchObject({
+      clientX: 31,
+      pointerType: "touch",
+    });
+    expect(deps.store.selectPointerGesture()).toMatchObject({
+      pointerId: 1,
+      moved: false,
+    });
+    expect(deps.store.selectHoveredSelection()).toBeUndefined();
+    expect(deps.graphicsService.render).not.toHaveBeenCalled();
+  });
+
   it("observes a normal click without consuming the authored gesture", () => {
     const deps = createDeps();
     const event = runClick(deps);
@@ -245,5 +373,189 @@ describe("layoutEditorCanvas pointer selection", () => {
       itemId: "child",
       occurrenceId: "child",
     });
+  });
+
+  it("moves selection chrome when another occurrence of the selected item is clicked", () => {
+    const deps = createDeps({ selectedItemId: "parent" });
+    const repeatedElements = [
+      {
+        id: "parent-instance-0",
+        type: "container",
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 20,
+      },
+      {
+        id: "parent-instance-1",
+        type: "container",
+        x: 60,
+        y: 0,
+        width: 20,
+        height: 20,
+      },
+    ];
+    deps.store.setSelectionOccurrences({
+      occurrencesById: {
+        "parent-instance-0": {
+          ownerItemId: "parent",
+          authoredPath: ["parent"],
+        },
+        "parent-instance-1": {
+          ownerItemId: "parent",
+          authoredPath: ["parent"],
+        },
+      },
+      occurrenceIdsByOwner: {
+        parent: ["parent-instance-0", "parent-instance-1"],
+      },
+    });
+    deps.store.setCanvasRenderState({
+      elements: repeatedElements,
+      baseElements: repeatedElements,
+      parsedElements: repeatedElements,
+      canvasUnitsPerCssPixel: 1,
+    });
+    deps.graphicsService.hitTestElementBounds.mockReturnValue([
+      {
+        path: [
+          {
+            id: "parent-instance-1",
+            type: "container",
+            bounds: bounds(60, 0, 20, 20),
+          },
+        ],
+      },
+    ]);
+
+    runClick(deps);
+
+    const renderedElements =
+      deps.graphicsService.render.mock.calls.at(-1)[0].elements;
+    expect(deps.store.selectSelectedOccurrenceId()).toBe("parent-instance-1");
+    expect(renderedElements.at(-1)).toMatchObject({
+      id: "selected-border-group",
+      x: 60,
+      width: 20,
+    });
+    expect(deps.dispatchEvent.mock.calls.at(-1)[0].detail.metrics.id).toBe(
+      "parent-instance-1",
+    );
+  });
+
+  it("restores hover chrome after a full canvas render", async () => {
+    const deps = createDeps();
+    handleCanvasPointerMove(deps, {
+      _event: {
+        pointerId: 1,
+        pointerType: "mouse",
+        clientX: 30,
+        clientY: 30,
+        metaKey: false,
+        ctrlKey: false,
+      },
+    });
+    deps.graphicsService.render.mockClear();
+
+    await handleOnUpdate(deps, {
+      oldProps: deps.props,
+      newProps: {
+        ...deps.props,
+        previewData: {
+          changed: true,
+        },
+      },
+    });
+
+    const renderedElements =
+      deps.graphicsService.render.mock.calls.at(-1)[0].elements;
+    expect(renderedElements.map(({ id }) => id)).toContain(
+      "hover-border-inner",
+    );
+    expect(deps.store.selectHoveredSelection()).toMatchObject({
+      itemId: "parent",
+      occurrenceId: "parent",
+    });
+  });
+
+  it("rebuilds editor chrome with the current canvas CSS scale", () => {
+    const deps = createDeps({ selectedItemId: "parent" });
+    const { elements, baseElements, parsedElements } =
+      deps.store.selectCanvasRenderState();
+    deps.store.setCanvasRenderState({
+      elements,
+      baseElements,
+      parsedElements,
+      canvasUnitsPerCssPixel: 1,
+    });
+    deps.canvasBounds.width = 50;
+
+    expect(handleCanvasResize(deps)).toBe(true);
+
+    const renderedElements =
+      deps.graphicsService.render.mock.calls.at(-1)[0].elements;
+    const overlayChildren = renderedElements.at(-1).children;
+    expect(
+      overlayChildren.find(({ id }) => id === "selected-border-outer").border
+        .width,
+    ).toBe(2);
+    expect(
+      overlayChildren.find(({ id }) => id === "selected-border-inner").border
+        .width,
+    ).toBe(2);
+    expect(
+      overlayChildren.find(({ id }) => id === "selected-border-anchor").width,
+    ).toBe(16);
+    expect(deps.store.selectCanvasRenderState().canvasUnitsPerCssPixel).toBe(2);
+  });
+
+  it("observes canvas size changes and disconnects on unmount", () => {
+    const deps = createDeps({ selectedItemId: "parent" });
+    const frameCallbacks = [];
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    let resizeCallback;
+    vi.stubGlobal("window", new EventTarget());
+    vi.stubGlobal("requestAnimationFrame", (callback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback) {
+          resizeCallback = callback;
+        }
+
+        observe = observe;
+        disconnect = disconnect;
+      },
+    );
+    deps.appService = {
+      isInputFocused: vi.fn(() => false),
+    };
+    deps.subject = new Subject();
+    deps.graphicsService.destroy = vi.fn();
+    const { elements, baseElements, parsedElements } =
+      deps.store.selectCanvasRenderState();
+    deps.store.setCanvasRenderState({
+      elements,
+      baseElements,
+      parsedElements,
+      canvasUnitsPerCssPixel: 1,
+    });
+
+    const cleanup = handleBeforeMount(deps);
+    frameCallbacks.shift()();
+    expect(observe).toHaveBeenCalledWith(deps.refs.canvas);
+
+    deps.canvasBounds.width = 50;
+    resizeCallback();
+    frameCallbacks.shift()();
+    expect(deps.graphicsService.render).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
+++ b/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleCanvasClick,
+  handleCanvasDoubleClick,
+  handleCanvasPointerDown,
+  handleCanvasPointerMove,
+  handleCanvasPointerUp,
+} from "../../src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js";
+import * as canvasStore from "../../src/components/layoutEditorCanvas/layoutEditorCanvas.store.js";
+
+const bounds = (x, y, width, height) => ({
+  x,
+  y,
+  width,
+  height,
+  corners: [
+    { x, y },
+    { x: x + width, y },
+    { x: x + width, y: y + height },
+    { x, y: y + height },
+  ],
+});
+
+const createNestedContentHits = () => [
+  {
+    path: [
+      {
+        id: "parent",
+        type: "container",
+        bounds: bounds(0, 0, 100, 100),
+      },
+      {
+        id: "child",
+        type: "rect",
+        bounds: bounds(20, 20, 40, 40),
+      },
+    ],
+  },
+];
+
+const createStore = (props) => {
+  const state = canvasStore.createInitialState();
+  const bindAction = (action) => (payload) => action({ state, props }, payload);
+  const bindSelector = (selector) => (payload) =>
+    selector({ state, props }, payload);
+
+  return {
+    state,
+    setSelectionOccurrences: bindAction(canvasStore.setSelectionOccurrences),
+    selectSelectionOccurrencesById: bindSelector(
+      canvasStore.selectSelectionOccurrencesById,
+    ),
+    selectHoveredSelection: bindSelector(canvasStore.selectHoveredSelection),
+    setHoveredSelection: bindAction(canvasStore.setHoveredSelection),
+    clearHoveredSelection: bindAction(canvasStore.clearHoveredSelection),
+    setSelectedOccurrence: bindAction(canvasStore.setSelectedOccurrence),
+    clearSelectedOccurrence: bindAction(canvasStore.clearSelectedOccurrence),
+    setPointerGesture: bindAction(canvasStore.setPointerGesture),
+    selectPointerGesture: bindSelector(canvasStore.selectPointerGesture),
+    clearPointerGesture: bindAction(canvasStore.clearPointerGesture),
+    setPendingClickGesture: bindAction(canvasStore.setPendingClickGesture),
+    selectPendingClickGesture: bindSelector(
+      canvasStore.selectPendingClickGesture,
+    ),
+    clearPendingClickGesture: bindAction(canvasStore.clearPendingClickGesture),
+    setDoubleClickSequence: bindAction(canvasStore.setDoubleClickSequence),
+    selectDoubleClickSequence: bindSelector(
+      canvasStore.selectDoubleClickSequence,
+    ),
+    clearDoubleClickSequence: bindAction(canvasStore.clearDoubleClickSequence),
+    setLastPointerPosition: bindAction(canvasStore.setLastPointerPosition),
+    selectLastPointerPosition: bindSelector(
+      canvasStore.selectLastPointerPosition,
+    ),
+    clearLastPointerPosition: bindAction(canvasStore.clearLastPointerPosition),
+    setDeepSelectActive: bindAction(canvasStore.setDeepSelectActive),
+    selectDeepSelectActive: bindSelector(canvasStore.selectDeepSelectActive),
+    selectResolvedSelectedOccurrenceId: bindSelector(
+      canvasStore.selectResolvedSelectedOccurrenceId,
+    ),
+    setHoverFrameId: bindAction(canvasStore.setHoverFrameId),
+    selectHoverFrameId: bindSelector(canvasStore.selectHoverFrameId),
+    setCanvasRenderState: bindAction(canvasStore.setCanvasRenderState),
+    selectCanvasRenderState: bindSelector(canvasStore.selectCanvasRenderState),
+  };
+};
+
+const createDeps = ({ selectedItemId } = {}) => {
+  const props = {
+    selectedItemId,
+    resolution: {
+      width: 100,
+      height: 100,
+    },
+  };
+  const store = createStore(props);
+  store.setSelectionOccurrences({
+    occurrencesById: {
+      parent: {
+        ownerItemId: "parent",
+        authoredPath: ["parent"],
+      },
+      child: {
+        ownerItemId: "child",
+        authoredPath: ["parent", "child"],
+      },
+    },
+    occurrenceIdsByOwner: {
+      parent: ["parent"],
+      child: ["child"],
+    },
+  });
+  store.setCanvasRenderState({
+    elements: [
+      { id: "base", type: "rect", width: 100, height: 100 },
+      {
+        id: "selected-border-group",
+        type: "container",
+        width: 100,
+        height: 100,
+        children: [],
+      },
+    ],
+    canvasUnitsPerCssPixel: 2,
+  });
+
+  return {
+    props,
+    store,
+    refs: {
+      canvas: {
+        getBoundingClientRect: () => ({
+          left: 0,
+          top: 0,
+          width: 100,
+          height: 100,
+        }),
+      },
+    },
+    graphicsService: {
+      hitTestElementBounds: vi.fn(createNestedContentHits),
+      render: vi.fn(),
+    },
+    dispatchEvent: vi.fn(),
+    render: vi.fn(),
+  };
+};
+
+const runClick = (deps, { clickCount = 1, metaKey = false } = {}) => {
+  const event = {
+    button: 0,
+    isPrimary: true,
+    pointerId: clickCount,
+    clientX: 30,
+    clientY: 30,
+    metaKey,
+    ctrlKey: false,
+    detail: clickCount,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  };
+
+  handleCanvasPointerDown(deps, { _event: event });
+  handleCanvasPointerUp(deps, { _event: event });
+  handleCanvasClick(deps, { _event: event });
+
+  return event;
+};
+
+describe("layoutEditorCanvas pointer selection", () => {
+  it("renders hover with Route Graphics rects and a one-CSS-pixel black line", () => {
+    const deps = createDeps();
+
+    handleCanvasPointerMove(deps, {
+      _event: {
+        pointerId: 1,
+        clientX: 30,
+        clientY: 30,
+        metaKey: false,
+        ctrlKey: false,
+      },
+    });
+
+    const renderedElements =
+      deps.graphicsService.render.mock.calls[0][0].elements;
+    expect(renderedElements.map(({ id }) => id)).toEqual([
+      "base",
+      "hover-border-outer",
+      "hover-border-inner",
+      "selected-border-group",
+    ]);
+    expect(renderedElements[2].border).toMatchObject({
+      color: "#b3b3b3",
+      width: 2,
+    });
+  });
+
+  it("observes a normal click without consuming the authored gesture", () => {
+    const deps = createDeps();
+    const event = runClick(deps);
+
+    expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(deps.dispatchEvent.mock.calls[0][0].detail).toEqual({
+      itemId: "parent",
+      occurrenceId: "parent",
+    });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("deep-selects with Command and descends one level on double-click", () => {
+    const deepDeps = createDeps();
+    runClick(deepDeps, { metaKey: true });
+
+    expect(deepDeps.dispatchEvent.mock.calls[0][0].detail).toMatchObject({
+      itemId: "child",
+    });
+
+    const doubleClickDeps = createDeps();
+    runClick(doubleClickDeps, { clickCount: 1 });
+    doubleClickDeps.graphicsService.hitTestElementBounds.mockImplementationOnce(
+      () => [
+        {
+          path: [
+            {
+              id: "selected-border-group",
+              type: "container",
+              bounds: bounds(0, 0, 100, 100),
+            },
+            {
+              id: "selected-border",
+              type: "rect",
+              bounds: bounds(0, 0, 100, 100),
+            },
+          ],
+        },
+        ...createNestedContentHits(),
+      ],
+    );
+    runClick(doubleClickDeps, { clickCount: 2 });
+    handleCanvasDoubleClick(doubleClickDeps);
+
+    expect(doubleClickDeps.dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(doubleClickDeps.dispatchEvent.mock.calls[1][0].detail).toEqual({
+      itemId: "child",
+      occurrenceId: "child",
+    });
+  });
+});

--- a/tests/layoutEditor/layoutEditorCanvasSelection.test.js
+++ b/tests/layoutEditor/layoutEditorCanvasSelection.test.js
@@ -1,0 +1,423 @@
+import { describe, expect, it } from "vitest";
+import { createLayoutEditorRenderedElements } from "../../src/components/layoutEditorCanvas/support/layoutEditorCanvasRender.js";
+import {
+  LAYOUT_EDITOR_SELECTION_METADATA_KEY,
+  createLayoutEditorSelectionElementMapper,
+  extractLayoutEditorSelectionOccurrences,
+  resolveLayoutEditorCanvasHitPath,
+  selectLayoutEditorCanvasHit,
+  selectLayoutEditorCanvasHover,
+  selectNextLayoutEditorCanvasHit,
+} from "../../src/components/layoutEditorCanvas/support/layoutEditorCanvasSelection.js";
+
+const bounds = (x = 0, y = 0, width = 10, height = 10) => ({
+  x,
+  y,
+  width,
+  height,
+  corners: [
+    { x, y },
+    { x: x + width, y },
+    { x: x + width, y: y + height },
+    { x, y: y + height },
+  ],
+});
+
+describe("layoutEditorCanvasSelection", () => {
+  it("keeps fragment descendants owned by the current layout fragment reference", () => {
+    const mapElement = createLayoutEditorSelectionElementMapper({
+      layoutId: "layout-main",
+    });
+    const element = mapElement({
+      element: {
+        id: "fragment-ref--fragment-child",
+        type: "rect",
+      },
+      ancestry: [
+        {
+          layoutId: "layout-main",
+          node: { id: "outer" },
+        },
+        {
+          layoutId: "layout-main",
+          node: { id: "fragment-ref" },
+        },
+        {
+          layoutId: "fragment-layout",
+          node: { id: "fragment-child" },
+        },
+      ],
+    });
+
+    expect(element[LAYOUT_EDITOR_SELECTION_METADATA_KEY]).toEqual({
+      ownerItemId: "fragment-ref",
+      authoredPath: ["outer", "fragment-ref"],
+    });
+  });
+
+  it("extracts a clean rendered tree and an explicit occurrence sidecar", () => {
+    const extracted = extractLayoutEditorSelectionOccurrences([
+      {
+        id: "repeat-instance-2",
+        type: "container",
+        [LAYOUT_EDITOR_SELECTION_METADATA_KEY]: {
+          ownerItemId: "repeat",
+          authoredPath: ["repeat"],
+        },
+        children: [
+          {
+            id: "child-instance-2",
+            type: "rect",
+            [LAYOUT_EDITOR_SELECTION_METADATA_KEY]: {
+              ownerItemId: "child",
+              authoredPath: ["repeat", "child"],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(extracted.occurrencesById).toEqual({
+      "repeat-instance-2": {
+        occurrenceId: "repeat-instance-2",
+        ownerItemId: "repeat",
+        authoredPath: ["repeat"],
+      },
+      "child-instance-2": {
+        occurrenceId: "child-instance-2",
+        ownerItemId: "child",
+        authoredPath: ["repeat", "child"],
+      },
+    });
+    expect(extracted.occurrenceIdsByOwner).toEqual({
+      repeat: ["repeat-instance-2"],
+      child: ["child-instance-2"],
+    });
+    expect(extracted.elements).not.toHaveProperty(
+      `0.${LAYOUT_EDITOR_SELECTION_METADATA_KEY}`,
+    );
+    expect(extracted.elements).not.toHaveProperty(
+      `0.children.0.${LAYOUT_EDITOR_SELECTION_METADATA_KEY}`,
+    );
+  });
+
+  it("resolves normal, deep, and repeated double-click hierarchy targets", () => {
+    const occurrencesById = {
+      a: {
+        ownerItemId: "a",
+        authoredPath: ["a"],
+      },
+      b: {
+        ownerItemId: "b",
+        authoredPath: ["a", "b"],
+      },
+      c: {
+        ownerItemId: "c",
+        authoredPath: ["a", "b", "c"],
+      },
+    };
+    const hitResolution = resolveLayoutEditorCanvasHitPath({
+      hits: [
+        {
+          path: [
+            { id: "a", type: "container", bounds: bounds(0, 0, 100, 100) },
+            { id: "b", type: "container", bounds: bounds(10, 10, 80, 80) },
+            { id: "c", type: "rect", bounds: bounds(20, 20, 40, 40) },
+          ],
+        },
+      ],
+      occurrencesById,
+    });
+
+    expect(selectLayoutEditorCanvasHit(hitResolution)).toMatchObject({
+      itemId: "a",
+      occurrenceId: "a",
+    });
+    expect(
+      selectLayoutEditorCanvasHit(hitResolution, { deepSelect: true }),
+    ).toMatchObject({
+      itemId: "c",
+      occurrenceId: "c",
+    });
+    expect(
+      selectNextLayoutEditorCanvasHit(hitResolution, { selectedItemId: "a" }),
+    ).toMatchObject({ itemId: "b" });
+    expect(
+      selectNextLayoutEditorCanvasHit(hitResolution, { selectedItemId: "b" }),
+    ).toMatchObject({ itemId: "c" });
+    expect(
+      selectNextLayoutEditorCanvasHit(hitResolution, {
+        selectedItemId: "unrelated",
+      }),
+    ).toMatchObject({ itemId: "b" });
+  });
+
+  it("does not hover an ancestor while the selected descendant is under the pointer", () => {
+    const hitResolution = {
+      blocked: false,
+      path: [
+        { itemId: "outer", occurrenceId: "outer-instance" },
+        { itemId: "text", occurrenceId: "text-instance" },
+      ],
+    };
+
+    expect(
+      selectLayoutEditorCanvasHover(hitResolution, {
+        selectedOccurrenceId: "text-instance",
+      }),
+    ).toBeUndefined();
+    expect(
+      selectLayoutEditorCanvasHover(hitResolution, {
+        deepSelect: true,
+        selectedOccurrenceId: "outer-instance",
+      }),
+    ).toMatchObject({
+      itemId: "text",
+      occurrenceId: "text-instance",
+    });
+  });
+
+  it("lets editor chrome own the gesture and skips other unowned branches", () => {
+    const chromeHit = resolveLayoutEditorCanvasHitPath({
+      hits: [
+        {
+          path: [
+            {
+              id: "selected-border-resize-left",
+              type: "rect",
+              bounds: bounds(),
+            },
+          ],
+        },
+        {
+          path: [{ id: "owned", type: "rect", bounds: bounds() }],
+        },
+      ],
+      occurrencesById: {
+        owned: {
+          ownerItemId: "owned",
+          authoredPath: ["owned"],
+        },
+      },
+    });
+    const backgroundHit = resolveLayoutEditorCanvasHitPath({
+      hits: [
+        {
+          path: [{ id: "synthetic-background", bounds: bounds() }],
+        },
+        {
+          path: [{ id: "owned", bounds: bounds() }],
+        },
+      ],
+      occurrencesById: {
+        owned: {
+          ownerItemId: "owned",
+          authoredPath: ["owned"],
+        },
+      },
+    });
+
+    expect(chromeHit).toEqual({ blocked: true, path: [] });
+    expect(selectLayoutEditorCanvasHit(backgroundHit)).toMatchObject({
+      itemId: "owned",
+    });
+  });
+
+  it("resolves content beneath the selected move surface for nested clicks", () => {
+    const hitResolution = resolveLayoutEditorCanvasHitPath({
+      hits: [
+        {
+          path: [
+            {
+              id: "selected-border-group",
+              type: "container",
+              bounds: bounds(),
+            },
+            { id: "selected-border", type: "rect", bounds: bounds() },
+          ],
+        },
+        {
+          path: [
+            { id: "parent", type: "container", bounds: bounds() },
+            { id: "child", type: "text", bounds: bounds() },
+          ],
+        },
+      ],
+      occurrencesById: {
+        parent: {
+          ownerItemId: "parent",
+          authoredPath: ["parent"],
+        },
+        child: {
+          ownerItemId: "child",
+          authoredPath: ["parent", "child"],
+        },
+      },
+    });
+
+    expect(
+      selectNextLayoutEditorCanvasHit(hitResolution, {
+        selectedItemId: "parent",
+      }),
+    ).toMatchObject({
+      itemId: "child",
+      occurrenceId: "child",
+    });
+  });
+
+  it("uses the renderer's front-to-back hit order for overlapping siblings", () => {
+    const hitResolution = resolveLayoutEditorCanvasHitPath({
+      hits: [
+        {
+          path: [{ id: "front", type: "rect", bounds: bounds() }],
+        },
+        {
+          path: [{ id: "back", type: "rect", bounds: bounds() }],
+        },
+      ],
+      occurrencesById: {
+        front: {
+          ownerItemId: "front",
+          authoredPath: ["front"],
+        },
+        back: {
+          ownerItemId: "back",
+          authoredPath: ["back"],
+        },
+      },
+    });
+
+    expect(selectLayoutEditorCanvasHit(hitResolution)).toMatchObject({
+      itemId: "front",
+      occurrenceId: "front",
+    });
+  });
+
+  it("builds fragment occurrence ownership without exposing metadata to graphics", () => {
+    const rendered = createLayoutEditorRenderedElements({
+      layoutState: {
+        id: "layout-main",
+        layoutType: "general",
+        elements: {
+          items: {
+            outer: {
+              type: "container",
+              x: 0,
+              y: 0,
+              width: 200,
+              height: 100,
+            },
+            "fragment-ref": {
+              type: "fragment-ref",
+              fragmentLayoutId: "fragment-layout",
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 50,
+            },
+          },
+          tree: [
+            {
+              id: "outer",
+              children: [{ id: "fragment-ref" }],
+            },
+          ],
+        },
+      },
+      repositoryState: {
+        layouts: {
+          items: {
+            "fragment-layout": {
+              id: "fragment-layout",
+              type: "layout",
+              isFragment: true,
+              elements: {
+                items: {
+                  "fragment-child": {
+                    type: "rect",
+                    x: 0,
+                    y: 0,
+                    width: 50,
+                    height: 20,
+                  },
+                },
+                tree: [{ id: "fragment-child" }],
+              },
+            },
+          },
+        },
+        images: { items: {} },
+        textStyles: { items: {} },
+        colors: { items: {} },
+        fonts: { items: {} },
+      },
+      previewData: {},
+      graphicsService: {
+        parse: ({ elements }) => ({ elements }),
+      },
+    });
+
+    expect(rendered.occurrencesById["fragment-ref--fragment-child"]).toEqual({
+      occurrenceId: "fragment-ref--fragment-child",
+      ownerItemId: "fragment-ref",
+      authoredPath: ["outer", "fragment-ref"],
+    });
+    expect(rendered.elements[0].children[0].children[0]).not.toHaveProperty(
+      LAYOUT_EDITOR_SELECTION_METADATA_KEY,
+    );
+  });
+
+  it("keeps the selected repeated occurrence separate from its authored owner", () => {
+    const rendered = createLayoutEditorRenderedElements({
+      layoutState: {
+        id: "layout-history",
+        layoutType: "history",
+        elements: {
+          items: {
+            row: {
+              type: "container-ref-history-line",
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 40,
+            },
+            child: {
+              type: "rect",
+              x: 0,
+              y: 0,
+              width: 20,
+              height: 10,
+            },
+          },
+          tree: [{ id: "row", children: [{ id: "child" }] }],
+        },
+      },
+      repositoryState: {
+        layouts: { items: {} },
+        images: { items: {} },
+        textStyles: { items: {} },
+        colors: { items: {} },
+        fonts: { items: {} },
+      },
+      previewData: {
+        historyDialogue: [
+          { characterName: "A", text: "First" },
+          { characterName: "B", text: "Second" },
+          { characterName: "C", text: "Third" },
+        ],
+      },
+      selectedItemId: "child",
+      selectedOccurrenceId: "child-instance-2",
+      graphicsService: {
+        parse: ({ elements }) => ({ elements }),
+      },
+    });
+
+    expect(rendered.occurrenceIdsByOwner.child).toEqual([
+      "child-instance-0",
+      "child-instance-1",
+      "child-instance-2",
+    ]);
+    expect(rendered.selectedElementMetrics.id).toBe("child-instance-2");
+  });
+});

--- a/tests/layoutEditor/layoutEditorPreview.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createLayoutEditorHoverOverlay,
   createLayoutEditorRenderedElements,
   createLayoutEditorRenderState,
   createLayoutEditorSelectionOverlay,
@@ -13,6 +14,80 @@ import {
 } from "../../src/internal/layoutConditions.js";
 
 describe("layoutEditorPreview", () => {
+  it("creates one-sided hover rects with CSS-scaled renderer strokes", () => {
+    const overlays = createLayoutEditorHoverOverlay({
+      bounds: {
+        corners: [
+          { x: 10, y: 20 },
+          { x: 110, y: 20 },
+          { x: 110, y: 60 },
+          { x: 10, y: 60 },
+        ],
+      },
+      canvasUnitsPerCssPixel: 2,
+    });
+
+    expect(overlays).toHaveLength(2);
+    expect(overlays[0]).toMatchObject({
+      id: "hover-border-outer",
+      x: 9,
+      y: 19,
+      width: 102,
+      height: 42,
+      border: {
+        color: "#ffffff",
+        width: 2,
+      },
+    });
+    expect(overlays[1]).toMatchObject({
+      id: "hover-border-inner",
+      x: 11,
+      y: 21,
+      width: 98,
+      height: 38,
+      border: {
+        color: "#b3b3b3",
+        width: 2,
+      },
+    });
+
+    const selectionOverlays = createLayoutEditorSelectionOverlay({
+      selectedItemId: "selected",
+      occurrencesById: {
+        selected: {
+          ownerItemId: "selected",
+        },
+      },
+      occurrenceIdsByOwner: {
+        selected: ["selected"],
+      },
+      selectedItem: {
+        type: "container-ref-choice-item",
+      },
+      parsedElements: [
+        {
+          id: "selected",
+          type: "rect",
+          width: 100,
+          height: 40,
+        },
+      ],
+      canvasUnitsPerCssPixel: 2,
+    });
+    const [selectionOuter, selectionInner, , selectionAnchor] =
+      selectionOverlays[0].children;
+
+    expect(selectionOuter.border.width).toBe(2);
+    expect(selectionInner.border.width).toBe(2);
+    expect(selectionAnchor).toMatchObject({
+      width: 16,
+      height: 16,
+      border: {
+        width: 2,
+      },
+    });
+  });
+
   it("builds stable preview data from variables, dialogue defaults, and choices", () => {
     const previewData = createLayoutEditorPreviewData({
       variablesData: {
@@ -674,6 +749,17 @@ describe("layoutEditorPreview", () => {
   it("creates a draggable overlay only for the first repeated instance", () => {
     const overlays = createLayoutEditorSelectionOverlay({
       selectedItemId: "target",
+      occurrencesById: {
+        "target-instance-0": {
+          ownerItemId: "target",
+        },
+        "target-instance-1": {
+          ownerItemId: "target",
+        },
+      },
+      occurrenceIdsByOwner: {
+        target: ["target-instance-0", "target-instance-1"],
+      },
       parsedElements: [
         {
           id: "target-instance-0",
@@ -698,16 +784,45 @@ describe("layoutEditorPreview", () => {
 
     expect(overlays).toHaveLength(1);
     expect(overlays[0].id).toBe("selected-border-group");
-    expect(overlays[0].children).toHaveLength(6);
-    expect(overlays[0].children[0].id).toBe("selected-border");
-    expect(overlays[0].children[0].x).toBe(0);
-    expect(overlays[0].children[0].y).toBe(0);
-    expect(overlays[0].children[0].drag).toEqual({
+    expect(overlays[0].children).toHaveLength(8);
+    expect(overlays[0].children[0]).toMatchObject({
+      id: "selected-border-outer",
+      x: -0.5,
+      y: -0.5,
+      width: 101,
+      height: 41,
+      border: {
+        color: "#ffffff",
+        width: 1,
+        alpha: 1,
+      },
+    });
+    expect(overlays[0].children[1]).toMatchObject({
+      id: "selected-border-inner",
+      x: 0.5,
+      y: 0.5,
+      width: 99,
+      height: 39,
+      border: {
+        color: "#b3b3b3",
+        width: 1,
+        alpha: 1,
+      },
+    });
+    expect(overlays[0].children[2]).toMatchObject({
+      id: "selected-border",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 40,
+    });
+    expect(overlays[0].children[2].border).toBeUndefined();
+    expect(overlays[0].children[2].drag).toEqual({
       start: { payload: {} },
       move: { payload: {} },
       end: { payload: {} },
     });
-    expect(overlays[0].children[5]).toEqual({
+    expect(overlays[0].children[7]).toEqual({
       id: "selected-border-anchor",
       type: "rect",
       x: 46,
@@ -719,7 +834,7 @@ describe("layoutEditorPreview", () => {
         alpha: 1,
       },
       border: {
-        color: "#111111",
+        color: "#b3b3b3",
         width: 1,
         alpha: 1,
       },
@@ -729,6 +844,14 @@ describe("layoutEditorPreview", () => {
   it("does not add resize handles for container items without size controls", () => {
     const overlays = createLayoutEditorSelectionOverlay({
       selectedItemId: "choice-item",
+      occurrencesById: {
+        "choice-item": {
+          ownerItemId: "choice-item",
+        },
+      },
+      occurrenceIdsByOwner: {
+        "choice-item": ["choice-item"],
+      },
       selectedItem: {
         type: "container-ref-choice-item",
       },
@@ -746,6 +869,8 @@ describe("layoutEditorPreview", () => {
 
     expect(overlays).toHaveLength(1);
     expect(overlays[0].children.map((item) => item.id)).toEqual([
+      "selected-border-outer",
+      "selected-border-inner",
       "selected-border",
       "selected-border-anchor",
     ]);
@@ -754,6 +879,14 @@ describe("layoutEditorPreview", () => {
   it("does not add resize handles for auto-width text items", () => {
     const overlays = createLayoutEditorSelectionOverlay({
       selectedItemId: "text-item",
+      occurrencesById: {
+        "text-item": {
+          ownerItemId: "text-item",
+        },
+      },
+      occurrenceIdsByOwner: {
+        "text-item": ["text-item"],
+      },
       selectedItem: {
         type: "text",
         width: undefined,
@@ -772,6 +905,8 @@ describe("layoutEditorPreview", () => {
 
     expect(overlays).toHaveLength(1);
     expect(overlays[0].children.map((item) => item.id)).toEqual([
+      "selected-border-outer",
+      "selected-border-inner",
       "selected-border",
       "selected-border-anchor",
     ]);

--- a/tests/layoutEditor/layoutEditorPreview.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.test.js
@@ -82,10 +82,11 @@ describe("layoutEditorPreview", () => {
     expect(selectionAnchor).toMatchObject({
       width: 16,
       height: 16,
-      border: {
-        width: 2,
+      fill: {
+        type: "radial-gradient",
       },
     });
+    expect(selectionAnchor.border).toBeUndefined();
   });
 
   it("builds stable preview data from variables, dialogue defaults, and choices", () => {
@@ -830,13 +831,19 @@ describe("layoutEditorPreview", () => {
       width: 8,
       height: 8,
       fill: {
-        color: "#ffffff",
-        alpha: 1,
-      },
-      border: {
-        color: "#b3b3b3",
-        width: 1,
-        alpha: 1,
+        type: "radial-gradient",
+        innerCenter: { x: 0.5, y: 0.5 },
+        innerRadius: 0,
+        outerCenter: { x: 0.5, y: 0.5 },
+        outerRadius: 0.5,
+        coordinateSpace: "local",
+        stops: [
+          { offset: 0, color: "#ffffff" },
+          { offset: 0.75, color: "#ffffff" },
+          { offset: 0.75, color: "#b3b3b3" },
+          { offset: 1, color: "#b3b3b3" },
+          { offset: 1, color: "transparent" },
+        ],
       },
     });
   });


### PR DESCRIPTION
## Summary
- document the implemented layout-editor hover and selection behavior for nesting, overlap, fragments, and repeated occurrences
- update to route-graphics 1.29.0 and use live transformed bounds hit testing with explicit authored occurrence metadata
- add canvas hover, click, deep select, double-click descent, explorer/detail synchronization, and one-sided editor chrome while preserving authored renderer interactions
- render hover and selection chrome through Route Graphics with CSS-consistent sizing, deterministic z-order, and a circular anchor marker

## Review fixes
- rebuild selection chrome and metrics immediately when choosing another rendered occurrence of the already-selected authored item
- invalidate and restore stationary hover chrome after full canvas renders
- keep touch pointer movement in gesture tracking without rendering hover chrome
- observe canvas CSS-size changes and rebuild chrome from cached authored/parsed render data
- identify metrics events by authored item while retaining occurrence-specific rendered metrics

## Behavior notes
- empty canvas space clears selection; no Escape selection shortcut is added
- locked elements, layer-picker menus, multiple selection, marquee selection, and dedicated VT coverage remain deferred
- hover uses the live renderer tree at animation-frame cadence; resolved render elements and authored-occurrence metadata remain cached

## Testing
- `bunx vitest run tests/layoutEditor --exclude tests/layoutEditor/layoutEditorPreview.handlers.test.js` (176 passed)
- `bunx vitest run tests/project/layout.soundVariants.test.js tests/project/layout.schemaVersion.test.js tests/project/layout.choiceSingleItems.test.js tests/project/layout.gapFields.test.js tests/project/layout.dialogue.test.js tests/project/layout.richText.test.js tests/project/layout.history.test.js tests/project/layout.spritesheetFps.test.js` (21 passed)
- `bun run lint`
- `git diff --check`

## Notes
- `tests/layoutEditor/layoutEditorPreview.handlers.test.js` remains excluded because its existing fixture is missing `selectDialogueDefaultValues`; the untouched file currently has 3 failures.