### PR TITLE
fix: correct character custom transform editing

### DIFF
--- a/src/components/actionTransformEditor/actionTransformEditor.handlers.js
+++ b/src/components/actionTransformEditor/actionTransformEditor.handlers.js
@@ -2,7 +2,10 @@ import {
   applyTransformPositionIntent,
   createTransformKeyboardIntent,
 } from "../../internal/transformKeyboard.js";
-import { normalizeBackgroundTransformEditorTransform } from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
+import {
+  applyBackgroundTransformAnchorOrigin,
+  normalizeBackgroundTransformEditorTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 
 const dispatchTransformChange = (
   { dispatchEvent },
@@ -23,7 +26,11 @@ const dispatchTransformChange = (
   );
 };
 
-const createTransformFromInspectorValues = (currentTransform, values = {}) => {
+const createTransformFromInspectorValues = (
+  currentTransform,
+  values = {},
+  selectedElementMetrics,
+) => {
   const nextTransform = {
     ...currentTransform,
     ...values,
@@ -37,7 +44,10 @@ const createTransformFromInspectorValues = (currentTransform, values = {}) => {
   }
   delete nextTransform.anchor;
 
-  return normalizeBackgroundTransformEditorTransform(nextTransform);
+  return applyBackgroundTransformAnchorOrigin({
+    transform: nextTransform,
+    selectedElementMetrics,
+  });
 };
 
 export const handleBeforeMount = ({ store, uiConfig }) => {
@@ -45,10 +55,12 @@ export const handleBeforeMount = ({ store, uiConfig }) => {
 };
 
 export const handleInspectorUpdate = (deps, payload) => {
+  const { props } = deps;
   const detail = payload._event.detail;
   const transform = createTransformFromInspectorValues(
-    deps.props.transform,
+    props.transform,
     detail.formValues,
+    props.selectedElementMetrics,
   );
 
   dispatchTransformChange(deps, {

--- a/src/components/commandLineCharacters/commandLineCharacters.handlers.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.handlers.js
@@ -430,6 +430,15 @@ export const handleCustomTransformButtonClick = (deps, payload) => {
   );
 };
 
+export const handleCustomTransformButtonKeyDown = (deps, payload) => {
+  const event = payload._event;
+  if (event.key !== "Enter" && event.key !== " ") {
+    return;
+  }
+
+  handleCustomTransformButtonClick(deps, payload);
+};
+
 export const handleAnimationChange = (deps, payload) => {
   const { store, render } = deps;
   const index = Number.parseInt(payload._event.currentTarget.dataset.index, 10);

--- a/src/components/commandLineCharacters/commandLineCharacters.store.js
+++ b/src/components/commandLineCharacters/commandLineCharacters.store.js
@@ -1733,13 +1733,8 @@ export const selectViewData = ({ state, i18n }) => {
     noAvatarLabel: localizeCommandLineText("No Avatar", copy),
     noPreviewLabel: localizeCommandLineText("No preview", copy),
     noSpriteLabel: localizeCommandLineText("No Sprite", copy),
-    editButtonLabel: localizeCommandLineText("Edit", copy),
     opacityLabel: localizeCommandLineText("Opacity", copy),
     removeOpacityLabel: localizeCommandLineText("Remove Opacity", copy),
-    animationPlaybackLoopDisabledDescription: localizeCommandLineText(
-      "loopingRequiresKeyframesDescription",
-      copy,
-    ),
     selectAnimationPlaceholder: localizeCommandLineText(
       "Select animation",
       copy,

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -74,10 +74,8 @@ refs:
     eventListeners:
       click:
         handler: handleCustomTransformButtonClick
-  customTransformChip*:
-    eventListeners:
-      click:
-        handler: handleCustomTransformButtonClick
+      keydown:
+        handler: handleCustomTransformButtonKeyDown
   animation*:
     eventListeners:
       value-change:
@@ -166,13 +164,12 @@ template:
                           - $if !character.customTransform:
                               - 'rtgl-select#transform${i} slot=${character.predefinedTransformFormSlot} data-index=${character.characterIndex} key=${character.transformId} :options=${defaultValues.transformOptions} :selectedValue=${character.transformId} w=f no-clear': null
                           - $if character.customTransform:
-                              - 'rtgl-view.characterRow slot=${character.customTransformFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} d=h av=c w=f g=md':
-                                  - rtgl-view d=h av=c w=1fg g=sm wrap:
+                              - 'rtgl-view#customTransformButton${i}.characterRow slot=${character.customTransformFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} data-target-name="${character.displayName}" role=button tabindex=0 aria-label="${transformEditorTitle}" w=f p=md bw=xs bc=bo h-bc=pr br=md bgc=bg cur=pointer style="box-sizing: border-box;"':
+                                  - rtgl-grid cols=2 g=md w=f:
                                       - $for item, j in character.customTransformDetails:
-                                          - 'rtgl-view#customTransformChip${i}x${j} data-index=${character.characterIndex} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
-                                              - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
-                                              - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
-                                  - rtgl-button#customTransformButton${i} data-index=${character.characterIndex} data-target-name="${character.displayName}" v=se: ${editButtonLabel}
+                                          - rtgl-view d=h av=c g=sm:
+                                              - rtgl-text s=sm c=mu-fg: ${item.label}
+                                              - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums;"': ${item.value}
                           - 'rtgl-view.characterRow slot=${character.animationFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} w=f':
                               - rtgl-select#animation${i} data-index=${character.characterIndex} key=${character.animationId} :options=${defaultValues.animationOptions} :selectedValue=${character.animationId} w=f placeholder=${selectAnimationPlaceholder}: null
                           - $if character.animationId:
@@ -183,8 +180,6 @@ template:
                               - $if character.animationMode == 'update':
                                   - 'rtgl-view.characterRow slot=${character.playbackLoopFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} g=xs w=f':
                                       - rtgl-segmented-control#animationPlaybackLoop${i} data-index=${character.characterIndex} w=f no-clear ?disabled=${character.animationLoopDisabled} :selectedValue=${character.animationPlaybackLoop} :options=${defaultValues.animationPlaybackLoopOptions}: null
-                                      - $if !character.animationCanLoop:
-                                          - rtgl-text s=xs c=mu-fg: ${animationPlaybackLoopDisabledDescription}
                           - $if character.opacityOptionEnabled:
                               - 'rtgl-view.characterRow slot=${character.opacityFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} g=md w=f':
                                   - rtgl-view d=h av=c w=f g=md:
@@ -202,7 +197,7 @@ template:
                                   - $for spriteGroup, j in character.spriteGroupBoxes:
                                       - 'rtgl-view.characterSpriteGroupBox data-index=${character.characterIndex} data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
                                           - rtgl-text s=xs: ${spriteGroup.name}
-                  - rtgl-button#addCharacterButton v=ol w=f mt=md: ${addCharacterButtonLabel}
+                  - rtgl-button#addCharacterButton v=ol w=f mt=md mh=lg: ${addCharacterButtonLabel}
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}

--- a/src/internal/ui/sceneEditor/backgroundTransformEditor.js
+++ b/src/internal/ui/sceneEditor/backgroundTransformEditor.js
@@ -118,6 +118,25 @@ export const normalizeBackgroundTransformEditorTransform = (
   };
 };
 
+export const applyBackgroundTransformAnchorOrigin = ({
+  transform,
+  selectedElementMetrics,
+} = {}) => {
+  const normalizedTransform =
+    normalizeBackgroundTransformEditorTransform(transform);
+  const width = Number(selectedElementMetrics?.width);
+  const height = Number(selectedElementMetrics?.height);
+
+  if (Number.isFinite(width) && width > 0) {
+    normalizedTransform.originX = normalizedTransform.anchorX * width;
+  }
+  if (Number.isFinite(height) && height > 0) {
+    normalizedTransform.originY = normalizedTransform.anchorY * height;
+  }
+
+  return normalizedTransform;
+};
+
 export const createBackgroundWithInlineTransform = (
   background = {},
   transform = {},
@@ -790,6 +809,31 @@ const updateElementById = (elements, targetId, updateElement) => {
   return { elements: nextElements, updated };
 };
 
+const applyTransformEditorTargetAnchorOrigin = (
+  elements,
+  selectedPath,
+  editorState,
+) => {
+  const selectedElement = selectedPath?.[selectedPath.length - 1];
+  if (!selectedElement) {
+    return elements;
+  }
+
+  const transform = applyBackgroundTransformAnchorOrigin({
+    transform: editorState.transform,
+    selectedElementMetrics: {
+      width: getRenderableWidth(selectedElement),
+      height: getRenderableHeight(selectedElement),
+    },
+  });
+
+  return updateElementById(elements, selectedElement.id, (element) => ({
+    ...element,
+    originX: transform.originX,
+    originY: transform.originY,
+  })).elements;
+};
+
 const translateTransformEditorTarget = (
   elements,
   editorState,
@@ -851,7 +895,18 @@ export const createBackgroundTransformEditorCanvasState = ({
     parsedState?.elements,
     editorState,
   );
-  const selectedPath = initialSelectedPath;
+  const originAdjustedElements = applyTransformEditorTargetAnchorOrigin(
+    renderedElements,
+    initialSelectedPath,
+    editorState,
+  );
+  const originAdjustedState = initialSelectedPath
+    ? graphicsService?.parse?.({ elements: originAdjustedElements })
+    : parsedState;
+  const selectedPath = selectBackgroundElementPath(
+    originAdjustedState?.elements,
+    editorState,
+  );
   const overlayPath =
     selectedPath?.length > 1 ? selectedPath.slice(1) : selectedPath;
   const overlayElement = selectedPath
@@ -862,7 +917,7 @@ export const createBackgroundTransformEditorCanvasState = ({
       })
     : undefined;
   const elementsWithOverlay = addOverlayToRenderedElements({
-    elements: renderedElements,
+    elements: originAdjustedElements,
     path: selectedPath ?? [],
     overlayElement,
   });

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -33,6 +33,7 @@ import {
   updateSceneEditorSectionChanges,
 } from "../../internal/ui/sceneEditor/runtime.js";
 import {
+  applyBackgroundTransformAnchorOrigin,
   createActionItemWithInlineTransform,
   createBackgroundTransformEditorPositionPreviewCanvasState,
   createBackgroundWithInlineTransform,
@@ -1451,9 +1452,11 @@ export const handleBackgroundTransformEditorChange = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   const { store, render, subject } = deps;
   const transient = payload?._event?.detail?.transient === true;
-  const transform = normalizeBackgroundTransformEditorTransform(
-    payload?._event?.detail?.transform,
-  );
+  const editor = store.selectBackgroundTransformEditor?.();
+  const transform = applyBackgroundTransformAnchorOrigin({
+    transform: payload?._event?.detail?.transform,
+    selectedElementMetrics: editor?.selectedElementMetrics,
+  });
 
   store.clearBackgroundTransformEditorDragStartPosition?.();
   store.setBackgroundTransformEditorTransform?.({ transform });

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.store.js
@@ -15,7 +15,10 @@ import {
   constructProjectData,
   getSectionPresentation,
 } from "../../internal/project/projection.js";
-import { normalizeBackgroundTransformEditorTransform } from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
+import {
+  applyBackgroundTransformAnchorOrigin,
+  normalizeBackgroundTransformEditorTransform,
+} from "../../internal/ui/sceneEditor/backgroundTransformEditor.js";
 import {
   emitSceneEditorTiming,
   getSceneEditorTimingDurationMs,
@@ -958,6 +961,11 @@ export const setBackgroundTransformEditorSelectedElementMetrics = (
   { metrics } = {},
 ) => {
   state.backgroundTransformEditor.selectedElementMetrics = metrics;
+  state.backgroundTransformEditor.transform =
+    applyBackgroundTransformAnchorOrigin({
+      transform: state.backgroundTransformEditor.transform,
+      selectedElementMetrics: metrics,
+    });
 };
 
 export const setBackgroundTransformEditorTransform = (

--- a/tests/actionTransformEditor/actionTransformEditor.handlers.test.js
+++ b/tests/actionTransformEditor/actionTransformEditor.handlers.test.js
@@ -25,6 +25,10 @@ describe("actionTransformEditor.handlers", () => {
       {
         props: {
           transform: BASE_TRANSFORM,
+          selectedElementMetrics: {
+            width: 1920,
+            height: 1080,
+          },
         },
         dispatchEvent: (event) => dispatchedEvents.push(event),
       },
@@ -50,9 +54,55 @@ describe("actionTransformEditor.handlers", () => {
       transform: {
         anchorX: 1,
         anchorY: 0,
+        originX: 1920,
+        originY: 0,
       },
     });
     expect(dispatchedEvents[0].detail.transform).not.toHaveProperty("anchor");
+  });
+
+  it("repairs a stale origin when another transform field changes", () => {
+    const dispatchedEvents = [];
+
+    handleInspectorUpdate(
+      {
+        props: {
+          transform: {
+            ...BASE_TRANSFORM,
+            originX: 0,
+            originY: 0,
+          },
+          selectedElementMetrics: {
+            width: 400,
+            height: 600,
+          },
+        },
+        dispatchEvent: (event) => dispatchedEvents.push(event),
+      },
+      {
+        _event: {
+          detail: {
+            name: "rotation",
+            value: 20,
+            formValues: {
+              ...BASE_TRANSFORM,
+              originX: 0,
+              originY: 0,
+              rotation: 20,
+              anchor: { x: 0.5, y: 0.5 },
+            },
+          },
+        },
+      },
+    );
+
+    expect(dispatchedEvents[0].detail.transform).toMatchObject({
+      rotation: 20,
+      anchorX: 0.5,
+      anchorY: 0.5,
+      originX: 200,
+      originY: 300,
+    });
   });
 
   it("owns arrow-key movement while no editor input is focused", () => {

--- a/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.handlers.test.js
@@ -11,6 +11,7 @@ import {
   handleCharacterItemClick,
   handleCharacterContextMenu,
   handleCharacterSpriteGroupBoxClick,
+  handleCustomTransformButtonKeyDown,
   handleDropdownMenuClickItem,
   handleOpacityInput,
   handleSpriteItemClick,
@@ -124,6 +125,57 @@ const createStoreApi = (state) => ({
 });
 
 describe("commandLineCharacters.handlers", () => {
+  it("opens the custom transform editor from the summary box with the keyboard", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+    const store = createStoreApi(state);
+    const event = {
+      key: "Enter",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+      currentTarget: {
+        dataset: {
+          index: "0",
+          targetName: "Hero",
+        },
+      },
+    };
+
+    setExistingCharacters(
+      { state },
+      {
+        characters: [
+          {
+            id: "character-hero",
+            x: 100,
+            y: 200,
+            sprites: [],
+          },
+        ],
+      },
+    );
+
+    handleCustomTransformButtonKeyDown(
+      {
+        store,
+        dispatchEvent,
+      },
+      { _event: event },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "action-transform-customize",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toMatchObject({
+      targetType: "character",
+      itemIndex: 0,
+      targetName: "Hero",
+    });
+  });
+
   it("opens a transform dropdown before character selection", () => {
     const state = createInitialState();
     const render = vi.fn();

--- a/tests/commandLineCharacters/commandLineCharacters.sections.test.js
+++ b/tests/commandLineCharacters/commandLineCharacters.sections.test.js
@@ -278,6 +278,13 @@ describe("commandLineCharacters sections", () => {
     expect(view).toContain("slot=${character.animationFormSlot}");
     expect(view).toContain("slot=${character.playbackSpeedFormSlot}");
     expect(view).toContain("rtgl-slider-input#animationPlaybackSpeed${i}");
+    expect(view).toContain("handler: handleCustomTransformButtonKeyDown");
+    expect(view).toContain("rtgl-view#customTransformButton${i}.characterRow");
+    expect(view).toContain("rtgl-grid cols=2 g=md w=f");
+    expect(view).toContain(
+      "rtgl-button#addCharacterButton v=ol w=f mt=md mh=lg",
+    );
+    expect(view).not.toContain("animationPlaybackLoopDisabledDescription");
     expect(view).not.toContain("slot=characters");
   });
 });

--- a/tests/sceneEditor/backgroundTransformEditor.test.js
+++ b/tests/sceneEditor/backgroundTransformEditor.test.js
@@ -37,11 +37,13 @@ describe("backgroundTransformEditor", () => {
       id: "bg-cg-background-sprite",
       x: 107,
       y: 74,
+      originX: 960,
+      originY: 540,
     });
     expect(canvasState.renderState.elements[1]).toMatchObject({
       id: "selected-border-group",
-      x: 107,
-      y: 74,
+      x: 1067,
+      y: 614,
     });
   });
 
@@ -243,6 +245,11 @@ describe("backgroundTransformEditor", () => {
 
     const overlay = canvasState.renderState.elements[1];
 
+    expect(canvasState.renderState.elements[0]).toMatchObject({
+      originX: 100,
+      originY: 50,
+    });
+
     expect(overlay.children[5]).toMatchObject({
       id: "selected-border-anchor",
       x: 96,
@@ -257,8 +264,8 @@ describe("backgroundTransformEditor", () => {
       scaleY: 2,
       renderedX: 10,
       renderedY: 20,
-      renderedOriginX: 50,
-      renderedOriginY: 25,
+      renderedOriginX: 100,
+      renderedOriginY: 50,
       renderedRotation: 15,
       renderedScaleX: 2,
       renderedScaleY: 2,

--- a/tests/sceneEditor/sceneEditor.store.test.js
+++ b/tests/sceneEditor/sceneEditor.store.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   clearTemporaryPresentationState,
+  openBackgroundTransformEditor,
   refreshSceneTextStats,
   selectEffectivePresentationState,
   selectViewData,
@@ -9,6 +10,7 @@ import {
   setRepositoryState,
   setSceneId,
   setPresentationState,
+  setBackgroundTransformEditorSelectedElementMetrics,
   setProjectLanguage,
   setSectionLineChangesBySectionId,
   setTemporaryPresentationState,
@@ -18,6 +20,39 @@ import {
 import { EN_I18N } from "../support/i18n.js";
 
 describe("sceneEditorLexical.store", () => {
+  it("resolves the transform origin when rendered target metrics arrive", () => {
+    const state = createInitialState();
+
+    openBackgroundTransformEditor(
+      { state },
+      {
+        targetType: "character",
+        transform: {
+          anchorX: 0.5,
+          anchorY: 1,
+          originX: 0,
+          originY: 0,
+        },
+      },
+    );
+    setBackgroundTransformEditorSelectedElementMetrics(
+      { state },
+      {
+        metrics: {
+          width: 400,
+          height: 600,
+        },
+      },
+    );
+
+    expect(state.backgroundTransformEditor.transform).toMatchObject({
+      anchorX: 0.5,
+      anchorY: 1,
+      originX: 200,
+      originY: 600,
+    });
+  });
+
   it("shows a localized add-section menu for empty editor space", () => {
     const state = createInitialState();
 

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -998,6 +998,12 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     const deps = {
       store: {
         clearBackgroundTransformEditorDragStartPosition: vi.fn(),
+        selectBackgroundTransformEditor: vi.fn(() => ({
+          selectedElementMetrics: {
+            width: 400,
+            height: 600,
+          },
+        })),
         setBackgroundTransformEditorTransform,
       },
       render: vi.fn(),
@@ -1013,8 +1019,12 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
           transform: {
             x: 320,
             y: 180,
+            anchorX: 0.5,
+            anchorY: 1,
             scaleX: 1.2,
             scaleY: 0.8,
+            originX: 0,
+            originY: 0,
           },
         },
       },
@@ -1024,8 +1034,12 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       transform: expect.objectContaining({
         x: 320,
         y: 180,
+        anchorX: 0.5,
+        anchorY: 1,
         scaleX: 1.2,
         scaleY: 0.8,
+        originX: 200,
+        originY: 600,
       }),
     });
     expect(deps.render).toHaveBeenCalledTimes(1);

--- a/vt/specs/project/action-transform-editor.yaml
+++ b/vt/specs/project/action-transform-editor.yaml
@@ -137,6 +137,30 @@ steps:
     args:
       - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const sceneEditor = deepQuery(document, 'rvn-scene-editor-lexical'); const metrics = sceneEditor?.store?.selectBackgroundTransformEditor?.()?.selectedElementMetrics; return `${metrics?.width}x${metrics?.height}`; })()"
     value: "1920x1080"
+  - action: select
+    selector: "rvn-action-transform-editor#actionTransformEditor rvn-layout-anchor-grid[data-name='anchor'] #anchorCell2"
+    steps:
+      - action: click
+  - action: wait
+    ms: 100
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const sceneEditor = deepQuery(document, 'rvn-scene-editor-lexical'); const transform = sceneEditor?.store?.selectBackgroundTransformEditor?.()?.transform; return `${transform?.anchorX},${transform?.anchorY}:${transform?.originX},${transform?.originY}`; })()"
+    value: "1,0:1920,0"
+  - action: select
+    selector: "rvn-action-transform-editor#actionTransformEditor rvn-layout-anchor-grid[data-name='anchor'] #anchorCell4"
+    steps:
+      - action: click
+  - action: wait
+    ms: 100
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const sceneEditor = deepQuery(document, 'rvn-scene-editor-lexical'); const transform = sceneEditor?.store?.selectBackgroundTransformEditor?.()?.transform; return `${transform?.anchorX},${transform?.anchorY}:${transform?.originX},${transform?.originY}`; })()"
+    value: "0.5,0.5:960,540"
   - action: waitFor
     selector: "rvn-action-transform-editor#actionTransformEditor #actionTransformCanvasHost canvas"
     state: visible


### PR DESCRIPTION
## Summary
- derive renderer origins from transform anchors and live target dimensions for initial previews and subsequent edits
- keep rotation, scaling, and animation positioning centered on the selected anchor
- align the character custom-transform control with the background control, add horizontal spacing to Add Character, and remove the zero-duration looping warning copy
- add focused unit coverage and action-transform VT assertions

## Testing
- `bunx vitest run tests/actionTransformEditor tests/sceneEditor/backgroundTransformEditor.test.js tests/sceneEditor/sceneEditor.store.test.js tests/sceneEditor/sceneEditorLexical.handlers.test.js tests/sceneEditor/runtime.test.js tests/commandLineCharacters` (137 passed)
- `bun run build:web`
- browser validation: top-right anchor produced origin `1920,0`; center anchor produced `960,540`
- pre-push hook: `oxlint` and `bun prettier --check src`