### PR TITLE
fix: correct layout editor drag and preview behavior

### DIFF
--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -621,8 +621,10 @@ const updateCanvasElementsByOccurrence = (
 
     let nextElement = element;
     if (occurrenceIds.has(element.id)) {
-      nextElement = updateElement(element);
       updateCount += 1;
+      // Apply transient changes at each outer occurrence only. Fragment children
+      // share that owner and would otherwise receive the same delta twice.
+      return updateElement(element);
     }
 
     if (Array.isArray(element.children)) {

--- a/src/components/layoutEditorPreview/layoutEditorPreview.constants.yaml
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.constants.yaml
@@ -5,18 +5,21 @@ dialogueForm:
       type: select
       options: "${characterOptions}"
       clearable: false
-    - name: dialogue-custom-character-name
-      label: Custom Character Name
-      type: segmented-control
-      noClear: true
-      options:
-        - label: "No"
-          value: false
-        - label: "Yes"
-          value: true
-    - name: dialogue-character-name
-      label: Character Name
-      type: input-text
+    - type: row
+      stackAt: sm
+      fields:
+        - name: dialogue-custom-character-name
+          label: Custom Character Name
+          type: segmented-control
+          noClear: true
+          options:
+            - label: "No"
+              value: false
+            - label: "Yes"
+              value: true
+        - name: dialogue-character-name
+          label: Character Name
+          type: input-text
     - name: dialogue-content
       label: Dialogue Content
       type: input-text

--- a/src/components/layoutEditorPreview/layoutEditorPreview.store.js
+++ b/src/components/layoutEditorPreview/layoutEditorPreview.store.js
@@ -152,14 +152,26 @@ const withDialogueCharacterNameField = (form, { visible } = {}) => {
     return form;
   }
 
+  const filterCharacterNameField = (field) => {
+    const nextField = cloneFormField(field);
+
+    if (Array.isArray(nextField?.fields)) {
+      nextField.fields = nextField.fields
+        .map((childField) => filterCharacterNameField(childField))
+        .filter(Boolean);
+    }
+
+    if (!visible && nextField?.name === DIALOGUE_CHARACTER_NAME_FIELD) {
+      return undefined;
+    }
+
+    return nextField;
+  };
+
   return {
     ...form,
     fields: Array.isArray(form.fields)
-      ? form.fields
-          .map((field) => cloneFormField(field))
-          .filter(
-            (field) => visible || field?.name !== DIALOGUE_CHARACTER_NAME_FIELD,
-          )
+      ? form.fields.map(filterCharacterNameField).filter(Boolean)
       : [],
   };
 };

--- a/src/components/layoutEditorPreview/support/layoutEditorPreviewPersistence.js
+++ b/src/components/layoutEditorPreview/support/layoutEditorPreviewPersistence.js
@@ -1,5 +1,16 @@
-import { toVariableConditionTarget } from "../../../internal/layoutConditions.js";
+import {
+  AUTO_MODE_CONDITION_TARGET,
+  LINE_COMPLETED_CONDITION_TARGET,
+  SKIP_MODE_CONDITION_TARGET,
+  toVariableConditionTarget,
+} from "../../../internal/layoutConditions.js";
 import { toRuntimeConditionTarget } from "../../../internal/runtimeFields.js";
+
+const DIALOGUE_RUNTIME_CONDITION_TARGETS = new Set([
+  AUTO_MODE_CONDITION_TARGET,
+  LINE_COMPLETED_CONDITION_TARGET,
+  SKIP_MODE_CONDITION_TARGET,
+]);
 
 const isPlainObject = (value) => {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -41,6 +52,7 @@ export const normalizePersistedPreviewData = (previewData) => {
 export const createPersistedPreviewState = (previewData) => {
   const normalizedPreviewData = normalizePersistedPreviewData(previewData);
   const dialogue = normalizedPreviewData.dialogue ?? {};
+  const hasDialoguePreview = isPlainObject(normalizedPreviewData.dialogue);
   const dialogueLines = getDialogueLines(dialogue);
   const historyDialogue = getHistoryLines(
     normalizedPreviewData.historyDialogue,
@@ -74,7 +86,10 @@ export const createPersistedPreviewState = (previewData) => {
     normalizedPreviewData.runtime ?? {},
   )) {
     const target = toRuntimeConditionTarget(runtimeId);
-    if (!target) {
+    if (
+      !target ||
+      (hasDialoguePreview && DIALOGUE_RUNTIME_CONDITION_TARGETS.has(target))
+    ) {
       continue;
     }
     previewVariableValues[target] = value;

--- a/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
+++ b/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
@@ -599,6 +599,111 @@ describe("layoutEditorCanvas pointer selection", () => {
     });
   });
 
+  it("moves only the outer fragment container in cached drag previews", async () => {
+    const deps = createDeps({ selectedItemId: "fragment-ref" });
+    deps.props.layoutState.elements.items["fragment-ref"] = {
+      type: "fragment-ref",
+      fragmentLayoutId: "fragment-layout",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    };
+    const fragmentElements = [
+      {
+        id: "fragment-ref",
+        type: "container",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        children: [
+          {
+            id: "fragment-ref--fragment-child",
+            type: "rect",
+            x: 20,
+            y: 20,
+            width: 40,
+            height: 40,
+          },
+        ],
+      },
+    ];
+    deps.store.setSelectionOccurrences({
+      occurrencesById: {
+        "fragment-ref": {
+          ownerItemId: "fragment-ref",
+          authoredPath: ["fragment-ref"],
+        },
+        "fragment-ref--fragment-child": {
+          ownerItemId: "fragment-ref",
+          authoredPath: ["fragment-ref"],
+        },
+      },
+      occurrenceIdsByOwner: {
+        "fragment-ref": ["fragment-ref", "fragment-ref--fragment-child"],
+      },
+    });
+    deps.store.setCanvasRenderState({
+      elements: fragmentElements,
+      baseElements: fragmentElements,
+      parsedElements: fragmentElements,
+      canvasUnitsPerCssPixel: 1,
+    });
+    deps.graphicsService.hitTestElementBounds.mockReturnValue([
+      {
+        path: [
+          {
+            id: "fragment-ref",
+            type: "container",
+            bounds: bounds(0, 0, 100, 100),
+          },
+          {
+            id: "fragment-ref--fragment-child",
+            type: "rect",
+            bounds: bounds(20, 20, 40, 40),
+          },
+        ],
+      },
+    ]);
+    deps.graphicsService.render.mockClear();
+    const currentTarget = {
+      setPointerCapture: vi.fn(),
+    };
+    const pointerEvent = {
+      button: 0,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "mouse",
+      currentTarget,
+      clientX: 30,
+      clientY: 30,
+      metaKey: false,
+      ctrlKey: false,
+    };
+
+    handleCanvasPointerDown(deps, { _event: pointerEvent });
+    await handleCanvasPointerMove(deps, {
+      _event: {
+        ...pointerEvent,
+        clientX: 40,
+        clientY: 35,
+      },
+    });
+
+    const lastRender = deps.graphicsService.render.mock.calls.at(-1)[0];
+    expect(lastRender.elements[0]).toMatchObject({
+      id: "fragment-ref",
+      x: 10,
+      y: 5,
+    });
+    expect(lastRender.elements[0].children[0]).toMatchObject({
+      id: "fragment-ref--fragment-child",
+      x: 20,
+      y: 20,
+    });
+  });
+
   it("moves the selected item from its center after crossing the drag threshold", async () => {
     const deps = createDeps({ selectedItemId: "parent" });
     deps.graphicsService.hitTestElementBounds.mockReturnValue([

--- a/tests/layoutEditor/layoutEditorPreview.store.test.js
+++ b/tests/layoutEditor/layoutEditorPreview.store.test.js
@@ -21,10 +21,15 @@ const TEST_CONSTANTS = {
         name: "dialogue-character-id",
       },
       {
-        name: "dialogue-custom-character-name",
-      },
-      {
-        name: "dialogue-character-name",
+        type: "row",
+        fields: [
+          {
+            name: "dialogue-custom-character-name",
+          },
+          {
+            name: "dialogue-character-name",
+          },
+        ],
       },
       {
         name: "dialogue-content",
@@ -47,9 +52,21 @@ const TEST_CONSTANTS = {
 
 describe("layoutEditorPreview.store", () => {
   const getNamedFieldNames = (form) => {
-    return form.fields
-      .map((field) => field.name)
-      .filter((name) => typeof name === "string" && name.length > 0);
+    const getFieldNames = (fields = []) => {
+      return fields.flatMap((field) => {
+        const names =
+          typeof field.name === "string" && field.name.length > 0
+            ? [field.name]
+            : [];
+        return [...names, ...getFieldNames(field.fields)];
+      });
+    };
+
+    return getFieldNames(form.fields);
+  };
+
+  const getDialogueNameRow = (form) => {
+    return form.fields.find((field) => field.type === "row");
   };
 
   it("shows dialogue preview and character options for general layouts using dialogue.characterId", () => {
@@ -121,6 +138,9 @@ describe("layoutEditorPreview.store", () => {
       "dialogue-custom-character-name",
       "dialogue-content",
     ]);
+    expect(
+      getNamedFieldNames(getDialogueNameRow(viewData.dialogueForm)),
+    ).toEqual(["dialogue-custom-character-name"]);
     expect(viewData.dialogueContext.characterOptions).toEqual([
       {
         value: "",
@@ -184,6 +204,9 @@ describe("layoutEditorPreview.store", () => {
       "dialogue-character-name",
       "dialogue-content",
     ]);
+    expect(
+      getNamedFieldNames(getDialogueNameRow(viewData.dialogueForm)),
+    ).toEqual(["dialogue-custom-character-name", "dialogue-character-name"]);
   });
 
   it("shows preview controls for every input field in the layout", () => {

--- a/tests/layoutEditor/layoutEditorPreviewPersistence.test.js
+++ b/tests/layoutEditor/layoutEditorPreviewPersistence.test.js
@@ -8,6 +8,7 @@ import {
   createInitialState as createPreviewComponentState,
   hydratePreviewState,
   selectPreviewData,
+  setDialogueDefaultValue,
   setLayoutState,
   setRepositoryState,
 } from "../../src/components/layoutEditorPreview/layoutEditorPreview.store.js";
@@ -119,6 +120,70 @@ describe("layoutEditor preview persistence", () => {
         content: [{ text: "Saved dialogue preview" }],
       },
     });
+  });
+
+  it("applies dialogue runtime toggles after hydrating persisted preview data", () => {
+    const state = createPreviewComponentState();
+    setLayoutState(
+      { state },
+      {
+        layoutState: {
+          id: "layout-dialogue",
+          layoutType: "dialogue-adv",
+          elements: EMPTY_COLLECTION,
+        },
+      },
+    );
+    setRepositoryState(
+      { state },
+      {
+        repositoryState: {
+          layouts: EMPTY_COLLECTION,
+          images: EMPTY_COLLECTION,
+          variables: EMPTY_COLLECTION,
+        },
+      },
+    );
+    hydratePreviewState(
+      { state },
+      {
+        previewData: {
+          runtime: {
+            skipMode: false,
+          },
+          dialogue: {
+            content: [{ text: "Saved dialogue preview" }],
+          },
+        },
+      },
+    );
+
+    setDialogueDefaultValue(
+      { state },
+      {
+        name: "dialogue-skip-mode",
+        fieldValue: true,
+      },
+    );
+
+    expect(selectPreviewData({ state }).runtime.skipMode).toBe(true);
+  });
+
+  it("keeps runtime overrides for previews without dialogue data", () => {
+    const state = createPreviewComponentState();
+
+    hydratePreviewState(
+      { state },
+      {
+        previewData: {
+          runtime: {
+            skipMode: true,
+          },
+        },
+      },
+    );
+
+    expect(state.previewVariableValues["runtime.skipMode"]).toBe(true);
   });
 
   it("loads persisted preview data but preserves unsaved local preview edits on refresh", () => {

--- a/vt/specs/project/layouts.yaml
+++ b/vt/specs/project/layouts.yaml
@@ -262,4 +262,59 @@ steps:
   - action: wait
     ms: 600
   - action: screenshot
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { window.dispatchEvent(new CustomEvent('routevn:vt:navigate', { detail: { path: '/project/layouts' } })); return 'requested'; })()"
+    value: "requested"
+  - action: waitFor
+    selector: rvn-layouts
+    state: attached
+    timeoutMs: 10000
+  - action: assert
+    type: url
+    value: /project/layouts
+  - action: waitFor
+    selector: "#groupview [data-item-id='fKr5fa67MQWh']"
+    state: visible
+    timeoutMs: 10000
+  - action: select
+    selector: "#groupview [data-item-id='fKr5fa67MQWh']"
+    steps:
+      - action: dblclick
+  - action: waitFor
+    selector: rvn-layout-editor
+    state: attached
+    timeoutMs: 20000
+  - action: waitFor
+    selector: "#fileExplorer [data-item-id='wTne3pvWw7ui'] rtgl-text"
+    state: visible
+    timeoutMs: 10000
+  - action: select
+    selector: "#fileExplorer [data-item-id='wTne3pvWw7ui'] rtgl-text"
+    steps:
+      - action: click
+  - action: wait
+    ms: 300
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const findById = (elements, id) => { for (const element of Array.isArray(elements) ? elements : []) { if (element?.id === id) return element; const child = findById(element?.children, id); if (child) return child; } }; const fragmentId = 'wTne3pvWw7ui'; const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas'); const renderState = canvas?.store?.selectCanvasRenderState?.(); const occurrenceState = canvas?.store?.selectSelectionOccurrenceState?.(); const root = findById(renderState?.baseElements, fragmentId); const descendantIds = (occurrenceState?.occurrenceIdsByOwner?.[fragmentId] ?? []).filter((id) => id !== fragmentId); const descendants = descendantIds.map((id) => findById(renderState?.baseElements, id)).filter(Boolean); if (!canvas || !root || descendants.length < 2) return 'missing-fragment'; window.__vtFragmentDragBaseline = descendants.map(({ id, x, y, width, height, rotation }) => ({ id, x, y, width, height, rotation })); window.__vtFragmentDragExpected = { x: (root.x ?? 0) + 20, y: (root.y ?? 0) + 10 }; const graphicsService = canvas.deps.graphicsService; window.__vtFragmentOriginalRender = graphicsService.render; graphicsService.render = (payload) => { window.__vtFragmentDragElements = payload?.elements; return window.__vtFragmentOriginalRender(payload); }; canvas.deps.subject.dispatch('border-drag-start', { targetId: 'selected-border' }); canvas.deps.subject.dispatch('border-drag-move', { x: 0, y: 0 }); canvas.deps.subject.dispatch('border-drag-move', { x: 20, y: 10 }); return canvas.store.selectDragging().isDragging && window.__vtFragmentDragElements ? 'dragged' : 'missing-drag'; })()"
+    value: "dragged"
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const findById = (elements, id) => { for (const element of Array.isArray(elements) ? elements : []) { if (element?.id === id) return element; const child = findById(element?.children, id); if (child) return child; } }; const root = findById(window.__vtFragmentDragElements, 'wTne3pvWw7ui'); const fields = ['x', 'y', 'width', 'height', 'rotation']; const descendantsStayedLocal = window.__vtFragmentDragBaseline.every((before) => { const after = findById(window.__vtFragmentDragElements, before.id); return after && fields.every((field) => Object.is(after[field], before[field])); }); return String(root?.x === window.__vtFragmentDragExpected.x && root?.y === window.__vtFragmentDragExpected.y && descendantsStayedLocal); })()"
+    value: "true"
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas'); if (!canvas || !window.__vtFragmentOriginalRender) return 'missing-drag'; canvas.deps.graphicsService.render = window.__vtFragmentOriginalRender; canvas.deps.subject.dispatch('border-drag-end'); delete window.__vtFragmentOriginalRender; delete window.__vtFragmentDragElements; delete window.__vtFragmentDragBaseline; delete window.__vtFragmentDragExpected; return 'released'; })()"
+    value: "released"
+  - action: wait
+    ms: 500
 ---

--- a/vt/specs/project/layouts.yaml
+++ b/vt/specs/project/layouts.yaml
@@ -317,4 +317,52 @@ steps:
     value: "released"
   - action: wait
     ms: 500
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { window.dispatchEvent(new CustomEvent('routevn:vt:navigate', { detail: { path: '/project/layouts' } })); return 'requested'; })()"
+    value: "requested"
+  - action: waitFor
+    selector: rvn-layouts
+    state: attached
+    timeoutMs: 10000
+  - action: waitFor
+    selector: "#groupview [data-item-id='6E1mZaxeXgaN']"
+    state: visible
+    timeoutMs: 10000
+  - action: select
+    selector: "#groupview [data-item-id='6E1mZaxeXgaN']"
+    steps:
+      - action: dblclick
+  - action: waitFor
+    selector: rvn-layout-editor
+    state: attached
+    timeoutMs: 20000
+  - action: waitFor
+    selector: "#dialogueForm rtgl-segmented-control[data-field-name='dialogue-skip-mode'] #option1"
+    state: visible
+    timeoutMs: 10000
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const customNameField = deepQuery(document, \"rtgl-segmented-control[data-field-name='dialogue-custom-character-name']\"); const characterNameField = deepQuery(document, \"rtgl-input[data-field-name='dialogue-character-name']\"); const customNameTop = customNameField?.closest('.form-field')?.getBoundingClientRect()?.top; const characterNameTop = characterNameField?.closest('.form-field')?.getBoundingClientRect()?.top; return String(Number.isFinite(customNameTop) && Number.isFinite(characterNameTop) && Math.abs(customNameTop - characterNameTop) < 1); })()"
+    value: "true"
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const findById = (elements, id) => { for (const element of Array.isArray(elements) ? elements : []) { if (element?.id === id) return element; const child = findById(element?.children, id); if (child) return child; } }; const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas'); const elements = canvas?.store?.selectCanvasRenderState?.()?.baseElements; return String(canvas?.props?.previewData?.runtime?.skipMode === false && !findById(elements, '5Ubcqe8z5qbv')); })()"
+    value: "true"
+  - action: select
+    selector: "#dialogueForm rtgl-segmented-control[data-field-name='dialogue-skip-mode'] #option1"
+    steps:
+      - action: click
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(async () => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const findById = (elements, id) => { for (const element of Array.isArray(elements) ? elements : []) { if (element?.id === id) return element; const child = findById(element?.children, id); if (child) return child; } }; const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas'); const deadline = Date.now() + 10000; while (Date.now() < deadline) { const elements = canvas?.store?.selectCanvasRenderState?.()?.baseElements; if (canvas?.props?.previewData?.runtime?.skipMode === true && Boolean(findById(elements, '5Ubcqe8z5qbv'))) return 'true'; await new Promise((resolve) => setTimeout(resolve, 100)); } return 'false'; })()"
+    value: "true"
 ---


### PR DESCRIPTION
## Summary
- update transient canvas occurrences only at their outer owned node so nested fragment content keeps its local geometry during drag
- let dialogue preview controls own Auto Mode, Skip Mode, and Line Completed values after persisted preview hydration
- place Custom Character Name and Character Name in the same responsive form row
- extend unit and layouts VT regression coverage for the drag and preview behavior

## Testing
- `bunx vitest run tests/layoutEditor/layoutEditorCanvas.handlers.test.js tests/layoutEditor/layoutEditorCanvasSelection.test.js` (31 passed)
- `bunx vitest run tests/layoutEditor/layoutEditorPreviewPersistence.test.js tests/layoutEditor/layoutEditorPreview.store.test.js tests/layoutEditor/layoutEditorPreview.test.js` (33 passed)
- focused local Playwright validation against the built app:
  - fragment root moved while all 11 descendants retained local geometry
  - enabling Skip Mode changed canvas runtime state and rendered the seeded conditional group
  - Custom Character Name and Character Name had the same row position
- `bun run build:web`
- pre-push hook: `oxlint`
- pre-push hook: `bun prettier --check src`

## Notes
- the broader `bunx vitest run tests/layoutEditor` run has 3 unrelated failures in `layoutEditorPreview.handlers.test.js` because its mock store does not provide `selectDialogueDefaultValues`; the other 207 tests passed
- the local full VT runner stopped before completing the layouts scenario with `Cannot read properties of undefined (reading invoke)`; focused browser validation of the added scenarios passed
