### PR TITLE
Organize command line visuals into sections

### DIFF
--- a/src/components/commandLineVisual/commandLineVisual.handlers.js
+++ b/src/components/commandLineVisual/commandLineVisual.handlers.js
@@ -320,6 +320,11 @@ export const handleCustomTransformButtonClick = (deps, payload) => {
   payload?._event?.stopPropagation?.();
   payload?._event?.stopImmediatePropagation?.();
   const { dispatchEvent, store } = deps;
+
+  if (typeof dispatchEvent !== "function") {
+    return;
+  }
+
   const index = getIndexFromEvent(payload._event);
   const visual = store.selectSelectedVisuals()?.[index];
   if (index === undefined || !visual) {
@@ -343,6 +348,15 @@ export const handleCustomTransformButtonClick = (deps, payload) => {
       composed: true,
     }),
   );
+};
+
+export const handleCustomTransformButtonKeyDown = (deps, payload) => {
+  const event = payload._event;
+  if (event.key !== "Enter" && event.key !== " ") {
+    return;
+  }
+
+  handleCustomTransformButtonClick(deps, payload);
 };
 
 export const handleAnimationChange = (deps, payload) => {

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -361,11 +361,20 @@ const createVisualsForm = (visuals = []) => ({
     return {
       type: "section",
       id: visual.formSectionId,
-      label: visual.displayName,
       fields,
     };
   }),
 });
+
+const createLocalizedVisualsForm = (visuals = [], copy = {}) => {
+  const form = localizeCommandLineForm(createVisualsForm(visuals), copy);
+
+  for (const [index, visual] of visuals.entries()) {
+    form.fields[index].label = visual.displayName;
+  }
+
+  return form;
+};
 
 const isHierarchyCollection = (value) =>
   !!value &&
@@ -1589,10 +1598,7 @@ export const selectViewData = ({ state, i18n }) => {
     fullSpritesheetPreviewAnimation: state.fullSpritesheetPreviewAnimation,
     fullSpritesheetPreviewKey: state.fullSpritesheetPreviewKey,
     breadcrumb: localizeCommandLineBreadcrumb(breadcrumb, copy),
-    form: localizeCommandLineForm(
-      createVisualsForm(defaultValues.visuals),
-      copy,
-    ),
+    form: createLocalizedVisualsForm(defaultValues.visuals, copy),
     formKey:
       defaultValues.visuals
         .map((visual) =>

--- a/src/components/commandLineVisual/commandLineVisual.store.js
+++ b/src/components/commandLineVisual/commandLineVisual.store.js
@@ -192,6 +192,181 @@ const createAddVisualForm = ({ transformOptions, layerOptions } = {}) => ({
   },
 });
 
+const createVisualFormSlots = (visualIndex) => {
+  const prefix = `visual-${visualIndex}`;
+  return {
+    formSectionId: prefix,
+    previewFormSlot: `${prefix}-preview`,
+    layerFormSlot: `${prefix}-layer`,
+    transformModeFormSlot: `${prefix}-transform-mode`,
+    predefinedTransformFormSlot: `${prefix}-predefined-transform`,
+    transformSpacerFormSlot: `${prefix}-transform-spacer`,
+    customTransformFormSlot: `${prefix}-custom-transform`,
+    animationFormSlot: `${prefix}-animation`,
+    playbackSpeedFormSlot: `${prefix}-playback-speed`,
+    playbackContinuityFormSlot: `${prefix}-playback-continuity`,
+    playbackLoopFormSlot: `${prefix}-playback-loop`,
+    playbackLoopSpacerFormSlot: `${prefix}-playback-loop-spacer`,
+    opacityFormSlot: `${prefix}-opacity`,
+    blurToggleFormSlot: `${prefix}-blur-toggle`,
+    blurXFormSlot: `${prefix}-blur-x`,
+    blurYFormSlot: `${prefix}-blur-y`,
+    blurQualityFormSlot: `${prefix}-blur-quality`,
+    blurKernelSizeFormSlot: `${prefix}-blur-kernel-size`,
+    blurRepeatEdgePixelsFormSlot: `${prefix}-blur-repeat-edge-pixels`,
+  };
+};
+
+const createVisualsForm = (visuals = []) => ({
+  fields: visuals.map((visual) => {
+    const fields = [
+      {
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: visual.previewFormSlot,
+            label: "Visuals",
+          },
+          {
+            type: "slot",
+            slot: visual.layerFormSlot,
+            label: "Layer",
+          },
+        ],
+      },
+      {
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: visual.transformModeFormSlot,
+            label: "Transform",
+          },
+          {
+            type: "slot",
+            slot: visual.customTransform
+              ? visual.transformSpacerFormSlot
+              : visual.predefinedTransformFormSlot,
+            label: visual.customTransform ? undefined : "Predefined Transform",
+          },
+        ],
+      },
+    ];
+
+    if (visual.customTransform) {
+      fields.push({
+        type: "slot",
+        slot: visual.customTransformFormSlot,
+      });
+    }
+
+    fields.push({
+      type: "slot",
+      slot: visual.animationFormSlot,
+      label: "Animation",
+    });
+
+    if (visual.animationId) {
+      fields.push({
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: visual.playbackSpeedFormSlot,
+            label: "Playback Speed",
+          },
+          {
+            type: "slot",
+            slot: visual.playbackContinuityFormSlot,
+            label: "Continuity",
+          },
+        ],
+      });
+    }
+
+    if (visual.animationId && visual.animationMode === "update") {
+      fields.push({
+        type: "row",
+        fields: [
+          {
+            type: "slot",
+            slot: visual.playbackLoopFormSlot,
+            label: "Loop",
+          },
+          {
+            type: "slot",
+            slot: visual.playbackLoopSpacerFormSlot,
+          },
+        ],
+      });
+    }
+
+    fields.push({
+      type: "row",
+      fields: [
+        {
+          type: "slot",
+          slot: visual.opacityFormSlot,
+          label: "Opacity",
+        },
+        {
+          type: "slot",
+          slot: visual.blurToggleFormSlot,
+          label: "Blur",
+        },
+      ],
+    });
+
+    if (visual.blurEnabled) {
+      fields.push(
+        {
+          type: "row",
+          fields: [
+            {
+              type: "slot",
+              slot: visual.blurXFormSlot,
+              label: "Blur X",
+            },
+            {
+              type: "slot",
+              slot: visual.blurYFormSlot,
+              label: "Blur Y",
+            },
+          ],
+        },
+        {
+          type: "row",
+          fields: [
+            {
+              type: "slot",
+              slot: visual.blurQualityFormSlot,
+              label: "Quality",
+            },
+            {
+              type: "slot",
+              slot: visual.blurKernelSizeFormSlot,
+              label: "Kernel Size",
+            },
+          ],
+        },
+        {
+          type: "slot",
+          slot: visual.blurRepeatEdgePixelsFormSlot,
+          label: "Repeat Edge Pixels",
+        },
+      );
+    }
+
+    return {
+      type: "section",
+      id: visual.formSectionId,
+      label: visual.displayName,
+      fields,
+    };
+  }),
+});
+
 const isHierarchyCollection = (value) =>
   !!value &&
   typeof value === "object" &&
