### PR TITLE
fix: remove asymmetric projects page padding

### DIFF
--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -159,7 +159,7 @@ template:
                         $else:
                           - rtgl-button#loginButton variant=se: ${loginButtonText}
           - 'rtgl-view w=f h=1fg ah=c sv style="min-height: 0;"':
-              - 'rtgl-view w=f d=v pl=md style="max-width: 1280px;"':
+              - 'rtgl-view w=f d=v style="max-width: 1280px;"':
                   - 'rtgl-view w=f ah=c':
                       - rtgl-view sm-w=f w=640 h=1fg d=v g=xl:
                           - rtgl-view w=f g=md pt=lg:


### PR DESCRIPTION
## Summary
- remove the left-only padding from the centered projects list container
- restore symmetric horizontal alignment across viewport sizes

## Testing
- `bun prettier --check src/pages/projects/projects.view.yaml`
- `bunx rtgl fe check`
- `bun run build:web`
- `bash ./scripts/run-vt-docker.sh vt screenshot --item projects/projects.yaml`
- pre-push hook: `oxlint && bun prettier --check src`