### PR TITLE
Fix resized sound-effect waveform rendering

### DIFF
--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -196,6 +196,7 @@ styles:
     min-width: "0"
     padding: "0 8px"
     text-align: left
+    width: 100%
   ".sfxChannelSelect:hover":
     color: var(--foreground)
   ".sfxChannelSelect:focus-visible":
@@ -210,7 +211,7 @@ template:
               - rtgl-view w=f g=lg ph=lg:
                   - $for channel, i in channels:
                       - 'rtgl-view#sfxChannel${i}.sfxChannel data-channel-id=${channel.id} w=f d=v pos=rel bgc=mu bw=xs bc=${channel.channelBorderColor} h-bc=${channel.channelHoverBorderColor} br=sm tabindex=0 role=group aria-label="${channel.id}" style="height: ${channel.channelHeightPx}px; flex-basis: ${channel.channelHeightPx}px;"':
-                          - rtgl-view.sfxChannelHeader:
+                          - rtgl-view.sfxChannelHeader w=f:
                               - 'button#channelSelectButton${i}.sfxChannelSelect type=button data-channel-id=${channel.id} aria-label="${channel.id}"':
                                   - span: ${channel.id}
                                   - span: ${channel.durationLabel}

--- a/src/components/waveformVisualizer/waveformVisualizer.handlers.js
+++ b/src/components/waveformVisualizer/waveformVisualizer.handlers.js
@@ -1,12 +1,85 @@
+export const renderWaveformCanvas = ({
+  canvas,
+  waveformData,
+  width,
+  height,
+}) => {
+  if (!canvas || width <= 0 || height <= 0) {
+    return;
+  }
+
+  const canvasWidth = Math.max(1, Math.round(width));
+  const canvasHeight = Math.max(1, Math.round(height));
+  canvas.width = canvasWidth;
+  canvas.height = canvasHeight;
+
+  const context = canvas.getContext("2d");
+  context.clearRect(0, 0, canvasWidth, canvasHeight);
+  context.fillStyle = "#1a1a1a";
+  context.fillRect(0, 0, canvasWidth, canvasHeight);
+
+  const amplitudes = waveformData?.amplitudes;
+  if (!amplitudes?.length) {
+    return;
+  }
+
+  const gradient = context.createLinearGradient(0, 0, 0, canvasHeight);
+  gradient.addColorStop(0, "#404040");
+  gradient.addColorStop(0.5, "#A1A1A1");
+  gradient.addColorStop(1, "#404040");
+  context.fillStyle = gradient;
+
+  const barCount = Math.min(canvasWidth, amplitudes.length);
+  const samplesPerBar = amplitudes.length / barCount;
+  const barWidth = canvasWidth / barCount;
+  const centerY = canvasHeight / 2;
+
+  for (let barIndex = 0; barIndex < barCount; barIndex += 1) {
+    const sampleStart = Math.floor(barIndex * samplesPerBar);
+    const sampleEnd = Math.max(
+      sampleStart + 1,
+      Math.floor((barIndex + 1) * samplesPerBar),
+    );
+    let amplitude = 0;
+    for (
+      let sampleIndex = sampleStart;
+      sampleIndex < sampleEnd && sampleIndex < amplitudes.length;
+      sampleIndex += 1
+    ) {
+      amplitude = Math.max(amplitude, amplitudes[sampleIndex]);
+    }
+
+    const barHeight = (amplitude / 255) * (canvasHeight * 0.85);
+    const x = barIndex * barWidth;
+    const y = centerY - barHeight / 2;
+    context.fillRect(x, y, Math.max(1, barWidth * 0.8), barHeight);
+  }
+
+  context.strokeStyle = "rgba(255, 255, 255, 0.1)";
+  context.lineWidth = 1;
+  context.beginPath();
+  context.moveTo(0, centerY);
+  context.lineTo(canvasWidth, centerY);
+  context.stroke();
+};
+
 export const handleBeforeMount = (deps) => {
-  const { refs, store, render } = deps;
+  const { refs, store } = deps;
   let resizeObserver;
+
+  const drawWaveform = ({ width, height }) => {
+    renderWaveformCanvas({
+      canvas: refs.waveformCanvas,
+      waveformData: store.selectWaveformData(),
+      width,
+      height,
+    });
+  };
 
   const updateRenderedSize = ({ width, height }) => {
     const renderedWidth = Math.round(width);
     const renderedHeight = Math.round(height);
     const currentSize = store.selectRenderedSize();
-
     if (
       renderedWidth <= 0 ||
       renderedHeight <= 0 ||
@@ -20,7 +93,7 @@ export const handleBeforeMount = (deps) => {
       width: renderedWidth,
       height: renderedHeight,
     });
-    render();
+    drawWaveform({ width: renderedWidth, height: renderedHeight });
   };
 
   const animationFrameId = requestAnimationFrame(() => {
@@ -42,7 +115,7 @@ export const handleBeforeMount = (deps) => {
 };
 
 export const handleAfterMount = async (deps) => {
-  const { props: attrs, store, render, projectService } = deps;
+  const { props: attrs, refs, store, render, projectService } = deps;
 
   if (!attrs.waveformDataFileId) {
     return;
@@ -56,6 +129,13 @@ export const handleAfterMount = async (deps) => {
     store.setWaveformData({ data: waveformData });
     store.setLoading({ isLoading: false });
     render();
+    const { width, height } = store.selectRenderedSize();
+    renderWaveformCanvas({
+      canvas: refs.waveformCanvas,
+      waveformData,
+      width,
+      height,
+    });
   } catch {
     store.setLoading({ isLoading: false });
     render();
@@ -63,7 +143,7 @@ export const handleAfterMount = async (deps) => {
 };
 
 export const handleOnUpdate = async (deps, payload) => {
-  const { store, render, projectService } = deps;
+  const { refs, store, render, projectService } = deps;
   const { newProps: attrs } = payload;
 
   if (!attrs?.waveformDataFileId) {
@@ -80,6 +160,13 @@ export const handleOnUpdate = async (deps, payload) => {
     store.setWaveformData({ data: waveformData });
     store.setLoading({ isLoading: false });
     render();
+    const { width, height } = store.selectRenderedSize();
+    renderWaveformCanvas({
+      canvas: refs.waveformCanvas,
+      waveformData,
+      width,
+      height,
+    });
   } catch {
     store.setLoading({ isLoading: false });
     render();

--- a/src/components/waveformVisualizer/waveformVisualizer.store.js
+++ b/src/components/waveformVisualizer/waveformVisualizer.store.js
@@ -28,12 +28,13 @@ export const selectRenderedSize = ({ state }) => ({
   height: state.renderedHeight,
 });
 
+export const selectWaveformData = ({ state }) => state.waveformData;
+
 export const selectViewData = ({ state, props: attrs }) => {
   return {
     isLoading: state.isLoading,
     w: attrs.w ?? "250",
     h: attrs.h ?? "150",
     waveformData: state.waveformData,
-    waveformRenderKey: `waveform${state.renderedWidth}x${state.renderedHeight}`,
   };
 };

--- a/src/components/waveformVisualizer/waveformVisualizer.view.yaml
+++ b/src/components/waveformVisualizer/waveformVisualizer.view.yaml
@@ -2,7 +2,8 @@ onMount:
   handler: handleAfterMount
 refs:
   waveformContainer: {}
+  waveformCanvas: {}
 template:
   - rtgl-view#waveformContainer w=${w} h=${h}:
       - $if waveformData:
-          - rtgl-waveform id=${waveformRenderKey} :waveformData=${waveformData} w=${w} h=${h}: null
+          - 'canvas#waveformCanvas style="display: block; width: 100%; height: 100%;"': null

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("commandLineSoundEffects view", () => {
+  it("makes the channel header a full-width pointer target", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const channelSelectStart = view.indexOf('  ".sfxChannelSelect":');
+    const channelSelectStyles = view.slice(
+      channelSelectStart,
+      view.indexOf('  ".sfxChannelSelect:hover":', channelSelectStart),
+    );
+
+    expect(view).toContain("rtgl-view.sfxChannelHeader w=f:");
+    expect(channelSelectStart).toBeGreaterThan(-1);
+    expect(channelSelectStyles).toContain("cursor: pointer");
+    expect(channelSelectStyles).toContain("width: 100%");
+  });
+});

--- a/tests/waveformVisualizer/waveformVisualizer.handlers.test.js
+++ b/tests/waveformVisualizer/waveformVisualizer.handlers.test.js
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { handleBeforeMount } from "../../src/components/waveformVisualizer/waveformVisualizer.handlers.js";
+import {
+  handleBeforeMount,
+  renderWaveformCanvas,
+} from "../../src/components/waveformVisualizer/waveformVisualizer.handlers.js";
 
 const originalResizeObserver = globalThis.ResizeObserver;
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
@@ -12,7 +15,7 @@ afterEach(() => {
 });
 
 describe("waveformVisualizer.handlers", () => {
-  it("rerenders the waveform when its rendered size changes", () => {
+  it("tracks changes to the waveform's rendered size", () => {
     let runAnimationFrame;
     let notifyResize;
     let renderedSize = { width: 0, height: 0 };
@@ -24,7 +27,6 @@ describe("waveformVisualizer.handlers", () => {
     const setRenderedSize = vi.fn((size) => {
       renderedSize = size;
     });
-    const render = vi.fn();
 
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       runAnimationFrame = callback;
@@ -44,9 +46,9 @@ describe("waveformVisualizer.handlers", () => {
       refs: { waveformContainer: container },
       store: {
         selectRenderedSize: () => renderedSize,
+        selectWaveformData: () => undefined,
         setRenderedSize,
       },
-      render,
     });
 
     runAnimationFrame();
@@ -55,21 +57,62 @@ describe("waveformVisualizer.handlers", () => {
       width: 120,
       height: 60,
     });
-    expect(render).toHaveBeenCalledTimes(1);
     expect(observe).toHaveBeenCalledWith(container);
 
     notifyResize([{ contentRect: { width: 120.2, height: 60.2 } }]);
-    expect(render).toHaveBeenCalledTimes(1);
+    expect(setRenderedSize).toHaveBeenCalledTimes(1);
 
     notifyResize([{ contentRect: { width: 240, height: 120 } }]);
     expect(setRenderedSize).toHaveBeenLastCalledWith({
       width: 240,
       height: 120,
     });
-    expect(render).toHaveBeenCalledTimes(2);
+    expect(setRenderedSize).toHaveBeenCalledTimes(2);
 
     cleanup();
     expect(globalThis.cancelAnimationFrame).toHaveBeenCalledWith(7);
     expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("downsamples the complete waveform into the canvas width", () => {
+    const fillRect = vi.fn();
+    const context = {
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      fillRect,
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      stroke: vi.fn(),
+    };
+    const canvas = {
+      getContext: vi.fn(() => context),
+      width: 0,
+      height: 0,
+    };
+
+    renderWaveformCanvas({
+      canvas,
+      waveformData: {
+        amplitudes: [255, 200, 64, 32, 192, 128, 16, 8],
+      },
+      width: 4,
+      height: 100,
+    });
+
+    expect(canvas.width).toBe(4);
+    expect(canvas.height).toBe(100);
+    expect(fillRect).toHaveBeenCalledTimes(5);
+    expect(
+      fillRect.mock.calls.slice(1).map(([x, , barWidth]) => [x, barWidth]),
+    ).toEqual([
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [3, 1],
+    ]);
+    expect(
+      fillRect.mock.calls.slice(1).map(([, , , barHeight]) => barHeight),
+    ).toEqual([85, (64 / 255) * 85, 64, (16 / 255) * 85]);
   });
 });

--- a/tests/waveformVisualizer/waveformVisualizer.store.test.js
+++ b/tests/waveformVisualizer/waveformVisualizer.store.test.js
@@ -7,7 +7,7 @@ import {
 } from "../../src/components/waveformVisualizer/waveformVisualizer.store.js";
 
 describe("waveformVisualizer.store", () => {
-  it("changes the waveform render key with the rendered size", () => {
+  it("tracks the rendered size", () => {
     const state = createInitialState();
 
     setRenderedSize({ state }, { width: 640, height: 360 });
@@ -19,7 +19,6 @@ describe("waveformVisualizer.store", () => {
     expect(selectViewData({ state, props: { w: "f", h: "f" } })).toMatchObject({
       w: "f",
       h: "f",
-      waveformRenderKey: "waveform640x360",
     });
   });
 });

--- a/tests/waveformVisualizer/waveformVisualizer.view.test.js
+++ b/tests/waveformVisualizer/waveformVisualizer.view.test.js
@@ -10,10 +10,9 @@ const viewSource = readFileSync(
 );
 
 describe("waveformVisualizer.view", () => {
-  it("keys the waveform by its latest rendered size", () => {
-    expect(viewSource).toContain(
-      "rtgl-waveform id=${waveformRenderKey} :waveformData=${waveformData}",
-    );
+  it("owns the resizable waveform canvas", () => {
+    expect(viewSource).toContain("canvas#waveformCanvas");
+    expect(viewSource).not.toContain("rtgl-waveform");
     expect(viewSource).toContain("rtgl-view#waveformContainer");
   });
 });


### PR DESCRIPTION
## Summary
- make the sound-effect channel header fill its row so the pointer target covers the full bar
- redraw waveform metadata into an app-owned canvas whenever its rendered size changes
- downsample the complete amplitude range so dragged sounds compress instead of clipping
- add focused view, store, and handler coverage

## Validation
- `bunx vitest run tests/commandLineSoundEffects tests/waveformVisualizer` — 23 passed
- scoped Prettier check passed
- `git diff --check` passed
- manually verified dragging a sound right resizes the canvas while preserving the complete waveform

## Note
- the repository-wide local lint hook is currently blocked by unrelated untracked `ssr-poc/` generated/minified files; that tree is not included in this PR