### PR TITLE
feat: refine command line option forms

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -81,7 +81,7 @@ template:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues} p=none:
+              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues} p=none mb=120:
                   - $if selectedResource:
                       - $if selectedResource.resourceType == 'image':
                           - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=md:

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -210,7 +210,7 @@ template:
                       - rtgl-view w=f:
                           - rtgl-text s=md: ${selectionHeading}
                           - rtgl-text s=sm c=mu-fg: ${selectionName}
-                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none: null
+                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none mb=120: null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -155,7 +155,7 @@ template:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md w=f:
-                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} p=none:
+                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} p=none mb=120:
                       - rtgl-view#charactersContainer slot=characters g=md w=f:
                           - $for character, i in defaultValues.characters:
                               - rtgl-view#character${i}.characterRow data-index=${character.characterIndex} data-character-id=${character.id} d=h g=md av=t pv=md br=md w=f:

--- a/src/components/commandLineChoices/commandLineChoices.view.yaml
+++ b/src/components/commandLineChoices/commandLineChoices.view.yaml
@@ -62,7 +62,7 @@ template:
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} p=none:
+                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} p=none mb=120:
                       - rtgl-view#choicesContainer slot=choices g=md w=f:
                           - $for item, index in defaultValues.items:
                               - rtgl-view#choiceItem${index} data-index=${index} d=h av=c w=f g=md p=sm bgc=mu br=sm cur=pointer:
@@ -76,7 +76,7 @@ template:
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#choiceForm key=${choiceFormKey} :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm} p=none:
+                  - rtgl-form#choiceForm key=${choiceFormKey} :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm} p=none mb=120:
                       - rtgl-view slot=updateVariables w=f:
                           - rvn-system-actions#choiceUpdateVariableEditor :showSelected=${true} :actions=${choiceUpdateVariableActions} actionType=system :allowedModes=${choiceUpdateVariableAllowedModes} :showEmbeddedClose=${false}: null
               - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':

--- a/src/components/commandLineControl/commandLineControl.view.yaml
+++ b/src/components/commandLineControl/commandLineControl.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -694,6 +694,12 @@ const syncDialogueFormValues = (deps) => {
     persistSprite,
     removePersistedSprite,
     characterSpriteEnabled,
+    spriteTransformId,
+    spriteAnimationId,
+    spriteAnimationMode,
+    spriteAnimationPlaybackSpeed,
+    spriteAnimationPlaybackLoop,
+    spriteAnimationPlaybackContinuity,
     clearPage,
     textSpeed,
   } = store.selectDialogueFormState();
@@ -703,6 +709,12 @@ const syncDialogueFormValues = (deps) => {
     customCharacterName,
     characterName,
     characterSpriteEnabled,
+    spriteTransformId,
+    spriteAnimationId,
+    spriteAnimationMode,
+    spriteAnimationPlaybackSpeed,
+    spriteAnimationPlaybackLoop,
+    spriteAnimationPlaybackContinuity,
     append: appendDialogue,
     persistCharacter,
     persistSprite,
@@ -766,6 +778,11 @@ export const handleFormChange = (deps, payload) => {
   });
   const persistCharacterVisibilityChanged =
     hadDialogueCharacter !== hasCharacter;
