### PR TITLE
fix: prevent scenes initial render drift

### DIFF
--- a/src/components/whiteboard/whiteboard.handlers.js
+++ b/src/components/whiteboard/whiteboard.handlers.js
@@ -1634,6 +1634,7 @@ export const handleInitialZoomAndPanSetup = (deps, payload) => {
 
   store.setInitialZoomAndPan({ zoomLevel, panX, panY });
   syncContainerSize(deps);
+  renderWithCursorSync(deps);
 };
 
 export const handleWindowResize = (deps) => {

--- a/src/pages/scenes/scenes.handlers.js
+++ b/src/pages/scenes/scenes.handlers.js
@@ -753,9 +753,15 @@ const openFolderEditDialogWithValues = ({ deps, folderId } = {}) => {
 };
 
 export const handleBeforeMount = (deps) => {
-  const { store, uiConfig } = deps;
+  const { store, projectService, uiConfig } = deps;
 
   store.setUiConfig({ uiConfig });
+  setInitialWhiteboardHydrationState({ store });
+  syncScenesState({
+    store,
+    projectService,
+    shouldRender: false,
+  });
 
   const subscription = createCollabRemoteRefreshStream({
     deps,
@@ -772,18 +778,15 @@ export const handleBeforeMount = (deps) => {
 export const handleAfterMount = async (deps) => {
   const { store, projectService, render, refs, appService } = deps;
 
-  await projectService.ensureRepository();
   const projectInfo = await projectService.getCurrentProjectInfo();
   store.setProjectLanguage({ language: projectInfo.language });
 
-  setInitialWhiteboardHydrationState({ store });
-  const initialSnapshot = syncScenesState({
-    store,
-    render,
-    projectService,
-    shouldRender: false,
-  });
-  const sceneItems = initialSnapshot?.sceneItems ?? [];
+  const sceneItems = store.selectWhiteboardItems() ?? [];
+  const domainState = projectService.getDomainState();
+  const orderedSceneIds = getOrderedSceneIds(domainState).filter(
+    (sceneId) => domainState?.scenes?.[sceneId]?.type !== "folder",
+  );
+  const requestId = store.selectSceneOverviewRequestId();
 
   const shouldHideMapAddHint =
     appService.getUserConfig("scenesMap.hideAddSceneHint") === true;
@@ -825,6 +828,7 @@ export const handleAfterMount = async (deps) => {
     });
   }
 
+  store.setSceneWorkspaceReady({ isReady: true });
   render();
 
   if (persistedSelectedSceneId && !store.selectIsTouchMode?.()) {
@@ -837,8 +841,8 @@ export const handleAfterMount = async (deps) => {
     store,
     render,
     projectService,
-    orderedSceneIds: initialSnapshot?.orderedSceneIds ?? [],
-    requestId: initialSnapshot?.requestId,
+    orderedSceneIds,
+    requestId,
   });
 
   focusFileExplorerKeyboardScope(deps);

--- a/src/pages/scenes/scenes.store.js
+++ b/src/pages/scenes/scenes.store.js
@@ -120,6 +120,7 @@ export const createInitialState = () => ({
   },
   sceneOverviewRequestId: 0,
   isTouchMode: false,
+  isSceneWorkspaceReady: false,
   isMobileFileExplorerOpen: false,
   isTouchMinimapReady: false,
   touchMinimapFrameId: undefined,
@@ -131,6 +132,10 @@ export const createInitialState = () => ({
 export const setUiConfig = ({ state }, { uiConfig } = {}) => {
   state.isTouchMode =
     uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
+};
+
+export const setSceneWorkspaceReady = ({ state }, { isReady } = {}) => {
+  state.isSceneWorkspaceReady = isReady === true;
 };
 
 export const setProjectLanguage = ({ state }, { language } = {}) => {
@@ -640,7 +645,10 @@ export const selectViewData = ({ state, i18n }) => {
     },
     previewVisible: state.previewVisible,
     previewSceneId: state.previewSceneId,
-    showMapAddHint: state.showMapAddHint,
+    showMapAddHint: state.isSceneWorkspaceReady && state.showMapAddHint,
+    sceneWorkspaceVisibility: state.isSceneWorkspaceReady
+      ? "visible"
+      : "hidden",
     sectionsListOpen: state.sectionsListOpen,
     selectedSceneSections,
     selectedSceneTextStatsLabel,

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -117,11 +117,11 @@ template:
                   - rtgl-view slot="content" w=f h=f:
                       - rtgl-text ml=lg s=sm c=mu-fg mv=md: ${title}
                       - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
-          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0;"':
+          - 'rtgl-view w=1fg h=f style="min-width: 0; min-height: 0; visibility: ${sceneWorkspaceVisibility};"':
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
                   - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId} :isTouchMode=${isTouchMode} :showArrows=${showWhiteboardConnections} :showMinimapInTouchMode=${showWhiteboardMinimapInTouchMode} :minimapPlacement=${whiteboardMinimapPlacement} :minimapHeightScale=${whiteboardMinimapHeightScale} :minimapTopInset=${whiteboardMinimapTopInset}: null
           - $if showDetailPanel:
-              - rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left":
+              - 'rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left" style="visibility: ${sceneWorkspaceVisibility};"':
                   - rtgl-view wh=f slot="content":
                       - 'div#fileExplorerDetailKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
                           - $if selectedDetailId:

--- a/tests/scenes/scenes.handlers.test.js
+++ b/tests/scenes/scenes.handlers.test.js
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Subject } from "rxjs";
 import {
   handleAfterMount,
+  handleBeforeMount,
   handleFileExplorerKeyboardScopeKeyDown,
   handleFileExplorerSelectionChanged,
   handleMobileFileExplorerClose,
@@ -85,6 +87,7 @@ const createDeps = ({ userConfig = {}, projectId = "project-1" } = {}) => {
       loadSceneOverviews: vi.fn(async () => ({})),
     },
     store: {
+      setUiConfig: vi.fn(),
       selectWhiteboardItems: vi.fn(() => []),
       setItems: vi.fn(),
       setLayouts: vi.fn(),
@@ -95,6 +98,7 @@ const createDeps = ({ userConfig = {}, projectId = "project-1" } = {}) => {
       }),
       setWhiteboardItems: vi.fn(),
       setProjectLanguage: vi.fn(),
+      setSceneWorkspaceReady: vi.fn(),
       hideMapAddHint: vi.fn(),
       setSelectedItemId: vi.fn(),
       setSelectedFolderId: vi.fn(),
@@ -127,6 +131,7 @@ const createDeps = ({ userConfig = {}, projectId = "project-1" } = {}) => {
         selectItem: vi.fn(),
       },
     },
+    subject: new Subject(),
     render: vi.fn(),
   };
 };
@@ -152,6 +157,32 @@ describe("scenes.handlers config keys", () => {
     globalThis.cancelIdleCallback = originalCancelIdleCallback;
   });
 
+  it("hydrates scenes synchronously before the first render", () => {
+    const deps = createDeps();
+
+    const cleanup = handleBeforeMount(deps);
+
+    expect(deps.store.setItems).toHaveBeenCalledWith({
+      scenesData: deps.projectService.getRepositoryState().scenes,
+    });
+    expect(deps.store.setWhiteboardItems).toHaveBeenCalledWith({
+      items: [
+        {
+          id: "scene-1",
+          isInit: false,
+          name: "Scene 1",
+          transitions: [],
+          x: 0,
+          y: 0,
+        },
+      ],
+    });
+    expect(deps.projectService.ensureRepository).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
   it("loads the scenes viewport from project-scoped userConfig keys", async () => {
     const deps = createDeps({
       userConfig: {
@@ -162,6 +193,7 @@ describe("scenes.handlers config keys", () => {
       },
     });
 
+    const cleanup = handleBeforeMount(deps);
     await handleAfterMount(deps);
 
     expect(deps.projectService.getCurrentProjectInfo).toHaveBeenCalledTimes(1);
@@ -188,6 +220,10 @@ describe("scenes.handlers config keys", () => {
       panX: 48,
       panY: 72,
     });
+    expect(deps.store.setSceneWorkspaceReady).toHaveBeenCalledWith({
+      isReady: true,
+    });
+    cleanup();
   });
 
   it("writes zoom and pan changes to project-scoped viewport keys", () => {
@@ -236,6 +272,7 @@ describe("scenes.handlers config keys", () => {
     const deps = createDeps();
     deps.projectService.loadSceneOverviews = loadSceneOverviews;
 
+    const cleanup = handleBeforeMount(deps);
     await handleAfterMount(deps);
 
     expect(deps.store.setItems).toHaveBeenCalled();
@@ -256,6 +293,7 @@ describe("scenes.handlers config keys", () => {
 
     resolveOverviews({});
     await Promise.resolve();
+    cleanup();
   });
 
   it("waits for idle time before loading scene overviews", async () => {
@@ -268,6 +306,7 @@ describe("scenes.handlers config keys", () => {
 
     const deps = createDeps();
 
+    const cleanup = handleBeforeMount(deps);
     await handleAfterMount(deps);
 
     expect(deps.projectService.loadSceneOverviews).not.toHaveBeenCalled();
@@ -280,6 +319,7 @@ describe("scenes.handlers config keys", () => {
     expect(deps.projectService.loadSceneOverviews).toHaveBeenCalledWith({
       sceneIds: ["scene-1"],
     });
+    cleanup();
   });
 
   it("animates scene map centering from file explorer scene selection", () => {

--- a/tests/scenes/scenes.store.test.js
+++ b/tests/scenes/scenes.store.test.js
@@ -6,6 +6,7 @@ import {
   selectIsMobileFileExplorerOpen,
   selectViewData,
   setProjectLanguage,
+  setSceneWorkspaceReady,
   setShowSceneForm,
   setTouchMinimapReady,
   setUiConfig,
@@ -14,6 +15,32 @@ import {
 import { EN_I18N } from "../support/i18n.js";
 
 describe("scenes.store mobile layout", () => {
+  it("shows the explorer before revealing the initialized scene workspace", () => {
+    const state = createInitialState();
+    state.scenesData = {
+      items: {
+        "scene-1": {
+          id: "scene-1",
+          type: "scene",
+          name: "Scene 1",
+        },
+      },
+      tree: [{ id: "scene-1" }],
+    };
+
+    const initialViewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(initialViewData.flatItems).toHaveLength(1);
+    expect(initialViewData.sceneWorkspaceVisibility).toBe("hidden");
+    expect(initialViewData.showMapAddHint).toBe(false);
+
+    setSceneWorkspaceReady({ state }, { isReady: true });
+    const readyViewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(readyViewData.sceneWorkspaceVisibility).toBe("visible");
+    expect(readyViewData.showMapAddHint).toBe(true);
+  });
+
   it("exposes the selected scene word-count label", () => {
     const state = createInitialState();
     state.selectedItemId = "scene-1";

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -2,6 +2,17 @@ import { readFileSync } from "fs";
 import { describe, expect, it } from "vitest";
 
 describe("scenes view", () => {
+  it("keeps the scene workspace mounted but hidden until setup is ready", () => {
+    const scenesView = readFileSync(
+      new URL("../../src/pages/scenes/scenes.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    expect(
+      scenesView.match(/visibility: \$\{sceneWorkspaceVisibility\}/g),
+    ).toHaveLength(2);
+  });
+
   it("opts into file explorer background deselection", () => {
     const scenesView = readFileSync(
       new URL("../../src/pages/scenes/scenes.view.yaml", import.meta.url),
@@ -9,9 +20,7 @@ describe("scenes view", () => {
     );
 
     expect(scenesView).toContain("selection-cleared:");
-    expect(scenesView).toContain(
-      "handler: handleFileExplorerSelectionChanged",
-    );
+    expect(scenesView).toContain("handler: handleFileExplorerSelectionChanged");
   });
 
   it("uses a bordered top-right mobile hamburger opener", () => {

--- a/tests/whiteboard/whiteboard.handlers.test.js
+++ b/tests/whiteboard/whiteboard.handlers.test.js
@@ -6,6 +6,7 @@ import {
   handleContainerGestureEvent,
   handleContainerWheel,
   handleEnsureItemVisible,
+  handleInitialZoomAndPanSetup,
   handleItemMouseDown,
   handleMinimapViewportMouseDown,
   handleMinimapViewportTouchEnd,
@@ -85,6 +86,7 @@ const createDeps = ({
     setPan: vi.fn(({ panX, panY }) => {
       currentPan = { x: panX, y: panY };
     }),
+    setInitialZoomAndPan: vi.fn(),
     selectPanAnimationFrameId: vi.fn(() => panAnimationFrameId),
     setPanAnimationFrameId: vi.fn(({ frameId }) => {
       panAnimationFrameId = frameId;
@@ -158,6 +160,25 @@ const createDeps = ({
     getZoomLevel: () => currentZoomLevel,
   };
 };
+
+describe("whiteboard initial viewport", () => {
+  it("renders the initialized viewport before the parent reveals it", () => {
+    const deps = createDeps();
+
+    handleInitialZoomAndPanSetup(deps, {
+      zoomLevel: 1.25,
+      panX: -80,
+      panY: -40,
+    });
+
+    expect(deps.store.setInitialZoomAndPan).toHaveBeenCalledWith({
+      zoomLevel: 1.25,
+      panX: -80,
+      panY: -40,
+    });
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+});
 
 const createTouchDragDeps = ({ selectedItemId = "scene-1" } = {}) => {
   let isDragging = false;


### PR DESCRIPTION
## Summary
- hydrate scene explorer data synchronously before the first render
- keep the map and detail workspace hidden until persisted viewport and selection setup completes
- render the whiteboard viewport while hidden so only the final position becomes visible
- add scenes and whiteboard lifecycle regression coverage

## Testing
- bun run lint
- bunx vitest run tests/scenes/scenes.handlers.test.js tests/scenes/scenes.store.test.js tests/scenes/scenes.view.test.js tests/scenes/scenes.fileExplorer.test.js tests/whiteboard/whiteboard.handlers.test.js tests/whiteboard/whiteboard.store.test.js
- headless browser frame sampling: hidden default viewport to visible persisted viewport, with no visible intermediate drift