### PR TITLE
fix: refine empty sound effect channels

### DIFF
--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -113,6 +113,8 @@ styles:
     box-shadow: none
     outline: none
   ".sfxTimelineTrack":
+    border-top: "1px solid var(--border)"
+    box-sizing: border-box
     min-width: 100%
     position: relative
   ".sfxTimelineContent":
@@ -189,13 +191,18 @@ styles:
     color: var(--muted-foreground)
     cursor: pointer
     display: flex
-    flex: "0 0 126px"
+    flex: "1 1 0"
     font-family: inherit
     font-size: 30px
-    height: 100%
+    height: auto
     justify-content: center
+    min-height: "0"
     padding: "0"
     width: 100%
+  ".sfxEmptyAddIcon":
+    display: block
+    line-height: "1"
+    transform: translateY(-16px)
   ".sfxEmptyAdd:hover":
     color: var(--foreground)
   ".sfxEmptyAdd:focus-visible":
@@ -203,7 +210,6 @@ styles:
     outline: none
   ".sfxChannelHeader":
     align-items: center
-    border-bottom: "1px solid var(--border)"
     display: flex
     flex: "0 0 32px"
     height: 32px
@@ -233,7 +239,8 @@ template:
                                   - span: ${channel.id}
                                   - span: ${channel.durationLabel}
                           - $if channel.sounds.length == 0:
-                              - 'div.sfxEmptyAdd aria-hidden=true': "+"
+                              - 'div.sfxEmptyAdd aria-hidden=true':
+                                  - span.sfxEmptyAddIcon: "+"
                             $else:
                               - 'rtgl-view.sfxTimelineTrack w=f pos=rel style="height: ${channel.timelineHeightPx}px; min-width: 100%;"':
                                   - 'rtgl-view.sfxTimelineContent w=f h=f pos=rel style="box-sizing: border-box; min-width: 0;"':
@@ -255,7 +262,7 @@ template:
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: ${submitButtonLabel}
-  - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg close-button:
+  - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=md close-button:
       - 'rtgl-view slot=content d=v w=f h=80vh g=lg style="min-width: 0; min-height: 0; overflow: hidden;"':
           - rtgl-text s=lg: ${channelEditorTitle}
           - $if mode == 'current':
@@ -268,7 +275,8 @@ template:
                                       - span: ${editorChannel.id}
                                       - span: ${editorChannel.durationLabel}
                               - $if editorChannel.sounds.length == 0:
-                                  - 'button#emptyAddButton0.sfxEmptyAdd type=button data-channel-id="${editorChannel.id}" aria-label="${addSoundLabel}"': "+"
+                                  - 'button#emptyAddButton0.sfxEmptyAdd type=button data-channel-id="${editorChannel.id}" aria-label="${addSoundLabel}"':
+                                      - span.sfxEmptyAddIcon: "+"
                                 $else:
                                   - 'rtgl-view.sfxTimelineTrack data-timeline-track=true data-timeline-duration-ms=${editorChannel.timelineDurationMs} w=f pos=rel style="height: ${editorChannel.timelineHeightPx}px; min-width: 100%;"':
                                       - 'rtgl-view.sfxTimelineContent w=f h=f pos=rel style="box-sizing: border-box; min-width: 0;"':

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js
@@ -2,6 +2,23 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("commandLineSoundEffects view", () => {
+  it("uses the medium size for the sound effect editor dialog", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).toContain(
+      "rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=md close-button:",
+    );
+    expect(view).not.toContain(
+      "rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg",
+    );
+  });
+
   it("makes the whole channel the editor target", () => {
     const view = readFileSync(
       new URL(
@@ -47,10 +64,37 @@ describe("commandLineSoundEffects view", () => {
       view.indexOf('  ".sfxEmptyAdd:hover":', emptyAddStyleStart),
     );
 
-    expect(mainView).toContain('div.sfxEmptyAdd aria-hidden=true\': "+"');
+    expect(mainView).toContain("div.sfxEmptyAdd aria-hidden=true':");
+    expect(mainView).toContain('span.sfxEmptyAddIcon: "+"');
     expect(mainView).not.toContain("${emptyAudioLabel}");
     expect(emptyAddStyles).toContain("align-items: center");
+    expect(emptyAddStyles).toContain('flex: "1 1 0"');
+    expect(emptyAddStyles).toContain("height: auto");
     expect(emptyAddStyles).toContain("justify-content: center");
+    expect(emptyAddStyles).toContain('min-height: "0"');
+    expect(emptyAddStyles).not.toContain("height: 100%");
+
+    const emptyAddIconStyleStart = view.indexOf('  ".sfxEmptyAddIcon":');
+    const emptyAddIconStyles = view.slice(
+      emptyAddIconStyleStart,
+      view.indexOf('  ".sfxEmptyAdd:hover":', emptyAddIconStyleStart),
+    );
+    const channelHeaderStyleStart = view.indexOf('  ".sfxChannelHeader":');
+    const channelHeaderStyles = view.slice(
+      channelHeaderStyleStart,
+      view.indexOf('  ".sfxChannelLabel":', channelHeaderStyleStart),
+    );
+    const timelineTrackStyleStart = view.indexOf('  ".sfxTimelineTrack":');
+    const timelineTrackStyles = view.slice(
+      timelineTrackStyleStart,
+      view.indexOf('  ".sfxTimelineContent":', timelineTrackStyleStart),
+    );
+
+    expect(emptyAddIconStyles).toContain("transform: translateY(-16px)");
+    expect(channelHeaderStyles).not.toContain("border-bottom");
+    expect(timelineTrackStyles).toContain(
+      'border-top: "1px solid var(--border)"',
+    );
   });
 
   it("renders channel controls before the add button and bottom scroll space", () => {


### PR DESCRIPTION
## Summary
- keep the empty-channel bottom border visible and center its add icon
- show the header separator only for populated sound channels
- use the medium size for the sound-effect editor dialog

## Validation
- bun run lint
- bunx vitest run tests/commandLineSoundEffects/commandLineSoundEffects.store.test.js tests/commandLineSoundEffects/commandLineSoundEffects.handlers.test.js tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js