### PR TITLE
fix(android): show Scene Editor keyboard toolbar

### DIFF
--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -719,6 +719,14 @@ export const handleMobileSheetClose = (deps) => {
   render();
 };
 
+export const handleSceneEditorKeyboardStateChange = (deps, payload = {}) => {
+  const { store, render } = deps;
+  const { isVisible } = payload._event.detail;
+
+  store.setSceneEditorKeyboardVisible({ isVisible });
+  render();
+};
+
 const subscriptions = (deps) => {
   const { appService, subject } = deps;
   const runRouteTransition = createRouteTransitionRunner(deps);

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -5,6 +5,7 @@ export const createInitialState = () => ({
   isTouchMode: false,
   isMobileSheetOpen: false,
   mobileSheetVariant: undefined,
+  isSceneEditorKeyboardVisible: false,
   isRepositoryLoading: false,
   repositoryLoadingPhase: "",
   repositoryLoadingCurrent: 0,
@@ -61,10 +62,14 @@ export const selectShowMobileTabBar = ({ state }) => {
   const normalizedRoutesWithoutMobileTabBar = routesWithoutMobileTabBar.map(
     (route) => route.replace(/\/$/, ""),
   );
+  const isSceneEditorKeyboardVisible =
+    normalizedPattern === "/project/scene-editor" &&
+    state.isSceneEditorKeyboardVisible;
 
   return (
     selectShowAppNavigation({ state }) &&
     state.isTouchMode &&
+    !isSceneEditorKeyboardVisible &&
     !normalizedRoutesWithoutMobileTabBar.includes(normalizedPattern)
   );
 };
@@ -177,8 +182,18 @@ export const setPlatform = ({ state }, { platform } = {}) => {
 };
 
 export const setCurrentRoute = ({ state }, { route, payload } = {}) => {
+  if (route !== state.currentRoute) {
+    state.isSceneEditorKeyboardVisible = false;
+  }
   state.currentRoute = route;
   state.currentRoutePayload = { ...payload };
+};
+
+export const setSceneEditorKeyboardVisible = (
+  { state },
+  { isVisible } = {},
+) => {
+  state.isSceneEditorKeyboardVisible = isVisible === true;
 };
 
 export const selectCurrentRoute = ({ state }) => state.currentRoute;

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -15,6 +15,10 @@ refs:
     eventListeners:
       close:
         handler: handleMobileSheetClose
+  sceneEditor:
+    eventListeners:
+      mobile-keyboard-state-change:
+        handler: handleSceneEditorKeyboardStateChange
 template:
   - 'rtgl-view d=${appShellDirection} w=f h=f style="min-width: 0; min-height: 0; height: var(--rvn-app-viewport-height, 100vh); max-height: var(--rvn-app-viewport-height, 100vh); overflow: hidden;"':
       - $if showSidebar:
@@ -57,7 +61,7 @@ template:
                 $elif currentRoutePattern == "/project/scenes":
                   - rvn-scenes: []
                 $elif currentRoutePattern == "/project/scene-editor":
-                  - rvn-scene-editor-lexical: []
+                  - rvn-scene-editor-lexical#sceneEditor: []
                 $elif currentRoutePattern == "/project/animation-editor":
                   - rvn-animation-editor: []
                 $elif currentRoutePattern == "/project/about":

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -2562,13 +2562,19 @@ export const handleMobileKeyboardToolbarActionClick = (deps, payload) => {
 };
 
 export const handleMobileKeyboardStateChange = (deps, payload) => {
-  const { store, render } = deps;
+  const { store, render, dispatchEvent } = deps;
   const startedAt = getSceneEditorTimingNow();
   const detail = payload?._event?.detail || {};
 
   store.setMobileKeyboardState(detail);
   const renderStartedAt = getSceneEditorTimingNow();
   render();
+  dispatchEvent(
+    new CustomEvent("mobile-keyboard-state-change", {
+      detail: store.selectMobileKeyboardState(),
+      bubbles: true,
+    }),
+  );
   const renderDurationMs = getSceneEditorTimingDurationMs(renderStartedAt);
   emitSceneEditorTiming("page.mobile-keyboard-state", {
     durationMs: getSceneEditorTimingDurationMs(startedAt),

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.schema.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.schema.yaml
@@ -2,3 +2,6 @@ componentName: rvn-scene-editor-lexical
 propsSchema:
   type: object
   properties: {}
+events:
+  mobile-keyboard-state-change:
+    type: object

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -773,6 +773,10 @@ export const setMobileKeyboardState = (
     : 0;
 };
 
+export const selectMobileKeyboardState = ({ state }) => ({
+  ...state.mobileKeyboardState,
+});
+
 export const setRepositoryState = ({ state }, { repository } = {}) => {
   state.repositoryState = repository;
 };

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -5,9 +5,34 @@ import Subject from "../../src/deps/subject.js";
 import {
   createRouteTransitionRunner,
   handleBeforeMount,
+  handleSceneEditorKeyboardStateChange,
   handleWindowPop,
   maybePromptLinuxAppImageDesktopIntegration,
 } from "../../src/pages/app/app.handlers.js";
+
+describe("app Scene Editor keyboard state", () => {
+  it("updates the app shell when the Scene Editor keyboard changes", () => {
+    const deps = {
+      store: {
+        setSceneEditorKeyboardVisible: vi.fn(),
+      },
+      render: vi.fn(),
+    };
+
+    handleSceneEditorKeyboardStateChange(deps, {
+      _event: {
+        detail: {
+          isVisible: true,
+        },
+      },
+    });
+
+    expect(deps.store.setSceneEditorKeyboardVisible).toHaveBeenCalledWith({
+      isVisible: true,
+    });
+    expect(deps.render).toHaveBeenCalledOnce();
+  });
+});
 
 describe("app route transitions", () => {
   it("updates Discord presence after the active locale changes", () => {

--- a/tests/app/app.store.test.js
+++ b/tests/app/app.store.test.js
@@ -10,6 +10,7 @@ import {
   setRepositoryLoading,
   setRepositoryLoadingPhase,
   setRepositoryLoadingProgress,
+  setSceneEditorKeyboardVisible,
   setUiConfig,
 } from "../../src/pages/app/app.store.js";
 
@@ -201,6 +202,38 @@ describe("app.store mobile tab active state", () => {
 
     expect(selectMobileTab({ state, tabId: "release" }).color).toBe("white");
     expect(selectMobileTab({ state, tabId: "assets" }).color).toBe("mu-fg");
+  });
+
+  it("replaces the scene editor tabs while the mobile keyboard is visible", () => {
+    const state = createInitialState();
+    setUiConfig({ state }, { uiConfig: { id: "touch", inputMode: "touch" } });
+    setCurrentRoute(
+      { state },
+      {
+        route: "/project/scene-editor",
+        payload: { p: "project-1", s: "scene-1" },
+      },
+    );
+
+    setSceneEditorKeyboardVisible({ state }, { isVisible: true });
+
+    expect(selectViewData({ state }).showMobileTabBar).toBe(false);
+
+    setSceneEditorKeyboardVisible({ state }, { isVisible: false });
+
+    expect(selectViewData({ state }).showMobileTabBar).toBe(true);
+  });
+
+  it("clears scene editor keyboard state when navigating away", () => {
+    const state = createInitialState();
+    setSceneEditorKeyboardVisible({ state }, { isVisible: true });
+
+    setCurrentRoute(
+      { state },
+      { route: "/project/scenes", payload: { p: "project-1" } },
+    );
+
+    expect(state.isSceneEditorKeyboardVisible).toBe(false);
   });
 });
 

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -15,6 +15,7 @@ import {
   handleEditorBlur,
   handleEditorDataChanged,
   handleBackClick,
+  handleMobileKeyboardStateChange,
   handleNewLine,
   handlePreviewClick,
   handleSectionMoveSceneFormActionClick,
@@ -27,6 +28,42 @@ import {
   syncSceneEditorRoutePayload,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js";
 import { EN_I18N } from "../support/i18n.js";
+
+describe("sceneEditorLexical.handlers mobile keyboard state", () => {
+  it("reports normalized keyboard visibility to the app shell", () => {
+    const keyboardState = {
+      isVisible: true,
+      bottom: 0,
+      keyboardInset: 255,
+      visualOffsetTop: 0,
+      pageTop: 0,
+      visualHeight: 567,
+      layoutHeight: 567,
+    };
+    const deps = {
+      store: {
+        setMobileKeyboardState: vi.fn(),
+        selectMobileKeyboardState: vi.fn(() => keyboardState),
+      },
+      render: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+
+    handleMobileKeyboardStateChange(deps, {
+      _event: {
+        detail: keyboardState,
+      },
+    });
+
+    expect(deps.store.setMobileKeyboardState).toHaveBeenCalledWith(
+      keyboardState,
+    );
+    expect(deps.render).toHaveBeenCalledOnce();
+    const [event] = deps.dispatchEvent.mock.calls[0];
+    expect(event.type).toBe("mobile-keyboard-state-change");
+    expect(event.detail).toEqual(keyboardState);
+  });
+});
 
 describe("sceneEditorLexical.handlers navigation preparation", () => {
   it("awaits the current text-stats cache before leaving the editor", async () => {


### PR DESCRIPTION
## Summary

- propagate Scene Editor keyboard visibility to the app shell
- hide the default mobile navigation tabs while the custom keyboard toolbar is active
- restore the default tabs when the keyboard closes or navigation leaves the Scene Editor
- add store and handler regression coverage

## Validation

- `bunx vitest run tests/app/app.store.test.js tests/app/app.handlers.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js` (109 tests passed)
- full push-hook Oxlint and Prettier checks passed
- verified on a Redmi K30 5G: keyboard open shows the custom toolbar with no default tabs; keyboard closed restores the default tabs

## Notes

- `bun run check:contracts` currently reports 3,742 pre-existing repository-wide Rettangoli registry/template errors unrelated to this change.