### PR TITLE
Refine animation editor controls and timeline behavior

### DIFF
--- a/src/components/keyframeTimeline/keyframeTimeline.handlers.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.handlers.js
@@ -1,5 +1,6 @@
 const DURATION_RESIZE_SNAP_MS = 100;
 const DEFAULT_KEYFRAME_DURATION_MS = 1000;
+const TIMELINE_EXTENSION_STEP_MS = 1000;
 
 const clamp = (value, min, max) => {
   return Math.min(Math.max(value, min), max);
@@ -37,6 +38,44 @@ const resolveTimelineDuration = (props = {}) => {
   }
 
   return maxDuration;
+};
+
+const getKeyframesDuration = (keyframes = []) => {
+  return keyframes.reduce((sum, keyframe) => {
+    return (
+      sum +
+      Math.max(0, parseFloat(keyframe.delay) || 0) +
+      (parseFloat(keyframe.duration) || DEFAULT_KEYFRAME_DURATION_MS)
+    );
+  }, 0);
+};
+
+const dispatchTimelineDurationExtendEvent = ({
+  dispatchEvent,
+  duration,
+} = {}) => {
+  dispatchEvent(
+    new CustomEvent("timeline-duration-extend", {
+      detail: { duration },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+const dispatchTimelineUsedDurationPreviewEvent = ({
+  active,
+  dispatchEvent,
+  duration,
+  side,
+} = {}) => {
+  dispatchEvent(
+    new CustomEvent("timeline-used-duration-preview", {
+      detail: { active, duration, side },
+      bubbles: true,
+      composed: true,
+    }),
+  );
 };
 
 const dispatchRulerScrubEvent = ({
@@ -571,6 +610,7 @@ export const handleKeyframeMoveStart = (deps, payload) => {
     startDelay,
     startFollowingDelay,
     duration: startDuration,
+    propertyDuration: getKeyframesDuration(keyframes),
     timelineDuration,
     trackWidth,
   });
@@ -584,7 +624,7 @@ export const handleKeyframeMoveStart = (deps, payload) => {
 };
 
 export const handleKeyframeMove = (deps, payload) => {
-  const { render, store } = deps;
+  const { dispatchEvent, props, render, store } = deps;
   const event = payload._event;
   const keyframeMove = store.selectKeyframeMove();
   if (!keyframeMove || keyframeMove.pointerId !== event.pointerId) {
@@ -598,7 +638,8 @@ export const handleKeyframeMove = (deps, payload) => {
     store.markKeyframeMoveDragged({});
   }
   const deltaDelay =
-    (deltaX / keyframeMove.trackWidth) * keyframeMove.timelineDuration;
+    (deltaX / keyframeMove.trackWidth) *
+    (keyframeMove.startTimelineDuration ?? keyframeMove.timelineDuration);
   const snappedDelay =
     Math.round(
       (keyframeMove.startDelay + deltaDelay) / DURATION_RESIZE_SNAP_MS,
@@ -612,9 +653,29 @@ export const handleKeyframeMove = (deps, payload) => {
     keyframeMove.startFollowingDelay === undefined
       ? undefined
       : keyframeMove.startFollowingDelay - (delay - keyframeMove.startDelay);
-  store.setKeyframeMoveTiming({
+  const timing = {
     delay,
     followingDelay,
+  };
+  if (keyframeMove.startFollowingDelay === undefined) {
+    const movedPropertyDuration =
+      keyframeMove.propertyDuration + delay - keyframeMove.startDelay;
+    if (movedPropertyDuration >= keyframeMove.timelineDuration) {
+      timing.timelineDuration =
+        (Math.floor(movedPropertyDuration / TIMELINE_EXTENSION_STEP_MS) + 1) *
+        TIMELINE_EXTENSION_STEP_MS;
+      dispatchTimelineDurationExtendEvent({
+        dispatchEvent,
+        duration: timing.timelineDuration,
+      });
+    }
+  }
+  store.setKeyframeMoveTiming(timing);
+  dispatchTimelineUsedDurationPreviewEvent({
+    active: true,
+    dispatchEvent,
+    duration: store.selectPreviewUsedDuration(),
+    side: props.side,
   });
   render();
 };
@@ -645,11 +706,17 @@ export const handleKeyframeMoveEnd = (deps, payload) => {
       index: keyframeMove.index,
     });
   }
+  dispatchTimelineUsedDurationPreviewEvent({
+    active: false,
+    dispatchEvent,
+    duration: undefined,
+    side: props.side,
+  });
   render();
 };
 
 export const handleKeyframeMoveCancel = (deps, payload) => {
-  const { render, store } = deps;
+  const { dispatchEvent, props, render, store } = deps;
   const event = payload._event;
   const keyframeMove = store.selectKeyframeMove();
   if (!keyframeMove || keyframeMove.pointerId !== event.pointerId) {
@@ -658,6 +725,12 @@ export const handleKeyframeMoveCancel = (deps, payload) => {
 
   event.stopPropagation();
   store.clearKeyframeMove({});
+  dispatchTimelineUsedDurationPreviewEvent({
+    active: false,
+    dispatchEvent,
+    duration: undefined,
+    side: props.side,
+  });
   render();
 };
 
@@ -705,7 +778,7 @@ export const handleDurationResizeStart = (deps, payload) => {
 };
 
 export const handleDurationResizeMove = (deps, payload) => {
-  const { render, store } = deps;
+  const { dispatchEvent, props, render, store } = deps;
   const event = payload._event;
   const durationResize = store.selectDurationResize();
   if (!durationResize || durationResize.pointerId !== event.pointerId) {
@@ -716,7 +789,8 @@ export const handleDurationResizeMove = (deps, payload) => {
   event.stopPropagation();
   const deltaX = event.clientX - durationResize.startX;
   const deltaDuration =
-    (deltaX / durationResize.trackWidth) * durationResize.timelineDuration;
+    (deltaX / durationResize.trackWidth) *
+    (durationResize.startTimelineDuration ?? durationResize.timelineDuration);
   let delay = durationResize.startDelay;
   let duration;
 
@@ -743,6 +817,23 @@ export const handleDurationResizeMove = (deps, payload) => {
   }
 
   store.setDurationResizeTiming({ delay, duration });
+  const usedDuration = store.selectPreviewUsedDuration();
+  if (usedDuration > durationResize.timelineDuration) {
+    const timelineDuration =
+      (Math.floor(usedDuration / TIMELINE_EXTENSION_STEP_MS) + 1) *
+      TIMELINE_EXTENSION_STEP_MS;
+    store.setDurationResizeTiming({ delay, duration, timelineDuration });
+    dispatchTimelineDurationExtendEvent({
+      dispatchEvent,
+      duration: timelineDuration,
+    });
+  }
+  dispatchTimelineUsedDurationPreviewEvent({
+    active: true,
+    dispatchEvent,
+    duration: usedDuration,
+    side: props.side,
+  });
   render();
 };
 
@@ -766,11 +857,17 @@ export const handleDurationResizeEnd = (deps, payload) => {
     side: props.side,
     index: durationResize.index,
   });
+  dispatchTimelineUsedDurationPreviewEvent({
+    active: false,
+    dispatchEvent,
+    duration: undefined,
+    side: props.side,
+  });
   render();
 };
 
 export const handleDurationResizeCancel = (deps, payload) => {
-  const { render, store } = deps;
+  const { dispatchEvent, props, render, store } = deps;
   const event = payload._event;
   const durationResize = store.selectDurationResize();
   if (!durationResize || durationResize.pointerId !== event.pointerId) {
@@ -779,6 +876,12 @@ export const handleDurationResizeCancel = (deps, payload) => {
 
   event.stopPropagation();
   store.clearDurationResize({});
+  dispatchTimelineUsedDurationPreviewEvent({
+    active: false,
+    dispatchEvent,
+    duration: undefined,
+    side: props.side,
+  });
   render();
 };
 
@@ -833,31 +936,4 @@ export const handlePropertyNameKeyDown = (deps, payload) => {
     x: rect.left + rect.width / 2,
     y: rect.top + rect.height / 2,
   });
-};
-
-export const handleInitialValueClick = (deps, payload) => {
-  const { dispatchEvent, props } = deps;
-  const target = payload._event.currentTarget;
-  if (target?.dataset?.interactive !== "true") {
-    return;
-  }
-
-  payload._event.stopPropagation();
-
-  const property =
-    target?.dataset?.property || target?.id?.replace("initialValue", "") || "";
-  const side = props?.side;
-
-  dispatchEvent(
-    new CustomEvent("initial-value-click", {
-      detail: {
-        property,
-        side,
-        x: payload._event.clientX,
-        y: payload._event.clientY,
-      },
-      bubbles: true,
-      composed: true,
-    }),
-  );
 };

--- a/src/components/keyframeTimeline/keyframeTimeline.schema.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.schema.yaml
@@ -24,6 +24,9 @@ propsSchema:
     timelineDuration:
       type: number
       description: Optional shared duration in milliseconds used for timeline sizing
+    usedDuration:
+      type: number
+      description: Actual used duration in milliseconds highlighted within the displayed timeline
     showTotalDuration:
       type: boolean
       description: Whether the timeline should render its duration header

--- a/src/components/keyframeTimeline/keyframeTimeline.store.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.store.js
@@ -63,6 +63,7 @@ export const startDurationResize = (
     startDuration,
     delay: resolvedStartDelay,
     duration: startDuration,
+    startTimelineDuration: timelineDuration,
     timelineDuration,
     trackWidth,
   };
@@ -70,11 +71,13 @@ export const startDurationResize = (
 
 export const setDurationResizeTiming = (
   { state },
-  { delay, duration } = {},
+  { delay, duration, timelineDuration } = {},
 ) => {
   if (state.durationResize) {
     state.durationResize.delay = delay;
     state.durationResize.duration = duration;
+    state.durationResize.timelineDuration =
+      timelineDuration ?? state.durationResize.timelineDuration;
   }
 };
 
@@ -96,6 +99,7 @@ export const startKeyframeMove = (
     startDelay,
     startFollowingDelay,
     duration,
+    propertyDuration,
     timelineDuration,
     trackWidth,
   } = {},
@@ -117,6 +121,8 @@ export const startKeyframeMove = (
     followingDelay: resolvedStartFollowingDelay,
     duration,
     dragged: false,
+    propertyDuration,
+    startTimelineDuration: timelineDuration,
     timelineDuration,
     trackWidth,
   };
@@ -130,11 +136,14 @@ export const markKeyframeMoveDragged = ({ state }, _payload = {}) => {
 
 export const setKeyframeMoveTiming = (
   { state },
-  { delay, followingDelay } = {},
+  { delay, followingDelay, timelineDuration } = {},
 ) => {
   if (state.keyframeMove) {
     state.keyframeMove.delay = delay;
     state.keyframeMove.followingDelay = followingDelay;
+    if (timelineDuration > state.keyframeMove.timelineDuration) {
+      state.keyframeMove.timelineDuration = timelineDuration;
+    }
   }
 };
 
@@ -148,6 +157,67 @@ export const clearKeyframeMove = (
 
 export const selectKeyframeMove = ({ state }) => {
   return state.keyframeMove;
+};
+
+const resolveKeyframeTiming = ({
+  state,
+  propertyName,
+  index,
+  keyframe,
+} = {}) => {
+  const durationResize = state.durationResize;
+  const keyframeMove = state.keyframeMove;
+  const isResizingKeyframe =
+    durationResize?.property === propertyName && durationResize.index === index;
+  const isMovingKeyframe =
+    keyframeMove?.property === propertyName && keyframeMove.index === index;
+  const isFollowingMovingKeyframe =
+    keyframeMove?.property === propertyName &&
+    keyframeMove.index + 1 === index &&
+    keyframeMove.followingDelay !== undefined;
+
+  return {
+    delay: isMovingKeyframe
+      ? Math.max(0, Number(keyframeMove.delay) || 0)
+      : isFollowingMovingKeyframe
+        ? Math.max(0, Number(keyframeMove.followingDelay) || 0)
+        : isResizingKeyframe
+          ? Math.max(0, Number(durationResize.delay) || 0)
+          : Math.max(0, parseFloat(keyframe.delay) || 0),
+    duration: isMovingKeyframe
+      ? keyframeMove.duration
+      : isResizingKeyframe
+        ? durationResize.duration
+        : parseFloat(keyframe.duration) || 1000,
+  };
+};
+
+const getPreviewPropertiesDuration = ({ state, props } = {}) => {
+  return Object.entries(props.properties ?? {}).reduce(
+    (maxDuration, [propertyName, propertyConfig]) => {
+      const propertyDuration = propertyConfig.auto
+        ? Number(propertyConfig.auto.duration) || 0
+        : (propertyConfig.keyframes ?? []).reduce(
+            (duration, keyframe, index) => {
+              const timing = resolveKeyframeTiming({
+                state,
+                propertyName,
+                index,
+                keyframe,
+              });
+              return duration + timing.delay + timing.duration;
+            },
+            0,
+          );
+
+      return Math.max(maxDuration, propertyDuration);
+    },
+    0,
+  );
+};
+
+export const selectPreviewUsedDuration = ({ state, props }) => {
+  return getPreviewPropertiesDuration({ state, props });
 };
 
 export const selectKeyframeClickSuppressed = ({ state }) => {
@@ -237,11 +307,11 @@ const createRulerTick = ({
 
   if (showLabel) {
     if (leftPercent <= 0) {
-      labelStyle = "top: 10px; left: 0; pointer-events: none;";
+      labelStyle = "top: 22px; left: 0; pointer-events: none;";
     } else if (leftPercent >= 100) {
-      labelStyle = "top: 10px; right: 0; pointer-events: none;";
+      labelStyle = "top: 22px; right: 0; pointer-events: none;";
     } else {
-      labelStyle = `top: 10px; left: ${leftPercent}%; transform: translateX(-50%); pointer-events: none;`;
+      labelStyle = `top: 22px; left: ${leftPercent}%; transform: translateX(-50%); pointer-events: none;`;
     }
   }
 
@@ -249,20 +319,20 @@ const createRulerTick = ({
     id: `tick-${timeMs}`,
     label: showLabel ? formatRulerTimeLabel(timeMs) : undefined,
     labelStyle,
-    tickStyle: `top: ${isMajor ? 32 : 37}px; left: ${leftPercent}%; width: ${isMajor ? 2 : 1}px; height: ${isMajor ? 12 : 7}px; transform: translateX(-${isMajor ? 1 : 0.5}px); pointer-events: none;`,
+    tickStyle: `top: ${isMajor ? 40 : 45}px; left: ${leftPercent}%; width: ${isMajor ? 2 : 1}px; height: ${isMajor ? 12 : 7}px; transform: translateX(-${isMajor ? 1 : 0.5}px); pointer-events: none;`,
   };
 };
 
 const createHoverIndicatorLabelStyle = (leftPercent) => {
   if (leftPercent <= 0) {
-    return "top: -10px; left: 0; pointer-events: none; z-index: 4; white-space: nowrap;";
+    return "top: 4px; left: 0; pointer-events: none; z-index: 10; white-space: nowrap;";
   }
 
   if (leftPercent >= 100) {
-    return "top: -10px; right: 0; pointer-events: none; z-index: 4; white-space: nowrap;";
+    return "top: 4px; right: 0; pointer-events: none; z-index: 10; white-space: nowrap;";
   }
 
-  return `top: -10px; left: ${leftPercent}%; transform: translateX(-50%); pointer-events: none; z-index: 4; white-space: nowrap;`;
+  return `top: 4px; left: ${leftPercent}%; transform: translateX(-50%); pointer-events: none; z-index: 10; white-space: nowrap;`;
 };
 
 const createRulerTicks = (durationMs) => {
@@ -302,10 +372,11 @@ const createRulerTicks = (durationMs) => {
     });
   }
 
-  upsertTick({
-    timeMs: durationMs,
+  const endpointTimeMs = Math.round(durationMs);
+  ticksByTime.set(endpointTimeMs, {
+    timeMs: endpointTimeMs,
     isMajor: true,
-    showLabel: true,
+    showLabel: false,
   });
 
   return Array.from(ticksByTime.values())
@@ -336,35 +407,6 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       state.hoverTarget?.mode === "empty"
     );
   };
-  const resolveKeyframeTiming = ({ propertyName, index, keyframe } = {}) => {
-    const durationResize = state.durationResize;
-    const keyframeMove = state.keyframeMove;
-    const isResizingKeyframe =
-      durationResize?.property === propertyName &&
-      durationResize.index === index;
-    const isMovingKeyframe =
-      keyframeMove?.property === propertyName && keyframeMove.index === index;
-    const isFollowingMovingKeyframe =
-      keyframeMove?.property === propertyName &&
-      keyframeMove.index + 1 === index &&
-      keyframeMove.followingDelay !== undefined;
-
-    return {
-      delay: isMovingKeyframe
-        ? Math.max(0, Number(keyframeMove.delay) || 0)
-        : isFollowingMovingKeyframe
-          ? Math.max(0, Number(keyframeMove.followingDelay) || 0)
-          : isResizingKeyframe
-            ? Math.max(0, Number(durationResize.delay) || 0)
-            : Math.max(0, parseFloat(keyframe.delay) || 0),
-      duration: isMovingKeyframe
-        ? keyframeMove.duration
-        : isResizingKeyframe
-          ? durationResize.duration
-          : parseFloat(keyframe.duration) || 1000,
-    };
-  };
-
   let selectedProperties = [];
   if (props.properties) {
     selectedProperties = Object.keys(props.properties).map((propertyName) => {
@@ -394,7 +436,6 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         thumbnailFileId: propertyConfig.thumbnailFileId,
         thumbnailName: propertyConfig.thumbnailName ?? propertyName,
         initialValue: autoConfig ? "" : isDefault ? "D" : value,
-        initialValueInteractive: !autoConfig,
         trackMode: autoConfig ? "auto" : "keyframes",
         keyframes: propertyConfig.keyframes,
         auto: autoConfig
@@ -407,22 +448,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     });
   }
 
-  let maxDuration = 0;
-  if (selectedProperties.length > 0) {
-    selectedProperties.forEach((property) => {
-      const propertyDuration = property.auto
-        ? getPropertyDuration(property)
-        : (property.keyframes ?? []).reduce((sum, keyframe, index) => {
-            const timing = resolveKeyframeTiming({
-              propertyName: property.name,
-              index,
-              keyframe,
-            });
-            return sum + timing.delay + timing.duration;
-          }, 0);
-      maxDuration = Math.max(maxDuration, propertyDuration);
-    });
-  }
+  const maxDuration = getPreviewPropertiesDuration({ state, props });
   const interactionTimelineDuration = Number(
     state.durationResize?.timelineDuration ??
       state.keyframeMove?.timelineDuration,
@@ -433,6 +459,20 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       : Number(props.timelineDuration) > 0
         ? Number(props.timelineDuration)
         : maxDuration;
+  const requestedUsedDuration = Number(props.usedDuration);
+  const interactionActive = Boolean(state.durationResize || state.keyframeMove);
+  const usedDuration =
+    interactionActive || !Number.isFinite(requestedUsedDuration)
+      ? maxDuration
+      : Math.max(0, requestedUsedDuration, maxDuration);
+  const usedDurationPercent =
+    resolvedTimelineDuration > 0
+      ? clamp((usedDuration / resolvedTimelineDuration) * 100, 0, 100)
+      : 0;
+  const usedDurationVisible = usedDurationPercent > 0;
+  const usedDurationStyle = usedDurationVisible
+    ? `left: 0; top: 0; bottom: 0; width: ${usedDurationPercent.toFixed(2)}%; pointer-events: none; z-index: 0;`
+    : "";
   const totalDuration =
     resolvedTimelineDuration > 0 ? `${resolvedTimelineDuration}ms` : "0ms";
   const externalIndicatorTimeMs = Number(attrs.indicatorTimeMs);
@@ -492,7 +532,6 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         propertyName: property.name,
         trackMode: property.trackMode,
       });
-      nextProperty.initialValueCursor = "default";
       nextProperty.emptyLabelVisible = true;
 
       return nextProperty;
@@ -508,6 +547,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         const effectiveKeyframes = property.keyframes.map(
           (keyframe, keyframeIndex) => {
             const timing = resolveKeyframeTiming({
+              state,
               propertyName: property.name,
               index: keyframeIndex,
               keyframe,
@@ -591,10 +631,6 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         propertyName: property.name,
         trackMode: property.trackMode,
       });
-      nextProperty.initialValueCursor =
-        attrs.editable && property.initialValueInteractive
-          ? "pointer"
-          : "default";
       nextProperty.emptyLabelVisible = resolveEmptyLabelVisible({
         propertyName: property.name,
       });
@@ -612,10 +648,6 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         propertyName: property.name,
         trackMode: property.trackMode,
       }),
-      initialValueCursor:
-        attrs.editable && property.initialValueInteractive
-          ? "pointer"
-          : "default",
       emptyLabelVisible: resolveEmptyLabelVisible({
         propertyName: property.name,
       }),
@@ -632,6 +664,9 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     rulerIndicatorVisible,
     playheadIndicatorTimeLabel,
     playheadIndicatorLabelStyle,
+    usedDurationVisible,
+    usedDuration,
+    usedDurationStyle,
     editable: attrs.editable,
   };
 

--- a/src/components/keyframeTimeline/keyframeTimeline.view.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.view.yaml
@@ -49,10 +49,6 @@ refs:
         handler: handlePropertyNameClick
       keydown:
         handler: handlePropertyNameKeyDown
-  initialValue*:
-    eventListeners:
-      click:
-        handler: handleInitialValueClick
 styles:
   ".keyframeTimelinePropertyRow:focus-visible":
     outline: "2px solid var(--ring)"
@@ -63,10 +59,12 @@ template:
           - rtgl-view d=v w=f g=xs:
               - $if showRuler:
                   - 'rtgl-view d=h w=f av=e bgc=bg style="position: sticky; top: 0; z-index: 7;"':
-                      - 'rtgl-view d=h h=48 w=104 bgc=bg bwr=xs bc=bo style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
+                      - 'rtgl-view d=h h=56 w=104 bgc=bg bwr=xs bc=bo style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
                           - rtgl-view w=72: null
                           - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                      - 'rtgl-view#rulerTrack w=f h=48 pos=rel style="min-width: 0; overflow: visible; cursor: ew-resize; touch-action: none;"':
+                      - 'rtgl-view#rulerTrack w=f h=56 pos=rel style="min-width: 0; overflow: visible; cursor: ew-resize; touch-action: none;"':
+                          - $if usedDurationVisible:
+                              - 'rtgl-view pos=abs bgc=su style="${usedDurationStyle}"': null
                           - $if rulerIndicatorVisible:
                               - 'rtgl-view pos=abs style="${playheadIndicatorLabelStyle}"':
                                   - rtgl-text s=xs c=fg: ${playheadIndicatorTimeLabel}
@@ -89,8 +87,8 @@ template:
                                     $else:
                                       - rtgl-text s=xs c=${property.nameColor}: ${property.name}
                               - 'rtgl-view h=24 w=24 av=c ah=e mr=sm ml=sm pos=rel style="z-index: 2;"':
-                                  - rtgl-text#initialValue${pIndex} data-property=${property.name} data-interactive=${property.initialValueInteractive} s=xs cur=${property.initialValueCursor}: ${property.initialValue}
-                          - 'rtgl-view#track${pIndex} data-keyframe-track=true data-property=${property.name} data-track-mode=${property.trackMode} d=h w=f h=24 bgc=mu br=sm g=xs pos=rel style="min-width: 0; overflow: hidden; cursor: ${property.trackCursor};"':
+                                  - rtgl-text s=xs: ${property.initialValue}
+                          - 'rtgl-view#track${pIndex} data-keyframe-track=true data-property=${property.name} data-track-mode=${property.trackMode} d=h w=f h=24 bgc=mu br=sm pos=rel style="min-width: 0; overflow: hidden; cursor: ${property.trackCursor};"':
                               - $if property.valueCurvePath:
                                   - 'svg data-value-curve=${property.name} aria-hidden=true viewBox="0 0 100 20" preserveAspectRatio="none" style="position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; opacity: 0.72; z-index: 3;"':
                                       - 'path d="${property.valueCurvePath}" fill="none" stroke="var(--accent-foreground)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"': null
@@ -109,7 +107,7 @@ template:
                                           - 'rtgl-view data-keyframe-slot=true h=f pos=rel style="width: ${keyframe.widthPercent}%; flex-shrink: 0;"':
                                               - $if keyframe.delay > 0:
                                                   - 'rtgl-view pos=abs bgc=mu style="top: 0; bottom: 0; left: 0; width: ${keyframe.delayPercent}%; pointer-events: none; z-index: 2;"': null
-                                              - 'rtgl-view#keyframe${pIndex}x${j} data-keyframe=true data-selected=${keyframe.selected} aria-selected=${keyframe.selected} data-property=${property.name} data-index=${j} d=h p=xs bgc=${keyframe.backgroundColor} bw=xs br=lg ah=e av=e pos=abs title="${keyframe.easingLabel}" style="top: 2px; bottom: 2px; left: ${keyframe.delayPercent}%; right: 0; overflow: hidden; box-sizing: border-box; border-color: ${keyframe.borderColor}; z-index: 2; cursor: ${keyframe.cursor}; touch-action: none;"':
+                                              - 'rtgl-view#keyframe${pIndex}x${j} data-keyframe=true data-selected=${keyframe.selected} aria-selected=${keyframe.selected} data-property=${property.name} data-index=${j} d=h p=xs bgc=${keyframe.backgroundColor} bw=xs br=md ah=e av=e pos=abs title="${keyframe.easingLabel}" style="top: 2px; bottom: 2px; left: ${keyframe.delayPercent}%; right: 0; overflow: hidden; box-sizing: border-box; border-color: ${keyframe.borderColor}; z-index: 2; cursor: ${keyframe.cursor}; touch-action: none;"':
                                                   - $if editable:
                                                       - 'rtgl-view#durationHandleLeft${pIndex}x${j} data-keyframe-duration-handle=left data-resize-edge=left data-property=${property.name} data-index=${j} pos=abs style="top: 0; bottom: 0; left: 0; width: 7px; cursor: ew-resize; touch-action: none; z-index: 3;"':
                                                           - 'rtgl-view pos=abs bgc=fg style="top: 5px; bottom: 5px; left: 6px; width: 1px; pointer-events: none;"': null

--- a/src/components/valuePopoverInput/valuePopoverInput.handlers.js
+++ b/src/components/valuePopoverInput/valuePopoverInput.handlers.js
@@ -1,0 +1,114 @@
+const normalizeValue = (value) => {
+  if (value === undefined || value === null || value === true) {
+    return "";
+  }
+
+  return String(value);
+};
+
+const focusInput = (refs) => {
+  setTimeout(() => {
+    refs.input.focus();
+    refs.input.shadowRoot?.querySelector("input")?.focus();
+  }, 50);
+};
+
+const openValuePopover = (deps, event) => {
+  const { props, refs, render, store } = deps;
+  if (props.disabled) {
+    return;
+  }
+
+  const value = normalizeValue(props.value);
+  const rect = event.currentTarget.getBoundingClientRect();
+  store.setValue({ value });
+  store.setTempValue({ value });
+  store.openPopover({
+    position: {
+      x: rect.left,
+      y: rect.bottom,
+    },
+  });
+  render();
+  focusInput(refs);
+};
+
+const commitValue = (deps) => {
+  const { dispatchEvent, render, store } = deps;
+  const value = normalizeValue(store.selectTempValue());
+  store.setValue({ value });
+  store.closePopover({});
+  dispatchEvent(
+    new CustomEvent("value-change", {
+      detail: { value },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+  render();
+};
+
+export const handleBeforeMount = ({ props, store }) => {
+  const value = normalizeValue(props.value);
+  store.setValue({ value });
+  store.setTempValue({ value });
+};
+
+export const handleOnUpdate = (deps, { oldProps, newProps } = {}) => {
+  if (oldProps?.value === newProps?.value) {
+    return;
+  }
+
+  const { render, store } = deps;
+  const value = normalizeValue(newProps?.value);
+  store.setValue({ value });
+  store.setTempValue({ value });
+  render();
+};
+
+export const handleTriggerClick = (deps, payload) => {
+  openValuePopover(deps, payload._event);
+};
+
+export const handleTriggerKeyDown = (deps, payload) => {
+  const event = payload._event;
+  if (event.key !== "Enter" && event.key !== " ") {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  openValuePopover(deps, event);
+};
+
+export const handlePopoverClose = ({ render, store }) => {
+  store.closePopover({});
+  render();
+};
+
+export const handleInputChange = ({ store }, payload) => {
+  store.setTempValue({
+    value: normalizeValue(payload._event.detail.value),
+  });
+};
+
+export const handleSubmitClick = (deps) => {
+  commitValue(deps);
+};
+
+export const handleInputKeyDown = (deps, payload) => {
+  const event = payload._event;
+  if (event.key === "Enter") {
+    event.preventDefault();
+    event.stopPropagation();
+    commitValue(deps);
+    return;
+  }
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    event.stopPropagation();
+    deps.store.closePopover({});
+    deps.render();
+  }
+};

--- a/src/components/valuePopoverInput/valuePopoverInput.schema.yaml
+++ b/src/components/valuePopoverInput/valuePopoverInput.schema.yaml
@@ -1,0 +1,18 @@
+componentName: rvn-value-popover-input
+propsSchema:
+  type: object
+  properties:
+    value:
+      type: string
+    placeholder:
+      type: string
+    label:
+      type: string
+    disabled:
+      type: boolean
+      default: false
+events:
+  value-change: {}
+methods:
+  type: object
+  properties: {}

--- a/src/components/valuePopoverInput/valuePopoverInput.store.js
+++ b/src/components/valuePopoverInput/valuePopoverInput.store.js
@@ -1,0 +1,50 @@
+export const createInitialState = () => ({
+  isOpen: false,
+  position: {
+    x: 0,
+    y: 0,
+  },
+  value: "",
+  tempValue: "",
+});
+
+export const setTempValue = ({ state }, { value } = {}) => {
+  state.tempValue = value;
+};
+
+export const selectTempValue = ({ state }) => {
+  return state.tempValue;
+};
+
+export const openPopover = ({ state }, { position } = {}) => {
+  state.position = position;
+  state.isOpen = true;
+};
+
+export const closePopover = ({ state }, _payload = {}) => {
+  state.isOpen = false;
+  state.tempValue = "";
+};
+
+export const setValue = ({ state }, { value } = {}) => {
+  state.value = value;
+};
+
+export const selectViewData = ({ i18n = {}, props, state }) => {
+  const hasValue = state.value !== "";
+  const disabled = props.disabled === true;
+
+  return {
+    disabled,
+    isOpen: state.isOpen,
+    label: props.label ?? "",
+    placeholder: props.placeholder ?? "",
+    position: state.position,
+    submitLabel: i18n.animationEditorPage?.doneButton ?? "Done",
+    tempValue: state.tempValue,
+    triggerCursor: disabled ? "default" : "pointer",
+    triggerTabIndex: disabled ? -1 : 0,
+    value: hasValue ? state.value : "-",
+    valueColor: hasValue ? "fg" : "mu-fg",
+  };
+};

--- a/src/components/valuePopoverInput/valuePopoverInput.view.yaml
+++ b/src/components/valuePopoverInput/valuePopoverInput.view.yaml
@@ -1,0 +1,29 @@
+refs:
+  trigger:
+    eventListeners:
+      click:
+        handler: handleTriggerClick
+      keydown:
+        handler: handleTriggerKeyDown
+  popover:
+    eventListeners:
+      close:
+        handler: handlePopoverClose
+  input:
+    eventListeners:
+      value-input:
+        handler: handleInputChange
+      keydown:
+        handler: handleInputKeyDown
+  submit:
+    eventListeners:
+      click:
+        handler: handleSubmitClick
+template:
+  - rtgl-view#trigger role=button tabindex=${triggerTabIndex} aria-disabled=${disabled} aria-haspopup=dialog w=f h=f d=h av=c cur=${triggerCursor}:
+      - rtgl-text c=${valueColor}: ${value}
+  - rtgl-popover#popover ?open=${isOpen} x=${position.x} y=${position.y} place=bs content-g=md content-w=240 content-ph=md content-pv=md:
+      - rtgl-text: ${label}
+      - rtgl-input#input w=f value=${tempValue} placeholder=${placeholder} ?disabled=${disabled}: null
+      - rtgl-view w=f ah=e:
+          - rtgl-button#submit s=sm v=pr ?disabled=${disabled}: ${submitLabel}

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -738,6 +738,8 @@ animationEditorPage:
   defaultLabel: "Default"
   delayMsLabel: "Delay (ms)"
   deletePropertyButtonLabel: "Delete property"
+  propertyRemoveConfirmMessage: "Delete this animation property? This cannot be undone."
+  propertyRemoveConfirmTitle: "Delete Property"
   deleteKeyframeMenuItem: "Delete keyframe"
   doneButton: "Done"
   durationMsLabel: "Duration (ms)"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -738,6 +738,8 @@ animationEditorPage:
   defaultLabel: "デフォルト"
   delayMsLabel: "遅延（ms）"
   deletePropertyButtonLabel: "プロパティを削除"
+  propertyRemoveConfirmMessage: "このアニメーションプロパティを削除しますか？この操作は元に戻せません。"
+  propertyRemoveConfirmTitle: "プロパティを削除"
   deleteKeyframeMenuItem: "キーフレームを削除"
   doneButton: "完了"
   durationMsLabel: "時間（ms）"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -738,6 +738,8 @@ animationEditorPage:
   defaultLabel: "默认"
   delayMsLabel: "延迟（ms）"
   deletePropertyButtonLabel: "删除属性"
+  propertyRemoveConfirmMessage: "要删除这个动画属性吗？此操作无法撤消。"
+  propertyRemoveConfirmTitle: "删除属性"
   deleteKeyframeMenuItem: "删除关键帧"
   doneButton: "完成"
   durationMsLabel: "时长（ms）"

--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -148,6 +148,11 @@ export const baseKeyframeDropdownItems = [
 
 export const propertyNameDropdownItems = [
   {
+    label: "Edit Initial Value",
+    type: "item",
+    value: "edit-initial-value",
+  },
+  {
     label: "Delete",
     type: "item",
     value: "delete-property",

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -811,6 +811,10 @@ const mountTimelinePanSubscriptions = (deps) => {
       type: "blur",
       listener: () => handleTimelinePanWindowBlur(deps),
     }),
+    browserEventsClient.subscribeWindowEvent({
+      type: "resize",
+      listener: () => handleTimelineViewportResize(deps),
+    }),
   ];
 
   return () => {
@@ -854,6 +858,7 @@ export const handleAfterMount = async (deps) => {
   const { projectService } = deps;
   await projectService.ensureRepository();
   await syncEditorState({ deps });
+  handleTimelineViewportResize(deps);
 };
 
 export const handleBackClick = async (deps) => {
@@ -987,15 +992,14 @@ export const handleClosePreviewDialog = (deps) => {
   render();
 };
 
-export const handleAddPropertiesClick = (deps, payload) => {
+const openAddProperties = (deps, { side, x, y } = {}) => {
   const { render, store } = deps;
-  const side = payload._event.currentTarget?.dataset?.side;
 
   if (!side && store.selectDialogType() === "transition") {
     store.setPopover({
       mode: "addPropertySideMenu",
-      x: payload._event.clientX,
-      y: payload._event.clientY,
+      x,
+      y,
       payload: {},
     });
     render();
@@ -1004,13 +1008,37 @@ export const handleAddPropertiesClick = (deps, payload) => {
 
   store.setPopover({
     mode: "addProperty",
-    x: payload._event.clientX,
-    y: payload._event.clientY,
+    x,
+    y,
     payload: {
       side: side ?? "update",
     },
   });
   render();
+};
+
+export const handleAddPropertiesClick = (deps, payload) => {
+  const event = payload._event;
+  openAddProperties(deps, {
+    side: event.currentTarget?.dataset?.side,
+    x: event.clientX,
+    y: event.clientY,
+  });
+};
+
+export const handleEmptyTimelineAddPropertiesKeyDown = (deps, payload) => {
+  const event = payload._event;
+  if (event.key !== "Enter" && event.key !== " ") {
+    return;
+  }
+
+  event.preventDefault();
+  const rect = event.currentTarget.getBoundingClientRect();
+  openAddProperties(deps, {
+    side: event.currentTarget.dataset.side,
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  });
 };
 
 export const handleTimelineZoomChange = (deps, payload) => {
@@ -1089,6 +1117,7 @@ export const handleTimelineZoomOut = (deps) => {
 export const handleTimelineScroll = (deps, payload) => {
   const { render, store } = deps;
   const wasPlayheadVisible = store.selectTimelinePlayheadVisible();
+  const previousViewportWidth = store.selectTimelineViewportWidth();
   const timelineViewport = payload._event.currentTarget;
 
   store.setTimelineScrollMetrics({
@@ -1096,9 +1125,47 @@ export const handleTimelineScroll = (deps, payload) => {
     viewportWidth: timelineViewport.clientWidth,
   });
 
-  if (wasPlayheadVisible !== store.selectTimelinePlayheadVisible()) {
+  if (
+    previousViewportWidth !== timelineViewport.clientWidth ||
+    wasPlayheadVisible !== store.selectTimelinePlayheadVisible()
+  ) {
     render();
   }
+};
+
+export const handleTimelineViewportResize = (deps) => {
+  const { refs, render, store } = deps;
+  const timelineViewport = refs.timelineScrollContainer;
+  if (
+    !timelineViewport ||
+    timelineViewport.clientWidth === store.selectTimelineViewportWidth()
+  ) {
+    return;
+  }
+
+  store.setTimelineScrollMetrics({
+    scrollLeft: timelineViewport.scrollLeft,
+    viewportWidth: timelineViewport.clientWidth,
+  });
+  render();
+};
+
+export const handleTimelineDurationExtend = (deps, payload) => {
+  const { render, store } = deps;
+  const { duration } = payload._event.detail;
+  store.extendTimelineDisplayDuration({ duration });
+  render();
+};
+
+export const handleTimelineUsedDurationPreview = (deps, payload) => {
+  const { render, store } = deps;
+  const { active, duration, side } = payload._event.detail;
+  if (active) {
+    store.setTimelineUsedDurationPreview({ side, duration });
+  } else {
+    store.clearTimelineUsedDurationPreview({});
+  }
+  render();
 };
 
 export const handleTimelinePanPointerEnter = (deps) => {
@@ -1530,6 +1597,24 @@ export const handleSelectedKeyframeRelativeChange = (deps, payload) => {
   commitSelectedKeyframeChange(deps);
 };
 
+export const handleSelectedPropertyInitialValueChange = (deps, payload) => {
+  const { render, store } = deps;
+  const selectedProperty = store.selectSelectedProperty();
+  if (!selectedProperty) {
+    return;
+  }
+
+  const { side, property } = selectedProperty;
+  store.updateInitialValue({
+    side,
+    property,
+    initialValue: resolveValueChange(payload),
+  });
+  invalidatePreview({ store });
+  render();
+  queueEditorAutosave({ deps });
+};
+
 const openSelectedMaskNumberPopover = (deps, payload, { mode, value } = {}) => {
   const { render, store } = deps;
   const event = payload._event;
@@ -1744,6 +1829,36 @@ export const handleSelectedPropertyDeleteClick = (deps) => {
     return;
   }
 
+  if (["prev", "next"].includes(selectedProperty.side)) {
+    store.closePopover();
+    store.openPropertyRemoveConfirmDialog({});
+    render();
+    return;
+  }
+
+  store.deleteProperty(selectedProperty);
+  store.closePopover();
+  invalidatePreview({ store });
+  render();
+  queueEditorAutosave({ deps });
+};
+
+export const handlePropertyRemoveConfirmDialogClose = (deps) => {
+  const { render, store } = deps;
+  store.closePropertyRemoveConfirmDialog({});
+  render();
+};
+
+export const handlePropertyRemoveConfirmClick = (deps) => {
+  const { render, store } = deps;
+  const selectedProperty = store.selectSelectedProperty();
+
+  store.closePropertyRemoveConfirmDialog({});
+  if (!selectedProperty) {
+    render();
+    return;
+  }
+
   store.deleteProperty(selectedProperty);
   store.closePopover();
   invalidatePreview({ store });
@@ -1763,6 +1878,13 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
     openSelectedKeyframeEditDialog(deps, { x, y });
     return;
   } else if (value === "delete-property") {
+    if (["prev", "next"].includes(side)) {
+      store.setSelectedProperty({ side, property });
+      store.closePopover();
+      store.openPropertyRemoveConfirmDialog({});
+      render();
+      return;
+    }
     store.deleteProperty({ side, property });
     store.closePopover();
     didMutate = true;
@@ -1901,20 +2023,6 @@ export const handleRulerTimeScrub = async (deps, payload) => {
   if (didChangePreviewState) {
     render();
   }
-};
-
-export const handleInitialValueClick = (deps, payload) => {
-  const { render, store } = deps;
-  store.setPopover({
-    mode: "editInitialValue",
-    x: payload._event.detail.x,
-    y: payload._event.detail.y,
-    payload: {
-      side: payload._event.detail.side,
-      property: payload._event.detail.property,
-    },
-  });
-  render();
 };
 
 const updatePopoverFieldValue = ({ store, detail } = {}) => {

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -1,3 +1,4 @@
+import { auditTime, filter, tap } from "rxjs";
 import { generateId } from "../../internal/id.js";
 import {
   createAnimationEditorPayload,
@@ -789,7 +790,7 @@ const syncEditorState = async ({ deps, repositoryState } = {}) => {
 };
 
 const mountTimelinePanSubscriptions = (deps) => {
-  const { browserEventsClient } = deps;
+  const { browserEventsClient, subject } = deps;
   const cleanupSubscriptions = [
     browserEventsClient.subscribeWindowEvent({
       type: "keydown",
@@ -816,9 +817,19 @@ const mountTimelinePanSubscriptions = (deps) => {
       listener: () => handleTimelineViewportResize(deps),
     }),
   ];
+  const panelResizeSubscription = subject
+    .pipe(
+      filter(({ action }) =>
+        ["panel-resize", "panel-resize-end"].includes(action),
+      ),
+      auditTime(0),
+      tap(() => handleTimelineViewportResize(deps)),
+    )
+    .subscribe();
 
   return () => {
     cleanupSubscriptions.forEach((cleanup) => cleanup());
+    panelResizeSubscription.unsubscribe();
   };
 };
 
@@ -1597,7 +1608,7 @@ export const handleSelectedKeyframeRelativeChange = (deps, payload) => {
   commitSelectedKeyframeChange(deps);
 };
 
-export const handleSelectedPropertyInitialValueChange = (deps, payload) => {
+const commitSelectedPropertyInitialValue = (deps, initialValue) => {
   const { render, store } = deps;
   const selectedProperty = store.selectSelectedProperty();
   if (!selectedProperty) {
@@ -1608,11 +1619,19 @@ export const handleSelectedPropertyInitialValueChange = (deps, payload) => {
   store.updateInitialValue({
     side,
     property,
-    initialValue: resolveValueChange(payload),
+    initialValue,
   });
   invalidatePreview({ store });
   render();
   queueEditorAutosave({ deps });
+};
+
+export const handleSelectedPropertyInitialValueChange = (deps, payload) => {
+  commitSelectedPropertyInitialValue(deps, resolveValueChange(payload));
+};
+
+export const handleSelectedPropertyUseDefaultClick = (deps) => {
+  commitSelectedPropertyInitialValue(deps, undefined);
 };
 
 const openSelectedMaskNumberPopover = (deps, payload, { mode, value } = {}) => {
@@ -1876,6 +1895,15 @@ export const handleKeyframeDropdownItemClick = (deps, payload) => {
 
   if (value === "edit") {
     openSelectedKeyframeEditDialog(deps, { x, y });
+    return;
+  } else if (value === "edit-initial-value") {
+    store.setPopover({
+      mode: "editInitialValue",
+      x,
+      y,
+      payload: { side, property },
+    });
+    render();
     return;
   } else if (value === "delete-property") {
     if (["prev", "next"].includes(side)) {

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -3463,6 +3463,7 @@ const buildSelectedPropertyPanelData = (
     editor: autoConfig
       ? undefined
       : {
+          hasInitialValue,
           initialValue,
           initialValueLabel: copy.initialValueLabel ?? "Initial value",
           initialValueSlider,
@@ -3722,7 +3723,21 @@ export const selectViewData = ({ state, i18n }) => {
 
   const keyframeDropdownItems = (() => {
     if (state.popover.mode !== "keyframeMenu") {
-      return localizeMenuItems(propertyNameDropdownItems, copy);
+      const propertyMenuItems = localizeMenuItems(
+        propertyNameDropdownItems,
+        copy,
+      );
+      if (state.popover.mode !== "propertyNameMenu") {
+        return propertyMenuItems;
+      }
+
+      const { side, property } = state.popover.payload;
+      const propertyConfig = getSectionProperties(state, side)[property];
+      return propertyConfig?.auto
+        ? propertyMenuItems.filter(
+            (item) => item.value !== "edit-initial-value",
+          )
+        : propertyMenuItems;
     }
 
     const { side, property, index } = state.popover.payload;
@@ -4050,6 +4065,8 @@ export const selectViewData = ({ state, i18n }) => {
     editKeyframeButtonLabel: copy.editKeyframeMenuItem ?? "Edit keyframe",
     imageLabel: copy.imageLabel ?? "Image",
     initialValueLabel: copy.initialValueLabel ?? "Initial value",
+    useDefaultValueButtonLabel:
+      copy.useDefaultValueSource ?? "Use Default Value",
     inTimelineLabel: copy.inTimelineLabel ?? "Incoming",
     invertLabel: copy.invertLabel ?? "Invert",
     detailsPanelTitle: selectedMask

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -1345,6 +1345,8 @@ export const createInitialState = () => ({
   timelineZoom: TIMELINE_ZOOM_DEFAULT,
   timelineScrollLeft: 0,
   timelineViewportWidth: undefined,
+  timelineDisplayDurationOverrideMs: undefined,
+  timelineUsedDurationPreview: undefined,
   dialogType: "update",
   targetGroupId: undefined,
   projectResolution: DEFAULT_PROJECT_RESOLUTION,
@@ -1379,6 +1381,7 @@ export const createInitialState = () => ({
   isTouchMode: false,
   isPreviewDialogOpen: false,
   maskRemoveConfirmDialogOpen: false,
+  propertyRemoveConfirmDialogOpen: false,
   popover: {
     mode: "none",
     x: undefined,
@@ -1446,6 +1449,41 @@ export const nudgeTimelineZoom = ({ state }, { delta } = {}) => {
 
 export const selectTimelineZoom = ({ state }) => {
   return state.timelineZoom;
+};
+
+export const selectTimelineViewportWidth = ({ state }) => {
+  return state.timelineViewportWidth;
+};
+
+export const extendTimelineDisplayDuration = ({ state }, { duration } = {}) => {
+  const numericDuration = Number(duration);
+  if (!Number.isFinite(numericDuration) || numericDuration <= 0) {
+    return;
+  }
+
+  state.timelineDisplayDurationOverrideMs = Math.max(
+    state.timelineDisplayDurationOverrideMs ?? 0,
+    numericDuration,
+  );
+};
+
+export const setTimelineUsedDurationPreview = (
+  { state },
+  { side, duration } = {},
+) => {
+  const numericDuration = Number(duration);
+  if (!side || !Number.isFinite(numericDuration) || numericDuration < 0) {
+    return;
+  }
+
+  state.timelineUsedDurationPreview = {
+    side,
+    duration: numericDuration,
+  };
+};
+
+export const clearTimelineUsedDurationPreview = ({ state }, _payload = {}) => {
+  state.timelineUsedDurationPreview = undefined;
 };
 
 export const setTimelinePanHovered = ({ state }, { hovered } = {}) => {
@@ -1569,6 +1607,10 @@ export const openDialog = (
   state.selectedProperty = undefined;
   state.selectedMask = false;
   state.selectedMaskIndex = undefined;
+  state.timelineDisplayDurationOverrideMs = undefined;
+  state.timelineUsedDurationPreview = undefined;
+  state.maskRemoveConfirmDialogOpen = false;
+  state.propertyRemoveConfirmDialogOpen = false;
   state.editMode = Boolean(editMode);
   state.editItemId = itemId;
   state.pendingTransitionMask = undefined;
@@ -3110,6 +3152,14 @@ export const closeMaskRemoveConfirmDialog = ({ state }, _payload = {}) => {
   state.maskRemoveConfirmDialogOpen = false;
 };
 
+export const openPropertyRemoveConfirmDialog = ({ state }, _payload = {}) => {
+  state.propertyRemoveConfirmDialogOpen = true;
+};
+
+export const closePropertyRemoveConfirmDialog = ({ state }, _payload = {}) => {
+  state.propertyRemoveConfirmDialogOpen = false;
+};
+
 const buildTransitionMaskPanelDataForMask = (
   state,
   transitionMask,
@@ -3360,6 +3410,10 @@ const buildSelectedPropertyPanelData = (
     propertyConfig.initialValue !== undefined &&
     propertyConfig.initialValue !== "";
   const autoConfig = propertyConfig.auto;
+  const initialValue = hasInitialValue
+    ? propertyConfig.initialValue
+    : (propertyFieldConfig[property]?.defaultValue ?? 0);
+  const initialValueSlider = propertyFieldConfig[property]?.slider;
   const fields = [
     {
       type: "text",
@@ -3371,13 +3425,19 @@ const buildSelectedPropertyPanelData = (
       label: copy.propertyLabel ?? "Property",
       value: propertyFieldConfig[property]?.label ?? property,
     },
-    {
-      type: "text",
-      label: copy.initialValueLabel ?? "Initial value",
-      value: hasInitialValue
-        ? propertyConfig.initialValue
-        : (copy.defaultLabel ?? "Default"),
-    },
+    autoConfig
+      ? {
+          type: "text",
+          label: copy.initialValueLabel ?? "Initial value",
+          value: hasInitialValue
+            ? propertyConfig.initialValue
+            : (copy.defaultLabel ?? "Default"),
+        }
+      : {
+          type: "slot",
+          label: copy.initialValueLabel ?? "Initial value",
+          slot: "property-initial-value",
+        },
   ];
 
   if (autoConfig) {
@@ -3400,17 +3460,36 @@ const buildSelectedPropertyPanelData = (
 
   return {
     id: `${side}:${property}`,
+    editor: autoConfig
+      ? undefined
+      : {
+          initialValue,
+          initialValueLabel: copy.initialValueLabel ?? "Initial value",
+          initialValueSlider,
+          initialValueStep: propertyFieldConfig[property]?.input?.step ?? "any",
+          initialValueUsesPopover: Boolean(
+            propertyFieldConfig[property]?.input,
+          ),
+        },
     fields,
   };
 };
 
 const createTimelineMetrics = ({ state, activeTimelineDuration }) => {
+  const timelinePixelsPerSecond = Math.round(
+    TIMELINE_BASE_PIXELS_PER_SECOND * state.timelineZoom,
+  );
+  const viewportTimelineDuration =
+    state.timelineViewportWidth > TIMELINE_PROPERTY_COLUMN_WIDTH
+      ? ((state.timelineViewportWidth - TIMELINE_PROPERTY_COLUMN_WIDTH) /
+          timelinePixelsPerSecond) *
+        1000
+      : 0;
   const timelineDisplayDuration = Math.max(
     TIMELINE_MIN_DISPLAY_DURATION_MS,
     activeTimelineDuration,
-  );
-  const timelinePixelsPerSecond = Math.round(
-    TIMELINE_BASE_PIXELS_PER_SECOND * state.timelineZoom,
+    viewportTimelineDuration,
+    state.timelineDisplayDurationOverrideMs ?? 0,
   );
   const timelineCanvasWidth = Math.round(
     TIMELINE_PROPERTY_COLUMN_WIDTH +
@@ -3444,15 +3523,40 @@ const createTimelineMetrics = ({ state, activeTimelineDuration }) => {
 };
 
 const getActiveTimelineDuration = (state) => {
+  const preview = state.timelineUsedDurationPreview;
   if (state.dialogType !== "transition") {
-    return getPropertiesDuration(getSectionProperties(state, "update"));
+    return preview?.side === "update"
+      ? preview.duration
+      : getPropertiesDuration(getSectionProperties(state, "update"));
   }
 
-  return getTransitionTimelineDuration({
-    prevProperties: getSectionProperties(state, "prev"),
-    nextProperties: getSectionProperties(state, "next"),
-    mask: getEffectiveTransitionMask(state),
-  });
+  const previousDuration =
+    preview?.side === "prev"
+      ? preview.duration
+      : getPropertiesDuration(getSectionProperties(state, "prev"));
+  const nextDuration =
+    preview?.side === "next"
+      ? preview.duration
+      : getPropertiesDuration(getSectionProperties(state, "next"));
+  const maskDuration = getTransitionMasks(state).reduce(
+    (maxDuration, mask, index) => {
+      const side = createMaskSide(index);
+      if (preview?.side !== side) {
+        return Math.max(maxDuration, getTransitionTimelineDuration({ mask }));
+      }
+
+      const committedProgressDuration = getPropertiesDuration(
+        getSectionProperties(state, side),
+      );
+      const committedMaskDuration = getTransitionTimelineDuration({ mask });
+      const previewMaskDuration =
+        committedMaskDuration - committedProgressDuration + preview.duration;
+      return Math.max(maxDuration, previewMaskDuration);
+    },
+    0,
+  );
+
+  return Math.max(previousDuration, nextDuration, maskDuration);
 };
 
 export const selectTimelinePlayheadVisible = ({ state }) => {
@@ -3478,15 +3582,9 @@ export const selectViewData = ({ state, i18n }) => {
   const updateProperties = getSectionProperties(state, "update");
   const previousProperties = getSectionProperties(state, "prev");
   const nextProperties = getSectionProperties(state, "next");
-  const transitionTimelineDuration = getTransitionTimelineDuration({
-    prevProperties: previousProperties,
-    nextProperties,
-    mask: getEffectiveTransitionMask(state),
-  });
-  const activeTimelineDuration =
-    dialogType === "transition"
-      ? transitionTimelineDuration
-      : getPropertiesDuration(updateProperties);
+  const activeTimelineDuration = getActiveTimelineDuration(state);
+  const transitionTimelineDuration =
+    dialogType === "transition" ? activeTimelineDuration : 0;
   const {
     timelineCanvasWidth,
     timelineDisplayDuration,
@@ -3498,8 +3596,13 @@ export const selectViewData = ({ state, i18n }) => {
     state.previewPlayheadVisible &&
     activeTimelineDuration > 0 &&
     timelinePlayheadWithinViewport;
+  const timelineUsedAreaRatio =
+    timelineDisplayDuration > 0
+      ? Math.min(1, activeTimelineDuration / timelineDisplayDuration)
+      : 0;
+  const timelineUsedAreaStyle = `top: 0; bottom: 0; left: 104px; width: calc((100% - 104px) * ${timelineUsedAreaRatio}); pointer-events: none; z-index: 0;`;
   const timelinePlayheadStyle = timelinePlayheadVisible
-    ? `top: 10px; bottom: 0; left: calc(104px + (100% - 104px) * ${timelinePlayheadRatio}); width: 1px; transform: translateX(-0.5px); pointer-events: none; z-index: 5;`
+    ? `top: 10px; bottom: 0; left: calc(104px + (100% - 104px) * ${timelinePlayheadRatio}); width: 1px; transform: translateX(-0.5px); pointer-events: none; z-index: 8;`
     : "";
   const updateTimelineDefaultValues = createTimelineDefaultValues(
     UPDATE_PROPERTY_KEYS,
@@ -3595,6 +3698,13 @@ export const selectViewData = ({ state, i18n }) => {
   );
   const maskTimelineRow = maskTimelineRows[0];
   const maskTimelineProperties = maskTimelineRow?.properties ?? {};
+  const previousTimelineVisible = Object.keys(previousProperties).length > 0;
+  const nextTimelineVisible = Object.keys(nextProperties).length > 0;
+  const maskTimelineVisible = maskTimelineRows.length > 0;
+  const activeTimelineEmpty =
+    dialogType === "transition"
+      ? !previousTimelineVisible && !nextTimelineVisible && !maskTimelineVisible
+      : Object.keys(updateProperties).length === 0;
   const previewPanel = buildPreviewPanelData(state, copy);
   const selectedKeyframePanel = buildSelectedKeyframePanelData(
     state,
@@ -3768,18 +3878,20 @@ export const selectViewData = ({ state, i18n }) => {
     previewLoopButtonVariant: state.previewLoopEnabled ? "pr" : "ol",
     timelinePlayheadVisible,
     timelinePlayheadStyle,
+    timelineUsedAreaStyle,
     timelineZoom: state.timelineZoom,
     timelineZoomMin: TIMELINE_ZOOM_MIN,
     timelineZoomMax: TIMELINE_ZOOM_MAX,
     timelineZoomStep: TIMELINE_ZOOM_STEP,
     timelinePixelsPerSecond,
-    timelineCanvasStyle: `width: ${timelineCanvasWidth}px; min-width: ${TIMELINE_PROPERTY_COLUMN_WIDTH}px; flex-shrink: 0;${state.timelinePanMode ? " pointer-events: none; user-select: none;" : ""}`,
+    timelineCanvasStyle: `width: ${timelineCanvasWidth}px; min-width: 100%; flex-shrink: 0;${state.timelinePanMode ? " pointer-events: none; user-select: none;" : ""}`,
     timelinePanCursor: state.timelinePan
       ? "grabbing"
       : state.timelinePanMode
         ? "grab"
         : "default",
     timelineDisplayDuration,
+    activeTimelineDuration,
     dialogTypeLabel:
       dialogType === "transition"
         ? (copy.transitionType ?? "Transition")
@@ -3794,6 +3906,8 @@ export const selectViewData = ({ state, i18n }) => {
     updateProperties,
     previousProperties,
     nextProperties,
+    previousTimelineVisible,
+    nextTimelineVisible,
     selectedKeyframe: state.selectedKeyframe,
     selectedProperty: state.selectedProperty,
     selectedKeyframeDetailId: selectedKeyframePanel?.id,
@@ -3801,9 +3915,12 @@ export const selectViewData = ({ state, i18n }) => {
     selectedKeyframeEditor: selectedKeyframePanel?.editor,
     selectedPropertyDetailId: selectedPropertyPanel?.id,
     selectedPropertyDetailFields: selectedPropertyPanel?.fields ?? [],
+    selectedPropertyEditor: selectedPropertyPanel?.editor,
     selectedMask,
     maskTimelineRow,
     maskTimelineRows,
+    maskTimelineVisible,
+    activeTimelineEmpty,
     maskTimelineProperties,
     maskTimelineDefaultValues: { [MASK_PROGRESS_PROPERTY]: 0 },
     updateTimelineDefaultValues,
@@ -3876,6 +3993,7 @@ export const selectViewData = ({ state, i18n }) => {
     fullImagePreviewImageId: state.fullImagePreviewImageId,
     isPreviewDialogOpen: state.isPreviewDialogOpen,
     maskRemoveConfirmDialogOpen: state.maskRemoveConfirmDialogOpen,
+    propertyRemoveConfirmDialogOpen: state.propertyRemoveConfirmDialogOpen,
     showRightPanel: !state.isTouchMode,
     selectedEditorTab: state.selectedEditorTab,
     editorTabs: [
@@ -3915,6 +4033,7 @@ export const selectViewData = ({ state, i18n }) => {
       getMaskEditorTransitionMask(state),
     ),
     addButton: copy.addButton ?? "Add",
+    addPropertyButtonLabel: copy.addPropertyButton ?? "Add Property",
     addMaskButton: copy.addMaskButton ?? "Add Mask",
     addMaskTitle: copy.addMaskTitle ?? "Add Mask",
     cancelButton: copy.cancelButton ?? "Cancel",
@@ -3922,6 +4041,11 @@ export const selectViewData = ({ state, i18n }) => {
     doneButton: copy.doneButton ?? "Done",
     deletePropertyButtonLabel:
       copy.deletePropertyButtonLabel ?? "Delete property",
+    propertyRemoveConfirmMessage:
+      copy.propertyRemoveConfirmMessage ??
+      "Delete this animation property? This cannot be undone.",
+    propertyRemoveConfirmTitle:
+      copy.propertyRemoveConfirmTitle ?? "Delete Property",
     editPreviewButton: copy.editPreviewButton ?? "Edit Preview",
     editKeyframeButtonLabel: copy.editKeyframeMenuItem ?? "Edit keyframe",
     imageLabel: copy.imageLabel ?? "Image",

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -620,15 +620,15 @@ template:
                   - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                       - $if selectedKeyframeDetailId:
                           - rvn-detail-view#selectedKeyframeDetails key=${selectedKeyframeDetailId} w=f :fields=${selectedKeyframeDetailFields} :fillHeight=${false}:
-                              - rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                              - 'rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                   - 'rtgl-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
-                              - rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                              - 'rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                   - 'rtgl-popover-input#selectedKeyframeDuration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
                               - rtgl-select#selectedKeyframeEasingSelect slot=keyframe-easing w=f no-clear :selectedValue=${selectedKeyframeEditor.easing} :options=${selectedKeyframeEditor.easingOptions}: null
                               - $if selectedKeyframeEditor.valueSlider:
                                   - rtgl-slider-input#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f value=${selectedKeyframeEditor.value} min=${selectedKeyframeEditor.valueSlider.min} max=${selectedKeyframeEditor.valueSlider.max} step=${selectedKeyframeEditor.valueSlider.step}: null
                                 $elif selectedKeyframeEditor.valueUsesPopover:
-                                  - rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                                  - 'rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                       - 'rtgl-popover-input#selectedKeyframeValuePopover value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
                                 $else:
                                   - rtgl-input-number#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f step=${selectedKeyframeEditor.valueStep} value=${selectedKeyframeEditor.value}: null
@@ -638,7 +638,7 @@ template:
                               - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
                                   - rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
                                 $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
-                                  - rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                                  - 'rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                       - 'rtgl-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
                                 $elif selectedPropertyEditor:
                                   - rtgl-input-number#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -284,6 +284,10 @@ refs:
     eventListeners:
       value-change:
         handler: handleSelectedPropertyInitialValueChange
+  selectedPropertyUseDefault:
+    eventListeners:
+      click:
+        handler: handleSelectedPropertyUseDefaultClick
   selectedMaskInitialValue:
     eventListeners:
       click:
@@ -635,13 +639,16 @@ template:
                               - rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type w=f no-clear :selectedValue=${selectedKeyframeEditor.relative} :options=${selectedKeyframeEditor.relativeOptions}: null
                         $elif selectedPropertyDetailId:
                           - rvn-detail-view#selectedPropertyDetails key=${selectedPropertyDetailId} w=f :fields=${selectedPropertyDetailFields} :fillHeight=${false}:
-                              - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
-                                  - rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
-                                $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
-                                  - 'rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
-                                      - 'rvn-value-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
-                                $elif selectedPropertyEditor:
-                                  - rtgl-input-number#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null
+                              - rtgl-view slot=property-initial-value d=v w=f g=xs:
+                                  - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
+                                      - rtgl-slider-input#selectedPropertyInitialValue key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
+                                    $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
+                                      - 'rtgl-view data-popover-input-field=true w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                          - 'rvn-value-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
+                                    $elif selectedPropertyEditor:
+                                      - rtgl-input-number#selectedPropertyInitialValue key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null
+                                  - $if selectedPropertyEditor && selectedPropertyEditor.hasInitialValue:
+                                      - rtgl-button#selectedPropertyUseDefault s=sm v=se w=f: ${useDefaultValueButtonLabel}
                         $elif selectedMask:
                           - rtgl-view#selectedMaskDetails data-timeline-selection-surface=true d=v w=f g=md p=md pb=xl:
                               - $if maskEditorPanel.unsupported:

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -620,15 +620,15 @@ template:
                   - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                       - $if selectedKeyframeDetailId:
                           - rvn-detail-view#selectedKeyframeDetails key=${selectedKeyframeDetailId} w=f :fields=${selectedKeyframeDetailFields} :fillHeight=${false}:
-                              - 'rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                              - 'rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                   - 'rtgl-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
-                              - 'rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                              - 'rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                   - 'rtgl-popover-input#selectedKeyframeDuration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
                               - rtgl-select#selectedKeyframeEasingSelect slot=keyframe-easing w=f no-clear :selectedValue=${selectedKeyframeEditor.easing} :options=${selectedKeyframeEditor.easingOptions}: null
                               - $if selectedKeyframeEditor.valueSlider:
                                   - rtgl-slider-input#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f value=${selectedKeyframeEditor.value} min=${selectedKeyframeEditor.valueSlider.min} max=${selectedKeyframeEditor.valueSlider.max} step=${selectedKeyframeEditor.valueSlider.step}: null
                                 $elif selectedKeyframeEditor.valueUsesPopover:
-                                  - 'rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                  - 'rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                       - 'rtgl-popover-input#selectedKeyframeValuePopover value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
                                 $else:
                                   - rtgl-input-number#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f step=${selectedKeyframeEditor.valueStep} value=${selectedKeyframeEditor.value}: null
@@ -638,7 +638,7 @@ template:
                               - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
                                   - rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
                                 $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
-                                  - 'rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                  - 'rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
                                       - 'rtgl-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
                                 $elif selectedPropertyEditor:
                                   - rtgl-input-number#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -528,6 +528,8 @@ template:
                               - 'rtgl-view#timelineScrollContainer w=f h=1fg sh sv cur=${timelinePanCursor} style="min-width: 0; min-height: 0;"':
                                   - 'rtgl-view d=v pos=rel style="${timelineCanvasStyle} min-height: 100%;"':
                                       - $if !activeTimelineEmpty:
+                                          - 'rtgl-view data-timeline-property-column-fill=true pos=abs style="inset: 0; pointer-events: none; z-index: 5;"':
+                                              - 'rtgl-view h=f w=104 bgc=bg style="min-width: 104px; position: sticky; left: 0;"': null
                                           - 'rtgl-view pos=abs bgc=su style="${timelineUsedAreaStyle}"': null
                                           - rvn-keyframe-timeline#updateTimeline editable=true ?showRuler=true ?interactiveRuler=true side=update ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration} :properties=${updateProperties} :defaultValues=${updateTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
                                       - $if activeTimelineEmpty:
@@ -542,6 +544,8 @@ template:
                               - 'rtgl-view#timelineScrollContainer w=f h=1fg sh sv cur=${timelinePanCursor} style="min-width: 0; min-height: 0;"':
                                   - 'rtgl-view d=v g=md pos=rel style="${timelineCanvasStyle} min-height: 100%;"':
                                       - $if !activeTimelineEmpty:
+                                          - 'rtgl-view data-timeline-property-column-fill=true pos=abs style="inset: 0; pointer-events: none; z-index: 5;"':
+                                              - 'rtgl-view h=f w=104 bgc=bg style="min-width: 104px; position: sticky; left: 0;"': null
                                           - 'rtgl-view pos=abs bgc=su style="${timelineUsedAreaStyle}"': null
                                           - 'rtgl-view w=f bgc=bg style="position: sticky; top: 0; z-index: 7;"':
                                               - rvn-keyframe-timeline#transitionRuler ?showRuler=true ?showTracks=false ?interactiveRuler=true ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration}: null

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -54,6 +54,18 @@ refs:
     eventListeners:
       click:
         handler: handleMaskRemoveConfirmClick
+  propertyRemoveConfirmDialog:
+    eventListeners:
+      close:
+        handler: handlePropertyRemoveConfirmDialogClose
+  propertyRemoveCancelButton:
+    eventListeners:
+      click:
+        handler: handlePropertyRemoveConfirmDialogClose
+  propertyRemoveConfirmButton:
+    eventListeners:
+      click:
+        handler: handlePropertyRemoveConfirmClick
   selectedMaskDeleteButton:
     eventListeners:
       click:
@@ -66,6 +78,12 @@ refs:
     eventListeners:
       click:
         handler: handleAddPropertiesClick
+  emptyTimelineAddPropertiesButton:
+    eventListeners:
+      click:
+        handler: handleAddPropertiesClick
+      keydown:
+        handler: handleEmptyTimelineAddPropertiesKeyDown
   timelineZoomSlider:
     eventListeners:
       value-change:
@@ -110,14 +128,16 @@ refs:
         handler: handleKeyframeSelect
       keyframe-duration-change:
         handler: handleKeyframeDurationChange
+      timeline-duration-extend:
+        handler: handleTimelineDurationExtend
+      timeline-used-duration-preview:
+        handler: handleTimelineUsedDurationPreview
       auto-track-click:
         handler: handleAutoTrackClick
       keyframe-right-click:
         handler: handleKeyframeRightClick
       property-name-click:
         handler: handlePropertyNameClick
-      initial-value-click:
-        handler: handleInitialValueClick
   transitionRuler:
     eventListeners:
       ruler-time-scrub:
@@ -132,12 +152,14 @@ refs:
         handler: handleKeyframeSelect
       keyframe-duration-change:
         handler: handleKeyframeDurationChange
+      timeline-duration-extend:
+        handler: handleTimelineDurationExtend
+      timeline-used-duration-preview:
+        handler: handleTimelineUsedDurationPreview
       keyframe-right-click:
         handler: handleKeyframeRightClick
       property-name-click:
         handler: handlePropertyNameClick
-      initial-value-click:
-        handler: handleInitialValueClick
   nextTimeline:
     eventListeners:
       add-keyframe:
@@ -148,12 +170,14 @@ refs:
         handler: handleKeyframeSelect
       keyframe-duration-change:
         handler: handleKeyframeDurationChange
+      timeline-duration-extend:
+        handler: handleTimelineDurationExtend
+      timeline-used-duration-preview:
+        handler: handleTimelineUsedDurationPreview
       keyframe-right-click:
         handler: handleKeyframeRightClick
       property-name-click:
         handler: handlePropertyNameClick
-      initial-value-click:
-        handler: handleInitialValueClick
   maskKeyframeTimeline*:
     eventListeners:
       add-keyframe:
@@ -164,12 +188,14 @@ refs:
         handler: handleKeyframeSelect
       keyframe-duration-change:
         handler: handleKeyframeDurationChange
+      timeline-duration-extend:
+        handler: handleTimelineDurationExtend
+      timeline-used-duration-preview:
+        handler: handleTimelineUsedDurationPreview
       keyframe-right-click:
         handler: handleKeyframeRightClick
       property-name-click:
         handler: handlePropertyNameClick
-      initial-value-click:
-        handler: handleSelectedMaskInitialValueClick
   addPropertyPopover:
     eventListeners:
       close:
@@ -250,6 +276,14 @@ refs:
     eventListeners:
       value-change:
         handler: handleSelectedKeyframeRelativeChange
+  selectedPropertyInitialValue:
+    eventListeners:
+      value-input:
+        handler: handleSelectedPropertyInitialValueChange
+  selectedPropertyInitialValuePopover:
+    eventListeners:
+      value-change:
+        handler: handleSelectedPropertyInitialValueChange
   selectedMaskInitialValue:
     eventListeners:
       click:
@@ -489,45 +523,62 @@ template:
                           - $if dialogType == 'update':
                               - 'rtgl-view#timelineScrollContainer w=f h=1fg sh sv cur=${timelinePanCursor} style="min-width: 0; min-height: 0;"':
                                   - 'rtgl-view d=v pos=rel style="${timelineCanvasStyle} min-height: 100%;"':
-                                      - rvn-keyframe-timeline#updateTimeline editable=true ?showRuler=true ?interactiveRuler=true side=update ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration} :properties=${updateProperties} :defaultValues=${updateTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                      - $if !activeTimelineEmpty:
+                                          - 'rtgl-view pos=abs bgc=su style="${timelineUsedAreaStyle}"': null
+                                          - rvn-keyframe-timeline#updateTimeline editable=true ?showRuler=true ?interactiveRuler=true side=update ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration} :properties=${updateProperties} :defaultValues=${updateTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                      - $if activeTimelineEmpty:
+                                          - rtgl-view w=f ph=md pt=md:
+                                              - 'rtgl-view#emptyTimelineAddPropertiesButton data-side=update role=button tabindex=0 aria-label="${addPropertyButtonLabel}" title="${addPropertyButtonLabel}" w=f h=200 av=c ah=c g=md bw=xs bc=bo br=md cur=pointer':
+                                                  - rtgl-svg svg=plus wh=24: null
+                                                  - rtgl-text: ${addPropertyButtonLabel}
                                       - 'rtgl-view h=32 style="flex-shrink: 0;"': null
                                       - $if timelinePlayheadVisible:
                                           - 'rtgl-view pos=abs bgc=fg op="0.5" style="${timelinePlayheadStyle}"': null
                             $else:
                               - 'rtgl-view#timelineScrollContainer w=f h=1fg sh sv cur=${timelinePanCursor} style="min-width: 0; min-height: 0;"':
                                   - 'rtgl-view d=v g=md pos=rel style="${timelineCanvasStyle} min-height: 100%;"':
-                                      - 'rtgl-view w=f bgc=bg style="position: sticky; top: 0; z-index: 7;"':
-                                          - rvn-keyframe-timeline#transitionRuler ?showRuler=true ?showTracks=false ?interactiveRuler=true ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration}: null
-                                      - rtgl-view d=v w=f g=xs:
-                                          - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                              - rtgl-view w=72 av=c ah=s pl=sm:
-                                                  - rtgl-text s=sm c=mu-fg: ${outTimelineLabel}
-                                              - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                                          - rvn-keyframe-timeline#previousTimeline editable=true side=prev ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${previousProperties} :defaultValues=${transitionTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
-                                      - rtgl-view d=v w=f g=xs:
-                                          - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                              - rtgl-view w=72 av=c ah=s pl=sm:
-                                                  - rtgl-text s=sm c=mu-fg: ${inTimelineLabel}
-                                              - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                                          - rvn-keyframe-timeline#nextTimeline editable=true side=next ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${nextProperties} :defaultValues=${transitionTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
-                                      - rtgl-view d=v w=f g=xs:
-                                          - 'rtgl-view#maskTimelineCategory d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                              - rtgl-view w=72 av=c ah=s pl=sm:
-                                                  - rtgl-text s=sm c=mu-fg: ${maskTitle}
-                                              - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                                          - $for maskTimelineRow, i in maskTimelineRows:
-                                              - $if maskTimelineRow.editable:
-                                                  - rtgl-view#maskTrackRow${i} data-timeline-selection-surface=true w=f:
-                                                      - rvn-keyframe-timeline#maskKeyframeTimeline${i} editable=true side=${maskTimelineRow.side} ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} :properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
-                                                $else:
-                                                  - 'rtgl-view#unsupportedMaskTimelineRow${i} data-timeline-selection-surface=true data-mask-index=${maskTimelineRow.index} data-selected=${maskTimelineRow.selected} role=button tabindex=0 aria-label="${maskTimelineRow.label}" aria-pressed="${maskTimelineRow.selected}" d=h w=f h=24 av=c cur=pointer':
-                                                      - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
-                                                          - rtgl-view w=72 av=c ah=s pl=sm:
-                                                              - 'rtgl-view w=28 h=18 bw=xs bc=${maskTimelineRow.imageBorderColor} br=sm overflow=hidden title="${maskTimelineRow.image.name}"':
-                                                                  - $if maskTimelineRow.image.previewFileId:
-                                                                      - rvn-file-image w=f h=f fileId=${maskTimelineRow.image.previewFileId}: null
-                                                          - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                                                      - 'rtgl-view w=f h=24 bgc=mu br=sm style="min-width: 0;"': null
+                                      - $if !activeTimelineEmpty:
+                                          - 'rtgl-view pos=abs bgc=su style="${timelineUsedAreaStyle}"': null
+                                          - 'rtgl-view w=f bgc=bg style="position: sticky; top: 0; z-index: 7;"':
+                                              - rvn-keyframe-timeline#transitionRuler ?showRuler=true ?showTracks=false ?interactiveRuler=true ?indicatorVisible=${timelinePlayheadVisible} indicatorTimeMs=${previewPlayheadTimeMs} timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration}: null
+                                      - $if previousTimelineVisible:
+                                          - rtgl-view d=v w=f g=xs:
+                                              - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
+                                                  - rtgl-view w=72 av=c ah=s pl=sm:
+                                                      - rtgl-text s=sm c=mu-fg: ${outTimelineLabel}
+                                                  - rtgl-view h=24 w=24 mr=sm ml=sm: null
+                                              - rvn-keyframe-timeline#previousTimeline editable=true side=prev ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration} :properties=${previousProperties} :defaultValues=${transitionTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                      - $if nextTimelineVisible:
+                                          - rtgl-view d=v w=f g=xs:
+                                              - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
+                                                  - rtgl-view w=72 av=c ah=s pl=sm:
+                                                      - rtgl-text s=sm c=mu-fg: ${inTimelineLabel}
+                                                  - rtgl-view h=24 w=24 mr=sm ml=sm: null
+                                              - rvn-keyframe-timeline#nextTimeline editable=true side=next ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration} :properties=${nextProperties} :defaultValues=${transitionTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                      - $if maskTimelineVisible:
+                                          - rtgl-view d=v w=f g=xs:
+                                              - 'rtgl-view#maskTimelineCategory d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
+                                                  - rtgl-view w=72 av=c ah=s pl=sm:
+                                                      - rtgl-text s=sm c=mu-fg: ${maskTitle}
+                                                  - rtgl-view h=24 w=24 mr=sm ml=sm: null
+                                              - $for maskTimelineRow, i in maskTimelineRows:
+                                                  - $if maskTimelineRow.editable:
+                                                      - rtgl-view#maskTrackRow${i} data-timeline-selection-surface=true w=f:
+                                                          - rvn-keyframe-timeline#maskKeyframeTimeline${i} editable=true side=${maskTimelineRow.side} ?showRuler=false ?showTotalDuration=false timelineDuration=${timelineDisplayDuration} usedDuration=${activeTimelineDuration} :properties=${maskTimelineRow.properties} :defaultValues=${maskTimelineDefaultValues} :selectedKeyframe=${selectedKeyframe} :selectedProperty=${selectedProperty}: null
+                                                    $else:
+                                                      - 'rtgl-view#unsupportedMaskTimelineRow${i} data-timeline-selection-surface=true data-mask-index=${maskTimelineRow.index} data-selected=${maskTimelineRow.selected} role=button tabindex=0 aria-label="${maskTimelineRow.label}" aria-pressed="${maskTimelineRow.selected}" d=h w=f h=24 av=c cur=pointer':
+                                                          - 'rtgl-view d=h h=24 w=104 bgc=bg bwr=xs bc=bo av=c style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
+                                                              - rtgl-view w=72 av=c ah=s pl=sm:
+                                                                  - 'rtgl-view w=28 h=18 bw=xs bc=${maskTimelineRow.imageBorderColor} br=sm overflow=hidden title="${maskTimelineRow.image.name}"':
+                                                                      - $if maskTimelineRow.image.previewFileId:
+                                                                          - rvn-file-image w=f h=f fileId=${maskTimelineRow.image.previewFileId}: null
+                                                              - rtgl-view h=24 w=24 mr=sm ml=sm: null
+                                                          - 'rtgl-view w=f h=24 bgc=mu br=sm style="min-width: 0;"': null
+                                      - $if activeTimelineEmpty:
+                                          - rtgl-view w=f ph=md pt=md:
+                                              - 'rtgl-view#emptyTimelineAddPropertiesButton role=button tabindex=0 aria-label="${addPropertyButtonLabel}" title="${addPropertyButtonLabel}" w=f h=200 av=c ah=c g=md bw=xs bc=bo br=md cur=pointer':
+                                                  - rtgl-svg svg=plus wh=24: null
+                                                  - rtgl-text: ${addPropertyButtonLabel}
                                       - 'rtgl-view h=32 style="flex-shrink: 0;"': null
                                       - $if timelinePlayheadVisible:
                                           - 'rtgl-view pos=abs bgc=fg op="0.5" style="${timelinePlayheadStyle}"': null
@@ -569,18 +620,28 @@ template:
                   - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                       - $if selectedKeyframeDetailId:
                           - rvn-detail-view#selectedKeyframeDetails key=${selectedKeyframeDetailId} w=f :fields=${selectedKeyframeDetailFields} :fillHeight=${false}:
-                              - 'rtgl-popover-input#selectedKeyframeDelay slot=keyframe-delay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
-                              - 'rtgl-popover-input#selectedKeyframeDuration slot=keyframe-duration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
+                              - rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                                  - 'rtgl-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
+                              - rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                                  - 'rtgl-popover-input#selectedKeyframeDuration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
                               - rtgl-select#selectedKeyframeEasingSelect slot=keyframe-easing w=f no-clear :selectedValue=${selectedKeyframeEditor.easing} :options=${selectedKeyframeEditor.easingOptions}: null
                               - $if selectedKeyframeEditor.valueSlider:
                                   - rtgl-slider-input#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f value=${selectedKeyframeEditor.value} min=${selectedKeyframeEditor.valueSlider.min} max=${selectedKeyframeEditor.valueSlider.max} step=${selectedKeyframeEditor.valueSlider.step}: null
                                 $elif selectedKeyframeEditor.valueUsesPopover:
-                                  - 'rtgl-popover-input#selectedKeyframeValuePopover slot=keyframe-value value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
+                                  - rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                                      - 'rtgl-popover-input#selectedKeyframeValuePopover value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
                                 $else:
                                   - rtgl-input-number#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f step=${selectedKeyframeEditor.valueStep} value=${selectedKeyframeEditor.value}: null
                               - rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type w=f no-clear :selectedValue=${selectedKeyframeEditor.relative} :options=${selectedKeyframeEditor.relativeOptions}: null
                         $elif selectedPropertyDetailId:
-                          - rvn-detail-view#selectedPropertyDetails key=${selectedPropertyDetailId} w=f :fields=${selectedPropertyDetailFields} :fillHeight=${false}: null
+                          - rvn-detail-view#selectedPropertyDetails key=${selectedPropertyDetailId} w=f :fields=${selectedPropertyDetailFields} :fillHeight=${false}:
+                              - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
+                                  - rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
+                                $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
+                                  - rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;":
+                                      - 'rtgl-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
+                                $elif selectedPropertyEditor:
+                                  - rtgl-input-number#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null
                         $elif selectedMask:
                           - rtgl-view#selectedMaskDetails data-timeline-selection-surface=true d=v w=f g=md p=md pb=xl:
                               - $if maskEditorPanel.unsupported:
@@ -703,6 +764,15 @@ template:
               - rtgl-view d=h g=sm w=f ah=e:
                   - rtgl-button#maskRemoveCancelButton s=sm v=se: ${cancelButton}
                   - rtgl-button#maskRemoveConfirmButton s=sm v=pr: ${removeButton}
+  - rtgl-dialog#propertyRemoveConfirmDialog ?open=${propertyRemoveConfirmDialogOpen} s=sm:
+      - $if propertyRemoveConfirmDialogOpen:
+          - rtgl-view slot=content d=v w=f g=lg p=lg:
+              - rtgl-view d=v w=f g=md:
+                  - rtgl-text s=lg: ${propertyRemoveConfirmTitle}
+                  - rtgl-text c=mu-fg: ${propertyRemoveConfirmMessage}
+              - rtgl-view d=h g=sm w=f ah=e:
+                  - rtgl-button#propertyRemoveCancelButton s=sm v=se: ${cancelButton}
+                  - rtgl-button#propertyRemoveConfirmButton s=sm v=pr: ${deletePropertyButtonLabel}
   - rtgl-dialog#previewDialog ?open=${isPreviewDialogOpen} s=md:
       - $if isPreviewDialogOpen:
           - 'rtgl-view slot=content d=v w=f g=md style="max-width: calc(100vw - 32px); max-height: calc(100vh - 96px);"':

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -620,16 +620,16 @@ template:
                   - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                       - $if selectedKeyframeDetailId:
                           - rvn-detail-view#selectedKeyframeDetails key=${selectedKeyframeDetailId} w=f :fields=${selectedKeyframeDetailFields} :fillHeight=${false}:
-                              - 'rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
-                                  - 'rtgl-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
-                              - 'rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
-                                  - 'rtgl-popover-input#selectedKeyframeDuration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
+                              - 'rtgl-view data-popover-input-field=true slot=keyframe-delay w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                  - 'rvn-value-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay} label="${selectedKeyframeEditor.delayLabel}"': null
+                              - 'rtgl-view data-popover-input-field=true slot=keyframe-duration w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                  - 'rvn-value-popover-input#selectedKeyframeDuration value=${selectedKeyframeEditor.duration} label="${selectedKeyframeEditor.durationLabel}"': null
                               - rtgl-select#selectedKeyframeEasingSelect slot=keyframe-easing w=f no-clear :selectedValue=${selectedKeyframeEditor.easing} :options=${selectedKeyframeEditor.easingOptions}: null
                               - $if selectedKeyframeEditor.valueSlider:
                                   - rtgl-slider-input#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f value=${selectedKeyframeEditor.value} min=${selectedKeyframeEditor.valueSlider.min} max=${selectedKeyframeEditor.valueSlider.max} step=${selectedKeyframeEditor.valueSlider.step}: null
                                 $elif selectedKeyframeEditor.valueUsesPopover:
-                                  - 'rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
-                                      - 'rtgl-popover-input#selectedKeyframeValuePopover value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
+                                  - 'rtgl-view data-popover-input-field=true slot=keyframe-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                      - 'rvn-value-popover-input#selectedKeyframeValuePopover value=${selectedKeyframeEditor.value} label="${selectedKeyframeEditor.valueLabel}"': null
                                 $else:
                                   - rtgl-input-number#selectedKeyframeValue slot=keyframe-value key=${selectedKeyframeDetailId} w=f step=${selectedKeyframeEditor.valueStep} value=${selectedKeyframeEditor.value}: null
                               - rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type w=f no-clear :selectedValue=${selectedKeyframeEditor.relative} :options=${selectedKeyframeEditor.relativeOptions}: null
@@ -638,8 +638,8 @@ template:
                               - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
                                   - rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
                                 $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
-                                  - 'rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=36 d=h av=c ph=lg bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
-                                      - 'rtgl-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
+                                  - 'rtgl-view data-popover-input-field=true slot=property-initial-value w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                      - 'rvn-value-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
                                 $elif selectedPropertyEditor:
                                   - rtgl-input-number#selectedPropertyInitialValue slot=property-initial-value key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null
                         $elif selectedMask:

--- a/tests/animationEditor/animationEditor.handlers.test.js
+++ b/tests/animationEditor/animationEditor.handlers.test.js
@@ -14,6 +14,7 @@ import {
   handleEditorSurfaceClick,
   handleEditorTabClick,
   handleEditorTabKeyDown,
+  handleEmptyTimelineAddPropertiesKeyDown,
   handleKeyframeClick,
   handleKeyframeSelect,
   handleKeyframeDurationChange,
@@ -23,6 +24,8 @@ import {
   handleMaskTimelineRowKeyDown,
   handleMaskRemoveRequestClick,
   handleOpenAddMaskClick,
+  handlePropertyRemoveConfirmClick,
+  handlePropertyRemoveConfirmDialogClose,
   handlePropertyNameClick,
   handlePreviewImageClick,
   handleReplayAnimation,
@@ -34,6 +37,7 @@ import {
   handleSelectedKeyframeEditClick,
   handleSelectedKeyframeRelativeChange,
   handleSelectedKeyframeValueChange,
+  handleSelectedPropertyInitialValueChange,
   handleSelectedMaskNumberConfirmClick,
   handleSelectedMaskNumberFieldKeyDown,
   handleSelectedMaskNumberInputChange,
@@ -53,6 +57,9 @@ import {
   handleTimelinePanPointerEnter,
   handleTimelinePanStart,
   handleTimelineScroll,
+  handleTimelineDurationExtend,
+  handleTimelineUsedDurationPreview,
+  handleTimelineViewportResize,
   handleTogglePreviewLoop,
 } from "../../src/pages/animationEditor/animationEditor.handlers.js";
 import { EN_I18N } from "../support/i18n.js";
@@ -102,8 +109,8 @@ describe("animationEditor.handlers", () => {
         uiConfig: { mode: "desktop" },
       });
       expect(unregisterBeforeNavigation).toHaveBeenCalledOnce();
-      expect(browserEventsClient.subscribeWindowEvent).toHaveBeenCalledTimes(3);
-      expect(cleanupWindowEvent).toHaveBeenCalledTimes(3);
+      expect(browserEventsClient.subscribeWindowEvent).toHaveBeenCalledTimes(4);
+      expect(cleanupWindowEvent).toHaveBeenCalledTimes(4);
       expect(store.setPreviewPlaybackRequestId).toHaveBeenCalledWith({
         requestId: undefined,
       });
@@ -200,6 +207,7 @@ describe("animationEditor.handlers", () => {
         .fn()
         .mockReturnValueOnce(true)
         .mockReturnValueOnce(false),
+      selectTimelineViewportWidth: vi.fn(() => 280),
       setTimelineScrollMetrics: vi.fn(),
     };
     const render = vi.fn();
@@ -214,6 +222,70 @@ describe("animationEditor.handlers", () => {
       viewportWidth: 300,
     });
     expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("measures the timeline viewport and extends its display duration", () => {
+    const store = {
+      extendTimelineDisplayDuration: vi.fn(),
+      selectTimelineViewportWidth: vi.fn(() => 600),
+      setTimelineScrollMetrics: vi.fn(),
+    };
+    const render = vi.fn();
+    const timelineScrollContainer = {
+      clientWidth: 704,
+      scrollLeft: 25,
+    };
+
+    handleTimelineViewportResize({
+      refs: { timelineScrollContainer },
+      render,
+      store,
+    });
+    handleTimelineDurationExtend(
+      { render, store },
+      { _event: { detail: { duration: 4000 } } },
+    );
+
+    expect(store.setTimelineScrollMetrics).toHaveBeenCalledWith({
+      scrollLeft: 25,
+      viewportWidth: 704,
+    });
+    expect(store.extendTimelineDisplayDuration).toHaveBeenCalledWith({
+      duration: 4000,
+    });
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks and clears the live used-duration preview", () => {
+    const store = {
+      clearTimelineUsedDurationPreview: vi.fn(),
+      setTimelineUsedDurationPreview: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleTimelineUsedDurationPreview(
+      { render, store },
+      {
+        _event: {
+          detail: { active: true, duration: 2400, side: "update" },
+        },
+      },
+    );
+    handleTimelineUsedDurationPreview(
+      { render, store },
+      {
+        _event: {
+          detail: { active: false, duration: undefined, side: "update" },
+        },
+      },
+    );
+
+    expect(store.setTimelineUsedDurationPreview).toHaveBeenCalledWith({
+      duration: 2400,
+      side: "update",
+    });
+    expect(store.clearTimelineUsedDurationPreview).toHaveBeenCalledWith({});
+    expect(render).toHaveBeenCalledTimes(2);
   });
 
   it("pans the timeline horizontally while Space is held", () => {
@@ -423,13 +495,32 @@ describe("animationEditor.handlers", () => {
     expect(store.setPopover).not.toHaveBeenCalled();
   });
 
-  it("deletes the selected property from the detail header", () => {
+  it("opens confirmation before deleting an outgoing property", () => {
     const selectedProperty = { side: "prev", property: "alpha" };
+    const store = {
+      closePopover: vi.fn(),
+      deleteProperty: vi.fn(),
+      openPropertyRemoveConfirmDialog: vi.fn(),
+      selectSelectedProperty: vi.fn(() => selectedProperty),
+    };
+    const render = vi.fn();
+
+    handleSelectedPropertyDeleteClick({ store, render });
+
+    expect(store.openPropertyRemoveConfirmDialog).toHaveBeenCalledWith({});
+    expect(store.closePopover).toHaveBeenCalledOnce();
+    expect(store.deleteProperty).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("deletes an update property without confirmation", () => {
+    const selectedProperty = { side: "update", property: "alpha" };
     const store = {
       ...createIdleAutosaveMocks(),
       bumpPreviewRenderVersion: vi.fn(),
       closePopover: vi.fn(),
       deleteProperty: vi.fn(),
+      openPropertyRemoveConfirmDialog: vi.fn(),
       queueAutosave: vi.fn(),
       selectPreviewPlaybackFrameId: vi.fn(() => undefined),
       selectSelectedProperty: vi.fn(() => selectedProperty),
@@ -440,9 +531,48 @@ describe("animationEditor.handlers", () => {
     handleSelectedPropertyDeleteClick({ store, render });
 
     expect(store.deleteProperty).toHaveBeenCalledWith(selectedProperty);
+    expect(store.openPropertyRemoveConfirmDialog).not.toHaveBeenCalled();
+    expect(store.bumpPreviewRenderVersion).toHaveBeenCalledOnce();
+    expect(store.queueAutosave).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("deletes the selected transition property after confirmation", () => {
+    const selectedProperty = { side: "next", property: "x" };
+    const store = {
+      ...createIdleAutosaveMocks(),
+      bumpPreviewRenderVersion: vi.fn(),
+      closePopover: vi.fn(),
+      closePropertyRemoveConfirmDialog: vi.fn(),
+      deleteProperty: vi.fn(),
+      queueAutosave: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      selectSelectedProperty: vi.fn(() => selectedProperty),
+      stopPreviewPlayback: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handlePropertyRemoveConfirmClick({ store, render });
+
+    expect(store.closePropertyRemoveConfirmDialog).toHaveBeenCalledWith({});
+    expect(store.deleteProperty).toHaveBeenCalledWith(selectedProperty);
     expect(store.closePopover).toHaveBeenCalledOnce();
     expect(store.bumpPreviewRenderVersion).toHaveBeenCalledOnce();
     expect(store.queueAutosave).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("closes property deletion confirmation without deleting", () => {
+    const store = {
+      closePropertyRemoveConfirmDialog: vi.fn(),
+      deleteProperty: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handlePropertyRemoveConfirmDialogClose({ store, render });
+
+    expect(store.closePropertyRemoveConfirmDialog).toHaveBeenCalledWith({});
+    expect(store.deleteProperty).not.toHaveBeenCalled();
     expect(render).toHaveBeenCalledOnce();
   });
 
@@ -845,6 +975,36 @@ describe("animationEditor.handlers", () => {
     expect(render).toHaveBeenCalledTimes(5);
   });
 
+  it("commits the selected property's initial value from the right panel", () => {
+    const store = {
+      bumpPreviewRenderVersion: vi.fn(),
+      queueAutosave: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      selectSelectedProperty: vi.fn(() => ({
+        side: "update",
+        property: "x",
+      })),
+      stopPreviewPlayback: vi.fn(),
+      updateInitialValue: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleSelectedPropertyInitialValueChange(
+      { render, store },
+      { _event: { detail: { value: -25.5 } } },
+    );
+
+    expect(store.updateInitialValue).toHaveBeenCalledWith({
+      side: "update",
+      property: "x",
+      initialValue: -25.5,
+    });
+    expect(store.bumpPreviewRenderVersion).toHaveBeenCalledWith({});
+    expect(store.queueAutosave).toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
   it.each([
     ["add-left", 2],
     ["add-right", 3],
@@ -903,6 +1063,45 @@ describe("animationEditor.handlers", () => {
       expect(render).toHaveBeenCalled();
     },
   );
+
+  it("opens confirmation for a transition property context-menu deletion", () => {
+    const store = {
+      closePopover: vi.fn(),
+      deleteProperty: vi.fn(),
+      openPropertyRemoveConfirmDialog: vi.fn(),
+      selectPopover: vi.fn(() => ({
+        x: 120,
+        y: 160,
+        payload: {
+          side: "next",
+          property: "x",
+          index: "2",
+        },
+      })),
+      setSelectedProperty: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleKeyframeDropdownItemClick(
+      { store, render },
+      {
+        _event: {
+          detail: {
+            item: { value: "delete-property" },
+          },
+        },
+      },
+    );
+
+    expect(store.setSelectedProperty).toHaveBeenCalledWith({
+      side: "next",
+      property: "x",
+    });
+    expect(store.openPropertyRemoveConfirmDialog).toHaveBeenCalledWith({});
+    expect(store.closePopover).toHaveBeenCalledOnce();
+    expect(store.deleteProperty).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
 
   it("opens the number popover for selected mask softness", () => {
     const store = {
@@ -1252,6 +1451,72 @@ describe("animationEditor.handlers", () => {
       payload: {},
     });
     expect(render).toHaveBeenCalled();
+  });
+
+  it("opens Add Property from the empty update timeline", () => {
+    const store = {
+      selectDialogType: vi.fn(() => "update"),
+      setPopover: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAddPropertiesClick(
+      { store, render },
+      {
+        _event: {
+          clientX: 320,
+          clientY: 240,
+          currentTarget: {
+            dataset: { side: "update" },
+          },
+        },
+      },
+    );
+
+    expect(store.setPopover).toHaveBeenCalledWith({
+      mode: "addProperty",
+      x: 320,
+      y: 240,
+      payload: { side: "update" },
+    });
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("opens the transition Add menu from the empty timeline keyboard action", () => {
+    const store = {
+      selectDialogType: vi.fn(() => "transition"),
+      setPopover: vi.fn(),
+    };
+    const render = vi.fn();
+    const preventDefault = vi.fn();
+
+    handleEmptyTimelineAddPropertiesKeyDown(
+      { store, render },
+      {
+        _event: {
+          currentTarget: {
+            dataset: {},
+            getBoundingClientRect: () => ({
+              left: 100,
+              top: 200,
+              width: 400,
+              height: 200,
+            }),
+          },
+          key: "Enter",
+          preventDefault,
+        },
+      },
+    );
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(store.setPopover).toHaveBeenCalledWith({
+      mode: "addPropertySideMenu",
+      x: 300,
+      y: 300,
+      payload: {},
+    });
+    expect(render).toHaveBeenCalledOnce();
   });
 
   it("opens Add Mask from the transition Add menu", () => {

--- a/tests/animationEditor/animationEditor.handlers.test.js
+++ b/tests/animationEditor/animationEditor.handlers.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { Subject } from "rxjs";
 import {
   handleAddMaskClick,
   handleAddKeyframeFromTimeline,
@@ -38,6 +39,7 @@ import {
   handleSelectedKeyframeRelativeChange,
   handleSelectedKeyframeValueChange,
   handleSelectedPropertyInitialValueChange,
+  handleSelectedPropertyUseDefaultClick,
   handleSelectedMaskNumberConfirmClick,
   handleSelectedMaskNumberFieldKeyDown,
   handleSelectedMaskNumberInputChange,
@@ -79,6 +81,7 @@ describe("animationEditor.handlers", () => {
     const browserEventsClient = {
       subscribeWindowEvent: vi.fn(() => cleanupWindowEvent),
     };
+    const subject = new Subject();
     const store = {
       ...createIdleAutosaveMocks(),
       selectPreviewPlaybackFrameId: vi.fn(() => 42),
@@ -99,6 +102,7 @@ describe("animationEditor.handlers", () => {
         },
         browserEventsClient,
         store,
+        subject,
         uiConfig: { mode: "desktop" },
       });
 
@@ -118,6 +122,54 @@ describe("animationEditor.handlers", () => {
       expect(store.stopPreviewPlayback).toHaveBeenCalledWith({});
     } finally {
       vi.unstubAllGlobals();
+    }
+  });
+
+  it("remeasures the timeline after a resizable panel changes width", async () => {
+    vi.useFakeTimers();
+    const subject = new Subject();
+    const store = {
+      ...createIdleAutosaveMocks(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      selectTimelineViewportWidth: vi.fn(() => 600),
+      setPreviewPlaybackRequestId: vi.fn(),
+      setTimelineScrollMetrics: vi.fn(),
+      setUiConfig: vi.fn(),
+      stopPreviewPlayback: vi.fn(),
+    };
+    const render = vi.fn();
+    const timelineScrollContainer = {
+      clientWidth: 704,
+      scrollLeft: 25,
+    };
+
+    try {
+      const cleanup = handleBeforeMount({
+        appService: {
+          registerBeforeNavigation: vi.fn(() => vi.fn()),
+        },
+        browserEventsClient: {
+          subscribeWindowEvent: vi.fn(() => vi.fn()),
+        },
+        refs: { timelineScrollContainer },
+        render,
+        store,
+        subject,
+        uiConfig: { mode: "desktop" },
+      });
+
+      subject.next({ action: "panel-resize", payload: { width: 360 } });
+      await vi.runAllTimersAsync();
+
+      expect(store.setTimelineScrollMetrics).toHaveBeenCalledWith({
+        scrollLeft: 25,
+        viewportWidth: 704,
+      });
+      expect(render).toHaveBeenCalledOnce();
+
+      await cleanup();
+    } finally {
+      vi.useRealTimers();
     }
   });
 
@@ -1002,6 +1054,67 @@ describe("animationEditor.handlers", () => {
     });
     expect(store.bumpPreviewRenderVersion).toHaveBeenCalledWith({});
     expect(store.queueAutosave).toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("restores the selected property's default initial value", () => {
+    const store = {
+      bumpPreviewRenderVersion: vi.fn(),
+      queueAutosave: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      selectSelectedProperty: vi.fn(() => ({
+        side: "prev",
+        property: "alpha",
+      })),
+      stopPreviewPlayback: vi.fn(),
+      updateInitialValue: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleSelectedPropertyUseDefaultClick({ render, store });
+
+    expect(store.updateInitialValue).toHaveBeenCalledWith({
+      side: "prev",
+      property: "alpha",
+      initialValue: undefined,
+    });
+    expect(store.bumpPreviewRenderVersion).toHaveBeenCalledWith({});
+    expect(store.queueAutosave).toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("opens the initial-value editor from the touch property menu", () => {
+    const store = {
+      selectPopover: vi.fn(() => ({
+        x: 120,
+        y: 160,
+        payload: {
+          side: "next",
+          property: "x",
+        },
+      })),
+      setPopover: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleKeyframeDropdownItemClick(
+      { render, store },
+      {
+        _event: {
+          detail: {
+            item: { value: "edit-initial-value" },
+          },
+        },
+      },
+    );
+
+    expect(store.setPopover).toHaveBeenCalledWith({
+      mode: "editInitialValue",
+      x: 120,
+      y: 160,
+      payload: { side: "next", property: "x" },
+    });
     expect(render).toHaveBeenCalledOnce();
   });
 

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -284,9 +284,9 @@ describe("animationEditor.store", () => {
     });
 
     clearTimelineUsedDurationPreview({ state });
-    expect(selectViewData({ state, i18n: EN_I18N }).activeTimelineDuration).toBe(
-      1000,
-    );
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).activeTimelineDuration,
+    ).toBe(1000);
   });
 
   it("hides the playhead while it is behind the sticky property column", () => {
@@ -528,11 +528,20 @@ describe("animationEditor.store", () => {
       },
     ]);
     expect(viewData.selectedPropertyEditor).toEqual({
+      hasInitialValue: true,
       initialValue: 0.5,
       initialValueLabel: "Initial value",
       initialValueSlider: { min: 0, max: 1, step: 0.01 },
       initialValueStep: "any",
       initialValueUsesPopover: false,
+    });
+    expect(viewData.useDefaultValueButtonLabel).toBe("Use Default Value");
+
+    delete state.tweenBySection.prev.alpha.initialValue;
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.selectedPropertyEditor).toMatchObject({
+      hasInitialValue: false,
+      initialValue: 1,
     });
 
     setSelectedKeyframe(
@@ -744,6 +753,39 @@ describe("animationEditor.store", () => {
       { label: "Outgoing", type: "item", value: "prev" },
       { label: "Incoming", type: "item", value: "next" },
     ]);
+  });
+
+  it("offers initial-value editing from a touch keyframed-property menu", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    setUiConfig({ state }, { uiConfig: { id: "touch", inputMode: "touch" } });
+    state.tweenBySection.update.x = {
+      keyframes: [{ duration: 1000, easing: "linear", value: 0 }],
+    };
+    setPopover(
+      { state },
+      {
+        mode: "propertyNameMenu",
+        payload: { side: "update", property: "x" },
+      },
+    );
+
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).keyframeDropdownItems,
+    ).toContainEqual({
+      label: "Edit Initial Value",
+      type: "item",
+      value: "edit-initial-value",
+    });
+
+    state.tweenBySection.update.x = {
+      auto: { duration: 1000, easing: "linear" },
+    };
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).keyframeDropdownItems,
+    ).not.toContainEqual(
+      expect.objectContaining({ value: "edit-initial-value" }),
+    );
   });
 
   it("exposes an existing mask for inline editing without a dialog", () => {

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -11,15 +11,19 @@ import {
   commitPendingTransitionMask,
   createInitialState,
   clearSelectedKeyframe,
+  clearTimelineUsedDurationPreview,
   clearTimelineSelection,
+  closePropertyRemoveConfirmDialog,
   deleteKeyframe,
   deleteProperty,
   disableTransitionMask,
   enableTransitionMask,
+  extendTimelineDisplayDuration,
   moveKeyframeLeft,
   moveKeyframeRight,
   nudgeTimelineZoom,
   openDialog,
+  openPropertyRemoveConfirmDialog,
   selectAnimationRenderStateWithAnimations,
   selectAnimationResetState,
   selectPreviewDurationMs,
@@ -53,6 +57,7 @@ import {
   stopTimelinePan,
   setTimelinePanMode,
   setTimelineScrollMetrics,
+  setTimelineUsedDurationPreview,
   setTimelineZoom,
   setTransitionMaskChannel,
   setTransitionMaskImage,
@@ -87,6 +92,58 @@ describe("animationEditor.store", () => {
 
     openDialog({ state }, { dialogType: "update" });
     expect(selectSelectedEditorTab({ state })).toBe("tween");
+  });
+
+  it("hides empty transition property categories", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "transition" });
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      activeTimelineEmpty: true,
+      previousTimelineVisible: false,
+      nextTimelineVisible: false,
+      maskTimelineVisible: false,
+    });
+
+    state.tweenBySection.prev.alpha = { keyframes: [] };
+    state.tweenBySection.next.x = { keyframes: [] };
+    enableTransitionMask({ state });
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      activeTimelineEmpty: false,
+      previousTimelineVisible: true,
+      nextTimelineVisible: true,
+      maskTimelineVisible: true,
+    });
+  });
+
+  it("shows the empty timeline action until an update property is added", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+
+    expect(selectViewData({ state, i18n: EN_I18N }).activeTimelineEmpty).toBe(
+      true,
+    );
+
+    state.tweenBySection.update.alpha = { keyframes: [] };
+
+    expect(selectViewData({ state, i18n: EN_I18N }).activeTimelineEmpty).toBe(
+      false,
+    );
+  });
+
+  it("exposes property removal confirmation state", () => {
+    const state = createInitialState();
+
+    openPropertyRemoveConfirmDialog({ state });
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).propertyRemoveConfirmDialogOpen,
+    ).toBe(true);
+
+    closePropertyRemoveConfirmDialog({ state });
+    expect(
+      selectViewData({ state, i18n: EN_I18N }).propertyRemoveConfirmDialogOpen,
+    ).toBe(false);
   });
 
   it("limits the preview canvas to half the viewport height", () => {
@@ -174,20 +231,61 @@ describe("animationEditor.store", () => {
     expect(viewData.timelinePlayheadStyle).toContain(
       "left: calc(104px + (100% - 104px) * 0.5)",
     );
+    expect(viewData.timelinePlayheadStyle).toContain("z-index: 8");
   });
 
-  it("positions the playhead against the minimum one-second timeline scale", () => {
+  it("fills the measured timeline viewport", () => {
     const state = createInitialState();
     state.tweenBySection.update.x = {
       keyframes: [{ duration: 500, value: 10 }],
     };
+    setTimelineScrollMetrics({ state }, { scrollLeft: 0, viewportWidth: 704 });
     setPreviewPlayhead({ state }, { timeMs: 500, visible: true });
 
     const viewData = selectViewData({ state, i18n: EN_I18N });
 
-    expect(viewData.timelineDisplayDuration).toBe(1000);
+    expect(viewData.timelineDisplayDuration).toBe(3000);
+    expect(viewData.activeTimelineDuration).toBe(500);
+    expect(viewData.timelineUsedAreaStyle).toContain(
+      "width: calc((100% - 104px) * 0.16666666666666666)",
+    );
     expect(viewData.timelinePlayheadStyle).toContain(
-      "left: calc(104px + (100% - 104px) * 0.5)",
+      "left: calc(104px + (100% - 104px) * 0.16666666666666666)",
+    );
+  });
+
+  it("expands and shrinks the used timeline area during interaction", () => {
+    const state = createInitialState();
+    state.tweenBySection.update.x = {
+      keyframes: [{ duration: 1000, value: 10 }],
+    };
+    setTimelineScrollMetrics({ state }, { scrollLeft: 0, viewportWidth: 704 });
+
+    setTimelineUsedDurationPreview(
+      { state },
+      { side: "update", duration: 2400 },
+    );
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      activeTimelineDuration: 2400,
+      timelineUsedAreaStyle: expect.stringContaining(
+        "width: calc((100% - 104px) * 0.8)",
+      ),
+    });
+
+    setTimelineUsedDurationPreview(
+      { state },
+      { side: "update", duration: 500 },
+    );
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      activeTimelineDuration: 500,
+      timelineUsedAreaStyle: expect.stringContaining(
+        "width: calc((100% - 104px) * 0.16666666666666666)",
+      ),
+    });
+
+    clearTimelineUsedDurationPreview({ state });
+    expect(selectViewData({ state, i18n: EN_I18N }).activeTimelineDuration).toBe(
+      1000,
     );
   });
 
@@ -229,7 +327,7 @@ describe("animationEditor.store", () => {
       timelineZoomMax: 4,
       timelineZoomStep: 0.125,
       timelinePixelsPerSecond: 525,
-      timelineCanvasStyle: "width: 1679px; min-width: 104px; flex-shrink: 0;",
+      timelineCanvasStyle: "width: 1679px; min-width: 100%; flex-shrink: 0;",
       timelineDisplayDuration: 3000,
       timelineZoomLabel: "Timeline zoom",
     });
@@ -249,8 +347,29 @@ describe("animationEditor.store", () => {
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
       timelineZoom: 1,
       timelinePixelsPerSecond: 200,
-      timelineCanvasStyle: "width: 504px; min-width: 104px; flex-shrink: 0;",
+      timelineCanvasStyle: "width: 504px; min-width: 100%; flex-shrink: 0;",
       timelineDisplayDuration: 2000,
+      activeTimelineDuration: 2000,
+    });
+  });
+
+  it("extends the ruler beyond the viewport-filled duration", () => {
+    const state = createInitialState();
+    state.tweenBySection.update.x = {
+      keyframes: [{ duration: 1000, value: 10 }],
+    };
+    setTimelineScrollMetrics({ state }, { scrollLeft: 0, viewportWidth: 704 });
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      timelineCanvasStyle: "width: 704px; min-width: 100%; flex-shrink: 0;",
+      timelineDisplayDuration: 3000,
+    });
+
+    extendTimelineDisplayDuration({ state }, { duration: 4000 });
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      timelineCanvasStyle: "width: 904px; min-width: 100%; flex-shrink: 0;",
+      timelineDisplayDuration: 4000,
     });
   });
 
@@ -402,8 +521,19 @@ describe("animationEditor.store", () => {
     expect(viewData.selectedPropertyDetailFields).toEqual([
       { type: "text", label: "Timeline", value: "Outgoing" },
       { type: "text", label: "Property", value: "Alpha" },
-      { type: "text", label: "Initial value", value: 0.5 },
+      {
+        type: "slot",
+        label: "Initial value",
+        slot: "property-initial-value",
+      },
     ]);
+    expect(viewData.selectedPropertyEditor).toEqual({
+      initialValue: 0.5,
+      initialValueLabel: "Initial value",
+      initialValueSlider: { min: 0, max: 1, step: 0.01 },
+      initialValueStep: "any",
+      initialValueUsesPopover: false,
+    });
 
     setSelectedKeyframe(
       { state },

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -108,22 +108,29 @@ describe("animationEditor view", () => {
       'rtgl-button#selectedPropertyDeleteButton sq v=gh pre=trash aria-label="${deletePropertyButtonLabel}" title="${deletePropertyButtonLabel}"',
     );
     expect(view).toContain("handler: handleSelectedPropertyDeleteClick");
+    expect(view).toContain("rtgl-dialog#propertyRemoveConfirmDialog");
+    expect(view).toContain("?open=${propertyRemoveConfirmDialogOpen}");
+    expect(view).toContain("handler: handlePropertyRemoveConfirmDialogClose");
+    expect(view).toContain("handler: handlePropertyRemoveConfirmClick");
     expect(view).toContain("rtgl-text s=sm c=mu-fg ta=c: ${noSelectionLabel}");
     expect(view).not.toContain("${selectTimelineItemPrompt}");
     expect(view).toContain("rtgl-button#editSelectedKeyframeButton");
     expect(view).toContain("rtgl-select#selectedKeyframeEasingSelect");
     expect(view).toContain("handler: handleSelectedKeyframeEasingChange");
     expect(view).toContain(
-      "rtgl-popover-input#selectedKeyframeDelay slot=keyframe-delay",
+      "data-popover-input-field=true slot=keyframe-delay",
     );
     expect(view).toContain(
-      "rtgl-popover-input#selectedKeyframeDuration slot=keyframe-duration",
+      "rtgl-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay}",
+    );
+    expect(view).toContain(
+      "data-popover-input-field=true slot=keyframe-duration",
     );
     expect(view).toContain(
       "rtgl-slider-input#selectedKeyframeValue slot=keyframe-value",
     );
     expect(view).toContain(
-      "rtgl-popover-input#selectedKeyframeValuePopover slot=keyframe-value",
+      "data-popover-input-field=true slot=keyframe-value",
     );
     expect(view).toContain(
       "rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type",
@@ -152,6 +159,17 @@ describe("animationEditor view", () => {
     expect(view).not.toContain("rtgl-view#animationMaskPanel");
     expect(view).toContain("rtgl-view#animationPreviewPanel");
     expect(view).toContain("rtgl-view#maskTimelineCategory");
+    expect(view).toContain("$if previousTimelineVisible");
+    expect(view).toContain("$if nextTimelineVisible");
+    expect(view).toContain("$if maskTimelineVisible");
+    expect(view).toContain("$if activeTimelineEmpty");
+    expect(view.match(/\$if !activeTimelineEmpty/g)).toHaveLength(2);
+    expect(view).toContain("rtgl-view#emptyTimelineAddPropertiesButton");
+    expect(view).toContain("w=f h=200 av=c ah=c g=md bw=xs bc=bo br=md");
+    expect(view).toContain("rtgl-svg svg=plus wh=24");
+    expect(view).toContain("rtgl-text: ${addPropertyButtonLabel}");
+    expect(view).toContain("handler: handleAddPropertiesClick");
+    expect(view).toContain("handler: handleEmptyTimelineAddPropertiesKeyDown");
     expect(view).toContain("rtgl-text s=sm c=mu-fg: ${maskTitle}");
     expect(view).toContain("rtgl-view w=72 av=c ah=s pl=sm");
     expect(view).not.toContain("rtgl-view w=72 av=c ah=c");
@@ -166,9 +184,6 @@ describe("animationEditor view", () => {
     const maskTimelineListeners = view.slice(
       view.indexOf("  maskKeyframeTimeline*:"),
       view.indexOf("  addPropertyPopover:"),
-    );
-    expect(maskTimelineListeners).toContain(
-      "handler: handleSelectedMaskInitialValueClick",
     );
     expect(maskTimelineListeners).not.toContain(
       "handler: handleInitialValueClick",
@@ -185,6 +200,16 @@ describe("animationEditor view", () => {
     expect(view).toContain("handler: handleSelectedMaskSoftnessClick");
     expect(view).toContain("rtgl-view#selectedMaskInitialValue");
     expect(view).toContain("handler: handleSelectedMaskInitialValueClick");
+    expect(view).toContain(
+      "rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value",
+    );
+    expect(view).toContain(
+      "data-popover-input-field=true slot=property-initial-value",
+    );
+    expect(view.match(/data-popover-input-field=true/g)).toHaveLength(4);
+    expect(view).toContain(
+      "handler: handleSelectedPropertyInitialValueChange",
+    );
     expect(view).not.toContain("rtgl-view#selectedMaskProgressDuration");
     expect(view).not.toContain(
       "handler: handleSelectedMaskProgressDurationClick",
@@ -278,6 +303,8 @@ describe("animationEditor view", () => {
     expect(view).toContain("handler: handleTimelinePanStart");
     expect(view).toContain("handler: handleTimelinePanMove");
     expect(view).toContain("handler: handleTimelinePanEnd");
+    expect(view).toContain("handler: handleTimelineDurationExtend");
+    expect(view).toContain("handler: handleTimelineUsedDurationPreview");
     expect(view).toContain("cur=${timelinePanCursor}");
     expect(view).not.toContain(
       'timelineScrollContainer w=f style="min-width: 0; overflow-x: auto',
@@ -291,8 +318,13 @@ describe("animationEditor view", () => {
       'rtgl-view w=f bgc=bg style="position: sticky; top: 0; z-index: 7;"',
     );
     expect(view).toContain("timelineDuration=${timelineDisplayDuration}");
+    expect(view).toContain("usedDuration=${activeTimelineDuration}");
+    expect(
+      view.match(
+        /rtgl-view pos=abs bgc=su style="\$\{timelineUsedAreaStyle\}"/g,
+      ),
+    ).toHaveLength(2);
     expect(view).not.toContain("timelineZoomPercent");
-    expect(view).not.toContain("min-width: 100%");
     expect(view).not.toContain("d=v h=f pos=rel");
     expect(view).toContain("$if timelinePlayheadVisible");
     expect(view).toContain('style="${timelinePlayheadStyle}"');

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -121,7 +121,7 @@ describe("animationEditor view", () => {
       "data-popover-input-field=true slot=keyframe-delay",
     );
     expect(view).toContain(
-      "rtgl-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay}",
+      "rvn-value-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay}",
     );
     expect(view).toContain(
       "data-popover-input-field=true slot=keyframe-duration",
@@ -207,6 +207,7 @@ describe("animationEditor view", () => {
       "data-popover-input-field=true slot=property-initial-value",
     );
     expect(view.match(/data-popover-input-field=true/g)).toHaveLength(4);
+    expect(view.match(/rvn-value-popover-input#/g)).toHaveLength(4);
     expect(view).toContain(
       "handler: handleSelectedPropertyInitialValueChange",
     );

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -324,6 +324,12 @@ describe("animationEditor view", () => {
         /rtgl-view pos=abs bgc=su style="\$\{timelineUsedAreaStyle\}"/g,
       ),
     ).toHaveLength(2);
+    expect(view.match(/data-timeline-property-column-fill=true/g)).toHaveLength(
+      2,
+    );
+    expect(view).toContain(
+      'rtgl-view h=f w=104 bgc=bg style="min-width: 104px; position: sticky; left: 0;"',
+    );
     expect(view).not.toContain("timelineZoomPercent");
     expect(view).not.toContain("d=v h=f pos=rel");
     expect(view).toContain("$if timelinePlayheadVisible");

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -117,9 +117,7 @@ describe("animationEditor view", () => {
     expect(view).toContain("rtgl-button#editSelectedKeyframeButton");
     expect(view).toContain("rtgl-select#selectedKeyframeEasingSelect");
     expect(view).toContain("handler: handleSelectedKeyframeEasingChange");
-    expect(view).toContain(
-      "data-popover-input-field=true slot=keyframe-delay",
-    );
+    expect(view).toContain("data-popover-input-field=true slot=keyframe-delay");
     expect(view).toContain(
       "rvn-value-popover-input#selectedKeyframeDelay value=${selectedKeyframeEditor.delay}",
     );
@@ -129,9 +127,7 @@ describe("animationEditor view", () => {
     expect(view).toContain(
       "rtgl-slider-input#selectedKeyframeValue slot=keyframe-value",
     );
-    expect(view).toContain(
-      "data-popover-input-field=true slot=keyframe-value",
-    );
+    expect(view).toContain("data-popover-input-field=true slot=keyframe-value");
     expect(view).toContain(
       "rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type",
     );
@@ -201,16 +197,19 @@ describe("animationEditor view", () => {
     expect(view).toContain("rtgl-view#selectedMaskInitialValue");
     expect(view).toContain("handler: handleSelectedMaskInitialValueClick");
     expect(view).toContain(
-      "rtgl-slider-input#selectedPropertyInitialValue slot=property-initial-value",
+      "rtgl-view slot=property-initial-value d=v w=f g=xs",
     );
     expect(view).toContain(
-      "data-popover-input-field=true slot=property-initial-value",
+      "rtgl-slider-input#selectedPropertyInitialValue key=${selectedPropertyDetailId}",
+    );
+    expect(view).toContain("data-popover-input-field=true w=f h=32");
+    expect(view).toContain(
+      "rtgl-button#selectedPropertyUseDefault s=sm v=se w=f",
     );
     expect(view.match(/data-popover-input-field=true/g)).toHaveLength(4);
     expect(view.match(/rvn-value-popover-input#/g)).toHaveLength(4);
-    expect(view).toContain(
-      "handler: handleSelectedPropertyInitialValueChange",
-    );
+    expect(view).toContain("handler: handleSelectedPropertyInitialValueChange");
+    expect(view).toContain("handler: handleSelectedPropertyUseDefaultClick");
     expect(view).not.toContain("rtgl-view#selectedMaskProgressDuration");
     expect(view).not.toContain(
       "handler: handleSelectedMaskProgressDurationClick",

--- a/tests/keyframeTimeline/keyframeTimeline.handlers.test.js
+++ b/tests/keyframeTimeline/keyframeTimeline.handlers.test.js
@@ -412,9 +412,14 @@ describe("keyframeTimeline.handlers", () => {
         durationResize = undefined;
       }),
       selectDurationResize: vi.fn(() => durationResize),
-      setDurationResizeTiming: vi.fn(({ delay, duration }) => {
+      selectPreviewUsedDuration: vi.fn(
+        () => durationResize.delay + durationResize.duration,
+      ),
+      setDurationResizeTiming: vi.fn(({ delay, duration, timelineDuration }) => {
         durationResize.delay = delay;
         durationResize.duration = duration;
+        durationResize.timelineDuration =
+          timelineDuration ?? durationResize.timelineDuration;
       }),
       startDurationResize: vi.fn((resize) => {
         durationResize = {
@@ -491,8 +496,11 @@ describe("keyframeTimeline.handlers", () => {
       duration: 1100,
     });
     expect(releasePointerCapture).toHaveBeenCalledWith(7);
-    expect(dispatchEvent).toHaveBeenCalledOnce();
-    expect(dispatchEvent.mock.calls[0][0]).toMatchObject({
+    expect(
+      dispatchEvent.mock.calls.find(
+        ([event]) => event.type === "keyframe-duration-change",
+      )[0],
+    ).toMatchObject({
       type: "keyframe-duration-change",
       detail: {
         delay: 0,
@@ -502,6 +510,18 @@ describe("keyframeTimeline.handlers", () => {
         index: 0,
       },
     });
+    expect(
+      dispatchEvent.mock.calls.find(
+        ([event]) => event.type === "timeline-duration-extend",
+      )[0],
+    ).toMatchObject({
+      detail: { duration: 2000 },
+    });
+    expect(
+      dispatchEvent.mock.calls.filter(
+        ([event]) => event.type === "timeline-used-duration-preview",
+      ),
+    ).toHaveLength(2);
     expect(store.clearDurationResize).toHaveBeenCalledWith({});
   });
 
@@ -539,9 +559,14 @@ describe("keyframeTimeline.handlers", () => {
         durationResize = undefined;
       }),
       selectDurationResize: vi.fn(() => durationResize),
-      setDurationResizeTiming: vi.fn(({ delay, duration }) => {
+      selectPreviewUsedDuration: vi.fn(
+        () => durationResize.delay + durationResize.duration,
+      ),
+      setDurationResizeTiming: vi.fn(({ delay, duration, timelineDuration }) => {
         durationResize.delay = delay;
         durationResize.duration = duration;
+        durationResize.timelineDuration =
+          timelineDuration ?? durationResize.timelineDuration;
       }),
       startDurationResize: vi.fn((resize) => {
         durationResize = {
@@ -632,7 +657,11 @@ describe("keyframeTimeline.handlers", () => {
       [{ delay: 900, duration: 100 }],
       [{ delay: 400, duration: 600 }],
     ]);
-    expect(dispatchEvent.mock.calls[0][0]).toMatchObject({
+    expect(
+      dispatchEvent.mock.calls.find(
+        ([event]) => event.type === "keyframe-duration-change",
+      )[0],
+    ).toMatchObject({
       type: "keyframe-duration-change",
       detail: {
         delay: 400,
@@ -660,6 +689,7 @@ describe("keyframeTimeline.handlers", () => {
       }),
       selectKeyframeClickSuppressed: vi.fn(() => keyframeClickSuppressed),
       selectKeyframeMove: vi.fn(() => keyframeMove),
+      selectPreviewUsedDuration: vi.fn(() => 1600),
       setKeyframeMoveTiming: vi.fn(({ delay, followingDelay }) => {
         keyframeMove.delay = delay;
         keyframeMove.followingDelay = followingDelay;
@@ -758,7 +788,11 @@ describe("keyframeTimeline.handlers", () => {
       [{ delay: 500, followingDelay: 0 }],
     ]);
     expect(releasePointerCapture).toHaveBeenCalledWith(11);
-    expect(dispatchEvent.mock.calls[1][0]).toMatchObject({
+    expect(
+      dispatchEvent.mock.calls.find(
+        ([event]) => event.type === "keyframe-duration-change",
+      )[0],
+    ).toMatchObject({
       type: "keyframe-duration-change",
       detail: {
         delay: 500,
@@ -782,7 +816,98 @@ describe("keyframeTimeline.handlers", () => {
       },
     });
 
-    expect(dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(dispatchEvent).toHaveBeenCalledTimes(5);
     expect(store.clearKeyframeClickSuppression).toHaveBeenCalledWith({});
+  });
+
+  it("extends the timeline when the last keyframe is dragged past its end", () => {
+    let keyframeMove;
+    const store = {
+      markKeyframeMoveDragged: vi.fn(() => {
+        keyframeMove.dragged = true;
+      }),
+      selectKeyframeMove: vi.fn(() => keyframeMove),
+      selectPreviewUsedDuration: vi.fn(
+        () =>
+          keyframeMove.propertyDuration +
+          keyframeMove.delay -
+          keyframeMove.startDelay,
+      ),
+      setKeyframeMoveTiming: vi.fn((timing) => {
+        keyframeMove.delay = timing.delay;
+        keyframeMove.followingDelay = timing.followingDelay;
+        keyframeMove.timelineDuration =
+          timing.timelineDuration ?? keyframeMove.timelineDuration;
+      }),
+      startKeyframeMove: vi.fn((move) => {
+        keyframeMove = {
+          ...move,
+          delay: move.startDelay,
+          dragged: false,
+          followingDelay: move.startFollowingDelay,
+          startTimelineDuration: move.timelineDuration,
+        };
+      }),
+    };
+    const dispatchEvent = vi.fn();
+    const render = vi.fn();
+    const trackElement = {
+      getBoundingClientRect: () => ({ width: 600 }),
+    };
+    const keyframeElement = {
+      closest: vi.fn(() => trackElement),
+      dataset: { property: "x", index: "0" },
+      setPointerCapture: vi.fn(),
+    };
+    const deps = {
+      dispatchEvent,
+      props: {
+        editable: true,
+        side: "update",
+        timelineDuration: 3000,
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000 }],
+          },
+        },
+      },
+      render,
+      store,
+    };
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    handleKeyframeMoveStart(deps, {
+      _event: {
+        button: 0,
+        clientX: 100,
+        currentTarget: keyframeElement,
+        pointerId: 12,
+        preventDefault,
+        stopPropagation,
+      },
+    });
+    handleKeyframeMove(deps, {
+      _event: {
+        clientX: 520,
+        pointerId: 12,
+        preventDefault,
+        stopPropagation,
+      },
+    });
+
+    expect(store.setKeyframeMoveTiming).toHaveBeenCalledWith({
+      delay: 2100,
+      followingDelay: undefined,
+      timelineDuration: 4000,
+    });
+    expect(dispatchEvent.mock.calls[1][0]).toMatchObject({
+      type: "timeline-duration-extend",
+      detail: { duration: 4000 },
+    });
+    expect(dispatchEvent.mock.calls[2][0]).toMatchObject({
+      type: "timeline-used-duration-preview",
+      detail: { active: true, duration: 3100, side: "update" },
+    });
   });
 });

--- a/tests/keyframeTimeline/keyframeTimeline.store.test.js
+++ b/tests/keyframeTimeline/keyframeTimeline.store.test.js
@@ -208,10 +208,58 @@ describe("keyframeTimeline easing curves", () => {
     expect(viewData.selectedProperties[0]).toMatchObject({
       backgroundColor: "bg",
       hoverBackgroundColor: "bg",
-      initialValueCursor: "default",
       rowCursor: "default",
       keyframes: [{ cursor: "default" }],
     });
+  });
+
+  it("highlights the used duration within a longer displayed timeline", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000, value: 100 }],
+          },
+        },
+        showRuler: true,
+        timelineDuration: 3000,
+        usedDuration: 1000,
+      },
+    });
+
+    expect(viewData.usedDurationVisible).toBe(true);
+    expect(viewData.usedDurationStyle).toContain("width: 33.33%");
+  });
+
+  it("previews used-duration expansion and shrink while resizing", () => {
+    const state = createInitialState();
+    state.durationResize = {
+      property: "x",
+      index: 0,
+      delay: 0,
+      duration: 1500,
+      timelineDuration: 3000,
+    };
+    const props = {
+      properties: {
+        x: {
+          keyframes: [{ duration: 1000, value: 100 }],
+        },
+      },
+      showRuler: true,
+      timelineDuration: 3000,
+      usedDuration: 1000,
+    };
+
+    expect(selectViewData({ state, props }).usedDurationStyle).toContain(
+      "width: 50.00%",
+    );
+
+    state.durationResize.duration = 500;
+    expect(selectViewData({ state, props }).usedDurationStyle).toContain(
+      "width: 16.67%",
+    );
   });
 
   it("renders decorative SVG paths without replacing keyframe click targets", () => {
@@ -221,6 +269,11 @@ describe("keyframeTimeline easing curves", () => {
     );
 
     expect(view).toContain("data-keyframe=true");
+    expect(view).toContain(
+      "p=xs bgc=${keyframe.backgroundColor} bw=xs br=md",
+    );
+    expect(view).toContain("data-keyframe-slot=true h=f pos=rel style=");
+    expect(view).not.toContain("data-keyframe-slot=true h=f pos=rel bgc=");
     expect(view).toContain("handler: handleRulerScrubStart");
     expect(view).toContain("handler: handleKeyframeMoveStart");
     expect(view).toContain("handler: handleKeyframeMove");
@@ -228,6 +281,18 @@ describe("keyframeTimeline easing curves", () => {
     expect(view).not.toContain("handler: handlePropertyNameRightClick");
     expect(view).not.toContain("property-name-right-click");
     expect(view).toContain("handler: handlePropertyNameKeyDown");
+    expect(view).not.toContain("handler: handleInitialValueClick");
+    expect(view).not.toContain("data-interactive=${property.initialValueInteractive}");
+    expect(
+      view.match(/rtgl-view pos=abs bgc=su style="\$\{usedDurationStyle\}"/g),
+    ).toHaveLength(1);
+    expect(view).toContain(
+      "data-keyframe-track=true data-property=${property.name} data-track-mode=${property.trackMode} d=h w=f h=24 bgc=mu",
+    );
+    expect(view).not.toContain(
+      "data-track-mode=${property.trackMode} d=h w=f h=24 bgc=mu br=sm g=xs",
+    );
+    expect(view).toContain('style="${usedDurationStyle}"');
     expect(view).toContain("$if property.thumbnail:");
     expect(view).toContain(
       "rtgl-view#propertyName${pIndex}.keyframeTimelinePropertyRow",
@@ -247,7 +312,7 @@ describe("keyframeTimeline easing curves", () => {
     );
     expect(view).toMatch(/w=104 bgc=bg bwr=xs bc=bo[^\n]+position: sticky/);
     expect(view).toContain("left: 0; z-index: 6");
-    expect(view).toMatch(/data-keyframe=true[^\n]+br=lg/);
+    expect(view).toMatch(/data-keyframe=true[^\n]+br=md/);
     expect(view).toMatch(/data-keyframe-slot=true[^\n]+flex-shrink: 0/);
     expect(view).toMatch(
       /data-keyframe=true[^\n]+top: 2px; bottom: 2px; left: \$\{keyframe.delayPercent\}%; right: 0/,
@@ -528,6 +593,29 @@ describe("keyframeTimeline easing curves", () => {
 
     expect(viewData.rulerIndicatorVisible).toBe(true);
     expect(viewData.playheadIndicatorTimeLabel).toBe("500 ms");
+    expect(viewData.playheadIndicatorLabelStyle).toContain("top: 4px");
+    expect(viewData.playheadIndicatorLabelStyle).toContain("z-index: 10");
+  });
+
+  it("keeps the exact endpoint unlabeled on the ruler", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        showRuler: true,
+        timelineDuration: 5200,
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000, value: 10 }],
+          },
+        },
+      },
+    });
+
+    expect(viewData.rulerTicks.at(-1)).toMatchObject({
+      id: "tick-5200",
+      label: undefined,
+    });
+    expect(viewData.rulerTicks.some((tick) => tick.label === "5s")).toBe(true);
   });
 });
 

--- a/tests/valuePopoverInput/valuePopoverInput.test.js
+++ b/tests/valuePopoverInput/valuePopoverInput.test.js
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleInputChange,
+  handleSubmitClick,
+  handleTriggerKeyDown,
+} from "../../src/components/valuePopoverInput/valuePopoverInput.handlers.js";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/components/valuePopoverInput/valuePopoverInput.store.js";
+
+describe("valuePopoverInput", () => {
+  it("renders a keyboard-accessible trigger and a padded popover form", () => {
+    const view = readFileSync(
+      "src/components/valuePopoverInput/valuePopoverInput.view.yaml",
+      "utf8",
+    );
+
+    expect(view).toContain("role=button tabindex=${triggerTabIndex}");
+    expect(view).toContain("content-ph=md content-pv=md");
+  });
+
+  it("opens from the keyboard and commits the entered value", () => {
+    vi.useFakeTimers();
+    const store = {
+      closePopover: vi.fn(),
+      openPopover: vi.fn(),
+      selectTempValue: vi.fn(() => "1250"),
+      setTempValue: vi.fn(),
+      setValue: vi.fn(),
+    };
+    const input = {
+      focus: vi.fn(),
+      shadowRoot: {
+        querySelector: vi.fn(() => ({ focus: vi.fn() })),
+      },
+    };
+    const dispatchEvent = vi.fn();
+    const render = vi.fn();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const deps = {
+      dispatchEvent,
+      props: { value: "1000" },
+      refs: { input },
+      render,
+      store,
+    };
+
+    handleTriggerKeyDown(deps, {
+      _event: {
+        currentTarget: {
+          getBoundingClientRect: () => ({ bottom: 80, left: 40 }),
+        },
+        key: "Enter",
+        preventDefault,
+        stopPropagation,
+      },
+    });
+    vi.runAllTimers();
+    handleInputChange(deps, { _event: { detail: { value: "1250" } } });
+    handleSubmitClick(deps);
+    vi.useRealTimers();
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(store.openPopover).toHaveBeenCalledWith({
+      position: { x: 40, y: 80 },
+    });
+    expect(input.focus).toHaveBeenCalledOnce();
+    expect(store.setTempValue).toHaveBeenCalledWith({ value: "1250" });
+    expect(dispatchEvent.mock.calls[0][0]).toMatchObject({
+      type: "value-change",
+      detail: { value: "1250" },
+    });
+  });
+
+  it("shows the current value and localized action", () => {
+    const state = createInitialState();
+    state.value = "500";
+
+    expect(
+      selectViewData({
+        i18n: { animationEditorPage: { doneButton: "Apply" } },
+        props: { label: "Duration" },
+        state,
+      }),
+    ).toMatchObject({
+      label: "Duration",
+      submitLabel: "Apply",
+      value: "500",
+      valueColor: "fg",
+    });
+  });
+});

--- a/vt/specs/project/animations.yaml
+++ b/vt/specs/project/animations.yaml
@@ -326,6 +326,36 @@ steps:
     state: visible
     timeoutMs: 5000
   - action: select
+    selector: "#previousTimeline #propertyName0[role='button']"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#selectedPropertyDetails"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    selector: "#selectedPropertyDeleteButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#propertyRemoveConfirmDialog[open]"
+    state: visible
+    timeoutMs: 5000
+  - action: screenshot
+  - action: select
+    selector: "#propertyRemoveConfirmButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#propertyRemoveConfirmDialog"
+    state: hidden
+    timeoutMs: 5000
+  - action: waitFor
+    selector: "#previousTimeline"
+    state: hidden
+    timeoutMs: 5000
+  - action: screenshot
+  - action: select
     selector: "#maskTrackRow0 #propertyName0[role='button']"
     steps:
       - action: focus
@@ -334,5 +364,58 @@ steps:
   - action: waitFor
     selector: "#selectedMaskDetails"
     state: attached
+    timeoutMs: 5000
+  - action: select
+    selector: "#selectedMaskDeleteButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#maskRemoveConfirmDialog[open]"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    selector: "#maskRemoveConfirmButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#maskTimelineCategory"
+    state: hidden
+    timeoutMs: 5000
+  - action: select
+    selector: "#nextTimeline #propertyName0[role='button']"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#selectedPropertyDetails"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    selector: "#selectedPropertyDeleteButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#propertyRemoveConfirmDialog[open]"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    selector: "#propertyRemoveConfirmButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#nextTimeline"
+    state: hidden
+    timeoutMs: 5000
+  - action: waitFor
+    selector: "#emptyTimelineAddPropertiesButton"
+    state: visible
+    timeoutMs: 5000
+  - action: screenshot
+  - action: select
+    selector: "#emptyTimelineAddPropertiesButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "rtgl-dropdown-menu#addPropertySideMenu"
+    state: visible
     timeoutMs: 5000
 ---


### PR DESCRIPTION
## Summary
- make animation keyframe and property values editable from the right detail panel with selectors, sliders, and visible popover fields
- support multiple transition masks while preserving mask timing, package imports, and preview textures
- add property deletion confirmations, empty timeline actions, responsive rulers, continuous used-duration highlighting, and live ruler extension
- improve timeline selection, playhead layering, ruler labels, and keyframe sizing

## Validation
- bunx vitest run tests/keyframeTimeline/keyframeTimeline.store.test.js tests/keyframeTimeline/keyframeTimeline.handlers.test.js tests/animationEditor/animationEditor.store.test.js tests/animationEditor/animationEditor.view.test.js tests/animationEditor/animationEditor.handlers.test.js
- bun run lint