### PR TITLE
fix: keep repository revisions monotonic

### DIFF
--- a/src/deps/services/shared/collab/clientStoreHistory.js
+++ b/src/deps/services/shared/collab/clientStoreHistory.js
@@ -37,7 +37,10 @@ export const areRepositoryHistoryStatsEqual = (left, right) => {
   );
 };
 
-export const toRepositoryEvent = (item, { created, projectId } = {}) => {
+export const toRepositoryEvent = (
+  item,
+  { created, projectId, repositoryRevision } = {},
+) => {
   if (typeof item?.partition !== "string" || item.partition.length === 0) {
     throw new Error("Stored collab row is missing partition");
   }
@@ -51,7 +54,7 @@ export const toRepositoryEvent = (item, { created, projectId } = {}) => {
     throw new Error("Stored collab row is missing projectId");
   }
 
-  return {
+  const repositoryEvent = {
     id: item.id,
     partition: item.partition,
     projectId: resolvedProjectId,
@@ -67,6 +70,15 @@ export const toRepositoryEvent = (item, { created, projectId } = {}) => {
     meta: item.meta ? structuredClone(item.meta) : {},
     ...(created !== undefined ? { serverTs: created } : {}),
   };
+
+  if (Number.isFinite(Number(repositoryRevision))) {
+    repositoryEvent.repositoryRevision = Math.max(
+      0,
+      Math.floor(Number(repositoryRevision)),
+    );
+  }
+
+  return repositoryEvent;
 };
 
 export const assertRepositoryEventShape = (event) => {
@@ -306,10 +318,11 @@ export const loadRepositoryEventsFromClientStore = async ({
   };
 
   const events = [];
-  for (const committedEvent of committed) {
+  for (const [committedIndex, committedEvent] of committed.entries()) {
     const nextEvent = toRepositoryEvent(committedEvent, {
       created: committedEvent.serverTs,
       projectId,
+      repositoryRevision: committedIndex + 1,
     });
     assertRepositoryEventShape(nextEvent);
     events.push(nextEvent);
@@ -333,10 +346,11 @@ export const loadRepositoryEventsFromClientStore = async ({
     });
   }
 
-  const draftEvents = drafts.map((draft) => {
+  const draftEvents = drafts.map((draft, draftIndex) => {
     const nextEvent = toRepositoryEvent(draft, {
       created: draft.createdAt,
       projectId,
+      repositoryRevision: committed.length + draftIndex + 1,
     });
     assertRepositoryEventShape(nextEvent);
     return nextEvent;

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -536,6 +536,27 @@ export const createProjectRepositoryRuntime = async ({
   let currentRevision = Number.isFinite(Number(initialRevision))
     ? Math.max(0, Math.floor(Number(initialRevision)))
     : events.length;
+  const createEventRevisions = (source = []) => {
+    let previousRevision = 0;
+    return source.map((event, index) => {
+      const explicitRevision = Number(event?.repositoryRevision);
+      const fallbackRevision = index + 1;
+      const revision = Number.isFinite(explicitRevision)
+        ? Math.max(
+            previousRevision + 1,
+            Math.floor(explicitRevision),
+            fallbackRevision,
+          )
+        : Math.max(previousRevision + 1, fallbackRevision);
+      previousRevision = revision;
+      return revision;
+    });
+  };
+  let eventRevisions = createEventRevisions(events);
+  currentRevision = Math.max(
+    currentRevision,
+    eventRevisions.at(-1) ?? events.length,
+  );
   let activeHydrationProgress;
   const hasDraftHistory = Number(historyStats?.draftCount || 0) > 0;
 
@@ -544,6 +565,48 @@ export const createProjectRepositoryRuntime = async ({
     // checkpoint revision still includes their positions.
     currentRevision = Math.max(currentRevision + 1, events.length);
     return currentRevision;
+  };
+
+  const resolveEventCountAtRevision = (untilRevision) => {
+    const parsedRevision = Number(untilRevision);
+    const targetRevision = Number.isFinite(parsedRevision)
+      ? Math.max(0, Math.floor(parsedRevision))
+      : currentRevision;
+    let lowerIndex = 0;
+    let upperIndex = eventRevisions.length;
+
+    while (lowerIndex < upperIndex) {
+      const middleIndex = Math.floor((lowerIndex + upperIndex) / 2);
+      if (eventRevisions[middleIndex] <= targetRevision) {
+        lowerIndex = middleIndex + 1;
+      } else {
+        upperIndex = middleIndex;
+      }
+    }
+
+    return lowerIndex;
+  };
+
+  const listLoadedEventsAfterRevision = ({ sinceCommittedId, limit } = {}) => {
+    const parsedRevision = Number(sinceCommittedId);
+    const revision = Number.isFinite(parsedRevision)
+      ? Math.max(0, Math.floor(parsedRevision))
+      : 0;
+    const startIndex = resolveEventCountAtRevision(revision);
+    const safeLimit =
+      Number.isInteger(limit) && limit > 0
+        ? limit
+        : Math.max(0, events.length - startIndex);
+
+    return events
+      .slice(startIndex, startIndex + safeLimit)
+      .map((event, index) =>
+        toCommittedProjectEvent({
+          event,
+          committedId: eventRevisions[startIndex + index],
+          projectId,
+        }),
+      );
   };
 
   const toProgressValue = (value) => {
@@ -576,8 +639,12 @@ export const createProjectRepositoryRuntime = async ({
         events = Array.isArray(loadedEvents)
           ? loadedEvents.map((event) => structuredClone(event))
           : [];
+        eventRevisions = createEventRevisions(events);
         hasLoadedEvents = true;
-        currentRevision = Math.max(currentRevision, events.length);
+        currentRevision = Math.max(
+          currentRevision,
+          eventRevisions.at(-1) ?? events.length,
+        );
         return events;
       })
       .catch((error) => {
@@ -690,7 +757,7 @@ export const createProjectRepositoryRuntime = async ({
       }),
     ],
     getLatestCommittedId: async () =>
-      hasLoadedEvents ? events.length : currentRevision,
+      hasLoadedEvents ? (eventRevisions.at(-1) ?? 0) : currentRevision,
     listCommittedAfter: async ({ sinceCommittedId, limit }) => {
       if (!hasLoadedEvents && !hasDraftHistory) {
         const committedBatch = await store.listCommittedAfter({
@@ -706,23 +773,10 @@ export const createProjectRepositoryRuntime = async ({
       }
 
       await ensureEventHistoryLoaded();
-      const startIndex = Math.max(
-        0,
-        Number.isFinite(Number(sinceCommittedId))
-          ? Math.floor(Number(sinceCommittedId))
-          : 0,
-      );
-      const safeLimit =
-        Number.isInteger(limit) && limit > 0 ? limit : events.length;
-      const batch = events
-        .slice(startIndex, startIndex + safeLimit)
-        .map((event, index) =>
-          toCommittedProjectEvent({
-            event,
-            committedId: startIndex + index + 1,
-            projectId,
-          }),
-        );
+      const batch = listLoadedEventsAfterRevision({
+        sinceCommittedId,
+        limit,
+      });
 
       reportHydrationProgressFromBatch(batch);
       return batch;
@@ -920,23 +974,7 @@ export const createProjectRepositoryRuntime = async ({
     }
 
     await ensureEventHistoryLoaded();
-    const startIndex = Math.max(
-      0,
-      Number.isFinite(Number(sinceCommittedId))
-        ? Math.floor(Number(sinceCommittedId))
-        : 0,
-    );
-    const safeLimit =
-      Number.isInteger(limit) && limit > 0 ? limit : events.length;
-    return events
-      .slice(startIndex, startIndex + safeLimit)
-      .map((event, index) =>
-        toCommittedProjectEvent({
-          event,
-          committedId: startIndex + index + 1,
-          projectId,
-        }),
-      );
+    return listLoadedEventsAfterRevision({ sinceCommittedId, limit });
   };
 
   const listSceneOverviewEventsAfterFromRepository = async ({
@@ -995,15 +1033,10 @@ export const createProjectRepositoryRuntime = async ({
       return tailEvents;
     }
 
-    return events
-      .slice(startIndex, startIndex + safeLimit)
-      .map((event, index) =>
-        toCommittedProjectEvent({
-          event,
-          committedId: startIndex + index + 1,
-          projectId,
-        }),
-      );
+    return listLoadedEventsAfterRevision({
+      sinceCommittedId,
+      limit: safeLimit,
+    });
   };
 
   const loadState = async (untilEventIndex) => {
@@ -1013,7 +1046,7 @@ export const createProjectRepositoryRuntime = async ({
         : await ensureEventHistoryLoaded();
       return replayEventsToRepositoryState({
         events: replayEvents,
-        untilEventIndex,
+        untilEventIndex: resolveEventCountAtRevision(untilEventIndex),
         createInitialState,
         reduceEventToState,
         reduceEventsToState,
@@ -1401,7 +1434,7 @@ export const createProjectRepositoryRuntime = async ({
       // that replay result directly avoids one more full clone during export.
       return replayEventsToRepositoryState({
         events,
-        untilEventIndex,
+        untilEventIndex: resolveEventCountAtRevision(untilEventIndex),
         createInitialState,
         reduceEventToState,
         reduceEventsToState,
@@ -1506,6 +1539,7 @@ export const createProjectRepositoryRuntime = async ({
 
       events.push(structuredClone(event));
       const committedId = advanceCurrentRevision();
+      eventRevisions.push(committedId);
 
       const committedEvent = toCommittedProjectEvent({
         event,
@@ -1542,6 +1576,7 @@ export const createProjectRepositoryRuntime = async ({
       for (const event of nextEvents) {
         events.push(structuredClone(event));
         const committedId = advanceCurrentRevision();
+        eventRevisions.push(committedId);
         const committedEvent = toCommittedProjectEvent({
           event,
           committedId,

--- a/src/deps/services/shared/projectRepositoryRuntime.js
+++ b/src/deps/services/shared/projectRepositoryRuntime.js
@@ -539,6 +539,13 @@ export const createProjectRepositoryRuntime = async ({
   let activeHydrationProgress;
   const hasDraftHistory = Number(historyStats?.draftCount || 0) > 0;
 
+  const advanceCurrentRevision = () => {
+    // Replayed history may omit preserved invalid drafts even though the
+    // checkpoint revision still includes their positions.
+    currentRevision = Math.max(currentRevision + 1, events.length);
+    return currentRevision;
+  };
+
   const toProgressValue = (value) => {
     const numericValue = Number(value);
     if (!Number.isFinite(numericValue)) {
@@ -1498,11 +1505,11 @@ export const createProjectRepositoryRuntime = async ({
       }
 
       events.push(structuredClone(event));
-      currentRevision = events.length;
+      const committedId = advanceCurrentRevision();
 
       const committedEvent = toCommittedProjectEvent({
         event,
-        committedId: currentRevision,
+        committedId,
         projectId,
       });
 
@@ -1534,10 +1541,10 @@ export const createProjectRepositoryRuntime = async ({
       const committedEvents = [];
       for (const event of nextEvents) {
         events.push(structuredClone(event));
-        currentRevision = events.length;
+        const committedId = advanceCurrentRevision();
         const committedEvent = toCommittedProjectEvent({
           event,
-          committedId: currentRevision,
+          committedId,
           projectId,
         });
         committedEvents.push(committedEvent);

--- a/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
+++ b/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
@@ -1132,6 +1132,8 @@ describe("projectRepositoryRuntime replay diagnostics", () => {
       size: 123,
       sha256: "particle-thumbnail-sha256",
     });
+    const versionRevision = repository.getRevision();
+    expect(versionRevision).toBe(3);
 
     const particleData = createParticlePreset({ presetId: "snow" });
     particleData.thumbnailFileId = "particle-thumbnail-1";
@@ -1155,6 +1157,20 @@ describe("projectRepositoryRuntime replay diagnostics", () => {
       id: "particle-1",
       thumbnailFileId: "particle-thumbnail-1",
     });
+    const versionState = await repository.loadState(versionRevision);
+    expect(versionState).toMatchObject({
+      files: {
+        items: {
+          "particle-thumbnail-1": {
+            id: "particle-thumbnail-1",
+          },
+        },
+      },
+    });
+    expect(versionState.particles.items["particle-1"]).toBeUndefined();
+    expect(
+      repository.getState(versionRevision).particles.items["particle-1"],
+    ).toBeUndefined();
     expect(repository.getRevision()).toBe(4);
     expect(loadEvents).toHaveBeenCalledTimes(1);
     await expect(repository.loadEvents()).resolves.toHaveLength(3);
@@ -1249,6 +1265,9 @@ describe("projectRepositoryRuntime replay diagnostics", () => {
     expect(repository.getRevision()).toBe(5);
     expect(loadEvents).toHaveBeenCalledTimes(1);
     await expect(repository.loadEvents()).resolves.toHaveLength(3);
+    await expect(repository.loadState(4)).resolves.toEqual({
+      appliedIds: ["event-1", "event-2"],
+    });
 
     await repository.flushMainCheckpoint();
 

--- a/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
+++ b/tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  createProjectRepository,
   createProjectCreateRepositoryEvent,
+  createRepositoryCommandEvent,
   initialProjectData,
 } from "../../src/deps/services/shared/projectRepository.js";
 import {
@@ -18,6 +20,8 @@ import {
   mainScenePartitionFor,
   scenePartitionFor,
 } from "../../src/deps/services/shared/collab/partitions.js";
+import { COMMAND_TYPES } from "../../src/internal/project/commands.js";
+import { createParticlePreset } from "../../src/pages/particles/support/particlePresets.js";
 
 const createBatchedReducer = (reduceEventToState) => {
   return ({ repositoryState, events }) => {
@@ -1053,6 +1057,206 @@ describe("projectRepositoryRuntime replay diagnostics", () => {
     await expect(repository.loadEvents()).resolves.toHaveLength(2);
     expect(repository.getState()).toEqual({
       appliedCount: 2,
+    });
+  });
+
+  it("applies a thumbnail file and particle after a checkpoint cursor exceeds replayed history", async () => {
+    const projectId = "project-1";
+    const bootstrapEvent = createProjectCreateRepositoryEvent({
+      projectId,
+      state: initialProjectData,
+      commandId: "project-create-1",
+      clientTs: 1,
+    });
+    const loadEvents = vi.fn(async () => [structuredClone(bootstrapEvent)]);
+    const savedMainCheckpoints = [];
+    const repository = await createProjectRepository({
+      projectId,
+      store: {
+        loadMaterializedViewCheckpoint: async () => ({
+          viewName: MAIN_VIEW_NAME,
+          viewVersion: "1",
+          partition: "m",
+          lastCommittedId: 2,
+          value: createMainProjectionState(initialProjectData),
+        }),
+        saveMaterializedViewCheckpoint: async (checkpoint) => {
+          savedMainCheckpoints.push(structuredClone(checkpoint));
+        },
+        deleteMaterializedViewCheckpoint: async () => {},
+      },
+      initialRevision: 2,
+      historyStats: {
+        committedCount: 1,
+        latestCommittedId: 1,
+        draftCount: 1,
+        latestDraftClock: 1,
+      },
+      loadEvents,
+    });
+    const createEvent = ({ id, type, payload, clientTs }) =>
+      createRepositoryCommandEvent({
+        command: {
+          id,
+          projectId,
+          partition: "m",
+          type,
+          payload,
+          actor: {
+            userId: "user-1",
+            clientId: "client-1",
+          },
+          clientTs,
+        },
+      });
+
+    await repository.addEvent(
+      createEvent({
+        id: "file-create-1",
+        type: COMMAND_TYPES.FILE_CREATE,
+        payload: {
+          fileId: "particle-thumbnail-1",
+          data: {
+            mimeType: "image/webp",
+            size: 123,
+            sha256: "particle-thumbnail-sha256",
+          },
+        },
+        clientTs: 2,
+      }),
+    );
+
+    expect(repository.getState().files.items["particle-thumbnail-1"]).toEqual({
+      id: "particle-thumbnail-1",
+      mimeType: "image/webp",
+      size: 123,
+      sha256: "particle-thumbnail-sha256",
+    });
+
+    const particleData = createParticlePreset({ presetId: "snow" });
+    particleData.thumbnailFileId = "particle-thumbnail-1";
+    await expect(
+      repository.addEvent(
+        createEvent({
+          id: "particle-create-1",
+          type: COMMAND_TYPES.PARTICLE_CREATE,
+          payload: {
+            particleId: "particle-1",
+            data: particleData,
+            parentId: null,
+            index: 0,
+          },
+          clientTs: 3,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(repository.getState().particles.items["particle-1"]).toMatchObject({
+      id: "particle-1",
+      thumbnailFileId: "particle-thumbnail-1",
+    });
+    expect(repository.getRevision()).toBe(4);
+    expect(loadEvents).toHaveBeenCalledTimes(1);
+    await expect(repository.loadEvents()).resolves.toHaveLength(3);
+
+    await repository.flushMainCheckpoint();
+
+    expect(savedMainCheckpoints.at(-1)).toMatchObject({
+      lastCommittedId: 4,
+      value: {
+        files: {
+          items: {
+            "particle-thumbnail-1": {
+              id: "particle-thumbnail-1",
+            },
+          },
+        },
+        particles: {
+          items: {
+            "particle-1": {
+              id: "particle-1",
+              thumbnailFileId: "particle-thumbnail-1",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("keeps batch event revisions ahead of a checkpoint cursor after filtered history", async () => {
+    const loadEvents = vi.fn(async () => [
+      {
+        id: "event-1",
+        type: "resource.update",
+        partition: "m",
+        payload: {},
+      },
+    ]);
+    const savedMainCheckpoints = [];
+    const reduceEventToState = ({ repositoryState, event }) => ({
+      appliedIds: [...(repositoryState?.appliedIds || []), event.id],
+    });
+    const repository = await createProjectRepositoryRuntime({
+      projectId: "project-1",
+      store: {
+        loadMaterializedViewCheckpoint: async () => ({
+          viewName: MAIN_VIEW_NAME,
+          viewVersion: "1",
+          partition: "m",
+          lastCommittedId: 3,
+          value: {
+            appliedIds: ["event-1"],
+          },
+        }),
+        saveMaterializedViewCheckpoint: async (checkpoint) => {
+          savedMainCheckpoints.push(structuredClone(checkpoint));
+        },
+        deleteMaterializedViewCheckpoint: async () => {},
+      },
+      initialRevision: 3,
+      historyStats: {
+        committedCount: 1,
+        latestCommittedId: 1,
+        draftCount: 2,
+        latestDraftClock: 2,
+      },
+      loadEvents,
+      createInitialState: () => ({
+        appliedIds: [],
+      }),
+      reduceEventToState,
+      reduceEventsToState: createBatchedReducer(reduceEventToState),
+    });
+
+    await repository.addEvents([
+      {
+        id: "event-2",
+        type: "resource.update",
+        partition: "m",
+        payload: {},
+      },
+      {
+        id: "event-3",
+        type: "resource.update",
+        partition: "m",
+        payload: {},
+      },
+    ]);
+
+    expect(repository.getState()).toEqual({
+      appliedIds: ["event-1", "event-2", "event-3"],
+    });
+    expect(repository.getRevision()).toBe(5);
+    expect(loadEvents).toHaveBeenCalledTimes(1);
+    await expect(repository.loadEvents()).resolves.toHaveLength(3);
+
+    await repository.flushMainCheckpoint();
+
+    expect(savedMainCheckpoints.at(-1)).toMatchObject({
+      lastCommittedId: 5,
+      value: {
+        appliedIds: ["event-1", "event-2", "event-3"],
+      },
     });
   });
 

--- a/tests/web/webRepositoryAdapter.test.js
+++ b/tests/web/webRepositoryAdapter.test.js
@@ -634,9 +634,23 @@ describe("webRepositoryAdapter", () => {
       clientTs: 120,
       createdAt: 120,
     };
+    const validDraft = {
+      ...duplicateDraft,
+      id: "tag-draft-valid",
+      payload: {
+        ...duplicateDraft.payload,
+        tagId: "image-tag-3",
+        data: {
+          type: "tag",
+          name: "Foreground",
+        },
+      },
+      clientTs: 130,
+      createdAt: 130,
+    };
     const rawClientStore = createRawClientStoreStub({
       committed: [committedEvent, committedTagCreate],
-      drafts: [duplicateDraft],
+      drafts: [duplicateDraft, validDraft],
       cursor: 2,
     });
     const adapter = await createInsiemeWebStoreAdapter(projectId, {
@@ -651,10 +665,17 @@ describe("webRepositoryAdapter", () => {
     ).resolves.toEqual([
       expect.objectContaining({
         type: "project.create",
+        repositoryRevision: 1,
       }),
       expect.objectContaining({
         type: "tag.create",
         id: "tag-committed-1",
+        repositoryRevision: 2,
+      }),
+      expect.objectContaining({
+        type: "tag.create",
+        id: "tag-draft-valid",
+        repositoryRevision: 4,
       }),
     ]);
 


### PR DESCRIPTION
## Summary
- keep appended repository-event revisions ahead of persisted materialized-view checkpoint cursors when replay omits preserved invalid drafts
- prevent newly stored thumbnail metadata from being skipped before particle creation
- cover both the exact `file.create` to `particle.create` regression and batched event appends

## Testing
- `bunx vitest run tests/projectRepositoryRuntime/projectRepositoryRuntime.test.js tests/commandApi/resourceFileBatching.test.js tests/web/webRepositoryAdapter.test.js tests/tauri/collabClientStore.locking.test.js` (50 tests passed)
- relevant repository/project/command/storage selection (49 files, 336 tests passed)
- `bun run test`
- `bun run test:puty`
- `bun run lint`
- full `bunx vitest run` attempted; the repository currently has 41 unrelated failures across 12 UI/service test files involving missing mocks/i18n setup and stale expectations