### PR TITLE
Refine command-line dialog sizing and scrolling

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -81,7 +81,7 @@ template:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues} p=none mb=120:
+              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues} p=none:
                   - $if selectedResource:
                       - $if selectedResource.resourceType == 'image':
                           - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=md:
@@ -130,6 +130,7 @@ template:
                               - rtgl-view d=h av=c g=sm:
                                   - rtgl-text s=sm c=mu-fg: ${item.label}
                                   - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums;"': ${item.value}
+              - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if backgroundTransformEditor.isOpen:

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -210,7 +210,8 @@ template:
                       - rtgl-view w=f:
                           - rtgl-text s=md: ${selectionHeading}
                           - rtgl-text s=sm c=mu-fg: ${selectionName}
-                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none mb=120: null
+                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none: null
+                      - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit
       - $if mode == 'gallery':

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -155,7 +155,7 @@ template:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md w=f:
-                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} p=none mb=120:
+                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} p=none:
                       - rtgl-view#charactersContainer slot=characters g=md w=f:
                           - $for character, i in defaultValues.characters:
                               - rtgl-view#character${i}.characterRow data-index=${character.characterIndex} data-character-id=${character.id} d=h g=md av=t pv=md br=md w=f:
@@ -222,6 +222,7 @@ template:
                                                   - 'rtgl-view.characterSpriteGroupBox data-index=${character.characterIndex} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
                                                       - rtgl-text s=xs: ${spriteGroup.name}
                   - rtgl-button#addCharacterButton v=ol w=f mt=md: ${addCharacterButtonLabel}
+                  - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'character-select':

--- a/src/components/commandLineChoices/commandLineChoices.view.yaml
+++ b/src/components/commandLineChoices/commandLineChoices.view.yaml
@@ -62,7 +62,7 @@ template:
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} p=none mb=120:
+                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} p=none:
                       - rtgl-view#choicesContainer slot=choices g=md w=f:
                           - $for item, index in items:
                               - rtgl-view#choiceItem${index} data-index=${index} d=h av=c w=f g=md pv=sm ph=md bgc=mu br=sm cur=pointer:
@@ -70,6 +70,7 @@ template:
                                       - rtgl-text w=f ellipsis=true: ${item.content}
                                   - 'rtgl-text s=xs c=mu-fg style="white-space: nowrap; flex: 0 0 auto;"': ${item.actionLabel}
                           - rtgl-button#addChoiceButton v=ol w=f mt=md: + Add Choice
+                  - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
               - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
                   - rtgl-button#submitButton: Submit
         $elif mode == "editChoice":
@@ -77,9 +78,10 @@ template:
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#choiceForm key=${choiceFormKey} :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm} p=none mb=120:
+                  - rtgl-form#choiceForm key=${choiceFormKey} :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm} p=none:
                       - rtgl-view slot=updateVariables w=f:
                           - rvn-system-actions#choiceUpdateVariableEditor :showSelected=${true} :actions=${choiceUpdateVariableActions} actionType=system :allowedModes=${choiceUpdateVariableAllowedModes} :showEmbeddedClose=${false}: null
+                  - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
               - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
                   - rtgl-button#cancelEditButton v=ol: Cancel
                   - rtgl-button#saveChoiceButton: Save Choice

--- a/src/components/commandLineControl/commandLineControl.view.yaml
+++ b/src/components/commandLineControl/commandLineControl.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -71,7 +71,7 @@ template:
       - $if mode == 'current':
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120:
+              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none:
                   - $if customizeTextSpeed:
                       - rtgl-view slot=textSpeed g=md w=f:
                           - rtgl-view d=h av=c w=f g=md:
@@ -95,6 +95,7 @@ template:
                                   - $for spriteGroup, i in selectedSpriteCharacter.spriteGroupBoxes:
                                       - 'rtgl-view.characterSpriteGroupBox data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
                                           - rtgl-text s=xs: ${spriteGroup.name}
+              - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: ${submitButtonLabel}
       - $if mode == 'character-select':

--- a/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
+++ b/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
@@ -11,6 +11,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineInput/commandLineInput.view.yaml
+++ b/src/components/commandLineInput/commandLineInput.view.yaml
@@ -38,7 +38,7 @@ template:
               - rtgl-view d=h g=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none mb=120:
+                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none:
                       - rtgl-view slot=${inputFieldsSlot} g=md w=f:
                           - $if hasFields:
                               - $for fieldRow, index in fieldRows:
