### PR TITLE
chore: update Rettangoli UI to 1.13.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@lexical/selection": "0.22.0",
         "@lexical/utils": "0.22.0",
         "@rettangoli/fe": "1.2.3",
-        "@rettangoli/ui": "1.12.0",
+        "@rettangoli/ui": "1.13.1",
         "@rettangoli/vt": "1.0.5",
         "@routevn/creator-model": "1.10.2",
         "@tauri-apps/api": "2.11.0",
@@ -314,7 +314,7 @@
 
     "@rettangoli/sites": ["@rettangoli/sites@1.2.0", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-taGLXClBbCL0Qbj7fFIZ0wW54yHNlKb43cJFZR1Poer2pxvo5GCnShvqZEvUfkPBqp/PKyvLfiOwMxGkbJxqyg=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.12.0", "", { "dependencies": { "@rettangoli/fe": "1.2.3", "jempl": "1.0.1" } }, "sha512-ztGq9VmuMu7l9VUASrWm3+1zZMnK9fTm5ce3xNEtyOZB3TqBdFxEa7T7Bjj+WAZFvMMLDKRs/sQWPf8UjrqyCg=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.13.1", "", { "dependencies": { "@rettangoli/fe": "1.2.3", "jempl": "1.0.1" } }, "sha512-2+CPEbXPcZPBwdGSuHyT5cWw3cvxlYOn3GELX7WOsoy1VizCOB2PnpA6UMIYst/0UHfVMFUrGV9henaFnr60/Q=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.0.5", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-YpZH5xQYj+x5Qy6gn+FUnMTUIQELrZkTA4qN8/U4n/1B4gpNHHPltJK/kVltZQVYVG0Tj676ZIKCMGN0ZAHdzg=="],
 

--- a/docs/resource-tags-spec.md
+++ b/docs/resource-tags-spec.md
@@ -306,7 +306,7 @@ already covers the filter-selection surface cleanly.
 
 ## Rettangoli UI Direction
 
-This spec assumes `@rettangoli/ui` `1.7.5`.
+This spec assumes `@rettangoli/ui` `1.13.1`.
 
 Relevant component support:
 
@@ -482,7 +482,7 @@ collection shape inside existing resource roots.
 Implement this in this order:
 
 1. `routevn-creator-model`
-2. client core contract, command API, and `@rettangoli/ui` `1.7.5`
+2. client core contract, command API, and `@rettangoli/ui` `1.13.1`
 3. shared media-page UI for images, sounds, and videos
 4. character-sprites integration
 5. tests, VT coverage, and manual validation

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@lexical/selection": "0.22.0",
     "@lexical/utils": "0.22.0",
     "@rettangoli/fe": "1.2.3",
-    "@rettangoli/ui": "1.12.0",
+    "@rettangoli/ui": "1.13.1",
     "@rettangoli/vt": "1.0.5",
     "@routevn/creator-model": "1.10.2",
     "@tauri-apps/api": "2.11.0",

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -14,7 +14,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script
       type="module"
       src="/public/main.js?v=20260224-collab-debug-v2"

--- a/static/ios/index.html
+++ b/static/ios/index.html
@@ -43,7 +43,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.1/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -6,7 +6,7 @@
     <title>VT E2E Runner</title>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.11.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.13.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module">
       const VT_RESET_KEY = "routevn.vt.indexeddb-reset-done";
 


### PR DESCRIPTION
## Summary
- update the direct `@rettangoli/ui` dependency and lockfile to `1.13.1`
- align checked-in static and VT entry points with the packaged UI version
- refresh the resource-tags specification UI version reference

## Testing
- `bun run lint`
- `bunx vitest run tests/windowChrome/windowChrome.test.js`
- pre-push hook: `oxlint` and `bun prettier --check src`