### PR TITLE
Improve animation editor controls and mask authoring

### DIFF
--- a/src/components/keyframeTimeline/keyframeTimeline.view.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.view.yaml
@@ -81,7 +81,7 @@ template:
                           - 'rtgl-view data-selected=${property.selected} d=h h=24 w=104 bgc=${property.backgroundColor} h-bgc=${property.hoverBackgroundColor} bwr=xs bc=bo av=c cur=${property.rowCursor} style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
                               - $if editable:
                                   - 'rtgl-view#propertyName${pIndex}.keyframeTimelinePropertyRow data-property=${property.name} role=button tabindex=0 aria-pressed="${property.selected}" aria-label="${property.thumbnailName}" w=f h=f pos=abs cur=pointer style="inset: 0; z-index: 0;"': null
-                              - 'rtgl-view w=72 av=c d=h ah=c pos=rel style="z-index: 1; pointer-events: none;"':
+                              - 'rtgl-view w=72 av=c d=h ah=s pl=sm pos=rel style="z-index: 1; pointer-events: none;"':
                                   - $if property.thumbnail:
                                       - 'rtgl-view w=28 h=18 bw=xs bc=${property.thumbnailBorderColor} br=sm overflow=hidden title="${property.thumbnailName}"':
                                           - $if property.thumbnailFileId:

--- a/src/internal/animationMasks.js
+++ b/src/internal/animationMasks.js
@@ -20,6 +20,12 @@ const hasMaskImageReference = (value) => {
   return typeof value === "string" && value.length > 0;
 };
 