@@ -588,6 +763,18 @@ const createCustomTransformDetails = (visual = {}) => {
     {
       label: "Scale",
       value: `${formatBackgroundTransformEditorMetric(transform.scaleX)} x ${formatBackgroundTransformEditorMetric(transform.scaleY)}`,
+    },
+    {
+      label: "Anchor",
+      value: `${formatBackgroundTransformEditorMetric(transform.anchorX)}, ${formatBackgroundTransformEditorMetric(transform.anchorY)}`,
+    },
+    {
+      label: "Rotation",
+      value: `${formatBackgroundTransformEditorMetric(transform.rotation)}°`,
+    },
+    {
+      label: "Origin",
+      value: `${formatBackgroundTransformEditorMetric(transform.originX)}, ${formatBackgroundTransformEditorMetric(transform.originY)}`,
     },
   ];
 };
@@ -1331,7 +1518,16 @@ export const selectViewData = ({ state, i18n }) => {
       layer: option.value,
       visuals,
     };
-  }).filter((group) => group.visuals.length > 0);
+  })
+    .filter((group) => group.visuals.length > 0)
+    .map((group, groupIndex) => ({
+      ...group,
+      visuals: group.visuals.map((visual, visualIndex) => ({
+        ...visual,
+        controlId: `${groupIndex}x${visualIndex}`,
+        ...createVisualFormSlots(visual.visualIndex),
+      })),
+    }));
 
   const defaultValues = {
     visualGroups,
@@ -1393,6 +1589,25 @@ export const selectViewData = ({ state, i18n }) => {
     fullSpritesheetPreviewAnimation: state.fullSpritesheetPreviewAnimation,
     fullSpritesheetPreviewKey: state.fullSpritesheetPreviewKey,
     breadcrumb: localizeCommandLineBreadcrumb(breadcrumb, copy),
+    form: localizeCommandLineForm(
+      createVisualsForm(defaultValues.visuals),
+      copy,
+    ),
+    formKey:
+      defaultValues.visuals
+        .map((visual) =>
+          [
+            visual.visualIndex,
+            visual.id,
+            visual.displayName,
+            visual.layer,
+            visual.customTransform ? "custom-transform" : "preset-transform",
+            visual.animationId ?? "no-animation",
+            visual.animationMode,
+            visual.blurEnabled ? "blur" : "no-blur",
+          ].join(":"),
+        )
+        .join("|") || "no-visuals",
     defaultValues,
     dropdownMenu: localizeCommandLineDropdownMenu(state.dropdownMenu, copy),
     addVisualPopover: {
@@ -1411,28 +1626,6 @@ export const selectViewData = ({ state, i18n }) => {
     addVisualDefaultValues,
     noThumbnailLabel: localizeCommandLineText("No thumbnail", copy),
     noResourceLabel: localizeCommandLineText("No Resource", copy),
-    layerLabel: localizeCommandLineText("Layer", copy),
-    opacityLabel: localizeCommandLineText("Opacity", copy),
-    blurLabel: localizeCommandLineText("Blur", copy),
-    qualityLabel: localizeCommandLineText("Quality", copy),
-    kernelLabel: localizeCommandLineText("Kernel", copy),
-    repeatEdgeLabel: localizeCommandLineText("Repeat Edge", copy),
-    transformLabel: localizeCommandLineText("Transform", copy),
-    editButtonLabel: localizeCommandLineText("Edit", copy),
-    predefinedTransformLabel: localizeCommandLineText(
-      "Predefined Transform",
-      copy,
-    ),
-    animationLabel: localizeCommandLineText("Animation", copy),
-    animationPlaybackSpeedLabel: localizeCommandLineText(
-      "Playback Speed",
-      copy,
-    ),
-    animationPlaybackLoopLabel: localizeCommandLineText("Loop", copy),
-    animationPlaybackContinuityLabel: localizeCommandLineText(
-      "Continuity",
-      copy,
-    ),
     animationPlaybackLoopDisabledDescription: localizeCommandLineText(
       "loopingRequiresKeyframesDescription",
       copy,
@@ -1445,6 +1638,5 @@ export const selectViewData = ({ state, i18n }) => {
     submitButtonLabel: localizeCommandLineText("Submit", copy),
     selectButtonLabel: localizeCommandLineText("Select", copy),
     transformEditorTitle: localizeCommandLineText("Transform", copy),
-    doneButtonLabel: localizeCommandLineText("Done", copy),
   };
 };

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -82,10 +82,8 @@ refs:
     eventListeners:
       click:
         handler: handleCustomTransformButtonClick
-  customTransformChip*:
-    eventListeners:
-      click:
-        handler: handleCustomTransformButtonClick
+      keydown:
+        handler: handleCustomTransformButtonKeyDown
   animation*:
     eventListeners:
       value-change:
@@ -139,89 +137,68 @@ template:
       - $if mode == 'current':
           - rtgl-view d=h g=md w=f ph=lg:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-view g=md w=f p=lg:
+          - 'rtgl-view h=1fg sv w=f g=md style="min-height: 0;"':
+              - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} p=lg:
                   - $for visualGroup, groupIndex in defaultValues.visualGroups:
-                      - rtgl-view g=sm w=f:
-                          - rtgl-text s=sm c=fg: ${visualGroup.label}
-                          - rtgl-view g=md w=f:
-                              - $for visual, i in visualGroup.visuals:
-                                  - rtgl-view#visualItem${groupIndex}x${i} data-index=${visual.visualIndex} data-visual-id=${visual.id} d=h g=md av=t p=md br=md w=f:
-                                      - 'rtgl-view#visualImage${groupIndex}x${i} data-index=${visual.visualIndex} cur=pointer bw=xs bc=bo h-bc=ac br=sm style="align-self: flex-start; flex: 0 0 auto;"':
-                                          - rtgl-view p=md g=md br=md:
-                                              - $if visual.resourceType == 'video':
-                                                  - rtgl-view pos=rel w=200 h=120:
-                                                      - $if visual.fileId:
-                                                          - rvn-file-image fileId=${visual.fileId} w=200 h=120: null
-                                                        $else:
-                                                          - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
-                                                              - rtgl-text s=sm c=mu-fg: ${noThumbnailLabel}
-                                                      - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
-                                                          - rtgl-icon icon=play s=xl c=fg: null
-                                                $elif visual.resourceType == 'spritesheet':
-                                                  - rvn-spritesheet-preview key=${visual.spritesheetPreviewKey} previewKey=${visual.spritesheetPreviewKey} fileId=${visual.spritesheetFileId} :atlas=${visual.spritesheetAtlas} :animation=${visual.spritesheetAnimation} w=200 h=120 emptyLabel=${noThumbnailLabel}: null
-                                                $elif visual.resourceType == 'layout':
-                                                  - $if visual.fileId:
-                                                      - rvn-file-image fileId=${visual.fileId} w=200 h=120: null
-                                                    $else:
-                                                      - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
-                                                          - rtgl-text s=sm c=mu-fg: ${noThumbnailLabel}
-                                                $elif visual.fileId:
+                      - $for visual, i in visualGroup.visuals:
+                          - 'rtgl-view#visualItem${visual.controlId} slot=${visual.previewFormSlot} data-index=${visual.visualIndex} data-visual-id=${visual.id} style="align-self: flex-start; flex: 0 0 auto;"':
+                              - 'rtgl-view#visualImage${visual.controlId} data-index=${visual.visualIndex} cur=pointer bw=xs bc=bo h-bc=ac br=sm':
+                                  - rtgl-view p=md g=md br=md:
+                                      - $if visual.resourceType == 'video':
+                                          - rtgl-view pos=rel w=200 h=120:
+                                              - $if visual.fileId:
                                                   - rvn-file-image fileId=${visual.fileId} w=200 h=120: null
                                                 $else:
                                                   - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
-                                                      - rtgl-text s=sm c=mu-fg: ${noResourceLabel}
-                                              - rtgl-text s=xs c=mu-fg ellipsis w=200: ${visual.displayName}
-                                      - rtgl-view w=1fg g=sm:
-                                          - rtgl-text s=sm c=mu-fg: ${layerLabel}
-                                          - rtgl-select#layer${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.layer} :options=${defaultValues.layerOptions} :selectedValue=${visual.layer} w=f no-clear: null
-                                          - rtgl-text s=sm c=mu-fg: ${opacityLabel}
-                                          - rtgl-slider-input#opacity${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.id} min=0 max=1 step=0.01 w=f value=${visual.opacity}: null
-                                          - rtgl-text s=sm c=mu-fg: ${blurLabel}
-                                          - rtgl-segmented-control#blurToggle${groupIndex}x${i} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.blurEnabled} :options=${defaultValues.blurToggleOptions}: null
-                                          - $if visual.blurEnabled:
-                                              - rtgl-view d=h wrap g=sm w=f:
-                                                  - rtgl-view w=90 g=xs:
-                                                      - rtgl-text s=xs c=mu-fg: X
-                                                      - rtgl-input#blurX${groupIndex}x${i} data-index=${visual.visualIndex} data-blur-field=x type=number w=f value=${visual.blur.x}: null
-                                                  - rtgl-view w=90 g=xs:
-                                                      - rtgl-text s=xs c=mu-fg: Y
-                                                      - rtgl-input#blurY${groupIndex}x${i} data-index=${visual.visualIndex} data-blur-field=y type=number w=f value=${visual.blur.y}: null
-                                                  - rtgl-view w=90 g=xs:
-                                                      - rtgl-text s=xs c=mu-fg: ${qualityLabel}
-                                                      - rtgl-input#blurQuality${groupIndex}x${i} data-index=${visual.visualIndex} data-blur-field=quality type=number min=1 step=1 w=f value=${visual.blur.quality}: null
-                                                  - rtgl-view w=120 g=xs:
-                                                      - rtgl-text s=xs c=mu-fg: ${kernelLabel}
-                                                      - rtgl-select#blurKernelSize${groupIndex}x${i} data-index=${visual.visualIndex} data-blur-field=kernelSize w=f no-clear :selectedValue=${visual.blur.kernelSize} :options=${defaultValues.blurKernelSizeOptions}: null
-                                                  - rtgl-view w=160 g=xs:
-                                                      - rtgl-text s=xs c=mu-fg: ${repeatEdgeLabel}
-                                                      - rtgl-segmented-control#blurRepeatEdgePixels${groupIndex}x${i} data-index=${visual.visualIndex} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${visual.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}: null
-                                          - rtgl-text s=sm c=mu-fg: ${transformLabel}
-                                          - rtgl-segmented-control#customTransformMode${groupIndex}x${i} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.customTransform} :options=${defaultValues.transformModeOptions}: null
-                                          - $if visual.customTransform:
-                                              - rtgl-view d=h av=c w=f g=md:
-                                                  - rtgl-view d=h av=c w=1fg g=sm wrap:
-                                                      - $for item, j in visual.customTransformDetails:
-                                                          - 'rtgl-view#customTransformChip${groupIndex}x${i}x${j} data-index=${visual.visualIndex} d=h av=c g=sm bw=xs bc=bo h-bc=pr br=full bgc=mu ph=md pv=sm cur=pointer style="max-width: 220px; box-sizing: border-box;"':
-                                                              - rtgl-text s=xs c=mu-fg ellipsis: ${item.label}
-                                                              - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums; white-space: nowrap;"': ${item.value}
-                                                  - rtgl-button#customTransformButton${groupIndex}x${i} data-index=${visual.visualIndex} data-target-name="${visual.displayName}" v=se: ${editButtonLabel}
+                                                      - rtgl-text s=sm c=mu-fg: ${noThumbnailLabel}
+                                              - rtgl-view pos=abs w=f h=f av=c ah=c bgc=bg-60:
+                                                  - rtgl-icon icon=play s=xl c=fg: null
+                                        $elif visual.resourceType == 'spritesheet':
+                                          - rvn-spritesheet-preview key=${visual.spritesheetPreviewKey} previewKey=${visual.spritesheetPreviewKey} fileId=${visual.spritesheetFileId} :atlas=${visual.spritesheetAtlas} :animation=${visual.spritesheetAnimation} w=200 h=120 emptyLabel=${noThumbnailLabel}: null
+                                        $elif visual.resourceType == 'layout':
+                                          - $if visual.fileId:
+                                              - rvn-file-image fileId=${visual.fileId} w=200 h=120: null
                                             $else:
-                                              - rtgl-text s=sm c=mu-fg: ${predefinedTransformLabel}
-                                              - rtgl-select#transform${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear: null
-                                          - rtgl-text s=sm c=mu-fg: ${animationLabel}
-                                          - rtgl-select#animation${groupIndex}x${i} data-index=${visual.visualIndex} key=${visual.animationId} :options=${defaultValues.animationOptions} :selectedValue=${visual.animationId} w=f placeholder=${selectAnimationPlaceholder}: null
-                                          - $if visual.animationId:
-                                              - rtgl-text s=sm c=mu-fg: ${animationPlaybackSpeedLabel}
-                                              - rtgl-input#animationPlaybackSpeed${groupIndex}x${i} data-index=${visual.visualIndex} type=number min=0.01 step=0.1 w=f value=${visual.animationPlaybackSpeed}: null
-                                              - $if visual.animationMode == 'update':
-                                                  - rtgl-text s=sm c=mu-fg: ${animationPlaybackLoopLabel}
-                                                  - rtgl-segmented-control#animationPlaybackLoop${groupIndex}x${i} data-index=${visual.visualIndex} w=f no-clear ?disabled=${visual.animationLoopDisabled} :selectedValue=${visual.animationPlaybackLoop} :options=${defaultValues.animationPlaybackLoopOptions}: null
-                                                  - $if !visual.animationCanLoop:
-                                                      - rtgl-text s=xs c=mu-fg: ${animationPlaybackLoopDisabledDescription}
-                                              - rtgl-text s=sm c=mu-fg: ${animationPlaybackContinuityLabel}
-                                              - rtgl-segmented-control#animationPlaybackContinuity${groupIndex}x${i} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.animationPlaybackContinuity} :options=${defaultValues.animationPlaybackContinuityOptions}: null
+                                              - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                                  - rtgl-text s=sm c=mu-fg: ${noThumbnailLabel}
+                                        $elif visual.fileId:
+                                          - rvn-file-image fileId=${visual.fileId} w=200 h=120: null
+                                        $else:
+                                          - rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg:
+                                              - rtgl-text s=sm c=mu-fg: ${noResourceLabel}
+                                      - rtgl-text s=xs c=mu-fg ellipsis w=200: ${visual.displayName}
+                          - 'rtgl-select#layer${visual.controlId} slot=${visual.layerFormSlot} data-index=${visual.visualIndex} key=${visual.layer} :options=${defaultValues.layerOptions} :selectedValue=${visual.layer} w=f no-clear': null
+                          - 'rtgl-view slot=${visual.transformModeFormSlot} data-index=${visual.visualIndex} w=f':
+                              - rtgl-segmented-control#customTransformMode${visual.controlId} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.customTransform} :options=${defaultValues.transformModeOptions}: null
+                          - $if !visual.customTransform:
+                              - 'rtgl-select#transform${visual.controlId} slot=${visual.predefinedTransformFormSlot} data-index=${visual.visualIndex} key=${visual.transformId} :options=${defaultValues.transformOptions} :selectedValue=${visual.transformId} w=f no-clear': null
+                          - $if visual.customTransform:
+                              - 'rtgl-view#customTransformButton${visual.controlId} slot=${visual.customTransformFormSlot} data-index=${visual.visualIndex} data-target-name="${visual.displayName}" role=button tabindex=0 aria-label="${transformEditorTitle}" w=f p=md bw=xs bc=bo h-bc=pr br=md bgc=bg cur=pointer style="box-sizing: border-box;"':
+                                  - rtgl-grid cols=2 g=md w=f:
+                                      - $for item, j in visual.customTransformDetails:
+                                          - rtgl-view d=h av=c g=sm:
+                                              - rtgl-text s=sm c=mu-fg: ${item.label}
+                                              - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums;"': ${item.value}
+                          - 'rtgl-select#animation${visual.controlId} slot=${visual.animationFormSlot} data-index=${visual.visualIndex} key=${visual.animationId} :options=${defaultValues.animationOptions} :selectedValue=${visual.animationId} w=f placeholder=${selectAnimationPlaceholder}': null
+                          - $if visual.animationId:
+                              - 'rtgl-input#animationPlaybackSpeed${visual.controlId} slot=${visual.playbackSpeedFormSlot} data-index=${visual.visualIndex} type=number min=0.01 step=0.1 w=f value=${visual.animationPlaybackSpeed}': null
+                              - 'rtgl-segmented-control#animationPlaybackContinuity${visual.controlId} slot=${visual.playbackContinuityFormSlot} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.animationPlaybackContinuity} :options=${defaultValues.animationPlaybackContinuityOptions}': null
+                              - $if visual.animationMode == 'update':
+                                  - 'rtgl-view slot=${visual.playbackLoopFormSlot} data-index=${visual.visualIndex} g=xs w=f':
+                                      - rtgl-segmented-control#animationPlaybackLoop${visual.controlId} data-index=${visual.visualIndex} w=f no-clear ?disabled=${visual.animationLoopDisabled} :selectedValue=${visual.animationPlaybackLoop} :options=${defaultValues.animationPlaybackLoopOptions}: null
+                                      - $if !visual.animationCanLoop:
+                                          - rtgl-text s=xs c=mu-fg: ${animationPlaybackLoopDisabledDescription}
+                          - 'rtgl-slider-input#opacity${visual.controlId} slot=${visual.opacityFormSlot} data-index=${visual.visualIndex} key=${visual.id} min=0 max=1 step=0.01 w=f value=${visual.opacity}': null
+                          - 'rtgl-segmented-control#blurToggle${visual.controlId} slot=${visual.blurToggleFormSlot} data-index=${visual.visualIndex} w=f no-clear :selectedValue=${visual.blurEnabled} :options=${defaultValues.blurToggleOptions}': null
+                          - $if visual.blurEnabled:
+                              - 'rtgl-input#blurX${visual.controlId} slot=${visual.blurXFormSlot} data-index=${visual.visualIndex} data-blur-field=x type=number w=f value=${visual.blur.x}': null
+                              - 'rtgl-input#blurY${visual.controlId} slot=${visual.blurYFormSlot} data-index=${visual.visualIndex} data-blur-field=y type=number w=f value=${visual.blur.y}': null
+                              - 'rtgl-input#blurQuality${visual.controlId} slot=${visual.blurQualityFormSlot} data-index=${visual.visualIndex} data-blur-field=quality type=number min=1 step=1 w=f value=${visual.blur.quality}': null
+                              - 'rtgl-select#blurKernelSize${visual.controlId} slot=${visual.blurKernelSizeFormSlot} data-index=${visual.visualIndex} data-blur-field=kernelSize w=f no-clear :selectedValue=${visual.blur.kernelSize} :options=${defaultValues.blurKernelSizeOptions}': null
+                              - 'rtgl-segmented-control#blurRepeatEdgePixels${visual.controlId} slot=${visual.blurRepeatEdgePixelsFormSlot} data-index=${visual.visualIndex} data-blur-field=repeatEdgePixels w=f no-clear :selectedValue=${visual.blur.repeatEdgePixels} :options=${defaultValues.blurRepeatEdgeOptions}': null
+              - rtgl-view w=f ph=lg:
                   - rtgl-button#addVisualButton v=ol w=f mt=md: ${addVisualButtonLabel}
+              - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'resource-select':

--- a/tests/commandLineVisual/commandLineVisual.handlers.test.js
+++ b/tests/commandLineVisual/commandLineVisual.handlers.test.js
@@ -7,6 +7,8 @@ import {
   handleBlurFieldInput,
   handleBlurToggleChange,
   handleButtonSelectClick,
+  handleCustomTransformButtonClick,
+  handleCustomTransformButtonKeyDown,
   handleDropdownMenuClickItem,
   handleFileExplorerItemClick,
   handleLayerChange,
@@ -1060,5 +1062,119 @@ describe("commandLineVisual.handlers animation controls", () => {
     expect(selectMode({ state })).toBe("resource-select");
     expect(selectTab({ state })).toBe("video");
     expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests the shared transform editor from the custom transform summary", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+      currentTarget: {
+        dataset: {
+          index: "0",
+          targetName: "Visual One",
+        },
+      },
+    };
+
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            resourceType: "image",
+            transformId: "visual-center",
+            layer: 50,
+          },
+        ],
+      },
+    );
+
+    handleCustomTransformButtonClick(
+      {
+        store: createStoreApi(state),
+        dispatchEvent,
+      },
+      { _event: event },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "action-transform-customize",
+    );
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      targetType: "visual",
+      actionKey: "visual",
+      itemIndex: 0,
+      item: {
+        id: "visual-1",
+        resourceId: "visual-image",
+        resourceType: "image",
+        transformId: "visual-center",
+        layer: 50,
+      },
+      targetName: "Visual One",
+      action: {
+        items: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            resourceType: "image",
+            transformId: "visual-center",
+            layer: 50,
+          },
+        ],
+      },
+    });
+  });
+
+  it("opens the custom transform summary with the keyboard", () => {
+    const state = createInitialState();
+    const dispatchEvent = vi.fn();
+    const event = {
+      key: "Enter",
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+      currentTarget: {
+        dataset: {
+          index: "0",
+          targetName: "Visual One",
+        },
+      },
+    };
+
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-1",
+            resourceId: "visual-image",
+            resourceType: "image",
+          },
+        ],
+      },
+    );
+
+    handleCustomTransformButtonKeyDown(
+      {
+        store: createStoreApi(state),
+        dispatchEvent,
+      },
+      { _event: event },
+    );
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0][0].type).toBe(
+      "action-transform-customize",
+    );
   });
 });

