### PR TITLE
Use a distinct stacked image icon for visuals

### DIFF
--- a/src/components/commandLineActions/commandLineActions.store.js
+++ b/src/components/commandLineActions/commandLineActions.store.js
@@ -193,7 +193,7 @@ const PRESENTATION_ACTION_SECTIONS = [
     {
       id: "8",
       label: "Visuals",
-      icon: "image",
+      icon: "stacked-images",
       mode: "visual",
     },
   ]),

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -113,7 +113,7 @@ template:
                                   - rvn-stacked-file-images :layers=${charData.spritePreviewLayers} w=32 h=32 br=${charData.spritePreviewBr} spritesheetBr=none spritesheetCheckerCellSize=4: null
               - $if preview.visual:
                   - 'rtgl-view#actionItemVisual data-mode=visual g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer style="order: ${presentationActionOrder.visual};"':
-                      - rtgl-svg svg=image wh=24: null
+                      - rtgl-svg svg=stacked-images wh=24: null
                       - rtgl-view d=h g=sm av=c:
                           - $for visualData, i in preview.visual.items:
                               - $if visualData.resourceType == 'spritesheet':

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -8632,7 +8632,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           stack.append(
             this.createMediaThumb({
               fileId: visual.fileId,
-              placeholderIcon: "image",
+              placeholderIcon: "stacked-images",
               size: "visual",
             }),
           );
@@ -8640,7 +8640,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       } else {
         stack.append(
           this.createMediaThumb({
-            placeholderIcon: "image",
+            placeholderIcon: "stacked-images",
             size: "visual",
           }),
         );

--- a/svg/stacked-images.svg
+++ b/svg/stacked-images.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8 3H19C20.1046 3 21 3.89543 21 5V15C21 16.6569 19.6569 18 18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 4C7.5 3.44772 7.94772 3 8.5 3H19C20.1046 3 21 3.89543 21 5V14.5C21 14.7761 20.7761 15 20.5 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <rect x="3" y="7" width="15" height="14" rx="2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M4 18L7.58579 14.4142C8.36684 13.6332 9.63316 13.6332 10.4142 14.4142L12 16L13.0858 14.9142C13.8668 14.1332 15.1332 14.1332 15.9142 14.9142L17 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M13.5 12C12.9477 12 12.5 11.5523 12.5 11C12.5 10.4477 12.9477 10 13.5 10C14.0523 10 14.5 10.4477 14.5 11C14.5 11.5523 14.0523 12 13.5 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/svg/stacked-images.svg
+++ b/svg/stacked-images.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8 3H19C20.1046 3 21 3.89543 21 5V16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 3H19C20.1046 3 21 3.89543 21 5V15C21 16.6569 19.6569 18 18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <rect x="3" y="7" width="15" height="14" rx="2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M4 18L7.58579 14.4142C8.36684 13.6332 9.63316 13.6332 10.4142 14.4142L12 16L13.0858 14.9142C13.8668 14.1332 15.1332 14.1332 15.9142 14.9142L17 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M13.5 12C12.9477 12 12.5 11.5523 12.5 11C12.5 10.4477 12.9477 10 13.5 10C14.0523 10 14.5 10.4477 14.5 11C14.5 11.5523 14.0523 12 13.5 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/svg/stacked-images.svg
+++ b/svg/stacked-images.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 3H19C20.1046 3 21 3.89543 21 5V16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="3" y="7" width="15" height="14" rx="2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 18L7.58579 14.4142C8.36684 13.6332 9.63316 13.6332 10.4142 14.4142L12 16L13.0858 14.9142C13.8668 14.1332 15.1332 14.1332 15.9142 14.9142L17 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 12C12.9477 12 12.5 11.5523 12.5 11C12.5 10.4477 12.9477 10 13.5 10C14.0523 10 14.5 10.4477 14.5 11C14.5 11.5523 14.0523 12 13.5 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/svg/stacked-images.svg
+++ b/svg/stacked-images.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7.5 4C7.5 3.44772 7.94772 3 8.5 3H19C20.1046 3 21 3.89543 21 5V14.5C21 14.7761 20.7761 15 20.5 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 4.5C8 4.22386 8.22386 4 8.5 4H19C20.1046 4 21 4.89543 21 6V15.5C21 15.7761 20.7761 16 20.5 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <rect x="3" y="7" width="15" height="14" rx="2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M4 18L7.58579 14.4142C8.36684 13.6332 9.63316 13.6332 10.4142 14.4142L12 16L13.0858 14.9142C13.8668 14.1332 15.1332 14.1332 15.9142 14.9142L17 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M13.5 12C12.9477 12 12.5 11.5523 12.5 11C12.5 10.4477 12.9477 10 13.5 10C14.0523 10 14.5 10.4477 14.5 11C14.5 11.5523 14.0523 12 13.5 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/tests/commandLineActions/commandLineActions.store.test.js
+++ b/tests/commandLineActions/commandLineActions.store.test.js
@@ -61,6 +61,19 @@ describe("commandLineActions.store", () => {
     expect(characterAction?.label).toBe("Character Sprites");
   });
 
+  it("distinguishes the visual icon from the background icon", () => {
+    const items = selectItems({
+      props: {
+        actionsType: "presentation",
+      },
+    });
+    const backgroundAction = items.find((item) => item.mode === "background");
+    const visualAction = items.find((item) => item.mode === "visual");
+
+    expect(backgroundAction?.icon).toBe("image");
+    expect(visualAction?.icon).toBe("stacked-images");
+  });
+
   it("uses settings icons for generic system actions", () => {
     const items = selectItems({
       props: {

--- a/tests/sceneEditor/lexicalLinePreview.test.js
+++ b/tests/sceneEditor/lexicalLinePreview.test.js
@@ -339,4 +339,30 @@ describe("lexical scene document editor line previews", () => {
       restoreDomGlobals();
     }
   });
+
+  it("distinguishes visual placeholders from background placeholders", async () => {
+    const restoreDomGlobals = installDomGlobals();
+
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorPrototype = LexicalSceneDocumentEditorElement.prototype;
+      const previewItems = editorPrototype.createPreviewItems.call(
+        editorPrototype,
+        {
+          background: {},
+          visual: { items: [] },
+        },
+      );
+
+      expect(
+        Array.from(previewItems.querySelectorAll("rtgl-svg")).map((icon) =>
+          icon.getAttribute("svg"),
+        ),
+      ).toEqual(["image", "stacked-images"]);
+    } finally {
+      restoreDomGlobals();
+    }
+  });
 });

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -53,6 +53,9 @@ describe("systemActions view", () => {
       "fileId=${visualData.spritesheetFileId}",
     );
     expect(systemActionsView).toContain(
+      "rtgl-svg svg=stacked-images wh=24",
+    );
+    expect(systemActionsView).toContain(
       'rtgl-view#actionItemDialogue data-mode=dialogue g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md w=f cur=pointer style="order: ${presentationActionOrder.dialogue}; min-height: 36px;"',
     );
     expect(systemActionsView).toContain(


### PR DESCRIPTION
## Summary
- add a stacked-images SVG that stays visually related to the existing image icon
- use it for Visuals in the action chooser and selected-action summary
- use it for Visual placeholders in the Lexical scene editor while keeping Background on the image icon

## Testing
- bunx vitest run tests/commandLineActions/commandLineActions.store.test.js tests/systemActions/systemActions.view.test.js tests/sceneEditor/lexicalLinePreview.test.js
- bun run lint