@@ -51,6 +51,7 @@ template:
                             $else:
                               - rtgl-view p=md bgc=mu br=md w=f:
                                   - rtgl-text s=sm c=mu-fg: ${noInputFieldsLabel}
+                  - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
               - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
                   - rtgl-button#submitButton ?disabled=${submitDisabled}: ${submitButtonLabel}
         $elif mode == "editField":

--- a/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
+++ b/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineNextLine/commandLineNextLine.view.yaml
+++ b/src/components/commandLineNextLine/commandLineNextLine.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
+++ b/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
@@ -17,6 +17,7 @@ template:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none mb=120: null
+              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none: null
+              - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton variant=pr: Submit

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
+++ b/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
@@ -17,6 +17,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton variant=pr: ${submitLabel}

--- a/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
+++ b/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineScreen/commandLineScreen.view.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.view.yaml
@@ -17,6 +17,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
@@ -17,6 +17,7 @@ template:
           - rtgl-view d=h g=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#transitionForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
+              - rtgl-form#transitionForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+              - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
+++ b/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
@@ -16,6 +16,7 @@ template:
       - rtgl-view d=h g=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none mb=120: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
+++ b/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
@@ -41,7 +41,7 @@ template:
       - $if mode == 'current':
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f p=none: null
-              - rtgl-view g=md mt=md mb=120:
+              - rtgl-view g=md mt=md:
                   - rtgl-view#confirmActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
                       - rtgl-view d=v:
                           - rtgl-text s=sm: Confirm Actions
@@ -50,6 +50,7 @@ template:
                       - rtgl-view d=v:
                           - rtgl-text s=sm: Cancel Actions
                           - rtgl-text s=xs c=mu-fg: ${cancelActionsSummary}
+              - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit
         $elif mode == 'confirmActions':

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -240,7 +240,8 @@ template:
                       - rtgl-view w=f:
                           - rtgl-text s=md: ${selectionHeading}
                           - rtgl-text s=sm c=mu-fg: ${selectionName}
-                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none mb=120: null
+                      - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none: null
+                      - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'gallery':

--- a/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
+++ b/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
+++ b/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
+++ b/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
+++ b/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
@@ -15,6 +15,7 @@ template:
   - rtgl-view w=f h=f p=lg:
       - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none mb=120: null
+          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f p=none: null
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineVoice/commandLineVoice.view.yaml
+++ b/src/components/commandLineVoice/commandLineVoice.view.yaml
@@ -190,7 +190,8 @@ template:
                   - rtgl-view w=f:
                       - rtgl-text s=md: ${selectionHeading}
                       - rtgl-text s=sm c=mu-fg: ${selectionName}
-                  - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none mb=120: null
+                  - rtgl-form#form key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=none: null
+                  - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit
   - $if showAudioPlayer:

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
@@ -38,5 +38,6 @@ export const selectViewData = ({ state, props }) => {
     panelHorizontalInset: "96px",
     panelWidthReduction: "64px",
     panelVerticalInset: "32px",
+    panelMaxHeight: "800px",
   };
 };

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.view.yaml
@@ -15,7 +15,7 @@ template:
           - 'rtgl-view slot=content tabindex=-1 autofocus pos=rel wh=f style="min-width: 0; min-height: 0; overflow: hidden; outline: none;"':
               - 'rtgl-view#overlay pos=fix edge=f style="z-index: 2000; background: transparent;"': null
               - 'rtgl-view pos=fix style="left: ${overlayHorizontalInset}; top: var(--rvn-window-content-offset, 0px); bottom: 0; width: ${panelWidth}; z-index: 2001; background: ${overlayBackground}; pointer-events: none;"': null
-              - 'rtgl-view pos=fix bgc=bg bw=xs bc=bo br=md style="left: ${panelHorizontalInset}; top: calc(var(--rvn-window-content-offset, 0px) + ${panelVerticalInset}); bottom: ${panelVerticalInset}; width: calc(${panelWidth} - ${panelWidthReduction}); max-width: calc(100vw - ${panelHorizontalInset}); min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden; z-index: 2002; box-shadow: 8px 0 24px rgba(15, 23, 42, 0.10);"':
+              - 'rtgl-view pos=fix bgc=bg bw=xs bc=bo br=md style="left: ${panelHorizontalInset}; top: calc(var(--rvn-window-content-offset, 0px) + ${panelVerticalInset}); bottom: ${panelVerticalInset}; width: calc(${panelWidth} - ${panelWidthReduction}); height: calc(100vh - var(--rvn-window-content-offset, 0px) - ${panelVerticalInset} - ${panelVerticalInset}); max-width: calc(100vw - ${panelHorizontalInset}); max-height: ${panelMaxHeight}; margin-block: auto; min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden; z-index: 2002; box-shadow: 8px 0 24px rgba(15, 23, 42, 0.10);"':
                   - slot name=content: null
     $else:
       - $if dialogSize:

--- a/tests/commandLineActions/commandLineFormSpacing.view.test.js
+++ b/tests/commandLineActions/commandLineFormSpacing.view.test.js
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const componentsDirectory = new URL("../../src/components/", import.meta.url);
+const bottomSpacer =
+  'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"';
+
+describe("command-line form spacing", () => {
+  it("adds explicit bottom scroll space to every command-line dialog form", () => {
+    const componentDirectories = readdirSync(componentsDirectory, {
+      withFileTypes: true,
+    }).filter(
+      (entry) => entry.isDirectory() && entry.name.startsWith("commandLine"),
+    );
+
+    let dialogFormCount = 0;
+    let bottomSpacerCount = 0;
+
+    for (const componentDirectory of componentDirectories) {
+      const viewUrl = new URL(
+        `${componentDirectory.name}/${componentDirectory.name}.view.yaml`,
+        componentsDirectory,
+      );
+      const view = readFileSync(viewUrl, "utf8");
+      const formLines = view
+        .split("\n")
+        .filter((line) => line.includes("- rtgl-form"));
+
+      dialogFormCount += formLines.filter(
+        (line) => !line.includes("slot=content"),
+      ).length;
+      bottomSpacerCount += view.split(bottomSpacer).length - 1;
+
+      expect(view).not.toContain("mb=120");
+    }
+
+    expect(dialogFormCount).toBeGreaterThan(0);
+    expect(bottomSpacerCount).toBe(dialogFormCount);
+  });
+});

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -213,7 +213,10 @@ describe("commandLineDialogueBox.handlers", () => {
     expect(view).toContain("rtgl-slider-input#textSpeed");
     expect(view).toContain("handler: handleTextSpeedChange");
     expect(view).toContain("rtgl-form#dialogueForm");
-    expect(view).toContain("w=f p=none mb=120:");
+    expect(view).toContain("w=f p=none:");
+    expect(view).toContain(
+      'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"',
+    );
     expect(view).toContain(
       "rtgl-button#characterSpriteMenuButton sq s=sm v=gh pre=ellipsis",
     );

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
@@ -25,6 +25,7 @@ describe("systemActionsDialogSurface.store", () => {
       panelHorizontalInset: "96px",
       panelWidthReduction: "64px",
       panelVerticalInset: "32px",
+      panelMaxHeight: "800px",
     });
   });
 
@@ -64,6 +65,7 @@ describe("systemActionsDialogSurface.store", () => {
       panelHorizontalInset: "96px",
       panelWidthReduction: "64px",
       panelVerticalInset: "32px",
+      panelMaxHeight: "800px",
     });
   });
 });

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.view.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.view.test.js
@@ -26,6 +26,12 @@ describe("systemActionsDialogSurface view", () => {
     expect(dialogSurfaceView).toContain(
       "top: calc(var(--rvn-window-content-offset, 0px) + ${panelVerticalInset}); bottom: ${panelVerticalInset};",
     );
+    expect(dialogSurfaceView).toContain(
+      "height: calc(100vh - var(--rvn-window-content-offset, 0px) - ${panelVerticalInset} - ${panelVerticalInset});",
+    );
+    expect(dialogSurfaceView).toContain(
+      "max-height: ${panelMaxHeight}; margin-block: auto;",
+    );
     expect(dialogSurfaceView).toContain("pos=fix bgc=bg bw=xs bc=bo br=md");
     expect(
       dialogSurfaceView.match(/slot=content tabindex=-1 autofocus/g),


### PR DESCRIPTION
## Summary

- cap the scene editor action panel at 800px while preserving responsive vertical centering
- replace command-line form bottom margins with explicit 240px scroll spacers across all main dialog forms
- exclude compact popover forms and add regression coverage for spacer consistency

## Tests

- `bunx vitest run tests/commandLine*/` (325 passed)
- focused spacer and dialogue-box tests (46 passed)
- targeted Oxlint and Prettier checks