### PR TITLE
Add language settings and contact section

### DIFF
--- a/docs/keyboard-navigation-shortcuts.md
+++ b/docs/keyboard-navigation-shortcuts.md
@@ -36,6 +36,7 @@ pressed within 1.5 seconds.
 | `g w s`  | Web Server       | `/project/releases/web-server` |
 | `g a b`  | About            | `/project/about`               |
 | `g a p`  | Appearance       | `/project/appearance`          |
+| `g s l`  | Language         | `/project/language`            |
 
 The sequence:
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -49,16 +49,7 @@
       "identifier": "opener:allow-open-url",
       "allow": [
         {
-          "url": "https://routevn.com/discord"
-        },
-        {
-          "url": "https://routevn.com/creator/*"
-        },
-        {
-          "url": "https://routevn.com/en/creator/download/"
-        },
-        {
-          "url": "https://routevn.com/en/creator/docs/*"
+          "url": "https://routevn.com/*"
         },
         {
           "url": "https://x.com/routevn"

--- a/src/components/mobileSidebar/mobileSidebar.store.js
+++ b/src/components/mobileSidebar/mobileSidebar.store.js
@@ -124,6 +124,12 @@ const settingsItems = [
     path: "/project/appearance",
     icon: "sun",
   },
+  {
+    id: "language",
+    label: "Language",
+    path: "/project/language",
+    icon: "website",
+  },
 ];
 
 const assetsSections = [

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -52,7 +52,7 @@ projectsPage:
   invalidProjectEntryImportAgain: "This project entry is invalid. Remove it from the list and import the project again."
   invalidProjectEntryRefresh: "This project entry is invalid. Refresh the projects page and try again."
   languageLabel: "Language"
-  languageMenuItem: "Language (Beta)"
+  languageMenuItem: "Language"
   languageTitle: "Language"
   lightThemeName: "Light"
   loadingMessage: "Loading..."
@@ -538,6 +538,7 @@ resourceTypes:
   videos: "Videos"
   about: "About"
   appearance: "Appearance"
+  language: "Language"
   versions: "Versions"
   webServer: "Web Server"
 colorsPage:
@@ -2166,6 +2167,9 @@ aboutPage:
   appVersionText: "RouteVN Creator {appVersion}"
   checkForUpdatesButton: "Check for Updates"
   communityTitle: "Community"
+  contactButton: "Contact Us"
+  contactDescription: "Have feedback, a comment, a bug report, or a feature request? Get in touch with us."
+  contactTitle: "Contact Us"
   title: "About"
   versionInformationTitle: "Version Information"
 settingsUserPage:
@@ -2177,3 +2181,7 @@ appearancePage:
   lightThemeName: "Light"
   themesTitle: "Themes"
   title: "Appearance"
+settingsLanguagePage:
+  description: "Choose the language used by RouteVN Creator."
+  failedChangeLanguage: "Could not change the language. Please try again."
+  title: "Language"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -52,7 +52,7 @@ projectsPage:
   invalidProjectEntryImportAgain: "このプロジェクト項目は無効です。一覧から削除して、もう一度プロジェクトを取り込んでください。"
   invalidProjectEntryRefresh: "このプロジェクト項目は無効です。プロジェクトページを更新して、もう一度お試しください。"
   languageLabel: "言語"
-  languageMenuItem: "言語（ベータ版）"
+  languageMenuItem: "言語"
   languageTitle: "言語"
   lightThemeName: "ライト"
   loadingMessage: "読み込み中..."
@@ -538,6 +538,7 @@ resourceTypes:
   videos: "動画"
   about: "情報"
   appearance: "外観"
+  language: "言語"
   versions: "バージョン"
   webServer: "Webサーバー"
 colorsPage:
@@ -2166,6 +2167,9 @@ aboutPage:
   appVersionText: "RouteVN Creator {appVersion}"
   checkForUpdatesButton: "アップデートを確認"
   communityTitle: "コミュニティ"
+  contactButton: "お問い合わせ"
+  contactDescription: "ご意見、ご感想、不具合の報告、機能のご要望がありましたら、お問い合わせください。"
+  contactTitle: "お問い合わせ"
   title: "情報"
   versionInformationTitle: "バージョン情報"
 settingsUserPage:
@@ -2177,3 +2181,7 @@ appearancePage:
   lightThemeName: "ライト"
   themesTitle: "テーマ"
   title: "外観"
+settingsLanguagePage:
+  description: "RouteVN Creatorで使用する言語を選択します。"
+  failedChangeLanguage: "言語を変更できませんでした。もう一度お試しください。"
+  title: "言語"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -52,7 +52,7 @@ projectsPage:
   invalidProjectEntryImportAgain: "该项目条目无效。请从列表中移除后重新导入项目。"
   invalidProjectEntryRefresh: "该项目条目无效。请刷新项目页面后重试。"
   languageLabel: "语言"
-  languageMenuItem: "语言（Beta）"
+  languageMenuItem: "语言"
   languageTitle: "语言"
   lightThemeName: "浅色"
   loadingMessage: "正在加载..."
@@ -538,6 +538,7 @@ resourceTypes:
   videos: "视频"
   about: "关于"
   appearance: "外观"
+  language: "语言"
   versions: "版本"
   webServer: "Web 服务器"
 colorsPage:
@@ -2166,6 +2167,9 @@ aboutPage:
   appVersionText: "RouteVN Creator {appVersion}"
   checkForUpdatesButton: "检查更新"
   communityTitle: "社区"
+  contactButton: "联系我们"
+  contactDescription: "如果你有反馈、意见、问题报告或功能建议，欢迎联系我们。"
+  contactTitle: "联系我们"
   title: "关于"
   versionInformationTitle: "版本信息"
 settingsUserPage:
@@ -2177,3 +2181,7 @@ appearancePage:
   lightThemeName: "浅色"
   themesTitle: "主题"
   title: "外观"
+settingsLanguagePage:
+  description: "选择 RouteVN Creator 使用的语言。"
+  failedChangeLanguage: "无法更改语言。请重试。"
+  title: "语言"

--- a/src/internal/routevnUrls.js
+++ b/src/internal/routevnUrls.js
@@ -1,5 +1,6 @@
 const ROUTEVN_CREATOR_DOCS_BASE_URL = "https://routevn.com/en/creator/docs";
 
+export const ROUTEVN_CONTACT_URL = "https://routevn.com/en/contact/";
 export const ROUTEVN_CREATOR_DOCS_URL = `${ROUTEVN_CREATOR_DOCS_BASE_URL}/introduction/`;
 export const ROUTEVN_CREATOR_DOCS_PAGE_INDEX_URL = `${ROUTEVN_CREATOR_DOCS_BASE_URL}/page-index/`;
 
@@ -30,6 +31,7 @@ const creatorDocsPathByRoutePattern = {
   "/project/releases/web-server": "/web-server/",
   "/project/about": "/page-index/#settings",
   "/project/appearance": "/page-index/#settings",
+  "/project/language": "/page-index/#settings",
   "/project/user": "/page-index/#settings",
 };
 

--- a/src/internal/ui/appLocale.js
+++ b/src/internal/ui/appLocale.js
@@ -1,0 +1,45 @@
+export const APP_LOCALE_CONFIG_KEY = "app.locale";
+export const DEFAULT_APP_LOCALE = "en";
+
+export const APP_LOCALE_OPTIONS = Object.freeze([
+  Object.freeze({ value: "en", label: "English" }),
+  Object.freeze({ value: "ja", label: "日本語 (Beta)" }),
+  Object.freeze({ value: "zh-hans", label: "简体中文 (Beta)" }),
+]);
+
+const getAvailableAppLocales = (localeService) => {
+  return (
+    localeService?.available?.() ??
+    APP_LOCALE_OPTIONS.map((option) => option.value)
+  );
+};
+
+export const resolveAppLocale = ({ appService, localeService } = {}) => {
+  const availableLocales = getAvailableAppLocales(localeService);
+  const storedLocale = appService?.getUserConfig?.(APP_LOCALE_CONFIG_KEY);
+  const currentLocale = localeService?.current?.();
+  const locale = storedLocale ?? currentLocale ?? DEFAULT_APP_LOCALE;
+
+  return availableLocales.includes(locale) ? locale : DEFAULT_APP_LOCALE;
+};
+
+export const activateAppLocale = async ({
+  appService,
+  localeService,
+  locale,
+  persist = true,
+} = {}) => {
+  const availableLocales = getAvailableAppLocales(localeService);
+  const nextLocale = availableLocales.includes(locale)
+    ? locale
+    : DEFAULT_APP_LOCALE;
+
+  await localeService?.set?.(nextLocale);
+  const activeLocale = localeService?.current?.() ?? nextLocale;
+
+  if (persist) {
+    appService?.setUserConfig?.(APP_LOCALE_CONFIG_KEY, activeLocale);
+  }
+
+  return activeLocale;
+};

--- a/src/internal/ui/appLocale.js
+++ b/src/internal/ui/appLocale.js
@@ -37,7 +37,7 @@ export const activateAppLocale = async ({
   await localeService?.set?.(nextLocale);
   const activeLocale = localeService?.current?.() ?? nextLocale;
 
-  if (persist) {
+  if (persist && activeLocale === nextLocale) {
     appService?.setUserConfig?.(APP_LOCALE_CONFIG_KEY, activeLocale);
   }
 

--- a/src/pages/about/about.handlers.js
+++ b/src/pages/about/about.handlers.js
@@ -1,3 +1,4 @@
+import { ROUTEVN_CONTACT_URL } from "../../internal/routevnUrls.js";
 import { resolveUpdatesEnabled } from "../../internal/updates.js";
 
 export const handleBeforeMount = (deps) => {
@@ -33,4 +34,9 @@ export const handleClickSocialButton = async (deps, payload) => {
   const id = _event.currentTarget?.dataset?.id;
   const social = store.selectSocial({ id });
   appService.openUrl(social.href);
+};
+
+export const handleClickContactButton = (deps) => {
+  const { appService } = deps;
+  appService.openUrl(ROUTEVN_CONTACT_URL);
 };

--- a/src/pages/about/about.store.js
+++ b/src/pages/about/about.store.js
@@ -73,6 +73,11 @@ export const selectViewData = ({ state, i18n }) => {
     ),
     checkForUpdatesButton: copy.checkForUpdatesButton ?? "Check for Updates",
     communityTitle: copy.communityTitle ?? "Community",
+    contactTitle: copy.contactTitle ?? "Contact Us",
+    contactDescription:
+      copy.contactDescription ??
+      "Have feedback, a comment, a bug report, or a feature request? Get in touch with us.",
+    contactButton: copy.contactButton ?? "Contact Us",
   };
 };
 

--- a/src/pages/about/about.view.yaml
+++ b/src/pages/about/about.view.yaml
@@ -11,6 +11,10 @@ refs:
     eventListeners:
       click:
         handler: handleClickSocialButton
+  contactButton:
+    eventListeners:
+      click:
+        handler: handleClickContactButton
 template:
   - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
       - 'rtgl-view d=h h=f style="min-width: 0; min-height: 0;"':
@@ -42,3 +46,11 @@ template:
                                   - rtgl-button#socialButton${i} data-id="${item.id}" v=se pre=${item.svg} w=f: ${item.label}
                                 $else:
                                   - rtgl-button#socialButton${i} data-id="${item.id}" v=se pre=${item.svg}: ${item.label}
+                  - rtgl-view g=md:
+                      - rtgl-text s=h4: ${contactTitle}
+                      - rtgl-text s=sm c=mu-fg: ${contactDescription}
+                      - rtgl-view d=h:
+                          - $if isTouchMode:
+                              - rtgl-button#contactButton v=se pre=chat w=f: ${contactButton}
+                            $else:
+                              - rtgl-button#contactButton v=se pre=chat: ${contactButton}

--- a/src/pages/app/app.handlers.js
+++ b/src/pages/app/app.handlers.js
@@ -530,6 +530,7 @@ const targetPathBySequence = {
   ws: "/project/releases/web-server",
   ab: "/project/about",
   ap: "/project/appearance",
+  sl: "/project/language",
 };
 
 const targetSequencePrefixes = new Set(

--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -40,6 +40,7 @@ const mobileTabIdByRoutePattern = {
   "/project": "settings",
   "/project/about": "settings",
   "/project/appearance": "settings",
+  "/project/language": "settings",
   "/project/user": "settings",
 };
 
@@ -97,6 +98,7 @@ export const selectCurrentRoutePattern = ({ state }) => {
     "/project/animation-editor",
     "/project/about",
     "/project/appearance",
+    "/project/language",
     "/project/user",
     "/project/fonts",
     "/project/layouts",

--- a/src/pages/app/app.view.yaml
+++ b/src/pages/app/app.view.yaml
@@ -68,6 +68,8 @@ template:
                   - rvn-about: []
                 $elif currentRoutePattern == "/project/appearance":
                   - rvn-appearance: []
+                $elif currentRoutePattern == "/project/language":
+                  - rvn-language: []
                 $elif currentRoutePattern == "/project/user":
                   - rvn-settings-user: []
                 $elif currentRoutePattern == "/project/colors":

--- a/src/pages/language/language.handlers.js
+++ b/src/pages/language/language.handlers.js
@@ -1,0 +1,62 @@
+import {
+  activateAppLocale,
+  resolveAppLocale,
+} from "../../internal/ui/appLocale.js";
+import { selectSettingsLanguagePageCopy } from "./support/settingsLanguagePageCopy.js";
+
+export const handleBeforeMount = (deps) => {
+  const { appService, locale, store, uiConfig } = deps;
+
+  store.setUiConfig({ uiConfig });
+  store.setCurrentLocale({
+    locale: resolveAppLocale({ appService, localeService: locale }),
+  });
+};
+
+export const handleAfterMount = async (deps) => {
+  const { appService, i18n, locale, render, store } = deps;
+  const copy = selectSettingsLanguagePageCopy(i18n);
+
+  try {
+    const activeLocale = await activateAppLocale({
+      appService,
+      localeService: locale,
+      locale: resolveAppLocale({ appService, localeService: locale }),
+      persist: false,
+    });
+    store.setCurrentLocale({ locale: activeLocale });
+    render();
+  } catch {
+    appService.showToast({ message: copy.failedChangeLanguage });
+  }
+};
+
+export const handleLanguageChange = async (deps, payload) => {
+  const { appService, i18n, locale, render, store } = deps;
+  const copy = selectSettingsLanguagePageCopy(i18n);
+  const { value: nextLocale } = payload._event.detail;
+  const previousLocale = store.selectCurrentLocale();
+
+  if (nextLocale === previousLocale) {
+    return;
+  }
+
+  store.setCurrentLocale({ locale: nextLocale });
+  render();
+
+  try {
+    const activeLocale = await activateAppLocale({
+      appService,
+      localeService: locale,
+      locale: nextLocale,
+    });
+    if (activeLocale !== nextLocale) {
+      store.setCurrentLocale({ locale: activeLocale });
+    }
+    render();
+  } catch {
+    store.setCurrentLocale({ locale: previousLocale });
+    render();
+    appService.showToast({ message: copy.failedChangeLanguage });
+  }
+};

--- a/src/pages/language/language.handlers.js
+++ b/src/pages/language/language.handlers.js
@@ -51,7 +51,13 @@ export const handleLanguageChange = async (deps, payload) => {
       locale: nextLocale,
     });
     if (activeLocale !== nextLocale) {
-      store.setCurrentLocale({ locale: activeLocale });
+      await activateAppLocale({
+        appService,
+        localeService: locale,
+        locale: previousLocale,
+        persist: false,
+      });
+      throw new Error("Selected locale fell back to another locale");
     }
     render();
   } catch {

--- a/src/pages/language/language.schema.yaml
+++ b/src/pages/language/language.schema.yaml
@@ -1,0 +1,4 @@
+componentName: rvn-language
+propsSchema:
+  type: object
+  properties: {}

--- a/src/pages/language/language.store.js
+++ b/src/pages/language/language.store.js
@@ -1,0 +1,41 @@
+import {
+  APP_LOCALE_OPTIONS,
+  DEFAULT_APP_LOCALE,
+} from "../../internal/ui/appLocale.js";
+import { selectSettingsLanguagePageCopy } from "./support/settingsLanguagePageCopy.js";
+
+export const createInitialState = () => ({
+  resourceCategory: "settings",
+  selectedResourceId: "language",
+  repositoryTarget: "settings",
+  currentLocale: DEFAULT_APP_LOCALE,
+  isTouchMode: false,
+});
+
+export const selectCurrentLocale = ({ state }) => {
+  return state.currentLocale;
+};
+
+export const selectViewData = ({ state, i18n }) => {
+  const copy = selectSettingsLanguagePageCopy(i18n);
+
+  return {
+    ...state,
+    showExplorerPanel: !state.isTouchMode,
+    contentPadding: state.isTouchMode ? "0" : "lg",
+    contentBodyPadding: state.isTouchMode ? "md" : "0",
+    contentBodyMarginTop: state.isTouchMode ? "0" : "lg",
+    title: copy.title,
+    description: copy.description,
+    languageOptions: APP_LOCALE_OPTIONS,
+  };
+};
+
+export const setCurrentLocale = ({ state }, { locale } = {}) => {
+  state.currentLocale = locale ?? DEFAULT_APP_LOCALE;
+};
+
+export const setUiConfig = ({ state }, { uiConfig } = {}) => {
+  state.isTouchMode =
+    uiConfig?.id === "touch" || uiConfig?.inputMode === "touch";
+};

--- a/src/pages/language/language.view.yaml
+++ b/src/pages/language/language.view.yaml
@@ -1,0 +1,24 @@
+refs:
+  languageSelect:
+    eventListeners:
+      value-change:
+        handler: handleLanguageChange
+template:
+  - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+      - 'rtgl-view d=h w=f h=f style="min-width: 0; min-height: 0;"':
+          - $if showExplorerPanel:
+              - rvn-resizable-panel#fileExplorer w=300 min-w=200 max-w=500 resize-side="right":
+                  - rtgl-view slot="content" w=f h=f:
+                      - rvn-resource-types :resourceCategory=${resourceCategory} :selectedResourceId=${selectedResourceId}: null
+          - 'rtgl-view w=1fg h=f p=${contentPadding} d=v style="min-width: 0; min-height: 0;"':
+              - $if isTouchMode:
+                  - 'rtgl-view h=48 w=f bgc=bg bwb=xs ph=md av=c style="position: sticky; top: 0px; z-index: 1000;"':
+                      - rtgl-view w=f d=h av=c g=md wrap:
+                          - rtgl-view av=c g=sm d=h w=1fg:
+                              - rtgl-text: ${title}
+                $else:
+                  - rtgl-text s=h2: ${title}
+              - 'rtgl-view w=f h=1fg mt=${contentBodyMarginTop} p=${contentBodyPadding} sv style="min-width: 0; min-height: 0;"':
+                  - rtgl-view w=560 sm-w=f g=lg:
+                      - rtgl-text s=sm c=mu-fg: ${description}
+                      - rtgl-select#languageSelect w=f no-clear :selectedValue=${currentLocale} :options=${languageOptions}: null

--- a/src/pages/language/support/settingsLanguagePageCopy.js
+++ b/src/pages/language/support/settingsLanguagePageCopy.js
@@ -1,0 +1,5 @@
+import { selectI18nCopy } from "../../../internal/ui/i18nCopy.js";
+
+export const selectSettingsLanguagePageCopy = (i18n = {}) => {
+  return selectI18nCopy(i18n, ["settingsLanguagePage"]);
+};

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -16,48 +16,14 @@ import {
 import { createProjectRoutePayload } from "../../internal/localProjectRoute.js";
 import { resolveUpdatesEnabled } from "../../internal/updates.js";
 import {
+  activateAppLocale,
+  DEFAULT_APP_LOCALE,
+  resolveAppLocale,
+} from "../../internal/ui/appLocale.js";
+import {
   formatProjectsPageCopy,
   selectProjectsPageCopy,
 } from "./support/projectsPageCopy.js";
-
-const APP_LOCALE_CONFIG_KEY = "app.locale";
-const DEFAULT_PROJECTS_LOCALE = "en";
-
-const getAvailableLocales = (localeService) => {
-  return localeService?.available?.() ?? ["en", "ja", "zh-hans"];
-};
-
-const resolveProjectsLocale = ({ appService, localeService } = {}) => {
-  const availableLocales = getAvailableLocales(localeService);
-  const storedLocale = appService?.getUserConfig?.(APP_LOCALE_CONFIG_KEY);
-  const currentLocale = localeService?.current?.();
-  const locale = storedLocale ?? currentLocale ?? DEFAULT_PROJECTS_LOCALE;
-
-  return availableLocales.includes(locale) ? locale : DEFAULT_PROJECTS_LOCALE;
-};
-
-const activateProjectsLocale = async ({
-  appService,
-  localeService,
-  store,
-  locale,
-  persist = true,
-} = {}) => {
-  const availableLocales = getAvailableLocales(localeService);
-  const nextLocale = availableLocales.includes(locale)
-    ? locale
-    : DEFAULT_PROJECTS_LOCALE;
-
-  await localeService?.set?.(nextLocale);
-  const activeLocale = localeService?.current?.() ?? nextLocale;
-
-  store.setCurrentLocale({ locale: activeLocale });
-  if (persist) {
-    appService?.setUserConfig?.(APP_LOCALE_CONFIG_KEY, activeLocale);
-  }
-
-  return activeLocale;
-};
 
 const mapCloudProject = (project, copy) => {
   const projectId = project?.id;
@@ -114,13 +80,13 @@ const loadCloudProjects = async ({
 
 export const handleAfterMount = async (deps) => {
   const { appService, apiService, store, render, locale } = deps;
-  await activateProjectsLocale({
+  const activeLocale = await activateAppLocale({
     appService,
     localeService: locale,
-    store,
-    locale: resolveProjectsLocale({ appService, localeService: locale }),
+    locale: resolveAppLocale({ appService, localeService: locale }),
     persist: false,
   });
+  store.setCurrentLocale({ locale: activeLocale });
   const copy = selectProjectsPageCopy(deps.i18n);
   const platform = appService.getPlatform();
   const showCloudProjects = store.selectShowCloudProjects();
@@ -579,7 +545,7 @@ export const handleAppVersionMenuClickItem = async (deps, payload) => {
 
   if (item.value === "language") {
     store.openLanguageDialog({
-      locale: resolveProjectsLocale({ appService, localeService: locale }),
+      locale: resolveAppLocale({ appService, localeService: locale }),
     });
     render();
     return;
@@ -630,15 +596,15 @@ export const handleLanguageFormAction = async (deps, payload) => {
     return;
   }
 
-  const selectedLocale = detail?.values?.locale ?? DEFAULT_PROJECTS_LOCALE;
+  const selectedLocale = detail?.values?.locale ?? DEFAULT_APP_LOCALE;
 
   try {
-    await activateProjectsLocale({
+    const activeLocale = await activateAppLocale({
       appService,
       localeService: locale,
-      store,
       locale: selectedLocale,
     });
+    store.setCurrentLocale({ locale: activeLocale });
     store.closeLanguageDialog();
     render();
   } catch {

--- a/src/pages/projects/projects.store.js
+++ b/src/pages/projects/projects.store.js
@@ -1,4 +1,5 @@
 import { normalizeTheme } from "../../internal/theme.js";
+import { APP_LOCALE_OPTIONS } from "../../internal/ui/appLocale.js";
 import {
   formatProjectsPageCopy,
   selectProjectsPageCopy,
@@ -656,20 +657,7 @@ export const selectViewData = ({ state, i18n }) => {
         type: "select",
         label: copy.languageLabel,
         required: true,
-        options: [
-          {
-            value: "en",
-            label: "English",
-          },
-          {
-            value: "ja",
-            label: "日本語",
-          },
-          {
-            value: "zh-hans",
-            label: "简体中文",
-          },
-        ],
+        options: APP_LOCALE_OPTIONS,
       },
     ],
     actions: {

--- a/src/pages/resourceTypes/resourceTypes.store.js
+++ b/src/pages/resourceTypes/resourceTypes.store.js
@@ -91,6 +91,11 @@ const settingsItems = [
     name: "Appearance",
     path: "/project/appearance",
   },
+  {
+    id: "language",
+    name: "Language",
+    path: "/project/language",
+  },
   // {
   //   id: "user",
   //   name: "User",

--- a/src/pages/sidebar/sidebar.store.js
+++ b/src/pages/sidebar/sidebar.store.js
@@ -173,6 +173,7 @@ export const selectViewData = ({ state, props = {}, i18n }) => {
     if (
       currentPath === "/project/about" ||
       currentPath === "/project/appearance" ||
+      currentPath === "/project/language" ||
       currentPath === "/project/user"
     ) {
       const settingsItem = state.items.find(

--- a/svg/chat.svg
+++ b/svg/chat.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 3C6.477 3 2 6.806 2 11.5C2 13.95 3.22 16.157 5.17 17.708L4 21L8.15 19.34C9.346 19.767 10.646 20 12 20C17.523 20 22 16.194 22 11.5C22 6.806 17.523 3 12 3Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="8" cy="11.5" r="1" fill="currentColor" />
+  <circle cx="12" cy="11.5" r="1" fill="currentColor" />
+  <circle cx="16" cy="11.5" r="1" fill="currentColor" />
+</svg>

--- a/tests/about/about.handlers.test.js
+++ b/tests/about/about.handlers.test.js
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { ROUTEVN_CONTACT_URL } from "../../src/internal/routevnUrls.js";
+import { handleClickContactButton } from "../../src/pages/about/about.handlers.js";
+
+const defaultCapability = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../../src-tauri/capabilities/default.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+);
+
+describe("about handlers", () => {
+  it("opens the RouteVN contact page", () => {
+    const appService = {
+      openUrl: vi.fn(),
+    };
+
+    handleClickContactButton({ appService });
+
+    expect(appService.openUrl).toHaveBeenCalledWith(ROUTEVN_CONTACT_URL);
+  });
+
+  it("allows RouteVN pages through the Tauri opener", () => {
+    const openerPermission = defaultCapability.permissions.find(
+      (permission) => permission.identifier === "opener:allow-open-url",
+    );
+
+    expect(openerPermission.allow).toContainEqual({
+      url: "https://routevn.com/*",
+    });
+  });
+});

--- a/tests/about/about.store.test.js
+++ b/tests/about/about.store.test.js
@@ -7,6 +7,17 @@ import {
 import { EN_I18N } from "../support/i18n.js";
 
 describe("about store", () => {
+  it("shows the localized contact section", () => {
+    const state = createInitialState();
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      contactTitle: "Contact Us",
+      contactDescription:
+        "Have feedback, a comment, a bug report, or a feature request? Get in touch with us.",
+      contactButton: "Contact Us",
+    });
+  });
+
   it("uses the navbar inset for touch-mode body padding", () => {
     const state = createInitialState();
 

--- a/tests/app/app.handlers.test.js
+++ b/tests/app/app.handlers.test.js
@@ -554,6 +554,7 @@ const navigationShortcutCases = [
   ["ws", "/project/releases/web-server"],
   ["ab", "/project/about"],
   ["ap", "/project/appearance"],
+  ["sl", "/project/language"],
 ];
 
 const createKeyboardScope = (harness) => {

--- a/tests/app/app.store.test.js
+++ b/tests/app/app.store.test.js
@@ -59,6 +59,15 @@ describe("app.store repository loading progress", () => {
     );
   });
 
+  it("resolves the language settings route", () => {
+    const state = createInitialState();
+    state.currentRoute = "/project/language";
+
+    expect(selectViewData({ state }).currentRoutePattern).toBe(
+      "/project/language",
+    );
+  });
+
   it("resolves the platform details route", () => {
     const state = createInitialState();
     state.currentRoute = "/project/releases/platform-details";
@@ -188,7 +197,7 @@ describe("app.store mobile tab active state", () => {
 
   it("highlights the settings tab on settings routes", () => {
     const state = createInitialState();
-    state.currentRoute = "/project/about";
+    state.currentRoute = "/project/language";
 
     expect(selectMobileTab({ state, tabId: "settings" }).color).toBe("white");
     expect(selectMobileTab({ state, tabId: "assets" }).color).toBe("mu-fg");

--- a/tests/app/app.view.test.js
+++ b/tests/app/app.view.test.js
@@ -11,6 +11,18 @@ describe("app view", () => {
     expect(appView).toContain("rvn-sidebar :currentRoute=${currentRoute}");
   });
 
+  it("renders the language settings page for its project route", () => {
+    const appView = readFileSync(
+      new URL("../../src/pages/app/app.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    expect(appView).toContain(
+      '$elif currentRoutePattern == "/project/language"',
+    );
+    expect(appView).toContain("rvn-language");
+  });
+
   it("prevents mobile tab tap feedback from rendering over the sheet", () => {
     const appView = readFileSync(
       new URL("../../src/pages/app/app.view.yaml", import.meta.url),

--- a/tests/internal/appLocale.test.js
+++ b/tests/internal/appLocale.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { activateAppLocale } from "../../src/internal/ui/appLocale.js";
+
+describe("app locale", () => {
+  it("does not persist a fallback locale as the requested preference", async () => {
+    const appService = {
+      setUserConfig: vi.fn(),
+    };
+    const localeService = {
+      available: vi.fn(() => ["en", "ja", "zh-hans"]),
+      current: vi.fn(() => "en"),
+      set: vi.fn(async () => {}),
+    };
+
+    const activeLocale = await activateAppLocale({
+      appService,
+      localeService,
+      locale: "ja",
+    });
+
+    expect(activeLocale).toBe("en");
+    expect(appService.setUserConfig).not.toHaveBeenCalled();
+  });
+});

--- a/tests/internal/routevnUrls.test.js
+++ b/tests/internal/routevnUrls.test.js
@@ -56,6 +56,9 @@ describe("routevnUrls", () => {
     expect(getRoutevnCreatorDocsUrl("/project/appearance")).toBe(
       "https://routevn.com/en/creator/docs/page-index/#settings",
     );
+    expect(getRoutevnCreatorDocsUrl("/project/language")).toBe(
+      "https://routevn.com/en/creator/docs/page-index/#settings",
+    );
     expect(getRoutevnCreatorDocsUrl("/project/user")).toBe(
       "https://routevn.com/en/creator/docs/page-index/#settings",
     );

--- a/tests/language/language.handlers.test.js
+++ b/tests/language/language.handlers.test.js
@@ -122,4 +122,32 @@ describe("settings language handlers", () => {
     });
     expect(deps.render).toHaveBeenCalledTimes(2);
   });
+
+  it("reports a locale fallback without replacing the saved preference", async () => {
+    const deps = createDeps();
+    deps.locale.set.mockResolvedValue(undefined);
+    deps.locale.current.mockReturnValue("en");
+
+    await handleLanguageChange(deps, {
+      _event: {
+        detail: {
+          value: "ja",
+        },
+      },
+    });
+
+    expect(deps.locale.set).toHaveBeenNthCalledWith(1, "ja");
+    expect(deps.locale.set).toHaveBeenNthCalledWith(2, "en");
+    expect(deps.appService.setUserConfig).not.toHaveBeenCalled();
+    expect(deps.store.setCurrentLocale).toHaveBeenNthCalledWith(1, {
+      locale: "ja",
+    });
+    expect(deps.store.setCurrentLocale).toHaveBeenNthCalledWith(2, {
+      locale: "en",
+    });
+    expect(deps.appService.showToast).toHaveBeenCalledWith({
+      message: "Could not change the language. Please try again.",
+    });
+    expect(deps.render).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/language/language.handlers.test.js
+++ b/tests/language/language.handlers.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleAfterMount,
+  handleBeforeMount,
+  handleLanguageChange,
+} from "../../src/pages/language/language.handlers.js";
+import { EN_I18N } from "../support/i18n.js";
+
+const createDeps = () => {
+  let currentLocale = "en";
+  const appService = {
+    getUserConfig: vi.fn(() => undefined),
+    setUserConfig: vi.fn(),
+    showToast: vi.fn(),
+  };
+  const locale = {
+    available: vi.fn(() => ["en", "ja", "zh-hans"]),
+    current: vi.fn(() => currentLocale),
+    set: vi.fn(async (nextLocale) => {
+      currentLocale = nextLocale;
+    }),
+  };
+
+  return {
+    appService,
+    locale,
+    store: {
+      selectCurrentLocale: vi.fn(() => currentLocale),
+      setCurrentLocale: vi.fn(),
+      setUiConfig: vi.fn(),
+    },
+    uiConfig: { id: "normal", inputMode: "pointer" },
+    i18n: EN_I18N,
+    render: vi.fn(),
+  };
+};
+
+describe("settings language handlers", () => {
+  it("loads the persisted app locale before mount", () => {
+    const deps = createDeps();
+    deps.appService.getUserConfig.mockReturnValue("ja");
+
+    handleBeforeMount(deps);
+
+    expect(deps.store.setUiConfig).toHaveBeenCalledWith({
+      uiConfig: deps.uiConfig,
+    });
+    expect(deps.store.setCurrentLocale).toHaveBeenCalledWith({ locale: "ja" });
+  });
+
+  it("activates the persisted locale after mount", async () => {
+    const deps = createDeps();
+    deps.appService.getUserConfig.mockReturnValue("ja");
+
+    await handleAfterMount(deps);
+
+    expect(deps.locale.set).toHaveBeenCalledWith("ja");
+    expect(deps.store.setCurrentLocale).toHaveBeenCalledWith({ locale: "ja" });
+    expect(deps.appService.setUserConfig).not.toHaveBeenCalled();
+    expect(deps.render).toHaveBeenCalledTimes(1);
+  });
+
+  it("activates and persists the selected locale", async () => {
+    const deps = createDeps();
+
+    await handleLanguageChange(deps, {
+      _event: {
+        detail: {
+          value: "zh-hans",
+        },
+      },
+    });
+
+    expect(deps.locale.set).toHaveBeenCalledWith("zh-hans");
+    expect(deps.appService.setUserConfig).toHaveBeenCalledWith(
+      "app.locale",
+      "zh-hans",
+    );
+    expect(deps.store.setCurrentLocale).toHaveBeenCalledWith({
+      locale: "zh-hans",
+    });
+    expect(deps.render).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing when the selected locale is already active", async () => {
+    const deps = createDeps();
+
+    await handleLanguageChange(deps, {
+      _event: {
+        detail: {
+          value: "en",
+        },
+      },
+    });
+
+    expect(deps.locale.set).not.toHaveBeenCalled();
+    expect(deps.appService.setUserConfig).not.toHaveBeenCalled();
+    expect(deps.store.setCurrentLocale).not.toHaveBeenCalled();
+    expect(deps.render).not.toHaveBeenCalled();
+  });
+
+  it("shows stable feedback when changing the locale fails", async () => {
+    const deps = createDeps();
+    deps.locale.set.mockRejectedValue(new Error("locale unavailable"));
+
+    await handleLanguageChange(deps, {
+      _event: {
+        detail: {
+          value: "ja",
+        },
+      },
+    });
+
+    expect(deps.appService.showToast).toHaveBeenCalledWith({
+      message: "Could not change the language. Please try again.",
+    });
+    expect(deps.store.setCurrentLocale).toHaveBeenNthCalledWith(1, {
+      locale: "ja",
+    });
+    expect(deps.store.setCurrentLocale).toHaveBeenNthCalledWith(2, {
+      locale: "en",
+    });
+    expect(deps.render).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/language/language.store.test.js
+++ b/tests/language/language.store.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setCurrentLocale,
+  setUiConfig,
+} from "../../src/pages/language/language.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("settings language store", () => {
+  it("builds the app language selector", () => {
+    const state = createInitialState();
+    setCurrentLocale({ state }, { locale: "ja" });
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+
+    expect(viewData).toMatchObject({
+      resourceCategory: "settings",
+      selectedResourceId: "language",
+      title: "Language",
+      description: "Choose the language used by RouteVN Creator.",
+      currentLocale: "ja",
+      languageOptions: [
+        { value: "en", label: "English" },
+        { value: "ja", label: "日本語 (Beta)" },
+        { value: "zh-hans", label: "简体中文 (Beta)" },
+      ],
+    });
+  });
+
+  it("uses the compact settings layout in touch mode", () => {
+    const state = createInitialState();
+    setUiConfig({ state }, { uiConfig: { id: "touch" } });
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      isTouchMode: true,
+      showExplorerPanel: false,
+      contentPadding: "0",
+      contentBodyPadding: "md",
+      contentBodyMarginTop: "0",
+    });
+  });
+});

--- a/tests/language/language.view.test.js
+++ b/tests/language/language.view.test.js
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("settings language view", () => {
+  it("uses a standalone selector that applies changes directly", () => {
+    const languageView = readFileSync(
+      new URL("../../src/pages/language/language.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    expect(languageView).toContain("rtgl-select#languageSelect");
+    expect(languageView).toContain("value-change:");
+    expect(languageView).toContain("handler: handleLanguageChange");
+    expect(languageView).not.toContain("rtgl-form");
+    expect(languageView).not.toContain("save-language");
+    expect(languageView).not.toContain("languageLabel");
+  });
+});

--- a/tests/projects/projects.store.test.js
+++ b/tests/projects/projects.store.test.js
@@ -154,7 +154,7 @@ describe("projects.store addProject", () => {
 
   it("opens the app version menu with a check update action", () => {
     const state = createInitialState();
-    expect(EN_I18N.projectsPage.languageMenuItem).toBe("Language (Beta)");
+    expect(EN_I18N.projectsPage.languageMenuItem).toBe("Language");
     const items = [
       {
         label: EN_I18N.projectsPage.checkUpdateMenuItem,
@@ -229,11 +229,11 @@ describe("projects.store addProject", () => {
             },
             {
               value: "ja",
-              label: "日本語",
+              label: "日本語 (Beta)",
             },
             {
               value: "zh-hans",
-              label: "简体中文",
+              label: "简体中文 (Beta)",
             },
           ],
         },

--- a/tests/sidebar/resourceTypes.store.test.js
+++ b/tests/sidebar/resourceTypes.store.test.js
@@ -26,7 +26,7 @@ describe("resource type navigation", () => {
     ]);
   });
 
-  it("shows appearance in settings resource menus", () => {
+  it("shows appearance and language in settings resource menus", () => {
     const desktopViewData = selectDesktopResourceTypesViewData({
       props: {
         resourceCategory: "settings",
@@ -43,12 +43,13 @@ describe("resource type navigation", () => {
     expect(desktopViewData.items.map((item) => item.id)).toEqual([
       "about",
       "appearance",
+      "language",
     ]);
     expect(
       mobileSidebarViewData.sections.flatMap((section) =>
         section.items.map((item) => item.id),
       ),
-    ).toEqual(["project", "about", "appearance"]);
+    ).toEqual(["project", "about", "appearance", "language"]);
   });
 
   it("shows platform details in desktop and mobile release menus", () => {

--- a/tests/sidebar/sidebar.handlers.test.js
+++ b/tests/sidebar/sidebar.handlers.test.js
@@ -98,7 +98,7 @@ describe("sidebar.handlers", () => {
     expect(
       selectViewData({
         state,
-        props: { currentRoute: "/project/about" },
+        props: { currentRoute: "/project/language" },
       }).selectedItemId,
     ).toBe("settings");
   });

--- a/vt/specs/project/language.yaml
+++ b/vt/specs/project/language.yaml
@@ -1,0 +1,78 @@
+---
+title: Project Language Settings Page
+description: Covers the language settings route, selector, and locale switching.
+url: /projects
+skipInitialScreenshot: true
+viewport:
+  id: wide
+  width: 1440
+  height: 900
+steps:
+  - action: waitFor
+    selector: "[data-testid='create-project-button']"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    testId: create-project-button
+    steps:
+      - action: click
+  - action: waitFor
+    selector: rtgl-form#createProjectForm rtgl-input#field0 input
+    state: attached
+    timeoutMs: 5000
+  - action: select
+    selector: rtgl-form#createProjectForm rtgl-input#field0 input
+    steps:
+      - action: clear
+      - action: write
+        value: Project One
+  - action: select
+    selector: "#createProjectSubmitButton"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "#projectItem0"
+    state: visible
+    timeoutMs: 30000
+  - action: select
+    selector: "#projectItem0"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: rvn-project
+    state: attached
+    timeoutMs: 10000
+  - action: customEvent
+    name: routevn:vt:navigate
+    detail:
+      path: /project/language
+  - action: waitFor
+    selector: rvn-language
+    state: attached
+    timeoutMs: 10000
+  - action: assert
+    type: url
+    value: /project/language
+  - action: waitFor
+    selector: "rtgl-select#languageSelect [data-testid='select-button']"
+    state: visible
+    timeoutMs: 5000
+  - action: wait
+    ms: 300
+  - action: screenshot
+  - action: select
+    selector: "rtgl-select#languageSelect [data-testid='select-button']"
+    steps:
+      - action: click
+  - action: waitFor
+    selector: "rtgl-select#languageSelect #option1"
+    state: attached
+    timeoutMs: 5000
+  - action: select
+    selector: "rtgl-select#languageSelect #option1"
+    steps:
+      - action: click
+  - action: wait
+    ms: 500
+  - action: screenshot
+---


### PR DESCRIPTION
## Summary

- add a Language project settings page with a standalone selector that applies and persists locale changes immediately
- move the Beta marker from the language menu to the Japanese and Simplified Chinese options
- add a localized Contact Us section to About with a rounded chat icon and Tauri opener permission for RouteVN links

## Validation

- bun run lint
- bunx vitest run tests/about tests/language tests/app/app.store.test.js tests/app/app.view.test.js tests/projects/projects.store.test.js tests/projects/projects.handlers.test.js tests/sidebar/resourceTypes.store.test.js tests/sidebar/sidebar.handlers.test.js tests/internal/routevnUrls.test.js
- bun run test:smoke