### PR TITLE
fix: match empty background preview size

### DIFF
--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -114,11 +114,17 @@ template:
                                   - rtgl-view w=f p=md:
                                       - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectedResource.name}
                         $else:
-                          - 'rtgl-view#backgroundImage w=355 bw=xs bc=bo h-bc=ac br=md bgc=mu av=c ah=c cur=pointer slot=background style="aspect-ratio: 16 / 9;"':
-                              - rtgl-text s=md c=mu-fg: ${selectBackgroundLabel}
+                          - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=bo h-bc=ac br=md:
+                              - 'rtgl-view br=md w=200 pos=rel overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
+                                  - 'rtgl-view w=f bgc=mu style="aspect-ratio: 16 / 9; overflow: hidden;"': null
+                                  - rtgl-view w=f p=md:
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectBackgroundLabel}
                     $else:
-                      - 'rtgl-view#backgroundImage w=355 bw=xs bc=bo h-bc=ac br=md bgc=mu av=c ah=c cur=pointer slot=background style="aspect-ratio: 16 / 9;"':
-                          - rtgl-text s=md c=mu-fg: ${selectBackgroundLabel}
+                      - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=bo h-bc=ac br=md:
+                          - 'rtgl-view br=md w=200 pos=rel overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
+                              - 'rtgl-view w=f bgc=mu style="aspect-ratio: 16 / 9; overflow: hidden;"': null
+                              - rtgl-view w=f p=md:
+                                  - rtgl-text s=xs c=mu-fg ellipsis w=f: ${selectBackgroundLabel}
                   - 'rtgl-view#customTransformButton slot=custom-transform data-target-name="${selectedResource.name}" role=button tabindex=0 aria-label="${transformEditorTitle}" w=f p=md bw=xs bc=bo h-bc=pr br=md bgc=bg cur=pointer style="box-sizing: border-box;"':
                       - rtgl-grid cols=2 g=md w=f:
                           - $for item, i in customTransformDetails:

--- a/tests/commandLineBackground/commandLineBackground.view.test.js
+++ b/tests/commandLineBackground/commandLineBackground.view.test.js
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("commandLineBackground view", () => {
+  it("uses the image resource-card dimensions for the empty placeholder", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineBackground/commandLineBackground.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).not.toContain("rtgl-view#backgroundImage w=355");
+    expect(
+      view.match(
+        /rtgl-text s=xs c=mu-fg ellipsis w=f: \$\{selectBackgroundLabel\}/g,
+      ),
+    ).toHaveLength(2);
+    expect(
+      view.match(
+        /rtgl-view br=md w=200 pos=rel overflow=hidden style="max-width: 100%; box-sizing: border-box;"/g,
+      ).length,
+    ).toBe(2);
+    expect(view).toContain(
+      'rtgl-view br=md w=200 pos=rel overflow=hidden style="${selectedResource.resourceCardStyle}"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace the oversized empty background selector with the same 200px card structure used by selected images
- keep the 16:9 thumbnail and caption geometry consistent so the form does not resize after image selection
- add a view regression test for the shared sizing contract

## Testing
- `bunx vitest run tests/commandLineBackground` (35 passed)
- `bun run build:web`
- browser validation: empty and selected-image cards both measured `202 × 142.5px` with no page errors
- pre-push hook: `oxlint` and `bun prettier --check src`