--- a/tests/commandLineVisual/commandLineVisual.sections.test.js
+++ b/tests/commandLineVisual/commandLineVisual.sections.test.js
@@ -7,7 +7,7 @@ import {
   setExistingVisuals,
   setImages,
 } from "../../src/components/commandLineVisual/commandLineVisual.store.js";
-import { EN_I18N } from "../support/i18n.js";
+import { EN_I18N, JA_I18N } from "../support/i18n.js";
 
 describe("commandLineVisual sections", () => {
   it("creates a named form section with two-column rows for each visual", () => {
@@ -132,5 +132,42 @@ describe("commandLineVisual sections", () => {
     );
     expect(view).toContain("rtgl-grid cols=2 g=md w=f:");
     expect(view).not.toContain("backgroundTransformEditor");
+  });
+
+  it("preserves user-authored visual names while localizing static labels", () => {
+    const state = createInitialState();
+    setImages(
+      { state },
+      {
+        images: {
+          items: {
+            "visual-one": {
+              id: "visual-one",
+              type: "image",
+              name: "Visuals",
+              fileId: "file-one",
+            },
+          },
+          tree: [{ id: "visual-one" }],
+        },
+      },
+    );
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-item-one",
+            resourceId: "visual-one",
+            resourceType: "image",
+          },
+        ],
+      },
+    );
+
+    const [section] = selectViewData({ state, i18n: JA_I18N }).form.fields;
+
+    expect(section.label).toBe("Visuals");
+    expect(section.fields[0].fields[0].label).toBe("表示素材");
   });
 });

