### PR TITLE
Improve animation timeline editing

### DIFF
--- a/src/components/keyframeTimeline/keyframeTimeline.handlers.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.handlers.js
@@ -189,6 +189,21 @@ const dispatchKeyframeDurationChangeEvent = ({
   );
 };
 
+const dispatchAutoDurationChangeEvent = ({
+  dispatchEvent,
+  duration,
+  property,
+  side,
+} = {}) => {
+  dispatchEvent(
+    new CustomEvent("auto-duration-change", {
+      detail: { duration, property, side },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
 const dispatchKeyframeClickEvent = ({
   dispatchEvent,
   property,
@@ -746,14 +761,22 @@ export const handleDurationResizeStart = (deps, payload) => {
   const trackWidth = trackElement?.getBoundingClientRect?.().width;
   const property = handleElement.dataset.property;
   const index = Number(handleElement.dataset.index);
+  const mode = handleElement.dataset.trackMode ?? "keyframes";
   const edge = handleElement.dataset.resizeEdge ?? "right";
-  const startDelay = Math.max(
-    0,
-    parseFloat(props.properties?.[property]?.keyframes?.[index]?.delay) || 0,
-  );
+  const startDelay =
+    mode === "auto"
+      ? 0
+      : Math.max(
+          0,
+          parseFloat(props.properties?.[property]?.keyframes?.[index]?.delay) ||
+            0,
+        );
   const startDuration =
-    parseFloat(props.properties?.[property]?.keyframes?.[index]?.duration) ||
-    1000;
+    mode === "auto"
+      ? parseFloat(props.properties?.[property]?.auto?.duration) || 1000
+      : parseFloat(
+          props.properties?.[property]?.keyframes?.[index]?.duration,
+        ) || 1000;
   const timelineDuration = resolveTimelineDuration(props);
 
   if (!(trackWidth > 0) || !(timelineDuration > 0)) {
@@ -767,6 +790,7 @@ export const handleDurationResizeStart = (deps, payload) => {
     pointerId: event.pointerId,
     property,
     index,
+    mode,
     edge,
     startX: event.clientX,
     startDelay,
@@ -849,14 +873,23 @@ export const handleDurationResizeEnd = (deps, payload) => {
   event.stopPropagation();
   event.currentTarget.releasePointerCapture?.(event.pointerId);
   store.clearDurationResize({});
-  dispatchKeyframeDurationChangeEvent({
-    dispatchEvent,
-    delay: durationResize.delay,
-    duration: durationResize.duration,
-    property: durationResize.property,
-    side: props.side,
-    index: durationResize.index,
-  });
+  if (durationResize.mode === "auto") {
+    dispatchAutoDurationChangeEvent({
+      dispatchEvent,
+      duration: durationResize.duration,
+      property: durationResize.property,
+      side: props.side,
+    });
+  } else {
+    dispatchKeyframeDurationChangeEvent({
+      dispatchEvent,
+      delay: durationResize.delay,
+      duration: durationResize.duration,
+      property: durationResize.property,
+      side: props.side,
+      index: durationResize.index,
+    });
+  }
   dispatchTimelineUsedDurationPreviewEvent({
     active: false,
     dispatchEvent,

--- a/src/components/keyframeTimeline/keyframeTimeline.store.js
+++ b/src/components/keyframeTimeline/keyframeTimeline.store.js
@@ -44,6 +44,7 @@ export const startDurationResize = (
     pointerId,
     property,
     index,
+    mode = "keyframes",
     edge,
     startX,
     startDelay,
@@ -57,6 +58,7 @@ export const startDurationResize = (
     pointerId,
     property,
     index: Number(index),
+    mode,
     edge,
     startX,
     startDelay: resolvedStartDelay,
@@ -168,7 +170,9 @@ const resolveKeyframeTiming = ({
   const durationResize = state.durationResize;
   const keyframeMove = state.keyframeMove;
   const isResizingKeyframe =
-    durationResize?.property === propertyName && durationResize.index === index;
+    durationResize?.mode !== "auto" &&
+    durationResize?.property === propertyName &&
+    durationResize.index === index;
   const isMovingKeyframe =
     keyframeMove?.property === propertyName && keyframeMove.index === index;
   const isFollowingMovingKeyframe =
@@ -195,8 +199,13 @@ const resolveKeyframeTiming = ({
 const getPreviewPropertiesDuration = ({ state, props } = {}) => {
   return Object.entries(props.properties ?? {}).reduce(
     (maxDuration, [propertyName, propertyConfig]) => {
+      const isResizingAuto =
+        state.durationResize?.mode === "auto" &&
+        state.durationResize.property === propertyName;
       const propertyDuration = propertyConfig.auto
-        ? Number(propertyConfig.auto.duration) || 0
+        ? isResizingAuto
+          ? Number(state.durationResize.duration) || 0
+          : Number(propertyConfig.auto.duration) || 0
         : (propertyConfig.keyframes ?? []).reduce(
             (duration, keyframe, index) => {
               const timing = resolveKeyframeTiming({
@@ -391,7 +400,8 @@ const createRulerTicks = (durationMs) => {
     );
 };
 
-export const selectViewData = ({ state, props, props: attrs }) => {
+export const selectViewData = ({ state, props, props: attrs, i18n = {} }) => {
+  const autoLabel = i18n.animationEditorPage?.autoTweenMode ?? "Auto";
   const showRuler = attrs.showRuler === true;
   const showTracks = attrs.showTracks !== false;
   const resolveTrackCursor = ({ propertyName, trackMode } = {}) => {
@@ -435,7 +445,12 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         thumbnailBorderColor: propertyConfig.thumbnailBorderColor ?? "bo",
         thumbnailFileId: propertyConfig.thumbnailFileId,
         thumbnailName: propertyConfig.thumbnailName ?? propertyName,
-        initialValue: autoConfig ? "" : isDefault ? "D" : value,
+        initialValue: autoConfig
+          ? autoLabel.toLocaleLowerCase()
+          : isDefault
+            ? "D"
+            : value,
+        initialValueColor: autoConfig ? "mu" : selected ? "ac-fg" : "fg",
         trackMode: autoConfig ? "auto" : "keyframes",
         keyframes: propertyConfig.keyframes,
         auto: autoConfig
@@ -511,7 +526,12 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       const nextProperty = {
         ...property,
       };
-      const propertyDuration = getPropertyDuration(property);
+      const isResizingAuto =
+        state.durationResize?.mode === "auto" &&
+        state.durationResize.property === property.name;
+      const propertyDuration = isResizingAuto
+        ? Number(state.durationResize.duration) || 0
+        : getPropertyDuration(property);
       const autoWidthPercent =
         resolvedTimelineDuration > 0
           ? (propertyDuration / resolvedTimelineDuration) * 100
@@ -519,8 +539,8 @@ export const selectViewData = ({ state, props, props: attrs }) => {
 
       nextProperty.auto = {
         ...property.auto,
+        duration: propertyDuration,
         easingLabel: formatEasingLabel(property.auto.easing),
-        label: `Auto ${propertyDuration}ms ${formatEasingLabel(property.auto.easing)}`,
         widthPercent: autoWidthPercent.toFixed(2),
       };
       nextProperty.fillerWidthPercent = Math.max(
@@ -660,6 +680,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     showTotalDuration: attrs.showTotalDuration !== false,
     showRuler,
     showTracks,
+    rulerCursor: attrs.interactiveRuler === true ? "ew-resize" : "default",
     rulerTicks,
     rulerIndicatorVisible,
     playheadIndicatorTimeLabel,

--- a/src/components/keyframeTimeline/keyframeTimeline.view.yaml
+++ b/src/components/keyframeTimeline/keyframeTimeline.view.yaml
@@ -53,6 +53,13 @@ styles:
   ".keyframeTimelinePropertyRow:focus-visible":
     outline: "2px solid var(--ring)"
     outline-offset: -2px
+  ".keyframeTimelineKeyframe":
+    container-type: inline-size
+  ".keyframeTimelineKeyframeValue":
+    min-width: "0"
+  '@container (max-width: 40px)':
+    ".keyframeTimelineKeyframeValue":
+      display: none
 template:
   - rtgl-view g=md w=f pos=rel:
       - $if showRuler || (showTracks && selectedProperties.length > 0):
@@ -62,7 +69,7 @@ template:
                       - 'rtgl-view d=h h=56 w=104 bgc=bg bwr=xs bc=bo style="min-width: 104px; flex-shrink: 0; position: sticky; left: 0; z-index: 6;"':
                           - rtgl-view w=72: null
                           - rtgl-view h=24 w=24 mr=sm ml=sm: null
-                      - 'rtgl-view#rulerTrack w=f h=56 pos=rel style="min-width: 0; overflow: visible; cursor: ew-resize; touch-action: none;"':
+                      - 'rtgl-view#rulerTrack w=f h=56 pos=rel style="min-width: 0; overflow: visible; cursor: ${rulerCursor}; touch-action: none;"':
                           - $if usedDurationVisible:
                               - 'rtgl-view pos=abs bgc=su style="${usedDurationStyle}"': null
                           - $if rulerIndicatorVisible:
@@ -87,7 +94,7 @@ template:
                                     $else:
                                       - rtgl-text s=xs c=${property.nameColor}: ${property.name}
                               - 'rtgl-view h=24 w=24 av=c ah=e mr=sm ml=sm pos=rel style="z-index: 2;"':
-                                  - rtgl-text s=xs: ${property.initialValue}
+                                  - 'rtgl-text s=xs c=${property.initialValueColor} ellipsis title="${property.initialValue}"': ${property.initialValue}
                           - 'rtgl-view#track${pIndex} data-keyframe-track=true data-property=${property.name} data-track-mode=${property.trackMode} d=h w=f h=24 bgc=mu br=sm pos=rel style="min-width: 0; overflow: hidden; cursor: ${property.trackCursor};"':
                               - $if property.valueCurvePath:
                                   - 'svg data-value-curve=${property.name} aria-hidden=true viewBox="0 0 100 20" preserveAspectRatio="none" style="position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; opacity: 0.72; z-index: 3;"':
@@ -98,7 +105,9 @@ template:
                                       - rtgl-text s=xs c=bg: +
                               - $if property.auto:
                                   - 'rtgl-view d=h p=xs h=f bgc=ac br=sm ah=c av=c pos=rel title="${property.auto.easingLabel}" style="width: ${property.auto.widthPercent}%; overflow: hidden;"':
-                                      - 'rtgl-text s=xs c=ac-fg style="position: relative; z-index: 1;"': ${property.auto.label}
+                                      - $if editable:
+                                          - 'rtgl-view#durationHandleAuto${pIndex} data-keyframe-duration-handle=right data-resize-edge=right data-track-mode=auto data-property=${property.name} data-index=0 pos=abs style="top: 0; bottom: 0; right: 0; width: 7px; cursor: ew-resize; touch-action: none; z-index: 3;"':
+                                              - 'rtgl-view pos=abs bgc=fg style="top: 5px; bottom: 5px; right: 6px; width: 1px; pointer-events: none;"': null
                                   - $if property.fillerWidthPercent && property.fillerWidthPercent > 0:
                                       - 'rtgl-view d=h h=f style="width: ${property.fillerWidthPercent}%"': null
                                 $else:
@@ -107,13 +116,13 @@ template:
                                           - 'rtgl-view data-keyframe-slot=true h=f pos=rel style="width: ${keyframe.widthPercent}%; flex-shrink: 0;"':
                                               - $if keyframe.delay > 0:
                                                   - 'rtgl-view pos=abs bgc=mu style="top: 0; bottom: 0; left: 0; width: ${keyframe.delayPercent}%; pointer-events: none; z-index: 2;"': null
-                                              - 'rtgl-view#keyframe${pIndex}x${j} data-keyframe=true data-selected=${keyframe.selected} aria-selected=${keyframe.selected} data-property=${property.name} data-index=${j} d=h p=xs bgc=${keyframe.backgroundColor} bw=xs br=md ah=e av=e pos=abs title="${keyframe.easingLabel}" style="top: 2px; bottom: 2px; left: ${keyframe.delayPercent}%; right: 0; overflow: hidden; box-sizing: border-box; border-color: ${keyframe.borderColor}; z-index: 2; cursor: ${keyframe.cursor}; touch-action: none;"':
+                                              - 'rtgl-view#keyframe${pIndex}x${j}.keyframeTimelineKeyframe data-keyframe=true data-selected=${keyframe.selected} aria-selected=${keyframe.selected} data-property=${property.name} data-index=${j} d=h p=xs bgc=${keyframe.backgroundColor} bw=xs br=md ah=e av=e pos=abs title="${keyframe.easingLabel}" style="top: 2px; bottom: 2px; left: ${keyframe.delayPercent}%; right: 0; overflow: hidden; box-sizing: border-box; border-color: ${keyframe.borderColor}; z-index: 2; cursor: ${keyframe.cursor}; touch-action: none;"':
                                                   - $if editable:
                                                       - 'rtgl-view#durationHandleLeft${pIndex}x${j} data-keyframe-duration-handle=left data-resize-edge=left data-property=${property.name} data-index=${j} pos=abs style="top: 0; bottom: 0; left: 0; width: 7px; cursor: ew-resize; touch-action: none; z-index: 3;"':
                                                           - 'rtgl-view pos=abs bgc=fg style="top: 5px; bottom: 5px; left: 6px; width: 1px; pointer-events: none;"': null
                                                       - 'rtgl-view#durationHandleRight${pIndex}x${j} data-keyframe-duration-handle=right data-resize-edge=right data-property=${property.name} data-index=${j} pos=abs style="top: 0; bottom: 0; right: 0; width: 7px; cursor: ew-resize; touch-action: none; z-index: 3;"':
                                                           - 'rtgl-view pos=abs bgc=fg style="top: 5px; bottom: 5px; right: 6px; width: 1px; pointer-events: none;"': null
-                                                  - 'rtgl-text s=xs c=${keyframe.foregroundColor} ta=e style="position: absolute; top: 50%; left: 10px; right: 13px; transform: translateY(-50%); z-index: 4; pointer-events: none; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"': ${keyframe.value}
+                                                  - 'rtgl-text.keyframeTimelineKeyframeValue s=xs c=${keyframe.foregroundColor} ta=e ellipsis style="position: absolute; top: 50%; left: 10px; right: 13px; transform: translateY(-50%); z-index: 4; pointer-events: none;"': ${keyframe.value}
                                       - $if property.fillerWidthPercent && property.fillerWidthPercent > 0:
                                           - 'rtgl-view d=h h=f style="width: ${property.fillerWidthPercent}%"': null
                                     $else:

--- a/src/pages/animationEditor/animationEditor.handlers.js
+++ b/src/pages/animationEditor/animationEditor.handlers.js
@@ -1558,10 +1558,18 @@ export const handleKeyframeDurationChange = (deps, payload) => {
     payload._event.detail;
   store.setSelectedKeyframe({ side, property, index });
   store.setSelectedKeyframeTiming({ delay, duration, followingDelay });
-  commitSelectedKeyframeChange(deps);
+  commitTimelineChange(deps);
 };
 
-const commitSelectedKeyframeChange = (deps) => {
+export const handleAutoDurationChange = (deps, payload) => {
+  const { store } = deps;
+  const { duration, property, side } = payload._event.detail;
+  store.setSelectedProperty({ side, property });
+  store.setSelectedPropertyAutoDuration({ duration });
+  commitTimelineChange(deps);
+};
+
+const commitTimelineChange = (deps) => {
   const { render, store } = deps;
   invalidatePreview({ store });
   render();
@@ -1573,7 +1581,7 @@ export const handleSelectedKeyframeDelayChange = (deps, payload) => {
   store.setSelectedKeyframeDelay({
     delay: resolveValueChange(payload),
   });
-  commitSelectedKeyframeChange(deps);
+  commitTimelineChange(deps);
 };
 
 export const handleSelectedKeyframeDurationChange = (deps, payload) => {
@@ -1581,7 +1589,7 @@ export const handleSelectedKeyframeDurationChange = (deps, payload) => {
   store.setSelectedKeyframeDuration({
     duration: resolveValueChange(payload),
   });
-  commitSelectedKeyframeChange(deps);
+  commitTimelineChange(deps);
 };
 
 export const handleSelectedKeyframeEasingChange = (deps, payload) => {
@@ -1589,7 +1597,7 @@ export const handleSelectedKeyframeEasingChange = (deps, payload) => {
   store.setSelectedKeyframeEasing({
     easing: resolveValueChange(payload),
   });
-  commitSelectedKeyframeChange(deps);
+  commitTimelineChange(deps);
 };
 
 export const handleSelectedKeyframeValueChange = (deps, payload) => {
@@ -1597,7 +1605,7 @@ export const handleSelectedKeyframeValueChange = (deps, payload) => {
   store.setSelectedKeyframeValue({
     value: resolveValueChange(payload),
   });
-  commitSelectedKeyframeChange(deps);
+  commitTimelineChange(deps);
 };
 
 export const handleSelectedKeyframeRelativeChange = (deps, payload) => {
@@ -1605,7 +1613,7 @@ export const handleSelectedKeyframeRelativeChange = (deps, payload) => {
   store.setSelectedKeyframeRelative({
     relative: resolveValueChange(payload),
   });
-  commitSelectedKeyframeChange(deps);
+  commitTimelineChange(deps);
 };
 
 const commitSelectedPropertyInitialValue = (deps, initialValue) => {
@@ -1632,6 +1640,22 @@ export const handleSelectedPropertyInitialValueChange = (deps, payload) => {
 
 export const handleSelectedPropertyUseDefaultClick = (deps) => {
   commitSelectedPropertyInitialValue(deps, undefined);
+};
+
+export const handleSelectedPropertyAutoDurationChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedPropertyAutoDuration({
+    duration: resolveValueChange(payload),
+  });
+  commitTimelineChange(deps);
+};
+
+export const handleSelectedPropertyAutoEasingChange = (deps, payload) => {
+  const { store } = deps;
+  store.setSelectedPropertyAutoEasing({
+    easing: resolveValueChange(payload),
+  });
+  commitTimelineChange(deps);
 };
 
 const openSelectedMaskNumberPopover = (deps, payload, { mode, value } = {}) => {
@@ -1762,13 +1786,22 @@ export const handleSelectedMaskNumberInputKeyDown = (deps, payload) => {
 
 export const handleAutoTrackClick = (deps, payload) => {
   const { render, store } = deps;
+  const { property, side, x, y } = payload._event.detail;
+  store.setSelectedProperty({ side, property });
+
+  if (!store.selectIsTouchMode()) {
+    store.closePopover();
+    render();
+    return;
+  }
+
   store.setPopover({
     mode: "editAuto",
-    x: payload._event.detail.x,
-    y: payload._event.detail.y,
+    x,
+    y,
     payload: {
-      side: payload._event.detail.side,
-      property: payload._event.detail.property,
+      side,
+      property,
     },
   });
   render();

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -1776,6 +1776,34 @@ export const selectSelectedProperty = ({ state }) => {
   return state.selectedProperty;
 };
 
+const getMutableSelectedAutoTween = (state) => {
+  const selectedProperty = state.selectedProperty;
+  if (!selectedProperty) {
+    return undefined;
+  }
+
+  const { side, property } = selectedProperty;
+  return getMutableSectionProperties(state, side)[property]?.auto;
+};
+
+export const setSelectedPropertyAutoDuration = (
+  { state },
+  { duration } = {},
+) => {
+  const auto = getMutableSelectedAutoTween(state);
+  const nextDuration = Number.parseInt(duration, 10);
+  if (auto && Number.isFinite(nextDuration) && nextDuration >= 1) {
+    auto.duration = nextDuration;
+  }
+};
+
+export const setSelectedPropertyAutoEasing = ({ state }, { easing } = {}) => {
+  const auto = getMutableSelectedAutoTween(state);
+  if (auto) {
+    auto.easing = easing;
+  }
+};
+
 export const setSelectedMask = ({ state }, { index, side } = {}) => {
   state.selectedKeyframe = undefined;
   state.selectedProperty = undefined;
@@ -3425,43 +3453,39 @@ const buildSelectedPropertyPanelData = (
       label: copy.propertyLabel ?? "Property",
       value: propertyFieldConfig[property]?.label ?? property,
     },
-    autoConfig
-      ? {
-          type: "text",
-          label: copy.initialValueLabel ?? "Initial value",
-          value: hasInitialValue
-            ? propertyConfig.initialValue
-            : (copy.defaultLabel ?? "Default"),
-        }
-      : {
-          type: "slot",
-          label: copy.initialValueLabel ?? "Initial value",
-          slot: "property-initial-value",
-        },
   ];
 
   if (autoConfig) {
     fields.push(
       {
-        type: "text",
+        type: "slot",
         label: copy.durationMsLabel ?? "Duration (ms)",
-        value: autoConfig.duration,
+        slot: "property-auto-duration",
       },
       {
-        type: "text",
+        type: "slot",
         label: copy.easingLabel ?? "Easing",
-        value: getOptionLabel(
-          createEasingOptions(copy),
-          autoConfig.easing ?? "linear",
-        ),
+        slot: "property-auto-easing",
       },
     );
+  } else {
+    fields.push({
+      type: "slot",
+      label: copy.initialValueLabel ?? "Initial value",
+      slot: "property-initial-value",
+    });
   }
 
   return {
     id: `${side}:${property}`,
     editor: autoConfig
-      ? undefined
+      ? {
+          auto: true,
+          duration: autoConfig.duration,
+          durationLabel: copy.durationMsLabel ?? "Duration (ms)",
+          easing: autoConfig.easing ?? "linear",
+          easingOptions: createEasingOptions(copy),
+        }
       : {
           hasInitialValue,
           initialValue,
@@ -3876,6 +3900,8 @@ export const selectViewData = ({ state, i18n }) => {
   const showAddKeyframeDialog =
     state.isTouchMode && state.popover.mode === "addKeyframe";
   const showEditKeyframeDialog = state.popover.mode === "editKeyframe";
+  const showEditAutoDialog =
+    state.isTouchMode && state.popover.mode === "editAuto";
   const showSelectedMaskSoftnessPopover =
     state.popover.mode === "editSelectedMaskSoftness";
   const showSelectedMaskInitialValuePopover =
@@ -3991,7 +4017,7 @@ export const selectViewData = ({ state, i18n }) => {
     popover: {
       ...state.popover,
       popoverIsOpen:
-        ["editAuto", "editInitialValue"].includes(state.popover.mode) ||
+        state.popover.mode === "editInitialValue" ||
         showAddPropertyPopover ||
         showAddKeyframePopover,
       maskDialogIsOpen: ["addMask", "editMask"].includes(state.popover.mode),
@@ -4040,6 +4066,7 @@ export const selectViewData = ({ state, i18n }) => {
     showAddPropertyDialog,
     showAddKeyframeDialog,
     showEditKeyframeDialog,
+    showEditAutoDialog,
     selectedMaskNumberPopoverIsOpen:
       showSelectedMaskInitialValuePopover || showSelectedMaskSoftnessPopover,
     showSelectedMaskInitialValuePopover,

--- a/src/pages/animationEditor/animationEditor.view.yaml
+++ b/src/pages/animationEditor/animationEditor.view.yaml
@@ -128,6 +128,8 @@ refs:
         handler: handleKeyframeSelect
       keyframe-duration-change:
         handler: handleKeyframeDurationChange
+      auto-duration-change:
+        handler: handleAutoDurationChange
       timeline-duration-extend:
         handler: handleTimelineDurationExtend
       timeline-used-duration-preview:
@@ -218,6 +220,10 @@ refs:
     eventListeners:
       close:
         handler: handleClosePopover
+  editAutoDialog:
+    eventListeners:
+      close:
+        handler: handleClosePopover
   maskDialog:
     eventListeners:
       close:
@@ -288,6 +294,14 @@ refs:
     eventListeners:
       click:
         handler: handleSelectedPropertyUseDefaultClick
+  selectedPropertyAutoDuration:
+    eventListeners:
+      value-change:
+        handler: handleSelectedPropertyAutoDurationChange
+  selectedPropertyAutoEasing:
+    eventListeners:
+      value-change:
+        handler: handleSelectedPropertyAutoEasingChange
   selectedMaskInitialValue:
     eventListeners:
       click:
@@ -643,16 +657,21 @@ template:
                               - rtgl-segmented-control#selectedKeyframeRelative slot=keyframe-value-type w=f no-clear :selectedValue=${selectedKeyframeEditor.relative} :options=${selectedKeyframeEditor.relativeOptions}: null
                         $elif selectedPropertyDetailId:
                           - rvn-detail-view#selectedPropertyDetails key=${selectedPropertyDetailId} w=f :fields=${selectedPropertyDetailFields} :fillHeight=${false}:
-                              - rtgl-view slot=property-initial-value d=v w=f g=xs:
-                                  - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
-                                      - rtgl-slider-input#selectedPropertyInitialValue key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
-                                    $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
-                                      - 'rtgl-view data-popover-input-field=true w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
-                                          - 'rvn-value-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
-                                    $elif selectedPropertyEditor:
-                                      - rtgl-input-number#selectedPropertyInitialValue key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null
-                                  - $if selectedPropertyEditor && selectedPropertyEditor.hasInitialValue:
-                                      - rtgl-button#selectedPropertyUseDefault s=sm v=se w=f: ${useDefaultValueButtonLabel}
+                              - $if selectedPropertyEditor && selectedPropertyEditor.auto:
+                                  - 'rtgl-view data-popover-input-field=true slot=property-auto-duration w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                      - 'rvn-value-popover-input#selectedPropertyAutoDuration value=${selectedPropertyEditor.duration} label="${selectedPropertyEditor.durationLabel}"': null
+                                  - rtgl-select#selectedPropertyAutoEasing slot=property-auto-easing w=f no-clear :selectedValue=${selectedPropertyEditor.easing} :options=${selectedPropertyEditor.easingOptions}: null
+                                $else:
+                                  - rtgl-view slot=property-initial-value d=v w=f g=xs:
+                                      - $if selectedPropertyEditor && selectedPropertyEditor.initialValueSlider:
+                                          - rtgl-slider-input#selectedPropertyInitialValue key=${selectedPropertyDetailId} w=f value=${selectedPropertyEditor.initialValue} min=${selectedPropertyEditor.initialValueSlider.min} max=${selectedPropertyEditor.initialValueSlider.max} step=${selectedPropertyEditor.initialValueSlider.step}: null
+                                        $elif selectedPropertyEditor && selectedPropertyEditor.initialValueUsesPopover:
+                                          - 'rtgl-view data-popover-input-field=true w=f h=32 d=h av=c ph=md bgc=mu bw=xs bc=bg h-bc=ac br=md cur=pointer style="box-sizing: border-box;"':
+                                              - 'rvn-value-popover-input#selectedPropertyInitialValuePopover value=${selectedPropertyEditor.initialValue} label="${selectedPropertyEditor.initialValueLabel}"': null
+                                        $elif selectedPropertyEditor:
+                                          - rtgl-input-number#selectedPropertyInitialValue key=${selectedPropertyDetailId} w=f step=${selectedPropertyEditor.initialValueStep} value=${selectedPropertyEditor.initialValue}: null
+                                      - $if selectedPropertyEditor && selectedPropertyEditor.hasInitialValue:
+                                          - rtgl-button#selectedPropertyUseDefault s=sm v=se w=f: ${useDefaultValueButtonLabel}
                         $elif selectedMask:
                           - rtgl-view#selectedMaskDetails data-timeline-selection-surface=true d=v w=f g=md p=md pb=xl:
                               - $if maskEditorPanel.unsupported:
@@ -695,9 +714,6 @@ template:
       - $if showAddKeyframePopover:
           - rtgl-view slot=content:
               - rtgl-form#addKeyframeForm :form=${addKeyframeForm} :defaultValues=${addKeyframeDefaultValues}: null
-      - $if popover.mode == 'editAuto':
-          - rtgl-view slot=content:
-              - rtgl-form#editAutoForm :form=${editAutoForm} :defaultValues=${editAutoDefaultValues}: null
       - $if popover.mode == 'editInitialValue':
           - rtgl-view slot=content:
               - rtgl-form#editInitialValueForm :form=${editInitialValueForm} :defaultValues=${editInitialValueDefaultValues} :context=${editInitialValueContext}: null
@@ -718,6 +734,9 @@ template:
   - $if showEditKeyframeDialog:
       - rtgl-dialog#editKeyframeDialog ?open=${showEditKeyframeDialog} s=sm:
           - rtgl-form#editKeyframeForm slot=content :form=${updateKeyframeForm} :defaultValues=${editKeyframeDefaultValues} w=f: null
+  - $if showEditAutoDialog:
+      - rtgl-dialog#editAutoDialog ?open=${showEditAutoDialog} s=sm:
+          - rtgl-form#editAutoForm slot=content :form=${editAutoForm} :defaultValues=${editAutoDefaultValues}: null
   - rtgl-dialog#maskDialog ?open=${popover.maskDialogIsOpen} s=sm:
       - $if popover.mode == 'addMask' || popover.mode == 'editMask':
           - 'rtgl-view slot=content d=v w=f g=md style="max-width: calc(100vw - 32px);"':

--- a/src/pages/project/project.view.yaml
+++ b/src/pages/project/project.view.yaml
@@ -150,6 +150,7 @@ template:
                               - rtgl-text s=sm w=1fg: ${i18n.projectPage.totalLabel}
                               - 'rtgl-text s=sm w=1fg style="font-variant-numeric: tabular-nums;"': ${totalLineCount}
                               - 'rtgl-text s=sm w=1fg style="font-variant-numeric: tabular-nums;"': ${totalTextCount}
+          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
   - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
       - rtgl-view slot=content:
           - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} w=f:

--- a/tests/animationEditor/animationEditor.handlers.test.js
+++ b/tests/animationEditor/animationEditor.handlers.test.js
@@ -8,6 +8,8 @@ import {
   handleAddPropertySideMenuItemClick,
   handleAddPropertyFormChange,
   handleAddPropertyFormSubmit,
+  handleAutoDurationChange,
+  handleAutoTrackClick,
   handleBeforeMount,
   handleConfirmMaskImageSelection,
   handleEditKeyframeFormSubmit,
@@ -39,6 +41,8 @@ import {
   handleSelectedKeyframeRelativeChange,
   handleSelectedKeyframeValueChange,
   handleSelectedPropertyInitialValueChange,
+  handleSelectedPropertyAutoDurationChange,
+  handleSelectedPropertyAutoEasingChange,
   handleSelectedPropertyUseDefaultClick,
   handleSelectedMaskNumberConfirmClick,
   handleSelectedMaskNumberFieldKeyDown,
@@ -1051,6 +1055,139 @@ describe("animationEditor.handlers", () => {
       side: "update",
       property: "x",
       initialValue: -25.5,
+    });
+    expect(store.bumpPreviewRenderVersion).toHaveBeenCalledWith({});
+    expect(store.queueAutosave).toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("selects an auto tween for editing in the desktop details panel", () => {
+    const store = {
+      closePopover: vi.fn(),
+      selectIsTouchMode: vi.fn(() => false),
+      setPopover: vi.fn(),
+      setSelectedProperty: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAutoTrackClick(
+      { render, store },
+      {
+        _event: {
+          detail: {
+            property: "alpha",
+            side: "update",
+            x: 120,
+            y: 160,
+          },
+        },
+      },
+    );
+
+    expect(store.setSelectedProperty).toHaveBeenCalledWith({
+      side: "update",
+      property: "alpha",
+    });
+    expect(store.closePopover).toHaveBeenCalledWith();
+    expect(store.setPopover).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("opens the auto-tween editor as a dialog on touch", () => {
+    const store = {
+      closePopover: vi.fn(),
+      selectIsTouchMode: vi.fn(() => true),
+      setPopover: vi.fn(),
+      setSelectedProperty: vi.fn(),
+    };
+    const render = vi.fn();
+
+    handleAutoTrackClick(
+      { render, store },
+      {
+        _event: {
+          detail: {
+            property: "alpha",
+            side: "update",
+            x: 120,
+            y: 160,
+          },
+        },
+      },
+    );
+
+    expect(store.setPopover).toHaveBeenCalledWith({
+      mode: "editAuto",
+      x: 120,
+      y: 160,
+      payload: { side: "update", property: "alpha" },
+    });
+    expect(store.closePopover).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("commits inline auto-tween field changes", () => {
+    const store = {
+      bumpPreviewRenderVersion: vi.fn(),
+      queueAutosave: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      setSelectedPropertyAutoDuration: vi.fn(),
+      setSelectedPropertyAutoEasing: vi.fn(),
+      stopPreviewPlayback: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+    const deps = { render, store };
+
+    handleSelectedPropertyAutoDurationChange(deps, {
+      _event: { detail: { value: 1250 } },
+    });
+    handleSelectedPropertyAutoEasingChange(deps, {
+      _event: { detail: { value: "easeOutQuad" } },
+    });
+
+    expect(store.setSelectedPropertyAutoDuration).toHaveBeenCalledWith({
+      duration: 1250,
+    });
+    expect(store.setSelectedPropertyAutoEasing).toHaveBeenCalledWith({
+      easing: "easeOutQuad",
+    });
+    expect(store.bumpPreviewRenderVersion).toHaveBeenCalledTimes(2);
+    expect(store.queueAutosave).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("commits an auto tween duration resized on the timeline", () => {
+    const store = {
+      bumpPreviewRenderVersion: vi.fn(),
+      queueAutosave: vi.fn(),
+      selectPreviewPlaybackFrameId: vi.fn(() => undefined),
+      setSelectedProperty: vi.fn(),
+      setSelectedPropertyAutoDuration: vi.fn(),
+      stopPreviewPlayback: vi.fn(),
+      ...createIdleAutosaveMocks(),
+    };
+    const render = vi.fn();
+
+    handleAutoDurationChange(
+      { render, store },
+      {
+        _event: {
+          detail: {
+            duration: 1400,
+            property: "alpha",
+            side: "update",
+          },
+        },
+      },
+    );
+
+    expect(store.setSelectedProperty).toHaveBeenCalledWith({
+      side: "update",
+      property: "alpha",
+    });
+    expect(store.setSelectedPropertyAutoDuration).toHaveBeenCalledWith({
+      duration: 1400,
     });
     expect(store.bumpPreviewRenderVersion).toHaveBeenCalledWith({});
     expect(store.queueAutosave).toHaveBeenCalled();

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -51,6 +51,8 @@ import {
   setSelectedKeyframeValue,
   setSelectedMask,
   setSelectedProperty,
+  setSelectedPropertyAutoDuration,
+  setSelectedPropertyAutoEasing,
   startPreviewPlayback,
   startTimelinePan,
   stopPreviewPlayback,
@@ -561,6 +563,68 @@ describe("animationEditor.store", () => {
     expect(viewData.selectedKeyframe).toBeUndefined();
     expect(viewData.detailsPanelTitle).toBeUndefined();
     expect(viewData.noSelectionLabel).toBe("No selection");
+  });
+
+  it("edits a selected auto tween in the property details panel", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    state.tweenBySection.update.alpha = {
+      auto: { duration: 1000, easing: "linear" },
+    };
+
+    setSelectedProperty({ state }, { side: "update", property: "alpha" });
+
+    let viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.selectedPropertyDetailFields).toEqual([
+      { type: "text", label: "Timeline", value: "Update" },
+      { type: "text", label: "Property", value: "Alpha" },
+      {
+        type: "slot",
+        label: "Duration (ms)",
+        slot: "property-auto-duration",
+      },
+      {
+        type: "slot",
+        label: "Easing",
+        slot: "property-auto-easing",
+      },
+    ]);
+    expect(viewData.selectedPropertyEditor).toMatchObject({
+      auto: true,
+      duration: 1000,
+      durationLabel: "Duration (ms)",
+      easing: "linear",
+    });
+
+    setSelectedPropertyAutoDuration({ state }, { duration: 1250.8 });
+    setSelectedPropertyAutoEasing({ state }, { easing: "easeOutQuad" });
+
+    expect(state.tweenBySection.update.alpha.auto).toEqual({
+      duration: 1250,
+      easing: "easeOutQuad",
+    });
+    viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.selectedPropertyEditor).toMatchObject({
+      duration: 1250,
+      easing: "easeOutQuad",
+    });
+  });
+
+  it("uses a dialog instead of a popover for touch auto-tween editing", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+    setUiConfig({ state }, { uiConfig: { id: "touch", inputMode: "touch" } });
+    setPopover(
+      { state },
+      {
+        mode: "editAuto",
+        payload: { side: "update", property: "alpha" },
+      },
+    );
+
+    const viewData = selectViewData({ state, i18n: EN_I18N });
+    expect(viewData.showEditAutoDialog).toBe(true);
+    expect(viewData.popover.popoverIsOpen).toBe(false);
   });
 
   it("keeps a single keyframe selected through timeline mutations", () => {

--- a/tests/animationEditor/animationEditor.view.test.js
+++ b/tests/animationEditor/animationEditor.view.test.js
@@ -42,12 +42,17 @@ describe("animationEditor view", () => {
     expect(view).toContain("rtgl-dialog#addPropertyDialog");
     expect(view).toContain("rtgl-dialog#addKeyframeDialog");
     expect(view).toContain("rtgl-dialog#editKeyframeDialog");
+    expect(view).toContain("rtgl-dialog#editAutoDialog");
     expect(view).toContain("?open=${showAddPropertyDialog}");
     expect(view).toContain("?open=${showAddKeyframeDialog}");
     expect(view).toContain("?open=${showEditKeyframeDialog}");
+    expect(view).toContain("?open=${showEditAutoDialog}");
     expect(view).not.toContain("$if popover.mode == 'addProperty'");
     expect(view).not.toContain("$if popover.mode == 'addKeyframe'");
     expect(view).not.toContain("$if popover.mode == 'editKeyframe'");
+    expect(view).not.toContain("$if popover.mode == 'editAuto'");
+    expect(view).toContain("auto-duration-change:");
+    expect(view).toContain("handler: handleAutoDurationChange");
   });
 
   it("keeps the mask image selector compact with a fixed preview ratio", () => {
@@ -206,8 +211,14 @@ describe("animationEditor view", () => {
     expect(view).toContain(
       "rtgl-button#selectedPropertyUseDefault s=sm v=se w=f",
     );
-    expect(view.match(/data-popover-input-field=true/g)).toHaveLength(4);
-    expect(view.match(/rvn-value-popover-input#/g)).toHaveLength(4);
+    expect(view).toContain(
+      "rvn-value-popover-input#selectedPropertyAutoDuration",
+    );
+    expect(view).toContain("rtgl-select#selectedPropertyAutoEasing");
+    expect(view).toContain("handler: handleSelectedPropertyAutoDurationChange");
+    expect(view).toContain("handler: handleSelectedPropertyAutoEasingChange");
+    expect(view.match(/data-popover-input-field=true/g)).toHaveLength(5);
+    expect(view.match(/rvn-value-popover-input#/g)).toHaveLength(5);
     expect(view).toContain("handler: handleSelectedPropertyInitialValueChange");
     expect(view).toContain("handler: handleSelectedPropertyUseDefaultClick");
     expect(view).not.toContain("rtgl-view#selectedMaskProgressDuration");

--- a/tests/keyframeTimeline/keyframeTimeline.handlers.test.js
+++ b/tests/keyframeTimeline/keyframeTimeline.handlers.test.js
@@ -415,12 +415,14 @@ describe("keyframeTimeline.handlers", () => {
       selectPreviewUsedDuration: vi.fn(
         () => durationResize.delay + durationResize.duration,
       ),
-      setDurationResizeTiming: vi.fn(({ delay, duration, timelineDuration }) => {
-        durationResize.delay = delay;
-        durationResize.duration = duration;
-        durationResize.timelineDuration =
-          timelineDuration ?? durationResize.timelineDuration;
-      }),
+      setDurationResizeTiming: vi.fn(
+        ({ delay, duration, timelineDuration }) => {
+          durationResize.delay = delay;
+          durationResize.duration = duration;
+          durationResize.timelineDuration =
+            timelineDuration ?? durationResize.timelineDuration;
+        },
+      ),
       startDurationResize: vi.fn((resize) => {
         durationResize = {
           ...resize,
@@ -525,6 +527,117 @@ describe("keyframeTimeline.handlers", () => {
     expect(store.clearDurationResize).toHaveBeenCalledWith({});
   });
 
+  it("drags an auto tween end handle to change its duration", () => {
+    let durationResize;
+    const store = {
+      clearDurationResize: vi.fn(() => {
+        durationResize = undefined;
+      }),
+      selectDurationResize: vi.fn(() => durationResize),
+      selectPreviewUsedDuration: vi.fn(() => durationResize.duration),
+      setDurationResizeTiming: vi.fn(
+        ({ delay, duration, timelineDuration }) => {
+          durationResize.delay = delay;
+          durationResize.duration = duration;
+          durationResize.timelineDuration =
+            timelineDuration ?? durationResize.timelineDuration;
+        },
+      ),
+      startDurationResize: vi.fn((resize) => {
+        durationResize = {
+          ...resize,
+          delay: resize.startDelay,
+          duration: resize.startDuration,
+        };
+      }),
+    };
+    const dispatchEvent = vi.fn();
+    const render = vi.fn();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    const handleElement = {
+      dataset: {
+        property: "alpha",
+        index: "0",
+        resizeEdge: "right",
+        trackMode: "auto",
+      },
+      closest: vi.fn(() => ({
+        getBoundingClientRect: () => ({ width: 400 }),
+      })),
+      releasePointerCapture: vi.fn(),
+      setPointerCapture: vi.fn(),
+    };
+    const deps = {
+      dispatchEvent,
+      props: {
+        editable: true,
+        side: "update",
+        timelineDuration: 2000,
+        properties: {
+          alpha: {
+            auto: { duration: 1000, easing: "linear" },
+          },
+        },
+      },
+      render,
+      store,
+    };
+
+    handleDurationResizeStart(deps, {
+      _event: {
+        button: 0,
+        clientX: 100,
+        currentTarget: handleElement,
+        pointerId: 8,
+        preventDefault,
+        stopPropagation,
+      },
+    });
+    handleDurationResizeMove(deps, {
+      _event: {
+        clientX: 120,
+        pointerId: 8,
+        preventDefault,
+        stopPropagation,
+      },
+    });
+    handleDurationResizeEnd(deps, {
+      _event: {
+        currentTarget: handleElement,
+        pointerId: 8,
+        preventDefault,
+        stopPropagation,
+      },
+    });
+
+    expect(store.startDurationResize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "auto",
+        property: "alpha",
+        startDelay: 0,
+        startDuration: 1000,
+      }),
+    );
+    expect(
+      dispatchEvent.mock.calls.find(
+        ([event]) => event.type === "auto-duration-change",
+      )[0],
+    ).toMatchObject({
+      type: "auto-duration-change",
+      detail: {
+        duration: 1100,
+        property: "alpha",
+        side: "update",
+      },
+    });
+    expect(
+      dispatchEvent.mock.calls.find(
+        ([event]) => event.type === "keyframe-duration-change",
+      ),
+    ).toBeUndefined();
+  });
+
   it("ignores non-primary pointer resize starts", () => {
     const store = {
       startDurationResize: vi.fn(),
@@ -562,12 +675,14 @@ describe("keyframeTimeline.handlers", () => {
       selectPreviewUsedDuration: vi.fn(
         () => durationResize.delay + durationResize.duration,
       ),
-      setDurationResizeTiming: vi.fn(({ delay, duration, timelineDuration }) => {
-        durationResize.delay = delay;
-        durationResize.duration = duration;
-        durationResize.timelineDuration =
-          timelineDuration ?? durationResize.timelineDuration;
-      }),
+      setDurationResizeTiming: vi.fn(
+        ({ delay, duration, timelineDuration }) => {
+          durationResize.delay = delay;
+          durationResize.duration = duration;
+          durationResize.timelineDuration =
+            timelineDuration ?? durationResize.timelineDuration;
+        },
+      ),
       startDurationResize: vi.fn((resize) => {
         durationResize = {
           ...resize,

--- a/tests/keyframeTimeline/keyframeTimeline.store.test.js
+++ b/tests/keyframeTimeline/keyframeTimeline.store.test.js
@@ -187,7 +187,34 @@ describe("keyframeTimeline easing curves", () => {
       easing: "easeInOutElastic",
       easingLabel: "Ease In Out Elastic",
     });
+    expect(autoProperty).toMatchObject({
+      initialValue: "auto",
+      initialValueColor: "mu",
+    });
     expect(autoProperty.valueCurvePath).toBeUndefined();
+  });
+
+  it("localizes the auto indicator beside the property name", () => {
+    const viewData = selectViewData({
+      state: createInitialState(),
+      props: {
+        properties: {
+          alpha: {
+            auto: { duration: 1000, easing: "linear" },
+          },
+        },
+      },
+      i18n: {
+        animationEditorPage: {
+          autoTweenMode: "Automatic",
+        },
+      },
+    });
+
+    expect(viewData.selectedProperties[0]).toMatchObject({
+      initialValue: "automatic",
+      initialValueColor: "mu",
+    });
   });
 
   it("uses non-interactive cursors for read-only keyframes", () => {
@@ -269,12 +296,12 @@ describe("keyframeTimeline easing curves", () => {
     );
 
     expect(view).toContain("data-keyframe=true");
-    expect(view).toContain(
-      "p=xs bgc=${keyframe.backgroundColor} bw=xs br=md",
-    );
+    expect(view).toContain("p=xs bgc=${keyframe.backgroundColor} bw=xs br=md");
     expect(view).toContain("data-keyframe-slot=true h=f pos=rel style=");
     expect(view).not.toContain("data-keyframe-slot=true h=f pos=rel bgc=");
     expect(view).toContain("handler: handleRulerScrubStart");
+    expect(view).toContain("cursor: ${rulerCursor}");
+    expect(view).not.toContain("cursor: ew-resize; touch-action: none;\"':");
     expect(view).toContain("handler: handleKeyframeMoveStart");
     expect(view).toContain("handler: handleKeyframeMove");
     expect(view).toContain("handler: handleKeyframeMoveEnd");
@@ -282,7 +309,9 @@ describe("keyframeTimeline easing curves", () => {
     expect(view).not.toContain("property-name-right-click");
     expect(view).toContain("handler: handlePropertyNameKeyDown");
     expect(view).not.toContain("handler: handleInitialValueClick");
-    expect(view).not.toContain("data-interactive=${property.initialValueInteractive}");
+    expect(view).not.toContain(
+      "data-interactive=${property.initialValueInteractive}",
+    );
     expect(
       view.match(/rtgl-view pos=abs bgc=su style="\$\{usedDurationStyle\}"/g),
     ).toHaveLength(1);
@@ -324,6 +353,9 @@ describe("keyframeTimeline easing curves", () => {
     expect(view).toMatch(
       /data-keyframe-duration-handle=right[^\n]+cursor: ew-resize/,
     );
+    expect(view).toMatch(
+      /durationHandleAuto[^\n]+data-track-mode=auto[^\n]+cursor: ew-resize/,
+    );
     expect(view.indexOf("$if editable:")).toBeLessThan(
       view.indexOf("data-keyframe-duration-handle=left"),
     );
@@ -331,8 +363,13 @@ describe("keyframeTimeline easing curves", () => {
     expect(view).toContain("top: 5px; bottom: 5px; left: 6px; width: 1px");
     expect(view).toContain("top: 5px; bottom: 5px; right: 6px; width: 1px");
     expect(view).toMatch(
-      /rtgl-text[^\n]+ta=e[^\n]+left: 10px; right: 13px[^\n]+keyframe.value/,
+      /rtgl-text\.keyframeTimelineKeyframeValue[^\n]+ta=e ellipsis[^\n]+left: 10px; right: 13px[^\n]+keyframe.value/,
     );
+    expect(view).toContain("container-type: inline-size");
+    expect(view).toContain("@container (max-width: 40px)");
+    expect(view).toContain('".keyframeTimelineKeyframeValue":');
+    expect(view).toContain("display: none");
+    expect(view).not.toContain("property.auto.label");
     expect(view).not.toContain("property.hoverTarget.mode != 'empty'");
     expect(view).toContain("data-value-curve=${property.name}");
     expect(view).toContain('d="${property.valueCurvePath}"');
@@ -491,6 +528,37 @@ describe("keyframeTimeline easing curves", () => {
     ]);
   });
 
+  it("previews an auto tween duration being resized", () => {
+    const state = createInitialState();
+    state.durationResize = {
+      mode: "auto",
+      property: "alpha",
+      delay: 0,
+      duration: 1500,
+      timelineDuration: 2000,
+    };
+
+    const viewData = selectViewData({
+      state,
+      props: {
+        editable: true,
+        side: "update",
+        timelineDuration: 2000,
+        properties: {
+          alpha: {
+            auto: { duration: 1000, easing: "linear" },
+          },
+        },
+      },
+    });
+
+    expect(viewData.selectedProperties[0].auto).toMatchObject({
+      duration: 1500,
+      widthPercent: "75.00",
+    });
+    expect(viewData.usedDurationStyle).toContain("width: 75.00%");
+  });
+
   it("previews delay and duration while the start marker is resized", () => {
     const state = createInitialState();
     state.durationResize = {
@@ -595,6 +663,20 @@ describe("keyframeTimeline easing curves", () => {
     expect(viewData.playheadIndicatorTimeLabel).toBe("500 ms");
     expect(viewData.playheadIndicatorLabelStyle).toContain("top: 4px");
     expect(viewData.playheadIndicatorLabelStyle).toContain("z-index: 10");
+  });
+
+  it("uses the resize cursor only for an interactive ruler", () => {
+    const state = createInitialState();
+
+    expect(
+      selectViewData({ state, props: { showRuler: true } }).rulerCursor,
+    ).toBe("default");
+    expect(
+      selectViewData({
+        state,
+        props: { interactiveRuler: true, showRuler: true },
+      }).rulerCursor,
+    ).toBe("ew-resize");
   });
 
   it("keeps the exact endpoint unlabeled on the ruler", () => {


### PR DESCRIPTION
## Summary

- add extra bottom scrolling space to the project page
- keep preview rulers non-interactive while preserving editor ruler scrubbing
- move desktop auto-tween editing into the right detail panel and support timeline duration resizing
- compact timeline labels, hide keyframe text at very small widths, and mark auto properties with a muted lowercase indicator

## Validation

- bun run lint
- bunx vitest run tests/animationEditor/animationEditor.store.test.js tests/animationEditor/animationEditor.handlers.test.js tests/animationEditor/animationEditor.view.test.js tests/keyframeTimeline/keyframeTimeline.store.test.js tests/keyframeTimeline/keyframeTimeline.handlers.test.js