### PR TITLE
chore: update route engine to 1.39.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "jszip": "3.10.1",
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
-        "route-engine-js": "1.34.0",
+        "route-engine-js": "1.39.1",
         "route-graphics": "1.39.1",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
@@ -907,7 +907,7 @@
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
-    "route-engine-js": ["route-engine-js@1.34.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1", "unicode-segmenter": "^0.17.0" } }, "sha512-YlpxMOM94IHnQmLhHhCWyMBlIBNAVHKgAum4334jFvcFePJbqkolHXfRt1tHHgkVTOvRExmR9SxGMD8TEZsIZg=="],
+    "route-engine-js": ["route-engine-js@1.39.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1", "unicode-segmenter": "^0.17.0" } }, "sha512-gU8WUU9bI5L9I/k++EJ5AEFQ/xnkRwO7p7Flw06ECSysGqf5RyyZTiKhBHHzXINnyjqSY2qkBw97W1padujSSw=="],
 
     "route-graphics": ["route-graphics@1.39.1", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "@wasm-audio-decoders/ogg-vorbis": "^0.1.20", "gsap": "3.15.0", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "ogg-opus-decoder": "^1.7.3", "pixi.js": "8.9.2", "playwright": "1.57.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-eNwOInUO4DqLVK/t/Tp8RJzbpEHcRczcknfBzvGogKPxoDKqdrMb47VRAnGaNdyvM2uiIIU+gIyIkYpAeQaGZA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jszip": "3.10.1",
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
-    "route-engine-js": "1.34.0",
+    "route-engine-js": "1.39.1",
     "route-graphics": "1.39.1",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",


### PR DESCRIPTION
## Summary
- update `route-engine-js` from 1.34.0 to 1.39.1
- refresh the Bun lockfile for the published package

## Testing
- `bun install`
- verified installed `route-engine-js` version is 1.39.1