--- a/tests/commandLineVisual/commandLineVisual.sections.test.js
+++ b/tests/commandLineVisual/commandLineVisual.sections.test.js
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  selectViewData,
+  setAnimations,
+  setExistingVisuals,
+  setImages,
+} from "../../src/components/commandLineVisual/commandLineVisual.store.js";
+import { EN_I18N } from "../support/i18n.js";
+
+describe("commandLineVisual sections", () => {
+  it("creates a named form section with two-column rows for each visual", () => {
+    const state = createInitialState();
+    setImages(
+      { state },
+      {
+        images: {
+          items: {
+            "visual-one": {
+              id: "visual-one",
+              type: "image",
+              name: "Visual One",
+              fileId: "file-one",
+            },
+          },
+          tree: [{ id: "visual-one" }],
+        },
+      },
+    );
+    setAnimations(
+      { state },
+      {
+        animations: {
+          items: {
+            fade: {
+              id: "fade",
+              type: "animation",
+              name: "Fade",
+              animation: { type: "update" },
+            },
+          },
+          tree: [{ id: "fade" }],
+        },
+      },
+    );
+    setExistingVisuals(
+      { state },
+      {
+        visuals: [
+          {
+            id: "visual-item-one",
+            resourceId: "visual-one",
+            resourceType: "image",
+            layer: 50,
+            opacity: 0.75,
+            blur: {
+              x: 4,
+              y: 6,
+              quality: 2,
+              kernelSize: 5,
+              repeatEdgePixels: false,
+            },
+            animations: { resourceId: "fade" },
+          },
+        ],
+      },
+    );
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+    const [section] = viewData.form.fields;
+    const rows = section.fields.map((field) =>
+      field.type === "row"
+        ? field.fields.map((nestedField) => nestedField.slot)
+        : field.slot,
+    );
+
+    expect(section).toMatchObject({
+      type: "section",
+      id: "visual-0",
+      label: "Visual One",
+    });
+    expect(rows).toEqual([
+      ["visual-0-preview", "visual-0-layer"],
+      ["visual-0-transform-mode", "visual-0-predefined-transform"],
+      "visual-0-animation",
+      ["visual-0-playback-speed", "visual-0-playback-continuity"],
+      ["visual-0-playback-loop", "visual-0-playback-loop-spacer"],
+      ["visual-0-opacity", "visual-0-blur-toggle"],
+      ["visual-0-blur-x", "visual-0-blur-y"],
+      ["visual-0-blur-quality", "visual-0-blur-kernel-size"],
+      "visual-0-blur-repeat-edge-pixels",
+    ]);
+    expect(viewData.defaultValues.visuals[0]).toMatchObject({
+      controlId: "0x0",
+      previewFormSlot: "visual-0-preview",
+      layerFormSlot: "visual-0-layer",
+    });
+    expect(viewData.formKey).toBe(
+      "0:visual-item-one:Visual One:50:preset-transform:fade:update:blur",
+    );
+  });
+
+  it("renders the visual controls through their matching form slots", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineVisual/commandLineVisual.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain("rtgl-form#form key=${formKey}");
+    expect(view).toContain("slot=${visual.previewFormSlot}");
+    expect(view).toContain("slot=${visual.layerFormSlot}");
+    expect(view).toContain("slot=${visual.transformModeFormSlot}");
+    expect(view).toContain("slot=${visual.predefinedTransformFormSlot}");
+    expect(view).toContain("slot=${visual.customTransformFormSlot}");
+    expect(view).toContain("slot=${visual.animationFormSlot}");
+    expect(view).toContain("slot=${visual.playbackSpeedFormSlot}");
+    expect(view).toContain("slot=${visual.playbackContinuityFormSlot}");
+    expect(view).toContain("slot=${visual.opacityFormSlot}");
+    expect(view).toContain("slot=${visual.blurToggleFormSlot}");
+    expect(view).toContain("slot=${visual.blurXFormSlot}");
+    expect(view).toContain("slot=${visual.blurYFormSlot}");
+    expect(view).toContain("slot=${visual.blurQualityFormSlot}");
+    expect(view).toContain("slot=${visual.blurKernelSizeFormSlot}");
+    expect(view).toContain("slot=${visual.blurRepeatEdgePixelsFormSlot}");
+    expect(view).toContain("handler: handleCustomTransformButtonKeyDown");
+    expect(view).toContain(
+      'data-target-name="${visual.displayName}" role=button tabindex=0',
+    );
+    expect(view).toContain("rtgl-grid cols=2 g=md w=f:");
+    expect(view).not.toContain("backgroundTransformEditor");
+  });
+});

