### PR TITLE
feat: improve scene section and BGM timeline menus

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -406,9 +406,16 @@ export const connectSoundToPrevious = ({ state }, { soundId } = {}) => {
     { state },
     { itemId: previousSound.resourceId },
   );
-  sound.startDelayMs =
+  const currentStartDelayMs = normalizeAudioStartDelayMs(sound.startDelayMs);
+  const connectedStartDelayMs =
     normalizeAudioStartDelayMs(previousSound.startDelayMs) +
     resolveAudioSoundDurationMs(previousSound, previousResource);
+  const shiftMs = connectedStartDelayMs - currentStartDelayMs;
+
+  for (const shiftedSound of state.bgm.sounds.slice(soundIndex)) {
+    shiftedSound.startDelayMs =
+      normalizeAudioStartDelayMs(shiftedSound.startDelayMs) + shiftMs;
+  }
   sortAudioSoundsByStartDelay(state.bgm.sounds);
 };
 

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -1754,6 +1754,7 @@ scenesPage:
   updateSceneDescription: "Update scene details"
 sceneEditorPage:
   actionsLabel: "Actions"
+  addSectionMenuItem: "Add section"
   addSectionAboveMenuItem: "Add section above"
   addSectionBelowMenuItem: "Add section below"
   autoLabel: "Auto"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -1754,6 +1754,7 @@ scenesPage:
   updateSceneDescription: "シーンの詳細を更新"
 sceneEditorPage:
   actionsLabel: "アクション"
+  addSectionMenuItem: "セクションを追加"
   addSectionAboveMenuItem: "上にセクションを追加"
   addSectionBelowMenuItem: "下にセクションを追加"
   autoLabel: "自動"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -1754,6 +1754,7 @@ scenesPage:
   updateSceneDescription: "更新场景详情"
 sceneEditorPage:
   actionsLabel: "动作"
+  addSectionMenuItem: "添加段落"
   addSectionAboveMenuItem: "在上方添加段落"
   addSectionBelowMenuItem: "在下方添加段落"
   autoLabel: "自动"

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -2926,6 +2926,27 @@ export const handleSectionTabRightClick = (deps, payload) => {
   openSectionTabDropdown(deps, payload._event);
 };
 
