### PR TITLE
Align animation editor and sound player controls

### DIFF
--- a/src/components/audioPlayer/audioPlayer.view.yaml
+++ b/src/components/audioPlayer/audioPlayer.view.yaml
@@ -40,14 +40,15 @@ template:
                       - 'rtgl-view#playerCloser w=32 h=32 av=c ah=c cur=pointer style="flex: 0 0 32px;"':
                           - rtgl-svg svg=cross w=16 h=16: null
                 $else:
-                  - 'rtgl-view ph=md d=h av=c w=f h=1fg p=md pos=rel style="min-height: 0;"':
-                      - rtgl-text w=250 ellipsis=true: ${title}
+                  - 'rtgl-view ph=md d=h av=c w=f h=1fg p=md pos=rel style="min-width: 0; min-height: 0;"':
+                      - 'rtgl-view w=1fg style="min-width: 0; padding-right: 32px; box-sizing: border-box;"':
+                          - 'rtgl-text w=f ellipsis=true style="min-width: 0;"': ${title}
                       - 'rtgl-view#playPauseBtn pos=abs cur=pointer style="left: 50%; top: 50%; transform: translate(-50%, -50%);"':
                           - $if isPlaying:
                               - rtgl-svg wh=32 svg=pause: null
                             $else:
                               - rtgl-svg wh=32 svg=play: null
-                      - rtgl-view d=h av=c g=lg w=1fg ah=e:
+                      - 'rtgl-view d=h av=c g=lg w=1fg ah=e style="min-width: 0; padding-left: 32px; box-sizing: border-box;"':
                           - rtgl-view d=h av=c g=sm:
                               - rtgl-text s=sm c=mu-fg: ${currentTimeFormatted}
                               - rtgl-text s=sm c=mu-fg: /

--- a/src/components/audioPlayer/audioPlayer.view.yaml
+++ b/src/components/audioPlayer/audioPlayer.view.yaml
@@ -40,17 +40,17 @@ template:
                       - 'rtgl-view#playerCloser w=32 h=32 av=c ah=c cur=pointer style="flex: 0 0 32px;"':
                           - rtgl-svg svg=cross w=16 h=16: null
                 $else:
-                  - 'rtgl-view ph=md d=h av=c w=f h=1fg p=md style="min-height: 0;"':
+                  - 'rtgl-view ph=md d=h av=c w=f h=1fg p=md pos=rel style="min-height: 0;"':
                       - rtgl-text w=250 ellipsis=true: ${title}
-                      - rtgl-view d=h av=c g=lg w=1fg ah=c:
-                          - rtgl-view#playPauseBtn cur=pointer:
-                              - $if isPlaying:
-                                  - rtgl-svg wh=32 svg=pause: null
-                                $else:
-                                  - rtgl-svg wh=32 svg=play: null
+                      - 'rtgl-view#playPauseBtn pos=abs cur=pointer style="left: 50%; top: 50%; transform: translate(-50%, -50%);"':
+                          - $if isPlaying:
+                              - rtgl-svg wh=32 svg=pause: null
+                            $else:
+                              - rtgl-svg wh=32 svg=play: null
+                      - rtgl-view d=h av=c g=lg w=1fg ah=e:
                           - rtgl-view d=h av=c g=sm:
                               - rtgl-text s=sm c=mu-fg: ${currentTimeFormatted}
                               - rtgl-text s=sm c=mu-fg: /
                               - rtgl-text s=sm c=mu-fg: ${durationFormatted}
-                      - rtgl-view#playerCloser w=24 h=24 av=c ah=c cur=pointer:
-                          - rtgl-svg svg=cross w=16 h=16: null
+                          - rtgl-view#playerCloser w=24 h=24 av=c ah=c cur=pointer:
+                              - rtgl-svg svg=cross w=16 h=16: null

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -836,7 +836,6 @@ animationEditorPage:
   translateYPropertyTooltip: "Uses viewport-height units. 1 moves by one full screen height, -1 moves by one full screen height upward."
   tweenModeLabel: "Tween Mode"
   tweenPropertiesTitle: "Tween Properties"
