### PR TITLE
Remove exported player logs and bump Creator to 1.10.2

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -104,8 +104,6 @@ const recordDiagnosticStep = (message, details) => {
   if (diagnosticEvents.length > MAX_DIAGNOSTIC_EVENTS) {
     diagnosticEvents.shift();
   }
-
-  console.info("[RouteVN player]", message, details ?? "");
 };
 
 document.addEventListener(

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "discord-rich-presence",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.10.1"
+version = "1.10.2"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.10.1" date="2026-07-22"/>
+    <release version="1.10.2" date="2026-07-22"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary
- remove routine diagnostic console output from the exported web player while retaining in-memory diagnostics for error reporting
- bump RouteVN Creator from 1.10.1 to 1.10.2 in the four documented release files
- leave the reusable player shell version unchanged

## Validation
- bun run test:smoke
- bun run lint
- bun run tauri:validate:linux-packaging