### PR TITLE
fix: harden project validation and initialization

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -772,6 +772,20 @@ public class MainActivity extends Activity {
         }
 
         @JavascriptInterface
+        public String getProjectStorageStatus(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                return bridgeSuccess(
+                    MainActivity.this.getProjectStorageStatus(
+                        payload.getString("projectId")
+                    )
+                );
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        @JavascriptInterface
         public String listProjectFolders(String payloadJson) {
             try {
                 return bridgeSuccess(MainActivity.this.listProjectFolders());
@@ -1185,6 +1199,29 @@ public class MainActivity extends Activity {
         if (!metadataRoot.exists() && !metadataRoot.mkdirs()) {
             throw new IllegalStateException("Failed to create project metadata directory.");
         }
+    }
+
+    private JSONObject getProjectStorageStatus(String projectId) throws Exception {
+        String safeProjectId = safePathSegment(projectId);
+        File databaseFile = getProjectDatabaseFile(safeProjectId);
+        File databaseDirectory = databaseFile.getParentFile();
+        File projectDirectory = getProjectRoot(safeProjectId);
+        boolean databaseFileExists = databaseFile.exists();
+        boolean databaseDirectoryExists =
+            databaseDirectory != null && databaseDirectory.exists();
+        boolean projectDirectoryExists = projectDirectory.exists();
+
+        JSONObject status = new JSONObject();
+        status.put(
+            "exists",
+            databaseFileExists ||
+                databaseDirectoryExists ||
+                projectDirectoryExists
+        );
+        status.put("databaseFileExists", databaseFileExists);
+        status.put("databaseDirectoryExists", databaseDirectoryExists);
+        status.put("projectDirectoryExists", projectDirectoryExists);
+        return status;
     }
 
     private JSONObject writeProjectFileBytes(

--- a/ios/routevn/routevn/RouteVNApp.swift
+++ b/ios/routevn/routevn/RouteVNApp.swift
@@ -246,6 +246,8 @@ final class RouteVNViewController: UIViewController, WKNavigationDelegate, WKScr
         case "ensureProjectStorage":
             try storage.ensureProjectDirectories(projectId: requiredString(payload, "projectId"))
             return true
+        case "getProjectStorageStatus":
+            return try storage.projectStorageStatus(projectId: requiredString(payload, "projectId"))
         case "listProjectFolders":
             return try listProjectFolders()
         case "writeProjectFile":
@@ -1989,6 +1991,30 @@ final class RouteVNNativeStorage {
             at: projectMetadataRoot(projectId: safeProjectId),
             withIntermediateDirectories: true
         )
+    }
+
+    func projectStorageStatus(projectId: String) throws -> [String: Any] {
+        let safeProjectId = try safePathSegment(projectId)
+        let databaseURL = try databaseURL(dbPath: projectDatabasePath(projectId: safeProjectId))
+        let databaseDirectoryURL = databaseURL.deletingLastPathComponent()
+        let projectDirectoryURL = try projectRoot(projectId: safeProjectId)
+        let fileManager = FileManager.default
+        let databaseFileExists = fileManager.fileExists(atPath: databaseURL.path)
+        let databaseDirectoryExists = fileManager.fileExists(
+            atPath: databaseDirectoryURL.path
+        )
+        let projectDirectoryExists = fileManager.fileExists(
+            atPath: projectDirectoryURL.path
+        )
+
+        return [
+            "exists": databaseFileExists ||
+                databaseDirectoryExists ||
+                projectDirectoryExists,
+            "databaseFileExists": databaseFileExists,
+            "databaseDirectoryExists": databaseDirectoryExists,
+            "projectDirectoryExists": projectDirectoryExists
+        ]
     }
 
     func writeProjectFile(projectId: String, fileId: String, data: Data, mimeType: String) throws {

--- a/src/deps/clients/web/indexedDb.js
+++ b/src/deps/clients/web/indexedDb.js
@@ -1,0 +1,25 @@
+const INSPECTION_ERROR_MESSAGE =
+  "RouteVN Creator cannot verify that browser project storage is empty.";
+
+export const listIndexedDbDatabaseNames = async () => {
+  const indexedDb = globalThis.indexedDB;
+  if (typeof indexedDb?.databases !== "function") {
+    throw new Error(INSPECTION_ERROR_MESSAGE);
+  }
+
+  let databases;
+  try {
+    databases = await indexedDb.databases();
+  } catch {
+    throw new Error(INSPECTION_ERROR_MESSAGE);
+  }
+  if (!Array.isArray(databases)) {
+    throw new Error(INSPECTION_ERROR_MESSAGE);
+  }
+
+  return new Set(
+    databases
+      .map((database) => database?.name)
+      .filter((name) => typeof name === "string" && name.length > 0),
+  );
+};

--- a/src/deps/clients/web/webRepositoryAdapter.js
+++ b/src/deps/clients/web/webRepositoryAdapter.js
@@ -188,8 +188,6 @@ export const initializeProject = async ({
 
   assertSupportedProjectState(templateData);
 
-  await adapter.clearMaterializedViewCheckpoints();
-
   const initialClientTs = Date.now();
   const initialEvent = createProjectCreateRepositoryEvent({
     projectId,

--- a/src/deps/services/android/appService.js
+++ b/src/deps/services/android/appService.js
@@ -204,19 +204,37 @@ export const createAppService = (params) => {
         },
       });
 
+      await addProjectEntry(projectEntry);
+
       if (iconFile) {
-        const storedIcon = await projectService.storeFileForProject({
-          projectId,
-          file: iconFile,
-        });
-        iconFileId = storedIcon.fileId;
-        projectEntry.iconFileId = iconFileId;
-        await projectService.updateProjectInfoById(projectId, {
-          iconFileId,
-        });
+        try {
+          const storedIcon = await projectService.storeFileForProject({
+            projectId,
+            file: iconFile,
+          });
+          const storedIconFileId = storedIcon.fileId;
+          await projectService.updateProjectInfoById(projectId, {
+            iconFileId: storedIconFileId,
+          });
+          await addProjectEntry({
+            ...projectEntry,
+            iconFileId: storedIconFileId,
+          });
+          iconFileId = storedIconFileId;
+          projectEntry.iconFileId = storedIconFileId;
+        } catch (error) {
+          console.error("Failed to save project icon:", error);
+          const copy = appService.getAppCopy?.() ?? {};
+          appService.showToast({
+            title: copy.errorTitle ?? "Error",
+            message:
+              copy.failedSaveProjectIcon ??
+              "The project was created, but its icon could not be saved.",
+            status: "error",
+          });
+        }
       }
 
-      await addProjectEntry(projectEntry);
       const fullProject = { ...projectEntry };
       if (iconFileId) {
         const iconResult = await platformAdapter.loadProjectIcon({

--- a/src/deps/services/android/appService.js
+++ b/src/deps/services/android/appService.js
@@ -178,13 +178,6 @@ export const createAppService = (params) => {
       const nativeApplicationIdentifier = createNativeApplicationIdentifier();
 
       let iconFileId = null;
-      if (iconFile) {
-        const storedIcon = await projectService.storeFileForProject({
-          projectId,
-          file: iconFile,
-        });
-        iconFileId = storedIcon.fileId;
-      }
 
       const projectEntry = {
         id: projectId,
@@ -207,9 +200,21 @@ export const createAppService = (params) => {
           name,
           description,
           language,
-          iconFileId,
+          iconFileId: null,
         },
       });
+
+      if (iconFile) {
+        const storedIcon = await projectService.storeFileForProject({
+          projectId,
+          file: iconFile,
+        });
+        iconFileId = storedIcon.fileId;
+        projectEntry.iconFileId = iconFileId;
+        await projectService.updateProjectInfoById(projectId, {
+          iconFileId,
+        });
+      }
 
       await addProjectEntry(projectEntry);
       const fullProject = { ...projectEntry };

--- a/src/deps/services/android/projectServiceAdapters.js
+++ b/src/deps/services/android/projectServiceAdapters.js
@@ -661,8 +661,6 @@ export const createAndroidProjectServiceAdapters = ({
         clientTs: initialClientTs,
       });
 
-      await store.clearEvents();
-      await store.clearMaterializedViewCheckpoints();
       await store.insertDraft(toBootstrappedDraftEvent(initialEvent, 0));
       await store.saveMaterializedViewCheckpoint({
         viewName: MAIN_VIEW_NAME,

--- a/src/deps/services/android/projectServiceAdapters.js
+++ b/src/deps/services/android/projectServiceAdapters.js
@@ -33,7 +33,10 @@ import {
   MAIN_VIEW_NAME,
   MAIN_VIEW_VERSION,
 } from "../shared/projectRepositoryViews/shared.js";
-import { toBootstrappedDraftEvent } from "../shared/collab/clientStoreHistory.js";
+import {
+  assertEmptyRepositoryHistory,
+  toBootstrappedDraftEvent,
+} from "../shared/collab/clientStoreHistory.js";
 import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
 import { normalizeProjectLanguage } from "../../../internal/projectLanguage.js";
 import { createWebIconAssets } from "../../clients/web/webIconAssets.js";
@@ -627,6 +630,11 @@ export const createAndroidProjectServiceAdapters = ({
         throw new Error("Template is required for project initialization");
       }
 
+      const store = await createPersistedAndroidProjectStore({
+        projectId: safeProjectId,
+      });
+      assertEmptyRepositoryHistory(await store.getRepositoryHistoryStats());
+
       ensureAndroidProjectStorage(safeProjectId);
 
       const loadedTemplateData = await loadTemplate(template);
@@ -651,9 +659,6 @@ export const createAndroidProjectServiceAdapters = ({
 
       assertSupportedProjectState(templateData);
 
-      const store = await createPersistedAndroidProjectStore({
-        projectId: safeProjectId,
-      });
       const initialClientTs = Date.now();
       const initialEvent = createProjectCreateRepositoryEvent({
         projectId: safeProjectId,

--- a/src/deps/services/android/projectServiceAdapters.js
+++ b/src/deps/services/android/projectServiceAdapters.js
@@ -33,12 +33,10 @@ import {
   MAIN_VIEW_NAME,
   MAIN_VIEW_VERSION,
 } from "../shared/projectRepositoryViews/shared.js";
-import {
-  assertEmptyRepositoryHistory,
-  toBootstrappedDraftEvent,
-} from "../shared/collab/clientStoreHistory.js";
+import { toBootstrappedDraftEvent } from "../shared/collab/clientStoreHistory.js";
 import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
 import { normalizeProjectLanguage } from "../../../internal/projectLanguage.js";
+import { PROJECT_STORAGE_NOT_EMPTY_MESSAGE } from "../../../internal/projectInitialization.js";
 import { createWebIconAssets } from "../../clients/web/webIconAssets.js";
 import {
   filterTemplateFileIds,
@@ -297,6 +295,17 @@ const ensureAndroidProjectStorage = (projectId) => {
       label: "Android project id",
     }),
   });
+};
+
+const assertUnusedAndroidProjectStorage = (projectId) => {
+  const status = callAndroidBridge("getProjectStorageStatus", {
+    projectId: assertSafeAndroidStorageSegment(projectId, {
+      label: "Android project id",
+    }),
+  });
+  if (status?.exists !== false) {
+    throw new Error(PROJECT_STORAGE_NOT_EMPTY_MESSAGE);
+  }
 };
 
 const writeAndroidProjectFile = ({ projectId, fileId, bytes, mimeType }) => {
@@ -630,10 +639,7 @@ export const createAndroidProjectServiceAdapters = ({
         throw new Error("Template is required for project initialization");
       }
 
-      const store = await createPersistedAndroidProjectStore({
-        projectId: safeProjectId,
-      });
-      assertEmptyRepositoryHistory(await store.getRepositoryHistoryStats());
+      assertUnusedAndroidProjectStorage(safeProjectId);
 
       ensureAndroidProjectStorage(safeProjectId);
 
@@ -659,6 +665,9 @@ export const createAndroidProjectServiceAdapters = ({
 
       assertSupportedProjectState(templateData);
 
+      const store = await createPersistedAndroidProjectStore({
+        projectId: safeProjectId,
+      });
       const initialClientTs = Date.now();
       const initialEvent = createProjectCreateRepositoryEvent({
         projectId: safeProjectId,

--- a/src/deps/services/ios/appService.js
+++ b/src/deps/services/ios/appService.js
@@ -204,19 +204,37 @@ export const createAppService = (params) => {
         },
       });
 
+      await addProjectEntry(projectEntry);
+
       if (iconFile) {
-        const storedIcon = await projectService.storeFileForProject({
-          projectId,
-          file: iconFile,
-        });
-        iconFileId = storedIcon.fileId;
-        projectEntry.iconFileId = iconFileId;
-        await projectService.updateProjectInfoById(projectId, {
-          iconFileId,
-        });
+        try {
+          const storedIcon = await projectService.storeFileForProject({
+            projectId,
+            file: iconFile,
+          });
+          const storedIconFileId = storedIcon.fileId;
+          await projectService.updateProjectInfoById(projectId, {
+            iconFileId: storedIconFileId,
+          });
+          await addProjectEntry({
+            ...projectEntry,
+            iconFileId: storedIconFileId,
+          });
+          iconFileId = storedIconFileId;
+          projectEntry.iconFileId = storedIconFileId;
+        } catch (error) {
+          console.error("Failed to save project icon:", error);
+          const copy = appService.getAppCopy?.() ?? {};
+          appService.showToast({
+            title: copy.errorTitle ?? "Error",
+            message:
+              copy.failedSaveProjectIcon ??
+              "The project was created, but its icon could not be saved.",
+            status: "error",
+          });
+        }
       }
 
-      await addProjectEntry(projectEntry);
       const fullProject = { ...projectEntry };
       if (iconFileId) {
         const iconResult = await platformAdapter.loadProjectIcon({

--- a/src/deps/services/ios/appService.js
+++ b/src/deps/services/ios/appService.js
@@ -178,13 +178,6 @@ export const createAppService = (params) => {
       const nativeApplicationIdentifier = createNativeApplicationIdentifier();
 
       let iconFileId = null;
-      if (iconFile) {
-        const storedIcon = await projectService.storeFileForProject({
-          projectId,
-          file: iconFile,
-        });
-        iconFileId = storedIcon.fileId;
-      }
 
       const projectEntry = {
         id: projectId,
@@ -207,9 +200,21 @@ export const createAppService = (params) => {
           name,
           description,
           language,
-          iconFileId,
+          iconFileId: null,
         },
       });
+
+      if (iconFile) {
+        const storedIcon = await projectService.storeFileForProject({
+          projectId,
+          file: iconFile,
+        });
+        iconFileId = storedIcon.fileId;
+        projectEntry.iconFileId = iconFileId;
+        await projectService.updateProjectInfoById(projectId, {
+          iconFileId,
+        });
+      }
 
       await addProjectEntry(projectEntry);
       const fullProject = { ...projectEntry };

--- a/src/deps/services/ios/projectServiceAdapters.js
+++ b/src/deps/services/ios/projectServiceAdapters.js
@@ -661,8 +661,6 @@ export const createIOSProjectServiceAdapters = ({
         clientTs: initialClientTs,
       });
 
-      await store.clearEvents();
-      await store.clearMaterializedViewCheckpoints();
       await store.insertDraft(toBootstrappedDraftEvent(initialEvent, 0));
       await store.saveMaterializedViewCheckpoint({
         viewName: MAIN_VIEW_NAME,

--- a/src/deps/services/ios/projectServiceAdapters.js
+++ b/src/deps/services/ios/projectServiceAdapters.js
@@ -33,7 +33,10 @@ import {
   MAIN_VIEW_NAME,
   MAIN_VIEW_VERSION,
 } from "../shared/projectRepositoryViews/shared.js";
-import { toBootstrappedDraftEvent } from "../shared/collab/clientStoreHistory.js";
+import {
+  assertEmptyRepositoryHistory,
+  toBootstrappedDraftEvent,
+} from "../shared/collab/clientStoreHistory.js";
 import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
 import { normalizeProjectLanguage } from "../../../internal/projectLanguage.js";
 import { createWebIconAssets } from "../../clients/web/webIconAssets.js";
@@ -627,6 +630,11 @@ export const createIOSProjectServiceAdapters = ({
         throw new Error("Template is required for project initialization");
       }
 
+      const store = await createPersistedIOSProjectStore({
+        projectId: safeProjectId,
+      });
+      assertEmptyRepositoryHistory(await store.getRepositoryHistoryStats());
+
       await ensureIOSProjectStorage(safeProjectId);
 
       const loadedTemplateData = await loadTemplate(template);
@@ -651,9 +659,6 @@ export const createIOSProjectServiceAdapters = ({
 
       assertSupportedProjectState(templateData);
 
-      const store = await createPersistedIOSProjectStore({
-        projectId: safeProjectId,
-      });
       const initialClientTs = Date.now();
       const initialEvent = createProjectCreateRepositoryEvent({
         projectId: safeProjectId,

--- a/src/deps/services/ios/projectServiceAdapters.js
+++ b/src/deps/services/ios/projectServiceAdapters.js
@@ -33,12 +33,10 @@ import {
   MAIN_VIEW_NAME,
   MAIN_VIEW_VERSION,
 } from "../shared/projectRepositoryViews/shared.js";
-import {
-  assertEmptyRepositoryHistory,
-  toBootstrappedDraftEvent,
-} from "../shared/collab/clientStoreHistory.js";
+import { toBootstrappedDraftEvent } from "../shared/collab/clientStoreHistory.js";
 import { assertSafeProjectFileId } from "../../../internal/projectFileIds.js";
 import { normalizeProjectLanguage } from "../../../internal/projectLanguage.js";
+import { PROJECT_STORAGE_NOT_EMPTY_MESSAGE } from "../../../internal/projectInitialization.js";
 import { createWebIconAssets } from "../../clients/web/webIconAssets.js";
 import {
   filterTemplateFileIds,
@@ -297,6 +295,17 @@ const ensureIOSProjectStorage = async (projectId) => {
       label: "iOS project id",
     }),
   });
+};
+
+const assertUnusedIOSProjectStorage = async (projectId) => {
+  const status = await callIOSBridge("getProjectStorageStatus", {
+    projectId: assertSafeIOSStorageSegment(projectId, {
+      label: "iOS project id",
+    }),
+  });
+  if (status?.exists !== false) {
+    throw new Error(PROJECT_STORAGE_NOT_EMPTY_MESSAGE);
+  }
 };
 
 const writeIOSProjectFile = async ({ projectId, fileId, bytes, mimeType }) => {
@@ -630,10 +639,7 @@ export const createIOSProjectServiceAdapters = ({
         throw new Error("Template is required for project initialization");
       }
 
-      const store = await createPersistedIOSProjectStore({
-        projectId: safeProjectId,
-      });
-      assertEmptyRepositoryHistory(await store.getRepositoryHistoryStats());
+      await assertUnusedIOSProjectStorage(safeProjectId);
 
       await ensureIOSProjectStorage(safeProjectId);
 
@@ -659,6 +665,9 @@ export const createIOSProjectServiceAdapters = ({
 
       assertSupportedProjectState(templateData);
 
+      const store = await createPersistedIOSProjectStore({
+        projectId: safeProjectId,
+      });
       const initialClientTs = Date.now();
       const initialEvent = createProjectCreateRepositoryEvent({
         projectId: safeProjectId,

--- a/src/deps/services/shared/collab/clientStoreHistory.js
+++ b/src/deps/services/shared/collab/clientStoreHistory.js
@@ -25,6 +25,16 @@ export const getRepositoryHistoryLength = (stats = {}) => {
   return normalizedStats.committedCount + normalizedStats.draftCount;
 };
 
+export const assertEmptyRepositoryHistory = (stats = {}) => {
+  if (getRepositoryHistoryLength(stats) === 0) {
+    return;
+  }
+
+  throw new Error(
+    "Project storage is not empty. New project initialization requires empty storage.",
+  );
+};
+
 export const areRepositoryHistoryStatsEqual = (left, right) => {
   const normalizedLeft = normalizeRepositoryHistoryStats(left);
   const normalizedRight = normalizeRepositoryHistoryStats(right);

--- a/src/deps/services/shared/collab/clientStoreHistory.js
+++ b/src/deps/services/shared/collab/clientStoreHistory.js
@@ -25,16 +25,6 @@ export const getRepositoryHistoryLength = (stats = {}) => {
   return normalizedStats.committedCount + normalizedStats.draftCount;
 };
 
-export const assertEmptyRepositoryHistory = (stats = {}) => {
-  if (getRepositoryHistoryLength(stats) === 0) {
-    return;
-  }
-
-  throw new Error(
-    "Project storage is not empty. New project initialization requires empty storage.",
-  );
-};
-
 export const areRepositoryHistoryStatsEqual = (left, right) => {
   const normalizedLeft = normalizeRepositoryHistoryStats(left);
   const normalizedRight = normalizeRepositoryHistoryStats(right);

--- a/src/deps/services/tauri/projectServiceAdapters.js
+++ b/src/deps/services/tauri/projectServiceAdapters.js
@@ -1,4 +1,10 @@
-import { mkdir, writeFile, readFile, exists } from "@tauri-apps/plugin-fs";
+import {
+  mkdir,
+  writeFile,
+  readFile,
+  readDir,
+  exists,
+} from "@tauri-apps/plugin-fs";
 import { join, resolveResource } from "@tauri-apps/api/path";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { fileTypeFromBuffer } from "file-type";
@@ -1018,6 +1024,13 @@ export const createTauriProjectServiceAdapters = ({
         throw new Error("Template is required for project initialization");
       }
 
+      const projectEntries = await readDir(projectPath);
+      if (projectEntries.length > 0) {
+        throw new Error(
+          "The selected folder must be empty. Please choose an empty folder for your new project.",
+        );
+      }
+
       const filesPath = await join(projectPath, "files");
       await mkdir(filesPath, { recursive: true });
 
@@ -1050,8 +1063,6 @@ export const createTauriProjectServiceAdapters = ({
         clientTs: initialClientTs,
       });
 
-      await store.clearEvents();
-      await store.clearMaterializedViewCheckpoints();
       await store.insertDraft(toBootstrappedDraftEvent(initialEvent, 0));
       await store.saveMaterializedViewCheckpoint({
         viewName: MAIN_VIEW_NAME,

--- a/src/deps/services/web/appService.js
+++ b/src/deps/services/web/appService.js
@@ -57,13 +57,6 @@ export const createAppService = (params) => {
       const namespace = generateId();
       const nativeApplicationIdentifier = createNativeApplicationIdentifier();
       let iconFileId = null;
-      if (iconFile) {
-        const storedIcon = await projectService.storeFileForProject({
-          projectId,
-          file: iconFile,
-        });
-        iconFileId = storedIcon.fileId;
-      }
 
       const projectEntry = {
         id: projectId,
@@ -86,9 +79,21 @@ export const createAppService = (params) => {
           name,
           description,
           language,
-          iconFileId,
+          iconFileId: null,
         },
       });
+
+      if (iconFile) {
+        const storedIcon = await projectService.storeFileForProject({
+          projectId,
+          file: iconFile,
+        });
+        iconFileId = storedIcon.fileId;
+        projectEntry.iconFileId = iconFileId;
+        await projectService.updateProjectInfoById(projectId, {
+          iconFileId,
+        });
+      }
 
       await addProjectEntry(projectEntry);
       const fullProject = { ...projectEntry };

--- a/src/deps/services/web/appService.js
+++ b/src/deps/services/web/appService.js
@@ -83,19 +83,37 @@ export const createAppService = (params) => {
         },
       });
 
+      await addProjectEntry(projectEntry);
+
       if (iconFile) {
-        const storedIcon = await projectService.storeFileForProject({
-          projectId,
-          file: iconFile,
-        });
-        iconFileId = storedIcon.fileId;
-        projectEntry.iconFileId = iconFileId;
-        await projectService.updateProjectInfoById(projectId, {
-          iconFileId,
-        });
+        try {
+          const storedIcon = await projectService.storeFileForProject({
+            projectId,
+            file: iconFile,
+          });
+          const storedIconFileId = storedIcon.fileId;
+          await projectService.updateProjectInfoById(projectId, {
+            iconFileId: storedIconFileId,
+          });
+          await addProjectEntry({
+            ...projectEntry,
+            iconFileId: storedIconFileId,
+          });
+          iconFileId = storedIconFileId;
+          projectEntry.iconFileId = storedIconFileId;
+        } catch (error) {
+          console.error("Failed to save project icon:", error);
+          const copy = appService.getAppCopy?.() ?? {};
+          appService.showToast({
+            title: copy.errorTitle ?? "Error",
+            message:
+              copy.failedSaveProjectIcon ??
+              "The project was created, but its icon could not be saved.",
+            status: "error",
+          });
+        }
       }
 
-      await addProjectEntry(projectEntry);
       const fullProject = { ...projectEntry };
       if (iconFileId) {
         const iconResult = await platformAdapter.loadProjectIcon({

--- a/src/deps/services/web/collabClientStore.js
+++ b/src/deps/services/web/collabClientStore.js
@@ -6,51 +6,6 @@ export const buildClientStoreDbName = (projectId) => {
   return `routevn-collab-client:${CLIENT_STORE_VERSION}:${projectId}`;
 };
 
-const deleteDatabaseOnce = (name) =>
-  new Promise((resolve) => {
-    if (typeof name !== "string" || name.length === 0) {
-      resolve(true);
-      return;
-    }
-
-    let settled = false;
-    const finish = (result) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(result);
-    };
-
-    const request = indexedDB.deleteDatabase(name);
-    request.onsuccess = () => finish(true);
-    request.onerror = () => finish(false);
-    request.onblocked = () => finish(false);
-  });
-
-export const deletePersistedInMemoryClientStore = async ({
-  projectId,
-  store,
-} = {}) => {
-  if (store && typeof store.close === "function") {
-    await store.close().catch(() => {});
-  }
-
-  const dbName = buildClientStoreDbName(projectId);
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const deleted = await deleteDatabaseOnce(dbName);
-    if (deleted) {
-      return;
-    }
-
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50 * (attempt + 1));
-    });
-  }
-
-  throw new Error(`Failed to reset web client store '${dbName}'`);
-};
-
 export const createPersistedInMemoryClientStore = async ({
   projectId,
   materializedViews = [],

--- a/src/deps/services/web/projectServiceAdapters.js
+++ b/src/deps/services/web/projectServiceAdapters.js
@@ -6,10 +6,8 @@ import {
 } from "../../clients/web/webRepositoryAdapter.js";
 import { createProjectCollabService } from "../shared/collab/createProjectCollabService.js";
 import { createWebSocketTransport } from "./collab/createWebSocketTransport.js";
-import {
-  createPersistedInMemoryClientStore,
-  deletePersistedInMemoryClientStore,
-} from "./collabClientStore.js";
+import { createPersistedInMemoryClientStore } from "./collabClientStore.js";
+import { listIndexedDbDatabaseNames } from "../../clients/web/indexedDb.js";
 import {
   clearCommittedCursor,
   loadCommittedCursor,
@@ -38,6 +36,7 @@ import {
   applyCommandToRepository,
   assertSupportedProjectState,
 } from "../shared/projectRepository.js";
+import { PROJECT_STORAGE_NOT_EMPTY_MESSAGE } from "../../../internal/projectInitialization.js";
 
 const countImageEntries = (imagesData) =>
   Object.values(imagesData?.items || {}).filter(
@@ -93,20 +92,6 @@ export const createWebProjectServiceAdapters = ({
     });
     collabClientStoresByProject.set(projectId, store);
     return store;
-  };
-
-  const evictCollabClientStore = async (projectId) => {
-    const existing = collabClientStoresByProject.get(projectId);
-    collabClientStoresByProject.delete(projectId);
-
-    if (!projectId) {
-      return;
-    }
-
-    await deletePersistedInMemoryClientStore({
-      projectId,
-      store: existing,
-    });
   };
 
   const ensureCommittedIdLoaded = async (projectId, getStoreByProject) => {
@@ -215,8 +200,20 @@ export const createWebProjectServiceAdapters = ({
       projectInfo,
       projectResolution,
     }) => {
+      const databaseNames = await listIndexedDbDatabaseNames();
+      const collabDatabaseSuffix = `:${projectId}`;
+      const hasProjectStorage = [...databaseNames].some((databaseName) => {
+        return (
+          databaseName === projectId ||
+          (databaseName.startsWith("routevn-collab-client:") &&
+            databaseName.endsWith(collabDatabaseSuffix))
+        );
+      });
+      if (hasProjectStorage || collabClientStoresByProject.has(projectId)) {
+        throw new Error(PROJECT_STORAGE_NOT_EMPTY_MESSAGE);
+      }
+
       clearProjectCollabCaches(projectId);
-      await evictCollabClientStore(projectId);
       const rawClientStore = await getCollabClientStore(projectId);
       return initializeWebProject({
         projectId,

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -178,6 +178,7 @@ appPage:
   failedLoadAppSettings: "Failed to load app settings. Using defaults."
   failedOpenLink: "Failed to open link."
   failedSaveAppSettings: "Failed to save app settings."
+  failedSaveProjectIcon: "The project was created, but its icon could not be saved."
   incompatibleProjectTitle: "Incompatible Project"
   latestVersionMessage: "You are already on the latest version"
   laterButton: "Later"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -178,6 +178,7 @@ appPage:
   failedLoadAppSettings: "アプリ設定を読み込めませんでした。既定値を使用します。"
   failedOpenLink: "リンクを開けませんでした。"
   failedSaveAppSettings: "アプリ設定を保存できませんでした。"
+  failedSaveProjectIcon: "プロジェクトは作成されましたが、プロジェクトアイコンを保存できませんでした。"
   incompatibleProjectTitle: "互換性のないプロジェクト"
   latestVersionMessage: "すでに最新バージョンです"
   laterButton: "後で"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -178,6 +178,7 @@ appPage:
   failedLoadAppSettings: "无法加载应用设置。将使用默认值。"
   failedOpenLink: "无法打开链接。"
   failedSaveAppSettings: "无法保存应用设置。"
+  failedSaveProjectIcon: "项目已创建，但无法保存项目图标。"
   incompatibleProjectTitle: "项目不兼容"
   latestVersionMessage: "当前已经是最新版本"
   laterButton: "稍后"

--- a/src/internal/projectInitialization.js
+++ b/src/internal/projectInitialization.js
@@ -1,0 +1,2 @@
+export const PROJECT_STORAGE_NOT_EMPTY_MESSAGE =
+  "Project storage is not empty. New project initialization requires empty storage.";

--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -87,6 +87,15 @@ const isProjectDataStructureValidationError = (error) => {
   );
 };
 
+const getProjectValidationErrorMessage = (error) => {
+  const detail =
+    typeof error?.message === "string" && error.message.trim()
+      ? error.message.trim()
+      : "";
+  const errorDetail = detail ? `\n\nError: ${detail}` : "";
+  return `RouteVN Creator couldn't safely open this project.${errorDetail}\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.`;
+};
+
 export const getProjectOpenErrorMessage = (error) => {
   if (isIncompatibleProjectOpenError(error)) {
     return getIncompatibleProjectOpenMessage(error);
@@ -99,9 +108,7 @@ export const getProjectOpenErrorMessage = (error) => {
   }
 
   if (isProjectDataStructureValidationError(error)) {
-    return withLatestCreatorVersionHint(
-      "Project data structure failed validation.",
-    );
+    return getProjectValidationErrorMessage(error);
   }
 
   if (isProjectDatabaseOpenError(error)) {

--- a/src/internal/projectOpenErrors.js
+++ b/src/internal/projectOpenErrors.js
@@ -87,13 +87,18 @@ const isProjectDataStructureValidationError = (error) => {
   );
 };
 
-const getProjectValidationErrorMessage = (error) => {
+const isProjectHistoryIntegrityError = (error) => {
+  const message = String(error?.message ?? "").toLowerCase();
+  return message.includes("committed event invariant violation");
+};
+
+const getProjectIntegrityErrorMessage = (error) => {
   const detail =
     typeof error?.message === "string" && error.message.trim()
       ? error.message.trim()
       : "";
-  const errorDetail = detail ? `\n\nError: ${detail}` : "";
-  return `RouteVN Creator couldn't safely open this project.${errorDetail}\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.`;
+  const technicalDetail = detail ? `\n\nTechnical details: ${detail}` : "";
+  return `RouteVN Creator couldn't safely open this project because its saved project history is inconsistent.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.${technicalDetail}`;
 };
 
 export const getProjectOpenErrorMessage = (error) => {
@@ -107,8 +112,11 @@ export const getProjectOpenErrorMessage = (error) => {
     );
   }
 
-  if (isProjectDataStructureValidationError(error)) {
-    return getProjectValidationErrorMessage(error);
+  if (
+    isProjectDataStructureValidationError(error) ||
+    isProjectHistoryIntegrityError(error)
+  ) {
+    return getProjectIntegrityErrorMessage(error);
   }
 
   if (isProjectDatabaseOpenError(error)) {

--- a/tests/android/projectServiceAdapters.test.js
+++ b/tests/android/projectServiceAdapters.test.js
@@ -4,12 +4,14 @@ import { parseBundle } from "../../src/deps/services/shared/projectExportService
 
 const mocked = vi.hoisted(() => ({
   callAndroidBridge: vi.fn(),
+  createPersistedAndroidProjectStore: vi.fn(),
   createWebIconAssets: vi.fn(async ({ variants }) =>
     variants.map(({ fileName, size }) => ({
       fileName,
       bytes: Uint8Array.from([size === 192 ? 192 : 255]),
     })),
   ),
+  loadTemplate: vi.fn(),
 }));
 
 vi.mock("../../src/deps/clients/android/bridge.js", async () => {
@@ -26,6 +28,27 @@ vi.mock("../../src/deps/clients/web/webIconAssets.js", () => ({
   createWebIconAssets: mocked.createWebIconAssets,
 }));
 
+vi.mock("../../src/deps/services/android/collabClientStore.js", async () => {
+  const actual = await vi.importActual(
+    "../../src/deps/services/android/collabClientStore.js",
+  );
+  return {
+    ...actual,
+    createPersistedAndroidProjectStore:
+      mocked.createPersistedAndroidProjectStore,
+  };
+});
+
+vi.mock("../../src/deps/clients/web/templateLoader.js", async () => {
+  const actual = await vi.importActual(
+    "../../src/deps/clients/web/templateLoader.js",
+  );
+  return {
+    ...actual,
+    loadTemplate: mocked.loadTemplate,
+  };
+});
+
 import { createAndroidProjectServiceAdapters } from "../../src/deps/services/android/projectServiceAdapters.js";
 
 const toBase64 = (bytes) => Buffer.from(bytes).toString("base64");
@@ -40,6 +63,8 @@ const toExactArrayBuffer = (bytes) => {
 describe("android project service adapters", () => {
   beforeEach(() => {
     mocked.callAndroidBridge.mockReset();
+    mocked.createPersistedAndroidProjectStore.mockReset();
+    mocked.loadTemplate.mockReset();
     vi.spyOn(console, "info").mockImplementation(() => {});
   });
 
@@ -175,5 +200,53 @@ describe("android project service adapters", () => {
         getStoreByProject: vi.fn(),
       }),
     ).rejects.toThrow("Android remote collaboration is disabled.");
+  });
+
+  it("rejects existing Android project history before initialization writes", async () => {
+    const store = {
+      getRepositoryHistoryStats: vi.fn(async () => ({
+        committedCount: 1,
+        latestCommittedId: 1,
+        draftCount: 0,
+        latestDraftClock: 0,
+      })),
+      insertDraft: vi.fn(async () => {}),
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      app: {
+        set: vi.fn(async () => {}),
+      },
+    };
+    mocked.createPersistedAndroidProjectStore.mockResolvedValue(store);
+    const { storageAdapter } = createAndroidProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 2,
+    });
+
+    await expect(
+      storageAdapter.initializeProject({
+        projectId: "project-1",
+        template: "blank",
+        projectInfo: {
+          id: "project-1",
+          name: "Project One",
+        },
+        projectResolution: {
+          width: 1280,
+          height: 720,
+        },
+      }),
+    ).rejects.toThrow(
+      "Project storage is not empty. New project initialization requires empty storage.",
+    );
+
+    expect(mocked.createPersistedAndroidProjectStore).toHaveBeenCalledWith({
+      projectId: "project-1",
+    });
+    expect(store.getRepositoryHistoryStats).toHaveBeenCalledTimes(1);
+    expect(mocked.callAndroidBridge).not.toHaveBeenCalled();
+    expect(mocked.loadTemplate).not.toHaveBeenCalled();
+    expect(store.insertDraft).not.toHaveBeenCalled();
+    expect(store.saveMaterializedViewCheckpoint).not.toHaveBeenCalled();
+    expect(store.app.set).not.toHaveBeenCalled();
   });
 });

--- a/tests/android/projectServiceAdapters.test.js
+++ b/tests/android/projectServiceAdapters.test.js
@@ -12,6 +12,7 @@ const mocked = vi.hoisted(() => ({
     })),
   ),
   loadTemplate: vi.fn(),
+  getTemplateFiles: vi.fn(),
 }));
 
 vi.mock("../../src/deps/clients/android/bridge.js", async () => {
@@ -46,10 +47,12 @@ vi.mock("../../src/deps/clients/web/templateLoader.js", async () => {
   return {
     ...actual,
     loadTemplate: mocked.loadTemplate,
+    getTemplateFiles: mocked.getTemplateFiles,
   };
 });
 
 import { createAndroidProjectServiceAdapters } from "../../src/deps/services/android/projectServiceAdapters.js";
+import { initialProjectData } from "../../src/deps/services/shared/projectRepository.js";
 
 const toBase64 = (bytes) => Buffer.from(bytes).toString("base64");
 
@@ -65,6 +68,8 @@ describe("android project service adapters", () => {
     mocked.callAndroidBridge.mockReset();
     mocked.createPersistedAndroidProjectStore.mockReset();
     mocked.loadTemplate.mockReset();
+    mocked.getTemplateFiles.mockReset();
+    mocked.getTemplateFiles.mockResolvedValue([]);
     vi.spyOn(console, "info").mockImplementation(() => {});
   });
 
@@ -202,14 +207,20 @@ describe("android project service adapters", () => {
     ).rejects.toThrow("Android remote collaboration is disabled.");
   });
 
-  it("rejects existing Android project history before initialization writes", async () => {
+  it("rejects existing Android project storage before initialization writes", async () => {
+    mocked.callAndroidBridge.mockImplementation((method) => {
+      if (method === "getProjectStorageStatus") {
+        return {
+          exists: true,
+          databaseFileExists: true,
+          databaseDirectoryExists: true,
+          projectDirectoryExists: false,
+        };
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
     const store = {
-      getRepositoryHistoryStats: vi.fn(async () => ({
-        committedCount: 1,
-        latestCommittedId: 1,
-        draftCount: 0,
-        latestDraftClock: 0,
-      })),
       insertDraft: vi.fn(async () => {}),
       saveMaterializedViewCheckpoint: vi.fn(async () => {}),
       app: {
@@ -239,14 +250,81 @@ describe("android project service adapters", () => {
       "Project storage is not empty. New project initialization requires empty storage.",
     );
 
-    expect(mocked.createPersistedAndroidProjectStore).toHaveBeenCalledWith({
-      projectId: "project-1",
-    });
-    expect(store.getRepositoryHistoryStats).toHaveBeenCalledTimes(1);
-    expect(mocked.callAndroidBridge).not.toHaveBeenCalled();
+    expect(mocked.callAndroidBridge).toHaveBeenCalledWith(
+      "getProjectStorageStatus",
+      {
+        projectId: "project-1",
+      },
+    );
+    expect(mocked.createPersistedAndroidProjectStore).not.toHaveBeenCalled();
     expect(mocked.loadTemplate).not.toHaveBeenCalled();
     expect(store.insertDraft).not.toHaveBeenCalled();
     expect(store.saveMaterializedViewCheckpoint).not.toHaveBeenCalled();
     expect(store.app.set).not.toHaveBeenCalled();
+  });
+
+  it("creates Android project storage only after the unused-storage check", async () => {
+    mocked.callAndroidBridge.mockImplementation((method) => {
+      if (method === "getProjectStorageStatus") {
+        return {
+          exists: false,
+          databaseFileExists: false,
+          databaseDirectoryExists: false,
+          projectDirectoryExists: false,
+        };
+      }
+      if (method === "ensureProjectStorage") {
+        return true;
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
+    mocked.loadTemplate.mockResolvedValue(structuredClone(initialProjectData));
+    const store = {
+      insertDraft: vi.fn(async () => {}),
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      app: {
+        set: vi.fn(async () => {}),
+      },
+    };
+    mocked.createPersistedAndroidProjectStore.mockResolvedValue(store);
+    const { storageAdapter } = createAndroidProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 2,
+    });
+
+    await storageAdapter.initializeProject({
+      projectId: "project-1",
+      template: "blank",
+      projectInfo: {
+        id: "project-1",
+        name: "Project One",
+      },
+      projectResolution: {
+        width: 1280,
+        height: 720,
+      },
+    });
+
+    expect(mocked.callAndroidBridge).toHaveBeenNthCalledWith(
+      1,
+      "getProjectStorageStatus",
+      {
+        projectId: "project-1",
+      },
+    );
+    expect(mocked.callAndroidBridge).toHaveBeenNthCalledWith(
+      2,
+      "ensureProjectStorage",
+      {
+        projectId: "project-1",
+      },
+    );
+    expect(mocked.createPersistedAndroidProjectStore).toHaveBeenCalledWith({
+      projectId: "project-1",
+    });
+    expect(store.insertDraft).toHaveBeenCalledTimes(1);
+    expect(store.saveMaterializedViewCheckpoint).toHaveBeenCalledTimes(1);
+    expect(store.app.set).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -151,6 +151,56 @@ describe("app route transitions", () => {
     expect(appService.prepareNavigation).not.toHaveBeenCalled();
   });
 
+  it("returns to projects when project route validation fails", async () => {
+    const error = new Error(
+      "state.story.initialSceneId must reference an existing scene",
+    );
+    error.code = "state_validation_failed";
+    const appService = {
+      prepareNavigation: vi.fn(async () => {}),
+      redirect: vi.fn(),
+      replace: vi.fn(),
+      getCurrentProjectId: vi.fn(() => "project-1"),
+      refreshCurrentProjectEntry: vi.fn(async () => {}),
+      getPlatform: vi.fn(() => "tauri"),
+      showAlert: vi.fn(),
+    };
+    const deps = {
+      appService,
+      projectService: {
+        ensureRepository: vi.fn(async () => {
+          throw error;
+        }),
+        getEnsuredProjectId: vi.fn(() => undefined),
+        releaseProjectRuntime: vi.fn(async () => {}),
+      },
+      store: {
+        setCurrentRoute: vi.fn(),
+        closeMobileSheet: vi.fn(),
+        setRepositoryLoading: vi.fn(),
+        setRepositoryLoadingPhase: vi.fn(),
+        setRepositoryLoadingProgress: vi.fn(),
+      },
+      render: vi.fn(),
+      i18n: {},
+    };
+
+    await createRouteTransitionRunner(deps)({
+      path: "/project",
+      payload: { p: "project-1" },
+    });
+
+    expect(appService.showAlert).toHaveBeenCalledWith({
+      message:
+        "RouteVN Creator couldn't safely open this project.\n\nError: state.story.initialSceneId must reference an existing scene\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+    });
+    expect(appService.redirect).toHaveBeenCalledWith("/projects");
+    expect(deps.store.setCurrentRoute).toHaveBeenCalledWith({
+      route: "/projects",
+      payload: {},
+    });
+  });
+
   it("prepares browser back navigation without rewriting the popped entry", async () => {
     const currentPath = "/projects";
     const currentPayload = {};

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -192,7 +192,7 @@ describe("app route transitions", () => {
 
     expect(appService.showAlert).toHaveBeenCalledWith({
       message:
-        "RouteVN Creator couldn't safely open this project.\n\nError: state.story.initialSceneId must reference an existing scene\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+        "RouteVN Creator couldn't safely open this project because its saved project history is inconsistent.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.\n\nTechnical details: state.story.initialSceneId must reference an existing scene",
     });
     expect(appService.redirect).toHaveBeenCalledWith("/projects");
     expect(deps.store.setCurrentRoute).toHaveBeenCalledWith({

--- a/tests/appService/projectEntryLanguagePlatforms.test.js
+++ b/tests/appService/projectEntryLanguagePlatforms.test.js
@@ -116,6 +116,31 @@ describe("project-entry language platform propagation", () => {
     },
   );
 
+  it("does not initialize a desktop project in a non-empty folder", async () => {
+    mocked.readDir.mockResolvedValue([{ name: "project.db" }]);
+    const db = createDb();
+    const projectService = createProjectService();
+    const appService = createDesktopAppService(
+      createParams({ db, projectService }),
+    );
+
+    await expect(
+      appService.createNewProject({
+        name: "Project One",
+        description: "",
+        language: "en",
+        projectPath: "/projects/existing-project",
+        template: "blank",
+        projectResolution: { width: 1280, height: 720 },
+      }),
+    ).rejects.toThrow(
+      "The selected folder must be empty. Please choose an empty folder for your new project.",
+    );
+
+    expect(projectService.initializeProject).not.toHaveBeenCalled();
+    await expect(db.get("projectEntries")).resolves.toEqual([]);
+  });
+
   it("keeps language when importing a desktop project", async () => {
     const db = createDb();
     const projectService = {

--- a/tests/appService/projectEntryLanguagePlatforms.test.js
+++ b/tests/appService/projectEntryLanguagePlatforms.test.js
@@ -124,7 +124,7 @@ describe("project-entry language platform propagation", () => {
     ["ios", createIOSAppService],
   ])(
     "initializes %s project storage before storing the selected icon",
-    async (platform, createAppService) => {
+    async (_, createAppService) => {
       const db = createDb();
       const projectService = createProjectService();
       const appService = createAppService(createParams({ db, projectService }));
@@ -160,20 +160,12 @@ describe("project-entry language platform propagation", () => {
           iconFileId: "icon-1",
         },
       );
-      if (platform === "web") {
-        expect(
-          projectService.initializeProject.mock.invocationCallOrder[0],
-        ).toBeLessThan(db.set.mock.invocationCallOrder[0]);
-        expect(db.set.mock.invocationCallOrder[0]).toBeLessThan(
-          projectService.storeFileForProject.mock.invocationCallOrder[0],
-        );
-      } else {
-        expect(
-          projectService.initializeProject.mock.invocationCallOrder[0],
-        ).toBeLessThan(
-          projectService.storeFileForProject.mock.invocationCallOrder[0],
-        );
-      }
+      expect(
+        projectService.initializeProject.mock.invocationCallOrder[0],
+      ).toBeLessThan(db.set.mock.invocationCallOrder[0]);
+      expect(db.set.mock.invocationCallOrder[0]).toBeLessThan(
+        projectService.storeFileForProject.mock.invocationCallOrder[0],
+      );
       expect(
         projectService.storeFileForProject.mock.invocationCallOrder[0],
       ).toBeLessThan(
@@ -188,76 +180,82 @@ describe("project-entry language platform propagation", () => {
     },
   );
 
-  it.each([
-    [
-      "storing the icon",
-      (projectService) => {
-        projectService.storeFileForProject.mockRejectedValue(
-          new Error("File read failed"),
-        );
-      },
-    ],
-    [
-      "updating project info",
-      (projectService) => {
-        projectService.updateProjectInfoById.mockRejectedValue(
-          new Error("Storage quota exceeded"),
-        );
-      },
-    ],
-  ])(
-    "keeps a web project reachable when %s fails",
-    async (_, arrangeFailure) => {
-      const consoleError = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const db = createDb();
-      const projectService = createProjectService();
-      arrangeFailure(projectService);
-      const globalUI = {
-        showToast: vi.fn(),
-      };
-      const appService = createWebAppService(
-        createParams({ db, projectService, globalUI }),
-      );
-      appService.setAppCopyProvider(() => ({
-        errorTitle: "Error",
-        failedSaveProjectIcon:
-          "The project was created, but its icon could not be saved.",
-      }));
-
-      const project = await appService.createNewProject({
-        name: "Project One",
-        description: "",
-        language: "en",
-        template: "blank",
-        projectResolution: { width: 1280, height: 720 },
-        iconFile: {
-          name: "icon.png",
-          type: "image/png",
+  describe.each([
+    ["web", createWebAppService],
+    ["android", createAndroidAppService],
+    ["ios", createIOSAppService],
+  ])("%s project icon persistence", (_, createAppService) => {
+    it.each([
+      [
+        "storing the icon",
+        (projectService) => {
+          projectService.storeFileForProject.mockRejectedValue(
+            new Error("File read failed"),
+          );
         },
-      });
+      ],
+      [
+        "updating project info",
+        (projectService) => {
+          projectService.updateProjectInfoById.mockRejectedValue(
+            new Error("Storage quota exceeded"),
+          );
+        },
+      ],
+    ])(
+      "keeps the project reachable when %s fails",
+      async (_, arrangeFailure) => {
+        const consoleError = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        const db = createDb();
+        const projectService = createProjectService();
+        arrangeFailure(projectService);
+        const globalUI = {
+          showToast: vi.fn(),
+        };
+        const appService = createAppService(
+          createParams({ db, projectService, globalUI }),
+        );
+        appService.setAppCopyProvider(() => ({
+          errorTitle: "Error",
+          failedSaveProjectIcon:
+            "The project was created, but its icon could not be saved.",
+        }));
 
-      expect(project.iconFileId).toBeNull();
-      await expect(db.get("projectEntries")).resolves.toEqual([
-        expect.objectContaining({
-          id: project.id,
-          iconFileId: null,
-        }),
-      ]);
-      expect(globalUI.showToast).toHaveBeenCalledWith({
-        title: "Error",
-        message:
-          "The project was created, but its icon could not be saved.",
-        status: "error",
-      });
-      expect(consoleError).toHaveBeenCalledWith(
-        "Failed to save project icon:",
-        expect.any(Error),
-      );
-      consoleError.mockRestore();
-    },
-  );
+        const project = await appService.createNewProject({
+          name: "Project One",
+          description: "",
+          language: "en",
+          template: "blank",
+          projectResolution: { width: 1280, height: 720 },
+          iconFile: {
+            name: "icon.png",
+            type: "image/png",
+          },
+        });
+
+        expect(project.iconFileId).toBeNull();
+        await expect(db.get("projectEntries")).resolves.toEqual([
+          expect.objectContaining({
+            id: project.id,
+            iconFileId: null,
+          }),
+        ]);
+        expect(globalUI.showToast).toHaveBeenCalledWith({
+          title: "Error",
+          message:
+            "The project was created, but its icon could not be saved.",
+          status: "error",
+        });
+        expect(consoleError).toHaveBeenCalledWith(
+          "Failed to save project icon:",
+          expect.any(Error),
+        );
+        consoleError.mockRestore();
+      },
+    );
+  });
 
   it("does not initialize a desktop project in a non-empty folder", async () => {
     mocked.readDir.mockResolvedValue([{ name: "project.db" }]);

--- a/tests/appService/projectEntryLanguagePlatforms.test.js
+++ b/tests/appService/projectEntryLanguagePlatforms.test.js
@@ -54,12 +54,12 @@ const createProjectService = () => ({
   getFileByProjectId: vi.fn(async () => undefined),
 });
 
-const createParams = ({ db, projectService }) => ({
+const createParams = ({ db, projectService, globalUI = {} }) => ({
   db,
   router: {
     getPayload: () => ({}),
   },
-  globalUI: {},
+  globalUI,
   filePicker: {},
   openUrl: vi.fn(),
   appVersion: "test",
@@ -124,7 +124,7 @@ describe("project-entry language platform propagation", () => {
     ["ios", createIOSAppService],
   ])(
     "initializes %s project storage before storing the selected icon",
-    async (_, createAppService) => {
+    async (platform, createAppService) => {
       const db = createDb();
       const projectService = createProjectService();
       const appService = createAppService(createParams({ db, projectService }));
@@ -160,11 +160,20 @@ describe("project-entry language platform propagation", () => {
           iconFileId: "icon-1",
         },
       );
-      expect(
-        projectService.initializeProject.mock.invocationCallOrder[0],
-      ).toBeLessThan(
-        projectService.storeFileForProject.mock.invocationCallOrder[0],
-      );
+      if (platform === "web") {
+        expect(
+          projectService.initializeProject.mock.invocationCallOrder[0],
+        ).toBeLessThan(db.set.mock.invocationCallOrder[0]);
+        expect(db.set.mock.invocationCallOrder[0]).toBeLessThan(
+          projectService.storeFileForProject.mock.invocationCallOrder[0],
+        );
+      } else {
+        expect(
+          projectService.initializeProject.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+          projectService.storeFileForProject.mock.invocationCallOrder[0],
+        );
+      }
       expect(
         projectService.storeFileForProject.mock.invocationCallOrder[0],
       ).toBeLessThan(
@@ -176,6 +185,77 @@ describe("project-entry language platform propagation", () => {
           iconFileId: "icon-1",
         }),
       ]);
+    },
+  );
+
+  it.each([
+    [
+      "storing the icon",
+      (projectService) => {
+        projectService.storeFileForProject.mockRejectedValue(
+          new Error("File read failed"),
+        );
+      },
+    ],
+    [
+      "updating project info",
+      (projectService) => {
+        projectService.updateProjectInfoById.mockRejectedValue(
+          new Error("Storage quota exceeded"),
+        );
+      },
+    ],
+  ])(
+    "keeps a web project reachable when %s fails",
+    async (_, arrangeFailure) => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const db = createDb();
+      const projectService = createProjectService();
+      arrangeFailure(projectService);
+      const globalUI = {
+        showToast: vi.fn(),
+      };
+      const appService = createWebAppService(
+        createParams({ db, projectService, globalUI }),
+      );
+      appService.setAppCopyProvider(() => ({
+        errorTitle: "Error",
+        failedSaveProjectIcon:
+          "The project was created, but its icon could not be saved.",
+      }));
+
+      const project = await appService.createNewProject({
+        name: "Project One",
+        description: "",
+        language: "en",
+        template: "blank",
+        projectResolution: { width: 1280, height: 720 },
+        iconFile: {
+          name: "icon.png",
+          type: "image/png",
+        },
+      });
+
+      expect(project.iconFileId).toBeNull();
+      await expect(db.get("projectEntries")).resolves.toEqual([
+        expect.objectContaining({
+          id: project.id,
+          iconFileId: null,
+        }),
+      ]);
+      expect(globalUI.showToast).toHaveBeenCalledWith({
+        title: "Error",
+        message:
+          "The project was created, but its icon could not be saved.",
+        status: "error",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to save project icon:",
+        expect.any(Error),
+      );
+      consoleError.mockRestore();
     },
   );
 

--- a/tests/appService/projectEntryLanguagePlatforms.test.js
+++ b/tests/appService/projectEntryLanguagePlatforms.test.js
@@ -48,8 +48,10 @@ const createDb = () => {
 
 const createProjectService = () => ({
   initializeProject: vi.fn(async () => {}),
-  storeFileForProject: vi.fn(),
+  storeFileForProject: vi.fn(async () => ({ fileId: "icon-1" })),
+  updateProjectInfoById: vi.fn(async () => {}),
   updateProjectInfoByPath: vi.fn(async () => {}),
+  getFileByProjectId: vi.fn(async () => undefined),
 });
 
 const createParams = ({ db, projectService }) => ({
@@ -113,6 +115,67 @@ describe("project-entry language platform propagation", () => {
           projectInfo: expect.objectContaining({ language: "ja" }),
         }),
       );
+    },
+  );
+
+  it.each([
+    ["web", createWebAppService],
+    ["android", createAndroidAppService],
+    ["ios", createIOSAppService],
+  ])(
+    "initializes %s project storage before storing the selected icon",
+    async (_, createAppService) => {
+      const db = createDb();
+      const projectService = createProjectService();
+      const appService = createAppService(createParams({ db, projectService }));
+      const iconFile = {
+        name: "icon.png",
+        type: "image/png",
+      };
+
+      const project = await appService.createNewProject({
+        name: "Project One",
+        description: "",
+        language: "en",
+        template: "blank",
+        projectResolution: { width: 1280, height: 720 },
+        iconFile,
+      });
+
+      expect(projectService.initializeProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: project.id,
+          projectInfo: expect.objectContaining({
+            iconFileId: null,
+          }),
+        }),
+      );
+      expect(projectService.storeFileForProject).toHaveBeenCalledWith({
+        projectId: project.id,
+        file: iconFile,
+      });
+      expect(projectService.updateProjectInfoById).toHaveBeenCalledWith(
+        project.id,
+        {
+          iconFileId: "icon-1",
+        },
+      );
+      expect(
+        projectService.initializeProject.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        projectService.storeFileForProject.mock.invocationCallOrder[0],
+      );
+      expect(
+        projectService.storeFileForProject.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        projectService.updateProjectInfoById.mock.invocationCallOrder[0],
+      );
+      await expect(db.get("projectEntries")).resolves.toEqual([
+        expect.objectContaining({
+          id: project.id,
+          iconFileId: "icon-1",
+        }),
+      ]);
     },
   );
 

--- a/tests/internal/projectOpenErrors.test.js
+++ b/tests/internal/projectOpenErrors.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getProjectOpenErrorMessage } from "../../src/internal/projectOpenErrors.js";
+
+describe("projectOpenErrors", () => {
+  it("shows the validation error and support guidance", () => {
+    const error = new Error(
+      "payload.sectionId must reference an existing section",
+    );
+    error.code = "precondition_validation_failed";
+
+    expect(getProjectOpenErrorMessage(error)).toBe(
+      "RouteVN Creator couldn't safely open this project.\n\nError: payload.sectionId must reference an existing section\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+    );
+  });
+
+  it("shows support guidance when validation has no error detail", () => {
+    const error = new Error("");
+    error.code = "state_validation_failed";
+
+    expect(getProjectOpenErrorMessage(error)).toBe(
+      "RouteVN Creator couldn't safely open this project.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+    );
+  });
+});

--- a/tests/internal/projectOpenErrors.test.js
+++ b/tests/internal/projectOpenErrors.test.js
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 import { getProjectOpenErrorMessage } from "../../src/internal/projectOpenErrors.js";
 
 describe("projectOpenErrors", () => {
-  it("shows the validation error and support guidance", () => {
+  it("shows plain-language guidance before validation details", () => {
     const error = new Error(
       "payload.sectionId must reference an existing section",
     );
     error.code = "precondition_validation_failed";
 
     expect(getProjectOpenErrorMessage(error)).toBe(
-      "RouteVN Creator couldn't safely open this project.\n\nError: payload.sectionId must reference an existing section\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+      "RouteVN Creator couldn't safely open this project because its saved project history is inconsistent.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.\n\nTechnical details: payload.sectionId must reference an existing section",
     );
   });
 
@@ -18,7 +18,17 @@ describe("projectOpenErrors", () => {
     error.code = "state_validation_failed";
 
     expect(getProjectOpenErrorMessage(error)).toBe(
-      "RouteVN Creator couldn't safely open this project.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+      "RouteVN Creator couldn't safely open this project because its saved project history is inconsistent.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+    );
+  });
+
+  it("explains committed event ID mismatches as inconsistent history", () => {
+    const error = new Error(
+      "committed event invariant violation for committedId 1: id mismatch",
+    );
+
+    expect(getProjectOpenErrorMessage(error)).toBe(
+      "RouteVN Creator couldn't safely open this project because its saved project history is inconsistent.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.\n\nTechnical details: committed event invariant violation for committedId 1: id mismatch",
     );
   });
 });

--- a/tests/ios/projectServiceAdapters.test.js
+++ b/tests/ios/projectServiceAdapters.test.js
@@ -4,12 +4,14 @@ import { parseBundle } from "../../src/deps/services/shared/projectExportService
 
 const mocked = vi.hoisted(() => ({
   callIOSBridge: vi.fn(),
+  createPersistedIOSProjectStore: vi.fn(),
   createWebIconAssets: vi.fn(async ({ variants }) =>
     variants.map(({ fileName, size }) => ({
       fileName,
       bytes: Uint8Array.from([size === 192 ? 192 : 255]),
     })),
   ),
+  loadTemplate: vi.fn(),
 }));
 
 vi.mock("../../src/deps/clients/ios/bridge.js", async () => {
@@ -23,6 +25,26 @@ vi.mock("../../src/deps/clients/ios/bridge.js", async () => {
 vi.mock("../../src/deps/clients/web/webIconAssets.js", () => ({
   createWebIconAssets: mocked.createWebIconAssets,
 }));
+
+vi.mock("../../src/deps/services/ios/collabClientStore.js", async () => {
+  const actual = await vi.importActual(
+    "../../src/deps/services/ios/collabClientStore.js",
+  );
+  return {
+    ...actual,
+    createPersistedIOSProjectStore: mocked.createPersistedIOSProjectStore,
+  };
+});
+
+vi.mock("../../src/deps/clients/web/templateLoader.js", async () => {
+  const actual = await vi.importActual(
+    "../../src/deps/clients/web/templateLoader.js",
+  );
+  return {
+    ...actual,
+    loadTemplate: mocked.loadTemplate,
+  };
+});
 
 import { createIOSProjectServiceAdapters } from "../../src/deps/services/ios/projectServiceAdapters.js";
 
@@ -38,6 +60,8 @@ const toExactArrayBuffer = (bytes) => {
 describe("ios project service adapters", () => {
   beforeEach(() => {
     mocked.callIOSBridge.mockReset();
+    mocked.createPersistedIOSProjectStore.mockReset();
+    mocked.loadTemplate.mockReset();
     vi.spyOn(console, "info").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
@@ -243,5 +267,53 @@ describe("ios project service adapters", () => {
         getStoreByProject: vi.fn(),
       }),
     ).rejects.toThrow("iOS remote collaboration is disabled.");
+  });
+
+  it("rejects existing iOS project history before initialization writes", async () => {
+    const store = {
+      getRepositoryHistoryStats: vi.fn(async () => ({
+        committedCount: 1,
+        latestCommittedId: 1,
+        draftCount: 0,
+        latestDraftClock: 0,
+      })),
+      insertDraft: vi.fn(async () => {}),
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      app: {
+        set: vi.fn(async () => {}),
+      },
+    };
+    mocked.createPersistedIOSProjectStore.mockResolvedValue(store);
+    const { storageAdapter } = createIOSProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 2,
+    });
+
+    await expect(
+      storageAdapter.initializeProject({
+        projectId: "project-1",
+        template: "blank",
+        projectInfo: {
+          id: "project-1",
+          name: "Project One",
+        },
+        projectResolution: {
+          width: 1280,
+          height: 720,
+        },
+      }),
+    ).rejects.toThrow(
+      "Project storage is not empty. New project initialization requires empty storage.",
+    );
+
+    expect(mocked.createPersistedIOSProjectStore).toHaveBeenCalledWith({
+      projectId: "project-1",
+    });
+    expect(store.getRepositoryHistoryStats).toHaveBeenCalledTimes(1);
+    expect(mocked.callIOSBridge).not.toHaveBeenCalled();
+    expect(mocked.loadTemplate).not.toHaveBeenCalled();
+    expect(store.insertDraft).not.toHaveBeenCalled();
+    expect(store.saveMaterializedViewCheckpoint).not.toHaveBeenCalled();
+    expect(store.app.set).not.toHaveBeenCalled();
   });
 });

--- a/tests/ios/projectServiceAdapters.test.js
+++ b/tests/ios/projectServiceAdapters.test.js
@@ -12,6 +12,7 @@ const mocked = vi.hoisted(() => ({
     })),
   ),
   loadTemplate: vi.fn(),
+  getTemplateFiles: vi.fn(),
 }));
 
 vi.mock("../../src/deps/clients/ios/bridge.js", async () => {
@@ -43,10 +44,12 @@ vi.mock("../../src/deps/clients/web/templateLoader.js", async () => {
   return {
     ...actual,
     loadTemplate: mocked.loadTemplate,
+    getTemplateFiles: mocked.getTemplateFiles,
   };
 });
 
 import { createIOSProjectServiceAdapters } from "../../src/deps/services/ios/projectServiceAdapters.js";
+import { initialProjectData } from "../../src/deps/services/shared/projectRepository.js";
 
 const toBase64 = (bytes) => Buffer.from(bytes).toString("base64");
 
@@ -62,6 +65,8 @@ describe("ios project service adapters", () => {
     mocked.callIOSBridge.mockReset();
     mocked.createPersistedIOSProjectStore.mockReset();
     mocked.loadTemplate.mockReset();
+    mocked.getTemplateFiles.mockReset();
+    mocked.getTemplateFiles.mockResolvedValue([]);
     vi.spyOn(console, "info").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
@@ -269,14 +274,20 @@ describe("ios project service adapters", () => {
     ).rejects.toThrow("iOS remote collaboration is disabled.");
   });
 
-  it("rejects existing iOS project history before initialization writes", async () => {
+  it("rejects existing iOS project storage before initialization writes", async () => {
+    mocked.callIOSBridge.mockImplementation(async (method) => {
+      if (method === "getProjectStorageStatus") {
+        return {
+          exists: true,
+          databaseFileExists: false,
+          databaseDirectoryExists: false,
+          projectDirectoryExists: true,
+        };
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
     const store = {
-      getRepositoryHistoryStats: vi.fn(async () => ({
-        committedCount: 1,
-        latestCommittedId: 1,
-        draftCount: 0,
-        latestDraftClock: 0,
-      })),
       insertDraft: vi.fn(async () => {}),
       saveMaterializedViewCheckpoint: vi.fn(async () => {}),
       app: {
@@ -306,14 +317,81 @@ describe("ios project service adapters", () => {
       "Project storage is not empty. New project initialization requires empty storage.",
     );
 
-    expect(mocked.createPersistedIOSProjectStore).toHaveBeenCalledWith({
-      projectId: "project-1",
-    });
-    expect(store.getRepositoryHistoryStats).toHaveBeenCalledTimes(1);
-    expect(mocked.callIOSBridge).not.toHaveBeenCalled();
+    expect(mocked.callIOSBridge).toHaveBeenCalledWith(
+      "getProjectStorageStatus",
+      {
+        projectId: "project-1",
+      },
+    );
+    expect(mocked.createPersistedIOSProjectStore).not.toHaveBeenCalled();
     expect(mocked.loadTemplate).not.toHaveBeenCalled();
     expect(store.insertDraft).not.toHaveBeenCalled();
     expect(store.saveMaterializedViewCheckpoint).not.toHaveBeenCalled();
     expect(store.app.set).not.toHaveBeenCalled();
+  });
+
+  it("creates iOS project storage only after the unused-storage check", async () => {
+    mocked.callIOSBridge.mockImplementation(async (method) => {
+      if (method === "getProjectStorageStatus") {
+        return {
+          exists: false,
+          databaseFileExists: false,
+          databaseDirectoryExists: false,
+          projectDirectoryExists: false,
+        };
+      }
+      if (method === "ensureProjectStorage") {
+        return true;
+      }
+
+      throw new Error(`Unexpected bridge method: ${method}`);
+    });
+    mocked.loadTemplate.mockResolvedValue(structuredClone(initialProjectData));
+    const store = {
+      insertDraft: vi.fn(async () => {}),
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      app: {
+        set: vi.fn(async () => {}),
+      },
+    };
+    mocked.createPersistedIOSProjectStore.mockResolvedValue(store);
+    const { storageAdapter } = createIOSProjectServiceAdapters({
+      collabLog: vi.fn(),
+      creatorVersion: 2,
+    });
+
+    await storageAdapter.initializeProject({
+      projectId: "project-1",
+      template: "blank",
+      projectInfo: {
+        id: "project-1",
+        name: "Project One",
+      },
+      projectResolution: {
+        width: 1280,
+        height: 720,
+      },
+    });
+
+    expect(mocked.callIOSBridge).toHaveBeenNthCalledWith(
+      1,
+      "getProjectStorageStatus",
+      {
+        projectId: "project-1",
+      },
+    );
+    expect(mocked.callIOSBridge).toHaveBeenNthCalledWith(
+      2,
+      "ensureProjectStorage",
+      {
+        projectId: "project-1",
+      },
+    );
+    expect(mocked.createPersistedIOSProjectStore).toHaveBeenCalledWith({
+      projectId: "project-1",
+    });
+    expect(store.insertDraft).toHaveBeenCalledTimes(1);
+    expect(store.saveMaterializedViewCheckpoint).toHaveBeenCalledTimes(1);
+    expect(store.app.set).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -315,7 +315,7 @@ describe("projects.handleProjectsClick", () => {
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "RouteVN Creator couldn't safely open this project.\n\nError: payload.sectionId must reference an existing section\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
+        "RouteVN Creator couldn't safely open this project because its saved project history is inconsistent.\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.\n\nTechnical details: payload.sectionId must reference an existing section",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -301,7 +301,7 @@ describe("projects.handleProjectsClick", () => {
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });
 
-  it("suggests updating RouteVN Creator for project data validation errors", async () => {
+  it("shows project validation details and support guidance", async () => {
     const deps = createDeps({
       ensureProjectCompatibleById: vi.fn(async () => {
         const error = new Error(
@@ -311,12 +311,11 @@ describe("projects.handleProjectsClick", () => {
         throw error;
       }),
     });
-
     await handleProjectsClick(deps, createPayload());
 
     expect(deps.appService.showAlert).toHaveBeenCalledWith({
       message:
-        "Project data structure failed validation.\nMake sure you're using the latest version of RouteVN Creator.",
+        "RouteVN Creator couldn't safely open this project.\n\nError: payload.sectionId must reference an existing section\n\nPlease make sure you're using the latest version of RouteVN Creator. If the problem continues, please reach out to RouteVN for support.",
     });
     expect(deps.appService.navigate).not.toHaveBeenCalled();
   });

--- a/tests/tauri/projectServiceAdapters.test.js
+++ b/tests/tauri/projectServiceAdapters.test.js
@@ -6,6 +6,7 @@ const mocked = vi.hoisted(() => ({
   mkdir: vi.fn(async () => {}),
   writeFile: vi.fn(async () => {}),
   readFile: vi.fn(),
+  readDir: vi.fn(async () => []),
   resolveResource: vi.fn(),
   convertFileSrc: vi.fn((value) => value),
   invoke: vi.fn(async () => {}),
@@ -41,6 +42,7 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
   mkdir: mocked.mkdir,
   writeFile: mocked.writeFile,
   readFile: mocked.readFile,
+  readDir: mocked.readDir,
   exists: mocked.exists,
 }));
 
@@ -178,6 +180,8 @@ describe("tauri project service adapters preflight reads", () => {
     mocked.mkdir.mockClear();
     mocked.writeFile.mockClear();
     mocked.readFile.mockReset();
+    mocked.readDir.mockReset();
+    mocked.readDir.mockResolvedValue([]);
     mocked.resolveResource.mockReset();
     mocked.convertFileSrc.mockClear();
     mocked.invoke.mockReset();
@@ -767,8 +771,8 @@ describe("tauri project service adapters preflight reads", () => {
       projectResolution: templateState.project.resolution,
     });
 
-    expect(store.clearEvents).toHaveBeenCalledTimes(1);
-    expect(store.clearMaterializedViewCheckpoints).toHaveBeenCalledTimes(1);
+    expect(store.clearEvents).not.toHaveBeenCalled();
+    expect(store.clearMaterializedViewCheckpoints).not.toHaveBeenCalled();
     expect(store.insertDraft).toHaveBeenCalledTimes(1);
     expect(store.saveMaterializedViewCheckpoint).toHaveBeenCalledTimes(1);
 
@@ -793,6 +797,49 @@ describe("tauri project service adapters preflight reads", () => {
       storedCreatorVersion: appValues.get("creatorVersion"),
       storedProjectInfo: appValues.get("projectInfo"),
     });
+  });
+
+  it("rejects a non-empty project folder before initialization writes", async () => {
+    mocked.readDir.mockResolvedValue([{ name: "project.db" }]);
+    const store = {
+      clearEvents: vi.fn(async () => {}),
+      clearMaterializedViewCheckpoints: vi.fn(async () => {}),
+      insertDraft: vi.fn(async () => {}),
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      app: {
+        set: vi.fn(async () => {}),
+      },
+    };
+    mocked.createPersistedTauriProjectStore.mockResolvedValue(store);
+    const { storageAdapter } = createTauriProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+
+    await expect(
+      storageAdapter.initializeProject({
+        projectId: "project-1",
+        projectPath: "/projects/existing-project",
+        template: "blank",
+        projectInfo: {
+          id: "project-1",
+          name: "Project One",
+        },
+        projectResolution: {
+          width: 1280,
+          height: 720,
+        },
+      }),
+    ).rejects.toThrow(
+      "The selected folder must be empty. Please choose an empty folder for your new project.",
+    );
+
+    expect(mocked.mkdir).not.toHaveBeenCalled();
+    expect(mocked.writeFile).not.toHaveBeenCalled();
+    expect(mocked.loadTemplate).not.toHaveBeenCalled();
+    expect(mocked.createPersistedTauriProjectStore).not.toHaveBeenCalled();
+    expect(store.clearEvents).not.toHaveBeenCalled();
+    expect(store.clearMaterializedViewCheckpoints).not.toHaveBeenCalled();
   });
 
   it("persists a projection gap for incompatible remote commands", async () => {

--- a/tests/web/indexedDb.test.js
+++ b/tests/web/indexedDb.test.js
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listIndexedDbDatabaseNames } from "../../src/deps/clients/web/indexedDb.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("web IndexedDB storage inspection", () => {
+  it("lists existing database names without opening or deleting them", async () => {
+    const databases = vi.fn(async () => [
+      { name: "project-1", version: 4 },
+      { name: "routevn-collab-client:2:project-1", version: 1 },
+      { name: undefined, version: 1 },
+    ]);
+    vi.stubGlobal("indexedDB", {
+      databases,
+      open: vi.fn(),
+      deleteDatabase: vi.fn(),
+    });
+
+    await expect(listIndexedDbDatabaseNames()).resolves.toEqual(
+      new Set(["project-1", "routevn-collab-client:2:project-1"]),
+    );
+    expect(databases).toHaveBeenCalledTimes(1);
+    expect(indexedDB.open).not.toHaveBeenCalled();
+    expect(indexedDB.deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when browser storage cannot be inspected", async () => {
+    vi.stubGlobal("indexedDB", {
+      open: vi.fn(),
+      deleteDatabase: vi.fn(),
+    });
+
+    await expect(listIndexedDbDatabaseNames()).rejects.toThrow(
+      "cannot verify that browser project storage is empty",
+    );
+    expect(indexedDB.open).not.toHaveBeenCalled();
+    expect(indexedDB.deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable error when browser storage inspection fails", async () => {
+    vi.stubGlobal("indexedDB", {
+      databases: vi.fn(async () => {
+        throw new Error("Browser storage unavailable");
+      }),
+      open: vi.fn(),
+      deleteDatabase: vi.fn(),
+    });
+
+    await expect(listIndexedDbDatabaseNames()).rejects.toThrow(
+      "cannot verify that browser project storage is empty",
+    );
+    expect(indexedDB.open).not.toHaveBeenCalled();
+    expect(indexedDB.deleteDatabase).not.toHaveBeenCalled();
+  });
+});

--- a/tests/web/projectServiceAdapters.test.js
+++ b/tests/web/projectServiceAdapters.test.js
@@ -4,9 +4,9 @@ const mocked = vi.hoisted(() => ({
   createInsiemeWebStoreAdapter: vi.fn(),
   initializeProject: vi.fn(),
   readProjectAppValue: vi.fn(),
+  listIndexedDbDatabaseNames: vi.fn(),
   createProjectCollabService: vi.fn(),
   createPersistedInMemoryClientStore: vi.fn(),
-  deletePersistedInMemoryClientStore: vi.fn(),
   loadCommittedCursor: vi.fn(),
   saveCommittedCursor: vi.fn(),
   clearCommittedCursor: vi.fn(),
@@ -21,6 +21,10 @@ vi.mock("../../src/deps/clients/web/webRepositoryAdapter.js", () => ({
   readProjectAppValue: mocked.readProjectAppValue,
 }));
 
+vi.mock("../../src/deps/clients/web/indexedDb.js", () => ({
+  listIndexedDbDatabaseNames: mocked.listIndexedDbDatabaseNames,
+}));
+
 vi.mock(
   "../../src/deps/services/shared/collab/createProjectCollabService.js",
   () => ({
@@ -30,7 +34,6 @@ vi.mock(
 
 vi.mock("../../src/deps/services/web/collabClientStore.js", () => ({
   createPersistedInMemoryClientStore: mocked.createPersistedInMemoryClientStore,
-  deletePersistedInMemoryClientStore: mocked.deletePersistedInMemoryClientStore,
 }));
 
 vi.mock("../../src/deps/services/web/collabCommittedCursorStore.js", () => ({
@@ -101,9 +104,9 @@ describe("web project service adapters", () => {
     mocked.createInsiemeWebStoreAdapter.mockReset();
     mocked.initializeProject.mockReset();
     mocked.readProjectAppValue.mockReset();
+    mocked.listIndexedDbDatabaseNames.mockReset();
     mocked.createProjectCollabService.mockReset();
     mocked.createPersistedInMemoryClientStore.mockReset();
-    mocked.deletePersistedInMemoryClientStore.mockReset();
     mocked.loadCommittedCursor.mockReset();
     mocked.saveCommittedCursor.mockReset();
     mocked.clearCommittedCursor.mockReset();
@@ -114,6 +117,7 @@ describe("web project service adapters", () => {
     mocked.createPersistedInMemoryClientStore.mockResolvedValue({
       close: vi.fn(async () => {}),
     });
+    mocked.listIndexedDbDatabaseNames.mockResolvedValue(new Set());
     mocked.loadCommittedCursor.mockResolvedValue(0);
     mocked.createWebSocketTransport.mockReturnValue({
       kind: "transport",
@@ -219,6 +223,109 @@ describe("web project service adapters", () => {
     await expect(fileAdapter.createDistributionZipStreamed()).rejects.toThrow(
       "Distribution ZIP export is only supported",
     );
+  });
+
+  it.each([
+    ["repository", new Set(["project-1"])],
+    ["collaboration", new Set(["routevn-collab-client:2:project-1"])],
+    ["legacy collaboration", new Set(["routevn-collab-client:1:project-1"])],
+  ])(
+    "rejects existing %s browser storage before initialization",
+    async (_, databaseNames) => {
+      mocked.listIndexedDbDatabaseNames.mockResolvedValue(databaseNames);
+      const { storageAdapter } = createWebProjectServiceAdapters({
+        collabLog: () => {},
+        creatorVersion: 2,
+      });
+
+      await expect(
+        storageAdapter.initializeProject({
+          projectId: "project-1",
+          template: "blank",
+          projectInfo: {
+            id: "project-1",
+            name: "Project One",
+          },
+          projectResolution: {
+            width: 1280,
+            height: 720,
+          },
+        }),
+      ).rejects.toThrow(
+        "Project storage is not empty. New project initialization requires empty storage.",
+      );
+
+      expect(mocked.createPersistedInMemoryClientStore).not.toHaveBeenCalled();
+      expect(mocked.initializeProject).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects an existing in-memory collaboration store before initialization", async () => {
+    const { storageAdapter } = createWebProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+    await storageAdapter.createStore({
+      reference: {
+        projectId: "project-1",
+      },
+    });
+
+    await expect(
+      storageAdapter.initializeProject({
+        projectId: "project-1",
+        template: "blank",
+        projectInfo: {
+          id: "project-1",
+          name: "Project One",
+        },
+        projectResolution: {
+          width: 1280,
+          height: 720,
+        },
+      }),
+    ).rejects.toThrow(
+      "Project storage is not empty. New project initialization requires empty storage.",
+    );
+
+    expect(mocked.createPersistedInMemoryClientStore).toHaveBeenCalledTimes(1);
+    expect(mocked.initializeProject).not.toHaveBeenCalled();
+  });
+
+  it("initializes browser projects only after confirming storage is unused", async () => {
+    const rawClientStore = {
+      close: vi.fn(async () => {}),
+    };
+    mocked.createPersistedInMemoryClientStore.mockResolvedValue(rawClientStore);
+    const { storageAdapter } = createWebProjectServiceAdapters({
+      collabLog: () => {},
+      creatorVersion: 2,
+    });
+    const payload = {
+      projectId: "project-1",
+      template: "blank",
+      projectInfo: {
+        id: "project-1",
+        name: "Project One",
+      },
+      projectResolution: {
+        width: 1280,
+        height: 720,
+      },
+    };
+
+    await storageAdapter.initializeProject(payload);
+
+    expect(mocked.listIndexedDbDatabaseNames).toHaveBeenCalledTimes(1);
+    expect(mocked.createPersistedInMemoryClientStore).toHaveBeenCalledWith({
+      projectId: "project-1",
+      logger: expect.any(Function),
+    });
+    expect(mocked.initializeProject).toHaveBeenCalledWith({
+      ...payload,
+      creatorVersion: 2,
+      rawClientStore,
+    });
   });
 
   it("persists a projection gap for incompatible remote commands", async () => {


### PR DESCRIPTION
## Summary
- explain project validation and committed-event ID mismatch failures as inconsistent saved project history
- keep raw validator/storage output as secondary technical details for support
- retain guidance to update RouteVN Creator and reach out to RouteVN for support
- return cleanly to Projects when route-level project loading fails
- remove event and checkpoint clearing from new-project initialization on desktop, Android, iOS, and web
- reject non-empty desktop project folders inside the storage adapter before any write occurs
- reject Android and iOS stores containing committed events or local drafts before project seeding begins

## Safety
- does not automatically repair projects or delete invalid drafts
- does not add support links, buttons, telemetry, or new localization
- new-project initialization only seeds fresh storage and no longer clears existing history or checkpoints
- the desktop empty-folder guard runs before directory creation, template copying, or project database creation/opening
- the mobile preflight opens the ID-backed database to inspect its history, then rejects existing history before template loading, file copying, bootstrap insertion, checkpoint replacement, or project-info writes

## Testing
- `bun run lint`
- targeted Vitest suites covering desktop, Android, iOS, web, app-service, project-loading, and history behavior
- `bun run test:smoke`
- `git diff --check`