### PR TITLE
Use paths for local project identity

### DIFF
--- a/src/deps/services/shared/appServiceCore.js
+++ b/src/deps/services/shared/appServiceCore.js
@@ -2,6 +2,7 @@ import { createAppShellService } from "./appShellService.js";
 import { createFileSelectionService } from "./fileSelectionService.js";
 import { createProjectEntriesService } from "./projectEntriesService.js";
 import { createUserConfigService } from "./userConfigService.js";
+import { getLocalProjectPathFromPayload } from "../../../internal/localProjectRoute.js";
 import { normalizeTheme } from "../../../internal/theme.js";
 
 export const createAppServiceCore = ({
@@ -24,9 +25,14 @@ export const createAppServiceCore = ({
     return router.getPayload()?.p ?? "";
   };
 
+  const getCurrentProjectPath = () => {
+    return getLocalProjectPathFromPayload(router.getPayload());
+  };
+
   const projectEntriesService = createProjectEntriesService({
     db,
     getCurrentProjectId,
+    getCurrentProjectPath,
     projectService,
     platformAdapter,
   });

--- a/src/deps/services/shared/projectCollabCore.js
+++ b/src/deps/services/shared/projectCollabCore.js
@@ -16,6 +16,7 @@ export const createProjectCollabCore = ({
   getCachedRepository,
   getRepositoryByProject,
   getAdapterByProject,
+  getProjectCacheKey = (projectId) => projectId,
   createSessionForProject,
   createTransport,
   onEnsureLocalSession,
@@ -25,7 +26,7 @@ export const createProjectCollabCore = ({
   const collabSessionsByProject = new Map();
   const collabSessionModeByProject = new Map();
   const localCollabActorsByProject = new Map();
-  const versionsByProject = new Map();
+  const versionsByProjectCacheKey = new Map();
 
   const getCurrentProjectId = () => {
     const { p } = router.getPayload();
@@ -207,16 +208,23 @@ export const createProjectCollabCore = ({
 
   const cacheVersions = (projectId, versions) => {
     const cachedVersions = structuredClone(versions);
-    versionsByProject.set(projectId, cachedVersions);
+    versionsByProjectCacheKey.set(
+      getProjectCacheKey(projectId),
+      cachedVersions,
+    );
     return structuredClone(cachedVersions);
   };
 
   const getCachedVersions = (projectId) => {
     const targetProjectId = projectId || getCurrentProjectId();
-    if (!targetProjectId || !versionsByProject.has(targetProjectId)) {
+    if (!targetProjectId) {
       return undefined;
     }
-    return structuredClone(versionsByProject.get(targetProjectId));
+    const projectCacheKey = getProjectCacheKey(targetProjectId);
+    if (!versionsByProjectCacheKey.has(projectCacheKey)) {
+      return undefined;
+    }
+    return structuredClone(versionsByProjectCacheKey.get(projectCacheKey));
   };
 
   const loadVersionsFromProject = async (projectId) => {

--- a/src/deps/services/shared/projectEntriesService.js
+++ b/src/deps/services/shared/projectEntriesService.js
@@ -25,24 +25,30 @@ const normalizeLocalProjectEntry = (entry) => ({
   iconFileId: entry?.iconFileId ?? null,
 });
 
-const mergeProjectEntriesPreservingWorkingPath = (currentEntry, nextEntry) => {
-  const mergedEntry = {
-    ...currentEntry,
-    ...nextEntry,
-  };
+const selectLocalProjectKey = (entry) => {
+  return entry?.projectPath ? entry.projectPath : entry?.id;
+};
 
-  if (
-    currentEntry?.id &&
-    nextEntry?.id &&
-    currentEntry.id === nextEntry.id &&
-    currentEntry?.projectPath &&
-    nextEntry?.projectPath &&
-    currentEntry.projectPath !== nextEntry.projectPath
-  ) {
-    mergedEntry.projectPath = currentEntry.projectPath;
+const isSameLocalProject = (left, right) => {
+  if (left?.projectPath || right?.projectPath) {
+    return Boolean(
+      left?.projectPath &&
+        right?.projectPath &&
+        left.projectPath === right.projectPath,
+    );
   }
 
-  return mergedEntry;
+  return Boolean(left?.id && right?.id && left.id === right.id);
+};
+
+const canUpdateLocalProject = (currentEntry, nextEntry) => {
+  if (!isSameLocalProject(currentEntry, nextEntry)) {
+    return false;
+  }
+
+  return Boolean(
+    !currentEntry?.id || !nextEntry?.id || currentEntry.id === nextEntry.id,
+  );
 };
 
 export const createProjectEntriesService = ({
@@ -54,22 +60,22 @@ export const createProjectEntriesService = ({
   let currentProjectEntry = createEmptyProjectEntry();
   let projectEntriesCache = [];
   let projectsCache;
-  const cachedIconCleanupByProjectId = new Map();
+  const cachedIconCleanupByProjectKey = new Map();
   let currentProjectIconCleanup;
 
-  const invalidateCachedProjectIcon = (projectId) => {
+  const invalidateCachedProjectIcon = (projectKey) => {
     const cachedProject = projectsCache?.find(
-      (project) => project.id === projectId,
+      (project) => selectLocalProjectKey(project) === projectKey,
     );
     if (cachedProject) {
       delete cachedProject.iconUrl;
     }
   };
 
-  const clearCachedProjectIcon = (projectId) => {
-    cachedIconCleanupByProjectId.get(projectId)?.();
-    cachedIconCleanupByProjectId.delete(projectId);
-    invalidateCachedProjectIcon(projectId);
+  const clearCachedProjectIcon = (projectKey) => {
+    cachedIconCleanupByProjectKey.get(projectKey)?.();
+    cachedIconCleanupByProjectKey.delete(projectKey);
+    invalidateCachedProjectIcon(projectKey);
   };
 
   const clearCurrentProjectIcon = () => {
@@ -93,12 +99,16 @@ export const createProjectEntriesService = ({
   };
 
   const syncProjectsCacheFromEntries = (entries) => {
-    const cachedProjectsById = new Map(
-      (projectsCache ?? []).map((project) => [project.id, project]),
+    const cachedProjectsByKey = new Map(
+      (projectsCache ?? []).map((project) => [
+        selectLocalProjectKey(project),
+        project,
+      ]),
     );
     const projects = entries.map((entry) => {
       const project = mapProjectEntryToProject(entry);
-      const cachedProject = cachedProjectsById.get(project.id);
+      const projectKey = selectLocalProjectKey(project);
+      const cachedProject = cachedProjectsByKey.get(projectKey);
       if (
         cachedProject?.iconUrl &&
         cachedProject.iconFileId === project.iconFileId
@@ -108,15 +118,15 @@ export const createProjectEntriesService = ({
         cachedProject &&
         cachedProject.iconFileId !== project.iconFileId
       ) {
-        clearCachedProjectIcon(project.id);
+        clearCachedProjectIcon(projectKey);
       }
       return project;
     });
 
-    const projectIds = new Set(projects.map((project) => project.id));
-    for (const projectId of cachedIconCleanupByProjectId.keys()) {
-      if (!projectIds.has(projectId)) {
-        clearCachedProjectIcon(projectId);
+    const projectKeys = new Set(projects.map(selectLocalProjectKey));
+    for (const projectKey of cachedIconCleanupByProjectKey.keys()) {
+      if (!projectKeys.has(projectKey)) {
+        clearCachedProjectIcon(projectKey);
       }
     }
 
@@ -124,12 +134,13 @@ export const createProjectEntriesService = ({
   };
 
   const cacheProject = (project) => {
-    if (!project?.id || projectsCache === undefined) {
+    const projectKey = selectLocalProjectKey(project);
+    if (!projectKey || projectsCache === undefined) {
       return;
     }
 
     const existingIndex = projectsCache.findIndex(
-      (cachedProject) => cachedProject.id === project.id,
+      (cachedProject) => selectLocalProjectKey(cachedProject) === projectKey,
     );
     if (existingIndex === -1) {
       projectsCache.push(structuredClone(project));
@@ -150,9 +161,16 @@ export const createProjectEntriesService = ({
       );
     }
 
-    const entryIndex = projectEntriesCache.findIndex(
-      (entry) => entry.id === projectId,
-    );
+    const selectedProjectPath =
+      currentProjectEntry.id === projectId
+        ? currentProjectEntry.projectPath
+        : undefined;
+    const entryIndex = projectEntriesCache.findIndex((entry) => {
+      if (selectedProjectPath) {
+        return entry?.projectPath === selectedProjectPath;
+      }
+      return entry.id === projectId;
+    });
     if (entryIndex !== -1) {
       projectEntriesCache[entryIndex] = {
         ...projectEntriesCache[entryIndex],
@@ -182,8 +200,12 @@ export const createProjectEntriesService = ({
       return undefined;
     }
 
+    const projectKey =
+      entryIndex === -1
+        ? projectId
+        : selectLocalProjectKey(projectEntriesCache[entryIndex]);
     const projectIndex = projectsCache.findIndex(
-      (project) => project.id === projectId,
+      (project) => selectLocalProjectKey(project) === projectKey,
     );
     if (projectIndex === -1) {
       return undefined;
@@ -199,7 +221,7 @@ export const createProjectEntriesService = ({
       normalizedUpdates.iconFileId !== previousProject.iconFileId;
     if (didIconChange) {
       delete project.iconUrl;
-      clearCachedProjectIcon(projectId);
+      clearCachedProjectIcon(projectKey);
     }
 
     projectsCache[projectIndex] = structuredClone(project);
@@ -231,12 +253,13 @@ export const createProjectEntriesService = ({
   };
 
   const setCachedProjectIcon = ({ project, iconResult }) => {
-    clearCachedProjectIcon(project?.id);
+    const projectKey = selectLocalProjectKey(project);
+    clearCachedProjectIcon(projectKey);
     return setProjectIcon({
       project,
       iconResult,
       setCleanup: (cleanup) => {
-        cachedIconCleanupByProjectId.set(project.id, cleanup);
+        cachedIconCleanupByProjectKey.set(projectKey, cleanup);
       },
     });
   };
@@ -253,12 +276,12 @@ export const createProjectEntriesService = ({
   };
 
   const pruneIconCleanup = (projects = []) => {
-    const activeIds = new Set(projects.map((project) => project.id));
-    for (const projectId of cachedIconCleanupByProjectId.keys()) {
-      if (activeIds.has(projectId)) {
+    const activeKeys = new Set(projects.map(selectLocalProjectKey));
+    for (const projectKey of cachedIconCleanupByProjectKey.keys()) {
+      if (activeKeys.has(projectKey)) {
         continue;
       }
-      clearCachedProjectIcon(projectId);
+      clearCachedProjectIcon(projectKey);
     }
   };
 
@@ -274,7 +297,15 @@ export const createProjectEntriesService = ({
         return createEmptyProjectEntry({ id: projectId, source: "local" });
       }
 
-      const localEntry = entries.find((entry) => entry?.id === projectId);
+      const selectedProjectPath =
+        currentProjectEntry.id === projectId
+          ? currentProjectEntry.projectPath
+          : undefined;
+      const localEntry =
+        entries.find(
+          (entry) =>
+            selectedProjectPath && entry?.projectPath === selectedProjectPath,
+        ) ?? entries.find((entry) => entry?.id === projectId);
       if (localEntry) {
         const project = normalizeLocalProjectEntry(localEntry);
         const iconResult = await platformAdapter.loadProjectIcon?.({
@@ -309,8 +340,8 @@ export const createProjectEntriesService = ({
   const addProjectEntry = async (entry) => {
     const normalizedEntry = normalizeCachedProjectEntry(entry);
     const entries = await getProjectEntries();
-    const existingEntryIndex = entries.findIndex(
-      (candidate) => candidate?.id && candidate.id === normalizedEntry.id,
+    const existingEntryIndex = entries.findIndex((candidate) =>
+      canUpdateLocalProject(candidate, normalizedEntry),
     );
     if (existingEntryIndex !== -1) {
       const existingEntry = entries[existingEntryIndex] || {};
@@ -363,13 +394,21 @@ export const createProjectEntriesService = ({
         : createEmptyProjectEntry();
     }
 
-    clearCachedProjectIcon(projectId);
     return filtered;
   };
 
   const updateProjectEntry = async (projectId, updates) => {
     const entries = await getProjectEntries();
-    const index = entries.findIndex((entry) => entry.id === projectId);
+    const selectedProjectPath =
+      currentProjectEntry.id === projectId
+        ? currentProjectEntry.projectPath
+        : undefined;
+    const index = entries.findIndex((entry) => {
+      if (selectedProjectPath) {
+        return entry?.projectPath === selectedProjectPath;
+      }
+      return entry.id === projectId;
+    });
     if (index !== -1) {
       entries[index] = normalizeCachedProjectEntry({
         ...entries[index],
@@ -446,14 +485,7 @@ export const createProjectEntriesService = ({
       }
 
       const duplicateIndex = nextEntries.findIndex((candidate) => {
-        if (nextEntry?.id && candidate?.id) {
-          return candidate.id === nextEntry.id;
-        }
-
-        return (
-          nextEntry?.projectPath &&
-          candidate?.projectPath === nextEntry.projectPath
-        );
+        return isSameLocalProject(candidate, nextEntry);
       });
 
       if (duplicateIndex === -1) {
@@ -461,10 +493,10 @@ export const createProjectEntriesService = ({
         continue;
       }
 
-      nextEntries[duplicateIndex] = mergeProjectEntriesPreservingWorkingPath(
-        nextEntries[duplicateIndex],
-        nextEntry,
-      );
+      nextEntries[duplicateIndex] = {
+        ...nextEntries[duplicateIndex],
+        ...nextEntry,
+      };
       didChange = true;
     }
 
@@ -539,9 +571,13 @@ export const createProjectEntriesService = ({
         return currentProjectEntry;
       }
 
-      const cachedEntry = projectEntriesCache.find(
-        (projectEntry) => projectEntry?.id === entry.id,
-      );
+      const cachedEntry = entry.projectPath
+        ? projectEntriesCache.find(
+            (projectEntry) => projectEntry?.projectPath === entry.projectPath,
+          )
+        : projectEntriesCache.find(
+            (projectEntry) => projectEntry?.id === entry.id,
+          );
 
       currentProjectEntry = normalizeLocalProjectEntry(cachedEntry || entry);
       return currentProjectEntry;

--- a/src/deps/services/shared/projectEntriesService.js
+++ b/src/deps/services/shared/projectEntriesService.js
@@ -54,6 +54,7 @@ const canUpdateLocalProject = (currentEntry, nextEntry) => {
 export const createProjectEntriesService = ({
   db,
   getCurrentProjectId,
+  getCurrentProjectPath = () => "",
   projectService,
   platformAdapter,
 }) => {
@@ -297,15 +298,19 @@ export const createProjectEntriesService = ({
         return createEmptyProjectEntry({ id: projectId, source: "local" });
       }
 
+      const routeProjectPath = getCurrentProjectPath();
       const selectedProjectPath =
-        currentProjectEntry.id === projectId
+        routeProjectPath ||
+        (currentProjectEntry.id === projectId
           ? currentProjectEntry.projectPath
-          : undefined;
-      const localEntry =
-        entries.find(
-          (entry) =>
-            selectedProjectPath && entry?.projectPath === selectedProjectPath,
-        ) ?? entries.find((entry) => entry?.id === projectId);
+          : undefined);
+      const localEntry = selectedProjectPath
+        ? entries.find(
+            (entry) =>
+              entry?.id === projectId &&
+              entry?.projectPath === selectedProjectPath,
+          )
+        : entries.find((entry) => entry?.id === projectId);
       if (localEntry) {
         const project = normalizeLocalProjectEntry(localEntry);
         const iconResult = await platformAdapter.loadProjectIcon?.({

--- a/src/deps/services/shared/projectRepositoryService.js
+++ b/src/deps/services/shared/projectRepositoryService.js
@@ -13,6 +13,7 @@ import { loadProjectionGap } from "./collab/projectionGapState.js";
 import { loadRepositoryEventsFromClientStore } from "./collab/clientStoreHistory.js";
 import { UNSUPPORTED_PROJECT_STORE_FORMAT_MESSAGE } from "../../../internal/projectOpenErrors.js";
 import { createNativeApplicationIdentifier } from "../../../internal/nativeApplicationIdentifier.js";
+import { getLocalProjectPathFromPayload } from "../../../internal/localProjectRoute.js";
 import { normalizeProjectLanguage } from "../../../internal/projectLanguage.js";
 
 const flushRepositoryMainCheckpoint = async (repository) => {
@@ -318,8 +319,16 @@ export const createProjectRepositoryService = ({
     return router.getPayload()?.p;
   };
 
+  const getCurrentProjectPath = () => {
+    return getLocalProjectPathFromPayload(router.getPayload());
+  };
+
   const getEnsuredProjectId = () => {
     return currentProjectId;
+  };
+
+  const getEnsuredProjectPath = () => {
+    return currentReference?.projectPath ?? "";
   };
 
   const emitRepositoryLoadStage = (onLoadStage, payload = {}) => {
@@ -586,6 +595,14 @@ export const createProjectRepositoryService = ({
     };
   };
 
+  const bindProjectReferenceToProjectId = (pathReference, projectId) => {
+    return {
+      ...pathReference,
+      projectId,
+      repositoryProjectId: projectId,
+    };
+  };
+
   const resolveProjectReferenceByProjectId = async (projectId) => {
     if (!projectId) {
       throw new Error("projectId is required");
@@ -655,6 +672,36 @@ export const createProjectRepositoryService = ({
       }),
       projectPath,
     );
+  };
+
+  const resolveCurrentProjectReference = async (projectId) => {
+    const projectPath = getCurrentProjectPath();
+    if (!projectPath) {
+      return resolveProjectReferenceByProjectId(projectId);
+    }
+
+    const cachedReference = referencesByProject.get(projectId);
+    if (cachedReference?.projectPath === projectPath) {
+      return cachedReference;
+    }
+
+    const entries = await db.get("projectEntries");
+    const selectedEntry = Array.isArray(entries)
+      ? entries.find(
+          (entry) =>
+            entry?.id === projectId && entry?.projectPath === projectPath,
+        )
+      : undefined;
+    if (!selectedEntry) {
+      throw new Error(
+        `Selected local project path is not registered for '${projectId}'`,
+      );
+    }
+
+    const pathReference = await resolveProjectReferenceByPath(projectPath);
+    const reference = bindProjectReferenceToProjectId(pathReference, projectId);
+    referencesByProject.set(projectId, reference);
+    return reference;
   };
 
   const getStoreByPath = async (projectPath) => {
@@ -1153,11 +1200,7 @@ export const createProjectRepositoryService = ({
   const ensureProjectCompatibleByPath = async (projectPath, projectId) => {
     const pathReference = await resolveProjectReferenceByPath(projectPath);
     const reference = projectId
-      ? {
-          ...pathReference,
-          projectId,
-          repositoryProjectId: projectId,
-        }
+      ? bindProjectReferenceToProjectId(pathReference, projectId)
       : pathReference;
     await ensureCompatibleCreatorVersionForReference(reference);
     const store = await getStoreByReference(reference);
@@ -1207,11 +1250,15 @@ export const createProjectRepositoryService = ({
       throw new Error("No project selected (missing ?p= in URL)");
     }
 
+    const projectPath = getCurrentProjectPath();
+    const isCurrentReferenceSelected =
+      !projectPath || currentReference?.projectPath === projectPath;
     if (
       currentProjectId === projectId &&
       currentRepository &&
       currentStore &&
-      currentReference
+      currentReference &&
+      isCurrentReferenceSelected
     ) {
       assertSupportedProjectState(currentRepository.getState());
       return currentRepository;
@@ -1222,7 +1269,7 @@ export const createProjectRepositoryService = ({
       label: "Resolving project reference...",
       projectId,
     });
-    const reference = await resolveProjectReferenceByProjectId(projectId);
+    const reference = await resolveCurrentProjectReference(projectId);
     const repository = await getRepositoryByReference(reference, {
       onHydrationProgress,
       onLoadStage,
@@ -1273,8 +1320,13 @@ export const createProjectRepositoryService = ({
       throw new Error("No project selected (missing ?p= in URL)");
     }
 
+    const projectPath = getCurrentProjectPath();
+    const isCurrentReferenceSelected =
+      !projectPath || currentReference?.projectPath === projectPath;
     let repository =
-      targetProjectId === currentProjectId ? currentRepository : undefined;
+      targetProjectId === currentProjectId && isCurrentReferenceSelected
+        ? currentRepository
+        : undefined;
 
     if (!repository) {
       const reference = referencesByProject.get(targetProjectId);
@@ -1294,7 +1346,12 @@ export const createProjectRepositoryService = ({
 
   const getCachedRepository = () => {
     const projectId = getCurrentProjectId();
-    if (!currentRepository || currentProjectId !== projectId) {
+    const projectPath = getCurrentProjectPath();
+    if (
+      !currentRepository ||
+      currentProjectId !== projectId ||
+      (projectPath && currentReference?.projectPath !== projectPath)
+    ) {
       throw new Error(
         "Repository not initialized. Call ensureRepository() first.",
       );
@@ -1304,7 +1361,12 @@ export const createProjectRepositoryService = ({
 
   const getCachedStore = () => {
     const projectId = getCurrentProjectId();
-    if (!currentStore || currentProjectId !== projectId) {
+    const projectPath = getCurrentProjectPath();
+    if (
+      !currentStore ||
+      currentProjectId !== projectId ||
+      (projectPath && currentReference?.projectPath !== projectPath)
+    ) {
       throw new Error(
         "Adapter not initialized. Call ensureRepository() first.",
       );
@@ -1314,7 +1376,12 @@ export const createProjectRepositoryService = ({
 
   const getCachedReference = () => {
     const projectId = getCurrentProjectId();
-    if (!currentReference || currentProjectId !== projectId) {
+    const projectPath = getCurrentProjectPath();
+    if (
+      !currentReference ||
+      currentProjectId !== projectId ||
+      (projectPath && currentReference.projectPath !== projectPath)
+    ) {
       throw new Error(
         "Project reference not initialized. Call ensureRepository() first.",
       );
@@ -1322,9 +1389,31 @@ export const createProjectRepositoryService = ({
     return currentReference;
   };
 
+  const getProjectCacheKey = (projectId) => {
+    const selectedProjectPath =
+      projectId === getCurrentProjectId() ? getCurrentProjectPath() : "";
+    if (selectedProjectPath) {
+      const selectedReference =
+        currentReference?.projectPath === selectedProjectPath
+          ? currentReference
+          : referencesByProject.get(projectId);
+      return selectedReference?.projectPath === selectedProjectPath
+        ? selectedReference.cacheKey
+        : selectedProjectPath;
+    }
+
+    const reference =
+      currentProjectId === projectId
+        ? currentReference
+        : referencesByProject.get(projectId);
+    return reference?.cacheKey ?? projectId;
+  };
+
   return {
     getCurrentProjectId,
     getEnsuredProjectId,
+    getEnsuredProjectPath,
+    getProjectCacheKey,
     ensureProjectCompatibleByProjectId,
     getProjectInfoByProjectId,
     getCurrentProjectInfo,

--- a/src/deps/services/shared/projectRepositoryService.js
+++ b/src/deps/services/shared/projectRepositoryService.js
@@ -542,7 +542,11 @@ export const createProjectRepositoryService = ({
     };
   };
 
-  const syncProjectEntryProjectInfo = async (projectId, projectInfo) => {
+  const syncProjectEntryProjectInfo = async (
+    projectId,
+    projectInfo,
+    projectPath,
+  ) => {
     if (!db || typeof db.get !== "function" || typeof db.set !== "function") {
       return;
     }
@@ -552,7 +556,9 @@ export const createProjectRepositoryService = ({
       return;
     }
 
-    const entryIndex = entries.findIndex((entry) => entry?.id === projectId);
+    const entryIndex = projectPath
+      ? entries.findIndex((entry) => entry?.projectPath === projectPath)
+      : entries.findIndex((entry) => entry?.id === projectId);
     if (entryIndex < 0) {
       return;
     }
@@ -803,7 +809,12 @@ export const createProjectRepositoryService = ({
     }
   };
 
-  const writeProjectInfoToStore = async ({ store, projectId, patch }) => {
+  const writeProjectInfoToStore = async ({
+    store,
+    projectId,
+    projectPath,
+    patch,
+  }) => {
     const currentProjectInfo = await readProjectInfoFromStore(store, {
       fallbackProjectId: projectId,
     });
@@ -819,7 +830,11 @@ export const createProjectRepositoryService = ({
     }
 
     if (projectId) {
-      await syncProjectEntryProjectInfo(projectId, nextProjectInfo);
+      await syncProjectEntryProjectInfo(
+        projectId,
+        nextProjectInfo,
+        projectPath,
+      );
     }
 
     return nextProjectInfo;
@@ -842,6 +857,7 @@ export const createProjectRepositoryService = ({
     return writeProjectInfoToStore({
       store,
       projectId,
+      projectPath: referencesByProject.get(projectId)?.projectPath,
       patch,
     });
   };
@@ -1134,11 +1150,22 @@ export const createProjectRepositoryService = ({
     return getRepositoryByReference(reference);
   };
 
-  const ensureProjectCompatibleByPath = async (projectPath) => {
-    const reference = await resolveProjectReferenceByPath(projectPath);
+  const ensureProjectCompatibleByPath = async (projectPath, projectId) => {
+    const pathReference = await resolveProjectReferenceByPath(projectPath);
+    const reference = projectId
+      ? {
+          ...pathReference,
+          projectId,
+          repositoryProjectId: projectId,
+        }
+      : pathReference;
     await ensureCompatibleCreatorVersionForReference(reference);
-    const store = await getStoreByPath(projectPath);
+    const store = await getStoreByReference(reference);
     await ensureStoreOpenCompatible(store);
+    if (projectId) {
+      referencesByProject.set(projectId, reference);
+      storesByProject.set(projectId, store);
+    }
   };
 
   const getProjectInfoByPath = async (projectPath) => {
@@ -1222,7 +1249,11 @@ export const createProjectRepositoryService = ({
       projectId,
       cacheKey: reference.cacheKey,
     });
-    await syncProjectEntryProjectInfo(projectId, projectInfo);
+    await syncProjectEntryProjectInfo(
+      projectId,
+      projectInfo,
+      reference.projectPath,
+    );
     emitRepositoryLoadStage(onLoadStage, {
       stage: "repository_ready",
       label: "Project ready.",
@@ -1339,8 +1370,8 @@ export const createProjectRepositoryService = ({
     async getRepositoryByPath(projectPath) {
       return getRepositoryByPath(projectPath);
     },
-    async ensureProjectCompatibleByPath(projectPath) {
-      return ensureProjectCompatibleByPath(projectPath);
+    async ensureProjectCompatibleByPath(projectPath, projectId) {
+      return ensureProjectCompatibleByPath(projectPath, projectId);
     },
     async getProjectInfoByPath(projectPath) {
       return getProjectInfoByPath(projectPath);

--- a/src/deps/services/shared/projectServiceCore.js
+++ b/src/deps/services/shared/projectServiceCore.js
@@ -79,6 +79,7 @@ export const createProjectServiceCore = ({
     getCachedRepository: repositoryService.getCachedRepository,
     getRepositoryByProject: repositoryService.getRepositoryByProject,
     getAdapterByProject: repositoryService.getStoreByProjectSync,
+    getProjectCacheKey: repositoryService.getProjectCacheKey,
     createSessionForProject: (payload) =>
       collabAdapter.createSessionForProject({
         ...payload,
@@ -547,6 +548,7 @@ export const createProjectServiceCore = ({
     getRepositoryById: repositoryService.getRepositoryById,
     getAdapterById: repositoryService.getAdapterById,
     getEnsuredProjectId: repositoryService.getEnsuredProjectId,
+    getEnsuredProjectPath: repositoryService.getEnsuredProjectPath,
     releaseCurrentRepository: repositoryService.releaseCurrentRepository,
     releaseProjectRuntime,
     ensureRepository,

--- a/src/internal/localProjectRoute.js
+++ b/src/internal/localProjectRoute.js
@@ -1,0 +1,24 @@
+export const LOCAL_PROJECT_PATH_PAYLOAD_KEY = "lp";
+
+export const getLocalProjectPathFromPayload = (payload = {}) => {
+  return payload?.[LOCAL_PROJECT_PATH_PAYLOAD_KEY] ?? "";
+};
+
+export const createProjectRoutePayload = ({
+  projectId,
+  projectPath,
+  payload = {},
+} = {}) => {
+  const nextPayload = {
+    ...payload,
+    p: projectId,
+  };
+
+  if (projectPath) {
+    nextPayload[LOCAL_PROJECT_PATH_PAYLOAD_KEY] = projectPath;
+  } else {
+    delete nextPayload[LOCAL_PROJECT_PATH_PAYLOAD_KEY];
+  }
+
+  return nextPayload;
+};

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -21,6 +21,7 @@ import {
   markNavigationPaintTiming,
   markNavigationTiming,
 } from "../../internal/navigationTiming.js";
+import { getLocalProjectPathFromPayload } from "../../internal/localProjectRoute.js";
 import { getRoutevnCreatorDocsUrl } from "../../internal/routevnUrls.js";
 import { resolveUpdatesEnabled } from "../../internal/updates.js";
 import { recordRecentSceneVisit } from "../../internal/ui/recentScenes.js";
@@ -331,14 +332,19 @@ export const createRouteTransitionRunner = (deps) => {
       canonicalPath,
       currentProjectId,
     );
+    const currentProjectPath = getLocalProjectPathFromPayload(nextPayload);
     const ensuredProjectId = projectService.getEnsuredProjectId();
-    const isAlreadyEnsured = currentProjectId === ensuredProjectId;
+    const ensuredProjectPath = projectService.getEnsuredProjectPath?.() ?? "";
+    const isAlreadyEnsured =
+      currentProjectId === ensuredProjectId &&
+      (!currentProjectPath || currentProjectPath === ensuredProjectPath);
     const shouldReleaseEnsuredRepository =
-      !!ensuredProjectId &&
-      (!needsRepository || ensuredProjectId !== currentProjectId);
+      !!ensuredProjectId && (!needsRepository || !isAlreadyEnsured);
     markNavigationTiming(routeTiming, "route.state.resolved", {
       currentProjectId,
+      currentProjectPath,
       ensuredProjectId,
+      ensuredProjectPath,
       needsRepository,
       isAlreadyEnsured,
       shouldReleaseEnsuredRepository,

--- a/src/pages/characters/characters.handlers.js
+++ b/src/pages/characters/characters.handlers.js
@@ -273,11 +273,11 @@ const readSpriteGroupIndex = (payload) =>
 
 const navigateToCharacterSprites = ({ deps, characterId } = {}) => {
   const { appService, render } = deps;
-  const { p } = appService.getPayload();
+  const payload = appService.getPayload();
 
   appService.navigate("/project/character-sprites", {
+    ...payload,
     characterId,
-    p,
   });
 
   render();

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -180,18 +180,9 @@ const getProjectPathFromEvent = (event) => {
   return event?.currentTarget?.dataset?.projectPath ?? "";
 };
 
-const getProjectIndexFromEvent = (event) => {
-  const value = event?.currentTarget?.dataset?.projectIndex;
-  const index = Number(value);
-  if (!Number.isInteger(index) || index < 0) {
-    return undefined;
-  }
-  return index;
-};
-
 const navigateToProjectRoute = async (
   { appService, projectService, store, i18n },
-  { projectId, path } = {},
+  { projectId, projectPath, path } = {},
 ) => {
   const copy = selectProjectsPageCopy(i18n);
   if (!projectId) {
@@ -201,12 +192,20 @@ const navigateToProjectRoute = async (
     return;
   }
 
-  const project = store
-    .selectProjects()
-    .find((entry) => entry?.id === projectId);
+  const projects = store.selectProjects();
+  const project = projectPath
+    ? projects.find((entry) => entry?.projectPath === projectPath)
+    : projects.find((entry) => entry?.id === projectId);
 
   try {
-    await projectService.ensureProjectCompatibleById(projectId);
+    if (projectPath) {
+      await projectService.ensureProjectCompatibleByPath(
+        projectPath,
+        projectId,
+      );
+    } else {
+      await projectService.ensureProjectCompatibleById(projectId);
+    }
   } catch (error) {
     if (isIncompatibleProjectOpenError(error)) {
       await appService.showAlert({
@@ -326,12 +325,6 @@ export const handleCreateDialogClose = (deps) => {
   if (!store.selectIsCreateDialogOpen()) {
     return;
   }
-  store.closeCreateDialog();
-  render();
-};
-
-export const handleCreateDialogCancel = (deps) => {
-  const { store, render } = deps;
   store.closeCreateDialog();
   render();
 };
@@ -846,9 +839,11 @@ export const handleProfileDropdownClickItem = async (deps, payload) => {
 };
 
 export const handleProjectsClick = async (deps, payload) => {
-  const id = getProjectIdFromEvent(payload._event);
+  const projectId = getProjectIdFromEvent(payload._event);
+  const projectPath = getProjectPathFromEvent(payload._event);
   return navigateToProjectRoute(deps, {
-    projectId: id,
+    projectId,
+    projectPath,
     path: "/project",
   });
 };
@@ -859,13 +854,7 @@ export const handleProjectContextMenu = (deps, payload) => {
   payload._event.preventDefault();
 
   const projectId = getProjectIdFromEvent(payload._event);
-  const projects = store.selectProjects();
-  const projectIndex = getProjectIndexFromEvent(payload._event);
-  const project =
-    projects.find((entry) => entry?.id === projectId) ??
-    (projectIndex === undefined ? undefined : projects[projectIndex]);
-  const projectPath =
-    project?.projectPath || getProjectPathFromEvent(payload._event);
+  const projectPath = getProjectPathFromEvent(payload._event);
   if (!projectId) {
     if (!projectPath) {
       appService.showAlert({
@@ -1050,12 +1039,12 @@ export const handleDeleteDialogConfirm = async (deps) => {
       await projectService.releaseProjectRuntime(projectId);
     }
 
-    if (projectId) {
-      await appService.removeProjectEntry(projectId);
-      store.removeProject({ projectId });
-    } else {
+    if (projectPath) {
       await appService.removeProjectEntryByPath(projectPath);
       store.removeProject({ projectPath });
+    } else {
+      await appService.removeProjectEntry(projectId);
+      store.removeProject({ projectId });
     }
   } catch {
     appService.showAlert({
@@ -1113,13 +1102,9 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
   }
 
   const projects = store.selectProjects();
-  const project = projects.find((projectItem) => {
-    if (projectId && projectItem?.id === projectId) {
-      return true;
-    }
-
-    return projectPath && projectItem?.projectPath === projectPath;
-  });
+  const project = projectPath
+    ? projects.find((projectItem) => projectItem?.projectPath === projectPath)
+    : projects.find((projectItem) => projectItem?.id === projectId);
 
   store.closeDropdownMenu();
   store.openDeleteDialog({

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -13,6 +13,7 @@ import {
   CUSTOM_PROJECT_RESOLUTION_PRESET,
   resolveProjectResolution,
 } from "../../internal/projectResolution.js";
+import { createProjectRoutePayload } from "../../internal/localProjectRoute.js";
 import { resolveUpdatesEnabled } from "../../internal/updates.js";
 import {
   formatProjectsPageCopy,
@@ -177,7 +178,8 @@ const getProjectIdFromEvent = (event) => {
 };
 
 const getProjectPathFromEvent = (event) => {
-  return event?.currentTarget?.dataset?.projectPath ?? "";
+  const encodedProjectPath = event?.currentTarget?.dataset?.projectPath ?? "";
+  return encodedProjectPath ? decodeURIComponent(encodedProjectPath) : "";
 };
 
 const navigateToProjectRoute = async (
@@ -230,7 +232,11 @@ const navigateToProjectRoute = async (
   const historyMode = currentHistoryState.preserveProjectsEntryOnProjectOpen
     ? "push"
     : "replace";
-  appService.navigate(path, { p: projectId }, { historyMode });
+  appService.navigate(
+    path,
+    createProjectRoutePayload({ projectId, projectPath }),
+    { historyMode },
+  );
 };
 
 const createProjectFromValues = async (deps, values = {}) => {

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -23,6 +23,10 @@ const createLocalProjectItemId = (project, index) => {
   return `projectItem${encodedPath}`;
 };
 
+const encodeProjectPathAttribute = (projectPath) => {
+  return projectPath ? encodeURIComponent(projectPath) : "";
+};
+
 export const createInitialState = () => ({
   isTouchMode: false,
   localTitle: "",
@@ -727,6 +731,7 @@ export const selectViewData = ({ state, i18n }) => {
     ? state.projects.map((project, index) => ({
         ...project,
         itemId: createLocalProjectItemId(project, index),
+        encodedProjectPath: encodeProjectPathAttribute(project.projectPath),
       }))
     : [];
   const cloudProjects = Array.isArray(state.cloudProjects)

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -4,6 +4,25 @@ import {
   selectProjectsPageCopy,
 } from "./support/projectsPageCopy.js";
 
+const selectLocalProjectKey = (project) => {
+  return project?.projectPath ? project.projectPath : project?.id;
+};
+
+const createLocalProjectItemId = (project, index) => {
+  if (!project?.projectPath) {
+    return `projectItem${index}`;
+  }
+
+  let encodedPath = "";
+  for (let i = 0; i < project.projectPath.length; i += 1) {
+    encodedPath += project.projectPath
+      .charCodeAt(i)
+      .toString(16)
+      .padStart(4, "0");
+  }
+  return `projectItem${encodedPath}`;
+};
+
 export const createInitialState = () => ({
   isTouchMode: false,
   localTitle: "",
@@ -135,12 +154,13 @@ export const setProjectsLoading = ({ state }, { loading } = {}) => {
 };
 
 export const addProject = ({ state }, { project } = {}) => {
-  if (!project?.id) {
+  const projectKey = selectLocalProjectKey(project);
+  if (!projectKey) {
     return;
   }
 
   const existingIndex = state.projects.findIndex(
-    (entry) => entry?.id === project.id,
+    (entry) => selectLocalProjectKey(entry) === projectKey,
   );
   if (existingIndex === -1) {
     state.projects.push(project);
@@ -199,11 +219,11 @@ export const setAuthUser = ({ state }, { user } = {}) => {
 
 export const removeProject = ({ state }, { projectId, projectPath } = {}) => {
   state.projects = state.projects.filter((project) => {
-    if (projectId && project?.id === projectId) {
-      return false;
+    if (projectPath) {
+      return project?.projectPath !== projectPath;
     }
 
-    if (projectPath && project?.projectPath === projectPath) {
+    if (projectId && project?.id === projectId) {
       return false;
     }
 
@@ -703,7 +723,12 @@ export const selectViewData = ({ state, i18n }) => {
     },
   };
 
-  const localProjects = Array.isArray(state.projects) ? state.projects : [];
+  const localProjects = Array.isArray(state.projects)
+    ? state.projects.map((project, index) => ({
+        ...project,
+        itemId: createLocalProjectItemId(project, index),
+      }))
+    : [];
   const cloudProjects = Array.isArray(state.cloudProjects)
     ? state.cloudProjects
     : [];
@@ -717,6 +742,7 @@ export const selectViewData = ({ state, i18n }) => {
 
   return {
     ...state,
+    projects: localProjects,
     localTitle: copy.title,
     cloudTitle: copy.cloudTitle,
     loginButtonText: copy.loginButton,

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -168,7 +168,7 @@ template:
                                           - rtgl-text s=lg c=mu-fg: ${localEmptyMessage}
                                           - rtgl-text s=sm c=mu-fg: ${localEmptySubMessage}
                               - $for project, i in projects:
-                                  - 'rtgl-view id=${project.itemId} data-project-id=${project.id} data-project-path="${project.projectPath}" h=auto w=f bw=xs bc=bo h-bc=ac p=md cur=pointer d=h av=c g=md':
+                                  - 'rtgl-view id=${project.itemId} data-project-id=${project.id} data-project-path="${project.encodedProjectPath}" h=auto w=f bw=xs bc=bo h-bc=ac p=md cur=pointer d=h av=c g=md':
                                       - $if project.iconUrl:
                                           - rtgl-image wh=56 src=${project.iconUrl} bw=xs bc=bo of=con br=md: null
                                         $else:

--- a/src/pages/projects/projects.view.yaml
+++ b/src/pages/projects/projects.view.yaml
@@ -121,10 +121,6 @@ refs:
       close:
         handler: handleCreateDialogClose
   projectCreateDialogBody: {}
-  createProjectCancelButton:
-    eventListeners:
-      click:
-        handler: handleCreateDialogCancel
   createProjectSubmitButton:
     eventListeners:
       click:
@@ -172,7 +168,7 @@ template:
                                           - rtgl-text s=lg c=mu-fg: ${localEmptyMessage}
                                           - rtgl-text s=sm c=mu-fg: ${localEmptySubMessage}
                               - $for project, i in projects:
-                                  - rtgl-view#projectItem${i} data-project-id=${project.id} data-project-index=${i} h=auto w=f bw=xs bc=bo h-bc=ac p=md cur=pointer d=h av=c g=md:
+                                  - 'rtgl-view id=${project.itemId} data-project-id=${project.id} data-project-path="${project.projectPath}" h=auto w=f bw=xs bc=bo h-bc=ac p=md cur=pointer d=h av=c g=md':
                                       - $if project.iconUrl:
                                           - rtgl-image wh=56 src=${project.iconUrl} bw=xs bc=bo of=con br=md: null
                                         $else:
@@ -231,7 +227,6 @@ template:
       - rtgl-view slot=content w=f p=lg g=lg:
           - rvn-project-create-dialog#projectCreateDialogBody key=${createDialog.formKey} :platform=${platform} :defaultValues=${createDialog.defaultValues}: null
           - rtgl-view d=h g=sm w=f ah=e:
-              - rtgl-button#createProjectCancelButton v=se: ${i18n.projectsPage.cancelButton}
               - rtgl-button#createProjectSubmitButton data-action-id=submit v=pr: ${i18n.projectsPage.submitButton}
   - rtgl-dialog#cloudCreateProjectDialog ?open=${cloudCreateDialog.isOpen} s=md:
       - rtgl-view slot=content w=f p=lg:

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -3794,8 +3794,9 @@ export const handlePreviewCurrentLineChanged = (deps, payload) => {
 
 export const handleBackClick = (deps) => {
   const { appService } = deps;
-  const { p } = appService.getPayload();
-  appService.navigate("/project/scenes", { p }, { historyMode: "replace" });
+  appService.navigate("/project/scenes", appService.getPayload(), {
+    historyMode: "replace",
+  });
 };
 
 export const handleSystemActionsActionDelete = async (deps, payload) => {

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -151,6 +151,55 @@ describe("app route transitions", () => {
     expect(appService.prepareNavigation).not.toHaveBeenCalled();
   });
 
+  it("reloads the repository when a same-id local route selects another path", async () => {
+    const appService = {
+      prepareNavigation: vi.fn(async () => {}),
+      getCurrentProjectId: vi.fn(() => "shared-project-id"),
+      refreshCurrentProjectEntry: vi.fn(async () => {}),
+      getPlatform: vi.fn(() => "tauri"),
+    };
+    const projectService = {
+      ensureRepository: vi.fn(async () => {}),
+      getEnsuredProjectId: vi.fn(() => "shared-project-id"),
+      getEnsuredProjectPath: vi.fn(() => "/projects/project-one"),
+      releaseProjectRuntime: vi.fn(async () => {}),
+    };
+    const store = {
+      setCurrentRoute: vi.fn(),
+      closeMobileSheet: vi.fn(),
+      setRepositoryLoading: vi.fn(),
+      setRepositoryLoadingPhase: vi.fn(),
+      setRepositoryLoadingProgress: vi.fn(),
+    };
+
+    await createRouteTransitionRunner({
+      appService,
+      projectService,
+      store,
+      render: vi.fn(),
+      i18n: {},
+    })({
+      path: "/project",
+      payload: {
+        p: "shared-project-id",
+        lp: "/projects/project-two",
+      },
+      navigationPrepared: true,
+    });
+
+    expect(projectService.releaseProjectRuntime).toHaveBeenCalledWith(
+      "shared-project-id",
+    );
+    expect(appService.refreshCurrentProjectEntry).toHaveBeenCalledOnce();
+    expect(projectService.ensureRepository).toHaveBeenCalledOnce();
+    expect(store.setRepositoryLoading).toHaveBeenNthCalledWith(1, {
+      isLoading: true,
+    });
+    expect(store.setRepositoryLoading).toHaveBeenLastCalledWith({
+      isLoading: false,
+    });
+  });
+
   it("prepares browser back navigation without rewriting the popped entry", async () => {
     const currentPath = "/projects";
     const currentPayload = {};

--- a/tests/appService/projectEntriesService.test.js
+++ b/tests/appService/projectEntriesService.test.js
@@ -24,6 +24,7 @@ const createService = (
   initialEntries = [],
   {
     getCurrentProjectId = () => "",
+    getCurrentProjectPath = () => "",
     projectService = {
       getProjectInfoByPath: vi.fn(async () => {
         throw new Error("unexpected getProjectInfoByPath call");
@@ -45,6 +46,7 @@ const createService = (
   const service = createProjectEntriesService({
     db,
     getCurrentProjectId,
+    getCurrentProjectPath,
     projectService,
     platformAdapter,
   });
@@ -98,6 +100,33 @@ describe("projectEntriesService", () => {
     await service.loadAllProjects();
 
     service.setCurrentProjectEntry(entries[1]);
+    const currentProject = await service.refreshCurrentProjectEntry();
+
+    expect(currentProject).toMatchObject({
+      id: "shared-project-id",
+      projectPath: "/projects/project-two",
+      name: "Project Two",
+    });
+  });
+
+  it("restores the selected local path from route state after reload", async () => {
+    const entries = [
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-one",
+        name: "Project One",
+      },
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-two",
+        name: "Project Two",
+      },
+    ];
+    const { service } = createService(entries, {
+      getCurrentProjectId: () => "shared-project-id",
+      getCurrentProjectPath: () => "/projects/project-two",
+    });
+
     const currentProject = await service.refreshCurrentProjectEntry();
 
     expect(currentProject).toMatchObject({

--- a/tests/appService/projectEntriesService.test.js
+++ b/tests/appService/projectEntriesService.test.js
@@ -79,6 +79,34 @@ describe("projectEntriesService", () => {
     ]);
   });
 
+  it("keeps the selected local path when project ids match", async () => {
+    const entries = [
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-one",
+        name: "Project One",
+      },
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-two",
+        name: "Project Two",
+      },
+    ];
+    const { service } = createService(entries, {
+      getCurrentProjectId: () => "shared-project-id",
+    });
+    await service.loadAllProjects();
+
+    service.setCurrentProjectEntry(entries[1]);
+    const currentProject = await service.refreshCurrentProjectEntry();
+
+    expect(currentProject).toMatchObject({
+      id: "shared-project-id",
+      projectPath: "/projects/project-two",
+      name: "Project Two",
+    });
+  });
+
   it("keeps the in-memory project list aligned with entry updates", async () => {
     const { service } = createService([
       {
@@ -210,7 +238,7 @@ describe("projectEntriesService", () => {
     expect(db.set).not.toHaveBeenCalled();
   });
 
-  it("replaces an existing local project entry when the same project id is re-added from a new path", async () => {
+  it("keeps local project entries with the same id when their paths differ", async () => {
     const { service } = createService([
       {
         id: "project-1",
@@ -238,13 +266,23 @@ describe("projectEntriesService", () => {
     expect(entries).toEqual([
       {
         id: "project-1",
+        projectPath: "/old/project-two-migrated",
+        name: "Project Two",
+        description: "old description",
+        language: "en",
+        iconFileId: "icon-old",
+        createdAt: 100,
+        lastOpenedAt: 200,
+      },
+      {
+        id: "project-1",
         projectPath: "/new/project-two-migrated",
         name: "Project Two",
         description: "new description",
         language: "ja",
         iconFileId: "icon-new",
-        createdAt: 100,
-        lastOpenedAt: 200,
+        createdAt: 300,
+        lastOpenedAt: null,
       },
     ]);
   });
@@ -317,7 +355,7 @@ describe("projectEntriesService", () => {
     ]);
   });
 
-  it("preserves the working path when duplicate repaired entries merge by project id", async () => {
+  it("keeps repaired local project entries separate when their paths differ", async () => {
     const getProjectInfoByPath = vi.fn(async () => ({
       id: "project-1",
       name: "Project Two",
@@ -356,11 +394,23 @@ describe("projectEntriesService", () => {
         id: "project-1",
         projectPath: "/projects/working",
       }),
+      expect.objectContaining({
+        id: "project-1",
+        projectPath: "/projects/stale",
+      }),
     ]);
     expect(db.set).toHaveBeenCalledWith("projectEntries", [
       {
         id: "project-1",
         projectPath: "/projects/working",
+        name: "Project Two",
+        description: "Working",
+        language: "en",
+        iconFileId: "icon-working",
+      },
+      {
+        id: "project-1",
+        projectPath: "/projects/stale",
         name: "Project Two",
         description: "Recovered",
         language: "zh-Hans",

--- a/tests/characters/characters.handlers.test.js
+++ b/tests/characters/characters.handlers.test.js
@@ -71,7 +71,10 @@ describe("characters item selection", () => {
   it("opens the selected character's sprites page with Enter", () => {
     const deps = {
       appService: {
-        getPayload: vi.fn(() => ({ p: "project-1" })),
+        getPayload: vi.fn(() => ({
+          p: "project-1",
+          lp: "/projects/project-one",
+        })),
         navigate: vi.fn(),
       },
       refs: {
@@ -98,6 +101,7 @@ describe("characters item selection", () => {
       "/project/character-sprites",
       {
         characterId: "character-1",
+        lp: "/projects/project-one",
         p: "project-1",
       },
     );

--- a/tests/projectRepositoryService/projectRepositoryService.compatibility.test.js
+++ b/tests/projectRepositoryService/projectRepositoryService.compatibility.test.js
@@ -29,6 +29,11 @@ const createService = ({
       cacheKey: `/tmp/${projectId}`,
       repositoryProjectId: projectId,
     })),
+    resolveProjectReferenceByPath: vi.fn(async ({ projectPath }) => ({
+      projectPath,
+      cacheKey: projectPath,
+      repositoryProjectId: projectPath,
+    })),
     readCreatorVersionByReference: vi.fn(readCreatorVersionByReference),
     evictStoreByReference: vi.fn(async () => {}),
     createStore: vi.fn(async () => ({
@@ -88,6 +93,32 @@ describe("projectRepositoryService compatibility ordering", () => {
     );
 
     expect(storageAdapter.createStore).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds a project id to the selected local project path", async () => {
+    const { service, storageAdapter } = createService();
+
+    await service.ensureProjectCompatibleByPath(
+      "/projects/project-two",
+      "shared-project-id",
+    );
+    await service.ensureProjectCompatibleByProjectId("shared-project-id");
+
+    expect(
+      storageAdapter.resolveProjectReferenceByProjectId,
+    ).not.toHaveBeenCalled();
+    expect(storageAdapter.createStore).toHaveBeenCalledTimes(2);
+    for (const [payload] of storageAdapter.createStore.mock.calls) {
+      expect(payload).toEqual({
+        reference: {
+          projectPath: "/projects/project-two",
+          cacheKey: "/projects/project-two",
+          projectId: "shared-project-id",
+          repositoryProjectId: "shared-project-id",
+        },
+        db: {},
+      });
+    }
   });
 
   it("rejects projects with a stored projection gap as incompatible", async () => {

--- a/tests/projectRepositoryService/projectRepositoryService.projectInfoSync.test.js
+++ b/tests/projectRepositoryService/projectRepositoryService.projectInfoSync.test.js
@@ -20,6 +20,16 @@ describe("projectRepositoryService project-info cache sync", () => {
     const projectEntries = [
       {
         id: "project-1",
+        projectPath: "/projects/copied-project",
+        name: "Copied Project",
+        description: "Copied description",
+        language: "en",
+        iconFileId: "icon-copy",
+        createdAt: 50,
+        lastOpenedAt: 75,
+      },
+      {
+        id: "project-1",
         projectPath: "/projects/sample-project",
         name: "Sample Project",
         description: "Sample description",
@@ -60,8 +70,8 @@ describe("projectRepositoryService project-info cache sync", () => {
     const storageAdapter = {
       readCreatorVersionByReference: vi.fn(async () => 1),
       resolveProjectReferenceByProjectId: vi.fn(async ({ projectId }) => ({
-        projectPath: `/projects/${projectId}`,
-        cacheKey: `/projects/${projectId}`,
+        projectPath: "/projects/sample-project",
+        cacheKey: "/projects/sample-project",
         repositoryProjectId: projectId,
       })),
       createStore: vi.fn(async () => store),
@@ -86,8 +96,9 @@ describe("projectRepositoryService project-info cache sync", () => {
       expect.objectContaining({ language: "ja" }),
     );
     expect(db.set).toHaveBeenCalledWith("projectEntries", [
+      projectEntries[0],
       {
-        ...projectEntries[0],
+        ...projectEntries[1],
         language: "ja",
       },
     ]);

--- a/tests/projectRepositoryService/projectRepositoryService.releaseRuntime.test.js
+++ b/tests/projectRepositoryService/projectRepositoryService.releaseRuntime.test.js
@@ -119,4 +119,161 @@ describe("projectRepositoryService release runtime", () => {
       storageAdapter.evictStoreByReference.mock.invocationCallOrder[0],
     );
   });
+
+  it("restores a path-selected duplicate-id project from route state", async () => {
+    const repositoryEvents = [
+      {
+        id: "project-create:shared-project-id",
+        partition: "m",
+        projectId: "shared-project-id",
+        type: "project.create",
+        schemaVersion: 1,
+        payload: {
+          state: structuredClone(initialProjectData),
+        },
+        clientTs: 1,
+        meta: {
+          clientTs: 1,
+        },
+      },
+    ];
+    const store = {
+      listCommittedAfter: vi.fn(async () => []),
+      listDraftsOrdered: vi.fn(async () =>
+        createDraftRowsFromRepositoryEvents(repositoryEvents),
+      ),
+      getCursor: vi.fn(async () => 0),
+      getRepositoryHistoryStats: async () => ({
+        committedCount: 0,
+        latestCommittedId: 0,
+        draftCount: 1,
+        latestDraftClock: 1,
+      }),
+      isRepositoryHistoryStatsEqual: (left, right) =>
+        JSON.stringify(left) === JSON.stringify(right),
+      loadMaterializedViewCheckpoint: async () => undefined,
+      loadMaterializedViewCheckpoints: async () => [],
+      loadMaterializedView: async () => undefined,
+      evictMaterializedView: async () => {},
+      invalidateMaterializedView: async () => {},
+      saveMaterializedViewCheckpoint: vi.fn(async () => {}),
+      deleteMaterializedViewCheckpoint: vi.fn(async () => {}),
+      app: {
+        get: async (key) => {
+          if (key === "creatorVersion") {
+            return 1;
+          }
+
+          if (key === "projectInfo") {
+            return {
+              id: "shared-project-id",
+              namespace: "namespace-1",
+              nativeApplicationIdentifier: "app-1",
+              name: "Project Two",
+              description: "",
+              iconFileId: null,
+            };
+          }
+
+          return undefined;
+        },
+        set: vi.fn(async () => {}),
+      },
+    };
+    const storageAdapter = {
+      readCreatorVersionByReference: vi.fn(async () => 1),
+      resolveProjectReferenceByProjectId: vi.fn(),
+      resolveProjectReferenceByPath: vi.fn(async ({ projectPath }) => ({
+        projectPath,
+        cacheKey: projectPath,
+        repositoryProjectId: projectPath,
+      })),
+      createStore: vi.fn(async () => store),
+      evictStoreByReference: vi.fn(async () => {}),
+    };
+    const db = {
+      get: vi.fn(async () => [
+        {
+          id: "shared-project-id",
+          projectPath: "/projects/project-one",
+          name: "Project One",
+        },
+        {
+          id: "shared-project-id",
+          projectPath: "/projects/project-two",
+          name: "Project Two",
+        },
+      ]),
+      set: vi.fn(async () => {}),
+    };
+    const service = createProjectRepositoryService({
+      router: {
+        getPayload: () => ({
+          p: "shared-project-id",
+          lp: "/projects/project-two",
+        }),
+      },
+      db,
+      creatorVersion: 1,
+      storageAdapter,
+      collabAdapter: noopCollabAdapter,
+    });
+
+    await service.ensureRepository();
+
+    expect(
+      storageAdapter.resolveProjectReferenceByProjectId,
+    ).not.toHaveBeenCalled();
+    expect(storageAdapter.resolveProjectReferenceByPath).toHaveBeenCalledWith({
+      projectPath: "/projects/project-two",
+    });
+    expect(service.getCachedReference()).toMatchObject({
+      projectId: "shared-project-id",
+      projectPath: "/projects/project-two",
+      cacheKey: "/projects/project-two",
+      repositoryProjectId: "shared-project-id",
+    });
+    expect(service.getEnsuredProjectPath()).toBe("/projects/project-two");
+    expect(service.getProjectCacheKey("shared-project-id")).toBe(
+      "/projects/project-two",
+    );
+  });
+
+  it("does not fall back to the first duplicate-id entry for a stale path route", async () => {
+    const storageAdapter = {
+      resolveProjectReferenceByProjectId: vi.fn(),
+      resolveProjectReferenceByPath: vi.fn(),
+    };
+    const service = createProjectRepositoryService({
+      router: {
+        getPayload: () => ({
+          p: "shared-project-id",
+          lp: "/projects/missing-project",
+        }),
+      },
+      db: {
+        get: vi.fn(async () => [
+          {
+            id: "shared-project-id",
+            projectPath: "/projects/project-one",
+          },
+          {
+            id: "shared-project-id",
+            projectPath: "/projects/project-two",
+          },
+        ]),
+      },
+      creatorVersion: 1,
+      storageAdapter,
+      collabAdapter: noopCollabAdapter,
+    });
+
+    await expect(service.ensureRepository()).rejects.toThrow(
+      "Selected local project path is not registered",
+    );
+    expect(
+      storageAdapter.resolveProjectReferenceByProjectId,
+    ).not.toHaveBeenCalled();
+    expect(storageAdapter.resolveProjectReferenceByPath).not.toHaveBeenCalled();
+  });
 });

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -137,7 +137,9 @@ const createPayload = (projectId = "project-1", projectPath = undefined) => {
       currentTarget: {
         dataset: {
           projectId,
-          projectPath,
+          projectPath: projectPath
+            ? encodeURIComponent(projectPath)
+            : undefined,
         },
       },
     },
@@ -409,6 +411,16 @@ describe("projects.handleProjectsClick", () => {
       name: "Project Two",
       projectPath: "/projects/project-two",
     });
+    expect(deps.appService.navigate).toHaveBeenCalledWith(
+      "/project",
+      {
+        p: "shared-project-id",
+        lp: "/projects/project-two",
+      },
+      {
+        historyMode: "replace",
+      },
+    );
   });
 });
 

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -24,6 +24,7 @@ const EN_I18N = yaml.load(readFileSync(EN_I18N_URL, "utf8"));
 
 const createDeps = ({
   ensureProjectCompatibleById = vi.fn(async () => {}),
+  ensureProjectCompatibleByPath = vi.fn(async () => {}),
   platform = "tauri",
 } = {}) => {
   const appService = {
@@ -52,6 +53,7 @@ const createDeps = ({
     appService,
     projectService: {
       ensureProjectCompatibleById,
+      ensureProjectCompatibleByPath,
       releaseProjectRuntime: vi.fn(async () => {}),
     },
     store: {
@@ -129,12 +131,13 @@ const createDeps = ({
   };
 };
 
-const createPayload = (projectId = "project-1") => {
+const createPayload = (projectId = "project-1", projectPath = undefined) => {
   return {
     _event: {
       currentTarget: {
         dataset: {
           projectId,
+          projectPath,
         },
       },
     },
@@ -376,6 +379,36 @@ describe("projects.handleProjectsClick", () => {
       },
     );
     expect(deps.appService.showAlert).not.toHaveBeenCalled();
+  });
+
+  it("opens the selected local project by path when project ids match", async () => {
+    const deps = createDeps();
+    deps.store.selectProjects.mockReturnValue([
+      {
+        id: "shared-project-id",
+        name: "Project One",
+        projectPath: "/projects/project-one",
+      },
+      {
+        id: "shared-project-id",
+        name: "Project Two",
+        projectPath: "/projects/project-two",
+      },
+    ]);
+
+    await handleProjectsClick(
+      deps,
+      createPayload("shared-project-id", "/projects/project-two"),
+    );
+
+    expect(
+      deps.projectService.ensureProjectCompatibleByPath,
+    ).toHaveBeenCalledWith("/projects/project-two", "shared-project-id");
+    expect(deps.appService.setCurrentProjectEntry).toHaveBeenCalledWith({
+      id: "shared-project-id",
+      name: "Project Two",
+      projectPath: "/projects/project-two",
+    });
   });
 });
 
@@ -758,19 +791,22 @@ describe("projects.handleDeleteDialogConfirm", () => {
   it("releases a local project runtime before removing its project entry", async () => {
     const deps = createDeps();
     deps.store.selectDeleteDialogProjectId.mockReturnValue("project-1");
+    deps.store.selectDeleteDialogProjectPath.mockReturnValue(
+      "/projects/project-one",
+    );
 
-    deps.appService.removeProjectEntry = vi.fn(async () => {});
+    deps.appService.removeProjectEntryByPath = vi.fn(async () => {});
 
     await handleDeleteDialogConfirm(deps);
 
     expect(deps.projectService.releaseProjectRuntime).toHaveBeenCalledWith(
       "project-1",
     );
-    expect(deps.appService.removeProjectEntry).toHaveBeenCalledWith(
-      "project-1",
+    expect(deps.appService.removeProjectEntryByPath).toHaveBeenCalledWith(
+      "/projects/project-one",
     );
     expect(deps.store.removeProject).toHaveBeenCalledWith({
-      projectId: "project-1",
+      projectPath: "/projects/project-one",
     });
     expect(deps.store.closeDeleteDialog).toHaveBeenCalledTimes(1);
   });
@@ -805,7 +841,7 @@ describe("projects.handleProjectContextMenu", () => {
         clientY: 20,
         currentTarget: {
           dataset: {
-            projectIndex: "0",
+            projectPath: "/projects/project-one",
           },
         },
       },
@@ -827,7 +863,7 @@ describe("projects.handleProjectContextMenu", () => {
     expect(deps.appService.showAlert).not.toHaveBeenCalled();
   });
 
-  it("derives the project path from store for a normal local project row", () => {
+  it("uses the row path for a normal local project", () => {
     const deps = createDeps();
 
     handleProjectContextMenu(deps, {
@@ -838,7 +874,7 @@ describe("projects.handleProjectContextMenu", () => {
         currentTarget: {
           dataset: {
             projectId: "project-1",
-            projectIndex: "0",
+            projectPath: "/projects/project-one",
           },
         },
       },

--- a/tests/projects/projects.render.test.js
+++ b/tests/projects/projects.render.test.js
@@ -23,7 +23,7 @@ const PROJECTS_VIEW = yaml.load(
 const handlers = { ...handlerExports };
 
 describe("projects render", () => {
-  it("renders a local project whose path contains spaces", () => {
+  it("renders a local project whose path contains spaces and quotes", () => {
     const state = createInitialState();
     setProjects(
       { state },
@@ -32,7 +32,7 @@ describe("projects render", () => {
           {
             id: "shared-project-id",
             name: "Project One",
-            projectPath: "/projects/Project One 2",
+            projectPath: '/projects/Project "Two" 2',
           },
         ],
       },

--- a/tests/projects/projects.render.test.js
+++ b/tests/projects/projects.render.test.js
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { h } from "snabbdom/build/h.js";
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+import { parseView } from "../../node_modules/@rettangoli/fe/src/parser.js";
+import { parse } from "../../node_modules/@rettangoli/fe/node_modules/jempl/src/index.js";
+import * as handlerExports from "../../src/pages/projects/projects.handlers.js";
+import {
+  createInitialState,
+  selectViewData,
+  setProjects,
+} from "../../src/pages/projects/projects.store.js";
+
+const EN_I18N = yaml.load(
+  readFileSync(new URL("../../src/i18n/en.yaml", import.meta.url), "utf8"),
+);
+const PROJECTS_VIEW = yaml.load(
+  readFileSync(
+    new URL("../../src/pages/projects/projects.view.yaml", import.meta.url),
+    "utf8",
+  ),
+);
+const handlers = { ...handlerExports };
+
+describe("projects render", () => {
+  it("renders a local project whose path contains spaces", () => {
+    const state = createInitialState();
+    setProjects(
+      { state },
+      {
+        projects: [
+          {
+            id: "shared-project-id",
+            name: "Project One",
+            projectPath: "/projects/Project One 2",
+          },
+        ],
+      },
+    );
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(() =>
+      parseView({
+        h,
+        template: parse(PROJECTS_VIEW.template),
+        viewData,
+        refs: PROJECTS_VIEW.refs,
+        handlers,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/projects/projects.store.test.js
+++ b/tests/projects/projects.store.test.js
@@ -115,6 +115,12 @@ describe("projects.store addProject", () => {
     expect(viewData.projects[0].itemId).not.toBe(viewData.projects[1].itemId);
     expect(viewData.projects[0].itemId).toMatch(/^projectItem[a-zA-Z0-9]+$/);
     expect(viewData.projects[1].itemId).toMatch(/^projectItem[a-zA-Z0-9]+$/);
+    expect(viewData.projects[0].encodedProjectPath).toBe(
+      encodeURIComponent("/projects/project-one"),
+    );
+    expect(viewData.projects[1].encodedProjectPath).toBe(
+      encodeURIComponent("/projects/project-two"),
+    );
   });
 
   it("removes only the local project at the selected path", () => {

--- a/tests/projects/projects.store.test.js
+++ b/tests/projects/projects.store.test.js
@@ -7,6 +7,7 @@ import {
   createInitialState,
   openLanguageDialog,
   openAppVersionMenu,
+  removeProject,
   selectViewData,
   setPlatform,
   setProjects,
@@ -16,7 +17,7 @@ const EN_I18N_URL = new URL("../../src/i18n/en.yaml", import.meta.url);
 const EN_I18N = yaml.load(readFileSync(EN_I18N_URL, "utf8"));
 
 describe("projects.store addProject", () => {
-  it("replaces an existing project with the same id instead of appending a duplicate", () => {
+  it("keeps local projects with the same id when their paths differ", () => {
     const state = createInitialState();
 
     addProject(
@@ -49,7 +50,98 @@ describe("projects.store addProject", () => {
       {
         id: "project-1",
         name: "Project Two",
+        projectPath: "/old/project-two-migrated",
+      },
+      {
+        id: "project-1",
+        name: "Project Two",
         projectPath: "/new/project-two-migrated",
+      },
+    ]);
+  });
+
+  it("replaces an existing local project with the same path", () => {
+    const state = createInitialState();
+    state.projects = [
+      {
+        id: "project-1",
+        name: "Project One",
+        projectPath: "/projects/project-one",
+      },
+    ];
+
+    addProject(
+      { state },
+      {
+        project: {
+          id: "project-2",
+          name: "Project One Updated",
+          projectPath: "/projects/project-one",
+        },
+      },
+    );
+
+    expect(state.projects).toEqual([
+      {
+        id: "project-2",
+        name: "Project One Updated",
+        projectPath: "/projects/project-one",
+      },
+    ]);
+  });
+
+  it("derives local project row ids from project paths", () => {
+    const state = createInitialState();
+    setProjects(
+      { state },
+      {
+        projects: [
+          {
+            id: "shared-project-id",
+            name: "Project One",
+            projectPath: "/projects/project-one",
+          },
+          {
+            id: "shared-project-id",
+            name: "Project Two",
+            projectPath: "/projects/project-two",
+          },
+        ],
+      },
+    );
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(viewData.projects[0].itemId).not.toBe(viewData.projects[1].itemId);
+    expect(viewData.projects[0].itemId).toMatch(/^projectItem[a-zA-Z0-9]+$/);
+    expect(viewData.projects[1].itemId).toMatch(/^projectItem[a-zA-Z0-9]+$/);
+  });
+
+  it("removes only the local project at the selected path", () => {
+    const state = createInitialState();
+    state.projects = [
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-one",
+      },
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-two",
+      },
+    ];
+
+    removeProject(
+      { state },
+      {
+        projectId: "shared-project-id",
+        projectPath: "/projects/project-two",
+      },
+    );
+
+    expect(state.projects).toEqual([
+      {
+        id: "shared-project-id",
+        projectPath: "/projects/project-one",
       },
     ]);
   });

--- a/tests/projects/projects.view.test.js
+++ b/tests/projects/projects.view.test.js
@@ -70,13 +70,16 @@ describe("projects view", () => {
     expect(projectsView).not.toContain("rtgl-view w=f ah=c pb=lg");
   });
 
-  it("uses the standard navbar inset for header and list content", () => {
+  it("keeps the project list container free of asymmetric padding", () => {
     const projectsView = readFileSync(
       new URL("../../src/pages/projects/projects.view.yaml", import.meta.url),
       "utf8",
     );
 
     expect(projectsView).toContain(
+      'rtgl-view w=f d=v style="max-width: 1280px;"',
+    );
+    expect(projectsView).not.toContain(
       'rtgl-view w=f d=v pl=md style="max-width: 1280px;"',
     );
     expect(projectsView).not.toContain(

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -14,6 +14,7 @@ import {
   handleDropdownMenuClickItem,
   handleEditorBlur,
   handleEditorDataChanged,
+  handleBackClick,
   handleNewLine,
   handlePreviewClick,
   handleSectionMoveSceneFormActionClick,
@@ -137,6 +138,33 @@ describe("sceneEditorLexical.handlers navigation preparation", () => {
 
     expect(deps.store.selectPendingDraftSections).toHaveBeenCalled();
     expect(deps.projectService.cacheSceneTextStats).toHaveBeenCalledOnce();
+  });
+});
+
+describe("sceneEditorLexical.handlers back navigation", () => {
+  it("preserves the selected local project path", () => {
+    const appService = {
+      getPayload: vi.fn(() => ({
+        p: "project-1",
+        lp: "/projects/project-one",
+        s: "scene-1",
+      })),
+      navigate: vi.fn(),
+    };
+
+    handleBackClick({ appService });
+
+    expect(appService.navigate).toHaveBeenCalledWith(
+      "/project/scenes",
+      {
+        p: "project-1",
+        lp: "/projects/project-one",
+        s: "scene-1",
+      },
+      {
+        historyMode: "replace",
+      },
+    );
   });
 });
 

--- a/tests/services/projectCollabCore.deleteIfUnused.test.js
+++ b/tests/services/projectCollabCore.deleteIfUnused.test.js
@@ -89,6 +89,55 @@ describe("createProjectCollabCore versions cache", () => {
       { id: "version-1", name: "Version One Updated" },
     ]);
   });
+
+  it("isolates same-id local version caches by project path", async () => {
+    let currentProjectPath = "/projects/project-one";
+    const versionsByPath = {
+      "/projects/project-one": [
+        { id: "version-1", name: "Project One Version" },
+      ],
+      "/projects/project-two": [
+        { id: "version-2", name: "Project Two Version" },
+      ],
+    };
+    const collabCore = createProjectCollabCore({
+      router: {
+        getPayload: () => ({ p: "shared-project-id" }),
+      },
+      idGenerator: () => "generated-id",
+      now: () => 0,
+      collabLog: () => {},
+      getCurrentRepository: async () => undefined,
+      getCachedRepository: () => undefined,
+      getRepositoryByProject: async () => undefined,
+      getAdapterByProject: () => ({
+        app: {
+          get: vi.fn(async () =>
+            structuredClone(versionsByPath[currentProjectPath]),
+          ),
+        },
+      }),
+      getProjectCacheKey: () => currentProjectPath,
+      createSessionForProject: async () => undefined,
+      createTransport: () => undefined,
+      onEnsureLocalSession: () => {},
+      onSessionCleared: () => {},
+      onSessionTransportUpdated: () => {},
+    });
+
+    await collabCore.loadVersionsFromProject("shared-project-id");
+    expect(collabCore.getCachedVersions("shared-project-id")).toEqual([
+      { id: "version-1", name: "Project One Version" },
+    ]);
+
+    currentProjectPath = "/projects/project-two";
+
+    expect(collabCore.getCachedVersions("shared-project-id")).toBeUndefined();
+    await collabCore.loadVersionsFromProject("shared-project-id");
+    expect(collabCore.getCachedVersions("shared-project-id")).toEqual([
+      { id: "version-2", name: "Project Two Version" },
+    ]);
+  });
 });
 
 describe("createProjectCollabCore deleteIfUnused", () => {


### PR DESCRIPTION
## Summary

- key local project entries, list rows, caches, and removal flows by filesystem path
- preserve independent local copies that share the same internal project ID
- open and synchronize project metadata using the selected local path
- remove the redundant Cancel button from the create-project dialog
- quote project path bindings and cover paths containing spaces with a render regression test

## Validation

- bunx vitest run tests/projects --reporter=dot (71 passed)
- related project-entry and repository service tests (18 passed)
- bun run lint
- git diff --check
- rendered all 25 saved local project entries successfully with loading settled