### PR TITLE
Fix particle velocity rotation conflict

### DIFF
--- a/src/pages/particles/support/particleForm.js
+++ b/src/pages/particles/support/particleForm.js
@@ -769,7 +769,7 @@ const createParticleFieldsByTab = ({ tagOptions = [], copy = {} } = {}) => {
           copy.faceVelocityDescription ??
           "Turn each particle so it points in the direction it is moving.",
         options: createFaceVelocityOptions(copy),
-        required: true,
+        required: false,
         clearable: false,
       },
     ],
@@ -1136,6 +1136,10 @@ export const buildParticlePayload = ({
   modules.appearance = {
     ...modules.appearance,
   };
+
+  if (modules.movement.faceVelocity) {
+    delete modules.appearance.rotation;
+  }
 
   if (
     areFieldsEqual(values, baseValues, ["textureImageId"]) &&

--- a/tests/particles/particles.form.test.js
+++ b/tests/particles/particles.form.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildParticleFormValues,
+  buildParticlePayload,
+  createParticleForm,
+} from "../../src/pages/particles/support/particleForm.js";
+import { createParticlePreset } from "../../src/pages/particles/support/particlePresets.js";
+
+const createSnowFormValues = () =>
+  buildParticleFormValues({
+    particle: createParticlePreset({ presetId: "snow" }),
+  });
+
+describe("particle form", () => {
+  it("allows Rotate Toward Movement to be off", () => {
+    const form = createParticleForm({ activeTab: "movement" });
+    const faceVelocityField = form.fields.find(
+      (field) => field.name === "faceVelocity",
+    );
+
+    expect(faceVelocityField).toMatchObject({
+      required: false,
+      clearable: false,
+    });
+    expect(createSnowFormValues().faceVelocity).toBe(false);
+  });
+
+  it("removes inherited appearance rotation when facing velocity", () => {
+    const baseParticle = createParticlePreset({ presetId: "snow" });
+    const values = {
+      ...createSnowFormValues(),
+      faceVelocity: true,
+    };
+
+    const particle = buildParticlePayload({
+      baseParticle,
+      values,
+    });
+
+    expect(particle.modules.movement.faceVelocity).toBe(true);
+    expect(particle.modules.appearance).not.toHaveProperty("rotation");
+  });
+
+  it("preserves appearance rotation when facing velocity is off", () => {
+    const baseParticle = createParticlePreset({ presetId: "snow" });
+    const particle = buildParticlePayload({
+      baseParticle,
+      values: createSnowFormValues(),
+    });
+
+    expect(particle.modules.movement.faceVelocity).toBe(false);
+    expect(particle.modules.appearance.rotation).toEqual(
+      baseParticle.modules.appearance.rotation,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- allow Rotate Toward Movement to remain Off without required-field validation
- remove inherited appearance rotation when velocity-facing is enabled
- preserve appearance rotation when velocity-facing is disabled
- add regression coverage for both payload paths

## Validation

- bunx vitest run tests/particles/particles.form.test.js tests/particles/particles.imageSelector.test.js tests/particles/particles.handlers.test.js
- bun run lint
- bun run build:web
- particle VT workflow: 1/1 captured successfully