### PR TITLE
Set animation editor defaults to black and 2x zoom

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -226,7 +226,7 @@ template:
                                           - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
           - $if showChannelControls:
               - rtgl-view w=f ph=lg:
-                  - rtgl-form#channelForm key=channel :form=${channelForm} :defaultValues=${channelDefaultValues} p=none: null
+                  - rtgl-form#channelForm key=channel :form=${channelForm} :defaultValues=${channelDefaultValues} p=lg: null
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit
@@ -263,7 +263,7 @@ template:
                   - $if hasSoundSelection:
                       - rtgl-view w=f g=md:
                           - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=lg: null
-                          - 'rtgl-view h=160 aria-hidden=true style="flex: 0 0 160px;"': null
+                          - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
             $elif mode == 'gallery':
               - rtgl-view d=h w=f av=c g=md ph=lg:
                   - rtgl-view w=1fg: null

--- a/src/components/commandLineVoice/commandLineVoice.view.yaml
+++ b/src/components/commandLineVoice/commandLineVoice.view.yaml
@@ -240,7 +240,7 @@ template:
               - $if hasSoundSelection:
                   - rtgl-view w=f g=md:
                       - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} p=lg: null
-                      - 'rtgl-view h=160 aria-hidden=true style="flex: 0 0 160px;"': null
+                      - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - $if showAudioPlayer:
               - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
                   - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null

