### PR TITLE
Fix Sound Effects channel creation styling

### DIFF
--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
@@ -487,8 +487,6 @@ export const addChannel = ({ state }, { id } = {}) => {
       sounds: [],
     }),
   );
-  state.selectedChannelId = channelId;
-  state.selectedSoundId = undefined;
 };
 
 export const removeChannel = ({ state }, { channelId } = {}) => {

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -271,7 +271,7 @@ template:
           - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: ${selectButtonLabel}
   - rtgl-popover#addChannelPopover ?open=${addChannelPopover.isOpen} x=${addChannelPopover.position.x} y=${addChannelPopover.position.y} place=bs:
-      - rtgl-form#addChannelForm key=${addChannelPopover.key} slot=content :defaultValues=${addChannelDefaultValues} :form=${addChannelForm} w=320 p=none: null
+      - rtgl-form#addChannelForm key=${addChannelPopover.key} slot=content :defaultValues=${addChannelDefaultValues} :form=${addChannelForm} w=320: null
   - $if showAudioPlayer:
       - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
           - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.handlers.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.handlers.test.js
@@ -170,7 +170,7 @@ describe("commandLineSoundEffects.handlers", () => {
         sounds: [],
       },
     ]);
-    expect(state.selectedChannelId).toBe("Weather");
+    expect(state.selectedChannelId).toBeUndefined();
     expect(render).toHaveBeenCalledOnce();
 
     handleAddChannelFormAction(deps, {
@@ -260,6 +260,7 @@ describe("commandLineSoundEffects.handlers", () => {
     const store = createStore(state);
     const render = vi.fn();
     store.addChannel({ id: "Weather" });
+    store.setSelectedChannel({ channelId: "Weather" });
 
     handleFormChange(
       { store, render },

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js
@@ -104,7 +104,12 @@ describe("commandLineSoundEffects.store", () => {
         },
       ],
     });
-    expect(state.selectedChannelId).toBe("UI");
+    expect(state.selectedChannelId).toBeUndefined();
+    expect(
+      selectViewData({ state, i18n }).channels.map(
+        (channel) => channel.channelBorderColor,
+      ),
+    ).toEqual(["bo", "bo"]);
 
     moveChannel({ state }, { channelId: "UI", direction: "up" });
     expect(state.channels.map((channel) => channel.id)).toEqual([
@@ -114,7 +119,7 @@ describe("commandLineSoundEffects.store", () => {
 
     removeChannel({ state }, { channelId: "UI" });
     expect(state.channels.map((channel) => channel.id)).toEqual(["Weather"]);
-    expect(state.selectedChannelId).toBe("Weather");
+    expect(state.selectedChannelId).toBeUndefined();
   });
 
   it("loads canonical channels and lays out overlapping clips in lanes", () => {


### PR DESCRIPTION
## Summary
- use the standard rtgl-form padding in the Add Channel popover
- keep newly created Sound Effects channels unselected until clicked
- retain the normal channel border instead of showing the selected white border immediately

## Tests
- bunx vitest run tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js tests/commandLineSoundEffects/commandLineSoundEffects.handlers.test.js tests/commandLineActions/commandLineFormSpacing.view.test.js