### PR TITLE
fix: align scene command dialogs with window chrome

### DIFF
--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
@@ -12,17 +12,17 @@ refs:
 template:
   - $if isSceneEditorLeft:
       - rtgl-dialog#dialog ?open=${open} layout=fixed bare:
-          - 'rtgl-view slot=content pos=rel wh=f style="min-width: 0; min-height: 0; overflow: hidden;"':
+          - 'rtgl-view slot=content tabindex=-1 autofocus pos=rel wh=f style="min-width: 0; min-height: 0; overflow: hidden; outline: none;"':
               - 'rtgl-view#overlay pos=fix edge=f style="z-index: 2000; background: transparent;"': null
-              - 'rtgl-view pos=fix style="left: ${overlayHorizontalInset}; top: 0; bottom: 0; width: ${panelWidth}; z-index: 2001; background: ${overlayBackground}; pointer-events: none;"': null
-              - 'rtgl-view pos=fix bgc=bg bw=xs bc=bo br=md style="left: ${panelHorizontalInset}; top: ${panelVerticalInset}; bottom: ${panelVerticalInset}; width: calc(${panelWidth} - ${panelWidthReduction}); max-width: calc(100vw - ${panelHorizontalInset}); min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden; z-index: 2002; box-shadow: 8px 0 24px rgba(15, 23, 42, 0.10);"':
+              - 'rtgl-view pos=fix style="left: ${overlayHorizontalInset}; top: var(--rvn-window-content-offset, 0px); bottom: 0; width: ${panelWidth}; z-index: 2001; background: ${overlayBackground}; pointer-events: none;"': null
+              - 'rtgl-view pos=fix bgc=bg bw=xs bc=bo br=md style="left: ${panelHorizontalInset}; top: calc(var(--rvn-window-content-offset, 0px) + ${panelVerticalInset}); bottom: ${panelVerticalInset}; width: calc(${panelWidth} - ${panelWidthReduction}); max-width: calc(100vw - ${panelHorizontalInset}); min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden; z-index: 2002; box-shadow: 8px 0 24px rgba(15, 23, 42, 0.10);"':
                   - slot name=content: null
     $else:
       - $if dialogSize:
           - rtgl-dialog#dialog ?open=${open} s=${dialogSize}:
-              - 'rtgl-view slot=content w=${dialogWidth} h=${dialogHeight} pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y;"':
+              - 'rtgl-view slot=content tabindex=-1 autofocus w=${dialogWidth} h=${dialogHeight} pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y; outline: none;"':
                   - slot name=content: null
         $else:
           - rtgl-dialog#dialog ?open=${open}:
-              - 'rtgl-view slot=content w=${dialogWidth} h=${dialogHeight} pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y;"':
+              - 'rtgl-view slot=content tabindex=-1 autofocus w=${dialogWidth} h=${dialogHeight} pos=rel style="min-width: 0; min-height: 0; max-width: 100%; box-sizing: border-box; overflow-x: hidden; touch-action: pan-y; outline: none;"':
                   - slot name=content: null

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.view.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.view.test.js
@@ -15,11 +15,22 @@ describe("systemActionsDialogSurface view", () => {
       "rtgl-dialog#dialog ?open=${open} layout=fixed bare",
     );
     expect(dialogSurfaceView).toContain(
+      'rtgl-view slot=content tabindex=-1 autofocus pos=rel wh=f style="min-width: 0; min-height: 0; overflow: hidden; outline: none;"',
+    );
+    expect(dialogSurfaceView).toContain(
       'rtgl-view#overlay pos=fix edge=f style="z-index: 2000; background: transparent;"',
     );
     expect(dialogSurfaceView).toContain(
-      "left: ${overlayHorizontalInset}; top: 0; bottom: 0; width: ${panelWidth}; z-index: 2001; background: ${overlayBackground}; pointer-events: none;",
+      "left: ${overlayHorizontalInset}; top: var(--rvn-window-content-offset, 0px); bottom: 0; width: ${panelWidth}; z-index: 2001; background: ${overlayBackground}; pointer-events: none;",
     );
+    expect(dialogSurfaceView).toContain(
+      "top: calc(var(--rvn-window-content-offset, 0px) + ${panelVerticalInset}); bottom: ${panelVerticalInset};",
+    );
+    expect(dialogSurfaceView).toContain("pos=fix bgc=bg bw=xs bc=bo br=md");
+    expect(
+      dialogSurfaceView.match(/slot=content tabindex=-1 autofocus/g),
+    ).toHaveLength(3);
+    expect(dialogSurfaceView.match(/outline: none;/g)).toHaveLength(3);
     expect(dialogSurfaceView).toContain("z-index: 2002;");
     expect(dialogSurfaceView).not.toContain("handleDocumentKeyDown");
   });


### PR DESCRIPTION
## Summary
- offset the scene editor command-dialog overlay and panel by the custom Windows chrome height in restored windows
- focus the outline-free dialog surface on open so command editors do not show an incidental initial-control focus ring
- preserve the existing command panel border and normal keyboard tab navigation
- extend shared dialog-surface regression coverage

## Testing
- `bun run lint`
- `bunx vitest run tests/systemActionsDialogSurface/systemActionsDialogSurface.view.test.js tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js tests/systemActionsDialogSurface/systemActionsDialogSurface.handlers.test.js tests/systemActions/systemActions.view.test.js tests/windowChrome/windowChrome.test.js` (33 tests)