### PR TITLE
feat: refine command line editor forms

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@lexical/selection": "0.22.0",
         "@lexical/utils": "0.22.0",
         "@rettangoli/fe": "1.4.1",
-        "@rettangoli/ui": "1.18.2",
+        "@rettangoli/ui": "1.18.4",
         "@rettangoli/vt": "1.1.0",
         "@routevn/creator-model": "1.12.2",
         "@tauri-apps/api": "2.11.0",
@@ -315,7 +315,7 @@
 
     "@rettangoli/sites": ["@rettangoli/sites@1.3.0", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-K2l0SaJ/xQ+QLmGq+Oa4f0p0V+02J8Tea4NOlkfQWZ/QVGpyWrJUZDTHxlxlS9XoEMpTCtztBBo8JMMbtKrYcA=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.18.2", "", { "dependencies": { "@rettangoli/fe": "1.4.1", "jempl": "1.0.1" } }, "sha512-+rvErt8dVbbAwdoc5+0ZR2Xq6Giw6u8X426AH7A/kgFnif/IcHzIiYTXfYWUzGrS5d0B3GutpxTAQ/42TDBUMg=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.18.4", "", { "dependencies": { "@rettangoli/fe": "1.4.1", "jempl": "1.0.1" } }, "sha512-HFJc6qbxP7EU6OcLIZu2MDbPa3qhWv3uVyGDmcw4/yYcpeu8elb1SAvV0NoQZPoCYFzndRZ73JbJj6jH8IKKJQ=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.1.0", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "parse5": "^7.3.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-0sT8M7hKH/S+IHzogpwUS6o59Q6Fdd6JswQLAn0ANGVHQDvDYsh4jMeXhXhMUXfa4tFQ9epvNDwS5eFRtuFmZw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@lexical/selection": "0.22.0",
     "@lexical/utils": "0.22.0",
     "@rettangoli/fe": "1.4.1",
-    "@rettangoli/ui": "1.18.2",
+    "@rettangoli/ui": "1.18.4",
     "@rettangoli/vt": "1.1.0",
     "@routevn/creator-model": "1.12.2",
     "@tauri-apps/api": "2.11.0",

--- a/src/components/commandLineActions/commandLineActions.view.yaml
+++ b/src/components/commandLineActions/commandLineActions.view.yaml
@@ -15,3 +15,4 @@ template:
                       - 'rtgl-view#action${i} data-action-id=${item.id} g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer style="min-width: 0; box-sizing: border-box;"':
                           - rtgl-svg svg=${item.icon} wh=24: null
                           - rtgl-text s=sm w=1fg ellipsis=true: ${item.label}
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null

--- a/src/components/commandLineBackground/commandLineBackground.handlers.js
+++ b/src/components/commandLineBackground/commandLineBackground.handlers.js
@@ -577,13 +577,6 @@ export const handleOptionsSectionAction = async (deps, payload) => {
     return;
   }
 
-  if (sectionId === "animation" && actionId === "remove") {
-    store.removeAnimationOption();
-    render();
-    dispatchTemporaryPresentationStateChange(deps);
-    return;
-  }
-
   if (sectionId !== "options" || actionId !== "add") {
     return;
   }
@@ -611,13 +604,6 @@ export const handleOptionsSectionAction = async (deps, payload) => {
       key: "blur",
     });
   }
-  if (!store.selectAnimationOptionEnabled()) {
-    items.push({
-      type: "item",
-      label: localizeCommandLineText("Animation", copy),
-      key: "animation",
-    });
-  }
   if (items.length === 0) {
     return;
   }
@@ -638,8 +624,6 @@ export const handleOptionsSectionAction = async (deps, payload) => {
     render();
     dispatchTemporaryPresentationStateChange(deps);
     return;
-  } else if (result?.item?.key === "animation") {
-    store.showAnimationOption();
   } else {
     return;
   }

--- a/src/components/commandLineBackground/commandLineBackground.store.js
+++ b/src/components/commandLineBackground/commandLineBackground.store.js
@@ -911,6 +911,11 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
           placeholder: "Select transform",
           options: transformOptions,
         },
+        {
+          $when: "customTransform == true",
+          type: "slot",
+          slot: "transformSpacer",
+        },
       ],
     },
     {
@@ -919,6 +924,50 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
       slot: "custom-transform",
     },
   ];
+
+  formFields.push({
+    name: "animationId",
+    label: "Animation",
+    type: "select",
+    clearable: true,
+    placeholder: "Select animation",
+    options: animationOptions,
+  });
+  if (selectedAnimationMode !== "none") {
+    formFields.push({
+      name: "playbackSpeed",
+      label: "Playback Speed",
+      type: "input-number",
+      min: 0.01,
+      step: 0.1,
+      required: true,
+    });
+  }
+  if (selectedAnimationMode === "update") {
+    formFields.push({
+      name: "playbackLoop",
+      label: "Loop",
+      type: "segmented-control",
+      clearable: false,
+      disabled: !selectedAnimationCanLoop,
+      description: selectedAnimationCanLoop
+        ? undefined
+        : "loopingRequiresKeyframesDescription",
+      options: [
+        { value: false, label: "Don't Loop" },
+        { value: true, label: "Loop" },
+      ],
+    });
+  }
+  if (selectedAnimationMode !== "none") {
+    formFields.push({
+      name: "playbackContinuity",
+      label: "Continuity",
+      type: "segmented-control",
+      clearable: false,
+      options: ANIMATION_PLAYBACK_CONTINUITY_OPTIONS,
+    });
+  }
 
   if (selectedResource?.resourceType === "video") {
     formFields.push({
@@ -1042,65 +1091,6 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
       ],
     });
   }
