### PR TITLE
fix: center Scenes empty detail state

### DIFF
--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -121,7 +121,7 @@ template:
               - 'div#fileExplorerKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
                   - rvn-whiteboard#whiteboard :items=${whiteboardItems} :cursor=${whiteboardCursor} :selectedItemId=${selectedItemId} :isTouchMode=${isTouchMode} :showArrows=${showWhiteboardConnections} :showMinimapInTouchMode=${showWhiteboardMinimapInTouchMode} :minimapPlacement=${whiteboardMinimapPlacement} :minimapHeightScale=${whiteboardMinimapHeightScale} :minimapTopInset=${whiteboardMinimapTopInset}: null
           - $if showDetailPanel:
-              - 'rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left" style="visibility: ${sceneWorkspaceVisibility};"':
+              - 'rvn-resizable-panel panel-type=detail-panel w=270 min-w=200 max-w=500 resize-side="left" style="height: 100%; visibility: ${sceneWorkspaceVisibility};"':
                   - rtgl-view wh=f slot="content":
                       - 'div#fileExplorerDetailKeyboardScope tabindex=-1 style="width: 100%; height: 100%; min-width: 0; min-height: 0; outline: none;"':
                           - $if selectedDetailId:


### PR DESCRIPTION
## Summary

- make the Scenes detail panel occupy the full available height
- center the “No selection” empty state horizontally and vertically

## Validation

- `bun run lint`
- Playwright verification at 1280×720: the label and detail-panel centers have a 0 px vertical delta and less than 0.01 px horizontal delta