### PR TITLE
Align Actions command-line breadcrumb

### DIFF
--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -1,9 +1,17 @@
 import { RUNTIME_ACTION_ITEMS } from "../../internal/runtimeActions.js";
 import { PRESENTATION_ACTION_MODE_ORDER } from "../../internal/presentationActionOrder.js";
 import {
+  localizeCommandLineBreadcrumb,
   localizeCommandLineItems,
   selectCommandLineCopy,
 } from "../../internal/ui/sceneEditor/commandLineCopy.js";
+
+const ACTIONS_BREADCRUMB = [
+  {
+    id: "actions",
+    label: "Actions",
+  },
+];
 
 const createSection = (label, items) => ({
   label,
@@ -337,6 +345,7 @@ export const selectViewData = ({ props: attrs, i18n }) => {
   const copy = selectCommandLineCopy(i18n);
 
   return {
+    breadcrumb: localizeCommandLineBreadcrumb(ACTIONS_BREADCRUMB, copy),
     items: localizeCommandLineItems(getActionItems(attrs), copy),
   };
 };

--- a/src/components/commandLineActions/commandLineActions.view.yaml
+++ b/src/components/commandLineActions/commandLineActions.view.yaml
@@ -5,8 +5,8 @@ refs:
         handler: handleActionClick
 template:
   - 'rtgl-view w=f h=f pv=lg br=md d=v style="min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden;"':
-      - rtgl-view w=f ph=lg:
-          - rtgl-text s=sm c=mu-fg: Actions
+      - rtgl-view w=f h=24 av=c ph=lg:
+          - rtgl-breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg w=f mt=lg sv style="min-width: 0; min-height: 0;"':
           - 'rtgl-view w=f d=v g=sm ph=lg style="min-width: 0; box-sizing: border-box;"':
               - $for item, i in items:

--- a/src/internal/sqliteLocking.js
+++ b/src/internal/sqliteLocking.js
@@ -12,13 +12,21 @@ export const isSqliteLockError = (error) => {
     return false;
   }
 
-  if (error.code === 5 || error.code === "SQLITE_BUSY") {
+  // 5 = SQLITE_BUSY, 6 = SQLITE_LOCKED. Both are retryable contention errors.
+  if (
+    error.code === 5 ||
+    error.code === 6 ||
+    error.code === "SQLITE_BUSY" ||
+    error.code === "SQLITE_LOCKED"
+  ) {
     return true;
   }
 
   const message = String(error?.message ?? error).toLowerCase();
   return (
     message.includes("database is locked") ||
+    message.includes("database table is locked") ||
+    message.includes("database schema is locked") ||
     message.includes("database busy") ||
     message.includes("database is busy") ||
     message.includes("sqlite_busy") ||

--- a/tests/commandLineActions/commandLineActions.store.test.js
+++ b/tests/commandLineActions/commandLineActions.store.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { selectItems as selectItemsBase } from "../../src/components/commandLineActions/commandLineActions.store.js";
+import {
+  selectItems as selectItemsBase,
+  selectViewData,
+} from "../../src/components/commandLineActions/commandLineActions.store.js";
 import { PRESENTATION_ACTION_MODE_ORDER } from "../../src/internal/presentationActionOrder.js";
 import { EN_I18N } from "../support/i18n.js";
 
@@ -27,6 +30,15 @@ const getSectionModes = (items, label) => {
 };
 
 describe("commandLineActions.store", () => {
+  it("provides the standard localized Actions breadcrumb", () => {
+    expect(
+      selectViewData({
+        props: { actionsType: "presentation" },
+        i18n: EN_I18N,
+      }).breadcrumb,
+    ).toEqual([{ id: "actions", label: "Actions" }]);
+  });
+
   it("uses the canonical presentation action order", () => {
     const modes = selectItems({
       props: {

--- a/tests/commandLineActions/commandLineActions.view.test.js
+++ b/tests/commandLineActions/commandLineActions.view.test.js
@@ -26,5 +26,11 @@ describe("commandLineActions view", () => {
     expect(commandLineActionsView).toContain(
       'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"',
     );
+    expect(commandLineActionsView).toContain(
+      "rtgl-view w=f h=24 av=c ph=lg:\n          - rtgl-breadcrumb :items=${breadcrumb}: null",
+    );
+    expect(commandLineActionsView).not.toContain(
+      "rtgl-text s=sm c=mu-fg: Actions",
+    );
   });
 });

--- a/tests/internal/sqliteLocking.test.js
+++ b/tests/internal/sqliteLocking.test.js
@@ -80,6 +80,18 @@ describe("sqliteLocking", () => {
     expect(operation).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry unrelated resources that are locked", async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValue(new Error("resource is locked"));
+
+    expect(isSqliteLockError(new Error("resource is locked"))).toBe(false);
+    await expect(withSqliteLockRetry(operation)).rejects.toThrow(
+      "resource is locked",
+    );
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
   it("can recover a missing transaction after a retried lock", async () => {
     vi.useFakeTimers();
     const operation = vi


### PR DESCRIPTION
## Summary
- replace the muted Actions label with the standard localized breadcrumb
- center the single-item breadcrumb in a 24px header to remove its one-pixel drift from multi-item breadcrumbs
- add store and view regression coverage

## Tests
- bunx vitest run tests/commandLineActions/commandLineActions.store.test.js tests/commandLineActions/commandLineActions.view.test.js tests/commandLineActions/commandLineFormSpacing.view.test.js