+  const spriteAnimationId = Object.hasOwn(formValues, "spriteAnimationId")
+    ? formValues.spriteAnimationId
+    : currentState.spriteAnimationId;
+  const animationPlaybackVisibilityChanged =
+    !!spriteAnimationId !== !!currentState.spriteAnimationId;
   let characterName = formValues.characterName ?? currentState.characterName;
 
   if (!customCharacterName) {
@@ -799,6 +816,10 @@ export const handleFormChange = (deps, payload) => {
   const persistSprite = currentState.characterSpriteEnabled
     ? (formValues.persistSprite ?? currentState.persistSprite)
     : currentState.persistSprite;
+  const persistSpriteChanged =
+    currentState.characterSpriteEnabled &&
+    Object.hasOwn(formValues, "persistSprite") &&
+    toBoolean(persistSprite) !== currentState.persistSprite;
   const removePersistedSprite = currentState.characterSpriteEnabled
     ? false
     : (formValues.removePersistedSprite ?? currentState.removePersistedSprite);
@@ -811,7 +832,7 @@ export const handleFormChange = (deps, payload) => {
   });
   store.setPersistSprite({
     persistSprite,
-    explicit: currentState.persistSpriteExplicit,
+    explicit: currentState.persistSpriteExplicit || persistSpriteChanged,
   });
   store.setRemovePersistedSprite({
     removePersistedSprite,
@@ -824,9 +845,45 @@ export const handleFormChange = (deps, payload) => {
     fallback: currentState.textSpeed,
   });
 
+  if (currentState.characterSpriteEnabled) {
+    store.setSpriteTransformId({
+      transformId:
+        formValues.spriteTransformId ?? currentState.spriteTransformId,
+    });
+
+    store.setSpriteAnimationId({ animationId: spriteAnimationId });
+
+    if (spriteAnimationId) {
+      store.setSpriteAnimationPlaybackSpeed({
+        speed:
+          formValues.spriteAnimationPlaybackSpeed ??
+          currentState.spriteAnimationPlaybackSpeed,
+      });
+      store.setSpriteAnimationPlaybackContinuity({
+        continuity:
+          formValues.spriteAnimationPlaybackContinuity ??
+          currentState.spriteAnimationPlaybackContinuity,
+      });
+
+      if (
+        getAnimationModeById(props?.animations, spriteAnimationId) === "update"
+      ) {
+        store.setSpriteAnimationPlaybackLoop({
+          loop:
+            formValues.spriteAnimationPlaybackLoop ??
+            currentState.spriteAnimationPlaybackLoop,
+        });
+      }
+    }
+  }
+
   render();
 
-  if (modeChanged || persistCharacterVisibilityChanged) {
+  if (
+    modeChanged ||
+    persistCharacterVisibilityChanged ||
+    animationPlaybackVisibilityChanged
+  ) {
     syncDialogueFormValues(deps);
   }
 
@@ -836,14 +893,6 @@ export const handleFormChange = (deps, payload) => {
 export const handleFormSectionAction = async (deps, payload) => {
   const { appService, i18n, render, store } = deps;
   const { sectionId, actionId, position } = payload._event.detail;
-
-  if (sectionId === "options" && actionId === "remove-custom-text-speed") {
-    store.setCustomizeTextSpeed({ customizeTextSpeed: false });
-    render();
-    syncDialogueFormValues(deps);
-    dispatchTemporaryPresentationStateChange(deps);
-    return;
-  }
 
   if (actionId !== "add") {
     return;
@@ -898,6 +947,24 @@ export const handleFormSectionAction = async (deps, payload) => {
   }
 
   store.setCustomizeTextSpeed({ customizeTextSpeed: true });
+  render();
+  syncDialogueFormValues(deps);
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleTextSpeedChange = (deps, payload) => {
+  const { render, store } = deps;
+  const { value } = payload._event.detail;
+
+  store.setTextSpeed({ textSpeed: value });
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleRemoveCustomTextSpeedClick = (deps) => {
+  const { render, store } = deps;
+
+  store.setCustomizeTextSpeed({ customizeTextSpeed: false });
   render();
   syncDialogueFormValues(deps);
   dispatchTemporaryPresentationStateChange(deps);
@@ -969,24 +1036,6 @@ export const handleCharacterSpriteMenuButtonClick = async (deps, payload) => {
     x: rect.left,
     y: rect.bottom,
   });
-};
-
-export const handleSpeakerSpriteTooltipMouseEnter = (deps, payload) => {
-  const { store, render } = deps;
-  const rect = payload._event.currentTarget.getBoundingClientRect();
-
-  store.showSpeakerSpriteTooltip({
-    x: rect.left + rect.width / 2,
-    y: rect.top - 8,
-  });
-  render();
-};
-
-export const handleSpeakerSpriteTooltipMouseLeave = (deps) => {
-  const { store, render } = deps;
-
-  store.hideSpeakerSpriteTooltip();
-  render();
 };
 
 export const handleCharacterSpriteGroupBoxClick = (deps, payload) => {
@@ -1106,66 +1155,6 @@ export const handleSpriteGroupTabClick = (deps, payload) => {
 
   store.setSelectedSpriteGroupId({ spriteGroupId });
   render();
-};
-
-export const handleTransformChange = (deps, payload) => {
-  const { store, render } = deps;
-  const value = payload._event.detail.value;
-  store.setSpriteTransformId({ transformId: value });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
-export const handleAnimationModeChange = (deps, payload) => {
-  const { store, render } = deps;
-  const value = payload._event.detail.value;
-  store.setSpriteAnimationMode({ mode: value });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
-export const handleAnimationChange = (deps, payload) => {
-  const { store, render } = deps;
-  const value = payload._event.detail.value;
-  store.setSpriteAnimationId({ animationId: value });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
-export const handleAnimationPlaybackSpeedInput = (deps, payload) => {
-  const { store, render } = deps;
-  store.setSpriteAnimationPlaybackSpeed({
-    speed: payload._event.detail.value,
-  });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
-export const handleAnimationPlaybackLoopChange = (deps, payload) => {
-  const { store, render } = deps;
-  store.setSpriteAnimationPlaybackLoop({
-    loop: payload._event.detail.value,
-  });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
-export const handleAnimationPlaybackContinuityChange = (deps, payload) => {
-  const { store, render } = deps;
-  store.setSpriteAnimationPlaybackContinuity({
-    continuity: payload._event.detail.value,
-  });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
-};
-
-export const handlePersistSpriteChange = (deps, payload) => {
-  const { store, render } = deps;
-  const { value } = payload._event.detail;
-
-  store.setPersistSprite({ persistSprite: value });
-  render();
-  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleButtonSelectClick = (deps) => {

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.store.js
@@ -17,25 +17,10 @@ import {
 import {
   localizeCommandLineBreadcrumb,
   localizeCommandLineForm,
-  localizeCommandLineOptions,
   localizeCommandLineText,
   selectCommandLineCopy,
 } from "../../internal/ui/sceneEditor/commandLineCopy.js";
 
-const ANIMATION_MODE_OPTIONS = [
-  {
-    label: "None",
-    value: "none",
-  },
-  {
-    label: "Update",
-    value: "update",
-  },
-  {
-    label: "Transition",
-    value: "transition",
-  },
-];
 const ANIMATION_PLAYBACK_LOOP_OPTIONS = [
   { value: false, label: "Don't Loop" },
   { value: true, label: "Loop" },
@@ -385,12 +370,6 @@ export const createInitialState = () => ({
   fullImagePreviewAtlas: undefined,
   fullImagePreviewAnimation: undefined,
   fullImagePreviewKey: undefined,
-  speakerSpriteTooltip: {
-    open: false,
-    x: 0,
-    y: 0,
-  },
-
   defaultValues: {
     resourceId: "",
     characterId: "",
@@ -494,8 +473,91 @@ export const createInitialState = () => ({
           },
           {
             $when: "values.characterSpriteEnabled == true",
-            type: "slot",
-            slot: "characterSprite",
+            type: "row",
+            fields: [
+              {
+                name: "characterSprite",
+                type: "slot",
+                slot: "characterSprite",
+                label: SPEAKER_SPRITE_LABEL,
+                tooltip: {
+                  content: SPEAKER_SPRITE_TOOLTIP,
+                },
+              },
+              {
+                name: "persistSprite",
+                type: "segmented-control",
+                label: "Persist Sprite",
+                required: true,
+                clearable: false,
+                options: PERSIST_SPRITE_OPTIONS,
+              },
+            ],
+          },
+          {
+            $when: "values.characterSpriteEnabled == true",
+            type: "row",
+            fields: [
+              {
+                name: "spriteTransformId",
+                type: "select",
+                label: "Transform",
+                required: true,
+                clearable: false,
+                options: [],
+              },
+              {
+                name: "spriteAnimationId",
+                type: "select",
+                label: "Animation",
+                clearable: true,
+                placeholder: "Select animation",
+                options: [],
+              },
+            ],
+          },
+          {
+            $when:
+              "values.characterSpriteEnabled == true && values.spriteAnimationId",
+            type: "row",
+            fields: [
+              {
+                name: "spriteAnimationPlaybackSpeed",
+                type: "slider-with-input",
+                label: "Playback Speed",
+                required: true,
+                min: 0.01,
+                max: 4,
+                step: 0.01,
+              },
+              {
+                name: "spriteAnimationPlaybackContinuity",
+                type: "segmented-control",
+                label: "Continuity",
+                required: true,
+                clearable: false,
+                options: ANIMATION_PLAYBACK_CONTINUITY_OPTIONS,
+              },
+            ],
+          },
+          {
+            $when:
+              "values.characterSpriteEnabled == true && values.spriteAnimationId && values.spriteAnimationMode == 'update'",
+            type: "row",
+            fields: [
+              {
+                name: "spriteAnimationPlaybackLoop",
+                type: "segmented-control",
+                label: "Loop",
+                required: true,
+                clearable: false,
+                options: ANIMATION_PLAYBACK_LOOP_OPTIONS,
+              },
+              {
+                type: "slot",
+                slot: "spriteAnimationPlaybackLoopSpacer",
+              },
+            ],
           },
         ],
       },
@@ -511,17 +573,6 @@ export const createInitialState = () => ({
         },
         fields: [
           {
-            $when: "values.customizeTextSpeed == true",
-            name: "textSpeed",
-            type: "slider-with-input",
-            label: "Text Speed",
-            description: "",
-            required: true,
-            min: 0,
-            max: 100,
-            step: 1,
-          },
-          {
             $when: 'dialogueMode == "adv"',
             name: "append",
             type: "segmented-control",
@@ -533,6 +584,11 @@ export const createInitialState = () => ({
               { value: false, label: "No" },
               { value: true, label: "Yes" },
             ],
+          },
+          {
+            $when: "values.customizeTextSpeed == true",
+            type: "slot",
+            slot: "textSpeed",
           },
           {
             $when: 'dialogueMode == "nvl"',
@@ -638,6 +694,23 @@ export const setSpriteAnimationId = (
   { animationId } = {},
 ) => {
   state.spriteAnimationId = animationId ?? "";
+  if (!state.spriteAnimationId) {
+    state.spriteAnimationMode = "none";
+  } else {
+    const selectedAnimation = toFlatItems(props?.animations).find(
+      (item) =>
+        item.id === state.spriteAnimationId && item.type === "animation",
+    );
+    const selectedAnimationMode = selectedAnimation
+      ? getAnimationType(selectedAnimation)
+      : undefined;
+    if (
+      selectedAnimationMode === "update" ||
+      selectedAnimationMode === "transition"
+    ) {
+      state.spriteAnimationMode = selectedAnimationMode;
+    }
+  }
   if (
     state.spriteAnimationMode !== "update" ||
     !canLoopAnimationById(props?.animations, state.spriteAnimationId)
@@ -794,16 +867,6 @@ export const hideFullImagePreview = ({ state }) => {
   state.fullImagePreviewKey = undefined;
 };
 
-export const showSpeakerSpriteTooltip = ({ state }, { x, y } = {}) => {
-  state.speakerSpriteTooltip.open = true;
-  state.speakerSpriteTooltip.x = x;
-  state.speakerSpriteTooltip.y = y;
-};
-
-export const hideSpeakerSpriteTooltip = ({ state }) => {
-  state.speakerSpriteTooltip.open = false;
-};
-
 export const setSelectedMode = ({ state }, { mode } = {}) => {
   const selectedMode = mode === "nvl" ? "nvl" : "adv";
   state.selectedMode = selectedMode;
@@ -915,6 +978,12 @@ export const selectDialogueFormState = ({ state }) => ({
   persistSprite: state.persistSprite,
   removePersistedSprite: state.removePersistedSprite,
   characterSpriteEnabled: state.characterSpriteEnabled,
+  spriteTransformId: state.spriteTransformId,
+  spriteAnimationId: state.spriteAnimationId,
+  spriteAnimationMode: state.spriteAnimationMode,
+  spriteAnimationPlaybackSpeed: state.spriteAnimationPlaybackSpeed,
+  spriteAnimationPlaybackLoop: state.spriteAnimationPlaybackLoop,
+  spriteAnimationPlaybackContinuity: state.spriteAnimationPlaybackContinuity,
   clearPage: state.clearPage,
   customizeTextSpeed: state.customizeTextSpeed,
   textSpeed: state.textSpeed,
@@ -927,6 +996,12 @@ export const selectDialogueFormChangeState = ({ state }) => ({
   customCharacterName: state.customCharacterName,
   characterName: state.characterName,
   characterSpriteEnabled: state.characterSpriteEnabled,
+  spriteTransformId: state.spriteTransformId,
+  spriteAnimationId: state.spriteAnimationId,
+  spriteAnimationMode: state.spriteAnimationMode,
+  spriteAnimationPlaybackSpeed: state.spriteAnimationPlaybackSpeed,
+  spriteAnimationPlaybackLoop: state.spriteAnimationPlaybackLoop,
+  spriteAnimationPlaybackContinuity: state.spriteAnimationPlaybackContinuity,
   persistSprite: state.persistSprite,
   persistSpriteExplicit: state.persistSpriteExplicit,
   removePersistedSprite: state.removePersistedSprite,
@@ -1068,17 +1143,18 @@ export const selectViewData = ({ state, props, i18n }) => {
   const animationItems = toFlatItems(animations).filter(
     (item) => item.type === "animation",
   );
-  const updateAnimationOptions = animationItems
-    .filter((item) => getAnimationType(item) === "update")
+  const animationOptions = animationItems
+    .filter((item) => {
+      const animationType = getAnimationType(item);
+      return animationType === "update" || animationType === "transition";
+    })
     .map((item) => ({
       value: item.id,
       label: item.name,
-    }));
-  const transitionAnimationOptions = animationItems
-    .filter((item) => getAnimationType(item) === "transition")
-    .map((item) => ({
-      value: item.id,
-      label: item.name,
+      suffixText:
+        getAnimationType(item) === "transition"
+          ? localizeCommandLineText("Transition", copy)
+          : localizeCommandLineText("Update", copy),
     }));
   const characterTreeData = buildSelectableTreeData({
     collection: characterCollection,
@@ -1163,6 +1239,11 @@ export const selectViewData = ({ state, props, i18n }) => {
     });
   }
 
+  const spriteAnimationCanLoop = canLoopAnimationById(
+    animations,
+    state.spriteAnimationId,
+  );
+
   const mapFormField = (field) => {
     if (field.id === "speaker") {
       const mappedSection = {
@@ -1180,11 +1261,7 @@ export const selectViewData = ({ state, props, i18n }) => {
         fields: field.fields.map(mapFormField),
       };
       if (state.customizeTextSpeed) {
-        mappedSection.action = {
-          id: "remove-custom-text-speed",
-          icon: "x",
-          label: "Remove custom text speed",
-        };
+        mappedSection.action = undefined;
       }
       return mappedSection;
     }
@@ -1219,6 +1296,54 @@ export const selectViewData = ({ state, props, i18n }) => {
       return {
         ...field,
         value: state.persistCharacter,
+      };
+    }
+    if (field.name === "persistSprite") {
+      return {
+        ...field,
+        value: state.persistSprite,
+      };
+    }
+    if (field.name === "spriteTransformId") {
+      return {
+        ...field,
+        options: transformOptions,
+        value: selectedSpriteTransformId,
+      };
+    }
+    if (field.name === "spriteAnimationId") {
+      return {
+        ...field,
+        options: animationOptions,
+        value: state.spriteAnimationId,
+      };
+    }
+    if (field.name === "spriteAnimationPlaybackSpeed") {
+      return {
+        ...field,
+        value: normalizeAnimationPlaybackSpeed(
+          state.spriteAnimationPlaybackSpeed,
+        ),
+      };
+    }
+    if (field.name === "spriteAnimationPlaybackContinuity") {
+      return {
+        ...field,
+        value: normalizeAnimationPlaybackContinuity(
+          state.spriteAnimationPlaybackContinuity,
+        ),
+      };
+    }
+    if (field.name === "spriteAnimationPlaybackLoop") {
+      return {
+        ...field,
+        disabled: !spriteAnimationCanLoop,
+        description: spriteAnimationCanLoop
+          ? undefined
+          : "loopingRequiresKeyframesDescription",
+        value: normalizeAnimationPlaybackLoop(
+          state.spriteAnimationPlaybackLoop,
+        ),
       };
     }
     if (field.name === "append") {
@@ -1258,6 +1383,18 @@ export const selectViewData = ({ state, props, i18n }) => {
     append: state.appendDialogue,
     persistCharacter: state.persistCharacter,
     persistSprite: state.persistSprite,
+    spriteTransformId: selectedSpriteTransformId,
+    spriteAnimationId: state.spriteAnimationId,
+    spriteAnimationMode: state.spriteAnimationMode,
+    spriteAnimationPlaybackSpeed: normalizeAnimationPlaybackSpeed(
+      state.spriteAnimationPlaybackSpeed,
+    ),
+    spriteAnimationPlaybackLoop: normalizeAnimationPlaybackLoop(
+      state.spriteAnimationPlaybackLoop,
+    ),
+    spriteAnimationPlaybackContinuity: normalizeAnimationPlaybackContinuity(
+      state.spriteAnimationPlaybackContinuity,
+    ),
     removePersistedSprite: state.removePersistedSprite,
     clearPage: state.clearPage,
     customizeTextSpeed: state.customizeTextSpeed,
@@ -1267,11 +1404,6 @@ export const selectViewData = ({ state, props, i18n }) => {
     dialogueMode: selectedMode,
     values: defaultValues,
   };
-
-  const spriteAnimationCanLoop = canLoopAnimationById(
-    animations,
-    state.spriteAnimationId,
-  );
 
   return {
     mode: state.mode,
@@ -1318,25 +1450,6 @@ export const selectViewData = ({ state, props, i18n }) => {
     context,
     items: characterTreeData.explorerItems,
     groups: characterTreeData.groups,
-    transformOptions,
-    animationModeOptions: localizeCommandLineOptions(
-      ANIMATION_MODE_OPTIONS,
-      copy,
-    ),
-    animationPlaybackLoopOptions: localizeCommandLineOptions(
-      ANIMATION_PLAYBACK_LOOP_OPTIONS,
-      copy,
-    ),
-    animationPlaybackContinuityOptions: localizeCommandLineOptions(
-      ANIMATION_PLAYBACK_CONTINUITY_OPTIONS,
-      copy,
-    ),
-    updateAnimationOptions,
-    transitionAnimationOptions,
-    persistSpriteOptions: localizeCommandLineOptions(
-      PERSIST_SPRITE_OPTIONS,
-      copy,
-    ),
     spriteItems,
     spriteGroups,
     showSpriteGroupTabs: spriteSelectionTabs.length > 1,
@@ -1346,30 +1459,13 @@ export const selectViewData = ({ state, props, i18n }) => {
     searchPlaceholder: localizeCommandLineText("Search...", copy),
     noAvatarLabel: localizeCommandLineText("No Avatar", copy),
     noPreviewLabel: localizeCommandLineText("No preview", copy),
-    transformLabel: localizeCommandLineText("Transform", copy),
-    animationLabel: localizeCommandLineText("Animation", copy),
-    animationPlaybackSpeedLabel: localizeCommandLineText(
-      "Playback Speed",
+    textSpeedLabel: localizeCommandLineText("Text Speed", copy),
+    removeCustomTextSpeedLabel: localizeCommandLineText(
+      "Remove custom text speed",
       copy,
     ),
-    animationPlaybackLoopLabel: localizeCommandLineText("Loop", copy),
-    animationPlaybackContinuityLabel: localizeCommandLineText(
-      "Continuity",
-      copy,
-    ),
-    animationPlaybackLoopDisabledDescription: localizeCommandLineText(
-      "loopingRequiresKeyframesDescription",
-      copy,
-    ),
-    persistSpriteLabel: localizeCommandLineText("Persist Sprite", copy),
     characterSpriteMenuLabel: localizeCommandLineText("Remove", copy),
     spriteGroupsLabel: localizeCommandLineText("Sprite Groups", copy),
-    speakerSpriteLabel: localizeCommandLineText(SPEAKER_SPRITE_LABEL, copy),
-    speakerSpriteTooltip: state.speakerSpriteTooltip,
-    speakerSpriteTooltipContent: localizeCommandLineText(
-      SPEAKER_SPRITE_TOOLTIP,
-      copy,
-    ),
     submitButtonLabel: localizeCommandLineText("Submit", copy),
     selectButtonLabel: localizeCommandLineText("Select", copy),
     fullImagePreviewVisible: state.fullImagePreviewVisible,

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -9,6 +9,14 @@ refs:
         handler: handleFormChange
       form-section-action:
         handler: handleFormSectionAction
+  textSpeed:
+    eventListeners:
+      value-change:
+        handler: handleTextSpeedChange
+  removeCustomTextSpeedButton:
+    eventListeners:
+      click:
+        handler: handleRemoveCustomTextSpeedClick
   characterSpriteBox:
     eventListeners:
       click:
@@ -19,48 +27,6 @@ refs:
     eventListeners:
       click:
         handler: handleCharacterSpriteMenuButtonClick
-  speakerSpriteTooltip:
-    eventListeners:
-      mouseenter:
-        handler: handleSpeakerSpriteTooltipMouseEnter
-      mouseleave:
-        handler: handleSpeakerSpriteTooltipMouseLeave
-      focus:
-        handler: handleSpeakerSpriteTooltipMouseEnter
-      blur:
-        handler: handleSpeakerSpriteTooltipMouseLeave
-  transform:
-    eventListeners:
-      value-change:
-        handler: handleTransformChange
-  animationMode:
-    eventListeners:
-      value-change:
-        handler: handleAnimationModeChange
-  updateAnimation:
-    eventListeners:
-      value-change:
-        handler: handleAnimationChange
-  transitionAnimation:
-    eventListeners:
-      value-change:
-        handler: handleAnimationChange
-  animationPlaybackSpeed:
-    eventListeners:
-      value-change:
-        handler: handleAnimationPlaybackSpeedInput
-  animationPlaybackLoop:
-    eventListeners:
-      value-change:
-        handler: handleAnimationPlaybackLoopChange
-  animationPlaybackContinuity:
-    eventListeners:
-      value-change:
-        handler: handleAnimationPlaybackContinuityChange
-  persistSprite:
-    eventListeners:
-      value-change:
-        handler: handlePersistSpriteChange
   .characterSpriteGroupBox:
     eventListeners:
       click:
@@ -100,78 +66,35 @@ refs:
     eventListeners:
       click:
         handler: handleSubmitClick
-styles:
-  ".commandLineDialogueBoxTooltipTrigger":
-    align-items: center
-    appearance: none
-    background: transparent
-    border: "1px solid var(--muted-foreground)"
-    border-radius: 50%
-    box-sizing: border-box
-    color: var(--muted-foreground)
-    cursor: help
-    display: flex
-    font-family: inherit
-    font-size: 11px
-    font-weight: 600
-    height: 16px
-    justify-content: center
-    line-height: 1
-    margin: 0
-    padding: 0
-    width: 16px
-  ".commandLineDialogueBoxTooltipTrigger:focus-visible":
-    outline: "2px solid var(--ring)"
-    outline-offset: 2px
 template:
   - rtgl-view w=f h=f p=lg:
       - $if mode == 'current':
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none:
+              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120:
+                  - $if customizeTextSpeed:
+                      - rtgl-view slot=textSpeed g=md w=f:
+                          - rtgl-view d=h av=c w=f g=md:
+                              - rtgl-text w=1fg: ${textSpeedLabel}
+                              - 'rtgl-button#removeCustomTextSpeedButton sq s=sm v=gh pre=x title="${removeCustomTextSpeedLabel}" aria-label="${removeCustomTextSpeedLabel}"': null
+                          - rtgl-slider-input#textSpeed w=f min=0 max=100 step=1 value=${textSpeed}: null
                   - $if characterSpriteEnabled:
                       - rtgl-view slot=characterSprite g=md w=f:
-                          - rtgl-view d=h g=md av=c:
-                              - rtgl-text: ${speakerSpriteLabel}
-                              - 'button#speakerSpriteTooltip.commandLineDialogueBoxTooltipTrigger type=button aria-label="${speakerSpriteTooltipContent}"': "?"
-                          - rtgl-view d=h g=md av=t pv=md br=md w=f:
-                              - rtgl-view#characterSpriteBox cur=pointer bw=xs bc=bo h-bc=ac br=sm:
-                                  - rtgl-view p=md g=md br=md:
-                                      - $if selectedSpriteCharacter.hasSpritePreview:
-                                          - rvn-stacked-file-images :layers=${selectedSpriteCharacter.spritePreviewLayers} w=200 h=120 br=sm lazy: null
-                                        $else:
-                                          - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg: null
-                                      - rtgl-view d=h av=c g=xs w=200:
-                                          - rtgl-text s=xs c=mu-fg ellipsis w=1fg: ${selectedSpriteCharacter.displayName}
-                                          - 'rtgl-button#characterSpriteMenuButton sq s=sm v=gh pre=ellipsis title="${characterSpriteMenuLabel}" aria-label="${characterSpriteMenuLabel}" aria-haspopup=menu': null
-                          - $if hasSpriteCharacter:
-                              - rtgl-view w=1fg g=sm:
-                                  - rtgl-text s=sm c=mu-fg: ${transformLabel}
-                                  - rtgl-select#transform key=${spriteTransformId} :options=${transformOptions} :selectedValue=${spriteTransformId} w=f no-clear: null
-                                  - rtgl-text s=sm c=mu-fg: ${animationLabel}
-                                  - rtgl-segmented-control#animationMode key=${spriteAnimationMode} :options=${animationModeOptions} :selectedValue=${spriteAnimationMode} w=f no-clear: null
-                                  - $if spriteAnimationMode == 'update':
-                                      - rtgl-select#updateAnimation key=${spriteAnimationId} :options=${updateAnimationOptions} :selectedValue=${spriteAnimationId} w=f no-clear: null
-                                    $elif spriteAnimationMode == 'transition':
-                                      - rtgl-select#transitionAnimation key=${spriteAnimationId} :options=${transitionAnimationOptions} :selectedValue=${spriteAnimationId} w=f no-clear: null
-                                  - $if spriteAnimationId:
-                                      - rtgl-text s=sm c=mu-fg: ${animationPlaybackSpeedLabel}
-                                      - rtgl-input#animationPlaybackSpeed type=number min=0.01 step=0.1 w=f value=${spriteAnimationPlaybackSpeed}: null
-                                      - $if spriteAnimationMode == 'update':
-                                          - rtgl-text s=sm c=mu-fg: ${animationPlaybackLoopLabel}
-                                          - rtgl-segmented-control#animationPlaybackLoop w=f no-clear ?disabled=${spriteAnimationLoopDisabled} :selectedValue=${spriteAnimationPlaybackLoop} :options=${animationPlaybackLoopOptions}: null
-                                          - $if !spriteAnimationCanLoop:
-                                              - rtgl-text s=xs c=mu-fg: ${animationPlaybackLoopDisabledDescription}
-                                      - rtgl-text s=sm c=mu-fg: ${animationPlaybackContinuityLabel}
-                                      - rtgl-segmented-control#animationPlaybackContinuity w=f no-clear :selectedValue=${spriteAnimationPlaybackContinuity} :options=${animationPlaybackContinuityOptions}: null
-                                  - rtgl-text s=sm c=mu-fg: ${persistSpriteLabel}
-                                  - rtgl-segmented-control#persistSprite :options=${persistSpriteOptions} :selectedValue=${persistSprite} w=f no-clear: null
-                                  - $if selectedSpriteCharacter.showSpriteGroupBoxes:
-                                      - rtgl-text s=sm c=mu-fg: ${spriteGroupsLabel}
-                                      - rtgl-view d=h wrap g=xs w=f:
-                                          - $for spriteGroup, i in selectedSpriteCharacter.spriteGroupBoxes:
-                                              - 'rtgl-view.characterSpriteGroupBox data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
-                                                  - rtgl-text s=xs: ${spriteGroup.name}
+                          - rtgl-view#characterSpriteBox cur=pointer bw=xs bc=bo h-bc=ac br=sm:
+                              - rtgl-view p=md g=md br=md:
+                                  - $if selectedSpriteCharacter.hasSpritePreview:
+                                      - rvn-stacked-file-images :layers=${selectedSpriteCharacter.spritePreviewLayers} w=200 h=120 br=sm lazy: null
+                                    $else:
+                                      - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg: null
+                                  - rtgl-view d=h av=c g=xs w=200:
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=1fg: ${selectedSpriteCharacter.displayName}
+                                      - 'rtgl-button#characterSpriteMenuButton sq s=sm v=gh pre=ellipsis title="${characterSpriteMenuLabel}" aria-label="${characterSpriteMenuLabel}" aria-haspopup=menu': null
+                          - $if selectedSpriteCharacter.showSpriteGroupBoxes:
+                              - rtgl-text s=sm c=mu-fg: ${spriteGroupsLabel}
+                              - rtgl-view d=h wrap g=xs w=f:
+                                  - $for spriteGroup, i in selectedSpriteCharacter.spriteGroupBoxes:
+                                      - 'rtgl-view.characterSpriteGroupBox data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
+                                          - rtgl-text s=xs: ${spriteGroup.name}
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: ${submitButtonLabel}
       - $if mode == 'character-select':
@@ -236,4 +159,3 @@ template:
                       - 'rvn-spritesheet-preview key=${fullImagePreviewKey} previewKey=${fullImagePreviewKey} fileId=${fullImagePreviewFileId} :atlas=${fullImagePreviewAtlas} :animation=${fullImagePreviewAnimation} w=80% h=80% emptyLabel="${noPreviewLabel}"': null
                     $else:
                       - rvn-file-image fileId=${fullImagePreviewFileId} w=80% h=80% bc=ac bw=xs br=md: null
-  - rtgl-tooltip ?open=${speakerSpriteTooltip.open} x=${speakerSpriteTooltip.x} y=${speakerSpriteTooltip.y} place="t" content="${speakerSpriteTooltipContent}": null

--- a/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
+++ b/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
@@ -11,6 +11,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineInput/commandLineInput.view.yaml
+++ b/src/components/commandLineInput/commandLineInput.view.yaml
@@ -38,7 +38,7 @@ template:
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none:
+                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none mb=120:
                       - rtgl-view slot=${inputFieldsSlot} g=md w=f:
                           - $if hasFields:
                               - $for fieldRow, index in fieldRows:

--- a/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
+++ b/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineNextLine/commandLineNextLine.view.yaml
+++ b/src/components/commandLineNextLine/commandLineNextLine.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
+++ b/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
@@ -17,6 +17,6 @@ template:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none: null
+              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none mb=120: null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton variant=pr: Submit

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
+++ b/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
@@ -17,6 +17,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton variant=pr: ${submitLabel}

--- a/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
+++ b/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineScreen/commandLineScreen.handlers.js
+++ b/src/components/commandLineScreen/commandLineScreen.handlers.js
@@ -1,3 +1,8 @@
+import {
+  localizeCommandLineText,
+  selectCommandLineCopy,
+} from "../../internal/ui/sceneEditor/commandLineCopy.js";
+
 const buildScreenDataFromState = (store) => {
   const transitionAnimationId = store.selectTransitionAnimationId();
   const playbackSpeed = store.selectAnimationPlaybackSpeed();
@@ -67,6 +72,11 @@ export const handleAfterMount = async (deps) => {
     formValues.blurRepeatEdgePixels = screen.blur?.repeatEdgePixels;
   }
 
+  store.setScreenOptionVisibility({
+    opacityEnabled: screen.opacity !== undefined,
+    blurEnabled: Boolean(screen.blur),
+    blurExplicit: Object.hasOwn(screen, "blur"),
+  });
   store.setAnimations({
     animations,
   });
@@ -84,6 +94,67 @@ export const handleFormChange = (deps, payload) => {
   }
 
   store.setFormValues({ values });
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
+export const handleOptionsSectionAction = async (deps, payload) => {
+  const { appService, i18n, render, store } = deps;
+  const { actionId, position, sectionId } = payload._event.detail;
+
+  if (sectionId === "opacity" && actionId === "remove") {
+    store.removeOpacityOption();
+    render();
+    dispatchTemporaryPresentationStateChange(deps);
+    return;
+  }
+
+  if (sectionId === "blur" && actionId === "remove") {
+    store.removeBlurOption();
+    render();
+    dispatchTemporaryPresentationStateChange(deps);
+    return;
+  }
+
+  if (sectionId !== "options" || actionId !== "add") {
+    return;
+  }
+
+  const copy = selectCommandLineCopy(i18n);
+  const items = [];
+  if (!store.selectOpacityOptionEnabled()) {
+    items.push({
+      type: "item",
+      label: localizeCommandLineText("Opacity", copy),
+      key: "opacity",
+    });
+  }
+  if (!store.selectBlurOptionEnabled()) {
+    items.push({
+      type: "item",
+      label: localizeCommandLineText("Blur", copy),
+      key: "blur",
+    });
+  }
+  if (items.length === 0) {
+    return;
+  }
+
+  const result = await appService.showDropdownMenu({
+    items,
+    x: position.x,
+    y: position.y,
+    place: "be",
+  });
+
+  if (result?.item?.key === "opacity") {
+    store.showOpacityOption();
+  } else if (result?.item?.key === "blur") {
+    store.showBlurOption();
+  } else {
+    return;
+  }
+
   render();
   dispatchTemporaryPresentationStateChange(deps);
 };

--- a/src/components/commandLineScreen/commandLineScreen.store.js
+++ b/src/components/commandLineScreen/commandLineScreen.store.js
@@ -163,7 +163,7 @@ const getSelectedFormValue = (formValues, fallbackValues, fieldName) => {
     : fallbackValues[fieldName];
 };
 
-const form = {
+const baseForm = {
   fields: [
     {
       name: "transitionAnimationId",
@@ -194,63 +194,6 @@ const form = {
         { value: "persistent", label: "Persistent" },
       ],
     },
-    {
-      name: "opacity",
-      label: "Opacity",
-      type: "slider-with-input",
-      min: 0,
-      max: 1,
-      step: 0.01,
-    },
-    {
-      name: "blur",
-      label: "Blur",
-      type: "segmented-control",
-      clearable: false,
-      options: [
-        { value: false, label: "No Blur" },
-        { value: true, label: "Blur" },
-      ],
-    },
-    {
-      $when: "blur == true",
-      name: "blurX",
-      label: "Blur X",
-      type: "input-number",
-    },
-    {
-      $when: "blur == true",
-      name: "blurY",
-      label: "Blur Y",
-      type: "input-number",
-    },
-    {
-      $when: "blur == true",
-      name: "blurQuality",
-      label: "Quality",
-      type: "input-number",
-    },
-    {
-      $when: "blur == true",
-      name: "blurKernelSize",
-      label: "Kernel Size",
-      type: "select",
-      options: SCREEN_BLUR_KERNEL_SIZE_OPTIONS.map((value) => ({
-        value,
-        label: String(value),
-      })),
-    },
-    {
-      $when: "blur == true",
-      name: "blurRepeatEdgePixels",
-      label: "Repeat Edge Pixels",
-      type: "segmented-control",
-      clearable: false,
-      options: [
-        { value: false, label: "No" },
-        { value: true, label: "Yes" },
-      ],
-    },
   ],
   actions: {
     layout: "",
@@ -261,6 +204,10 @@ const form = {
 export const createInitialState = () => ({
   animations: createEmptyCollection(),
   formValues: {},
+  opacityOptionEnabled: false,
+  blurOptionEnabled: false,
+  blurOptionExplicit: false,
+  optionVisibilityInitialized: false,
 });
 
 export const setAnimations = ({ state }, { animations } = {}) => {
@@ -268,7 +215,62 @@ export const setAnimations = ({ state }, { animations } = {}) => {
 };
 
 export const setFormValues = ({ state }, { values } = {}) => {
-  state.formValues = normalizeScreenFormValues(values ?? {});
+  const nextValues = { ...values };
+  const includesBlur = hasFormValue(nextValues, "blur");
+
+  if (!includesBlur && state.blurOptionExplicit) {
+    nextValues.blur = state.blurOptionEnabled;
+  }
+
+  state.formValues = normalizeScreenFormValues(nextValues);
+};
+
+export const setScreenOptionVisibility = (
+  { state },
+  { blurEnabled, blurExplicit, opacityEnabled } = {},
+) => {
+  state.opacityOptionEnabled = opacityEnabled === true;
+  state.blurOptionEnabled = blurEnabled === true;
+  state.blurOptionExplicit = blurExplicit === true;
+  state.optionVisibilityInitialized = true;
+};
+
+export const showOpacityOption = ({ state }) => {
+  state.opacityOptionEnabled = true;
+  state.optionVisibilityInitialized = true;
+  state.formValues.opacity =
+    normalizeScreenOpacity(state.formValues.opacity) ?? DEFAULT_SCREEN_OPACITY;
+};
+
+export const removeOpacityOption = ({ state }) => {
+  state.opacityOptionEnabled = false;
+  state.optionVisibilityInitialized = true;
+  state.formValues.opacity = undefined;
+};
+
+export const selectOpacityOptionEnabled = ({ state }) => {
+  return state.opacityOptionEnabled;
+};
+
+export const showBlurOption = ({ state }) => {
+  state.blurOptionEnabled = true;
+  state.blurOptionExplicit = true;
+  state.optionVisibilityInitialized = true;
+  state.formValues = normalizeScreenFormValues({
+    ...state.formValues,
+    blur: true,
+  });
+};
+
+export const removeBlurOption = ({ state }) => {
+  state.blurOptionEnabled = false;
+  state.blurOptionExplicit = true;
+  state.optionVisibilityInitialized = true;
+  state.formValues.blur = false;
+};
+
+export const selectBlurOptionEnabled = ({ state }) => {
+  return state.blurOptionEnabled;
 };
 
 export const selectTransitionAnimationId = ({ state }) => {
@@ -286,11 +288,15 @@ export const selectAnimationPlaybackContinuity = ({ state }) => {
 };
 
 export const selectScreenOpacity = ({ state }) => {
+  if (!state.opacityOptionEnabled) {
+    return undefined;
+  }
+
   return normalizeScreenOpacity(state.formValues?.opacity);
 };
 
 export const selectScreenBlur = ({ state }) => {
-  if (!normalizeScreenBlurEnabled(state.formValues?.blur)) {
+  if (!state.blurOptionEnabled) {
     return undefined;
   }
 
@@ -304,11 +310,11 @@ export const selectScreenBlur = ({ state }) => {
 };
 
 export const selectScreenBlurActionValue = ({ state }) => {
-  if (normalizeScreenBlurEnabled(state.formValues?.blur)) {
+  if (state.blurOptionEnabled) {
     return selectScreenBlur({ state });
   }
 
-  if (hasFormValue(state.formValues, "blur")) {
+  if (state.blurOptionExplicit) {
     return null;
   }
 
@@ -324,18 +330,24 @@ export const selectViewData = ({ state, props, i18n }) => {
     propsFormValues,
     "transitionAnimationId",
   );
-  const selectedOpacity = normalizeScreenOpacity(
-    getSelectedFormValue(formValues, propsFormValues, "opacity"),
-  );
+  const opacityOptionVisible =
+    state.opacityOptionEnabled ||
+    (!state.optionVisibilityInitialized &&
+      propsFormValues.opacity !== undefined);
+  const selectedOpacity = opacityOptionVisible
+    ? normalizeScreenOpacity(
+        getSelectedFormValue(formValues, propsFormValues, "opacity"),
+      )
+    : undefined;
   const selectedPlaybackSpeed = normalizeAnimationPlaybackSpeed(
     getSelectedFormValue(formValues, propsFormValues, "playbackSpeed"),
   );
   const selectedPlaybackContinuity = normalizeAnimationPlaybackContinuity(
     getSelectedFormValue(formValues, propsFormValues, "playbackContinuity"),
   );
-  const selectedBlurEnabled = normalizeScreenBlurEnabled(
-    getSelectedFormValue(formValues, propsFormValues, "blur"),
-  );
+  const selectedBlurEnabled =
+    state.blurOptionEnabled ||
+    (!state.optionVisibilityInitialized && propsFormValues.blur === true);
   const selectedBlur = normalizeScreenBlur({
     x: getSelectedFormValue(formValues, propsFormValues, "blurX"),
     y: getSelectedFormValue(formValues, propsFormValues, "blurY"),
@@ -351,8 +363,9 @@ export const selectViewData = ({ state, props, i18n }) => {
       "blurRepeatEdgePixels",
     ),
   });
+  const blurOptionVisible = selectedBlurEnabled;
   const formKey =
-    selectedOpacity !== undefined || selectedBlurEnabled
+    opacityOptionVisible || blurOptionVisible
       ? [
           selectedAnimationId ?? "new-screen",
           selectedPlaybackSpeed,
@@ -366,6 +379,114 @@ export const selectViewData = ({ state, props, i18n }) => {
           selectedBlur.repeatEdgePixels ? "repeat-edge" : "no-repeat-edge",
         ].join(":")
       : (selectedAnimationId ?? "new-screen");
+
+  const optionFields = [];
+  if (opacityOptionVisible) {
+    optionFields.push({
+      type: "section",
+      id: "opacity",
+      label: "Opacity",
+      action: {
+        id: "remove",
+        icon: "x",
+        label: "Remove",
+      },
+      fields: [
+        {
+          name: "opacity",
+          type: "slider-with-input",
+          min: 0,
+          max: 1,
+          step: 0.01,
+        },
+      ],
+    });
+  }
+  if (blurOptionVisible) {
+    optionFields.push({
+      type: "section",
+      id: "blur",
+      label: "Blur",
+      action: {
+        id: "remove",
+        icon: "x",
+        label: "Remove",
+      },
+      fields: [
+        {
+          type: "row",
+          fields: [
+            {
+              name: "blurX",
+              label: "Blur X",
+              type: "input-number",
+              min: 0,
+              required: true,
+            },
+            {
+              name: "blurY",
+              label: "Blur Y",
+              type: "input-number",
+              min: 0,
+              required: true,
+            },
+          ],
+        },
+        {
+          type: "row",
+          fields: [
+            {
+              name: "blurQuality",
+              label: "Quality",
+              type: "input-number",
+              min: 1,
+              required: true,
+            },
+            {
+              name: "blurKernelSize",
+              label: "Kernel Size",
+              type: "select",
+              noClear: true,
+              required: true,
+              options: SCREEN_BLUR_KERNEL_SIZE_OPTIONS.map((value) => ({
+                value,
+                label: String(value),
+              })),
+            },
+          ],
+        },
+        {
+          name: "blurRepeatEdgePixels",
+          label: "Repeat Edge Pixels",
+          type: "segmented-control",
+          noClear: true,
+          options: [
+            { value: false, label: "No" },
+            { value: true, label: "Yes" },
+          ],
+        },
+      ],
+    });
+  }
+
+  const optionsSection = {
+    type: "section",
+    id: "options",
+    label: "Options",
+    fields: optionFields,
+  };
+  if (!opacityOptionVisible || !blurOptionVisible) {
+    optionsSection.action = {
+      id: "add",
+      icon: "plus",
+      label: "Add Option",
+    };
+  }
+
+  const form = {
+    ...baseForm,
+    fields: [...baseForm.fields, optionsSection],
+  };
 
   return {
     breadcrumb: localizeCommandLineBreadcrumb(

--- a/src/components/commandLineScreen/commandLineScreen.view.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.view.yaml
@@ -7,6 +7,8 @@ refs:
     eventListeners:
       form-change:
         handler: handleFormChange
+      form-section-action:
+        handler: handleOptionsSectionAction
   submitButton:
     eventListeners:
       click:
@@ -15,6 +17,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
@@ -17,6 +17,6 @@ template:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#transitionForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+              - rtgl-form#transitionForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
+++ b/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
@@ -16,6 +16,6 @@ template:
       - rtgl-view d=h g=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
+++ b/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
@@ -41,7 +41,7 @@ template:
       - $if mode == 'current':
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none: null
-              - rtgl-view g=md mt=md:
+              - rtgl-view g=md mt=md mb=120:
                   - rtgl-view#confirmActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
                       - rtgl-view d=v:
                           - rtgl-text s=sm: Confirm Actions

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -240,7 +240,7 @@ template:
                       - rtgl-view w=f:
                           - rtgl-text s=md: ${selectionHeading}
                           - rtgl-text s=sm c=mu-fg: ${selectionName}
-                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none: null
+                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none mb=120: null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'gallery':

--- a/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
+++ b/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
+++ b/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
+++ b/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
+++ b/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
@@ -15,6 +15,6 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineVoice/commandLineVoice.view.yaml
+++ b/src/components/commandLineVoice/commandLineVoice.view.yaml
@@ -190,7 +190,7 @@ template:
                   - rtgl-view w=f:
                       - rtgl-text s=md: ${selectionHeading}
                       - rtgl-text s=sm c=mu-fg: ${selectionName}
-                  - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none: null
+                  - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none mb=120: null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit
   - $if showAudioPlayer:

--- a/tests/animationPlayback/commandLineAnimationPlayback.test.js
+++ b/tests/animationPlayback/commandLineAnimationPlayback.test.js
@@ -64,6 +64,21 @@ import {
 } from "../../src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.store.js";
 import { EN_I18N } from "../support/i18n.js";
 
+const findFormField = (fields = [], name) => {
+  for (const field of fields) {
+    if (field.name === name) {
+      return field;
+    }
+
+    const nestedField = findFormField(field.fields, name);
+    if (nestedField) {
+      return nestedField;
+    }
+  }
+
+  return undefined;
+};
+
 const animations = {
   tree: [
     { id: "looping-update" },
@@ -288,19 +303,33 @@ describe("command line animation playback", () => {
       spriteAnimationPlaybackLoop: true,
       spriteAnimationPlaybackContinuity: "persistent",
     });
-    expect(
-      selectDialogueViewData({
-        state: dialogueState,
-        props: { animations, layouts: [], characters: [] },
-        i18n: EN_I18N,
-      }),
-    ).toMatchObject({
+    const dialogueViewData = selectDialogueViewData({
+      state: dialogueState,
+      props: { animations, layouts: [], characters: [] },
+      i18n: EN_I18N,
+    });
+    expect(dialogueViewData).toMatchObject({
       spriteAnimationCanLoop: true,
       spriteAnimationLoopDisabled: false,
-      animationPlaybackSpeedLabel: "Playback Speed",
-      animationPlaybackLoopLabel: "Loop",
-      animationPlaybackContinuityLabel: "Continuity",
     });
+    expect(
+      findFormField(
+        dialogueViewData.form.fields,
+        "spriteAnimationPlaybackSpeed",
+      ),
+    ).toMatchObject({ label: "Playback Speed", value: 2 });
+    expect(
+      findFormField(
+        dialogueViewData.form.fields,
+        "spriteAnimationPlaybackLoop",
+      ),
+    ).toMatchObject({ label: "Loop", value: true });
+    expect(
+      findFormField(
+        dialogueViewData.form.fields,
+        "spriteAnimationPlaybackContinuity",
+      ),
+    ).toMatchObject({ label: "Continuity", value: "persistent" });
 
     setSelectedResource(dialogueDeps, { resourceId: "dialogue-layout" });
     setSpriteCharacterId(dialogueDeps, { characterId: "character-1" });

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -9,18 +9,16 @@ import {
   handleCharacterSpriteMenuButtonClick,
   handleFormChange,
   handleFormSectionAction,
-  handlePersistSpriteChange,
-  handleSpeakerSpriteTooltipMouseEnter,
-  handleSpeakerSpriteTooltipMouseLeave,
+  handleRemoveCustomTextSpeedClick,
   handleSpriteGroupTabClick,
   handleSpriteItemClick,
   handleSubmitClick,
+  handleTextSpeedChange,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js";
 import {
   clearCharacterSprite,
   clearTempSelectedSpriteIds,
   createInitialState,
-  hideSpeakerSpriteTooltip,
   setAppendDialogue,
   setCharacterSpriteEnabled,
   setCharacterName,
@@ -56,7 +54,6 @@ import {
   selectSpriteSelectionConfirmState,
   selectSpriteSelectionState,
   showFullImagePreview,
-  showSpeakerSpriteTooltip,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
 import { EN_I18N } from "../support/i18n.js";
 
@@ -166,10 +163,6 @@ const createStore = (state) => ({
   setSearchQuery: (payload) => setSearchQuery({ state }, payload),
   setMode: (payload) => setMode({ state }, payload),
   showFullImagePreview: (payload) => showFullImagePreview({ state }, payload),
-  showSpeakerSpriteTooltip: (payload) =>
-    showSpeakerSpriteTooltip({ state }, payload),
-  hideSpeakerSpriteTooltip: (payload) =>
-    hideSpeakerSpriteTooltip({ state }, payload),
   setSpriteAnimationMode: (payload) =>
     setSpriteAnimationMode({ state }, payload),
   setSpriteAnimationId: (payload) =>
@@ -198,7 +191,7 @@ const createFormRefs = () => ({
 });
 
 describe("commandLineDialogueBox.handlers", () => {
-  it("renders an accessible speaker sprite tooltip trigger", () => {
+  it("renders the dialogue sprite content through the form slot", () => {
     const view = readFileSync(
       new URL(
         "../../src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml",
@@ -207,64 +200,33 @@ describe("commandLineDialogueBox.handlers", () => {
       "utf8",
     );
 
-    expect(view).toContain(
-      "button#speakerSpriteTooltip.commandLineDialogueBoxTooltipTrigger",
-    );
-    expect(view).toContain(
-      'aria-label="${speakerSpriteTooltipContent}"\': "?"',
-    );
-    expect(view).toContain("handler: handleSpeakerSpriteTooltipMouseEnter");
-    expect(view).toContain("handler: handleSpeakerSpriteTooltipMouseLeave");
-    expect(view).toContain("rtgl-tooltip ?open=${speakerSpriteTooltip.open}");
+    expect(view).toContain("rtgl-view slot=characterSprite g=md w=f");
+    expect(view).not.toContain("speakerSpriteTooltip");
+    expect(view).not.toContain("commandLineDialogueBoxTooltipTrigger");
     expect(view).toContain("handler: handleCharacterSpriteBoxContextMenu");
     expect(view).not.toContain("addSpeakerSpriteButton");
     expect(view).toContain("handler: handleCharacterSpriteBoxClick");
     expect(view).toContain("form-section-action:");
     expect(view).toContain("handler: handleFormSectionAction");
+    expect(view).toContain("rtgl-button#removeCustomTextSpeedButton");
+    expect(view).toContain("handler: handleRemoveCustomTextSpeedClick");
+    expect(view).toContain("rtgl-slider-input#textSpeed");
+    expect(view).toContain("handler: handleTextSpeedChange");
     expect(view).toContain("rtgl-form#dialogueForm");
-    expect(view).toContain("w=f p=none:");
+    expect(view).toContain("w=f p=none mb=120:");
     expect(view).toContain(
       "rtgl-button#characterSpriteMenuButton sq s=sm v=gh pre=ellipsis",
     );
     expect(view).toContain("aria-haspopup=menu': null");
     expect(view).toContain("handler: handleCharacterSpriteMenuButtonClick");
     expect(view).not.toContain("clearCharacterSpriteButton");
-    expect(view).toContain("rtgl-segmented-control#persistSprite");
-    expect(
-      view.indexOf("rtgl-segmented-control#persistSprite"),
-    ).toBeGreaterThan(view.indexOf("rtgl-select#transitionAnimation"));
-  });
-
-  it("shows and hides the speaker sprite tooltip", () => {
-    const state = createInitialState();
-    const render = vi.fn();
-    const deps = {
-      store: createStore(state),
-      render,
-    };
-
-    handleSpeakerSpriteTooltipMouseEnter(deps, {
-      _event: {
-        currentTarget: {
-          getBoundingClientRect: () => ({
-            left: 100,
-            top: 80,
-            width: 16,
-          }),
-        },
-      },
-    });
-
-    expect(state.speakerSpriteTooltip).toEqual({
-      open: true,
-      x: 108,
-      y: 72,
-    });
-
-    handleSpeakerSpriteTooltipMouseLeave(deps);
-
-    expect(state.speakerSpriteTooltip.open).toBe(false);
-    expect(render).toHaveBeenCalledTimes(2);
+    expect(view).not.toContain("rtgl-select#transform");
+    expect(view).not.toContain("rtgl-select#animation");
+    expect(view).not.toContain("rtgl-slider-input#animationPlaybackSpeed");
+    expect(view).not.toContain("rtgl-segmented-control#persistSprite");
+    expect(view).not.toContain("rtgl-segmented-control#animationMode");
+    expect(view).not.toContain("rtgl-select#updateAnimation");
+    expect(view).not.toContain("rtgl-select#transitionAnimation");
   });
 
   it("hydrates persistCharacter and custom character name from props into the form state", () => {
@@ -522,8 +484,21 @@ describe("commandLineDialogueBox.handlers", () => {
     };
 
     handleBeforeMount(deps);
-    handlePersistSpriteChange(deps, {
-      _event: { detail: { value: false } },
+    handleFormChange(deps, {
+      _event: {
+        detail: {
+          values: {
+            resourceId: "layout-adv",
+            characterId: "character-1",
+            customCharacterName: false,
+            persistCharacter: true,
+            persistSprite: false,
+            spriteTransformId: "portrait-left",
+            spriteAnimationId: "",
+            append: false,
+          },
+        },
+      },
     });
     handleSubmitClick(deps);
 
@@ -618,41 +593,58 @@ describe("commandLineDialogueBox.handlers", () => {
     });
   });
 
-  it("removes custom text speed from the Options section action", async () => {
+  it("updates custom text speed from the slotted slider", () => {
     const state = createInitialState();
     const render = vi.fn();
-    const refs = createFormRefs();
-    const showDropdownMenu = vi.fn();
     const dispatchEvent = vi.fn();
     setCustomizeTextSpeed({ state }, { customizeTextSpeed: true });
-    setTextSpeed({ state }, { textSpeed: 42 });
 
-    await handleFormSectionAction(
+    handleTextSpeedChange(
       {
-        appService: { showDropdownMenu },
-        i18n: EN_I18N,
         props: {
           layouts,
           characters,
           dialogue: { content: [{ text: "Line text" }] },
         },
-        refs,
         render,
         store: createStore(state),
         dispatchEvent,
       },
       {
         _event: {
-          detail: {
-            sectionId: "options",
-            actionId: "remove-custom-text-speed",
-            position: { x: 120, y: 64 },
-          },
+          detail: { value: 42 },
         },
       },
     );
 
-    expect(showDropdownMenu).not.toHaveBeenCalled();
+    expect(state.textSpeed).toBe(42);
+    expect(render).toHaveBeenCalledOnce();
+    expect(
+      dispatchEvent.mock.calls[0][0].detail.presentationState.dialogue,
+    ).toMatchObject({ textSpeed: 42 });
+  });
+
+  it("removes custom text speed from its field action", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const refs = createFormRefs();
+    const dispatchEvent = vi.fn();
+    setCustomizeTextSpeed({ state }, { customizeTextSpeed: true });
+    setTextSpeed({ state }, { textSpeed: 42 });
+
+    handleRemoveCustomTextSpeedClick({
+      i18n: EN_I18N,
+      props: {
+        layouts,
+        characters,
+        dialogue: { content: [{ text: "Line text" }] },
+      },
+      refs,
+      render,
+      store: createStore(state),
+      dispatchEvent,
+    });
+
     expect(state.customizeTextSpeed).toBe(false);
     expect(state.textSpeed).toBe(42);
     expect(render).toHaveBeenCalledOnce();
@@ -1705,9 +1697,10 @@ describe("commandLineDialogueBox.handlers", () => {
     });
   });
 
-  it("updates sprite persistence from the sprite configuration panel", () => {
+  it("updates sprite configuration from the standard form rows", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();
+    const refs = createFormRefs();
     const render = vi.fn();
 
     setSelectedMode({ state }, { mode: "adv" });
@@ -1723,13 +1716,15 @@ describe("commandLineDialogueBox.handlers", () => {
       },
     );
 
-    handlePersistSpriteChange(
+    handleFormChange(
       {
         props: {
           layouts,
           characters,
           transforms,
+          animations,
         },
+        refs,
         store: createStore(state),
         dispatchEvent,
         render,
@@ -1737,18 +1732,107 @@ describe("commandLineDialogueBox.handlers", () => {
       {
         _event: {
           detail: {
-            value: false,
+            values: {
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: false,
+              persistCharacter: false,
+              persistSprite: false,
+              spriteTransformId: "portrait-left",
+              spriteAnimationId: "portrait-in",
+              spriteAnimationPlaybackSpeed: 1.5,
+              spriteAnimationPlaybackContinuity: "persistent",
+              append: false,
+            },
           },
         },
       },
     );
 
     expect(state.persistSprite).toBe(false);
+    expect(state.spriteTransformId).toBe("portrait-left");
+    expect(state.spriteAnimationId).toBe("portrait-in");
+    expect(state.spriteAnimationMode).toBe("transition");
+    expect(state.spriteAnimationPlaybackSpeed).toBe(1.5);
+    expect(state.spriteAnimationPlaybackContinuity).toBe("persistent");
     expect(render).toHaveBeenCalledTimes(1);
     expect(
       dispatchEvent.mock.calls[0][0].detail.presentationState.dialogue,
     ).toMatchObject({
       persistSprite: false,
+      character: {
+        sprite: {
+          transformId: "portrait-left",
+          animations: {
+            resourceId: "portrait-in",
+            playback: {
+              speed: 1.5,
+              continuity: "persistent",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("seeds playback defaults when selecting an animation", () => {
+    const state = createInitialState();
+    const refs = createFormRefs();
+    const render = vi.fn();
+
+    setSelectedMode({ state }, { mode: "adv" });
+    setSelectedResource({ state }, { resourceId: "layout-adv" });
+    setSpriteCharacterId({ state }, { characterId: "character-1" });
+    setSpriteTransformId({ state }, { transformId: "portrait-left" });
+    setSelectedSpriteIds(
+      { state },
+      {
+        spriteIdsByGroupId: {
+          body: "sprite-body",
+        },
+      },
+    );
+
+    handleFormChange(
+      {
+        props: {
+          layouts,
+          characters,
+          transforms,
+          animations,
+        },
+        refs,
+        store: createStore(state),
+        dispatchEvent: vi.fn(),
+        render,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: false,
+              persistCharacter: false,
+              persistSprite: true,
+              spriteTransformId: "portrait-left",
+              spriteAnimationId: "portrait-in",
+              append: false,
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.spriteAnimationPlaybackSpeed).toBe(1);
+    expect(state.spriteAnimationPlaybackContinuity).toBe("render");
+    expect(refs.dialogueForm.reset).toHaveBeenCalledOnce();
+    expect(refs.dialogueForm.setValues).toHaveBeenCalledWith({
+      values: expect.objectContaining({
+        spriteAnimationId: "portrait-in",
+        spriteAnimationPlaybackSpeed: 1,
+        spriteAnimationPlaybackContinuity: "render",
+      }),
     });
   });
 

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.store.test.js
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { parseAndRender } from "jempl";
 import {
   createInitialState,
-  hideSpeakerSpriteTooltip,
   setAppendDialogue,
   setCharacterName,
   setCustomCharacterName,
@@ -16,7 +15,6 @@ import {
   setSpriteTransformId,
   setCustomizeTextSpeed,
   setTextSpeed,
-  showSpeakerSpriteTooltip,
 } from "../../src/components/commandLineDialogueBox/commandLineDialogueBox.store.js";
 import { EN_I18N, JA_I18N, ZH_HANS_I18N } from "../support/i18n.js";
 
@@ -128,26 +126,24 @@ describe("commandLineDialogueBox.store", () => {
       (field) => field.slot === "characterSprite",
     );
     expect(characterSpriteField).toEqual({
-      $when: "values.characterSpriteEnabled == true",
+      label: "Dialogue sprite",
+      name: "characterSprite",
       slot: "characterSprite",
+      tooltip: {
+        content:
+          "Speaker's face that appears on top of the dialogue box. For body sprites use the Character Sprites action",
+      },
       type: "slot",
+    });
+    const characterSpriteRow = viewData.form.fields[1].fields.find((field) => {
+      return field.fields?.includes(characterSpriteField);
     });
     expect(
       isFieldVisible({
-        field: characterSpriteField,
+        field: characterSpriteRow,
         values: viewData.defaultValues,
       }),
     ).toBe(false);
-    expect(viewData).toMatchObject({
-      speakerSpriteLabel: "Dialogue sprite",
-      speakerSpriteTooltip: {
-        open: false,
-        x: 0,
-        y: 0,
-      },
-      speakerSpriteTooltipContent:
-        "Speaker's face that appears on top of the dialogue box. For body sprites use the Character Sprites action",
-    });
     expect(
       findFormField(viewData, (field) => field.name === "append"),
     ).toMatchObject({
@@ -194,7 +190,7 @@ describe("commandLineDialogueBox.store", () => {
     const speakerFields = viewData.form.fields[1].fields;
     expect(
       speakerFields.map((field) => field.name ?? field.slot ?? field.type),
-    ).toEqual(["row", "row", "characterSprite"]);
+    ).toEqual(["row", "row", "row", "row", "row", "row"]);
     expect(
       speakerFields.map((field) =>
         field.type === "row"
@@ -206,13 +202,14 @@ describe("commandLineDialogueBox.store", () => {
     ).toEqual([
       ["characterId", "persistCharacter", "persistCharacterSpacer"],
       ["customCharacterName", "characterName", "characterNameSpacer"],
-      "characterSprite",
+      ["characterSprite", "persistSprite"],
+      ["spriteTransformId", "spriteAnimationId"],
+      ["spriteAnimationPlaybackSpeed", "spriteAnimationPlaybackContinuity"],
+      ["spriteAnimationPlaybackLoop", "spriteAnimationPlaybackLoopSpacer"],
     ]);
-    expect(viewData.form.fields[2].fields.map((field) => field.name)).toEqual([
-      "textSpeed",
-      "append",
-      "clearPage",
-    ]);
+    expect(
+      viewData.form.fields[2].fields.map((field) => field.name ?? field.slot),
+    ).toEqual(["append", "textSpeed", "clearPage"]);
   });
 
   it("reserves right-hand columns while optional Speaker fields are hidden", () => {
@@ -402,7 +399,7 @@ describe("commandLineDialogueBox.store", () => {
 
     const textSpeedField = findFormField(
       viewData,
-      (field) => field.name === "textSpeed",
+      (field) => field.slot === "textSpeed",
     );
 
     expect(viewData.customizeTextSpeed).toBe(false);
@@ -419,13 +416,13 @@ describe("commandLineDialogueBox.store", () => {
     });
     expect(textSpeedField).toMatchObject({
       $when: "values.customizeTextSpeed == true",
-      label: "Text Speed",
-      type: "slider-with-input",
-      min: 0,
-      max: 100,
-      step: 1,
-      value: 75,
+      slot: "textSpeed",
+      type: "slot",
     });
+    expect(viewData.textSpeedLabel).toBe("Text Speed");
+    expect(viewData.removeCustomTextSpeedLabel).toBe(
+      "Remove custom text speed",
+    );
     expect(
       isFieldVisible({
         field: textSpeedField,
@@ -454,11 +451,7 @@ describe("commandLineDialogueBox.store", () => {
       },
     });
 
-    expect(customizedViewData.form.fields[2].action).toEqual({
-      id: "remove-custom-text-speed",
-      icon: "x",
-      label: "Remove custom text speed",
-    });
+    expect(customizedViewData.form.fields[2].action).toBeUndefined();
   });
 
   it("normalizes text speed values to the supported 0 to 100 range", () => {
@@ -564,9 +557,29 @@ describe("commandLineDialogueBox.store", () => {
         ],
       },
     });
+    let spriteRow = viewData.form.fields[1].fields.find((field) => {
+      return field.fields?.some((nestedField) => {
+        return nestedField.slot === "characterSprite";
+      });
+    });
+    expect(spriteRow).toMatchObject({
+      $when: "values.characterSpriteEnabled == true",
+      type: "row",
+    });
+    expect(
+      isFieldVisible({ field: spriteRow, values: viewData.defaultValues }),
+    ).toBe(false);
     expect(
       findFormField(viewData, (field) => field.name === "persistSprite"),
-    ).toBeUndefined();
+    ).toMatchObject({
+      label: "Persist Sprite",
+      type: "segmented-control",
+      options: [
+        { value: true, label: "Yes" },
+        { value: false, label: "No" },
+      ],
+      value: false,
+    });
     expect(
       findFormField(
         viewData,
@@ -601,14 +614,18 @@ describe("commandLineDialogueBox.store", () => {
         (field) => field.name === "removePersistedSprite",
       ),
     ).toBeUndefined();
-    expect(viewData).toMatchObject({
-      persistSprite: true,
-      persistSpriteLabel: "Persist Sprite",
-      persistSpriteOptions: [
-        { value: true, label: "Yes" },
-        { value: false, label: "No" },
-      ],
+    spriteRow = viewData.form.fields[1].fields.find((field) => {
+      return field.fields?.some((nestedField) => {
+        return nestedField.slot === "characterSprite";
+      });
     });
+    expect(
+      isFieldVisible({ field: spriteRow, values: viewData.defaultValues }),
+    ).toBe(true);
+    expect(viewData.persistSprite).toBe(true);
+    expect(
+      findFormField(viewData, (field) => field.name === "persistSprite"),
+    ).toMatchObject({ value: true });
   });
 
   it("preserves an explicit persistence choice when sprite layers change", () => {
@@ -723,7 +740,7 @@ describe("commandLineDialogueBox.store", () => {
           },
         },
         animations: {
-          tree: [{ id: "portrait-in" }],
+          tree: [{ id: "portrait-in" }, { id: "portrait-pulse" }],
           items: {
             "portrait-in": {
               id: "portrait-in",
@@ -733,27 +750,74 @@ describe("commandLineDialogueBox.store", () => {
                 type: "transition",
               },
             },
+            "portrait-pulse": {
+              id: "portrait-pulse",
+              type: "animation",
+              name: "Portrait Pulse",
+              animation: {
+                type: "update",
+              },
+            },
           },
         },
       },
     });
 
-    expect(
-      findFormField(viewData, (field) => field.slot === "characterSprite"),
-    ).toMatchObject({
+    const speakerFields = viewData.form.fields[1].fields;
+    const spriteRow = speakerFields.find((field) => {
+      return field.fields?.some((nestedField) => {
+        return nestedField.slot === "characterSprite";
+      });
+    });
+    expect(spriteRow).toMatchObject({
       $when: "values.characterSpriteEnabled == true",
-      slot: "characterSprite",
-      type: "slot",
+      type: "row",
+    });
+    expect(spriteRow.fields.map((field) => field.name ?? field.slot)).toEqual([
+      "characterSprite",
+      "persistSprite",
+    ]);
+    const transformAnimationRow = speakerFields.find((field) => {
+      return field.fields?.some((nestedField) => {
+        return nestedField.name === "spriteTransformId";
+      });
+    });
+    expect(transformAnimationRow.fields.map((field) => field.name)).toEqual([
+      "spriteTransformId",
+      "spriteAnimationId",
+    ]);
+    const playbackRow = speakerFields.find((field) => {
+      return field.fields?.some((nestedField) => {
+        return nestedField.name === "spriteAnimationPlaybackSpeed";
+      });
+    });
+    expect(playbackRow.fields.map((field) => field.name)).toEqual([
+      "spriteAnimationPlaybackSpeed",
+      "spriteAnimationPlaybackContinuity",
+    ]);
+    expect(playbackRow.fields[0]).toMatchObject({
+      label: "Playback Speed",
+      type: "slider-with-input",
+      min: 0.01,
+      max: 4,
+      step: 0.01,
+      value: 1,
+    });
+    expect(playbackRow.fields[1]).toMatchObject({
+      label: "Continuity",
+      type: "segmented-control",
+      value: "render",
+      options: [
+        { value: "render", label: "Single Line" },
+        { value: "persistent", label: "Persistent" },
+      ],
     });
     expect(viewData.hasSpriteCharacter).toBe(true);
     expect(viewData.characterSpriteEnabled).toBe(true);
     expect(viewData.form.fields[1].action).toBeUndefined();
     expect(
       isFieldVisible({
-        field: findFormField(
-          viewData,
-          (field) => field.slot === "characterSprite",
-        ),
+        field: spriteRow,
         values: viewData.defaultValues,
       }),
     ).toBe(true);
@@ -761,11 +825,26 @@ describe("commandLineDialogueBox.store", () => {
     expect(viewData.spriteTransformId).toBe("portrait-left");
     expect(viewData.spriteAnimationMode).toBe("transition");
     expect(viewData.spriteAnimationId).toBe("portrait-in");
-    expect(viewData.transformOptions).toEqual([
+    expect(transformAnimationRow.fields[0].options).toEqual([
       { value: "portrait-left", label: "Portrait Left" },
     ]);
-    expect(viewData.transitionAnimationOptions).toEqual([
-      { value: "portrait-in", label: "Portrait In" },
+    expect(transformAnimationRow.fields[1]).toMatchObject({
+      label: "Animation",
+      type: "select",
+      clearable: true,
+      placeholder: "Select animation",
+    });
+    expect(transformAnimationRow.fields[1].options).toEqual([
+      {
+        value: "portrait-in",
+        label: "Portrait In",
+        suffixText: "Transition",
+      },
+      {
+        value: "portrait-pulse",
+        label: "Portrait Pulse",
+        suffixText: "Update",
+      },
     ]);
     expect(viewData.selectedSpriteCharacter).toMatchObject({
       id: "character-1",
@@ -788,30 +867,39 @@ describe("commandLineDialogueBox.store", () => {
     });
   });
 
-  it("clears the selected sprite animation when animation mode changes", () => {
+  it("derives animation mode from the selected animation and clears it", () => {
     const state = createInitialState();
+    const animations = {
+      tree: [{ id: "portrait-update" }, { id: "portrait-transition" }],
+      items: {
+        "portrait-update": {
+          id: "portrait-update",
+          type: "animation",
+          animation: { type: "update" },
+        },
+        "portrait-transition": {
+          id: "portrait-transition",
+          type: "animation",
+          animation: { type: "transition" },
+        },
+      },
+    };
 
-    setSpriteAnimationMode({ state }, { mode: "update" });
-    setSpriteAnimationId({ state }, { animationId: "portrait-update" });
-    setSpriteAnimationMode({ state }, { mode: "transition" });
+    setSpriteAnimationId(
+      { state, props: { animations } },
+      { animationId: "portrait-update" },
+    );
+    expect(state.spriteAnimationMode).toBe("update");
 
+    setSpriteAnimationId(
+      { state, props: { animations } },
+      { animationId: "portrait-transition" },
+    );
     expect(state.spriteAnimationMode).toBe("transition");
+    expect(state.spriteAnimationId).toBe("portrait-transition");
+
+    setSpriteAnimationId({ state, props: { animations } }, {});
+    expect(state.spriteAnimationMode).toBe("none");
     expect(state.spriteAnimationId).toBe("");
-  });
-
-  it("tracks the speaker sprite tooltip position and visibility", () => {
-    const state = createInitialState();
-
-    showSpeakerSpriteTooltip({ state }, { x: 120, y: 64 });
-
-    expect(state.speakerSpriteTooltip).toEqual({
-      open: true,
-      x: 120,
-      y: 64,
-    });
-
-    hideSpeakerSpriteTooltip({ state });
-
-    expect(state.speakerSpriteTooltip.open).toBe(false);
   });
 });

--- a/tests/commandLineScreen/commandLineScreen.handlers.test.js
+++ b/tests/commandLineScreen/commandLineScreen.handlers.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createInitialState,
+  removeBlurOption,
+  removeOpacityOption,
+  selectBlurOptionEnabled,
+  selectOpacityOptionEnabled,
   selectAnimationPlaybackContinuity,
   selectAnimationPlaybackSpeed,
   selectScreenBlur,
@@ -8,13 +12,22 @@ import {
   selectScreenOpacity,
   selectTransitionAnimationId,
   setFormValues,
+  setScreenOptionVisibility,
+  showBlurOption,
+  showOpacityOption,
 } from "../../src/components/commandLineScreen/commandLineScreen.store.js";
 import {
   handleFormChange,
+  handleOptionsSectionAction,
   handleSubmitClick,
 } from "../../src/components/commandLineScreen/commandLineScreen.handlers.js";
+import { EN_I18N } from "../support/i18n.js";
 
 const createStoreApi = (state) => ({
+  removeBlurOption: () => removeBlurOption({ state }),
+  removeOpacityOption: () => removeOpacityOption({ state }),
+  selectBlurOptionEnabled: () => selectBlurOptionEnabled({ state }),
+  selectOpacityOptionEnabled: () => selectOpacityOptionEnabled({ state }),
   selectAnimationPlaybackContinuity: () =>
     selectAnimationPlaybackContinuity({ state }),
   selectAnimationPlaybackSpeed: () => selectAnimationPlaybackSpeed({ state }),
@@ -23,6 +36,10 @@ const createStoreApi = (state) => ({
   selectScreenOpacity: () => selectScreenOpacity({ state }),
   selectTransitionAnimationId: () => selectTransitionAnimationId({ state }),
   setFormValues: (payload) => setFormValues({ state }, payload),
+  setScreenOptionVisibility: (payload) =>
+    setScreenOptionVisibility({ state }, payload),
+  showBlurOption: () => showBlurOption({ state }),
+  showOpacityOption: () => showOpacityOption({ state }),
 });
 
 describe("commandLineScreen.handlers", () => {
@@ -30,6 +47,10 @@ describe("commandLineScreen.handlers", () => {
     const state = createInitialState();
     const render = vi.fn();
     const dispatchEvent = vi.fn();
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: true, blurEnabled: true, blurExplicit: true },
+    );
 
     handleFormChange(
       {
@@ -83,6 +104,154 @@ describe("commandLineScreen.handlers", () => {
     });
   });
 
+  it("does not enable hidden options when the form includes their defaults", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: false, blurEnabled: false, blurExplicit: false },
+    );
+
+    handleFormChange(
+      {
+        dispatchEvent,
+        render,
+        store: createStoreApi(state),
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              transitionAnimationId: "screen-crossfade",
+              opacity: 1,
+              blur: false,
+              blurX: 6,
+              blurY: 9,
+              blurQuality: 3,
+              blurKernelSize: 9,
+              blurRepeatEdgePixels: true,
+            },
+          },
+        },
+      },
+    );
+
+    expect(selectOpacityOptionEnabled({ state })).toBe(false);
+    expect(selectBlurOptionEnabled({ state })).toBe(false);
+    expect(dispatchEvent.mock.calls[0][0].detail.presentationState).toEqual({
+      screen: {
+        animations: {
+          resourceId: "screen-crossfade",
+          playback: { continuity: "render", speed: 1 },
+        },
+      },
+    });
+  });
+
+  it("adds screen options from the Options section menu", async () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const showDropdownMenu = vi
+      .fn()
+      .mockResolvedValueOnce({ item: { key: "opacity" } })
+      .mockResolvedValueOnce({ item: { key: "blur" } });
+    const deps = {
+      appService: { showDropdownMenu },
+      dispatchEvent,
+      i18n: EN_I18N,
+      render,
+      store: createStoreApi(state),
+    };
+    const payload = {
+      _event: {
+        detail: {
+          sectionId: "options",
+          actionId: "add",
+          position: { x: 120, y: 240 },
+        },
+      },
+    };
+
+    await handleOptionsSectionAction(deps, payload);
+
+    expect(showDropdownMenu).toHaveBeenNthCalledWith(1, {
+      items: [
+        { type: "item", label: "Opacity", key: "opacity" },
+        { type: "item", label: "Blur", key: "blur" },
+      ],
+      x: 120,
+      y: 240,
+      place: "be",
+    });
+    expect(selectOpacityOptionEnabled({ state })).toBe(true);
+    expect(dispatchEvent.mock.calls[0][0].detail.presentationState).toEqual({
+      screen: { opacity: 1 },
+    });
+
+    await handleOptionsSectionAction(deps, payload);
+
+    expect(showDropdownMenu).toHaveBeenNthCalledWith(2, {
+      items: [{ type: "item", label: "Blur", key: "blur" }],
+      x: 120,
+      y: 240,
+      place: "be",
+    });
+    expect(selectBlurOptionEnabled({ state })).toBe(true);
+    expect(dispatchEvent.mock.calls[1][0].detail.presentationState).toEqual({
+      screen: {
+        opacity: 1,
+        blur: {
+          x: 6,
+          y: 9,
+          quality: 3,
+          kernelSize: 9,
+          repeatEdgePixels: true,
+        },
+      },
+    });
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("removes opacity and blur from their option section actions", async () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    showOpacityOption({ state });
+    showBlurOption({ state });
+    const deps = {
+      dispatchEvent,
+      render,
+      store: createStoreApi(state),
+    };
+
+    await handleOptionsSectionAction(deps, {
+      _event: { detail: { sectionId: "opacity", actionId: "remove" } },
+    });
+    await handleOptionsSectionAction(deps, {
+      _event: { detail: { sectionId: "blur", actionId: "remove" } },
+    });
+
+    expect(selectOpacityOptionEnabled({ state })).toBe(false);
+    expect(selectBlurOptionEnabled({ state })).toBe(false);
+    expect(dispatchEvent.mock.calls[0][0].detail.presentationState).toEqual({
+      screen: {
+        blur: {
+          x: 6,
+          y: 9,
+          quality: 3,
+          kernelSize: 9,
+          repeatEdgePixels: true,
+        },
+      },
+    });
+    expect(dispatchEvent.mock.calls[1][0].detail.presentationState).toEqual({
+      screen: { blur: null },
+    });
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
   it("submits a screen animation payload", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();
@@ -121,6 +290,10 @@ describe("commandLineScreen.handlers", () => {
   it("submits screen opacity and blur without requiring an animation", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: true, blurEnabled: true, blurExplicit: true },
+    );
 
     setFormValues(
       { state },
@@ -163,6 +336,10 @@ describe("commandLineScreen.handlers", () => {
   it("omits screen opacity and clears blur when disabled", () => {
     const state = createInitialState();
     const dispatchEvent = vi.fn();
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: false, blurEnabled: false, blurExplicit: true },
+    );
 
     setFormValues(
       { state },

--- a/tests/commandLineScreen/commandLineScreen.store.test.js
+++ b/tests/commandLineScreen/commandLineScreen.store.test.js
@@ -1,19 +1,51 @@
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  removeBlurOption,
+  removeOpacityOption,
+  selectBlurOptionEnabled,
+  selectOpacityOptionEnabled,
   selectScreenBlur,
   selectScreenBlurActionValue,
   selectScreenOpacity,
   selectViewData,
   setAnimations,
   setFormValues,
+  setScreenOptionVisibility,
+  showBlurOption,
+  showOpacityOption,
 } from "../../src/components/commandLineScreen/commandLineScreen.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const DEFAULT_EXPECTED_BLUR = {
+  x: 6,
+  y: 9,
+  quality: 3,
+  kernelSize: 9,
+  repeatEdgePixels: true,
+};
+
+const findFormField = (fields, predicate) => {
+  for (const field of fields) {
+    if (predicate(field)) {
+      return field;
+    }
+    if (field.fields) {
+      const nestedField = findFormField(field.fields, predicate);
+      if (nestedField) {
+        return nestedField;
+      }
+    }
+  }
+  return undefined;
+};
 
 describe("commandLineScreen.store", () => {
   it("uses the current screen animation as the initial form value", () => {
     const state = createInitialState();
 
     const viewData = selectViewData({
+      i18n: EN_I18N,
       state,
       props: {
         screen: {
@@ -36,51 +68,17 @@ describe("commandLineScreen.store", () => {
       }),
     );
     expect(viewData.form.fields[0].required).toBeUndefined();
-    expect(
-      viewData.form.fields.find((field) => field.name === "opacity"),
-    ).toEqual(
-      expect.objectContaining({
-        label: "Opacity",
-        type: "slider-with-input",
-        min: 0,
-        max: 1,
-        step: 0.01,
-      }),
-    );
-    expect(viewData.form.fields.find((field) => field.name === "blur")).toEqual(
-      expect.objectContaining({
-        label: "Blur",
-        type: "segmented-control",
-        clearable: false,
-        options: [
-          {
-            value: false,
-            label: "No Blur",
-          },
-          {
-            value: true,
-            label: "Blur",
-          },
-        ],
-      }),
-    );
-    expect(
-      viewData.form.fields.find((field) => field.name === "blurKernelSize"),
-    ).toEqual(
-      expect.objectContaining({
-        $when: "blur == true",
-        label: "Kernel Size",
-        type: "select",
-        options: [
-          { value: 5, label: "5" },
-          { value: 7, label: "7" },
-          { value: 9, label: "9" },
-          { value: 11, label: "11" },
-          { value: 13, label: "13" },
-          { value: 15, label: "15" },
-        ],
-      }),
-    );
+    expect(viewData.form.fields.at(-1)).toEqual({
+      type: "section",
+      id: "options",
+      label: "Options",
+      action: {
+        id: "add",
+        icon: "plus",
+        label: "Add Option",
+      },
+      fields: [],
+    });
     expect(viewData.defaultValues.opacity).toBe(1);
     expect(viewData.defaultValues.blur).toBe(false);
     expect(viewData.defaultValues.blurX).toBe(6);
@@ -128,7 +126,7 @@ describe("commandLineScreen.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state, props: {} });
+    const viewData = selectViewData({ state, i18n: EN_I18N, props: {} });
 
     expect(viewData.context.transitionAnimationOptions).toEqual([
       {
@@ -153,6 +151,7 @@ describe("commandLineScreen.store", () => {
     );
 
     const viewData = selectViewData({
+      i18n: EN_I18N,
       state,
       props: {
         screen: {
@@ -169,6 +168,10 @@ describe("commandLineScreen.store", () => {
   it("uses selected screen opacity and blur values", () => {
     const state = createInitialState();
 
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: true, blurEnabled: true, blurExplicit: true },
+    );
     setFormValues(
       { state },
       {
@@ -185,7 +188,7 @@ describe("commandLineScreen.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state, props: {} });
+    const viewData = selectViewData({ state, i18n: EN_I18N, props: {} });
 
     expect(viewData.defaultValues.opacity).toBe(0.45);
     expect(viewData.defaultValues.blur).toBe(true);
@@ -202,12 +205,79 @@ describe("commandLineScreen.store", () => {
       kernelSize: 11,
       repeatEdgePixels: false,
     });
+
+    const optionsSection = viewData.form.fields.at(-1);
+    expect(optionsSection.action).toBeUndefined();
+    expect(optionsSection.fields.map((field) => field.id)).toEqual([
+      "opacity",
+      "blur",
+    ]);
+    expect(optionsSection.fields[0]).toMatchObject({
+      type: "section",
+      id: "opacity",
+      label: "Opacity",
+      action: { id: "remove", icon: "x", label: "Remove" },
+      fields: [
+        {
+          name: "opacity",
+          type: "slider-with-input",
+          min: 0,
+          max: 1,
+          step: 0.01,
+        },
+      ],
+    });
+    expect(optionsSection.fields[1]).toMatchObject({
+      type: "section",
+      id: "blur",
+      label: "Blur",
+      action: { id: "remove", icon: "x", label: "Remove" },
+    });
+    expect(
+      findFormField(optionsSection.fields, (field) => {
+        return field.name === "blurKernelSize";
+      }),
+    ).toEqual({
+      name: "blurKernelSize",
+      label: "Kernel Size",
+      type: "select",
+      noClear: true,
+      required: true,
+      options: [
+        { value: 5, label: "5" },
+        { value: 7, label: "7" },
+        { value: 9, label: "9" },
+        { value: 11, label: "11" },
+        { value: 13, label: "13" },
+        { value: 15, label: "15" },
+      ],
+    });
+  });
+
+  it("adds and removes screen options independently", () => {
+    const state = createInitialState();
+
+    showOpacityOption({ state });
+    expect(selectOpacityOptionEnabled({ state })).toBe(true);
+    expect(selectScreenOpacity({ state })).toBe(1);
+
+    showBlurOption({ state });
+    expect(selectBlurOptionEnabled({ state })).toBe(true);
+    expect(selectScreenBlur({ state })).toEqual(DEFAULT_EXPECTED_BLUR);
+
+    removeOpacityOption({ state });
+    removeBlurOption({ state });
+    expect(selectOpacityOptionEnabled({ state })).toBe(false);
+    expect(selectScreenOpacity({ state })).toBeUndefined();
+    expect(selectBlurOptionEnabled({ state })).toBe(false);
+    expect(selectScreenBlurActionValue({ state })).toBeNull();
   });
 
   it("uses screen effect props before form values are set", () => {
     const state = createInitialState();
 
     const viewData = selectViewData({
+      i18n: EN_I18N,
       state,
       props: {
         screen: {
@@ -238,6 +308,10 @@ describe("commandLineScreen.store", () => {
   it("uses screen blur null props as an explicit clear value", () => {
     const state = createInitialState();
 
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: false, blurEnabled: false, blurExplicit: true },
+    );
     setFormValues(
       { state },
       {
@@ -248,6 +322,7 @@ describe("commandLineScreen.store", () => {
     );
 
     const viewData = selectViewData({
+      i18n: EN_I18N,
       state,
       props: {
         screen: {
@@ -263,6 +338,10 @@ describe("commandLineScreen.store", () => {
   it("normalizes invalid screen blur kernel size to a supported option", () => {
     const state = createInitialState();
 
+    setScreenOptionVisibility(
+      { state },
+      { opacityEnabled: false, blurEnabled: true, blurExplicit: true },
+    );
     setFormValues(
       { state },
       {
@@ -273,7 +352,7 @@ describe("commandLineScreen.store", () => {
       },
     );
 
-    const viewData = selectViewData({ state, props: {} });
+    const viewData = selectViewData({ state, i18n: EN_I18N, props: {} });
 
     expect(viewData.defaultValues.blurKernelSize).toBe(11);
     expect(selectScreenBlur({ state })?.kernelSize).toBe(11);


### PR DESCRIPTION
## Summary

- reorganize dialogue sprite controls into standard form rows with combined animation selection and initialized playback defaults
- make Screen opacity and blur optional entries managed from the Options section
- add extra bottom scroll space to the main command-line forms

## Validation

- bun run lint against the clean committed snapshot
- 78 focused dialogue, screen, and animation playback tests