--- a/src/pages/animationEditor/animationEditor.constants.js
+++ b/src/pages/animationEditor/animationEditor.constants.js
@@ -5,7 +5,7 @@ export const EMPTY_TREE = {
 
 export const ANIMATION_RESOURCE_CATEGORY = "animatedAssets";
 export const ANIMATION_SELECTED_RESOURCE_ID = "animations";
-export const PREVIEW_BG_COLOR = "#4a4a4a";
+export const PREVIEW_BG_COLOR = "#000000";
 export const PREVIEW_UPDATE_ELEMENT_ID = "preview-element";
 export const PREVIEW_TRANSITION_ELEMENT_ID = "preview-transition-element";
 export const PREVIEW_TRANSITION_PREV_FILL = "#ffffff";

--- a/src/pages/animationEditor/animationEditor.store.js
+++ b/src/pages/animationEditor/animationEditor.store.js
@@ -46,7 +46,7 @@ import {
 } from "./animationEditor.constants.js";
 import { selectAnimationEditorPageCopy } from "./support/animationEditorPageCopy.js";
 
-const TIMELINE_ZOOM_DEFAULT = 1;
+const TIMELINE_ZOOM_DEFAULT = 2;
 const TIMELINE_ZOOM_MIN = 0.25;
 const TIMELINE_ZOOM_MAX = 4;
 const TIMELINE_BASE_PIXELS_PER_SECOND = 200;

--- a/tests/animationEditor/animationEditor.store.test.js
+++ b/tests/animationEditor/animationEditor.store.test.js
@@ -246,13 +246,13 @@ describe("animationEditor.store", () => {
 
     const viewData = selectViewData({ state, i18n: EN_I18N });
 
-    expect(viewData.timelineDisplayDuration).toBe(3000);
+    expect(viewData.timelineDisplayDuration).toBe(1500);
     expect(viewData.activeTimelineDuration).toBe(500);
     expect(viewData.timelineUsedAreaStyle).toContain(
-      "width: calc((100% - 104px) * 0.16666666666666666)",
+      "width: calc((100% - 104px) * 0.3333333333333333)",
     );
     expect(viewData.timelinePlayheadStyle).toContain(
-      "left: calc(104px + (100% - 104px) * 0.16666666666666666)",
+      "left: calc(104px + (100% - 104px) * 0.3333333333333333)",
     );
   });
 
@@ -270,7 +270,7 @@ describe("animationEditor.store", () => {
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
       activeTimelineDuration: 2400,
       timelineUsedAreaStyle: expect.stringContaining(
-        "width: calc((100% - 104px) * 0.8)",
+        "width: calc((100% - 104px) * 1)",
       ),
     });
 
@@ -281,7 +281,7 @@ describe("animationEditor.store", () => {
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
       activeTimelineDuration: 500,
       timelineUsedAreaStyle: expect.stringContaining(
-        "width: calc((100% - 104px) * 0.16666666666666666)",
+        "width: calc((100% - 104px) * 0.3333333333333333)",
       ),
     });
 
@@ -300,7 +300,7 @@ describe("animationEditor.store", () => {
 
     setTimelineScrollMetrics(
       { state },
-      { scrollLeft: 125, viewportWidth: 300 },
+      { scrollLeft: 225, viewportWidth: 300 },
     );
 
     expect(selectTimelinePlayheadVisible({ state })).toBe(false);
@@ -309,7 +309,10 @@ describe("animationEditor.store", () => {
       timelinePlayheadStyle: "",
     });
 
-    setTimelineScrollMetrics({ state }, { scrollLeft: 75, viewportWidth: 300 });
+    setTimelineScrollMetrics(
+      { state },
+      { scrollLeft: 175, viewportWidth: 300 },
+    );
 
     expect(selectTimelinePlayheadVisible({ state })).toBe(true);
   });
@@ -340,16 +343,16 @@ describe("animationEditor.store", () => {
     expect(state.timelineZoom).toBe(0.25);
   });
 
-  it("uses 200 pixels per second at the default timeline zoom", () => {
+  it("uses 400 pixels per second at the default timeline zoom", () => {
     const state = createInitialState();
     state.tweenBySection.update.x = {
       keyframes: [{ duration: 2000, value: 10 }],
     };
 
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
-      timelineZoom: 1,
-      timelinePixelsPerSecond: 200,
-      timelineCanvasStyle: "width: 504px; min-width: 100%; flex-shrink: 0;",
+      timelineZoom: 2,
+      timelinePixelsPerSecond: 400,
+      timelineCanvasStyle: "width: 904px; min-width: 100%; flex-shrink: 0;",
       timelineDisplayDuration: 2000,
       activeTimelineDuration: 2000,
     });
@@ -364,13 +367,13 @@ describe("animationEditor.store", () => {
 
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
       timelineCanvasStyle: "width: 704px; min-width: 100%; flex-shrink: 0;",
-      timelineDisplayDuration: 3000,
+      timelineDisplayDuration: 1500,
     });
 
     extendTimelineDisplayDuration({ state }, { duration: 4000 });
 
     expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
-      timelineCanvasStyle: "width: 904px; min-width: 100%; flex-shrink: 0;",
+      timelineCanvasStyle: "width: 1704px; min-width: 100%; flex-shrink: 0;",
       timelineDisplayDuration: 4000,
     });
   });
@@ -2013,6 +2016,19 @@ describe("animationEditor.store", () => {
     );
 
     expect(renderTransitionElement).toMatchObject({
+      type: "rect",
+      fill: "#000000",
+    });
+  });
+
+  it("uses black as the default preview background", () => {
+    const state = createInitialState();
+    openDialog({ state }, { dialogType: "update" });
+
+    const renderState = selectAnimationRenderStateWithAnimations({ state });
+
+    expect(renderState.elements[0]).toMatchObject({
+      id: "bg",
       type: "rect",
       fill: "#000000",
     });


### PR DESCRIPTION
## Summary

- use black as the default animation preview background
- start the animation timeline at 2x zoom (400 pixels per second)
- update timeline calculations and add regression coverage for the preview background
- restore standard padding and bottom scroll space for BGM and voice forms so the full test suite passes

## Validation

- `bun run test` — all Node suites passed; 379 Vitest files and 3,029 tests passed locally
- focused animation-editor suite — 56 tests passed
- focused BGM, voice, and command-line spacing suite — 44 tests passed
- targeted Prettier checks — passed
- full local `bun run lint` remains blocked by the unrelated untracked `ssr-poc/` directory, which is not included in this PR