### PR TITLE
Shorten Web identifier help text

### DIFF
--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -303,7 +303,7 @@ platformDetailsPage:
   saveChangesButton: "Save Changes"
   title: "Platform Details"
   warningTitle: "Warning"
-  webApplicationIdentifierDescription: "Identifies this Web app's save data. Use letters, numbers, hyphens, and periods, for example com.yourteam.yourvn. Changing it prevents access to existing saves."
+  webApplicationIdentifierDescription: "Identifies this Web app's save data. Use letters, numbers, hyphens, and periods. Changing it prevents access to existing saves."
   webApplicationIdentifierChangeConfirm: "Change Identifier"
   webApplicationIdentifierChangeMessage: "Users who update to a Web export with the new identifier will lose access to their existing saves."
   webApplicationIdentifierChangeTitle: "Change Application Identifier?"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -303,7 +303,7 @@ platformDetailsPage:
   saveChangesButton: "変更を保存"
   title: "プラットフォーム詳細"
   warningTitle: "警告"
-  webApplicationIdentifierDescription: "Web版のセーブデータを識別します。英字、数字、ハイフン、ピリオドのみを使用してください（例：com.yourteam.yourvn）。変更すると、既存のセーブデータを利用できなくなります。"
+  webApplicationIdentifierDescription: "Web版のセーブデータを識別します。英字、数字、ハイフン、ピリオドのみを使用してください。変更すると、既存のセーブデータを利用できなくなります。"
   webApplicationIdentifierChangeConfirm: "識別子を変更"
   webApplicationIdentifierChangeMessage: "新しい識別子の Web 書き出し版に更新したユーザーは、既存のセーブデータを利用できなくなります。"
   webApplicationIdentifierChangeTitle: "アプリケーション識別子を変更しますか？"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -303,7 +303,7 @@ platformDetailsPage:
   saveChangesButton: "保存更改"
   title: "平台详情"
   warningTitle: "警告"
-  webApplicationIdentifierDescription: "用于标识此 Web 应用的存档。仅可使用字母、数字、连字符和句点，例如 com.yourteam.yourvn。更改后将无法访问现有存档。"
+  webApplicationIdentifierDescription: "用于标识此 Web 应用的存档。仅可使用字母、数字、连字符和句点。更改后将无法访问现有存档。"
   webApplicationIdentifierChangeConfirm: "更改标识符"
   webApplicationIdentifierChangeMessage: "用户更新到使用新标识符的 Web 导出版本后，将无法访问现有存档。"
   webApplicationIdentifierChangeTitle: "更改应用标识符？"


### PR DESCRIPTION
## Summary
- remove the example application identifier from the Web save-data help text
- keep English, Japanese, and Simplified Chinese copy aligned

## Validation
- bun run lint
- bun run build:web