### PR TITLE
feat: add individual audio loop options

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -38,6 +38,7 @@ const syncSelectedSoundForm = ({ refs, store }) => {
   refs.form.setValues({
     values: {
       startDelayMs: sound.startDelayMs,
+      loop: sound.loop,
       volume: sound.volume,
     },
   });

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -60,6 +60,10 @@ const normalizeSounds = (sounds = []) => {
   });
 };
 
+const syncBgmChannelLoop = (bgm) => {
+  bgm.loop = !bgm.sounds.some((sound) => sound.loop);
+};
+
 const normalizeBgm = (bgm = {}) => {
   const normalizedBgm = {
     interruption: normalizeAudioChannelInterruption(bgm.interruption),
@@ -388,7 +392,7 @@ export const updateSound = ({ state }, { soundId, values = {} } = {}) => {
 
   if (values.loop !== undefined) {
     sound.loop = values.loop;
-    state.bgm.loop = !state.bgm.sounds.some((item) => item.loop);
+    syncBgmChannelLoop(state.bgm);
   }
   if (values.volume !== undefined) {
     sound.volume = normalizeVolume(values.volume, DEFAULT_SOUND_VOLUME);
@@ -497,6 +501,7 @@ export const insertSound = (
   });
   state.bgm.sounds.splice(insertIndex, 0, sound);
   sortAudioSoundsByStartDelay(state.bgm.sounds);
+  syncBgmChannelLoop(state.bgm);
   state.channelSelected = false;
   state.selectedSoundId = sound.id;
   state.tempSelectedResourceId = undefined;
@@ -504,6 +509,7 @@ export const insertSound = (
 
 export const removeSound = ({ state }, { soundId } = {}) => {
   state.bgm.sounds = state.bgm.sounds.filter((sound) => sound.id !== soundId);
+  syncBgmChannelLoop(state.bgm);
   state.channelSelected = true;
   state.selectedSoundId = undefined;
 };

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -47,7 +47,7 @@ const normalizeSounds = (sounds = []) => {
     const normalizedSound = {
       id,
       resourceId: sound.resourceId,
-      loop: false,
+      loop: sound.loop ?? false,
       volume: normalizeVolume(sound.volume, DEFAULT_SOUND_VOLUME),
       startDelayMs: normalizeAudioStartDelayMs(sound.startDelayMs),
     };
@@ -79,6 +79,12 @@ const normalizeBgm = (bgm = {}) => {
         startDelayMs: bgm.startDelayMs,
       },
     ]);
+  }
+
+  if (normalizedBgm.loop) {
+    normalizedBgm.sounds.forEach((sound) => {
+      sound.loop = false;
+    });
   }
 
   sortAudioSoundsByStartDelay(normalizedBgm.sounds);
@@ -124,6 +130,15 @@ const SOUND_FORM = {
       type: "input-duration",
       min: 0,
       step: 10,
+    },
+    {
+      name: "loop",
+      description: "Loop",
+      type: "segmented-control",
+      options: [
+        { value: true, label: "Loop" },
+        { value: false, label: "Don't Loop" },
+      ],
     },
     {
       name: "volume",
@@ -291,6 +306,7 @@ export const selectViewData = ({ state, i18n }) => {
   const defaultValues = selectedSound
     ? {
         startDelayMs: selectedSound.startDelayMs,
+        loop: selectedSound.loop,
         volume: selectedSound.volume,
       }
     : {
@@ -371,6 +387,11 @@ export const updateChannel = ({ state }, { values = {} } = {}) => {
   }
   if (values.loop !== undefined) {
     state.bgm.loop = values.loop;
+    if (values.loop) {
+      state.bgm.sounds.forEach((sound) => {
+        sound.loop = false;
+      });
+    }
   }
   if (values.volume !== undefined) {
     state.bgm.volume = normalizeVolume(values.volume, DEFAULT_CHANNEL_VOLUME);
@@ -383,6 +404,12 @@ export const updateSound = ({ state }, { soundId, values = {} } = {}) => {
     return;
   }
 
+  if (values.loop !== undefined) {
+    sound.loop = values.loop;
+    if (values.loop) {
+      state.bgm.loop = false;
+    }
+  }
   if (values.volume !== undefined) {
     sound.volume = normalizeVolume(values.volume, DEFAULT_SOUND_VOLUME);
   }

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -94,15 +94,6 @@ const normalizeBgm = (bgm = {}) => {
 const CHANNEL_FORM = {
   fields: [
     {
-      name: "loop",
-      description: "Loop",
-      type: "segmented-control",
-      options: [
-        { value: true, label: "Loop" },
-        { value: false, label: "Don't Loop" },
-      ],
-    },
-    {
       name: "interruption",
       description: "Interruption",
       type: "segmented-control",
@@ -311,7 +302,6 @@ export const selectViewData = ({ state, i18n }) => {
       }
     : {
         interruption: state.bgm.interruption,
-        loop: state.bgm.loop,
         volume: state.bgm.volume,
       };
 
@@ -385,14 +375,6 @@ export const updateChannel = ({ state }, { values = {} } = {}) => {
       values.interruption,
     );
   }
-  if (values.loop !== undefined) {
-    state.bgm.loop = values.loop;
-    if (values.loop) {
-      state.bgm.sounds.forEach((sound) => {
-        sound.loop = false;
-      });
-    }
-  }
   if (values.volume !== undefined) {
     state.bgm.volume = normalizeVolume(values.volume, DEFAULT_CHANNEL_VOLUME);
   }
@@ -406,9 +388,7 @@ export const updateSound = ({ state }, { soundId, values = {} } = {}) => {
 
   if (values.loop !== undefined) {
     sound.loop = values.loop;
-    if (values.loop) {
-      state.bgm.loop = false;
-    }
+    state.bgm.loop = !state.bgm.sounds.some((item) => item.loop);
   }
   if (values.volume !== undefined) {
     sound.volume = normalizeVolume(values.volume, DEFAULT_SOUND_VOLUME);

--- a/src/components/commandLineVoice/commandLineVoice.handlers.js
+++ b/src/components/commandLineVoice/commandLineVoice.handlers.js
@@ -157,6 +157,7 @@ const syncSelectedSoundForm = ({ refs, store }) => {
   refs.form.setValues({
     values: {
       startDelayMs: sound.startDelayMs,
+      loop: sound.loop,
       volume: sound.volume,
     },
   });

--- a/src/components/commandLineVoice/commandLineVoice.store.js
+++ b/src/components/commandLineVoice/commandLineVoice.store.js
@@ -47,7 +47,7 @@ const normalizeSounds = (sounds = []) => {
     const normalizedSound = {
       id,
       resourceId: sound.resourceId,
-      loop: false,
+      loop: sound.loop ?? false,
       volume: normalizeVolume(sound.volume, DEFAULT_SOUND_VOLUME),
       startDelayMs: normalizeAudioStartDelayMs(sound.startDelayMs),
     };
@@ -79,6 +79,12 @@ const normalizeVoice = (voice = {}) => {
         startDelayMs: voice.startDelayMs,
       },
     ]);
+  }
+
+  if (normalizedVoice.loop) {
+    normalizedVoice.sounds.forEach((sound) => {
+      sound.loop = false;
+    });
   }
 
   sortAudioSoundsByStartDelay(normalizedVoice.sounds);
@@ -124,6 +130,15 @@ const SOUND_FORM = {
       type: "input-duration",
       min: 0,
       step: 10,
+    },
+    {
+      name: "loop",
+      description: "Loop",
+      type: "segmented-control",
+      options: [
+        { value: true, label: "Loop" },
+        { value: false, label: "Don't Loop" },
+      ],
     },
     {
       name: "volume",
@@ -230,6 +245,7 @@ export const selectViewData = ({ state, i18n }) => {
   const defaultValues = selectedSound
     ? {
         startDelayMs: selectedSound.startDelayMs,
+        loop: selectedSound.loop,
         volume: selectedSound.volume,
       }
     : {
@@ -299,6 +315,11 @@ export const updateChannel = ({ state }, { values = {} } = {}) => {
   }
   if (values.loop !== undefined) {
     state.voice.loop = values.loop;
+    if (values.loop) {
+      state.voice.sounds.forEach((sound) => {
+        sound.loop = false;
+      });
+    }
   }
   if (values.volume !== undefined) {
     state.voice.volume = normalizeVolume(values.volume, DEFAULT_CHANNEL_VOLUME);
@@ -311,6 +332,12 @@ export const updateSound = ({ state }, { soundId, values = {} } = {}) => {
     return;
   }
 
+  if (values.loop !== undefined) {
+    sound.loop = values.loop;
+    if (values.loop) {
+      state.voice.loop = false;
+    }
+  }
   if (values.volume !== undefined) {
     sound.volume = normalizeVolume(values.volume, DEFAULT_SOUND_VOLUME);
   }

--- a/src/internal/audioRenderState.js
+++ b/src/internal/audioRenderState.js
@@ -33,19 +33,9 @@ export const prepareRenderStateAudioChannelsForGraphics = ({
     }
 
     changed = true;
-    const children = Array.isArray(element.children)
-      ? element.children.map((child) => {
-          if (child?.type !== "sound" || child.loop === false) {
-            return child;
-          }
-          return { ...child, loop: false };
-        })
-      : element.children;
-
     return {
       ...element,
       loop: channelLoopByRenderId.get(element.id),
-      children,
     };
   });
 

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -110,7 +110,7 @@ describe("commandLineBgm.handlers", () => {
     expect(render).toHaveBeenCalledOnce();
   });
 
-  it("updates only the selected clip timing and volume", () => {
+  it("updates only the selected clip timing, loop, and volume", () => {
     const state = createState();
     const store = createStore(state);
     const render = vi.fn();
@@ -120,13 +120,15 @@ describe("commandLineBgm.handlers", () => {
       { store, render },
       {
         _event: {
-          detail: { values: { startDelayMs: 750, volume: 35 } },
+          detail: { values: { startDelayMs: 750, loop: true, volume: 35 } },
         },
       },
     );
 
     expect(state.bgm.volume).toBe(75);
+    expect(state.bgm.loop).toBe(false);
     expect(state.bgm.sounds[0].startDelayMs).toBe(750);
+    expect(state.bgm.sounds[0].loop).toBe(true);
     expect(state.bgm.sounds[0].volume).toBe(35);
     expect(render).toHaveBeenCalledOnce();
   });
@@ -392,6 +394,7 @@ describe("commandLineBgm.handlers", () => {
     expect(setValues).toHaveBeenCalledWith({
       values: {
         startDelayMs: 2000,
+        loop: false,
         volume: 100,
       },
     });

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -93,7 +93,6 @@ describe("commandLineBgm.handlers", () => {
           detail: {
             values: {
               interruption: "loopEnd",
-              loop: false,
               volume: 60,
             },
           },
@@ -103,7 +102,7 @@ describe("commandLineBgm.handlers", () => {
 
     expect(state.bgm).toEqual({
       interruption: "loopEnd",
-      loop: false,
+      loop: true,
       volume: 60,
       sounds: [],
     });

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -13,6 +13,8 @@ import {
   setRepositoryState,
   setSelectedSound,
   startSoundDrag,
+  updateChannel,
+  updateSound,
   updateSoundDrag,
   finishSoundDrag,
 } from "../../src/components/commandLineBgm/commandLineBgm.store.js";
@@ -211,6 +213,7 @@ describe("commandLineBgm.store", () => {
     expect(selectedViewData.selectionName).toBe("Intro");
     expect(selectedViewData.form.fields.map((field) => field.name)).toEqual([
       "startDelayMs",
+      "loop",
       "volume",
     ]);
     expect(selectedViewData.form.fields[0]).toMatchObject({
@@ -222,8 +225,32 @@ describe("commandLineBgm.store", () => {
     });
     expect(selectedViewData.defaultValues).toEqual({
       startDelayMs: 0,
+      loop: false,
       volume: 90,
     });
+  });
+
+  it("keeps whole-channel and individual sound loops mutually exclusive", () => {
+    const state = createInitialState();
+    setBgm(
+      { state },
+      {
+        bgm: {
+          loop: false,
+          sounds: [{ id: "intro-clip", resourceId: "intro", loop: true }],
+        },
+      },
+    );
+
+    expect(selectBgm({ state }).sounds[0].loop).toBe(true);
+
+    updateChannel({ state }, { values: { loop: true } });
+    expect(selectBgm({ state }).loop).toBe(true);
+    expect(selectBgm({ state }).sounds[0].loop).toBe(false);
+
+    updateSound({ state }, { soundId: "intro-clip", values: { loop: true } });
+    expect(selectBgm({ state }).loop).toBe(false);
+    expect(selectBgm({ state }).sounds[0].loop).toBe(true);
   });
 
   it("places inserted sounds sequentially without reflowing after removal", () => {

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -251,6 +251,34 @@ describe("commandLineBgm.store", () => {
     expect(selectBgm({ state }).sounds[0].loop).toBe(true);
   });
 
+  it("restores the channel loop after removing the final looping sound", () => {
+    const state = createInitialState();
+    setBgm(
+      { state },
+      {
+        bgm: {
+          loop: false,
+          sounds: [
+            { id: "first-loop", resourceId: "intro", loop: true },
+            { id: "second-loop", resourceId: "theme", loop: true },
+            { id: "remaining-clip", resourceId: "intro", loop: false },
+          ],
+        },
+      },
+    );
+
+    removeSound({ state }, { soundId: "first-loop" });
+    expect(selectBgm({ state }).loop).toBe(false);
+
+    removeSound({ state }, { soundId: "second-loop" });
+    expect(selectBgm({ state }).loop).toBe(true);
+    expect(selectBgm({ state }).sounds).toHaveLength(1);
+    expect(selectBgm({ state }).sounds[0]).toMatchObject({
+      id: "remaining-clip",
+      loop: false,
+    });
+  });
+
   it("places inserted sounds sequentially without reflowing after removal", () => {
     const state = createInitialState();
     setRepositoryState({ state }, { sounds });

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -13,7 +13,6 @@ import {
   setRepositoryState,
   setSelectedSound,
   startSoundDrag,
-  updateChannel,
   updateSound,
   updateSoundDrag,
   finishSoundDrag,
@@ -97,13 +96,11 @@ describe("commandLineBgm.store", () => {
     expect(selectedViewData.selectionHeading).toBe("Channel");
     expect(selectedViewData.selectionName).toBe("BGM Channel");
     expect(selectedViewData.form.fields.map((field) => field.name)).toEqual([
-      "loop",
       "interruption",
       "volume",
     ]);
     expect(selectedViewData.defaultValues).toEqual({
       interruption: "immediate",
-      loop: true,
       volume: 75,
     });
   });
@@ -230,7 +227,7 @@ describe("commandLineBgm.store", () => {
     });
   });
 
-  it("keeps whole-channel and individual sound loops mutually exclusive", () => {
+  it("uses the channel loop by default unless an individual sound loops", () => {
     const state = createInitialState();
     setBgm(
       { state },
@@ -242,9 +239,10 @@ describe("commandLineBgm.store", () => {
       },
     );
 
+    expect(selectBgm({ state }).loop).toBe(false);
     expect(selectBgm({ state }).sounds[0].loop).toBe(true);
 
-    updateChannel({ state }, { values: { loop: true } });
+    updateSound({ state }, { soundId: "intro-clip", values: { loop: false } });
     expect(selectBgm({ state }).loop).toBe(true);
     expect(selectBgm({ state }).sounds[0].loop).toBe(false);
 

--- a/tests/commandLineVoice/commandLineVoice.handlers.test.js
+++ b/tests/commandLineVoice/commandLineVoice.handlers.test.js
@@ -173,7 +173,7 @@ describe("commandLineVoice.handlers", () => {
     ]);
   });
 
-  it("updates channel controls or only the selected clip timing and volume", () => {
+  it("updates channel controls or only the selected clip controls", () => {
     const state = voiceStore.createInitialState();
     const store = createStore(state);
     const render = vi.fn();
@@ -189,13 +189,15 @@ describe("commandLineVoice.handlers", () => {
       { store, render },
       {
         _event: {
-          detail: { values: { startDelayMs: 750, volume: 35 } },
+          detail: { values: { startDelayMs: 750, loop: true, volume: 35 } },
         },
       },
     );
 
     expect(state.voice.volume).toBe(70);
+    expect(state.voice.loop).toBe(false);
     expect(state.voice.sounds[0].startDelayMs).toBe(750);
+    expect(state.voice.sounds[0].loop).toBe(true);
     expect(state.voice.sounds[0].volume).toBe(35);
     expect(render).toHaveBeenCalledTimes(2);
   });
@@ -326,6 +328,7 @@ describe("commandLineVoice.handlers", () => {
     expect(setValues).toHaveBeenCalledWith({
       values: {
         startDelayMs: 2000,
+        loop: false,
         volume: 100,
       },
     });

--- a/tests/commandLineVoice/commandLineVoice.store.test.js
+++ b/tests/commandLineVoice/commandLineVoice.store.test.js
@@ -14,6 +14,8 @@ import {
   setSelectedSound,
   setVoice,
   startSoundDrag,
+  updateChannel,
+  updateSound,
   updateSoundDrag,
 } from "../../src/components/commandLineVoice/commandLineVoice.store.js";
 
@@ -187,6 +189,7 @@ describe("commandLineVoice.store", () => {
     expect(selectedViewData.selectionName).toBe("Intro");
     expect(selectedViewData.form.fields.map((field) => field.name)).toEqual([
       "startDelayMs",
+      "loop",
       "volume",
     ]);
     expect(selectedViewData.form.fields[0]).toMatchObject({
@@ -198,8 +201,32 @@ describe("commandLineVoice.store", () => {
     });
     expect(selectedViewData.defaultValues).toEqual({
       startDelayMs: 0,
+      loop: false,
       volume: 90,
     });
+  });
+
+  it("keeps whole-channel and individual Voice loops mutually exclusive", () => {
+    const state = createInitialState();
+    setVoice(
+      { state },
+      {
+        voice: {
+          loop: false,
+          sounds: [{ id: "intro-clip", resourceId: "intro", loop: true }],
+        },
+      },
+    );
+
+    expect(selectVoicePayload({ state }).sounds[0].loop).toBe(true);
+
+    updateChannel({ state }, { values: { loop: true } });
+    expect(selectVoicePayload({ state }).loop).toBe(true);
+    expect(selectVoicePayload({ state }).sounds[0].loop).toBe(false);
+
+    updateSound({ state }, { soundId: "intro-clip", values: { loop: true } });
+    expect(selectVoicePayload({ state }).loop).toBe(false);
+    expect(selectVoicePayload({ state }).sounds[0].loop).toBe(true);
   });
 
   it("places inserted Voice sounds without reflowing after removal", () => {

--- a/tests/internal/audioRenderState.test.js
+++ b/tests/internal/audioRenderState.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { prepareRenderStateAudioChannelsForGraphics } from "../../src/internal/audioRenderState.js";
 
 describe("prepareRenderStateAudioChannelsForGraphics", () => {
-  it("applies canonical BGM and Voice loops to channels instead of child sounds", () => {
+  it("applies canonical channel loops without erasing individual sound loops", () => {
     const renderState = {
       audio: [
         {
@@ -16,7 +16,7 @@ describe("prepareRenderStateAudioChannelsForGraphics", () => {
         {
           id: "channel:voice",
           type: "audio-channel",
-          children: [{ id: "voice:line", type: "sound", loop: true }],
+          children: [{ id: "voice:line", type: "sound", loop: false }],
         },
       ],
     };
@@ -44,8 +44,8 @@ describe("prepareRenderStateAudioChannelsForGraphics", () => {
         type: "audio-channel",
         loop: false,
         children: [
-          { id: "bgm:intro", type: "sound", loop: false },
-          { id: "bgm:theme", type: "sound", loop: false },
+          { id: "bgm:intro", type: "sound", loop: true },
+          { id: "bgm:theme", type: "sound", loop: true },
         ],
       },
       {

--- a/vt/specs/project/sounds.yaml
+++ b/vt/specs/project/sounds.yaml
@@ -355,5 +355,11 @@ steps:
       - action: click
   - action: wait
     ms: 250
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const bgm = deepQuery(document, 'rvn-command-line-bgm#commandLineBgm'); return Boolean(deepQuery(bgm?.shadowRoot, \"rtgl-form#form [data-field-name='loop']\")); })()"
+    value: false
   - action: screenshot
 ---

--- a/vt/specs/project/sounds.yaml
+++ b/vt/specs/project/sounds.yaml
@@ -295,6 +295,20 @@ steps:
   - action: wait
     ms: 300
   - action: screenshot
+  - action: waitFor
+    selector: "rvn-command-line-bgm#commandLineBgm rtgl-form#form rtgl-segmented-control[data-field-name='loop']"
+    state: visible
+    timeoutMs: 5000
+  - action: select
+    selector: "rvn-command-line-bgm#commandLineBgm rtgl-form#form rtgl-segmented-control[data-field-name='loop'] #option0"
+    steps:
+      - action: click
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const bgm = deepQuery(document, 'rvn-command-line-bgm#commandLineBgm'); const loop = deepQuery(bgm?.shadowRoot, \"rtgl-segmented-control[data-field-name='loop']\"); const option = deepQuery(loop?.shadowRoot, '#option0'); return option?.getAttribute('aria-pressed'); })()"
+    value: "true"
   - action: select
     selector: "rvn-command-line-bgm#commandLineBgm #insertAfterButton0"
     steps:


### PR DESCRIPTION
## Summary

- add an individual Loop control to BGM and Voice audio forms, matching existing SFX behavior
- keep whole-channel and individual sound looping mutually exclusive
- preserve child sound loop values in the Route Graphics render-state bridge
- extend focused unit and VT coverage

## Downstream compatibility

- fast-forwarded route-graphics and route-engine to latest origin/main
- confirmed Route Graphics supports sound-level loops and the channel/child mutual-exclusion contract
- confirmed Route Engine propagates individual BGM, Voice, and SFX loop values
- no downstream code changes were required

## Validation

- creator focused audio suites: 56 tests passed
- Route Graphics focused audio suites: 34 tests passed
- Route Engine Puty suite: 880 tests passed
- direct Route Engine BGM/Voice/SFX loop propagation check passed
- Rettangoli FE contract check passed
- Oxlint, Prettier, git diff check, and push hooks passed

## Not run

- build:web, per repository active-development guidance
- VT screenshots, because no in-app browser was connected in this session