-  tweenTitle: "Tween"
   unsupportedMaskDescription: "This existing mask will be preserved when you save. Remove it if you want to add a new single-image mask."
   unsupportedMaskMessageSuffix: "masks are hidden for now"
   updateAutoTweenButton: "Update Auto Tween"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -836,7 +836,6 @@ animationEditorPage:
   translateYPropertyTooltip: "画面高さ単位を使います。1で画面高さ1つ分下へ、-1で画面高さ1つ分上へ移動します。"
   tweenModeLabel: "トゥイーンモード"
   tweenPropertiesTitle: "トゥイーンプロパティ"
-  tweenTitle: "トゥイーン"
   unsupportedMaskDescription: "保存時に既存のマスクは保持されます。新しい単一画像マスクを追加したい場合は削除してください。"
   unsupportedMaskMessageSuffix: "形式のマスクは現在非表示です"
   updateAutoTweenButton: "自動トゥイーンを更新"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -836,7 +836,6 @@ animationEditorPage:
   translateYPropertyTooltip: "使用视口高度单位。1 表示向下移动一个完整屏幕高度，-1 表示向上移动一个完整屏幕高度。"
   tweenModeLabel: "补间模式"
   tweenPropertiesTitle: "补间属性"
-  tweenTitle: "补间"
   unsupportedMaskDescription: "保存时会保留这个现有遮罩。如果要添加新的单图遮罩，请先移除它。"
   unsupportedMaskMessageSuffix: "遮罩暂时隐藏"
   updateAutoTweenButton: "更新自动补间"

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -4014,7 +4014,7 @@ export const selectViewData = ({ state, i18n }) => {
     editorTabs: [
       {
         id: DEFAULT_EDITOR_TAB,
-        label: copy.tweenTitle ?? "Tween",
+        label: copy.timelineLabel ?? "Timeline",
         panelId: "animationTweenPanel",
       },
       {

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -522,6 +522,9 @@ template:
                               - rtgl-button#addPropertiesButton data-side=update pre=plus s=sm: ${addButton}
                           - $if dialogType == 'transition' && transitionAddPropertyButtonVisible:
                               - rtgl-button#addPropertiesButton pre=plus s=sm: ${addButton}
+                        $else:
+                          - rtgl-view w=1fg: null
+                          - rtgl-button#savePreviewButton s=sm: ${saveButton}
                   - $if selectedEditorTab == 'tween':
                       - 'rtgl-view#animationTweenPanel role=tabpanel aria-labelledby=animationEditorTab0 d=v w=f h=1fg g=md style="min-height: 0;"':
                           - $if dialogType == 'update':
@@ -592,9 +595,6 @@ template:
                                           - 'rtgl-view pos=abs bgc=fg op="0.5" style="${timelinePlayheadStyle}"': null
                     $else:
                       - 'rtgl-view#animationPreviewPanel role=tabpanel aria-labelledby=animationEditorTab1 w=f h=1fg d=v style="min-height: 0;"':
-                          - rtgl-view h=40 w=f d=h av=c g=sm:
-                              - rtgl-view w=1fg: null
-                              - rtgl-button#savePreviewButton s=sm: ${saveButton}
                           - 'rtgl-view w=f h=1fg sv style="min-height: 0;"':
                               - rtgl-view d=v w=f g=md pb=xl:
                                   - $for item, i in previewPanel.items:

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -69,14 +69,14 @@ import {
 import { EN_I18N } from "../support/i18n.js";
 
 describe("animationEditor.store", () => {
-  it("defaults to Tween and exposes Tween and Preview tabs", () => {
+  it("defaults to Timeline and exposes Timeline and Preview tabs", () => {
     const state = createInitialState();
 
     expect(selectSelectedEditorTab({ state })).toBe("tween");
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
       selectedEditorTab: "tween",
       editorTabs: [
-        { id: "tween", label: "Tween" },
+        { id: "tween", label: "Timeline" },
         { id: "preview", label: "Preview" },
       ],
     });

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -270,7 +270,7 @@ describe("animationEditor view", () => {
     expect(view).not.toContain("property-name-right-click");
   });
 
-  it("places zoom controls before Add and lets the timeline scroll on both axes", () => {
+  it("places tab actions in the toolbar and lets the timeline scroll on both axes", () => {
     const view = readFileSync(
       new URL(
         "../../src/pages/animationEditor/animationEditor.view.yaml",
@@ -284,6 +284,7 @@ describe("animationEditor view", () => {
     );
     const toolbarStart = view.indexOf("rtgl-view#animationEditorToolbar");
     const tweenPanelStart = view.indexOf("rtgl-view#animationTweenPanel");
+    const previewPanelStart = view.indexOf("rtgl-view#animationPreviewPanel");
     expect(toolbarStart).toBeGreaterThan(-1);
     expect(view.indexOf("rtgl-view#animationEditorTabs")).toBeGreaterThan(
       toolbarStart,
@@ -293,6 +294,12 @@ describe("animationEditor view", () => {
     );
     expect(view.indexOf("rtgl-button#addPropertiesButton")).toBeLessThan(
       tweenPanelStart,
+    );
+    expect(view.indexOf("rtgl-button#savePreviewButton")).toBeGreaterThan(
+      toolbarStart,
+    );
+    expect(view.indexOf("rtgl-button#savePreviewButton")).toBeLessThan(
+      previewPanelStart,
     );
     expect(view).toContain(
       "min=${timelineZoomMin} max=${timelineZoomMax} step=${timelineZoomStep} value=${timelineZoom}",

--- a/tests/audioPlayer/audioPlayer.view.test.js
+++ b/tests/audioPlayer/audioPlayer.view.test.js
@@ -47,12 +47,12 @@ describe("audio player view", () => {
       'rtgl-view d=h av=c w=f h=1fg p=md g=md style="min-width: 0; min-height: 0; box-sizing: border-box;"',
     );
     expect(audioPlayerView).toContain(
-      'rtgl-view ph=md d=h av=c w=f h=1fg p=md pos=rel style="min-height: 0;"',
+      'rtgl-view ph=md d=h av=c w=f h=1fg p=md pos=rel style="min-width: 0; min-height: 0;"',
     );
     expect(audioPlayerView).not.toContain("rtgl-view w=f g=md bgc=mu");
   });
 
-  it("centers the desktop play button in the player", () => {
+  it("centers the desktop play button without overlapping narrow titles", () => {
     const audioPlayerView = readFileSync(
       new URL(
         "../../src/components/audioPlayer/audioPlayer.view.yaml",
@@ -68,11 +68,19 @@ describe("audio player view", () => {
     const desktopBranch = audioPlayerView.slice(desktopBranchStart);
 
     expect(desktopBranchStart).toBeGreaterThan(-1);
-    expect(desktopBranch).toContain("rtgl-text w=250 ellipsis=true");
-    expect(desktopBranch).toContain("rtgl-view d=h av=c g=lg w=1fg ah=e");
+    expect(desktopBranch).toContain(
+      'rtgl-view w=1fg style="min-width: 0; padding-right: 32px; box-sizing: border-box;"',
+    );
+    expect(desktopBranch).toContain(
+      'rtgl-text w=f ellipsis=true style="min-width: 0;"',
+    );
     expect(desktopBranch).toContain(
       'rtgl-view#playPauseBtn pos=abs cur=pointer style="left: 50%; top: 50%; transform: translate(-50%, -50%);"',
     );
+    expect(desktopBranch).toContain(
+      'rtgl-view d=h av=c g=lg w=1fg ah=e style="min-width: 0; padding-left: 32px; box-sizing: border-box;"',
+    );
+    expect(desktopBranch).not.toContain("rtgl-text w=250 ellipsis=true");
     expect(desktopBranch).toContain(
       "rtgl-view#playerCloser w=24 h=24 av=c ah=c cur=pointer",
     );

--- a/tests/audioPlayer/audioPlayer.view.test.js
+++ b/tests/audioPlayer/audioPlayer.view.test.js
@@ -47,12 +47,12 @@ describe("audio player view", () => {
       'rtgl-view d=h av=c w=f h=1fg p=md g=md style="min-width: 0; min-height: 0; box-sizing: border-box;"',
     );
     expect(audioPlayerView).toContain(
-      'rtgl-view ph=md d=h av=c w=f h=1fg p=md style="min-height: 0;"',
+      'rtgl-view ph=md d=h av=c w=f h=1fg p=md pos=rel style="min-height: 0;"',
     );
     expect(audioPlayerView).not.toContain("rtgl-view w=f g=md bgc=mu");
   });
 
-  it("keeps desktop playback controls centered after the title", () => {
+  it("centers the desktop play button in the player", () => {
     const audioPlayerView = readFileSync(
       new URL(
         "../../src/components/audioPlayer/audioPlayer.view.yaml",
@@ -69,10 +69,15 @@ describe("audio player view", () => {
 
     expect(desktopBranchStart).toBeGreaterThan(-1);
     expect(desktopBranch).toContain("rtgl-text w=250 ellipsis=true");
-    expect(desktopBranch).toContain("rtgl-view d=h av=c g=lg w=1fg ah=c");
-    expect(desktopBranch).toContain("rtgl-view#playPauseBtn cur=pointer");
+    expect(desktopBranch).toContain("rtgl-view d=h av=c g=lg w=1fg ah=e");
+    expect(desktopBranch).toContain(
+      'rtgl-view#playPauseBtn pos=abs cur=pointer style="left: 50%; top: 50%; transform: translate(-50%, -50%);"',
+    );
     expect(desktopBranch).toContain(
       "rtgl-view#playerCloser w=24 h=24 av=c ah=c cur=pointer",
+    );
+    expect(desktopBranch.indexOf("${title}")).toBeLessThan(
+      desktopBranch.indexOf("rtgl-view#playPauseBtn"),
     );
     expect(desktopBranch.indexOf("rtgl-view#playPauseBtn")).toBeLessThan(
       desktopBranch.indexOf("${currentTimeFormatted}"),

--- a/vt/specs/project/sounds.yaml
+++ b/vt/specs/project/sounds.yaml
@@ -125,6 +125,12 @@ steps:
     type: js
     fn: eval
     args:
+      - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const player = deepQuery(document, '#rvnAudioPlayer'); const playerBody = deepQuery(player?.shadowRoot, 'rtgl-view[bgc=\"mu\"]'); const playButton = deepQuery(player?.shadowRoot, '#playPauseBtn'); if (!playerBody || !playButton) return false; const playerRect = playerBody.getBoundingClientRect(); const buttonRect = playButton.getBoundingClientRect(); return Math.abs(buttonRect.left + buttonRect.width / 2 - (playerRect.left + playerRect.width / 2)) <= 1; })()"
+    value: true
+  - action: assert
+    type: js
+    fn: eval
+    args:
       - "(() => { const deepQuery = (root, selector) => { if (!root) return undefined; const direct = root.querySelector?.(selector); if (direct) return direct; for (const node of root.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const player = deepQuery(document, '#rvnAudioPlayer'); const progressTrack = deepQuery(player?.shadowRoot, '#progressBar'); const playerBody = deepQuery(player?.shadowRoot, 'rtgl-view[bgc=\"mu\"]'); return Boolean(progressTrack && playerBody && getComputedStyle(progressTrack).backgroundColor !== getComputedStyle(playerBody).backgroundColor); })()"
     value: true
   - action: keypress


### PR DESCRIPTION
## Summary

- move the animation preview Save action into the shared tab toolbar
- rename the Tween tab to Timeline using existing localized timeline copy
- center the desktop audio player play control while preserving the original vertical layout
- add focused view and VT regression coverage

## Validation

- bun run lint
- bunx vitest run tests/animationEditor
- bunx vitest run tests/audioPlayer tests/sounds