+const resolveTransitionMaskDelay = (mask = {}) => {
+  return Number.isSafeInteger(mask.delay) && mask.delay >= 0
+    ? mask.delay
+    : undefined;
+};
+
 const cloneCompositeItem = (item = {}) => {
   return {
     imageId: item.imageId,
@@ -228,6 +234,10 @@ export const normalizeTransitionMaskForEditor = (mask, imageItems = {}) => {
   nextMask.progressDuration = progress.duration;
   nextMask.progressEasing = progress.easing;
   nextMask.progress = normalizeProgressForEditor(mask, progress);
+  const delay = resolveTransitionMaskDelay(mask);
+  if (delay !== undefined) {
+    nextMask.delay = delay;
+  }
   nextMask.imageId = resolveEditorSingleMaskImageId(mask, imageItems);
   nextMask.channel = normalizeTransitionMaskChannel(mask.channel);
   nextMask.invert = mask.invert ?? nextMask.invert;
@@ -289,6 +299,10 @@ export const serializeTransitionMask = (mask) => {
         ? Number(mask.softness)
         : DEFAULT_TRANSITION_MASK_SOFTNESS,
   };
+  const delay = resolveTransitionMaskDelay(mask);
+  if (delay !== undefined) {
+    serializedMask.delay = delay;
+  }
 
   if (mask.progress?.keyframes?.length > 0) {
     serializedMask.progress = serializeProgressForModel(mask.progress);
@@ -370,6 +384,10 @@ export const compileTransitionMaskForRuntime = (mask, imageItems = {}) => {
         : DEFAULT_TRANSITION_MASK_SOFTNESS,
     progress: runtimeProgress,
   };
+  const delay = resolveTransitionMaskDelay(mask);
+  if (delay !== undefined) {
+    runtimeMask.delay = delay;
+  }
 
   if (mask.kind === "single") {
     const texture =
@@ -481,5 +499,7 @@ export const getTransitionMaskDuration = (mask = {}) => {
   }
 
   const progress = resolveMaskProgress(mask);
-  return progress.delay + progress.duration;
+  return (
+    (resolveTransitionMaskDelay(mask) ?? 0) + progress.delay + progress.duration
+  );
 };

--- a/src/internal/animationMasks.js
+++ b/src/internal/animationMasks.js
@@ -236,6 +236,10 @@ export const normalizeTransitionMaskForEditor = (mask, imageItems = {}) => {
 };
 
 export const isTransitionMaskComplete = (mask) => {
+  if (Array.isArray(mask)) {
+    return mask.length > 0 && mask.every(isTransitionMaskComplete);
+  }
+
   if (!mask || !TRANSITION_MASK_KINDS.has(mask.kind)) {
     return false;
   }
@@ -268,6 +272,11 @@ export const isTransitionMaskComplete = (mask) => {
 };
 
 export const serializeTransitionMask = (mask) => {
+  if (Array.isArray(mask)) {
+    const serializedMasks = mask.map(serializeTransitionMask).filter(Boolean);
+    return serializedMasks.length > 0 ? serializedMasks : undefined;
+  }
+
   if (!isTransitionMaskComplete(mask)) {
     return undefined;
   }
@@ -325,6 +334,13 @@ export const serializeTransitionMask = (mask) => {
 };
 
 export const compileTransitionMaskForRuntime = (mask, imageItems = {}) => {
+  if (Array.isArray(mask)) {
+    const runtimeMasks = mask
+      .map((item) => compileTransitionMaskForRuntime(item, imageItems))
+      .filter(Boolean);
+    return runtimeMasks.length > 0 ? runtimeMasks : undefined;
+  }
+
   if (!mask || !TRANSITION_MASK_KINDS.has(mask.kind)) {
     return undefined;
   }
@@ -417,6 +433,14 @@ export const compileTransitionMaskForRuntime = (mask, imageItems = {}) => {
 };
 
 export const collectTransitionMaskImageIds = (mask, imageItems = {}) => {
+  if (Array.isArray(mask)) {
+    return Array.from(
+      new Set(
+        mask.flatMap((item) => collectTransitionMaskImageIds(item, imageItems)),
+      ),
+    );
+  }
+
   if (!mask || !TRANSITION_MASK_KINDS.has(mask.kind)) {
     return [];
   }
@@ -446,6 +470,12 @@ export const collectTransitionMaskImageIds = (mask, imageItems = {}) => {
 };
 
 export const getTransitionMaskDuration = (mask = {}) => {
+  if (Array.isArray(mask)) {
+    return mask.reduce((duration, item) => {
+      return Math.max(duration, getTransitionMaskDuration(item));
+    }, 0);
+  }
+
   if (!mask || !TRANSITION_MASK_KINDS.has(mask.kind)) {
     return 0;
   }

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -5,6 +5,7 @@ import {
   resolveAnimationEditorPayload,
 } from "../../internal/animationEditorRoute.js";
 import {
+  isEditableTransitionMaskKind,
   isTransitionMaskComplete,
   serializeTransitionMask,
 } from "../../internal/animationMasks.js";
@@ -165,6 +166,10 @@ const invalidatePreview = ({ store } = {}) => {
 };
 
 const collectRuntimeMaskTextureIds = (mask = {}) => {
+  if (Array.isArray(mask)) {
+    return mask.flatMap(collectRuntimeMaskTextureIds);
+  }
+
   if (!mask) {
     return [];
   }
@@ -424,20 +429,20 @@ const getAnimationItem = ({ repositoryState, animationId } = {}) => {
   return item?.type === "animation" ? item : undefined;
 };
 
-const resolvePersistedTransitionMask = ({ store, serializedMask } = {}) => {
-  if (store.selectTransitionMaskRemoved()) {
+const serializeTransitionMasksForPersistence = (masks = []) => {
+  const serializedMasks = masks
+    .map((mask) => {
+      return isEditableTransitionMaskKind(mask.kind)
+        ? serializeTransitionMask(mask)
+        : structuredClone(mask);
+    })
+    .filter(Boolean);
+
+  if (serializedMasks.length === 0) {
     return undefined;
   }
 
-  if (serializedMask) {
-    return serializedMask;
-  }
-
-  if (!store.selectEditMode()) {
-    return undefined;
-  }
-
-  return structuredClone(store.selectEditItemData()?.animation?.mask);
+  return serializedMasks.length === 1 ? serializedMasks[0] : serializedMasks;
 };
 
 const createAnimationPersistSnapshot = ({ copy, store } = {}) => {
@@ -447,13 +452,9 @@ const createAnimationPersistSnapshot = ({ copy, store } = {}) => {
   if (dialogType === "transition") {
     const prevTween = normalizeTween(store.selectProperties({ side: "prev" }));
     const nextTween = normalizeTween(store.selectProperties({ side: "next" }));
-    const serializedTransitionMask = serializeTransitionMask(
-      store.selectTransitionMask(),
+    const transitionMask = serializeTransitionMasksForPersistence(
+      store.selectTransitionMasks(),
     );
-    const transitionMask = resolvePersistedTransitionMask({
-      store,
-      serializedMask: serializedTransitionMask,
-    });
 
     animationData = {
       type: "transition",
@@ -1489,6 +1490,46 @@ const commitSelectedKeyframeChange = (deps) => {
   queueEditorAutosave({ deps });
 };
 
+export const handleSelectedKeyframeDelayChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedKeyframeDelay({
+    delay: resolveValueChange(payload),
+  });
+  commitSelectedKeyframeChange(deps);
+};
+
+export const handleSelectedKeyframeDurationChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedKeyframeDuration({
+    duration: resolveValueChange(payload),
+  });
+  commitSelectedKeyframeChange(deps);
+};
+
+export const handleSelectedKeyframeEasingChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedKeyframeEasing({
+    easing: resolveValueChange(payload),
+  });
+  commitSelectedKeyframeChange(deps);
+};
+
+export const handleSelectedKeyframeValueChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedKeyframeValue({
+    value: resolveValueChange(payload),
+  });
+  commitSelectedKeyframeChange(deps);
+};
+
+export const handleSelectedKeyframeRelativeChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedKeyframeRelative({
+    relative: resolveValueChange(payload),
+  });
+  commitSelectedKeyframeChange(deps);
+};
+
 const openSelectedMaskNumberPopover = (deps, payload, { mode, value } = {}) => {
   const { render, store } = deps;
   const event = payload._event;
@@ -1515,6 +1556,10 @@ export const handleSelectedMaskSoftnessClick = (deps, payload) => {
 
 export const handleSelectedMaskInitialValueClick = (deps, payload) => {
   const { store } = deps;
+  const side = payload._event.detail?.side;
+  if (side?.startsWith("mask:")) {
+    store.setSelectedMask({ side });
+  }
   openSelectedMaskNumberPopover(deps, payload, {
     mode: "editSelectedMaskInitialValue",
     value: store.selectMaskEditorTransitionMask()?.progress?.initialValue ?? 0,
@@ -1628,8 +1673,8 @@ export const handleAutoTrackClick = (deps, payload) => {
 export const handlePropertyNameClick = (deps, payload) => {
   const { render, store } = deps;
   const { property, side, x, y } = payload._event.detail;
-  if (side === "mask") {
-    selectMaskTimelineRow(deps, { clientX: x, clientY: y });
+  if (side === "mask" || side?.startsWith("mask:")) {
+    selectMaskTimelineRow(deps, { clientX: x, clientY: y }, { side });
     return;
   }
 
@@ -1650,9 +1695,9 @@ export const handlePropertyNameClick = (deps, payload) => {
   render();
 };
 
-const selectMaskTimelineRow = (deps, event) => {
+const selectMaskTimelineRow = (deps, event, { index, side } = {}) => {
   const { render, store } = deps;
-  store.setSelectedMask({});
+  store.setSelectedMask({ index, side });
   if (store.selectIsTouchMode()) {
     store.setPopover({
       mode: "editMask",
@@ -1667,7 +1712,13 @@ const selectMaskTimelineRow = (deps, event) => {
 };
 
 export const handleMaskTimelineRowClick = (deps, payload) => {
-  selectMaskTimelineRow(deps, payload._event);
+  const event = payload._event;
+  const index = Number.parseInt(event.currentTarget?.dataset?.maskIndex, 10);
+  const selection = {};
+  if (Number.isInteger(index)) {
+    selection.index = index;
+  }
+  selectMaskTimelineRow(deps, event, selection);
 };
 
 export const handleMaskTimelineRowKeyDown = (deps, payload) => {
@@ -1678,7 +1729,12 @@ export const handleMaskTimelineRowKeyDown = (deps, payload) => {
 
   event.preventDefault();
   event.stopPropagation();
-  selectMaskTimelineRow(deps, event);
+  const index = Number.parseInt(event.currentTarget?.dataset?.maskIndex, 10);
+  const selection = {};
+  if (Number.isInteger(index)) {
+    selection.index = index;
+  }
+  selectMaskTimelineRow(deps, event, selection);
 };
 
 export const handleSelectedPropertyDeleteClick = (deps) => {

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -1250,6 +1250,7 @@ const cloneTransitionMask = (mask = {}) => {
   nextMask.sample = mask.sample;
   nextMask.softness = mask.softness;
   nextMask.invert = mask.invert;
+  nextMask.delay = mask.delay;
   nextMask.progress = cloneMaskProgress(mask.progress);
   nextMask.progressDelay = mask.progressDelay;
   nextMask.progressDuration = mask.progressDuration;
@@ -3922,6 +3923,7 @@ export const selectViewData = ({ state, i18n }) => {
     deletePropertyButtonLabel:
       copy.deletePropertyButtonLabel ?? "Delete property",
     editPreviewButton: copy.editPreviewButton ?? "Edit Preview",
+    editKeyframeButtonLabel: copy.editKeyframeMenuItem ?? "Edit keyframe",
     imageLabel: copy.imageLabel ?? "Image",
     initialValueLabel: copy.initialValueLabel ?? "Initial value",
     inTimelineLabel: copy.inTimelineLabel ?? "Incoming",

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -53,6 +53,7 @@ const TIMELINE_BASE_PIXELS_PER_SECOND = 200;
 const TIMELINE_MIN_DISPLAY_DURATION_MS = 1000;
 const TIMELINE_PROPERTY_COLUMN_WIDTH = 104;
 const MASK_PROGRESS_PROPERTY = "progress";
+const MASK_SIDE_PREFIX = "mask";
 const DEFAULT_EDITOR_TAB = "tween";
 const EDITOR_TAB_IDS = new Set([DEFAULT_EDITOR_TAB, "preview"]);
 
@@ -87,45 +88,35 @@ const createPropertyFieldConfig = (
     x: {
       label: copy.positionXPropertyLabel ?? "Position X",
       defaultValue: width / 2,
-      slider: {
-        min: -width,
-        max: width,
+      input: {
         step: 0.01,
       },
     },
     y: {
       label: copy.positionYPropertyLabel ?? "Position Y",
       defaultValue: height / 2,
-      slider: {
-        min: -height,
-        max: height,
+      input: {
         step: 0.01,
       },
     },
     scaleX: {
       label: copy.scaleXPropertyLabel ?? "Scale X",
       defaultValue: 1,
-      slider: {
-        min: 0,
-        max: 5,
+      input: {
         step: 0.01,
       },
     },
     scaleY: {
       label: copy.scaleYPropertyLabel ?? "Scale Y",
       defaultValue: 1,
-      slider: {
-        min: 0,
-        max: 5,
+      input: {
         step: 0.01,
       },
     },
     rotation: {
       label: copy.rotationPropertyLabel ?? "Rotation",
       defaultValue: 0,
-      slider: {
-        min: -360,
-        max: 360,
+      input: {
         step: 1,
       },
       tooltip: {
@@ -707,6 +698,24 @@ const createSliderField = ({
     };
   }
 
+  if (config.input) {
+    const field = {
+      name,
+      type: "input-number",
+      label: label ?? fallbackLabel,
+    };
+    Object.assign(field, config.input);
+
+    if (required) {
+      field.required = true;
+    }
+    if (config.tooltip) {
+      field.tooltip = config.tooltip;
+    }
+
+    return field;
+  }
+
   const field = {
     name,
     type: "slider-with-input",
@@ -1105,9 +1114,79 @@ const createEmptyMaskPanelData = (copy = {}) => ({
   compositeItems: [],
 });
 
+const isMaskSide = (side) => {
+  return side === MASK_SIDE_PREFIX || side?.startsWith(`${MASK_SIDE_PREFIX}:`);
+};
+
+const getMaskIndexFromSide = (side, fallbackIndex = 0) => {
+  if (side === MASK_SIDE_PREFIX) {
+    return fallbackIndex;
+  }
+
+  const index = Number.parseInt(side?.slice(MASK_SIDE_PREFIX.length + 1), 10);
+  return Number.isInteger(index) && index >= 0 ? index : fallbackIndex;
+};
+
+const createMaskSide = (index) => `${MASK_SIDE_PREFIX}:${index}`;
+
+const getTransitionMasks = (state) => {
+  const masks = [];
+  if (state.transitionMask) {
+    masks.push(state.transitionMask);
+  }
+  masks.push(...(state.additionalTransitionMasks ?? []));
+  return masks;
+};
+
+const getTransitionMask = (state, index = state.selectedMaskIndex ?? 0) => {
+  if (index === 0) {
+    return state.transitionMask;
+  }
+
+  return state.additionalTransitionMasks?.[index - 1];
+};
+
+const setTransitionMaskAtIndex = (state, index, mask) => {
+  if (index === 0) {
+    state.transitionMask = mask;
+    return;
+  }
+
+  state.additionalTransitionMasks[index - 1] = mask;
+};
+
+const appendTransitionMask = (state, mask) => {
+  if (!state.transitionMask) {
+    state.transitionMask = mask;
+    return 0;
+  }
+
+  state.additionalTransitionMasks.push(mask);
+  return state.additionalTransitionMasks.length;
+};
+
+const removeTransitionMaskAtIndex = (state, index) => {
+  if (index === 0) {
+    state.transitionMask = state.additionalTransitionMasks.shift();
+    return;
+  }
+
+  state.additionalTransitionMasks.splice(index - 1, 1);
+};
+
+const getTransitionMaskValue = (state) => {
+  const masks = getTransitionMasks(state);
+  if (masks.length === 0) {
+    return undefined;
+  }
+
+  return masks.length === 1 ? masks[0] : masks;
+};
+
 const getSectionProperties = (state, side) => {
-  if (side === "mask") {
-    const progress = state.transitionMask?.progress;
+  if (isMaskSide(side)) {
+    const maskIndex = getMaskIndexFromSide(side, state.selectedMaskIndex ?? 0);
+    const progress = getTransitionMask(state, maskIndex)?.progress;
     return progress ? { [MASK_PROGRESS_PROPERTY]: progress } : {};
   }
 
@@ -1126,10 +1205,6 @@ const getDefaultInitialValues = (state) => {
   return createDefaultInitialValuesByProperty(getPropertyFieldConfig(state));
 };
 
-const getTransitionMask = (state) => {
-  return state.transitionMask;
-};
-
 const getMaskEditorTransitionMask = (state) => {
   return state.popover.mode === "addMask"
     ? state.pendingTransitionMask
@@ -1142,7 +1217,7 @@ const setMaskEditorTransitionMask = (state, mask) => {
     return;
   }
 
-  state.transitionMask = mask;
+  setTransitionMaskAtIndex(state, state.selectedMaskIndex ?? 0, mask);
 };
 
 const cloneMaskProgress = (progress) => {
@@ -1182,34 +1257,8 @@ const cloneTransitionMask = (mask = {}) => {
   return nextMask;
 };
 
-const getPersistedTransitionMask = (state) => {
-  if (!state.editItemId) {
-    return undefined;
-  }
-
-  return state.data?.items?.[state.editItemId]?.animation?.mask;
-};
-
-const getUnsupportedPersistedTransitionMask = (state) => {
-  if (state.dialogType !== "transition" || state.transitionMaskRemoved) {
-    return undefined;
-  }
-
-  const persistedMask = getPersistedTransitionMask(state);
-  if (
-    !persistedMask?.kind ||
-    isEditableTransitionMaskKind(persistedMask.kind)
-  ) {
-    return undefined;
-  }
-
-  return persistedMask;
-};
-
 const getEffectiveTransitionMask = (state) => {
-  return (
-    getTransitionMask(state) ?? getUnsupportedPersistedTransitionMask(state)
-  );
+  return getTransitionMaskValue(state);
 };
 
 const getImageItems = (state) => {
@@ -1287,6 +1336,7 @@ export const createInitialState = () => ({
   selectedKeyframe: undefined,
   selectedProperty: undefined,
   selectedMask: false,
+  selectedMaskIndex: undefined,
   timelinePan: undefined,
   timelinePanClickSuppressed: false,
   timelinePanHovered: false,
@@ -1299,6 +1349,7 @@ export const createInitialState = () => ({
   projectResolution: DEFAULT_PROJECT_RESOLUTION,
   tweenBySection: createEmptyTweenBySection(),
   transitionMask: undefined,
+  additionalTransitionMasks: [],
   pendingTransitionMask: undefined,
   dialogDefaultValues: {
     name: "",
@@ -1337,7 +1388,6 @@ export const createInitialState = () => ({
   imageSelectorDialog: createInitialImageSelectorDialogState(),
   fullImagePreviewVisible: false,
   fullImagePreviewImageId: undefined,
-  transitionMaskRemoved: false,
 });
 
 export const setItems = ({ state }, { data } = {}) => {
@@ -1484,15 +1534,25 @@ const cloneTweenBySectionFromItem = (itemData, dialogType) => {
   return tweenBySection;
 };
 
-const cloneTransitionMaskFromItem = (state, itemData, dialogType) => {
+const cloneTransitionMasksFromItem = (state, itemData, dialogType) => {
   if (dialogType !== "transition") {
-    return undefined;
+    return [];
   }
 
-  return normalizeTransitionMaskForEditor(
-    itemData?.animation?.mask,
-    getImageItems(state),
-  );
+  const persistedMask = itemData?.animation?.mask;
+  const persistedMasks = Array.isArray(persistedMask)
+    ? persistedMask
+    : persistedMask
+      ? [persistedMask]
+      : [];
+
+  return persistedMasks.map((mask) => {
+    if (!isEditableTransitionMaskKind(mask.kind)) {
+      return structuredClone(mask);
+    }
+
+    return normalizeTransitionMaskForEditor(mask, getImageItems(state));
+  });
 };
 
 export const openDialog = (
@@ -1507,9 +1567,9 @@ export const openDialog = (
   state.selectedKeyframe = undefined;
   state.selectedProperty = undefined;
   state.selectedMask = false;
+  state.selectedMaskIndex = undefined;
   state.editMode = Boolean(editMode);
   state.editItemId = itemId;
-  state.transitionMaskRemoved = false;
   state.pendingTransitionMask = undefined;
   state.previewImages = normalizeAnimationPreviewData(itemData?.preview);
 
@@ -1523,11 +1583,13 @@ export const openDialog = (
       itemData,
       resolvedDialogType,
     );
-    state.transitionMask = cloneTransitionMaskFromItem(
+    const transitionMasks = cloneTransitionMasksFromItem(
       state,
       itemData,
       resolvedDialogType,
     );
+    state.transitionMask = transitionMasks[0];
+    state.additionalTransitionMasks = transitionMasks.slice(1);
     return;
   }
 
@@ -1541,7 +1603,7 @@ export const openDialog = (
   };
   state.tweenBySection = createEmptyTweenBySection();
   state.transitionMask = undefined;
-  state.transitionMaskRemoved = false;
+  state.additionalTransitionMasks = [];
 };
 
 export const selectTargetGroupId = ({ state }) => {
@@ -1605,8 +1667,12 @@ const resolveDialogSide = (state, side) => {
 
 const getMutableSectionProperties = (state, side) => {
   const resolvedSide = resolveDialogSide(state, side);
-  if (resolvedSide === "mask") {
-    const progress = state.transitionMask?.progress;
+  if (isMaskSide(resolvedSide)) {
+    const maskIndex = getMaskIndexFromSide(
+      resolvedSide,
+      state.selectedMaskIndex ?? 0,
+    );
+    const progress = getTransitionMask(state, maskIndex)?.progress;
     return progress ? { [MASK_PROGRESS_PROPERTY]: progress } : {};
   }
 
@@ -1625,6 +1691,7 @@ export const setSelectedKeyframe = (
 ) => {
   state.selectedProperty = undefined;
   state.selectedMask = false;
+  state.selectedMaskIndex = undefined;
   const resolvedSide = resolveDialogSide(state, side);
   const resolvedIndex = Number(index);
   const keyframe = getSectionProperties(state, resolvedSide)[property]
@@ -1656,6 +1723,7 @@ export const setSelectedProperty = ({ state }, { side, property } = {}) => {
 
   state.selectedKeyframe = undefined;
   state.selectedMask = false;
+  state.selectedMaskIndex = undefined;
   state.selectedProperty = selectedProperty
     ? { side: resolvedSide, property }
     : undefined;
@@ -1665,29 +1733,40 @@ export const selectSelectedProperty = ({ state }) => {
   return state.selectedProperty;
 };
 
-export const setSelectedMask = ({ state }, _payload = {}) => {
+export const setSelectedMask = ({ state }, { index, side } = {}) => {
   state.selectedKeyframe = undefined;
   state.selectedProperty = undefined;
+  const maskIndex = Number.isInteger(Number(index))
+    ? Number(index)
+    : getMaskIndexFromSide(side, state.selectedMaskIndex ?? 0);
   state.selectedMask =
     state.dialogType === "transition" &&
-    Boolean(getEffectiveTransitionMask(state));
+    Boolean(getTransitionMask(state, maskIndex));
+  state.selectedMaskIndex = state.selectedMask ? maskIndex : undefined;
 };
 
 export const selectSelectedMask = ({ state }) => {
   return state.selectedMask;
 };
 
+export const selectSelectedMaskIndex = ({ state }) => {
+  return state.selectedMaskIndex;
+};
+
 export const clearTimelineSelection = ({ state }, _payload = {}) => {
   state.selectedKeyframe = undefined;
   state.selectedProperty = undefined;
   state.selectedMask = false;
+  state.selectedMaskIndex = undefined;
 };
 
 export const selectTimelineSelection = ({ state }) => {
   return (
     state.selectedKeyframe ??
     state.selectedProperty ??
-    (state.selectedMask ? { type: "mask" } : undefined)
+    (state.selectedMask
+      ? { type: "mask", index: state.selectedMaskIndex }
+      : undefined)
   );
 };
 
@@ -2216,7 +2295,7 @@ export const deleteKeyframe = ({ state }, { side, property, index } = {}) => {
   if (!Array.isArray(keyframes)) {
     return;
   }
-  if (resolvedSide === "mask" && keyframes.length <= 1) {
+  if (isMaskSide(resolvedSide) && keyframes.length <= 1) {
     return;
   }
 
@@ -2240,7 +2319,7 @@ export const deleteProperty = ({ state }, { side, property } = {}) => {
   const resolvedSide = resolveDialogSide(state, side);
   const properties = getMutableSectionProperties(state, side);
 
-  if (!property || !properties || resolvedSide === "mask") {
+  if (!property || !properties || isMaskSide(resolvedSide)) {
     return;
   }
 
@@ -2383,13 +2462,13 @@ export const updateAutoProperty = (
 };
 
 export const enableTransitionMask = ({ state }, _payload = {}) => {
-  state.transitionMask = createDefaultTransitionMask();
-  state.transitionMaskRemoved = false;
+  if (!state.transitionMask) {
+    state.transitionMask = createDefaultTransitionMask();
+  }
 };
 
 export const startPendingTransitionMask = ({ state }, _payload = {}) => {
   state.pendingTransitionMask = createDefaultTransitionMask();
-  state.transitionMaskRemoved = false;
 };
 
 export const commitPendingTransitionMask = ({ state }, _payload = {}) => {
@@ -2397,19 +2476,28 @@ export const commitPendingTransitionMask = ({ state }, _payload = {}) => {
     return;
   }
 
-  state.transitionMask = cloneTransitionMask(state.pendingTransitionMask);
+  state.selectedMaskIndex = appendTransitionMask(
+    state,
+    cloneTransitionMask(state.pendingTransitionMask),
+  );
+  state.selectedMask = true;
   state.pendingTransitionMask = undefined;
-  state.transitionMaskRemoved = false;
 };
 
 export const disableTransitionMask = ({ state }, _payload = {}) => {
-  state.transitionMask = undefined;
-  state.transitionMaskRemoved = true;
+  removeTransitionMaskAtIndex(state, state.selectedMaskIndex ?? 0);
   state.selectedMask = false;
+  state.selectedMaskIndex = undefined;
+  state.selectedKeyframe = undefined;
+  state.selectedProperty = undefined;
 };
 
 export const selectTransitionMask = ({ state }) => {
   return getTransitionMask(state);
+};
+
+export const selectTransitionMasks = ({ state }) => {
+  return getTransitionMasks(state);
 };
 
 export const selectHasEffectiveTransitionMask = ({ state }) => {
@@ -2418,10 +2506,6 @@ export const selectHasEffectiveTransitionMask = ({ state }) => {
 
 export const selectMaskEditorTransitionMask = ({ state }) => {
   return getMaskEditorTransitionMask(state);
-};
-
-export const selectTransitionMaskRemoved = ({ state }) => {
-  return state.transitionMaskRemoved === true;
 };
 
 export const setTransitionMaskKind = ({ state }, { kind } = {}) => {
@@ -3028,21 +3112,20 @@ export const closeMaskRemoveConfirmDialog = ({ state }, _payload = {}) => {
 const buildTransitionMaskPanelDataForMask = (
   state,
   transitionMask,
-  unsupportedPersistedMask,
   copy = {},
 ) => {
-  if (!transitionMask && !unsupportedPersistedMask) {
+  if (!transitionMask) {
     return createEmptyMaskPanelData(copy);
   }
 
-  if (unsupportedPersistedMask) {
+  if (!isEditableTransitionMaskKind(transitionMask.kind)) {
     return {
       ...createEmptyMaskPanelData(copy),
       enabled: true,
       unsupported: true,
-      unsupportedKind: unsupportedPersistedMask.kind,
+      unsupportedKind: transitionMask.kind,
       unsupportedMessage: `${
-        unsupportedPersistedMask.kind
+        transitionMask.kind
       } ${copy.unsupportedMaskMessageSuffix ?? "masks are hidden for now"}`,
       unsupportedDescription:
         copy.unsupportedMaskDescription ??
@@ -3124,7 +3207,6 @@ const buildTransitionMaskPanelData = (state, copy = {}) => {
   return buildTransitionMaskPanelDataForMask(
     state,
     getTransitionMask(state),
-    getUnsupportedPersistedTransitionMask(state),
     copy,
   );
 };
@@ -3154,7 +3236,6 @@ const buildMaskEditorPanelData = (state, copy = {}) => {
     return buildTransitionMaskPanelDataForMask(
       state,
       state.pendingTransitionMask,
-      undefined,
       copy,
     );
   }
@@ -3185,19 +3266,31 @@ const buildSelectedKeyframePanelData = (
       ? (copy.outTimelineLabel ?? "Outgoing")
       : side === "next"
         ? (copy.inTimelineLabel ?? "Incoming")
-        : side === "mask"
+        : isMaskSide(side)
           ? (copy.maskTitle ?? "Mask")
           : (copy.updateType ?? "Update");
   const easing = keyframe.easing ?? "linear";
-  const easingLabel =
-    createEasingOptions(copy).find((option) => option.value === easing)
-      ?.label ?? formatEasingLabel(easing);
-  const valueTypeLabel =
-    keyframe.relative === true
-      ? (copy.relativeValueType ?? "Relative")
-      : (copy.absoluteValueType ?? "Absolute");
+  const valueSlider = propertyFieldConfig[property]?.slider;
   return {
     id: `${side}:${property}:${index}`,
+    editor: {
+      delay: keyframe.delay ?? 0,
+      delayLabel: copy.delayMsLabel ?? "Delay (ms)",
+      duration: keyframe.duration,
+      durationLabel: copy.durationMsLabel ?? "Duration (ms)",
+      easing,
+      easingOptions: createEasingOptions(copy),
+      relative: keyframe.relative ?? false,
+      relativeOptions: [
+        { label: copy.absoluteValueType ?? "Absolute", value: false },
+        { label: copy.relativeValueType ?? "Relative", value: true },
+      ],
+      value: keyframe.value,
+      valueLabel: copy.valueLabel ?? "Value",
+      valueStep: propertyFieldConfig[property]?.input?.step ?? "any",
+      valueSlider,
+      valueUsesPopover: Boolean(propertyFieldConfig[property]?.input),
+    },
     fields: [
       {
         type: "text",
@@ -3210,29 +3303,29 @@ const buildSelectedKeyframePanelData = (
         value: propertyFieldConfig[property]?.label ?? property,
       },
       {
-        type: "text",
+        type: "slot",
         label: copy.delayMsLabel ?? "Delay (ms)",
-        value: keyframe.delay ?? 0,
+        slot: "keyframe-delay",
       },
       {
-        type: "text",
+        type: "slot",
         label: copy.durationMsLabel ?? "Duration (ms)",
-        value: keyframe.duration,
+        slot: "keyframe-duration",
       },
       {
-        type: "text",
+        type: "slot",
         label: copy.easingLabel ?? "Easing",
-        value: easingLabel,
+        slot: "keyframe-easing",
       },
       {
-        type: "text",
+        type: "slot",
         label: copy.valueLabel ?? "Value",
-        value: keyframe.value,
+        slot: "keyframe-value",
       },
       {
-        type: "text",
+        type: "slot",
         label: copy.valueTypeLabel ?? "Value type",
-        value: valueTypeLabel,
+        slot: "keyframe-value-type",
       },
     ],
   };
@@ -3259,7 +3352,7 @@ const buildSelectedPropertyPanelData = (
       ? (copy.outTimelineLabel ?? "Outgoing")
       : side === "next"
         ? (copy.inTimelineLabel ?? "Incoming")
-        : side === "mask"
+        : isMaskSide(side)
           ? (copy.maskTitle ?? "Mask")
           : (copy.updateType ?? "Update");
   const hasInitialValue =
@@ -3434,7 +3527,7 @@ export const selectViewData = ({ state, i18n }) => {
     createTransitionAddPropertySideMenuItems({
       previousAvailable: previousAddPropertyOptions.length > 0,
       nextAvailable: nextAddPropertyOptions.length > 0,
-      maskAvailable: !getEffectiveTransitionMask(state),
+      maskAvailable: true,
       copy,
     });
   const transitionPropertySideOptions =
@@ -3457,32 +3550,50 @@ export const selectViewData = ({ state, i18n }) => {
   const transitionMaskPanel = buildTransitionMaskPanelData(state, copy);
   const maskEditorPanel = buildMaskEditorPanelData(state, copy);
   const selectedMask = state.selectedMask && transitionMaskPanel.enabled;
-  const maskProgress = getSectionProperties(state, "mask")[
-    MASK_PROGRESS_PROPERTY
-  ];
-  const maskTimelineImage =
-    transitionMaskPanel.singleImage ?? transitionMaskPanel.imageItems[0] ?? {};
-  const maskTimelineRow = transitionMaskPanel.enabled
-    ? {
-        editable: !transitionMaskPanel.unsupported && Boolean(maskProgress),
-        image: maskTimelineImage,
-        imageBorderColor: selectedMask ? "pr" : "bo",
-        label: copy.maskTitle ?? "Mask",
-        selected: selectedMask,
-      }
-    : undefined;
-  const maskTimelineProperties = maskTimelineRow?.editable
-    ? {
-        [MASK_PROGRESS_PROPERTY]: {
-          ...maskProgress,
-          selected: selectedMask,
-          thumbnail: true,
-          thumbnailBorderColor: maskTimelineRow.imageBorderColor,
-          thumbnailFileId: maskTimelineImage.previewFileId,
-          thumbnailName: maskTimelineImage.name ?? maskTimelineRow.label,
-        },
-      }
-    : {};
+  const maskTimelineRows = getTransitionMasks(state).map(
+    (transitionMask, index) => {
+      const side = createMaskSide(index);
+      const panel = buildTransitionMaskPanelDataForMask(
+        state,
+        transitionMask,
+        copy,
+      );
+      const progress = getSectionProperties(state, side)[
+        MASK_PROGRESS_PROPERTY
+      ];
+      const rowSelected =
+        state.selectedMask && state.selectedMaskIndex === index;
+      const image = panel.singleImage ?? panel.imageItems[0] ?? {};
+      const imageBorderColor = rowSelected ? "pr" : "bo";
+      const label = copy.maskTitle ?? "Mask";
+      const editable = !panel.unsupported && Boolean(progress);
+      const properties = editable
+        ? {
+            [MASK_PROGRESS_PROPERTY]: {
+              ...progress,
+              selected: rowSelected,
+              thumbnail: true,
+              thumbnailBorderColor: imageBorderColor,
+              thumbnailFileId: image.previewFileId,
+              thumbnailName: image.name ?? label,
+            },
+          }
+        : {};
+
+      return {
+        editable,
+        image,
+        imageBorderColor,
+        index,
+        label,
+        properties,
+        selected: rowSelected,
+        side,
+      };
+    },
+  );
+  const maskTimelineRow = maskTimelineRows[0];
+  const maskTimelineProperties = maskTimelineRow?.properties ?? {};
   const previewPanel = buildPreviewPanelData(state, copy);
   const selectedKeyframePanel = buildSelectedKeyframePanelData(
     state,
@@ -3513,7 +3624,7 @@ export const selectViewData = ({ state, i18n }) => {
     return localizeMenuItems(baseKeyframeDropdownItems, copy).filter((item) => {
       if (
         item.value === "delete-keyframe" &&
-        side === "mask" &&
+        isMaskSide(side) &&
         keyframes.length <= 1
       ) {
         return false;
@@ -3686,10 +3797,12 @@ export const selectViewData = ({ state, i18n }) => {
     selectedProperty: state.selectedProperty,
     selectedKeyframeDetailId: selectedKeyframePanel?.id,
     selectedKeyframeDetailFields: selectedKeyframePanel?.fields ?? [],
+    selectedKeyframeEditor: selectedKeyframePanel?.editor,
     selectedPropertyDetailId: selectedPropertyPanel?.id,
     selectedPropertyDetailFields: selectedPropertyPanel?.fields ?? [],
     selectedMask,
     maskTimelineRow,
+    maskTimelineRows,
     maskTimelineProperties,
     maskTimelineDefaultValues: { [MASK_PROGRESS_PROPERTY]: 0 },
     updateTimelineDefaultValues,
@@ -3808,7 +3921,6 @@ export const selectViewData = ({ state, i18n }) => {
     doneButton: copy.doneButton ?? "Done",
     deletePropertyButtonLabel:
       copy.deletePropertyButtonLabel ?? "Delete property",
-    editButton: copy.editMenuItem ?? "Edit",
     editPreviewButton: copy.editPreviewButton ?? "Edit Preview",
     imageLabel: copy.imageLabel ?? "Image",
     initialValueLabel: copy.initialValueLabel ?? "Initial value",

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -154,7 +154,7 @@ refs:
         handler: handlePropertyNameClick
       initial-value-click:
         handler: handleInitialValueClick
-  maskTimeline:
+  maskTimeline*:
     eventListeners:
       add-keyframe:
         handler: handleAddKeyframeFromTimeline
@@ -222,10 +222,30 @@ refs:
         handler: handleEditInitialValueFormSubmit
       form-change:
         handler: handleEditInitialValueFormChange
-  editSelectedKeyframeButton:
+  selectedKeyframeDelay:
     eventListeners:
-      click:
-        handler: handleSelectedKeyframeEditClick
+      value-change:
+        handler: handleSelectedKeyframeDelayChange
+  selectedKeyframeDuration:
+    eventListeners:
+      value-change:
+        handler: handleSelectedKeyframeDurationChange
+  selectedKeyframeEasingSelect:
+    eventListeners:
+      value-change:
+        handler: handleSelectedKeyframeEasingChange
+  selectedKeyframeValue:
+    eventListeners:
+      value-input:
+        handler: handleSelectedKeyframeValueChange
+  selectedKeyframeValuePopover:
+    eventListeners:
+      value-change:
+        handler: handleSelectedKeyframeValueChange
+  selectedKeyframeRelative:
+    eventListeners:
+      value-change:
+        handler: handleSelectedKeyframeRelativeChange
   selectedMaskInitialValue:
     eventListeners:
       click:
@@ -266,7 +286,7 @@ refs:
     eventListeners:
       click:
         handler: handleDisableMaskClick
-  unsupportedMaskTimelineRow:
+  unsupportedMaskTimelineRow*:
     eventListeners:
       click:
         handler: handleMaskTimelineRowClick
@@ -411,7 +431,7 @@ styles:
   ".animationEditorTab:focus-visible":
     outline: "2px solid var(--ring)"
     outline-offset: 2px
-  "#unsupportedMaskTimelineRow:focus-visible":
+  '[id^="unsupportedMaskTimelineRow"]:focus-visible':
     outline: "2px solid var(--ring)"
     outline-offset: 2px
   "#selectedMaskSoftness:focus-visible":
@@ -491,12 +511,12 @@ template:
                                               - rtgl-view w=72 av=c ah=c:
                                                   - rtgl-text s=sm c=mu-fg: ${maskTitle}
                                               - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                                          - $if maskTimelineRow:
+                                          - $for maskTimelineRow, i in maskTimelineRows:
                                               - $if maskTimelineRow.editable:
-                                                  - rtgl-view#maskTimelineRow data-timeline-selection-surface=true w=f:
-                                                      - rvn-keyframe-timeline#maskTimeline editable=true side=mask ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${maskTimelineProperties} :defaultValues=${maskTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                                  - rtgl-view#maskTimelineRow${i} data-timeline-selection-surface=true w=f:
+                                                      - rvn-keyframe-timeline#maskTimeline${i} editable=true side=${maskTimelineRow.side} ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
                                                 $else:
-                                                  - 'rtgl-view#unsupportedMaskTimelineRow data-timeline-selection-surface=true data-selected=${maskTimelineRow.selected} role=button tabindex=0 aria-label="${maskTimelineRow.label}" aria-pressed="${maskTimelineRow.selected}" d=h w=f h=24 av=c cur=pointer':
+                                                  - 'rtgl-view#unsupportedMaskTimelineRow${i} data-timeline-selection-surface=true data-mask-index=${maskTimelineRow.index} data-selected=${maskTimelineRow.selected} role=button tabindex=0 aria-label="${maskTimelineRow.label}" aria-pressed="${maskTimelineRow.selected}" d=h w=f h=24 av=c cur=pointer':
                                                       - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
                                                           - rtgl-view w=72 av=c ah=c:
                                                               - 'rtgl-view w=28 h=18 bw=xs bc=${maskTimelineRow.imageBorderColor} br=sm overflow=hidden title="${maskTimelineRow.image.name}"':
@@ -542,9 +562,17 @@ template:
                               - 'rtgl-button#selectedPropertyDeleteButton sq v=gh pre=trash aria-label="${deletePropertyButtonLabel}" title="${deletePropertyButtonLabel}"': null
                   - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                       - $if selectedKeyframeDetailId:
-                          - rvn-detail-view#selectedKeyframeDetails key=${selectedKeyframeDetailId} w=f :fields=${selectedKeyframeDetailFields} :fillHeight=${false}: null
-                          - rtgl-view d=h w=f ah=e ph=md pb=md:
-                              - rtgl-button#editSelectedKeyframeButton pre=edit s=sm: ${editButton}
+                          - rvn-detail-view#selectedKeyframeDetails key=${selectedKeyframeDetailId} w=f :fields=${selectedKeyframeDetailFields} :fillHeight=${false}:
+                              - 'rtgl-popover-input#selectedKeyframeDelay slot=keyframe-delay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
+                              - 'rtgl-popover-input#selectedKeyframeDuration slot=keyframe-duration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
+                              - rtgl-select#selectedKeyframeEasingSelect slot=keyframe-easing w=f no-clear :selectedValue=${selectedKeyframeEditor.easing} :options=${selectedKeyframeEditor.easingOptions}: null
+                              - $if selectedKeyframeEditor.valueSlider:
+                                  - rtgl-slider-input#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f value=${selectedKeyframeEditor.value} min=${selectedKeyframeEditor.valueSlider.min} max=${selectedKeyframeEditor.valueSlider.max} step=${selectedKeyframeEditor.valueSlider.step}: null
+                                $elif selectedKeyframeEditor.valueUsesPopover:
+                                  - 'rtgl-popover-input#selectedKeyframeValuePopover slot=keyframe-value value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
+                                $else:
+                                  - rtgl-input-number#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f step=${selectedKeyframeEditor.valueStep} value=${selectedKeyframeEditor.value}: null
+                              - rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type w=f no-clear :selectedValue=${selectedKeyframeEditor.relative} :options=${selectedKeyframeEditor.relativeOptions}: null
                         $elif selectedPropertyDetailId:
                           - rvn-detail-view#selectedPropertyDetails key=${selectedPropertyDetailId} w=f :fields=${selectedPropertyDetailFields} :fillHeight=${false}: null
                         $elif selectedMask:

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -154,7 +154,7 @@ refs:
         handler: handlePropertyNameClick
       initial-value-click:
         handler: handleInitialValueClick
-  maskTimeline*:
+  maskKeyframeTimeline*:
     eventListeners:
       add-keyframe:
         handler: handleAddKeyframeFromTimeline
@@ -212,6 +212,10 @@ refs:
     eventListeners:
       form-action:
         handler: handleEditKeyframeFormSubmit
+  editSelectedKeyframeButton:
+    eventListeners:
+      click:
+        handler: handleSelectedKeyframeEditClick
   editAutoForm:
     eventListeners:
       form-action:
@@ -513,8 +517,8 @@ template:
                                               - rtgl-view h=24 w=24 mr=sm ml=sm: null
                                           - $for maskTimelineRow, i in maskTimelineRows:
                                               - $if maskTimelineRow.editable:
-                                                  - rtgl-view#maskTimelineRow${i} data-timeline-selection-surface=true w=f:
-                                                      - rvn-keyframe-timeline#maskTimeline${i} editable=true side=${maskTimelineRow.side} ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                                  - rtgl-view#maskTrackRow${i} data-timeline-selection-surface=true w=f:
+                                                      - rvn-keyframe-timeline#maskKeyframeTimeline${i} editable=true side=${maskTimelineRow.side} ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
                                                 $else:
                                                   - 'rtgl-view#unsupportedMaskTimelineRow${i} data-timeline-selection-surface=true data-mask-index=${maskTimelineRow.index} data-selected=${maskTimelineRow.selected} role=button tabindex=0 aria-label="${maskTimelineRow.label}" aria-pressed="${maskTimelineRow.selected}" d=h w=f h=24 av=c cur=pointer':
                                                       - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
@@ -556,7 +560,9 @@ template:
                   - $if detailsPanelTitle:
                       - rtgl-view#timelineDetailsHeader h=48 w=f d=h av=c ph=md bwb=xs bc=bo:
                           - rtgl-text w=1fg: ${detailsPanelTitle}
-                          - $if selectedMask:
+                          - $if selectedKeyframeDetailId:
+                              - 'rtgl-button#editSelectedKeyframeButton sq v=gh pre=edit aria-label="${editKeyframeButtonLabel}" title="${editKeyframeButtonLabel}"': null
+                            $elif selectedMask:
                               - 'rtgl-button#selectedMaskDeleteButton sq v=gh pre=trash aria-label="${removeButton}" title="${removeButton}"': null
                             $elif selectedPropertyDetailId:
                               - 'rtgl-button#selectedPropertyDeleteButton sq v=gh pre=trash aria-label="${deletePropertyButtonLabel}" title="${deletePropertyButtonLabel}"': null

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -500,19 +500,19 @@ template:
                                           - rvn-keyframe-timeline#transitionRuler ?showRuler=true ?showTracks=false ?interactiveRuler=true ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration}: null
                                       - rtgl-view d=v w=f g=xs:
                                           - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                              - rtgl-view w=72 av=c ah=c:
+                                              - rtgl-view w=72 av=c ah=s pl=sm:
                                                   - rtgl-text s=sm c=mu-fg: ${outTimelineLabel}
                                               - rtgl-view h=24 w=24 mr=sm ml=sm: null
                                           - rvn-keyframe-timeline#previousTimeline editable=true side=prev ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${previousProperties} :defaultValues=${transitionTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
                                       - rtgl-view d=v w=f g=xs:
                                           - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                              - rtgl-view w=72 av=c ah=c:
+                                              - rtgl-view w=72 av=c ah=s pl=sm:
                                                   - rtgl-text s=sm c=mu-fg: ${inTimelineLabel}
                                               - rtgl-view h=24 w=24 mr=sm ml=sm: null
                                           - rvn-keyframe-timeline#nextTimeline editable=true side=next ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${nextProperties} :defaultValues=${transitionTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
                                       - rtgl-view d=v w=f g=xs:
                                           - 'rtgl-view#maskTimelineCategory d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                              - rtgl-view w=72 av=c ah=c:
+                                              - rtgl-view w=72 av=c ah=s pl=sm:
                                                   - rtgl-text s=sm c=mu-fg: ${maskTitle}
                                               - rtgl-view h=24 w=24 mr=sm ml=sm: null
                                           - $for maskTimelineRow, i in maskTimelineRows:
@@ -522,7 +522,7 @@ template:
                                                 $else:
                                                   - 'rtgl-view#unsupportedMaskTimelineRow${i} data-timeline-selection-surface=true data-mask-index=${maskTimelineRow.index} data-selected=${maskTimelineRow.selected} role=button tabindex=0 aria-label="${maskTimelineRow.label}" aria-pressed="${maskTimelineRow.selected}" d=h w=f h=24 av=c cur=pointer':
                                                       - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                                          - rtgl-view w=72 av=c ah=c:
+                                                          - rtgl-view w=72 av=c ah=s pl=sm:
                                                               - 'rtgl-view w=28 h=18 bw=xs bc=${maskTimelineRow.imageBorderColor} br=sm overflow=hidden title="${maskTimelineRow.image.name}"':
                                                                   - $if maskTimelineRow.image.previewFileId:
                                                                       - rvn-file-image w=f h=f fileId=${maskTimelineRow.image.previewFileId}: null

--- a/src/pages/animations/animations.handlers.js
+++ b/src/pages/animations/animations.handlers.js
@@ -91,6 +91,11 @@ const resolveAnimationImportItems = (input) => {
 };
 
 const collectMaskImageIds = (mask, imageIds) => {
+  if (Array.isArray(mask)) {
+    mask.forEach((item) => collectMaskImageIds(item, imageIds));
+    return;
+  }
+
   if (!isPlainObject(mask)) {
     return;
   }
@@ -327,6 +332,10 @@ const resolveImageId = (imageId, imageIdMap) => {
 };
 
 const rewriteMaskImageRefs = (mask, imageIdMap) => {
+  if (Array.isArray(mask)) {
+    return mask.map((item) => rewriteMaskImageRefs(item, imageIdMap));
+  }
+
   if (!isPlainObject(mask) || imageIdMap.size === 0) {
     return mask;
   }

--- a/src/pages/animations/support/animationPreviewRuntime.js
+++ b/src/pages/animations/support/animationPreviewRuntime.js
@@ -7,6 +7,10 @@ import { selectAnimationsPageCopy } from "./animationsPageCopy.js";
 const ANIMATION_PREVIEW_LOOP_PAUSE_MS = 1000;
 
 const collectRuntimeMaskTextureIds = (mask = {}) => {
+  if (Array.isArray(mask)) {
+    return mask.flatMap(collectRuntimeMaskTextureIds);
+  }
+
   if (!mask) {
     return [];
   }

--- a/tests/animationEditor/animationEditor.handlers.test.js
+++ b/tests/animationEditor/animationEditor.handlers.test.js
@@ -28,7 +28,12 @@ import {
   handleReplayAnimation,
   handleRulerTimeScrub,
   handleSavePreviewClick,
+  handleSelectedKeyframeDelayChange,
+  handleSelectedKeyframeDurationChange,
+  handleSelectedKeyframeEasingChange,
   handleSelectedKeyframeEditClick,
+  handleSelectedKeyframeRelativeChange,
+  handleSelectedKeyframeValueChange,
   handleSelectedMaskNumberConfirmClick,
   handleSelectedMaskNumberFieldKeyDown,
   handleSelectedMaskNumberInputChange,
@@ -786,6 +791,58 @@ describe("animationEditor.handlers", () => {
     expect(store.bumpPreviewRenderVersion).toHaveBeenCalledWith({});
     expect(store.queueAutosave).toHaveBeenCalled();
     expect(render).toHaveBeenCalled();
+  });
+
+  it("commits inline selected-keyframe field changes", () => {
+    const store = {
+      bumpPreviewRenderVersion: vi.fn(),
+      queueAutosave: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      setSelectedKeyframeDelay: vi.fn(),
+      setSelectedKeyframeDuration: vi.fn(),
+      setSelectedKeyframeEasing: vi.fn(),
+      setSelectedKeyframeRelative: vi.fn(),
+      setSelectedKeyframeValue: vi.fn(),
+      stopPreviewPlayback: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+    const deps = { store, render };
+
+    handleSelectedKeyframeDelayChange(deps, {
+      _event: { detail: { value: 125 } },
+    });
+    handleSelectedKeyframeDurationChange(deps, {
+      _event: { detail: { value: 750 } },
+    });
+    handleSelectedKeyframeEasingChange(deps, {
+      _event: { detail: { value: "easeInQuad" } },
+    });
+    handleSelectedKeyframeValueChange(deps, {
+      _event: { detail: { value: -12.5 } },
+    });
+    handleSelectedKeyframeRelativeChange(deps, {
+      _event: { detail: { value: true } },
+    });
+
+    expect(store.setSelectedKeyframeDelay).toHaveBeenCalledWith({
+      delay: 125,
+    });
+    expect(store.setSelectedKeyframeDuration).toHaveBeenCalledWith({
+      duration: 750,
+    });
+    expect(store.setSelectedKeyframeEasing).toHaveBeenCalledWith({
+      easing: "easeInQuad",
+    });
+    expect(store.setSelectedKeyframeValue).toHaveBeenCalledWith({
+      value: -12.5,
+    });
+    expect(store.setSelectedKeyframeRelative).toHaveBeenCalledWith({
+      relative: true,
+    });
+    expect(store.bumpPreviewRenderVersion).toHaveBeenCalledTimes(5);
+    expect(store.queueAutosave).toHaveBeenCalledTimes(5);
+    expect(render).toHaveBeenCalledTimes(5);
   });
 
   it.each([

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -14,6 +14,7 @@ import {
   clearTimelineSelection,
   deleteKeyframe,
   deleteProperty,
+  disableTransitionMask,
   enableTransitionMask,
   moveKeyframeLeft,
   moveKeyframeRight,
@@ -29,6 +30,7 @@ import {
   selectTimelinePanClickSuppressed,
   selectTimelinePanMode,
   selectTimelinePlayheadVisible,
+  selectTransitionMasks,
   selectViewData,
   setImages,
   setPopover,
@@ -308,12 +310,41 @@ describe("animationEditor.store", () => {
     expect(viewData.selectedKeyframeDetailFields).toEqual([
       { type: "text", label: "Timeline", value: "Update" },
       { type: "text", label: "Property", value: "Position X" },
-      { type: "text", label: "Delay (ms)", value: 125 },
-      { type: "text", label: "Duration (ms)", value: 450 },
-      { type: "text", label: "Easing", value: "Ease Out Bounce" },
-      { type: "text", label: "Value", value: 120 },
-      { type: "text", label: "Value type", value: "Relative" },
+      { type: "slot", label: "Delay (ms)", slot: "keyframe-delay" },
+      {
+        type: "slot",
+        label: "Duration (ms)",
+        slot: "keyframe-duration",
+      },
+      { type: "slot", label: "Easing", slot: "keyframe-easing" },
+      { type: "slot", label: "Value", slot: "keyframe-value" },
+      {
+        type: "slot",
+        label: "Value type",
+        slot: "keyframe-value-type",
+      },
     ]);
+    expect(viewData.selectedKeyframeEditor).toMatchObject({
+      delay: 125,
+      delayLabel: "Delay (ms)",
+      duration: 450,
+      durationLabel: "Duration (ms)",
+      easing: "easeOutBounce",
+      relative: true,
+      relativeOptions: [
+        { label: "Absolute", value: false },
+        { label: "Relative", value: true },
+      ],
+      value: 120,
+      valueLabel: "Value",
+      valueStep: 0.01,
+      valueUsesPopover: true,
+    });
+    expect(viewData.selectedKeyframeEditor.valueSlider).toBeUndefined();
+    expect(viewData.selectedKeyframeEditor.easingOptions).toContainEqual({
+      label: "Ease Out Bounce",
+      value: "easeOutBounce",
+    });
     expect(selectSelectedKeyframeFormValues({ state })).toEqual({
       delay: 125,
       duration: 450,
@@ -336,6 +367,18 @@ describe("animationEditor.store", () => {
       relative: false,
       value: -12.5,
     });
+
+    state.tweenBySection.update.alpha = {
+      keyframes: [{ duration: 500, easing: "linear", value: 0.5 }],
+    };
+    setSelectedKeyframe(
+      { state },
+      { side: "update", property: "alpha", index: 0 },
+    );
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).selectedKeyframeEditor
+        .valueSlider,
+    ).toEqual({ min: 0, max: 1, step: 0.01 });
   });
 
   it("shows selected property details and keeps property and keyframe selection exclusive", () => {
@@ -518,7 +561,7 @@ describe("animationEditor.store", () => {
     );
   });
 
-  it("shows Mask in the transition Add menu until a mask exists", () => {
+  it("keeps Mask in the transition Add menu when masks already exist", () => {
     const state = createInitialState();
     openDialog({ state }, { dialogType: "transition" });
     for (const property of TRANSITION_PROPERTY_KEYS) {
@@ -539,8 +582,14 @@ describe("animationEditor.store", () => {
 
     enableTransitionMask({ state });
     const enabledViewData = selectViewData({ state, i18n: EN_I18N });
-    expect(enabledViewData.addPropertySideMenuItems).toEqual([]);
-    expect(enabledViewData.transitionAddPropertyButtonVisible).toBe(false);
+    expect(enabledViewData.addPropertySideMenuItems).toEqual([
+      {
+        label: "Mask",
+        type: "item",
+        value: "mask",
+      },
+    ]);
+    expect(enabledViewData.transitionAddPropertyButtonVisible).toBe(true);
   });
 
   it("keeps Mask out of the touch Add Property side control", () => {
@@ -632,6 +681,58 @@ describe("animationEditor.store", () => {
 
     clearTimelineSelection({ state });
     expect(selectViewData({ state, i18n: EN_I18N }).selectedMask).toBe(false);
+  });
+
+  it("loads, selects, edits, previews, and removes multiple masks", () => {
+    const state = createInitialState();
+    setImages(
+      { state },
+      {
+        images: {
+          tree: [],
+          items: {
+            first: { type: "image", fileId: "first.png" },
+            second: { type: "image", fileId: "second.png" },
+          },
+        },
+      },
+    );
+    openDialog(
+      { state },
+      {
+        dialogType: "transition",
+        editMode: true,
+        itemData: {
+          animation: {
+            type: "transition",
+            mask: [
+              { kind: "single", imageId: "first" },
+              { kind: "single", imageId: "second" },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(selectTransitionMasks({ state })).toHaveLength(2);
+    expect(selectViewData({ state, i18n: EN_I18N }).maskTimelineRows).toEqual([
+      expect.objectContaining({ index: 0, side: "mask:0" }),
+      expect.objectContaining({ index: 1, side: "mask:1" }),
+    ]);
+
+    setSelectedMask({ state }, { index: 1 });
+    setTransitionMaskChannel({ state }, { channel: "alpha" });
+    expect(state.additionalTransitionMasks[0].channel).toBe("alpha");
+    expect(
+      selectAnimationRenderStateWithAnimations({ state }).animations[0].mask,
+    ).toEqual([
+      expect.objectContaining({ texture: "first.png" }),
+      expect.objectContaining({ texture: "second.png", channel: "alpha" }),
+    ]);
+
+    disableTransitionMask({ state });
+    expect(selectTransitionMasks({ state })).toHaveLength(1);
+    expect(state.transitionMask.imageId).toBe("first");
   });
 
   it("adds, selects, moves, resizes, and protects mask progress keyframes", () => {
@@ -936,7 +1037,7 @@ describe("animationEditor.store", () => {
     expect(state.transitionMask.channel).toBe("red");
   });
 
-  it("allows negative two-decimal position keyframe values", () => {
+  it("uses unbounded position, rotation, and scale keyframe inputs", () => {
     const state = createInitialState();
     setProjectResolution(
       { state },
@@ -976,16 +1077,29 @@ describe("animationEditor.store", () => {
       i18n: EN_I18N,
     }).addKeyframeForm.fields.find((field) => field.name === "value");
 
-    expect(xField).toMatchObject({
-      min: -1920,
-      max: 1920,
-      step: 0.01,
-    });
-    expect(yField).toMatchObject({
-      min: -1080,
-      max: 1080,
-      step: 0.01,
-    });
+    expect(xField).toMatchObject({ type: "input-number", step: 0.01 });
+    expect(yField).toMatchObject({ type: "input-number", step: 0.01 });
+    expect(xField).not.toHaveProperty("min");
+    expect(xField).not.toHaveProperty("max");
+    expect(yField).not.toHaveProperty("min");
+    expect(yField).not.toHaveProperty("max");
+
+    for (const property of ["rotation", "scaleX", "scaleY"]) {
+      setPopover(
+        { state },
+        {
+          mode: "addKeyframe",
+          payload: { property },
+        },
+      );
+      const valueField = selectViewData({
+        state,
+        i18n: EN_I18N,
+      }).addKeyframeForm.fields.find((field) => field.name === "value");
+      expect(valueField.type).toBe("input-number");
+      expect(valueField).not.toHaveProperty("min");
+      expect(valueField).not.toHaveProperty("max");
+    }
   });
 
   it("exposes supported update properties with tuned value ranges", () => {
@@ -1028,16 +1142,16 @@ describe("animationEditor.store", () => {
       },
     );
     viewData = selectViewData({ state, i18n: EN_I18N });
-    expect(
-      viewData.addPropertyForm.fields.find(
-        (field) => field.name === "initialValue",
-      ),
-    ).toMatchObject({
+    const rotationInitialValueField = viewData.addPropertyForm.fields.find(
+      (field) => field.name === "initialValue",
+    );
+    expect(rotationInitialValueField).toMatchObject({
       defaultValue: 0,
-      min: -360,
-      max: 360,
+      type: "input-number",
       step: 1,
     });
+    expect(rotationInitialValueField).not.toHaveProperty("min");
+    expect(rotationInitialValueField).not.toHaveProperty("max");
 
     updatePopoverFormValues(
       { state },
@@ -1252,6 +1366,27 @@ describe("animationEditor.store", () => {
       { duration: 900, value: 1, easing: "linear" },
     ]);
     expect(nextState.pendingTransitionMask).toBeUndefined();
+  });
+
+  it("appends each newly committed mask", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "transition" });
+
+    for (const imageId of ["first", "second"]) {
+      startPendingTransitionMask({ state });
+      setPopover({ state }, { mode: "addMask" });
+      setTransitionMaskImage({ state }, { imageId });
+      commitPendingTransitionMask({ state });
+      setPopover({ state }, { mode: "none" });
+    }
+
+    expect(
+      selectTransitionMasks({ state }).map((mask) => mask.imageId),
+    ).toEqual(["first", "second"]);
+    expect(state.selectedMaskIndex).toBe(1);
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).maskTimelineRows,
+    ).toHaveLength(2);
   });
 
   it("includes the mask image data in the read-only mask panel", () => {

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -153,6 +153,8 @@ describe("animationEditor view", () => {
     expect(view).toContain("rtgl-view#animationPreviewPanel");
     expect(view).toContain("rtgl-view#maskTimelineCategory");
     expect(view).toContain("rtgl-text s=sm c=mu-fg: ${maskTitle}");
+    expect(view).toContain("rtgl-view w=72 av=c ah=s pl=sm");
+    expect(view).not.toContain("rtgl-view w=72 av=c ah=c");
     expect(view).toContain("$for maskTimelineRow, i in maskTimelineRows");
     expect(view).toContain("rtgl-view#maskTrackRow${i}");
     expect(view).toContain(

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -110,14 +110,24 @@ describe("animationEditor view", () => {
     expect(view).toContain("handler: handleSelectedPropertyDeleteClick");
     expect(view).toContain("rtgl-text s=sm c=mu-fg ta=c: ${noSelectionLabel}");
     expect(view).not.toContain("${selectTimelineItemPrompt}");
-    expect(view).toContain("rtgl-button#editSelectedKeyframeButton");
-    expect(view).toContain("handler: handleSelectedKeyframeEditClick");
-    expect(view).not.toContain("selectedKeyframeEasingSelect");
-    expect(view).not.toContain("selectedKeyframeDelay slot=keyframe-delay");
-    expect(view).not.toContain(
-      "selectedKeyframeDuration slot=keyframe-duration",
+    expect(view).not.toContain("rtgl-button#editSelectedKeyframeButton");
+    expect(view).toContain("rtgl-select#selectedKeyframeEasingSelect");
+    expect(view).toContain("handler: handleSelectedKeyframeEasingChange");
+    expect(view).toContain(
+      "rtgl-popover-input#selectedKeyframeDelay slot=keyframe-delay",
     );
-    expect(view).not.toContain("selectedKeyframeValue slot=keyframe-value");
+    expect(view).toContain(
+      "rtgl-popover-input#selectedKeyframeDuration slot=keyframe-duration",
+    );
+    expect(view).toContain(
+      "rtgl-slider-input#selectedKeyframeValue slot=keyframe-value",
+    );
+    expect(view).toContain(
+      "rtgl-popover-input#selectedKeyframeValuePopover slot=keyframe-value",
+    );
+    expect(view).toContain(
+      "rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type",
+    );
     expect(view).toContain("rtgl-input-number#selectedMaskNumberInput");
     expect(view).toContain(
       "rtgl-popover#selectedMaskNumberPopover ?open=${selectedMaskNumberPopoverIsOpen}",
@@ -143,15 +153,16 @@ describe("animationEditor view", () => {
     expect(view).toContain("rtgl-view#animationPreviewPanel");
     expect(view).toContain("rtgl-view#maskTimelineCategory");
     expect(view).toContain("rtgl-text s=sm c=mu-fg: ${maskTitle}");
-    expect(view).toContain("rtgl-view#maskTimelineRow");
+    expect(view).toContain("$for maskTimelineRow, i in maskTimelineRows");
+    expect(view).toContain("rtgl-view#maskTimelineRow${i}");
     expect(view).toContain(
-      "rvn-keyframe-timeline#maskTimeline editable=true side=mask",
+      "rvn-keyframe-timeline#maskTimeline${i} editable=true side=${maskTimelineRow.side}",
     );
     expect(view).toContain(
-      ":properties=${maskTimelineProperties} :defaultValues=${maskTimelineDefaultValues}",
+      ":properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues}",
     );
     const maskTimelineListeners = view.slice(
-      view.indexOf("  maskTimeline:"),
+      view.indexOf("  maskTimeline*:"),
       view.indexOf("  addPropertyPopover:"),
     );
     expect(maskTimelineListeners).toContain(

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -110,7 +110,7 @@ describe("animationEditor view", () => {
     expect(view).toContain("handler: handleSelectedPropertyDeleteClick");
     expect(view).toContain("rtgl-text s=sm c=mu-fg ta=c: ${noSelectionLabel}");
     expect(view).not.toContain("${selectTimelineItemPrompt}");
-    expect(view).not.toContain("rtgl-button#editSelectedKeyframeButton");
+    expect(view).toContain("rtgl-button#editSelectedKeyframeButton");
     expect(view).toContain("rtgl-select#selectedKeyframeEasingSelect");
     expect(view).toContain("handler: handleSelectedKeyframeEasingChange");
     expect(view).toContain(
@@ -154,15 +154,15 @@ describe("animationEditor view", () => {
     expect(view).toContain("rtgl-view#maskTimelineCategory");
     expect(view).toContain("rtgl-text s=sm c=mu-fg: ${maskTitle}");
     expect(view).toContain("$for maskTimelineRow, i in maskTimelineRows");
-    expect(view).toContain("rtgl-view#maskTimelineRow${i}");
+    expect(view).toContain("rtgl-view#maskTrackRow${i}");
     expect(view).toContain(
-      "rvn-keyframe-timeline#maskTimeline${i} editable=true side=${maskTimelineRow.side}",
+      "rvn-keyframe-timeline#maskKeyframeTimeline${i} editable=true side=${maskTimelineRow.side}",
     );
     expect(view).toContain(
       ":properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues}",
     );
     const maskTimelineListeners = view.slice(
-      view.indexOf("  maskTimeline*:"),
+      view.indexOf("  maskKeyframeTimeline*:"),
       view.indexOf("  addPropertyPopover:"),
     );
     expect(maskTimelineListeners).toContain(
@@ -171,9 +171,13 @@ describe("animationEditor view", () => {
     expect(maskTimelineListeners).not.toContain(
       "handler: handleInitialValueClick",
     );
+    expect(view).not.toContain("rtgl-view#maskTimelineRow${i}");
     expect(view).toContain("handler: handleMaskTimelineRowClick");
     expect(view).toContain("handler: handleMaskTimelineRowKeyDown");
     expect(view).toContain("$elif selectedMask");
+    expect(view).toContain(
+      "rtgl-button#editSelectedKeyframeButton sq v=gh pre=edit",
+    );
     expect(view).toContain("rtgl-view#selectedMaskDetails");
     expect(view).toContain("rtgl-view#selectedMaskSoftness");
     expect(view).toContain("handler: handleSelectedMaskSoftnessClick");

--- a/tests/animations/animations.handlers.test.js
+++ b/tests/animations/animations.handlers.test.js
@@ -6,6 +6,7 @@ import {
   handleImportAnimationClick,
   handleImportFormActionClick,
 } from "../../src/pages/animations/animations.handlers.js";
+import { EN_I18N } from "../support/i18n.js";
 
 const originalFetch = globalThis.fetch;
 
@@ -282,6 +283,18 @@ describe("animations.handlers", () => {
             },
           },
         },
+        mask: [
+          {
+            kind: "single",
+            imageId: "mask-first",
+            progressDuration: 1000,
+          },
+          {
+            kind: "single",
+            imageId: "mask-second",
+            progressDuration: 1000,
+          },
+        ],
       },
     };
     let previewRequestId;
@@ -299,9 +312,24 @@ describe("animations.handlers", () => {
       projectService: {
         getRepositoryState: vi.fn(() => ({
           images: {
-            items: {},
+            items: {
+              "mask-first": {
+                id: "mask-first",
+                type: "image",
+                fileId: "mask-first.png",
+              },
+              "mask-second": {
+                id: "mask-second",
+                type: "image",
+                fileId: "mask-second.png",
+              },
+            },
           },
           files: {},
+        })),
+        getFileContent: vi.fn(async (fileId) => ({
+          url: `asset://${fileId}`,
+          type: "image/png",
         })),
       },
       refs: {
@@ -329,7 +357,18 @@ describe("animations.handlers", () => {
         selectPreviewRuntime: vi.fn(() => ({})),
         setPreviewRuntime: vi.fn(),
         selectImagesData: vi.fn(() => ({
-          items: {},
+          items: {
+            "mask-first": {
+              id: "mask-first",
+              type: "image",
+              fileId: "mask-first.png",
+            },
+            "mask-second": {
+              id: "mask-second",
+              type: "image",
+              fileId: "mask-second.png",
+            },
+          },
           tree: [],
         })),
         selectAnimationPreviewFrameId: vi.fn(() => undefined),
@@ -355,6 +394,16 @@ describe("animations.handlers", () => {
     });
 
     expect(deps.graphicsService.render).toHaveBeenCalledTimes(4);
+    expect(deps.graphicsService.loadAssets).toHaveBeenCalledWith({
+      "mask-first.png": {
+        type: "image/png",
+        url: "asset://mask-first.png",
+      },
+      "mask-second.png": {
+        type: "image/png",
+        url: "asset://mask-second.png",
+      },
+    });
     expect(deps.graphicsService.render.mock.calls[0][0].animations).toEqual([]);
     expect(
       deps.graphicsService.render.mock.calls[1][0].animations[0].type,
@@ -392,6 +441,7 @@ describe("animations.handlers", () => {
     await handleImportFormActionClick(
       {
         appService,
+        i18n: EN_I18N,
         projectService: {},
         render: vi.fn(),
         store: {},
@@ -459,6 +509,7 @@ describe("animations.handlers", () => {
     await handleImportFormActionClick(
       {
         appService,
+        i18n: EN_I18N,
         projectService: {},
         render: vi.fn(),
         store,
@@ -502,11 +553,18 @@ describe("animations.handlers", () => {
               name: "Mask Animation",
               animation: {
                 type: "transition",
-                mask: {
-                  kind: "single",
-                  imageId: "image.mask",
-                  channel: "alpha",
-                },
+                mask: [
+                  {
+                    kind: "single",
+                    imageId: "image.mask",
+                    channel: "alpha",
+                  },
+                  {
+                    kind: "single",
+                    imageId: "image.mask.secondary",
+                    channel: "red",
+                  },
+                ],
               },
             },
           },
@@ -520,12 +578,22 @@ describe("animations.handlers", () => {
               name: "Mask",
               fileId: "file.mask",
             },
+            "image.mask.secondary": {
+              id: "image.mask.secondary",
+              type: "image",
+              name: "Secondary Mask",
+              fileId: "file.mask.secondary",
+            },
           },
         },
       },
       files: {
         "file.mask": {
           url: "https://example.com/mask.png",
+          mimeType: "image/png",
+        },
+        "file.mask.secondary": {
+          url: "https://example.com/mask-secondary.png",
           mimeType: "image/png",
         },
       },
@@ -541,6 +609,7 @@ describe("animations.handlers", () => {
     await handleImportFormActionClick(
       {
         appService,
+        i18n: EN_I18N,
         projectService: {},
         render: vi.fn(),
         store,
@@ -604,11 +673,18 @@ describe("animations.handlers", () => {
               name: "Mask Animation",
               animation: {
                 type: "transition",
-                mask: {
-                  kind: "single",
-                  imageId: "image.mask",
-                  channel: "alpha",
-                },
+                mask: [
+                  {
+                    kind: "single",
+                    imageId: "image.mask",
+                    channel: "alpha",
+                  },
+                  {
+                    kind: "single",
+                    imageId: "image.mask.secondary",
+                    channel: "red",
+                  },
+                ],
               },
             },
           },
@@ -622,6 +698,12 @@ describe("animations.handlers", () => {
               name: "Mask",
               fileId: "file.mask",
             },
+            "image.mask.secondary": {
+              id: "image.mask.secondary",
+              type: "image",
+              name: "Secondary Mask",
+              fileId: "file.mask.secondary",
+            },
           },
         },
       },
@@ -629,6 +711,11 @@ describe("animations.handlers", () => {
         "file.mask": {
           url: "https://example.com/mask.png",
           name: "mask.png",
+          mimeType: "image/png",
+        },
+        "file.mask.secondary": {
+          url: "https://example.com/mask-secondary.png",
+          name: "mask-secondary.png",
           mimeType: "image/png",
         },
       },
@@ -662,9 +749,10 @@ describe("animations.handlers", () => {
       clearPreviewRuntime: vi.fn(),
     };
     const projectService = {
-      importImageFile: vi.fn(async () => ({
-        imageId: "project-image-mask",
-      })),
+      importImageFile: vi
+        .fn()
+        .mockResolvedValueOnce({ imageId: "project-image-mask" })
+        .mockResolvedValueOnce({ imageId: "project-image-mask-secondary" }),
       createAnimation: vi.fn(async (input) => {
         importedAnimations.push(input);
         return input.animationId;
@@ -700,6 +788,7 @@ describe("animations.handlers", () => {
     await handleImportFormActionClick(
       {
         appService,
+        i18n: EN_I18N,
         projectService,
         refs: {
           fileExplorer: {
@@ -723,6 +812,7 @@ describe("animations.handlers", () => {
       },
     );
 
+    expect(projectService.importImageFile).toHaveBeenCalledTimes(2);
     expect(projectService.importImageFile).toHaveBeenCalledWith({
       file: expect.objectContaining({
         name: "mask.png",
@@ -763,9 +853,14 @@ describe("animations.handlers", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           animation: expect.objectContaining({
-            mask: expect.objectContaining({
-              imageId: "project-image-mask",
-            }),
+            mask: [
+              expect.objectContaining({
+                imageId: "project-image-mask",
+              }),
+              expect.objectContaining({
+                imageId: "project-image-mask-secondary",
+              }),
+            ],
           }),
         }),
         parentId: "folder-animation",

--- a/tests/internal/animationMasks.test.js
+++ b/tests/internal/animationMasks.test.js
@@ -112,4 +112,50 @@ describe("animationMasks", () => {
       keyframes: [{ duration: 1200, value: 1, easing: "easeInQuad" }],
     });
   });
+
+  it("serializes and compiles multiple transition masks", () => {
+    const masks = [
+      {
+        ...createDefaultTransitionMask(),
+        imageId: "first",
+      },
+      {
+        ...createDefaultTransitionMask(),
+        imageId: "second",
+        channel: "alpha",
+        progress: {
+          initialValue: 0,
+          keyframes: [{ duration: 1400, value: 1, easing: "linear" }],
+        },
+      },
+    ];
+    const imageItems = {
+      first: { fileId: "first.png" },
+      second: { fileId: "second.png" },
+    };
+
+    const serializedMasks = serializeTransitionMask(masks);
+    expect(serializedMasks).toHaveLength(2);
+    expect(getTransitionMaskDuration(masks)).toBe(1400);
+    expect(compileTransitionMaskForRuntime(masks, imageItems)).toEqual([
+      expect.objectContaining({ texture: "first.png", channel: "red" }),
+      expect.objectContaining({ texture: "second.png", channel: "alpha" }),
+    ]);
+    expect(
+      validatePayload({
+        type: "animation.create",
+        payload: {
+          animationId: "animation-a",
+          data: {
+            type: "animation",
+            name: "Transition",
+            animation: {
+              type: "transition",
+              mask: serializedMasks,
+            },
+          },
+        },
+      }),
+    ).toEqual({ valid: true });
+  });
 });

--- a/tests/internal/animationMasks.test.js
+++ b/tests/internal/animationMasks.test.js
@@ -19,6 +19,7 @@ describe("animationMasks", () => {
       kind: "single",
       imageId: "mask-image",
       channel: "red",
+      delay: 250,
       progress: {
         initialValue: 0,
         keyframes: [
@@ -38,16 +39,21 @@ describe("animationMasks", () => {
     );
 
     expect(editorMask).toMatchObject({
+      delay: 250,
       progressDelay: 500,
       progressDuration: 1000,
       progressEasing: "linear",
     });
-    expect(getTransitionMaskDuration(editorMask)).toBe(1500);
+    expect(getTransitionMaskDuration(editorMask)).toBe(1750);
     expect(
-      compileTransitionMaskForRuntime(editorMask, imageItems)?.progress,
-    ).toEqual(delayedMask.progress);
+      compileTransitionMaskForRuntime(editorMask, imageItems),
+    ).toMatchObject({
+      delay: 250,
+      progress: delayedMask.progress,
+    });
 
     const serializedMask = serializeTransitionMask(editorMask);
+    expect(serializedMask.delay).toBe(250);
     expect(serializedMask.progress).toEqual({
       initialValue: 0,
       keyframes: [
@@ -123,6 +129,7 @@ describe("animationMasks", () => {
         ...createDefaultTransitionMask(),
         imageId: "second",
         channel: "alpha",
+        delay: 500,
         progress: {
           initialValue: 0,
           keyframes: [{ duration: 1400, value: 1, easing: "linear" }],
@@ -136,10 +143,14 @@ describe("animationMasks", () => {
 
     const serializedMasks = serializeTransitionMask(masks);
     expect(serializedMasks).toHaveLength(2);
-    expect(getTransitionMaskDuration(masks)).toBe(1400);
+    expect(getTransitionMaskDuration(masks)).toBe(1900);
     expect(compileTransitionMaskForRuntime(masks, imageItems)).toEqual([
       expect.objectContaining({ texture: "first.png", channel: "red" }),
-      expect.objectContaining({ texture: "second.png", channel: "alpha" }),
+      expect.objectContaining({
+        texture: "second.png",
+        channel: "alpha",
+        delay: 500,
+      }),
     ]);
     expect(
       validatePayload({

--- a/tests/keyframeTimeline/keyframeTimeline.store.test.js
+++ b/tests/keyframeTimeline/keyframeTimeline.store.test.js
@@ -232,6 +232,8 @@ describe("keyframeTimeline easing curves", () => {
     expect(view).toContain(
       "rtgl-view#propertyName${pIndex}.keyframeTimelinePropertyRow",
     );
+    expect(view).toContain("rtgl-view w=72 av=c d=h ah=s pl=sm pos=rel");
+    expect(view).not.toContain("rtgl-view w=72 av=c d=h ah=c pos=rel");
     expect(view).toContain("$if editable:");
     expect(view).toContain(
       "w=104 bgc=${property.backgroundColor} h-bgc=${property.hoverBackgroundColor}",

--- a/vt/specs/project/animations.yaml
+++ b/vt/specs/project/animations.yaml
@@ -207,7 +207,7 @@ steps:
     steps:
       - action: click
   - action: waitFor
-    selector: "#maskTimelineRow0"
+    selector: "#maskTrackRow0"
     state: visible
     timeoutMs: 5000
   - action: waitFor
@@ -215,7 +215,7 @@ steps:
     state: visible
     timeoutMs: 5000
   - action: waitFor
-    selector: "#maskTimelineRow0 rvn-file-image"
+    selector: "#maskTrackRow0 rvn-file-image"
     state: visible
     timeoutMs: 5000
   - action: waitFor
@@ -319,14 +319,14 @@ steps:
     type: js
     fn: eval
     args:
-      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return Boolean(deepQuery(document, '#selectedKeyframeEasingSelect')) && !deepQuery(document, '#editSelectedKeyframeButton'); })()"
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return Boolean(deepQuery(document, '#selectedKeyframeEasingSelect')) && Boolean(deepQuery(document, '#editSelectedKeyframeButton')); })()"
     value: true
   - action: waitFor
     selector: "#selectedKeyframeDetails"
     state: visible
     timeoutMs: 5000
   - action: select
-    selector: "#maskTimelineRow0 #propertyName0[role='button']"
+    selector: "#maskTrackRow0 #propertyName0[role='button']"
     steps:
       - action: focus
   - action: keypress

--- a/vt/specs/project/animations.yaml
+++ b/vt/specs/project/animations.yaml
@@ -207,7 +207,7 @@ steps:
     steps:
       - action: click
   - action: waitFor
-    selector: "#maskTimelineRow"
+    selector: "#maskTimelineRow0"
     state: visible
     timeoutMs: 5000
   - action: waitFor
@@ -215,7 +215,7 @@ steps:
     state: visible
     timeoutMs: 5000
   - action: waitFor
-    selector: "#maskTimelineRow rvn-file-image"
+    selector: "#maskTimelineRow0 rvn-file-image"
     state: visible
     timeoutMs: 5000
   - action: waitFor
@@ -281,12 +281,12 @@ steps:
     value: "true"
   - action: screenshot
   - action: select
-    selector: "#editSelectedKeyframeButton"
+    selector: "#selectedKeyframeDelay #textDisplay"
     steps:
       - action: click
   - action: waitFor
-    selector: "#editKeyframeDialog[open]"
-    state: attached
+    selector: "#selectedKeyframeDelay #popover[open]"
+    state: visible
     timeoutMs: 5000
   - action: wait
     ms: 300
@@ -294,11 +294,39 @@ steps:
   - action: keypress
     key: Escape
   - action: waitFor
-    selector: "#editKeyframeDialog"
+    selector: "#selectedKeyframeDelay #popover"
     state: hidden
     timeoutMs: 5000
   - action: select
-    selector: "#maskTimelineRow #propertyName0[role='button']"
+    selector: "#selectedKeyframeEasingSelect [data-testid='select-button']"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#selectedKeyframeEasingSelect #option1"
+    state: visible
+    timeoutMs: 5000
+  - action: wait
+    ms: 300
+  - action: screenshot
+  - action: select
+    selector: "#selectedKeyframeEasingSelect #option1"
+    steps:
+      - action: click
+  - action: wait
+    ms: 300
+  - action: screenshot
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; return Boolean(deepQuery(document, '#selectedKeyframeEasingSelect')) && !deepQuery(document, '#editSelectedKeyframeButton'); })()"
+    value: true
+  - action: waitFor
+    selector: "#selectedKeyframeDetails"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    selector: "#maskTimelineRow0 #propertyName0[role='button']"
     steps:
       - action: focus
   - action: keypress


### PR DESCRIPTION
## Summary

- make selected keyframe fields editable directly in the right detail panel
- use property-aware slider or unbounded popover inputs and an easing selector
- allow transition animations to add, select, edit, preview, and remove multiple masks
- keep single-mask persistence compatible while serializing multiple masks as an array
- preserve per-mask delays and support mask arrays in imports and resource previews
- keep keyboard access through the keyframe detail header edit action

## Validation

- `bun run lint`
- 151 focused animation editor, mask, import, playback, preview, and projection tests

The repository-wide contract checker still reports the existing baseline diagnostics.