### PR TITLE
Bump RouteVN Creator to 1.10.0

### DIFF
--- a/docs/runbooks/linux-release.md
+++ b/docs/runbooks/linux-release.md
@@ -5,8 +5,13 @@ Linux direct releases are AppImage-only.
 
 ## Versioning
 
-- Keep the app version in `src-tauri/tauri.conf.json` and
-  `src-tauri/Cargo.toml` aligned.
+- For every app release, update the version in all four of these places:
+  - `src-tauri/tauri.conf.json`: the top-level `version`
+  - `src-tauri/Cargo.toml`: the `routevn-creator` package version
+  - `src-tauri/Cargo.lock`: the `routevn-creator` package entry
+  - `src-tauri/assets/com.routevn.creator.metainfo.xml`: the latest Linux
+    `<release>` entry, including its release date
+- Keep all four version values aligned.
 - Do not change the app version only to represent a package rebuild.
 
 ## Build

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.9.4"
+version = "1.10.0"
 dependencies = [
  "discord-rich-presence",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.9.4"
+version = "1.10.0"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.9.4" date="2026-07-16"/>
+    <release version="1.10.0" date="2026-07-21"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary

- bump RouteVN Creator release metadata to `1.10.0`
- update the Linux AppStream release date to 2026-07-21
- document the four files that must stay aligned during version updates

## Testing

- `cargo metadata --locked --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml`
- `xmllint --noout src-tauri/assets/com.routevn.creator.metainfo.xml`
- verified all four release metadata values resolve to `1.10.0`
- `bun run lint`
- Prettier checks passed for the updated runbook and Tauri config