-  if (state.animationOptionEnabled) {
-    const animationFields = [
-      {
-        name: "animationId",
-        type: "select",
-        noClear: true,
-        required: true,
-        placeholder: "Select animation",
-        options: animationOptions,
-      },
-    ];
-    if (selectedAnimationMode !== "none") {
-      animationFields.push({
-        name: "playbackSpeed",
-        label: "Playback Speed",
-        type: "input-number",
-        min: 0.01,
-        step: 0.1,
-        required: true,
-      });
-    }
-    if (selectedAnimationMode === "update") {
-      animationFields.push({
-        name: "playbackLoop",
-        label: "Loop",
-        type: "segmented-control",
-        clearable: false,
-        disabled: !selectedAnimationCanLoop,
-        description: selectedAnimationCanLoop
-          ? undefined
-          : "loopingRequiresKeyframesDescription",
-        options: [
-          { value: false, label: "Don't Loop" },
-          { value: true, label: "Loop" },
-        ],
-      });
-    }
-    if (selectedAnimationMode !== "none") {
-      animationFields.push({
-        name: "playbackContinuity",
-        label: "Continuity",
-        type: "segmented-control",
-        clearable: false,
-        options: ANIMATION_PLAYBACK_CONTINUITY_OPTIONS,
-      });
-    }
-    optionFields.push({
-      type: "section",
-      id: "animation",
-      label: "Animation",
-      action: {
-        id: "remove",
-        icon: "x",
-        label: "Remove",
-      },
-      fields: animationFields,
-    });
-  }
-
   const optionsSection = {
     type: "section",
     id: "options",
@@ -1110,8 +1100,7 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
   const allOptionsVisible =
     state.backgroundColorOptionEnabled &&
     state.opacityOptionEnabled &&
-    state.selectedBlurEnabled &&
-    state.animationOptionEnabled;
+    state.selectedBlurEnabled;
   if (!allOptionsVisible) {
     optionsSection.action = {
       id: "add",

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -1,4 +1,8 @@
 import { buildCharacterSpritePreviewLayer } from "../../internal/characterSpritePreview.js";
+import {
+  localizeCommandLineText,
+  selectCommandLineCopy,
+} from "../../internal/ui/sceneEditor/commandLineCopy.js";
 
 const getCharacterIndexFromEvent = (event) => {
   const index = Number.parseInt(event?.currentTarget?.dataset?.index, 10);
@@ -7,6 +11,18 @@ const getCharacterIndexFromEvent = (event) => {
 
 const getEventValue = (event) =>
   event?.detail?.value ?? event?.currentTarget?.value ?? event?.target?.value;
+
+const parseCharacterSectionId = (sectionId) => {
+  const match = /^character-(\d+)(?:-(blur))?$/.exec(sectionId ?? "");
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    characterIndex: Number.parseInt(match[1], 10),
+    option: match[2],
+  };
+};
 
 const TRANSFORM_FIELDS = [
   "x",
@@ -151,7 +167,7 @@ const beginNewCharacterSpriteSelection = (store, characterId) => {
   });
 
   const currentCharacters = store.selectSelectedCharacters();
-  const newCharacterIndex = currentCharacters.length - 1;
+  const newCharacterIndex = 0;
   const spriteSelectionGroups =
     store.selectSpriteSelectionGroupsForCharacterIndex({
       index: newCharacterIndex,
@@ -564,6 +580,19 @@ export const handleBlurFieldInput = (deps, payload) => {
 
 export const handleBlurFieldChange = handleBlurFieldInput;
 
+export const handleRemoveCharacterOpacityClick = (deps, payload) => {
+  const { store, render } = deps;
+  const index = getCharacterIndexFromEvent(payload._event);
+
+  if (index === undefined) {
+    return;
+  }
+
+  store.removeCharacterOpacityOption({ index });
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
 export const handleFileExplorerItemClick = (deps, payload) => {
   const { refs, store, render } = deps;
   const { itemId, isFolder } = payload._event.detail;
@@ -604,6 +633,64 @@ export const handleFormExtra = () => {
 
 export const handleFormChange = () => {
   // Transform and animation updates are handled by direct value-change listeners.
+};
+
+export const handleFormSectionAction = async (deps, payload) => {
+  const { appService, i18n, render, store } = deps;
+  const { actionId, position, sectionId } = payload._event.detail;
+  const section = parseCharacterSectionId(sectionId);
+  if (section === undefined) {
+    return;
+  }
+
+  const { characterIndex, option } = section;
+  if (actionId === "remove" && option === "blur") {
+    store.removeCharacterBlurOption({ index: characterIndex });
+    render();
+    dispatchTemporaryPresentationStateChange(deps);
+    return;
+  }
+  if (actionId !== "add" || option) {
+    return;
+  }
+
+  const copy = selectCommandLineCopy(i18n);
+  const items = [];
+  if (!store.selectCharacterOpacityOptionEnabled({ index: characterIndex })) {
+    items.push({
+      type: "item",
+      label: localizeCommandLineText("Opacity", copy),
+      key: "opacity",
+    });
+  }
+  if (!store.selectCharacterBlurOptionEnabled({ index: characterIndex })) {
+    items.push({
+      type: "item",
+      label: localizeCommandLineText("Blur", copy),
+      key: "blur",
+    });
+  }
+  if (items.length === 0) {
+    return;
+  }
+
+  const result = await appService.showDropdownMenu({
+    items,
+    x: position.x,
+    y: position.y,
+    place: "be",
+  });
+
+  if (result?.item?.key === "opacity") {
+    store.showCharacterOpacityOption({ index: characterIndex });
+  } else if (result?.item?.key === "blur") {
+    store.showCharacterBlurOption({ index: characterIndex });
+  } else {
+    return;
+  }
+
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
 };
 
 export const handleCharacterItemClick = (deps, payload) => {

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -281,8 +281,7 @@ const normalizeSelectedCharacter = (character = {}, animations = {}) => {
   );
   nextCharacter.opacityOptionEnabled =
     nextCharacter.opacityOptionEnabled ?? nextCharacter.opacity !== undefined;
-  nextCharacter.blurOptionEnabled =
-    nextCharacter.blurOptionEnabled ?? nextCharacter.blur !== undefined;
+  nextCharacter.blurOptionEnabled = Boolean(nextCharacter.blur);
   const selectedAnimationId = nextCharacter?.animations?.resourceId;
   const selectedAnimationMode = getAnimationModeById(
     animations,

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -17,7 +17,6 @@ import {
 import {
   COMMAND_LINE_ITEM_BLUR_KERNEL_SIZE_SELECT_OPTIONS,
   COMMAND_LINE_ITEM_BLUR_REPEAT_EDGE_OPTIONS,
-  COMMAND_LINE_ITEM_BLUR_TOGGLE_OPTIONS,
   DEFAULT_COMMAND_LINE_ITEM_BLUR,
   DEFAULT_COMMAND_LINE_ITEM_OPACITY,
   normalizeCommandLineItemBlur,
@@ -280,6 +279,10 @@ const normalizeSelectedCharacter = (character = {}, animations = {}) => {
   const nextCharacter = normalizeCommandLineItemEffects(
     structuredClone(character ?? {}),
   );
+  nextCharacter.opacityOptionEnabled =
+    nextCharacter.opacityOptionEnabled ?? nextCharacter.opacity !== undefined;
+  nextCharacter.blurOptionEnabled =
+    nextCharacter.blurOptionEnabled ?? nextCharacter.blur !== undefined;
   const selectedAnimationId = nextCharacter?.animations?.resourceId;
   const selectedAnimationMode = getAnimationModeById(
     animations,
@@ -498,14 +501,23 @@ export const addCharacter = ({ state }, { id, transformId } = {}) => {
     characterId: id,
   });
 
-  // Store raw character data (same structure as from props)
-  state.selectedCharacters.push({
+  // Source order is bottom-first while the form displays characters top-first.
+  state.selectedCharacters.unshift({
     id: id,
     transformId: defaultTransform,
     sprites: buildDefaultCharacterSprites({ characterData }),
     spriteName: "",
     animationMode: "none",
+    opacityOptionEnabled: false,
+    blurOptionEnabled: false,
   });
+
+  if (Number.isInteger(state.selectedCharacterIndex)) {
+    state.selectedCharacterIndex += 1;
+  }
+  if (Number.isInteger(state.pendingCharacterIndex)) {
+    state.pendingCharacterIndex += 1;
+  }
 };
 
 export const removeCharacter = ({ state }, { index } = {}) => {
@@ -724,10 +736,41 @@ export const updateCharacterOpacity = ({ state }, { index, opacity } = {}) => {
   const normalizedOpacity = normalizeCommandLineItemOpacity(opacity);
   if (normalizedOpacity === undefined) {
     delete character.opacity;
+    character.opacityOptionEnabled = false;
     return;
   }
 
   character.opacity = normalizedOpacity;
+  character.opacityOptionEnabled = true;
+};
+
+export const showCharacterOpacityOption = ({ state }, { index } = {}) => {
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
+  }
+
+  character.opacityOptionEnabled = true;
+  character.opacity =
+    normalizeCommandLineItemOpacity(character.opacity) ??
+    DEFAULT_COMMAND_LINE_ITEM_OPACITY;
+};
+
+export const removeCharacterOpacityOption = ({ state }, { index } = {}) => {
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
+  }
+
+  character.opacityOptionEnabled = false;
+  delete character.opacity;
+};
+
+export const selectCharacterOpacityOptionEnabled = (
+  { state },
+  { index } = {},
+) => {
+  return state.selectedCharacters[index]?.opacityOptionEnabled === true;
 };
 
 export const updateCharacterBlurEnabled = (
@@ -739,6 +782,8 @@ export const updateCharacterBlurEnabled = (
     return;
   }
 
+  character.blurOptionEnabled = true;
+
   if (!normalizeCommandLineItemBlurEnabled(enabled)) {
     character.blur = null;
     return;
@@ -749,6 +794,32 @@ export const updateCharacterBlurEnabled = (
   );
 };
 
+export const showCharacterBlurOption = ({ state }, { index } = {}) => {
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
+  }
+
+  character.blurOptionEnabled = true;
+  character.blur = normalizeCommandLineItemBlur(
+    character.blur ?? DEFAULT_COMMAND_LINE_ITEM_BLUR,
+  );
+};
+
+export const removeCharacterBlurOption = ({ state }, { index } = {}) => {
+  const character = state.selectedCharacters[index];
+  if (!character) {
+    return;
+  }
+
+  character.blurOptionEnabled = false;
+  character.blur = null;
+};
+
+export const selectCharacterBlurOptionEnabled = ({ state }, { index } = {}) => {
+  return state.selectedCharacters[index]?.blurOptionEnabled === true;
+};
+
 export const updateCharacterBlurField = (
   { state },
   { index, fieldName, value } = {},
@@ -757,6 +828,8 @@ export const updateCharacterBlurField = (
   if (!character) {
     return;
   }
+
+  character.blurOptionEnabled = true;
 
   character.blur = normalizeCommandLineItemBlurWithField({
     blur: character.blur,
@@ -1071,7 +1144,9 @@ export const selectCharactersWithRepositoryData = ({ state, copy }) => {
         ...getInlineTransformFields(char),
         animations: char.animations,
         animationMode: char.animationMode,
+        opacityOptionEnabled: char.opacityOptionEnabled,
         opacity: char.opacity,
+        blurOptionEnabled: char.blurOptionEnabled,
         blur: char.blur,
         spriteGroups: spriteSelectionGroups,
         spriteGroupBoxes,
@@ -1101,7 +1176,9 @@ export const selectCharactersWithRepositoryData = ({ state, copy }) => {
       ...getInlineTransformFields(char),
       animations: char.animations,
       animationMode: char.animationMode,
+      opacityOptionEnabled: char.opacityOptionEnabled,
       opacity: char.opacity,
+      blurOptionEnabled: char.blurOptionEnabled,
       blur: char.blur,
       spriteGroups: spriteSelectionGroups,
       spriteGroupBoxes,
@@ -1116,15 +1193,199 @@ export const selectCharactersWithRepositoryData = ({ state, copy }) => {
   });
 };
 
-const form = {
-  fields: [
-    {
-      type: "slot",
-      slot: "characters",
-      description: "Characters",
-    },
-  ],
+const createCharacterFormSlots = (characterIndex) => {
+  const prefix = `character-${characterIndex}`;
+  return {
+    formSectionId: prefix,
+    spriteFormSlot: `${prefix}-sprite`,
+    spriteSpacerFormSlot: `${prefix}-sprite-spacer`,
+    transformModeFormSlot: `${prefix}-transform-mode`,
+    predefinedTransformFormSlot: `${prefix}-predefined-transform`,
+    transformSpacerFormSlot: `${prefix}-transform-spacer`,
+    customTransformFormSlot: `${prefix}-custom-transform`,
+    animationFormSlot: `${prefix}-animation`,
+    playbackSpeedFormSlot: `${prefix}-playback-speed`,
+    playbackContinuityFormSlot: `${prefix}-playback-continuity`,
+    playbackLoopFormSlot: `${prefix}-playback-loop`,
+    playbackLoopSpacerFormSlot: `${prefix}-playback-loop-spacer`,
+    opacityFormSlot: `${prefix}-opacity`,
+    blurXFormSlot: `${prefix}-blur-x`,
+    blurYFormSlot: `${prefix}-blur-y`,
+    blurQualityFormSlot: `${prefix}-blur-quality`,
+    blurKernelSizeFormSlot: `${prefix}-blur-kernel-size`,
+    blurRepeatEdgePixelsFormSlot: `${prefix}-blur-repeat-edge-pixels`,
+    spriteGroupsFormSlot: `${prefix}-sprite-groups`,
+  };
 };
+
+const createCharactersForm = (characters = []) => ({
+  fields: characters.map((character) => {
+    const fields = [
+      {
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: character.spriteFormSlot,
+            label: "Sprite",
+          },
+          {
+            type: "slot",
+            slot: character.spriteSpacerFormSlot,
+          },
+        ],
+      },
+      {
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: character.transformModeFormSlot,
+            label: "Transform",
+          },
+          {
+            type: "slot",
+            slot: character.customTransform
+              ? character.transformSpacerFormSlot
+              : character.predefinedTransformFormSlot,
+            label: character.customTransform
+              ? undefined
+              : "Predefined Transform",
+          },
+        ],
+      },
+    ];
+
+    if (character.customTransform) {
+      fields.push({
+        type: "slot",
+        slot: character.customTransformFormSlot,
+      });
+    }
+
+    fields.push({
+      type: "slot",
+      slot: character.animationFormSlot,
+      label: "Animation",
+    });
+
+    if (character.animationId) {
+      fields.push({
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: character.playbackSpeedFormSlot,
+            label: "Playback Speed",
+          },
+          {
+            type: "slot",
+            slot: character.playbackContinuityFormSlot,
+            label: "Continuity",
+          },
+        ],
+      });
+    }
+
+    if (character.animationId && character.animationMode === "update") {
+      fields.push({
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: character.playbackLoopFormSlot,
+            label: "Loop",
+          },
+          {
+            type: "slot",
+            slot: character.playbackLoopSpacerFormSlot,
+          },
+        ],
+      });
+    }
+
+    if (character.opacityOptionEnabled) {
+      fields.push({
+        type: "slot",
+        slot: character.opacityFormSlot,
+      });
+    }
+
+    if (character.blurOptionEnabled) {
+      fields.push({
+        type: "section",
+        id: `${character.formSectionId}-blur`,
+        label: "Blur",
+        separator: false,
+        action: {
+          id: "remove",
+          icon: "x",
+          label: "Remove",
+        },
+        fields: [
+          {
+            type: "row",
+            fields: [
+              {
+                type: "slot",
+                slot: character.blurXFormSlot,
+                label: "Blur X",
+              },
+              {
+                type: "slot",
+                slot: character.blurYFormSlot,
+                label: "Blur Y",
+              },
+            ],
+          },
+          {
+            type: "row",
+            fields: [
+              {
+                type: "slot",
+                slot: character.blurQualityFormSlot,
+                label: "Quality",
+              },
+              {
+                type: "slot",
+                slot: character.blurKernelSizeFormSlot,
+                label: "Kernel Size",
+              },
+            ],
+          },
+          {
+            type: "slot",
+            slot: character.blurRepeatEdgePixelsFormSlot,
+            label: "Repeat Edge Pixels",
+          },
+        ],
+      });
+    }
+
+    if (character.showSpriteGroupBoxes) {
+      fields.push({
+        type: "slot",
+        slot: character.spriteGroupsFormSlot,
+        label: "Sprite Groups",
+      });
+    }
+
+    return {
+      type: "section",
+      id: character.formSectionId,
+      label: character.displayName,
+      action:
+        character.opacityOptionEnabled && character.blurOptionEnabled
+          ? undefined
+          : {
+              id: "add",
+              icon: "plus",
+              label: "Add option",
+            },
+      fields,
+    };
+  }),
+});
 
 export const selectViewData = ({ state, props = {}, i18n }) => {
   const copy = selectCommandLineCopy(i18n);
@@ -1415,7 +1676,9 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
         ),
         animationCanLoop,
         animationLoopDisabled: !animationCanLoop,
+        opacityOptionEnabled: char.opacityOptionEnabled === true,
         opacity: char.opacity ?? DEFAULT_COMMAND_LINE_ITEM_OPACITY,
+        blurOptionEnabled: char.blurOptionEnabled === true,
         blurEnabled: Boolean(char.blur),
         blur: normalizeCommandLineItemBlur(
           char.blur ?? DEFAULT_COMMAND_LINE_ITEM_BLUR,
@@ -1425,8 +1688,15 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
   );
 
   // Create default values with character data and options
+  const displayedCharacters = characterControls
+    .slice()
+    .reverse()
+    .map((character) => ({
+      ...character,
+      ...createCharacterFormSlots(character.characterIndex),
+    }));
   const defaultValues = {
-    characters: characterControls.slice().reverse(),
+    characters: displayedCharacters,
     transformOptions,
     animationOptions,
     animationPlaybackLoopOptions: localizeCommandLineOptions(
@@ -1439,10 +1709,6 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
     ),
     transformModeOptions: localizeCommandLineOptions(
       TRANSFORM_MODE_OPTIONS,
-      copy,
-    ),
-    blurToggleOptions: localizeCommandLineOptions(
-      COMMAND_LINE_ITEM_BLUR_TOGGLE_OPTIONS,
       copy,
     ),
     blurKernelSizeOptions: localizeCommandLineOptions(
@@ -1482,33 +1748,35 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
       props,
     }),
     breadcrumb: localizeCommandLineBreadcrumb(breadcrumb, copy),
-    form: localizeCommandLineForm(form, copy),
+    form: localizeCommandLineForm(
+      createCharactersForm(displayedCharacters),
+      copy,
+    ),
+    formKey:
+      displayedCharacters
+        .map((character) =>
+          [
+            character.characterIndex,
+            character.id,
+            character.displayName,
+            character.customTransform ? "custom-transform" : "preset-transform",
+            character.animationId ?? "no-animation",
+            character.animationMode,
+            character.opacityOptionEnabled ? "opacity" : "no-opacity",
+            character.blurOptionEnabled ? "blur-option" : "no-blur-option",
+            character.blurEnabled ? "blur" : "no-blur",
+            character.showSpriteGroupBoxes ? "sprite-groups" : "no-groups",
+          ].join(":"),
+        )
+        .join("|") || "no-characters",
     defaultValues,
     dropdownMenu: localizeCommandLineDropdownMenu(state.dropdownMenu, copy),
     noAvatarLabel: localizeCommandLineText("No Avatar", copy),
     noPreviewLabel: localizeCommandLineText("No preview", copy),
     noSpriteLabel: localizeCommandLineText("No Sprite", copy),
-    transformLabel: localizeCommandLineText("Transform", copy),
     editButtonLabel: localizeCommandLineText("Edit", copy),
-    predefinedTransformLabel: localizeCommandLineText(
-      "Predefined Transform",
-      copy,
-    ),
     opacityLabel: localizeCommandLineText("Opacity", copy),
-    blurLabel: localizeCommandLineText("Blur", copy),
-    qualityLabel: localizeCommandLineText("Quality", copy),
-    kernelLabel: localizeCommandLineText("Kernel", copy),
-    repeatEdgeLabel: localizeCommandLineText("Repeat Edge", copy),
-    animationLabel: localizeCommandLineText("Animation", copy),
-    animationPlaybackSpeedLabel: localizeCommandLineText(
-      "Playback Speed",
-      copy,
-    ),
-    animationPlaybackLoopLabel: localizeCommandLineText("Loop", copy),
-    animationPlaybackContinuityLabel: localizeCommandLineText(
-      "Continuity",
-      copy,
-    ),
+    removeOpacityLabel: localizeCommandLineText("Remove Opacity", copy),
     animationPlaybackLoopDisabledDescription: localizeCommandLineText(
       "loopingRequiresKeyframesDescription",
       copy,
@@ -1517,7 +1785,6 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
       "Select animation",
       copy,
     ),
-    spriteGroupsLabel: localizeCommandLineText("Sprite Groups", copy),
     addCharacterButtonLabel: localizeCommandLineText("+ Add Character", copy),
     submitButtonLabel: localizeCommandLineText("Submit", copy),
     selectButtonLabel: localizeCommandLineText("Select", copy),

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -7,14 +7,12 @@ refs:
     eventListeners:
       click:
         handler: handleRemoveCharacterClick
-  .characterRow:
-    eventListeners:
-      contextmenu:
-        handler: handleCharacterContextMenu
   characterSpriteBox*:
     eventListeners:
       click:
         handler: handleCharacterClick
+      contextmenu:
+        handler: handleCharacterContextMenu
   baseFileExplorer:
     eventListeners:
       item-click:
@@ -56,6 +54,8 @@ refs:
         handler: handleFormExtra
       form-change:
         handler: handleFormChange
+      form-section-action:
+        handler: handleFormSectionAction
   dropdownMenu:
     eventListeners:
       close:
@@ -103,10 +103,10 @@ refs:
     eventListeners:
       value-input:
         handler: handleOpacityInput
-  blurToggle*:
+  removeCharacterOpacity*:
     eventListeners:
-      value-change:
-        handler: handleBlurToggleChange
+      click:
+        handler: handleRemoveCharacterOpacityClick
   blurX*:
     eventListeners:
       value-input:
@@ -155,72 +155,58 @@ template:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md w=f:
-                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} p=none:
-                      - rtgl-view#charactersContainer slot=characters g=md w=f:
-                          - $for character, i in defaultValues.characters:
-                              - rtgl-view#character${i}.characterRow data-index=${character.characterIndex} data-character-id=${character.id} d=h g=md av=t pv=md br=md w=f:
-                                  - 'rtgl-view#characterSpriteBox${i} data-index=${character.characterIndex} cur=pointer bw=xs bc=bo h-bc=ac br=sm style="align-self: flex-start; flex: 0 0 auto;"':
-                                      - rtgl-view p=md g=md br=md:
-                                          - $if character.hasSpritePreview:
-                                              - 'div.commandLineCharacterThumbnailTransparencyGrid style="display: block; width: 200px; height: 120px; overflow: hidden; border-radius: 4px;"':
-                                                  - rvn-stacked-file-images :layers=${character.spritePreviewLayers} w=f h=f br=sm spritesheetBr=none spritesheetCheckerCellSize=6 showSpritesheetCheckerboard=false lazy: null
-                                            $else:
-                                              - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
-                                                  - rtgl-text s=sm c=mu-fg: ${noSpriteLabel}
-                                          - rtgl-text s=xs c=mu-fg ellipsis w=200: ${character.displayName}
-                                  - rtgl-view w=1fg g=sm:
-                                      - rtgl-text s=sm c=mu-fg: ${transformLabel}
-                                      - rtgl-segmented-control#customTransformMode${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.customTransform} :options=${defaultValues.transformModeOptions}: null
-                                      - $if character.customTransform:
-                                          - rtgl-view d=h av=c w=f g=md:
-                                              - rtgl-view d=h av=c w=1fg g=sm wrap:
-                                                  - $for item, j in character.customTransformDetails:
-                                                      - 'rtgl-view#customTransformChip${i}x${j} data-index=${character.characterIndex} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
-                                                          - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
-                                                          - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
-                                              - rtgl-button#customTransformButton${i} data-index=${character.characterIndex} v=se: ${editButtonLabel}
-                                        $else:
-                                          - rtgl-text s=sm c=mu-fg: ${predefinedTransformLabel}
-                                          - rtgl-select#transform${i} data-index=${character.characterIndex} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear: null
-                                      - rtgl-text s=sm c=mu-fg: ${opacityLabel}
-                                      - rtgl-slider-input#opacity${i} data-index=${character.characterIndex} key=${character.id} min=0 max=1 step=0.01 w=f value=${character.opacity}: null
-                                      - rtgl-text s=sm c=mu-fg: ${blurLabel}
-                                      - rtgl-segmented-control#blurToggle${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.blurEnabled} :options=${defaultValues.blurToggleOptions}: null
-                                      - $if character.blurEnabled:
-                                          - rtgl-view d=h wrap g=sm w=f:
-                                              - rtgl-view w=90 g=xs:
-                                                  - rtgl-text s=xs c=mu-fg: X
-                                                  - rtgl-input#blurX${i} data-index=${character.characterIndex} data-blur-field=x type=number w=f value=${character.blur.x}: null
-                                              - rtgl-view w=90 g=xs:
-                                                  - rtgl-text s=xs c=mu-fg: Y
-                                                  - rtgl-input#blurY${i} data-index=${character.characterIndex} data-blur-field=y type=number w=f value=${character.blur.y}: null
-                                              - rtgl-view w=90 g=xs:
-                                                  - rtgl-text s=xs c=mu-fg: ${qualityLabel}
-                                                  - rtgl-input#blurQuality${i} data-index=${character.characterIndex} data-blur-field=quality type=number min=1 step=1 w=f value=${character.blur.quality}: null
-                                              - rtgl-view w=120 g=xs:
-                                                  - rtgl-text s=xs c=mu-fg: ${kernelLabel}
-                                                  - rtgl-select#blurKernelSize${i} data-index=${character.characterIndex} data-blur-field=kernelSize w=f no-clear :selectedValue=${character.blur.kernelSize} :options=${defaultValues.blurKernelSizeOptions}: null
-                                              - rtgl-view w=160 g=xs:
-                                                  - rtgl-text s=xs c=mu-fg: ${repeatEdgeLabel}
-                                                  - rtgl-segmented-control#blurRepeatEdgePixels${i} data-index=${character.characterIndex} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${character.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}: null
-                                      - rtgl-text s=sm c=mu-fg: ${animationLabel}
-                                      - rtgl-select#animation${i} data-index=${character.characterIndex} key=${character.animationId} :options=${defaultValues.animationOptions} :selectedValue=${character.animationId} w=f placeholder=${selectAnimationPlaceholder}: null
-                                      - $if character.animationId:
-                                          - rtgl-text s=sm c=mu-fg: ${animationPlaybackSpeedLabel}
-                                          - rtgl-input#animationPlaybackSpeed${i} data-index=${character.characterIndex} type=number min=0.01 step=0.1 w=f value=${character.animationPlaybackSpeed}: null
-                                          - $if character.animationMode == 'update':
-                                              - rtgl-text s=sm c=mu-fg: ${animationPlaybackLoopLabel}
-                                              - rtgl-segmented-control#animationPlaybackLoop${i} data-index=${character.characterIndex} w=f no-clear ?disabled=${character.animationLoopDisabled} :selectedValue=${character.animationPlaybackLoop} :options=${defaultValues.animationPlaybackLoopOptions}: null
-                                              - $if !character.animationCanLoop:
-                                                  - rtgl-text s=xs c=mu-fg: ${animationPlaybackLoopDisabledDescription}
-                                          - rtgl-text s=sm c=mu-fg: ${animationPlaybackContinuityLabel}
-                                          - rtgl-segmented-control#animationPlaybackContinuity${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.animationPlaybackContinuity} :options=${defaultValues.animationPlaybackContinuityOptions}: null
-                                      - $if character.showSpriteGroupBoxes:
-                                          - rtgl-text s=sm c=mu-fg: ${spriteGroupsLabel}
-                                          - rtgl-view d=h wrap g=xs w=f:
-                                              - $for spriteGroup, j in character.spriteGroupBoxes:
-                                                  - 'rtgl-view.characterSpriteGroupBox data-index=${character.characterIndex} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
-                                                      - rtgl-text s=xs: ${spriteGroup.name}
+                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} p=none:
+                      - $for character, i in defaultValues.characters:
+                          - 'rtgl-view#characterSpriteBox${i}.characterRow slot=${character.spriteFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} cur=pointer bw=xs bc=bo h-bc=ac br=sm style="align-self: flex-start; flex: 0 0 auto;"':
+                              - rtgl-view p=md g=md br=md:
+                                  - $if character.hasSpritePreview:
+                                      - 'div.commandLineCharacterThumbnailTransparencyGrid style="display: block; width: 200px; height: 120px; overflow: hidden; border-radius: 4px;"':
+                                          - rvn-stacked-file-images :layers=${character.spritePreviewLayers} w=f h=f br=sm spritesheetBr=none spritesheetCheckerCellSize=6 showSpritesheetCheckerboard=false lazy: null
+                                    $else:
+                                      - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                          - rtgl-text s=sm c=mu-fg: ${noSpriteLabel}
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=200: ${character.displayName}
+                          - 'rtgl-view.characterRow slot=${character.transformModeFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} w=f':
+                              - rtgl-segmented-control#customTransformMode${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.customTransform} :options=${defaultValues.transformModeOptions}: null
+                          - $if !character.customTransform:
+                              - 'rtgl-select#transform${i} slot=${character.predefinedTransformFormSlot} data-index=${character.characterIndex} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear': null
+                          - $if character.customTransform:
+                              - 'rtgl-view.characterRow slot=${character.customTransformFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} d=h av=c w=f g=md':
+                                  - rtgl-view d=h av=c w=1fg g=sm wrap:
+                                      - $for item, j in character.customTransformDetails:
+                                          - 'rtgl-view#customTransformChip${i}x${j} data-index=${character.characterIndex} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
+                                              - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
+                                              - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
+                                  - rtgl-button#customTransformButton${i} data-index=${character.characterIndex} v=se: ${editButtonLabel}
+                          - 'rtgl-view.characterRow slot=${character.animationFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} w=f':
+                              - rtgl-select#animation${i} data-index=${character.characterIndex} key=${character.animationId} :options=${defaultValues.animationOptions} :selectedValue=${character.animationId} w=f placeholder=${selectAnimationPlaceholder}: null
+                          - $if character.animationId:
+                              - 'rtgl-view.characterRow slot=${character.playbackSpeedFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} w=f':
+                                  - rtgl-slider-input#animationPlaybackSpeed${i} data-index=${character.characterIndex} min=0.01 max=4 step=0.01 w=f value=${character.animationPlaybackSpeed}: null
+                              - 'rtgl-view.characterRow slot=${character.playbackContinuityFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} w=f':
+                                  - rtgl-segmented-control#animationPlaybackContinuity${i} data-index=${character.characterIndex} w=f no-clear :selectedValue=${character.animationPlaybackContinuity} :options=${defaultValues.animationPlaybackContinuityOptions}: null
+                              - $if character.animationMode == 'update':
+                                  - 'rtgl-view.characterRow slot=${character.playbackLoopFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} g=xs w=f':
+                                      - rtgl-segmented-control#animationPlaybackLoop${i} data-index=${character.characterIndex} w=f no-clear ?disabled=${character.animationLoopDisabled} :selectedValue=${character.animationPlaybackLoop} :options=${defaultValues.animationPlaybackLoopOptions}: null
+                                      - $if !character.animationCanLoop:
+                                          - rtgl-text s=xs c=mu-fg: ${animationPlaybackLoopDisabledDescription}
+                          - $if character.opacityOptionEnabled:
+                              - 'rtgl-view.characterRow slot=${character.opacityFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} g=md w=f':
+                                  - rtgl-view d=h av=c w=f g=md:
+                                      - rtgl-text w=1fg: ${opacityLabel}
+                                      - 'rtgl-button#removeCharacterOpacity${i} data-index=${character.characterIndex} sq s=sm v=gh pre=x title="${removeOpacityLabel}" aria-label="${removeOpacityLabel}"': null
+                                  - rtgl-slider-input#opacity${i} data-index=${character.characterIndex} key=${character.id} min=0 max=1 step=0.01 w=f value=${character.opacity}: null
+                          - $if character.blurOptionEnabled:
+                              - 'rtgl-input-number#blurX${i} slot=${character.blurXFormSlot} data-index=${character.characterIndex} data-blur-field=x min=0 w=f value=${character.blur.x}': null
+                              - 'rtgl-input-number#blurY${i} slot=${character.blurYFormSlot} data-index=${character.characterIndex} data-blur-field=y min=0 w=f value=${character.blur.y}': null
+                              - 'rtgl-input-number#blurQuality${i} slot=${character.blurQualityFormSlot} data-index=${character.characterIndex} data-blur-field=quality min=1 step=1 w=f value=${character.blur.quality}': null
+                              - 'rtgl-select#blurKernelSize${i} slot=${character.blurKernelSizeFormSlot} data-index=${character.characterIndex} data-blur-field=kernelSize w=f no-clear :selectedValue=${character.blur.kernelSize} :options=${defaultValues.blurKernelSizeOptions}': null
+                              - 'rtgl-segmented-control#blurRepeatEdgePixels${i} slot=${character.blurRepeatEdgePixelsFormSlot} data-index=${character.characterIndex} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${character.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}': null
+                          - $if character.showSpriteGroupBoxes:
+                              - 'rtgl-view.characterRow slot=${character.spriteGroupsFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} d=h wrap g=xs w=f':
+                                  - $for spriteGroup, j in character.spriteGroupBoxes:
+                                      - 'rtgl-view.characterSpriteGroupBox data-index=${character.characterIndex} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
+                                          - rtgl-text s=xs: ${spriteGroup.name}
                   - rtgl-button#addCharacterButton v=ol w=f mt=md: ${addCharacterButtonLabel}
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg style="flex: 0 0 auto;"':

--- a/src/components/commandLineScreen/commandLineScreen.store.js
+++ b/src/components/commandLineScreen/commandLineScreen.store.js
@@ -176,22 +176,27 @@ const baseForm = {
     },
     {
       $when: "transitionAnimationId",
-      name: "playbackSpeed",
-      label: "Playback Speed",
-      type: "input-number",
-      min: 0.01,
-      step: 0.1,
-      required: true,
-    },
-    {
-      $when: "transitionAnimationId",
-      name: "playbackContinuity",
-      label: "Continuity",
-      type: "segmented-control",
-      clearable: false,
-      options: [
-        { value: "render", label: "Single Line" },
-        { value: "persistent", label: "Persistent" },
+      type: "row",
+      fields: [
+        {
+          name: "playbackSpeed",
+          label: "Playback Speed",
+          type: "slider-with-input",
+          min: 0.01,
+          max: 4,
+          step: 0.01,
+          required: true,
+        },
+        {
+          name: "playbackContinuity",
+          label: "Continuity",
+          type: "segmented-control",
+          clearable: false,
+          options: [
+            { value: "render", label: "Single Line" },
+            { value: "persistent", label: "Persistent" },
+          ],
+        },
       ],
     },
   ],

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -1925,6 +1925,7 @@ commandLinePage:
   "Custom name": "Custom name"
   "Custom text speed": "Custom text speed"
   "Remove custom text speed": "Remove custom text speed"
+  "Remove Opacity": "Remove Opacity"
   "Decimal Places": "Decimal Places"
   "Default branch": "Default branch"
   "Default hide only": "Default hide only"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -1925,6 +1925,7 @@ commandLinePage:
   "Custom name": "カスタム名"
   "Custom text speed": "カスタムテキスト速度"
   "Remove custom text speed": "カスタムテキスト速度を削除"
+  "Remove Opacity": "不透明度を削除"
   "Decimal Places": "小数桁数"
   "Default branch": "デフォルト分岐"
   "Default hide only": "標準では非表示のみ"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -1925,6 +1925,7 @@ commandLinePage:
   "Custom name": "自定义名称"
   "Custom text speed": "自定义文本速度"
   "Remove custom text speed": "移除自定义文本速度"
+  "Remove Opacity": "移除不透明度"
   "Decimal Places": "小数位数"
   "Default branch": "默认分支"
   "Default hide only": "默认仅隐藏"

--- a/src/internal/ui/sceneEditor/commandLineCopy.js
+++ b/src/internal/ui/sceneEditor/commandLineCopy.js
@@ -146,6 +146,7 @@ export const localizeCommandLineFormField = (field = {}, copy = {}) => {
 export const localizeCommandLineForm = (form = {}, copy = {}) => {
   const localizedForm = {
     ...form,
+    rowStackAt: "lg",
     title: localizeCommandLineText(form.title, copy),
     description: localizeCommandLineText(form.description, copy),
   };

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -14,7 +14,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -6,11 +6,8 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
-    <script
-      type="module"
-      src="/public/main.js?v=20260224-collab-debug-v2"
-    ></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script type="module" src="/public/main.js?v=20260224-collab-debug-v2"></script>
   </head>
   <body class="dark">
     <rvn-app></rvn-app>

--- a/static/ios/index.html
+++ b/static/ios/index.html
@@ -43,7 +43,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/tests/animationPlayback/commandLineAnimationPlayback.test.js
+++ b/tests/animationPlayback/commandLineAnimationPlayback.test.js
@@ -399,12 +399,13 @@ describe("command line animation playback", () => {
       playbackSpeed: 1.25,
       playbackContinuity: "persistent",
     });
-    expect(screenView.form.fields.map((field) => field.name)).toEqual(
+    const screenFieldNames = screenView.form.fields
+      .flatMap((field) => (field.type === "row" ? field.fields : [field]))
+      .map((field) => field.name);
+    expect(screenFieldNames).toEqual(
       expect.arrayContaining(["playbackSpeed", "playbackContinuity"]),
     );
-    expect(screenView.form.fields.map((field) => field.name)).not.toContain(
-      "playbackLoop",
-    );
+    expect(screenFieldNames).not.toContain("playbackLoop");
   });
 
   it("remounts conditional transition forms with initialized playback values", () => {

--- a/tests/commandLineActions/commandLineActions.view.test.js
+++ b/tests/commandLineActions/commandLineActions.view.test.js
@@ -23,5 +23,8 @@ describe("commandLineActions view", () => {
       expect(view).toContain('style="min-width: 0; box-sizing: border-box;"');
       expect(view).toContain("rtgl-text s=sm w=1fg ellipsis=true");
     }
+    expect(commandLineActionsView).toContain(
+      'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"',
+    );
   });
 });

--- a/tests/commandLineActions/commandLineFormSpacing.view.test.js
+++ b/tests/commandLineActions/commandLineFormSpacing.view.test.js
@@ -14,7 +14,6 @@ describe("command-line form spacing", () => {
     );
 
     let dialogFormCount = 0;
-    let bottomSpacerCount = 0;
 
     for (const componentDirectory of componentDirectories) {
       const viewUrl = new URL(
@@ -26,15 +25,19 @@ describe("command-line form spacing", () => {
         .split("\n")
         .filter((line) => line.includes("- rtgl-form"));
 
-      dialogFormCount += formLines.filter(
+      const componentDialogFormCount = formLines.filter(
         (line) => !line.includes("slot=content"),
       ).length;
-      bottomSpacerCount += view.split(bottomSpacer).length - 1;
+      const componentBottomSpacerCount = view.split(bottomSpacer).length - 1;
+
+      dialogFormCount += componentDialogFormCount;
+      expect(componentBottomSpacerCount).toBeGreaterThanOrEqual(
+        componentDialogFormCount,
+      );
 
       expect(view).not.toContain("mb=120");
     }
 
     expect(dialogFormCount).toBeGreaterThan(0);
-    expect(bottomSpacerCount).toBe(dialogFormCount);
   });
 });

--- a/tests/commandLineBackground/commandLineBackground.handlers.test.js
+++ b/tests/commandLineBackground/commandLineBackground.handlers.test.js
@@ -16,7 +16,6 @@ import {
 } from "../../src/components/commandLineBackground/commandLineBackground.handlers.js";
 import {
   createInitialState,
-  removeAnimationOption,
   removeOpacityOption,
   selectAnimationOptionEnabled,
   selectBackgroundLoop,
@@ -63,7 +62,6 @@ import {
   setSelectedOpacity,
   setSelectedResource,
   setSelectedTransform,
-  showAnimationOption,
   showBackgroundColorOption,
   showBlurOption,
   showOpacityOption,
@@ -78,7 +76,6 @@ const createEmptyCollection = () => ({
 });
 
 const createStoreApi = (state) => ({
-  removeAnimationOption: (payload) => removeAnimationOption({ state }, payload),
   removeOpacityOption: (payload) => removeOpacityOption({ state }, payload),
   selectAnimationOptionEnabled: () => selectAnimationOptionEnabled({ state }),
   selectBackgroundLoop: () => selectBackgroundLoop({ state }),
@@ -142,7 +139,6 @@ const createStoreApi = (state) => ({
   setTempSelectedResource: (payload) =>
     setTempSelectedResource({ state }, payload),
   setUiConfig: (payload) => setUiConfig({ state }, payload),
-  showAnimationOption: (payload) => showAnimationOption({ state }, payload),
   showBackgroundColorOption: (payload) =>
     showBackgroundColorOption({ state }, payload),
   showBlurOption: (payload) => showBlurOption({ state }, payload),
@@ -797,11 +793,6 @@ describe("commandLineBackground.handlers", () => {
           label: "Blur",
           key: "blur",
         },
-        {
-          type: "item",
-          label: "Animation",
-          key: "animation",
-        },
       ],
       x: 120,
       y: 240,
@@ -1007,11 +998,6 @@ describe("commandLineBackground.handlers", () => {
           label: "Blur",
           key: "blur",
         },
-        {
-          type: "item",
-          label: "Animation",
-          key: "animation",
-        },
       ],
       x: 120,
       y: 240,
@@ -1182,7 +1168,7 @@ describe("commandLineBackground.handlers", () => {
     expect(render).toHaveBeenCalledTimes(1);
   });
 
-  it("removes animation from its section action", async () => {
+  it("clears animation from its primary select", () => {
     const state = createInitialState();
     const render = vi.fn();
     const dispatchEvent = vi.fn();
@@ -1202,7 +1188,7 @@ describe("commandLineBackground.handlers", () => {
       },
     );
 
-    await handleOptionsSectionAction(
+    handleFormInputChange(
       {
         store: createStoreApi(state),
         render,
@@ -1211,8 +1197,8 @@ describe("commandLineBackground.handlers", () => {
       {
         _event: {
           detail: {
-            sectionId: "animation",
-            actionId: "remove",
+            name: "animationId",
+            value: undefined,
           },
         },
       },

--- a/tests/commandLineBackground/commandLineBackground.store.test.js
+++ b/tests/commandLineBackground/commandLineBackground.store.test.js
@@ -15,7 +15,6 @@ import {
   setSelectedResource,
   setTempSelectedResource,
   setSelectedTransform,
-  showAnimationOption,
 } from "../../src/components/commandLineBackground/commandLineBackground.store.js";
 
 const TEST_I18N = {
@@ -31,13 +30,6 @@ const createEmptyCollection = () => ({
   items: {},
   tree: [],
 });
-
-const selectOptionFields = (viewData, optionId) => {
-  const optionsSection = viewData.dialogueForm.form.fields.find(
-    (field) => field.id === "options",
-  );
-  return optionsSection.fields.find((field) => field.id === optionId)?.fields;
-};
 
 describe("commandLineBackground.store", () => {
   it("keeps optional background fields hidden until they are added", () => {
@@ -128,7 +120,8 @@ describe("commandLineBackground.store", () => {
     const transformRow = viewData.dialogueForm.form.fields.find(
       (field) => field.type === "row",
     );
-    const [transformModeField, transformField] = transformRow.fields;
+    const [transformModeField, transformField, transformSpacerField] =
+      transformRow.fields;
     const animationField = viewData.dialogueForm.form.fields.find(
       (field) => field.name === "animationId",
     );
@@ -168,7 +161,24 @@ describe("commandLineBackground.store", () => {
         },
       ],
     });
-    expect(animationField).toBeUndefined();
+    expect(transformSpacerField).toMatchObject({
+      $when: "customTransform == true",
+      type: "slot",
+      slot: "transformSpacer",
+    });
+    expect(animationField).toMatchObject({
+      name: "animationId",
+      label: "Animation",
+      type: "select",
+      clearable: true,
+      placeholder: "Select animation",
+    });
+    expect(
+      viewData.dialogueForm.form.fields.indexOf(animationField),
+    ).toBeGreaterThan(viewData.dialogueForm.form.fields.indexOf(transformRow));
+    expect(
+      viewData.dialogueForm.form.fields.indexOf(animationField),
+    ).toBeLessThan(viewData.dialogueForm.form.fields.indexOf(optionsSection));
     expect(opacityField).toBeUndefined();
     expect(colorField).toBeUndefined();
     expect(blurField).toBeUndefined();
@@ -265,7 +275,7 @@ describe("commandLineBackground.store", () => {
     );
 
     const viewData = selectViewData({ state });
-    const animationFields = selectOptionFields(viewData, "animation");
+    const animationFields = viewData.dialogueForm.form.fields;
     const animationField = animationFields.find(
       (field) => field.name === "animationId",
     );
@@ -280,9 +290,9 @@ describe("commandLineBackground.store", () => {
     );
 
     expect(animationField).toMatchObject({
+      label: "Animation",
       type: "select",
-      noClear: true,
-      required: true,
+      clearable: true,
       options: [
         {
           value: "bg-pan",
@@ -380,10 +390,9 @@ describe("commandLineBackground.store", () => {
       },
     );
 
-    const loopField = selectOptionFields(
-      selectViewData({ state }),
-      "animation",
-    ).find((field) => field.name === "playbackLoop");
+    const loopField = selectViewData({ state }).dialogueForm.form.fields.find(
+      (field) => field.name === "playbackLoop",
+    );
 
     expect(loopField).toMatchObject({
       disabled: true,
@@ -419,7 +428,7 @@ describe("commandLineBackground.store", () => {
       },
     );
 
-    const fields = selectOptionFields(selectViewData({ state }), "animation");
+    const fields = selectViewData({ state }).dialogueForm.form.fields;
 
     expect(
       fields.find((field) => field.name === "playbackSpeed"),
@@ -474,6 +483,9 @@ describe("commandLineBackground.store", () => {
     const transformField = transformRow.fields.find(
       (field) => field.name === "transformId",
     );
+    const transformSpacerField = transformRow.fields.find(
+      (field) => field.slot === "transformSpacer",
+    );
     const customTransformSlot = viewData.dialogueForm.form.fields.find(
       (field) => field.slot === "custom-transform",
     );
@@ -481,6 +493,10 @@ describe("commandLineBackground.store", () => {
     expect(viewData.dialogueForm.defaultValues.customTransform).toBe(true);
     expect(transformField).toMatchObject({
       $when: "customTransform == false",
+    });
+    expect(transformSpacerField).toMatchObject({
+      $when: "customTransform == true",
+      type: "slot",
     });
     expect(customTransformSlot).toMatchObject({
       $when: "customTransform == true",
@@ -681,7 +697,6 @@ describe("commandLineBackground.store", () => {
     setSelectedColor({ state }, { colorId: "color-night" });
     setSelectedOpacity({ state }, { opacity: 1 });
     setSelectedBlur({ state }, { blur: {} });
-    showAnimationOption({ state });
 
     const viewData = selectViewData({ state });
     const optionsSection = viewData.dialogueForm.form.fields.at(-1);

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -965,6 +965,31 @@ describe("commandLineCharacters.handlers", () => {
     });
   });
 
+  it("selects the bottom source index for a newly added character", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const store = createStoreApi(state);
+
+    setExistingCharacters({ state }, { characters: [{ id: "character-1" }] });
+
+    handleCharacterItemClick(
+      { store, render },
+      {
+        _event: {
+          currentTarget: {
+            dataset: { characterId: "character-2" },
+          },
+        },
+      },
+    );
+
+    expect(
+      selectSelectedCharacters({ state }).map((character) => character.id),
+    ).toEqual(["character-2", "character-1"]);
+    expect(selectPendingCharacterIndex({ state })).toBe(0);
+    expect(selectSelectedCharacterIndex({ state })).toBe(0);
+  });
+
   it("keeps existing characters when returning from sprite selection", () => {
     const state = createInitialState();
     const render = vi.fn();

--- a/tests/commandLineCharacters/commandLineCharacters.options.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.options.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleFormSectionAction,
+  handleRemoveCharacterOpacityClick,
+} from "../../src/components/commandLineCharacters/commandLineCharacters.handlers.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("commandLineCharacters character options", () => {
+  it("adds a missing option to the selected character section", async () => {
+    const render = vi.fn();
+    const showCharacterBlurOption = vi.fn();
+    const showDropdownMenu = vi.fn().mockResolvedValue({
+      item: { key: "blur" },
+    });
+    const store = {
+      selectCharacterOpacityOptionEnabled: vi.fn().mockReturnValue(false),
+      selectCharacterBlurOptionEnabled: vi.fn().mockReturnValue(false),
+      showCharacterOpacityOption: vi.fn(),
+      showCharacterBlurOption,
+    };
+
+    await handleFormSectionAction(
+      {
+        appService: { showDropdownMenu },
+        i18n: EN_I18N,
+        render,
+        store,
+      },
+      {
+        _event: {
+          detail: {
+            sectionId: "character-0",
+            actionId: "add",
+            position: { x: 120, y: 240 },
+          },
+        },
+      },
+    );
+
+    expect(showDropdownMenu).toHaveBeenCalledWith({
+      items: [
+        { type: "item", label: "Opacity", key: "opacity" },
+        { type: "item", label: "Blur", key: "blur" },
+      ],
+      x: 120,
+      y: 240,
+      place: "be",
+    });
+    expect(showCharacterBlurOption).toHaveBeenCalledWith({ index: 0 });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes an option from the matching character field", () => {
+    const render = vi.fn();
+    const removeCharacterOpacityOption = vi.fn();
+
+    handleRemoveCharacterOpacityClick(
+      {
+        render,
+        store: { removeCharacterOpacityOption },
+      },
+      {
+        _event: {
+          currentTarget: {
+            dataset: { index: "3" },
+          },
+        },
+      },
+    );
+
+    expect(removeCharacterOpacityOption).toHaveBeenCalledWith({ index: 3 });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes blur through its separator-free nested section action", async () => {
+    const render = vi.fn();
+    const removeCharacterBlurOption = vi.fn();
+
+    await handleFormSectionAction(
+      {
+        render,
+        store: { removeCharacterBlurOption },
+      },
+      {
+        _event: {
+          detail: {
+            sectionId: "character-0-blur",
+            actionId: "remove",
+          },
+        },
+      },
+    );
+
+    expect(removeCharacterBlurOption).toHaveBeenCalledWith({ index: 0 });
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/commandLineCharacters/commandLineCharacters.sections.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.sections.test.js
@@ -13,7 +13,7 @@ import {
   showCharacterBlurOption,
   showCharacterOpacityOption,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
-import { EN_I18N } from "../support/i18n.js";
+import { EN_I18N, JA_I18N, ZH_HANS_I18N } from "../support/i18n.js";
 
 describe("commandLineCharacters sections", () => {
   it("creates a named form section for each displayed character", () => {
@@ -210,6 +210,51 @@ describe("commandLineCharacters sections", () => {
     );
     expect(state.selectedCharacters[0].opacity).toBeUndefined();
     expect(state.selectedCharacters[0].blur).toBeNull();
+  });
+
+  it("keeps an explicit blur clear hidden when reopening the form", () => {
+    const state = createInitialState();
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            hero: { id: "hero", type: "character", name: "Hero" },
+          },
+          tree: [{ id: "hero" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      { characters: [{ id: "hero", blur: null }] },
+    );
+
+    expect(state.selectedCharacters[0]).toMatchObject({
+      blur: null,
+      blurOptionEnabled: false,
+    });
+    expect(selectCharacterBlurOptionEnabled({ state }, { index: 0 })).toBe(
+      false,
+    );
+
+    const [section] = selectViewData({ state, i18n: EN_I18N }).form.fields;
+    expect(section.action).toMatchObject({ id: "add", icon: "plus" });
+    expect(section.fields).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "character-0-blur" }),
+      ]),
+    );
+  });
+
+  it("localizes the opacity removal label", () => {
+    const state = createInitialState();
+
+    expect(
+      [EN_I18N, JA_I18N, ZH_HANS_I18N].map(
+        (i18n) => selectViewData({ state, i18n }).removeOpacityLabel,
+      ),
+    ).toEqual(["Remove Opacity", "不透明度を削除", "移除不透明度"]);
   });
 
   it("renders each character row through its matching form section slot", () => {

--- a/tests/commandLineCharacters/commandLineCharacters.sections.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.sections.test.js
@@ -1,0 +1,238 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  removeCharacterBlurOption,
+  removeCharacterOpacityOption,
+  selectCharacterBlurOptionEnabled,
+  selectCharacterOpacityOptionEnabled,
+  selectViewData,
+  setAnimations,
+  setExistingCharacters,
+  setItems,
+  showCharacterBlurOption,
+  showCharacterOpacityOption,
+} from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("commandLineCharacters sections", () => {
+  it("creates a named form section for each displayed character", () => {
+    const state = createInitialState();
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            hero: { id: "hero", type: "character", name: "Hero" },
+            rival: { id: "rival", type: "character", name: "Rival" },
+          },
+          tree: [{ id: "hero" }, { id: "rival" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [{ id: "hero" }, { id: "rival" }],
+      },
+    );
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(
+      viewData.form.fields.map((section) => ({
+        id: section.id,
+        label: section.label,
+        rows: section.fields.map((field) =>
+          field.type === "row"
+            ? field.fields.map((nestedField) => nestedField.slot)
+            : field.slot,
+        ),
+      })),
+    ).toEqual([
+      {
+        id: "character-1",
+        label: "Rival",
+        rows: [
+          ["character-1-sprite", "character-1-sprite-spacer"],
+          ["character-1-transform-mode", "character-1-predefined-transform"],
+          "character-1-animation",
+        ],
+      },
+      {
+        id: "character-0",
+        label: "Hero",
+        rows: [
+          ["character-0-sprite", "character-0-sprite-spacer"],
+          ["character-0-transform-mode", "character-0-predefined-transform"],
+          "character-0-animation",
+        ],
+      },
+    ]);
+    expect(viewData.formKey).toBe(
+      "1:rival:Rival:preset-transform:no-animation:none:no-opacity:no-blur-option:no-blur:no-groups|0:hero:Hero:preset-transform:no-animation:none:no-opacity:no-blur-option:no-blur:no-groups",
+    );
+    expect(
+      viewData.defaultValues.characters.map(
+        (character) => character.spriteFormSlot,
+      ),
+    ).toEqual(["character-1-sprite", "character-0-sprite"]);
+  });
+
+  it("matches the dialogue sprite animation row layout", () => {
+    const state = createInitialState();
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            hero: { id: "hero", type: "character", name: "Hero" },
+          },
+          tree: [{ id: "hero" }],
+        },
+      },
+    );
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            idle: {
+              id: "idle",
+              type: "animation",
+              name: "Idle",
+              animation: { type: "update" },
+            },
+          },
+          tree: [{ id: "idle" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "hero",
+            animations: { resourceId: "idle" },
+          },
+        ],
+      },
+    );
+
+    const [section] = selectViewData({ state, i18n: EN_I18N }).form.fields;
+    const rows = section.fields.map((field) =>
+      field.type === "row"
+        ? field.fields.map((nestedField) => nestedField.slot)
+        : field.slot,
+    );
+
+    expect(rows).toEqual([
+      ["character-0-sprite", "character-0-sprite-spacer"],
+      ["character-0-transform-mode", "character-0-predefined-transform"],
+      "character-0-animation",
+      ["character-0-playback-speed", "character-0-playback-continuity"],
+      ["character-0-playback-loop", "character-0-playback-loop-spacer"],
+    ]);
+  });
+
+  it("adds opacity and blur through individual character options", () => {
+    const state = createInitialState();
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            hero: { id: "hero", type: "character", name: "Hero" },
+          },
+          tree: [{ id: "hero" }],
+        },
+      },
+    );
+    setExistingCharacters({ state }, { characters: [{ id: "hero" }] });
+
+    let [section] = selectViewData({ state, i18n: EN_I18N }).form.fields;
+    expect(section.action).toMatchObject({ id: "add", icon: "plus" });
+    expect(section.fields.map((field) => field.id).filter(Boolean)).toEqual([]);
+
+    showCharacterOpacityOption({ state }, { index: 0 });
+    expect(selectCharacterOpacityOptionEnabled({ state }, { index: 0 })).toBe(
+      true,
+    );
+    [section] = selectViewData({ state, i18n: EN_I18N }).form.fields;
+    expect(section.action).toMatchObject({ id: "add", icon: "plus" });
+    expect(section.fields.at(-1)).toMatchObject({
+      type: "slot",
+      slot: "character-0-opacity",
+    });
+
+    showCharacterBlurOption({ state }, { index: 0 });
+    expect(selectCharacterBlurOptionEnabled({ state }, { index: 0 })).toBe(
+      true,
+    );
+    [section] = selectViewData({ state, i18n: EN_I18N }).form.fields;
+    expect(section.action).toBeUndefined();
+    expect(section.fields.at(-1)).toMatchObject({
+      type: "section",
+      id: "character-0-blur",
+      label: "Blur",
+      separator: false,
+      action: { id: "remove", icon: "x" },
+      fields: [
+        {
+          type: "row",
+          fields: [
+            { slot: "character-0-blur-x", label: "Blur X" },
+            { slot: "character-0-blur-y", label: "Blur Y" },
+          ],
+        },
+        {
+          type: "row",
+          fields: [
+            { slot: "character-0-blur-quality", label: "Quality" },
+            { slot: "character-0-blur-kernel-size", label: "Kernel Size" },
+          ],
+        },
+        {
+          slot: "character-0-blur-repeat-edge-pixels",
+          label: "Repeat Edge Pixels",
+        },
+      ],
+    });
+
+    removeCharacterOpacityOption({ state }, { index: 0 });
+    removeCharacterBlurOption({ state }, { index: 0 });
+    expect(selectCharacterOpacityOptionEnabled({ state }, { index: 0 })).toBe(
+      false,
+    );
+    expect(selectCharacterBlurOptionEnabled({ state }, { index: 0 })).toBe(
+      false,
+    );
+    expect(state.selectedCharacters[0].opacity).toBeUndefined();
+    expect(state.selectedCharacters[0].blur).toBeNull();
+  });
+
+  it("renders each character row through its matching form section slot", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineCharacters/commandLineCharacters.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain("rtgl-form#form key=${formKey}");
+    expect(view).toContain("handler: handleFormSectionAction");
+    expect(view).toMatch(
+      /characterSpriteBox\*:[\s\S]*?contextmenu:[\s\S]*?handler: handleCharacterContextMenu/,
+    );
+    expect(view).toContain("slot=${character.spriteFormSlot}");
+    expect(view).toContain("slot=${character.transformModeFormSlot}");
+    expect(view).toContain("slot=${character.predefinedTransformFormSlot}");
+    expect(view).toContain("slot=${character.customTransformFormSlot}");
+    expect(view).toContain("slot=${character.animationFormSlot}");
+    expect(view).toContain("slot=${character.playbackSpeedFormSlot}");
+    expect(view).toContain("rtgl-slider-input#animationPlaybackSpeed${i}");
+    expect(view).not.toContain("slot=characters");
+  });
+});

--- a/tests/commandLineCharacters/commandLineCharacters.store.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.store.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  addCharacter,
   createInitialState,
   moveCharacter,
   selectViewData,
@@ -17,6 +18,7 @@ import {
   updateCharacterCustomTransformEnabled,
   updateCharacterOpacity,
 } from "../../src/components/commandLineCharacters/commandLineCharacters.store.js";
+import { EN_I18N } from "../support/i18n.js";
 
 const createSpriteSelectState = () => {
   const state = createInitialState();
@@ -175,7 +177,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.defaultValues.characters[0]).toMatchObject({
       id: "character-hero",
@@ -199,7 +201,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
   it("orders sprite group tabs with the top preview layer first", () => {
     const state = createSpriteSelectState();
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.spriteSelectionTabs).toEqual([
       {
@@ -220,7 +222,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
 
     setMode({ state }, { mode: "current" });
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.defaultValues.characters[0].showSpriteGroupBoxes).toBe(
       true,
@@ -282,7 +284,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       },
     );
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(
       viewData.selectedCharacters.map((character) => character.id),
@@ -321,10 +323,12 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       "character-hero",
     ]);
     expect(
-      selectViewData({ state }).defaultValues.characters.map((character) => ({
-        id: character.id,
-        characterIndex: character.characterIndex,
-      })),
+      selectViewData({ state, i18n: EN_I18N }).defaultValues.characters.map(
+        (character) => ({
+          id: character.id,
+          characterIndex: character.characterIndex,
+        }),
+      ),
     ).toEqual([
       {
         id: "character-hero",
@@ -335,6 +339,45 @@ describe("commandLineCharacters.store sprite group filtering", () => {
         characterIndex: 0,
       },
     ]);
+  });
+
+  it("adds a new character at the bottom of the displayed character list", () => {
+    const state = createInitialState();
+
+    setItems(
+      { state },
+      {
+        items: {
+          items: {
+            hero: { id: "hero", type: "character", name: "Hero" },
+            rival: { id: "rival", type: "character", name: "Rival" },
+            newcomer: {
+              id: "newcomer",
+              type: "character",
+              name: "Newcomer",
+            },
+          },
+          tree: [{ id: "hero" }, { id: "rival" }, { id: "newcomer" }],
+        },
+      },
+    );
+    setExistingCharacters(
+      { state },
+      { characters: [{ id: "hero" }, { id: "rival" }] },
+    );
+
+    addCharacter({ state }, { id: "newcomer" });
+
+    expect(state.selectedCharacters.map((character) => character.id)).toEqual([
+      "newcomer",
+      "hero",
+      "rival",
+    ]);
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).defaultValues.characters.map(
+        (character) => character.id,
+      ),
+    ).toEqual(["rival", "hero", "newcomer"]);
   });
 
   it("normalizes character opacity and blur controls", () => {
@@ -384,7 +427,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       repeatEdgePixels: false,
     });
 
-    let viewData = selectViewData({ state });
+    let viewData = selectViewData({ state, i18n: EN_I18N });
     expect(viewData.defaultValues.characters[0]).toMatchObject({
       opacity: 0.6,
       blurEnabled: true,
@@ -426,7 +469,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       repeatEdgePixels: false,
     });
 
-    viewData = selectViewData({ state });
+    viewData = selectViewData({ state, i18n: EN_I18N });
     expect(viewData.defaultValues.characters[0]).toMatchObject({
       opacity: 0,
       blurEnabled: true,
@@ -459,7 +502,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     );
     setMode({ state }, { mode: "current" });
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.defaultValues.characters[0].spritePreviewFileIds).toEqual([
       "file-body",
@@ -545,7 +588,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
       },
     );
 
-    let viewData = selectViewData({ state });
+    let viewData = selectViewData({ state, i18n: EN_I18N });
     expect(viewData.defaultValues.characters[0]).toMatchObject({
       hasSpritePreview: true,
       spritePreviewFileIds: ["file-expression-sheet"],
@@ -574,7 +617,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     setSelectedCharacterIndex({ state }, { index: 0 });
     setSelectedSpriteGroupId({ state }, { spriteGroupId: "expression" });
 
-    viewData = selectViewData({ state });
+    viewData = selectViewData({ state, i18n: EN_I18N });
     expect(viewData.spriteGroups).toHaveLength(1);
     expect(viewData.spriteGroups[0].children).toEqual([
       expect.objectContaining({
@@ -595,7 +638,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     const state = createSpriteSelectState();
     setSelectedSpriteGroupId({ state }, { spriteGroupId: "face" });
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
 
     expect(viewData.spriteItems.map((item) => item.id)).toEqual([
       "folder-variants",
@@ -610,7 +653,7 @@ describe("commandLineCharacters.store sprite group filtering", () => {
     const state = createSpriteSelectState();
     setSelectedSpriteGroupId({ state }, { spriteGroupId: "body" });
 
-    const viewData = selectViewData({ state });
+    const viewData = selectViewData({ state, i18n: EN_I18N });
     const visibleSpriteIds = viewData.spriteGroups.flatMap((group) =>
       group.children.map((item) => item.id),
     );
@@ -704,19 +747,19 @@ describe("commandLineCharacters.store custom transforms", () => {
       },
     );
 
-    expect(selectViewData({ state }).defaultValues.characters[0]).toMatchObject(
-      {
-        transformId: "character-center",
-        customTransform: true,
-        x: 980,
-        y: 560,
-        scaleX: 1.25,
-        scaleY: 1.25,
-        customTransformDetails: expect.arrayContaining([
-          { label: "Position", value: "980, 560" },
-          { label: "Scale", value: "1.25 x 1.25" },
-        ]),
-      },
-    );
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).defaultValues.characters[0],
+    ).toMatchObject({
+      transformId: "character-center",
+      customTransform: true,
+      x: 980,
+      y: 560,
+      scaleX: 1.25,
+      scaleY: 1.25,
+      customTransformDetails: expect.arrayContaining([
+        { label: "Position", value: "980, 560" },
+        { label: "Scale", value: "1.25 x 1.25" },
+      ]),
+    });
   });
 });

--- a/tests/commandLineScreen/commandLineScreen.store.test.js
+++ b/tests/commandLineScreen/commandLineScreen.store.test.js
@@ -68,6 +68,27 @@ describe("commandLineScreen.store", () => {
       }),
     );
     expect(viewData.form.fields[0].required).toBeUndefined();
+    expect(viewData.form.fields[1]).toMatchObject({
+      $when: "transitionAnimationId",
+      type: "row",
+      fields: [
+        {
+          name: "playbackSpeed",
+          label: "Playback Speed",
+          type: "slider-with-input",
+          min: 0.01,
+          max: 4,
+          step: 0.01,
+          required: true,
+        },
+        {
+          name: "playbackContinuity",
+          label: "Continuity",
+          type: "segmented-control",
+          clearable: false,
+        },
+      ],
+    });
     expect(viewData.form.fields.at(-1)).toEqual({
       type: "section",
       id: "options",

--- a/tests/internal/commandLineCopy.test.js
+++ b/tests/internal/commandLineCopy.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { localizeCommandLineForm } from "../../src/internal/ui/sceneEditor/commandLineCopy.js";
+
+describe("command-line form layout", () => {
+  it("stacks form rows at the large breakpoint by default", () => {
+    const form = localizeCommandLineForm({
+      fields: [
+        {
+          type: "row",
+          fields: [
+            { name: "first", type: "input-text" },
+            { name: "second", type: "input-text" },
+          ],
+        },
+        {
+          type: "row",
+          stackAt: "sm",
+          fields: [
+            { name: "third", type: "input-text" },
+            { name: "fourth", type: "input-text" },
+          ],
+        },
+      ],
+    });
+
+    expect(form.rowStackAt).toBe("lg");
+    expect(form.fields[1].stackAt).toBe("sm");
+  });
+});

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -6,7 +6,7 @@
     <title>VT E2E Runner</title>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.18.2/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.18.4/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module">
       const VT_RESET_KEY = "routevn.vt.indexeddb-reset-done";
 


### PR DESCRIPTION
## Summary

- refine Character sections, sprite animation controls, effect options, ordering, and context actions
- move Background animation below transforms and align Screen playback controls
- stack command-line form rows at the large breakpoint and retain bottom scroll space
- update Rettangoli UI references to ui-v1.18.4

## Validation

- 359 command-line and UI-reference tests passed
- staged JavaScript passed oxlint with zero warnings or errors
- staged JavaScript and JSON passed Prettier
- git diff --check passed

The repository-wide pre-push hook was bypassed because it scans the unrelated untracked ssr-poc directory; the focused PR files passed the checks above.