+export const handleSectionsEmptySpaceContextMenu = (deps, payload) => {
+  const { store, render } = deps;
+  const event = payload._event;
+  if (
+    isSectionsOverviewOpen(store) ||
+    event.target?.closest?.("[data-section-block-id]")
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  store.showAddSectionDropdownMenu({
+    position: {
+      x: event.clientX,
+      y: event.clientY,
+    },
+  });
+  render();
+};
+
 export const handleActionsDialogClose = (deps) => {
   const { render, store, subject } = deps;
   const suppressNext = store.selectSuppressNextActionsDialogClose?.() === true;
@@ -3052,6 +3073,14 @@ export const handleDropdownMenuClickItem = async (deps, payload) => {
       render();
       return;
     }
+  }
+
+  if (action === "add-section") {
+    store.showSectionCreateDialog({
+      defaultName: getDefaultSectionName(store, copy),
+    });
+    render();
+    return;
   }
 
   if (action === "add-section-above" || action === "add-section-below") {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -61,6 +61,7 @@ const MOBILE_PREVIEW_VERTICAL_PADDING_PX = 16;
 const MOBILE_PREVIEW_MIN_HEIGHT_PX = 72;
 
 const SCENE_EDITOR_DROPDOWN_COPY_KEYS = Object.freeze({
+  "Add section": "addSectionMenuItem",
   "Add section above": "addSectionAboveMenuItem",
   "Add section below": "addSectionBelowMenuItem",
   "Move up": "moveUpMenuItem",
@@ -1458,6 +1459,17 @@ export const showSectionDropdownMenu = (
     actionsType: null,
     lineId: undefined,
   };
+};
+
+export const showAddSectionDropdownMenu = ({ state }, { position } = {}) => {
+  state.dropdownMenu.isOpen = true;
+  state.dropdownMenu.position = position;
+  state.dropdownMenu.items = [
+    { label: "Add section", type: "item", value: "add-section" },
+  ];
+  state.dropdownMenu.sectionId = null;
+  state.dropdownMenu.actionsType = null;
+  state.dropdownMenu.lineId = undefined;
 };
 
 export const showSectionsOverviewDropdownMenu = (

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -1,4 +1,8 @@
 refs:
+  sceneEditorSectionsScroll:
+    eventListeners:
+      contextmenu:
+        handler: handleSectionsEmptySpaceContextMenu
   sectionEditor*:
     eventListeners:
       scene-lines-changed:

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -345,6 +345,11 @@ describe("commandLineBgm.handlers", () => {
       soundId: "theme-clip",
       values: { startDelayMs: 5000 },
     });
+    store.insertSound({ id: "outro-clip", resourceId: "intro", index: 2 });
+    store.updateSound({
+      soundId: "outro-clip",
+      values: { startDelayMs: 12000 },
+    });
     const showDropdownMenu = vi.fn().mockResolvedValue({
       item: { key: "connect-to-previous" },
     });
@@ -382,6 +387,7 @@ describe("commandLineBgm.handlers", () => {
       place: "bs",
     });
     expect(state.bgm.sounds[1].startDelayMs).toBe(2000);
+    expect(state.bgm.sounds[2].startDelayMs).toBe(9000);
     expect(state.selectedSoundId).toBe("theme-clip");
     expect(setValues).toHaveBeenCalledWith({
       values: {

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -274,6 +274,11 @@ describe("commandLineBgm.store", () => {
               resourceId: "theme",
               startDelayMs: 4000,
             },
+            {
+              id: "outro-clip",
+              resourceId: "intro",
+              startDelayMs: 7500,
+            },
           ],
         },
       },
@@ -282,6 +287,7 @@ describe("commandLineBgm.store", () => {
     connectSoundToPrevious({ state }, { soundId: "theme-clip" });
 
     expect(selectBgm({ state }).sounds[1].startDelayMs).toBe(1000);
+    expect(selectBgm({ state }).sounds[2].startDelayMs).toBe(4500);
   });
 
   it("updates a sound start delay from a horizontal timeline drag", () => {

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -12,11 +12,28 @@ import {
   setProjectLanguage,
   setSectionLineChangesBySectionId,
   setTemporaryPresentationState,
+  showAddSectionDropdownMenu,
   showSectionDropdownMenu,
 } from "../../src/pages/sceneEditorLexical/sceneEditorLexical.store.js";
 import { EN_I18N } from "../support/i18n.js";
 
 describe("sceneEditorLexical.store", () => {
+  it("shows a localized add-section menu for empty editor space", () => {
+    const state = createInitialState();
+
+    showAddSectionDropdownMenu({ state }, { position: { x: 120, y: 240 } });
+
+    expect(state.dropdownMenu).toMatchObject({
+      isOpen: true,
+      position: { x: 120, y: 240 },
+      sectionId: null,
+      items: [{ label: "Add section", type: "item", value: "add-section" }],
+    });
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).dropdownMenu.items[0].label,
+    ).toBe("Add section");
+  });
+
   it("uses the project language to select the scene text count mode", () => {
     const state = createInitialState();
     setProjectLanguage({ state }, { language: "zh-Hans" });

--- a/tests/sceneEditor/sceneEditor.view.test.js
+++ b/tests/sceneEditor/sceneEditor.view.test.js
@@ -36,4 +36,17 @@ describe("sceneEditorLexical view", () => {
     );
     expect(view).toContain("handler: handleDownloadCanvasClick");
   });
+
+  it("opens the section menu from empty space in the sections scroller", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain("sceneEditorSectionsScroll:");
+    expect(view).toContain("handler: handleSectionsEmptySpaceContextMenu");
+  });
 });

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -19,6 +19,7 @@ import {
   handleNewLine,
   handlePreviewClick,
   handleSectionMoveSceneFormActionClick,
+  handleSectionsEmptySpaceContextMenu,
   handleSelectedLineChanged,
   handleSystemActionsActionDelete,
   handleSystemActionsDialogOpen,
@@ -2954,6 +2955,91 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       defaultName: "Section 3",
       placementPosition: "after",
       placementTargetSectionId: "section-1",
+    });
+    expect(deps.render).toHaveBeenCalledOnce();
+  });
+
+  it("opens an add-section dropdown from empty space below the sections", () => {
+    const store = {
+      selectIsSectionsOverviewOpen: vi.fn(() => false),
+      showAddSectionDropdownMenu: vi.fn(),
+    };
+    const render = vi.fn();
+    const event = {
+      target: {
+        closest: vi.fn(() => null),
+      },
+      clientX: 120,
+      clientY: 240,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleSectionsEmptySpaceContextMenu({ store, render }, { _event: event });
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    expect(store.showAddSectionDropdownMenu).toHaveBeenCalledWith({
+      position: { x: 120, y: 240 },
+    });
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("keeps existing context-menu behavior inside a section", () => {
+    const store = {
+      selectIsSectionsOverviewOpen: vi.fn(() => false),
+      showAddSectionDropdownMenu: vi.fn(),
+    };
+    const render = vi.fn();
+    const event = {
+      target: {
+        closest: vi.fn(() => ({ dataset: { sectionBlockId: "section-1" } })),
+      },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleSectionsEmptySpaceContextMenu({ store, render }, { _event: event });
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(store.showAddSectionDropdownMenu).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it("opens the section create dialog from the empty-space dropdown", async () => {
+    const store = {
+      selectDropdownMenu: vi.fn(() => ({ sectionId: null })),
+      hideDropdownMenu: vi.fn(),
+      selectScene: vi.fn(() => ({
+        sections: [{ id: "section-1" }, { id: "section-2" }],
+      })),
+      showSectionCreateDialog: vi.fn(),
+      selectSceneId: vi.fn(() => "scene-1"),
+    };
+    const deps = {
+      i18n: EN_I18N,
+      store,
+      render: vi.fn(),
+      projectService: {},
+      subject: {
+        dispatch: vi.fn(),
+      },
+      appService: {},
+    };
+
+    await handleDropdownMenuClickItem(deps, {
+      _event: {
+        detail: {
+          item: {
+            value: "add-section",
+          },
+        },
+      },
+    });
+
+    expect(store.hideDropdownMenu).toHaveBeenCalledOnce();
+    expect(store.showSectionCreateDialog).toHaveBeenCalledWith({
+      defaultName: "Section 3",
     });
     expect(deps.render).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## Summary
- show an Add section context menu when right-clicking empty space below Scene Editor sections
- open the existing section creation flow from the new menu with localized labels
- shift the selected BGM sound and all following sounds when connecting it to the previous sound, preserving downstream spacing
- add regression coverage for both workflows

## Testing
- bunx vitest run tests/commandLineBgm/commandLineBgm.store.test.js tests/commandLineBgm/commandLineBgm.handlers.test.js tests/sceneEditor/sceneEditor.store.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/sceneEditor.view.test.js
- bunx oxlint src tests/sceneEditor tests/commandLineBgm
- bunx prettier --check src