### PR TITLE
Refine command-line dialogue and audio selection UI

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -140,6 +140,7 @@ export const createInitialState = () => ({
   items: { items: {}, tree: [] },
   tempSelectedResourceId: undefined,
   pendingInsertIndex: 0,
+  channelSelected: false,
   selectedSoundId: undefined,
   soundDrag: undefined,
   suppressChannelClickUntil: 0,
@@ -282,18 +283,19 @@ export const selectViewData = ({ state, i18n }) => {
   const selectedSound = sounds.find(
     (sound) => sound.id === state.selectedSoundId,
   );
-  const channelSelected = selectedSound === undefined;
+  const channelSelected = state.channelSelected && selectedSound === undefined;
+  const hasSelection = channelSelected || selectedSound !== undefined;
   const channelName = localizeCommandLineText("BGM Channel", copy);
-  const form = channelSelected ? CHANNEL_FORM : SOUND_FORM;
-  const defaultValues = channelSelected
+  const form = selectedSound ? SOUND_FORM : CHANNEL_FORM;
+  const defaultValues = selectedSound
     ? {
+        startDelayMs: selectedSound.startDelayMs,
+        volume: selectedSound.volume,
+      }
+    : {
         interruption: state.bgm.interruption,
         loop: state.bgm.loop,
         volume: state.bgm.volume,
-      }
-    : {
-        startDelayMs: selectedSound.startDelayMs,
-        volume: selectedSound.volume,
       };
 
   return {
@@ -301,6 +303,7 @@ export const selectViewData = ({ state, i18n }) => {
     items: folderItems,
     groups,
     sounds,
+    hasSelection,
     channelBorderColor: channelSelected ? "pr" : "bo",
     channelHoverBorderColor: channelSelected ? "pr" : "ac",
     channelLabel: channelName,
@@ -312,12 +315,15 @@ export const selectViewData = ({ state, i18n }) => {
     addAudioLabel: localizeCommandLineText("Add BGM audio", copy),
     addBeforeLabel: localizeCommandLineText("Add audio before", copy),
     addAfterLabel: localizeCommandLineText("Add audio after", copy),
-    selectionHeading: localizeCommandLineText(
-      channelSelected ? "Channel" : "Audio",
-      copy,
-    ),
-    selectionName: channelSelected ? channelName : selectedSound.name,
-    selectionKey: channelSelected ? "channel" : `sound-${selectedSound.id}`,
+    selectionHeading: hasSelection
+      ? localizeCommandLineText(selectedSound ? "Audio" : "Channel", copy)
+      : "",
+    selectionName: selectedSound?.name ?? (channelSelected ? channelName : ""),
+    selectionKey: selectedSound
+      ? `sound-${selectedSound.id}`
+      : channelSelected
+        ? "channel"
+        : "none",
     form: localizeCommandLineForm(form, copy),
     defaultValues,
     tempSelectedResourceId: state.tempSelectedResourceId,
@@ -334,6 +340,7 @@ export const selectViewData = ({ state, i18n }) => {
 
 export const setBgm = ({ state }, { bgm } = {}) => {
   state.bgm = normalizeBgm(bgm);
+  state.channelSelected = false;
   state.selectedSoundId = undefined;
 };
 
@@ -346,10 +353,12 @@ export const setRepositoryState = ({ state }, { sounds } = {}) => {
 };
 
 export const clearSelectedSound = ({ state }, _payload = {}) => {
+  state.channelSelected = true;
   state.selectedSoundId = undefined;
 };
 
 export const setSelectedSound = ({ state }, { soundId } = {}) => {
+  state.channelSelected = false;
   state.selectedSoundId = soundId;
 };
 
@@ -391,6 +400,7 @@ export const startSoundDrag = (
     return;
   }
 
+  state.channelSelected = false;
   state.selectedSoundId = soundId;
   const resourceById = new Map(
     toFlatItems(state.items).map((item) => [item.id, item]),
@@ -468,12 +478,14 @@ export const insertSound = (
   });
   state.bgm.sounds.splice(insertIndex, 0, sound);
   sortAudioSoundsByStartDelay(state.bgm.sounds);
+  state.channelSelected = false;
   state.selectedSoundId = sound.id;
   state.tempSelectedResourceId = undefined;
 };
 
 export const removeSound = ({ state }, { soundId } = {}) => {
   state.bgm.sounds = state.bgm.sounds.filter((sound) => sound.id !== soundId);
+  state.channelSelected = true;
   state.selectedSoundId = undefined;
 };
 

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -205,11 +205,12 @@ template:
                                       - rtgl-view d=h w=f h=30 ph=sm av=c g=sm:
                                           - rtgl-text s=xs c=mu-fg ellipsis w=1fg: ${sound.name}
                                           - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
-              - rtgl-view w=f g=md:
-                  - rtgl-view w=f:
-                      - rtgl-text s=md: ${selectionHeading}
-                      - rtgl-text s=sm c=mu-fg: ${selectionName}
-                  - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues}: null
+              - $if hasSelection:
+                  - rtgl-view w=f g=md:
+                      - rtgl-view w=f:
+                          - rtgl-text s=md: ${selectionHeading}
+                          - rtgl-text s=sm c=mu-fg: ${selectionName}
+                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues}: null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -34,8 +34,16 @@ const createEmptyCollection = () => ({
   tree: [],
 });
 
-const getLayoutTypeByMode = (mode) => {
-  return mode === "nvl" ? "dialogue-nvl" : "dialogue-adv";
+const getDialogueModeByLayoutType = (layoutType) => {
+  if (layoutType === "dialogue-nvl") {
+    return "nvl";
+  }
+
+  if (layoutType === "dialogue-adv") {
+    return "adv";
+  }
+
+  return undefined;
 };
 
 const resolveDialogueMode = ({ layouts, dialogue } = {}) => {
@@ -44,17 +52,15 @@ const resolveDialogueMode = ({ layouts, dialogue } = {}) => {
     (layout) => layout.id === resourceId,
   )?.layoutType;
 
-  if (dialogue?.mode === "nvl" || layoutType === "dialogue-nvl") {
-    return "nvl";
-  }
-
-  return "adv";
+  return (
+    getDialogueModeByLayoutType(layoutType) ??
+    (dialogue?.mode === "nvl" ? "nvl" : "adv")
+  );
 };
 
 const resolveSelectedResourceId = ({ layouts, mode, resourceId } = {}) => {
-  const selectedLayoutType = getLayoutTypeByMode(mode);
-  const availableLayouts = (layouts ?? []).filter(
-    (layout) => layout.layoutType === selectedLayoutType,
+  const availableLayouts = (layouts ?? []).filter((layout) =>
+    getDialogueModeByLayoutType(layout.layoutType),
   );
 
   if (
@@ -62,6 +68,14 @@ const resolveSelectedResourceId = ({ layouts, mode, resourceId } = {}) => {
     availableLayouts.some((layout) => layout.id === resourceId)
   ) {
     return resourceId;
+  }
+
+  const matchingModeLayout = availableLayouts.find(
+    (layout) => getDialogueModeByLayoutType(layout.layoutType) === mode,
+  );
+
+  if (matchingModeLayout) {
+    return matchingModeLayout.id;
   }
 
   return availableLayouts[0]?.id ?? "";
@@ -671,7 +685,6 @@ const syncDialogueFormValues = (deps) => {
   }
 
   const {
-    selectedMode,
     selectedResourceId,
     selectedCharacterId,
     customCharacterName,
@@ -686,7 +699,6 @@ const syncDialogueFormValues = (deps) => {
     textSpeed,
   } = store.selectDialogueFormState();
   const values = {
-    mode: selectedMode,
     resourceId: selectedResourceId,
     characterId: selectedCharacterId,
     customCharacterName,
@@ -729,7 +741,20 @@ export const handleFormChange = (deps, payload) => {
   }
 
   const currentState = store.selectDialogueFormChangeState();
-  const selectedMode = formValues.mode === "nvl" ? "nvl" : "adv";
+  const selectedResourceId = resolveSelectedResourceId({
+    layouts: props?.layouts,
+    mode: currentState.selectedMode,
+    resourceId: formValues.resourceId ?? "",
+  });
+  const selectedMode = resolveDialogueMode({
+    layouts: props?.layouts,
+    dialogue: {
+      mode: currentState.selectedMode,
+      ui: {
+        resourceId: selectedResourceId,
+      },
+    },
+  });
   const modeChanged = selectedMode !== currentState.selectedMode;
   const customCharacterName = toBoolean(formValues.customCharacterName);
   const customizeTextSpeed = toBoolean(formValues.customizeTextSpeed);
@@ -765,11 +790,7 @@ export const handleFormChange = (deps, payload) => {
 
   store.setSelectedMode({ mode: selectedMode });
   store.setSelectedResource({
-    resourceId: resolveSelectedResourceId({
-      layouts: props?.layouts,
-      mode: selectedMode,
-      resourceId: formValues.resourceId ?? "",
-    }),
+    resourceId: selectedResourceId,
   });
   store.setSelectedCharacterId({ characterId: selectedCharacterId });
   store.setCustomCharacterName({
@@ -800,7 +821,9 @@ export const handleFormChange = (deps, payload) => {
   store.setRemovePersistedSprite({
     removePersistedSprite,
   });
-  store.setClearPage({ clearPage: formValues.clearPage });
+  store.setClearPage({
+    clearPage: selectedMode === "nvl" && toBoolean(formValues.clearPage),
+  });
   store.setCustomizeTextSpeed({
     customizeTextSpeed,
   });

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.schema.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.schema.yaml
@@ -11,6 +11,11 @@ propsSchema:
             type: string
           name:
             type: string
+          layoutType:
+            type: string
+            enum:
+              - dialogue-adv
+              - dialogue-nvl
     characters:
       type: array
       items:

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -82,18 +82,37 @@ const toCharacterCollection = ({ characters = [], tree } = {}) => {
   };
 };
 
-const getLayoutTypeByMode = (mode) => {
-  return mode === "nvl" ? "dialogue-nvl" : "dialogue-adv";
+const getDialogueModeByLayoutType = (layoutType) => {
+  if (layoutType === "dialogue-nvl") {
+    return "nvl";
+  }
+
+  if (layoutType === "dialogue-adv") {
+    return "adv";
+  }
+
+  return undefined;
 };
 
-const getLayoutOptions = ({ layouts, mode } = {}) => {
-  const layoutType = getLayoutTypeByMode(mode);
+const getLayoutOptions = ({ layouts } = {}) => {
   return (layouts ?? [])
-    .filter((layout) => layout.layoutType === layoutType)
+    .filter((layout) => getDialogueModeByLayoutType(layout.layoutType))
     .map((layout) => ({
       value: layout.id,
       label: layout.name,
+      suffixText: getDialogueModeByLayoutType(layout.layoutType).toUpperCase(),
     }));
+};
+
+const resolveSelectedMode = ({ layouts, resourceId, fallbackMode } = {}) => {
+  const layoutType = (layouts ?? []).find(
+    (layout) => layout.id === resourceId,
+  )?.layoutType;
+
+  return (
+    getDialogueModeByLayoutType(layoutType) ??
+    (fallbackMode === "nvl" ? "nvl" : "adv")
+  );
 };
 
 const resolveSelectedResourceId = ({ layoutOptions, resourceId } = {}) => {
@@ -373,7 +392,6 @@ export const createInitialState = () => ({
   },
 
   defaultValues: {
-    mode: "adv",
     resourceId: "",
     characterId: "",
     customCharacterName: false,
@@ -391,18 +409,6 @@ export const createInitialState = () => ({
   form: {
     fields: [
       {
-        name: "mode",
-        type: "segmented-control",
-        label: "Mode",
-        description: "",
-        required: true,
-        clearable: false,
-        options: [
-          { value: "adv", label: "ADV" },
-          { value: "nvl", label: "NVL" },
-        ],
-      },
-      {
         name: "resourceId",
         type: "select",
         label: "Layout",
@@ -413,99 +419,113 @@ export const createInitialState = () => ({
         options: [],
       },
       {
-        name: "characterId",
-        type: "select",
         label: "Speaker",
         description: "",
-        required: false,
-        placeholder: "Choose a speaker...",
-        options: [],
-      },
-      {
-        name: "customCharacterName",
-        type: "segmented-control",
-        label: "Custom Speaker Name",
-        description: "",
-        required: true,
-        clearable: false,
-        options: [
-          { value: false, label: "No" },
-          { value: true, label: "Yes" },
+        type: "section",
+        fields: [
+          {
+            name: "characterId",
+            type: "select",
+            label: "Speaker",
+            description: "",
+            required: false,
+            placeholder: "Choose a speaker...",
+            options: [],
+          },
+          {
+            $when: "values.characterId || values.customCharacterName",
+            name: "persistCharacter",
+            type: "segmented-control",
+            label: "Persist Speaker",
+            description: "",
+            required: true,
+            clearable: false,
+            options: [
+              { value: false, label: "No" },
+              { value: true, label: "Yes" },
+            ],
+          },
+          {
+            name: "customCharacterName",
+            type: "segmented-control",
+            label: "Custom Speaker Name",
+            description: "",
+            required: true,
+            clearable: false,
+            options: [
+              { value: false, label: "No" },
+              { value: true, label: "Yes" },
+            ],
+          },
+          {
+            $when: "values.customCharacterName == true",
+            name: "characterName",
+            type: "input-text",
+            label: "Speaker Name",
+            description: "",
+            required: true,
+            placeholder: "Enter speaker name",
+          },
+          {
+            type: "slot",
+            slot: "characterSprite",
+          },
         ],
       },
       {
-        $when: "values.customCharacterName == true",
-        name: "characterName",
-        type: "input-text",
-        label: "Speaker Name",
+        label: "Options",
         description: "",
-        required: true,
-        placeholder: "Enter speaker name",
-      },
-      {
-        type: "slot",
-        slot: "characterSprite",
-      },
-      {
-        name: "customizeTextSpeed",
-        type: "segmented-control",
-        label: "Customize Text Speed",
-        description: "",
-        required: true,
-        clearable: false,
-        options: [
-          { value: false, label: "No" },
-          { value: true, label: "Yes" },
-        ],
-      },
-      {
-        $when: "values.customizeTextSpeed == true",
-        name: "textSpeed",
-        type: "slider-with-input",
-        label: "Text Speed",
-        description: "",
-        required: true,
-        min: 0,
-        max: 100,
-        step: 1,
-      },
-      {
-        $when: 'values.mode == "adv"',
-        name: "append",
-        type: "segmented-control",
-        label: "Append",
-        description: "",
-        required: true,
-        clearable: false,
-        options: [
-          { value: false, label: "No" },
-          { value: true, label: "Yes" },
-        ],
-      },
-      {
-        $when: "values.characterId || values.customCharacterName",
-        name: "persistCharacter",
-        type: "segmented-control",
-        label: "Persist Speaker",
-        description: "",
-        required: true,
-        clearable: false,
-        options: [
-          { value: false, label: "No" },
-          { value: true, label: "Yes" },
-        ],
-      },
-      {
-        $when: 'values.mode == "nvl"',
-        name: "clearPage",
-        type: "segmented-control",
-        label: "Clear Page",
-        description: "",
-        required: true,
-        clearable: false,
-        options: [
-          { value: false, label: "No" },
-          { value: true, label: "Yes" },
+        type: "section",
+        fields: [
+          {
+            name: "customizeTextSpeed",
+            type: "segmented-control",
+            label: "Customize Text Speed",
+            description: "",
+            required: true,
+            clearable: false,
+            options: [
+              { value: false, label: "No" },
+              { value: true, label: "Yes" },
+            ],
+          },
+          {
+            $when: "values.customizeTextSpeed == true",
+            name: "textSpeed",
+            type: "slider-with-input",
+            label: "Text Speed",
+            description: "",
+            required: true,
+            min: 0,
+            max: 100,
+            step: 1,
+          },
+          {
+            $when: 'dialogueMode == "adv"',
+            name: "append",
+            type: "segmented-control",
+            label: "Append",
+            description: "",
+            required: true,
+            clearable: false,
+            options: [
+              { value: false, label: "No" },
+              { value: true, label: "Yes" },
+            ],
+          },
+          {
+            $when: 'dialogueMode == "nvl"',
+            name: "clearPage",
+            type: "segmented-control",
+            label: "Clear Page",
+            description: "",
+            required: true,
+            clearable: false,
+            options: [
+              { value: false, label: "No" },
+              { value: true, label: "Yes" },
+            ],
+          },
         ],
       },
     ],
@@ -766,7 +786,6 @@ export const hideSpeakerSpriteTooltip = ({ state }) => {
 export const setSelectedMode = ({ state }, { mode } = {}) => {
   const selectedMode = mode === "nvl" ? "nvl" : "adv";
   state.selectedMode = selectedMode;
-  state.defaultValues.mode = selectedMode;
 };
 
 export const setAppendDialogue = ({ state }, { append } = {}) => {
@@ -866,7 +885,6 @@ export const selectDialogueBuildState = ({ state }) => ({
 });
 
 export const selectDialogueFormState = ({ state }) => ({
-  selectedMode: state.selectedMode,
   selectedResourceId: state.selectedResourceId,
   selectedCharacterId: state.selectedCharacterId,
   customCharacterName: state.customCharacterName,
@@ -942,18 +960,21 @@ export const selectCurrentSpriteItemById = (
 
 export const selectViewData = ({ state, props, i18n }) => {
   const copy = selectCommandLineCopy(i18n);
-  const layouts = props.layouts || [];
-  const characters = props.characters || [];
-  const transforms = props.transforms || createEmptyCollection();
-  const animations = props.animations || createEmptyCollection();
-  const selectedMode = state.selectedMode || "adv";
+  const layouts = props.layouts ?? [];
+  const characters = props.characters ?? [];
+  const transforms = props.transforms ?? createEmptyCollection();
+  const animations = props.animations ?? createEmptyCollection();
   const layoutOptions = getLayoutOptions({
     layouts,
-    mode: selectedMode,
   });
   const selectedResourceId = resolveSelectedResourceId({
     layoutOptions,
     resourceId: state.selectedResourceId,
+  });
+  const selectedMode = resolveSelectedMode({
+    layouts,
+    resourceId: selectedResourceId,
+    fallbackMode: state.selectedMode,
   });
   const characterCollection = toCharacterCollection({
     characters,
@@ -1121,13 +1142,7 @@ export const selectViewData = ({ state, props, i18n }) => {
     });
   }
 
-  const mappedFields = state.form.fields.map((field) => {
-    if (field.name === "mode") {
-      return {
-        ...field,
-        value: selectedMode,
-      };
-    }
+  const mapFormField = (field) => {
     if (field.name === "resourceId") {
       return {
         ...field,
@@ -1185,11 +1200,17 @@ export const selectViewData = ({ state, props, i18n }) => {
         value: normalizeTextSpeed(state.textSpeed),
       };
     }
+    if (Array.isArray(field.fields)) {
+      return {
+        ...field,
+        fields: field.fields.map(mapFormField),
+      };
+    }
     return field;
-  });
+  };
+  const mappedFields = state.form.fields.map(mapFormField);
 
   const defaultValues = {
-    mode: selectedMode,
     resourceId: selectedResourceId,
     characterId: state.selectedCharacterId,
     customCharacterName: state.customCharacterName,
@@ -1204,6 +1225,7 @@ export const selectViewData = ({ state, props, i18n }) => {
     textSpeed: normalizeTextSpeed(state.textSpeed),
   };
   const context = {
+    dialogueMode: selectedMode,
     values: defaultValues,
   };
 

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
@@ -467,7 +467,7 @@ export const setRepositoryState = ({ state }, { sounds } = {}) => {
 
 export const setSfx = ({ state }, { sfx } = {}) => {
   state.channels = normalizeSfxChannels(sfx);
-  state.selectedChannelId = state.channels[0]?.id;
+  state.selectedChannelId = undefined;
   state.selectedSoundId = undefined;
 };
 

--- a/src/components/commandLineVoice/commandLineVoice.store.js
+++ b/src/components/commandLineVoice/commandLineVoice.store.js
@@ -137,6 +137,7 @@ const SOUND_FORM = {
 
 export const createInitialState = () => ({
   items: { items: {}, tree: [] },
+  channelSelected: false,
   selectedSoundId: undefined,
   soundDrag: undefined,
   suppressChannelClickUntil: 0,
@@ -221,22 +222,24 @@ export const selectViewData = ({ state, i18n }) => {
   const selectedSound = sounds.find(
     (sound) => sound.id === state.selectedSoundId,
   );
-  const channelSelected = selectedSound === undefined;
+  const channelSelected = state.channelSelected && selectedSound === undefined;
+  const hasSelection = channelSelected || selectedSound !== undefined;
   const channelName = localizeCommandLineText("Voice Channel", copy);
-  const form = channelSelected ? CHANNEL_FORM : SOUND_FORM;
-  const defaultValues = channelSelected
+  const form = selectedSound ? SOUND_FORM : CHANNEL_FORM;
+  const defaultValues = selectedSound
     ? {
+        startDelayMs: selectedSound.startDelayMs,
+        volume: selectedSound.volume,
+      }
+    : {
         interruption: state.voice.interruption,
         loop: state.voice.loop,
         volume: state.voice.volume,
-      }
-    : {
-        startDelayMs: selectedSound.startDelayMs,
-        volume: selectedSound.volume,
       };
 
   return {
     sounds,
+    hasSelection,
     channelBorderColor: channelSelected ? "pr" : "bo",
     channelHoverBorderColor: channelSelected ? "pr" : "ac",
     channelLabel: channelName,
@@ -247,12 +250,15 @@ export const selectViewData = ({ state, i18n }) => {
     addAudioLabel: localizeCommandLineText("Add voice audio", copy),
     addBeforeLabel: localizeCommandLineText("Add audio before", copy),
     addAfterLabel: localizeCommandLineText("Add audio after", copy),
-    selectionHeading: localizeCommandLineText(
-      channelSelected ? "Channel" : "Audio",
-      copy,
-    ),
-    selectionName: channelSelected ? channelName : selectedSound.name,
-    selectionKey: channelSelected ? "channel" : `sound-${selectedSound.id}`,
+    selectionHeading: hasSelection
+      ? localizeCommandLineText(selectedSound ? "Audio" : "Channel", copy)
+      : "",
+    selectionName: selectedSound?.name ?? (channelSelected ? channelName : ""),
+    selectionKey: selectedSound
+      ? `sound-${selectedSound.id}`
+      : channelSelected
+        ? "channel"
+        : "none",
     form: localizeCommandLineForm(form, copy),
     defaultValues,
     playingSound: state.playingSound,
@@ -270,14 +276,17 @@ export const setRepositoryState = ({ state }, { voices } = {}) => {
 
 export const setVoice = ({ state }, { voice } = {}) => {
   state.voice = normalizeVoice(voice);
+  state.channelSelected = false;
   state.selectedSoundId = undefined;
 };
 
 export const clearSelectedSound = ({ state }, _payload = {}) => {
+  state.channelSelected = true;
   state.selectedSoundId = undefined;
 };
 
 export const setSelectedSound = ({ state }, { soundId } = {}) => {
+  state.channelSelected = false;
   state.selectedSoundId = soundId;
 };
 
@@ -319,6 +328,7 @@ export const startSoundDrag = (
     return;
   }
 
+  state.channelSelected = false;
   state.selectedSoundId = soundId;
   const resourceById = new Map(
     toFlatItems(state.items).map((item) => [item.id, item]),
@@ -396,6 +406,7 @@ export const insertSound = (
   });
   state.voice.sounds.splice(insertIndex, 0, sound);
   sortAudioSoundsByStartDelay(state.voice.sounds);
+  state.channelSelected = false;
   state.selectedSoundId = sound.id;
   closeAudioPlayer({ state });
 };
@@ -404,6 +415,7 @@ export const removeSound = ({ state }, { soundId } = {}) => {
   state.voice.sounds = state.voice.sounds.filter(
     (sound) => sound.id !== soundId,
   );
+  state.channelSelected = true;
   state.selectedSoundId = undefined;
   closeAudioPlayer({ state });
 };

--- a/src/components/commandLineVoice/commandLineVoice.view.yaml
+++ b/src/components/commandLineVoice/commandLineVoice.view.yaml
@@ -185,11 +185,12 @@ template:
                                   - rtgl-view d=h w=f h=30 ph=sm av=c g=sm:
                                       - rtgl-text s=xs c=mu-fg ellipsis w=1fg: ${sound.name}
                                       - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
-          - rtgl-view w=f g=md:
-              - rtgl-view w=f:
-                  - rtgl-text s=md: ${selectionHeading}
-                  - rtgl-text s=sm c=mu-fg: ${selectionName}
-              - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues}: null
+          - $if hasSelection:
+              - rtgl-view w=f g=md:
+                  - rtgl-view w=f:
+                      - rtgl-text s=md: ${selectionHeading}
+                      - rtgl-text s=sm c=mu-fg: ${selectionName}
+                  - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues}: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit
   - $if showAudioPlayer:

--- a/src/internal/ui/sceneEditor/commandLineCopy.js
+++ b/src/internal/ui/sceneEditor/commandLineCopy.js
@@ -121,6 +121,12 @@ export const localizeCommandLineFormField = (field = {}, copy = {}) => {
     );
   }
 
+  if (Array.isArray(localizedField.fields)) {
+    localizedField.fields = localizedField.fields.map((nestedField) =>
+      localizeCommandLineFormField(nestedField, copy),
+    );
+  }
+
   if (localizedField.tooltip?.content) {
     localizedField.tooltip = {
       ...localizedField.tooltip,

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -140,6 +140,7 @@ describe("commandLineBgm.handlers", () => {
     const stopPropagation = vi.fn();
     handleChannelClick({ store, render }, { _event: { stopPropagation } });
 
+    expect(state.channelSelected).toBe(true);
     expect(state.selectedSoundId).toBeUndefined();
     expect(stopPropagation).toHaveBeenCalledOnce();
     expect(render).toHaveBeenCalledOnce();

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import * as bgmStore from "../../src/components/commandLineBgm/commandLineBgm.store.js";
 import {
+  clearSelectedSound,
   createInitialState,
   insertSound,
   removeSound,
@@ -67,7 +68,7 @@ describe("commandLineBgm.store", () => {
     });
   });
 
-  it("starts with an empty selected channel and channel controls", () => {
+  it("starts with an unselected channel and selects it explicitly", () => {
     const state = createInitialState();
     const viewData = selectViewData({ state, i18n });
 
@@ -77,16 +78,27 @@ describe("commandLineBgm.store", () => {
       volume: 75,
       sounds: [],
     });
-    expect(viewData.selectionHeading).toBe("Channel");
-    expect(viewData.selectionName).toBe("BGM Channel");
+    expect(viewData.hasSelection).toBe(false);
+    expect(viewData.channelBorderColor).toBe("bo");
+    expect(viewData.channelHoverBorderColor).toBe("ac");
+    expect(viewData.selectionHeading).toBe("");
+    expect(viewData.selectionName).toBe("");
     expect(viewData.channelLabel).toBe("BGM Channel");
     expect(viewData.channelDurationLabel).toBe("0:00");
-    expect(viewData.form.fields.map((field) => field.name)).toEqual([
+
+    clearSelectedSound({ state });
+    const selectedViewData = selectViewData({ state, i18n });
+    expect(selectedViewData.hasSelection).toBe(true);
+    expect(selectedViewData.channelBorderColor).toBe("pr");
+    expect(selectedViewData.channelHoverBorderColor).toBe("pr");
+    expect(selectedViewData.selectionHeading).toBe("Channel");
+    expect(selectedViewData.selectionName).toBe("BGM Channel");
+    expect(selectedViewData.form.fields.map((field) => field.name)).toEqual([
       "loop",
       "interruption",
       "volume",
     ]);
-    expect(viewData.defaultValues).toEqual({
+    expect(selectedViewData.defaultValues).toEqual({
       interruption: "immediate",
       loop: true,
       volume: 75,

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -716,6 +716,58 @@ describe("commandLineDialogueBox.handlers", () => {
     expect(render).toHaveBeenCalledTimes(2);
   });
 
+  it("derives the dialogue mode from the selected layout", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const refs = createFormRefs();
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+        },
+        refs,
+        render,
+        dispatchEvent,
+        store: createStore(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              resourceId: "layout-nvl",
+              characterId: "",
+              customCharacterName: false,
+              characterName: "",
+              append: true,
+              persistCharacter: false,
+              clearPage: true,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.selectedMode).toBe("nvl");
+    expect(state.selectedResourceId).toBe("layout-nvl");
+    expect(state.appendDialogue).toBe(false);
+    expect(state.clearPage).toBe(true);
+    expect(
+      refs.dialogueForm.setValues.mock.calls.at(-1)[0].values,
+    ).not.toHaveProperty("mode");
+    expect(
+      dispatchEvent.mock.calls[0][0].detail.presentationState.dialogue,
+    ).toMatchObject({
+      mode: "nvl",
+      ui: {
+        resourceId: "layout-nvl",
+      },
+      clearPage: true,
+    });
+  });
+
   it("tracks explicit removal of a persistent sprite from the form", () => {
     const state = createInitialState();
     const render = vi.fn();

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
@@ -23,6 +23,15 @@ import { EN_I18N } from "../support/i18n.js";
 const selectTestViewData = ({ state, props }) =>
   selectViewData({ state, props, i18n: EN_I18N });
 
+const flattenFormFields = (fields = []) =>
+  fields.flatMap((field) => [
+    field,
+    ...(Array.isArray(field.fields) ? flattenFormFields(field.fields) : []),
+  ]);
+
+const findFormField = (viewData, predicate) =>
+  flattenFormFields(viewData.form.fields).find(predicate);
+
 const isFieldVisible = ({ field, values }) => {
   const rendered = parseAndRender(
     {
@@ -87,32 +96,28 @@ describe("commandLineDialogueBox.store", () => {
     expect(viewData.defaultValues.persistCharacter).toBe(true);
     expect(viewData.addSpeakerSpriteLabel).toBe("Add Speaker Sprite");
     expect(
-      viewData.form.fields.find((field) => field.name === "mode"),
-    ).toMatchObject({
-      label: "Mode",
-    });
+      findFormField(viewData, (field) => field.name === "mode"),
+    ).toBeUndefined();
     expect(
-      viewData.form.fields.find((field) => field.name === "resourceId"),
+      findFormField(viewData, (field) => field.name === "resourceId"),
     ).toMatchObject({
       label: "Layout",
     });
     expect(
-      viewData.form.fields.find((field) => field.name === "characterId"),
+      findFormField(viewData, (field) => field.name === "characterId"),
     ).toMatchObject({
       label: "Speaker",
       placeholder: "Choose a speaker...",
     });
     expect(
-      viewData.form.fields.find(
-        (field) => field.name === "customCharacterName",
-      ),
+      findFormField(viewData, (field) => field.name === "customCharacterName"),
     ).toMatchObject({
       label: "Custom Speaker Name",
       type: "segmented-control",
       value: true,
     });
     expect(
-      viewData.form.fields.find((field) => field.name === "characterName"),
+      findFormField(viewData, (field) => field.name === "characterName"),
     ).toMatchObject({
       label: "Speaker Name",
       placeholder: "Enter speaker name",
@@ -120,7 +125,7 @@ describe("commandLineDialogueBox.store", () => {
       value: "Boss",
     });
     expect(
-      viewData.form.fields.find((field) => field.slot === "characterSprite"),
+      findFormField(viewData, (field) => field.slot === "characterSprite"),
     ).toEqual({
       slot: "characterSprite",
       type: "slot",
@@ -136,29 +141,50 @@ describe("commandLineDialogueBox.store", () => {
         "Speaker's face that appears on top of the dialogue box. For body sprites use the Character Sprites action",
     });
     expect(
-      viewData.form.fields.find((field) => field.name === "append"),
+      findFormField(viewData, (field) => field.name === "append"),
     ).toMatchObject({
-      $when: 'values.mode == "adv"',
+      $when: 'dialogueMode == "adv"',
       label: "Append",
       type: "segmented-control",
       value: false,
     });
     expect(
-      viewData.form.fields.find(
+      findFormField(
+        viewData,
         (field) => field.name === "characterSpriteEnabled",
       ),
     ).toBeUndefined();
     expect(
-      viewData.form.fields.find((field) => field.name === "persistCharacter"),
+      findFormField(viewData, (field) => field.name === "persistCharacter"),
     ).toMatchObject({
       $when: "values.characterId || values.customCharacterName",
       label: "Persist Speaker",
       type: "segmented-control",
       value: true,
     });
+    expect(viewData.form.fields.map((field) => field.label)).toEqual([
+      "Layout",
+      "Speaker",
+      "Options",
+    ]);
+    expect(
+      viewData.form.fields[1].fields.map((field) => field.name ?? field.slot),
+    ).toEqual([
+      "characterId",
+      "persistCharacter",
+      "customCharacterName",
+      "characterName",
+      "characterSprite",
+    ]);
+    expect(viewData.form.fields[2].fields.map((field) => field.name)).toEqual([
+      "customizeTextSpeed",
+      "textSpeed",
+      "append",
+      "clearPage",
+    ]);
   });
 
-  it("uses one layout label for every dialogue mode", () => {
+  it("shows ADV and NVL layouts together with right-side mode labels", () => {
     const state = createInitialState();
 
     const viewData = selectTestViewData({
@@ -166,26 +192,10 @@ describe("commandLineDialogueBox.store", () => {
       props: {
         layouts: [
           {
-            id: "layout-nvl",
-            name: "NVL Layout",
-            layoutType: "dialogue-nvl",
+            id: "layout-adv",
+            name: "ADV Layout",
+            layoutType: "dialogue-adv",
           },
-        ],
-        characters: [],
-      },
-    });
-
-    expect(
-      viewData.form.fields.find((field) => field.name === "resourceId"),
-    ).toMatchObject({
-      label: "Layout",
-    });
-
-    state.selectedMode = "nvl";
-    const nvlViewData = selectTestViewData({
-      state,
-      props: {
-        layouts: [
           {
             id: "layout-nvl",
             name: "NVL Layout",
@@ -197,10 +207,50 @@ describe("commandLineDialogueBox.store", () => {
     });
 
     expect(
-      nvlViewData.form.fields.find((field) => field.name === "resourceId"),
+      findFormField(viewData, (field) => field.name === "resourceId"),
     ).toMatchObject({
       label: "Layout",
+      options: [
+        {
+          value: "layout-adv",
+          label: "ADV Layout",
+          suffixText: "ADV",
+        },
+        {
+          value: "layout-nvl",
+          label: "NVL Layout",
+          suffixText: "NVL",
+        },
+      ],
     });
+
+    state.selectedResourceId = "layout-nvl";
+    const nvlViewData = selectTestViewData({
+      state,
+      props: {
+        layouts: [
+          {
+            id: "layout-adv",
+            name: "ADV Layout",
+            layoutType: "dialogue-adv",
+          },
+          {
+            id: "layout-nvl",
+            name: "NVL Layout",
+            layoutType: "dialogue-nvl",
+          },
+        ],
+        characters: [],
+      },
+    });
+
+    expect(
+      findFormField(nvlViewData, (field) => field.name === "resourceId"),
+    ).toMatchObject({
+      value: "layout-nvl",
+    });
+    expect(nvlViewData.selectedMode).toBe("nvl");
+    expect(nvlViewData.context.dialogueMode).toBe("nvl");
   });
 
   it("tracks append in form defaults and field values", () => {
@@ -230,7 +280,7 @@ describe("commandLineDialogueBox.store", () => {
     expect(viewData.appendDialogue).toBe(true);
     expect(viewData.defaultValues.append).toBe(true);
     expect(
-      viewData.form.fields.find((field) => field.name === "append"),
+      findFormField(viewData, (field) => field.name === "append"),
     ).toMatchObject({
       label: "Append",
       type: "segmented-control",
@@ -255,10 +305,12 @@ describe("commandLineDialogueBox.store", () => {
       },
     });
 
-    const customizeTextSpeedField = viewData.form.fields.find(
+    const customizeTextSpeedField = findFormField(
+      viewData,
       (field) => field.name === "customizeTextSpeed",
     );
-    const textSpeedField = viewData.form.fields.find(
+    const textSpeedField = findFormField(
+      viewData,
       (field) => field.name === "textSpeed",
     );
 
@@ -336,7 +388,8 @@ describe("commandLineDialogueBox.store", () => {
         characters: [],
       },
     });
-    const persistCharacterField = viewData.form.fields.find(
+    const persistCharacterField = findFormField(
+      viewData,
       (field) => field.name === "persistCharacter",
     );
 
@@ -407,10 +460,11 @@ describe("commandLineDialogueBox.store", () => {
       },
     });
     expect(
-      viewData.form.fields.find((field) => field.name === "persistSprite"),
+      findFormField(viewData, (field) => field.name === "persistSprite"),
     ).toBeUndefined();
     expect(
-      viewData.form.fields.find(
+      findFormField(
+        viewData,
         (field) => field.name === "removePersistedSprite",
       ),
     ).toBeUndefined();
@@ -437,7 +491,8 @@ describe("commandLineDialogueBox.store", () => {
       },
     });
     expect(
-      viewData.form.fields.find(
+      findFormField(
+        viewData,
         (field) => field.name === "removePersistedSprite",
       ),
     ).toBeUndefined();
@@ -579,7 +634,7 @@ describe("commandLineDialogueBox.store", () => {
     });
 
     expect(
-      viewData.form.fields.find((field) => field.slot === "characterSprite"),
+      findFormField(viewData, (field) => field.slot === "characterSprite"),
     ).toEqual({
       slot: "characterSprite",
       type: "slot",

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js
@@ -11,6 +11,7 @@ import {
   selectSfx,
   selectViewData,
   setRepositoryState,
+  setSelectedChannel,
   setSelectedSound,
   setSfx,
   startSoundDrag,
@@ -162,7 +163,12 @@ describe("commandLineSoundEffects.store", () => {
         startDelayMs: 999,
       },
     ]);
-    const channelView = selectViewData({ state, i18n }).channels[0];
+    const unselectedViewData = selectViewData({ state, i18n });
+    expect(unselectedViewData.hasSelection).toBe(false);
+    expect(unselectedViewData.channels[0].channelBorderColor).toBe("bo");
+    expect(unselectedViewData.channels[0].channelHoverBorderColor).toBe("ac");
+
+    const channelView = unselectedViewData.channels[0];
     expect(channelView.durationLabel).toBe("0:06");
     expect(channelView.channelHeightPx).toBe(276);
     expect(
@@ -193,7 +199,10 @@ describe("commandLineSoundEffects.store", () => {
       },
     ]);
 
+    setSelectedChannel({ state }, { channelId: "Weather" });
     const channelSelection = selectViewData({ state, i18n });
+    expect(channelSelection.channels[0].channelBorderColor).toBe("pr");
+    expect(channelSelection.channels[0].channelHoverBorderColor).toBe("pr");
     expect(channelSelection.selectionHeading).toBe("Channel");
     expect(channelSelection.selectionName).toBe("Weather");
     expect(channelSelection.form.fields.map((field) => field.name)).toEqual([

--- a/tests/commandLineVoice/commandLineVoice.handlers.test.js
+++ b/tests/commandLineVoice/commandLineVoice.handlers.test.js
@@ -211,6 +211,7 @@ describe("commandLineVoice.handlers", () => {
       { _event: { stopPropagation: vi.fn() } },
     );
 
+    expect(state.channelSelected).toBe(true);
     expect(state.selectedSoundId).toBeUndefined();
     expect(render).toHaveBeenCalledOnce();
   });

--- a/tests/commandLineVoice/commandLineVoice.store.test.js
+++ b/tests/commandLineVoice/commandLineVoice.store.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import * as voiceStore from "../../src/components/commandLineVoice/commandLineVoice.store.js";
 import {
+  clearSelectedSound,
   createInitialState,
   insertSound,
   removeSound,
@@ -55,7 +56,7 @@ describe("commandLineVoice.store", () => {
     });
   });
 
-  it("starts with an empty selected Voice channel", () => {
+  it("starts with an unselected Voice channel and selects it explicitly", () => {
     const state = createInitialState();
     const viewData = selectViewData({ state, i18n });
 
@@ -67,14 +68,25 @@ describe("commandLineVoice.store", () => {
     });
     expect(viewData.channelLabel).toBe("Voice Channel");
     expect(viewData.channelDurationLabel).toBe("0:00");
-    expect(viewData.selectionHeading).toBe("Channel");
-    expect(viewData.selectionName).toBe("Voice Channel");
-    expect(viewData.form.fields.map((field) => field.name)).toEqual([
+    expect(viewData.hasSelection).toBe(false);
+    expect(viewData.channelBorderColor).toBe("bo");
+    expect(viewData.channelHoverBorderColor).toBe("ac");
+    expect(viewData.selectionHeading).toBe("");
+    expect(viewData.selectionName).toBe("");
+
+    clearSelectedSound({ state });
+    const selectedViewData = selectViewData({ state, i18n });
+    expect(selectedViewData.hasSelection).toBe(true);
+    expect(selectedViewData.channelBorderColor).toBe("pr");
+    expect(selectedViewData.channelHoverBorderColor).toBe("pr");
+    expect(selectedViewData.selectionHeading).toBe("Channel");
+    expect(selectedViewData.selectionName).toBe("Voice Channel");
+    expect(selectedViewData.form.fields.map((field) => field.name)).toEqual([
       "loop",
       "interruption",
       "volume",
     ]);
-    expect(viewData.defaultValues).toEqual({
+    expect(selectedViewData.defaultValues).toEqual({
       interruption: "immediate",
       loop: false,
       volume: 100,


### PR DESCRIPTION
## Summary

- replace the separate dialogue ADV/NVL mode control with a combined layout selector that shows each layout mode
- group dialogue speaker fields and options using standard form sections, with Persist Speaker directly below Speaker
- start BGM, Voice, and Sound Effects channels unselected and reserve the bright border for explicit channel selection
- support nested form-field localization and keep dialogue serialization aligned with the selected layout mode

## Validation

- bun run lint
- 98 focused command-line component tests
- bun run test:smoke
- bun run test:integration
- Chromium checks for dialogue sections/layout labels and audio channel borders before and after selection