--- a/tests/commandLineVisual/commandLineVisual.store.test.js
+++ b/tests/commandLineVisual/commandLineVisual.store.test.js
@@ -1041,6 +1041,9 @@ describe("commandLineVisual.store custom transforms", () => {
       customTransformDetails: expect.arrayContaining([
         { label: "Position", value: "1000, 600" },
         { label: "Scale", value: "1.5 x 1.5" },
+        { label: "Anchor", value: "0.5, 0.5" },
+        { label: "Rotation", value: "10°" },
+        { label: "Origin", value: "100, 80" },
       ]),
     });
   });

--- a/tests/commandLineVisual/commandLineVisual.view.test.js
+++ b/tests/commandLineVisual/commandLineVisual.view.test.js
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("commandLineVisual view", () => {
-  it("keeps the custom transform Edit button inside its horizontal row", () => {
+  it("uses the same accessible transform summary card as Background", () => {
     const view = readFileSync(
       new URL(
         "../../src/components/commandLineVisual/commandLineVisual.view.yaml",
@@ -10,18 +10,15 @@ describe("commandLineVisual view", () => {
       ),
       "utf8",
     );
-    const lines = view.split("\n");
-    const rowIndex = lines.findIndex((line) =>
-      line.includes("- rtgl-view d=h av=c w=f g=md:"),
-    );
-    const buttonIndex = lines.findIndex((line) =>
-      line.includes("- rtgl-button#customTransformButton${groupIndex}"),
-    );
-    expect(rowIndex).toBeGreaterThan(-1);
-    expect(buttonIndex).toBeGreaterThan(rowIndex);
 
-    const rowIndent = lines[rowIndex].match(/^\s*/)[0].length;
-    const buttonIndent = lines[buttonIndex].match(/^\s*/)[0].length;
-    expect(buttonIndent).toBe(rowIndent + 4);
+    expect(view).toContain("customTransformButton*:");
+    expect(view).toContain("handler: handleCustomTransformButtonClick");
+    expect(view).toContain("handler: handleCustomTransformButtonKeyDown");
+    expect(view).toContain(
+      'rtgl-view#customTransformButton${visual.controlId} slot=${visual.customTransformFormSlot} data-index=${visual.visualIndex} data-target-name="${visual.displayName}" role=button tabindex=0 aria-label="${transformEditorTitle}"',
+    );
+    expect(view).toContain("rtgl-grid cols=2 g=md w=f:");
+    expect(view).toContain("$for item, j in visual.customTransformDetails:");
+    expect(view).not.toContain("backgroundTransformEditor");
   });
 });


### PR DESCRIPTION
## Summary
- render each visual as its own form section
- use two-column rows for related visual controls
- align custom transform editing with Background's accessible summary and shared full-screen editor

## Validation
- bunx vitest run tests/commandLineVisual/commandLineVisual.handlers.test.js tests/commandLineVisual/commandLineVisual.store.test.js tests/commandLineVisual/commandLineVisual.view.test.js tests/commandLineVisual/commandLineVisual.sections.test.js tests/commandLineCharacters/commandLineCharacters.sections.test.js tests/versions/versions.store.test.js
- bunx oxlint on changed JavaScript files
- bunx prettier --check on changed files
- git diff --check