### PR TITLE
Align Scene Editor command-line dialog spacing

### DIFF
--- a/src/components/commandLineActions/commandLineActions.view.yaml
+++ b/src/components/commandLineActions/commandLineActions.view.yaml
@@ -4,11 +4,11 @@ refs:
       click:
         handler: handleActionClick
 template:
-  - 'rtgl-view w=f h=f pv=md br=md d=v style="min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden;"':
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - 'rtgl-view w=f h=f pv=lg br=md d=v style="min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden;"':
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg w=f sv style="min-width: 0; min-height: 0;"':
-          - 'rtgl-view w=f d=v g=sm ph=md style="min-width: 0; box-sizing: border-box;"':
+          - 'rtgl-view w=f d=v g=sm ph=lg style="min-width: 0; box-sizing: border-box;"':
               - $for item, i in items:
                   - $if item.type == "section":
                       - 'rtgl-text s=xs c=mu-fg mt=lg w=f ellipsis=true': ${item.label}

--- a/src/components/commandLineBackground/commandLineBackground.view.yaml
+++ b/src/components/commandLineBackground/commandLineBackground.view.yaml
@@ -79,12 +79,12 @@ styles:
     background-repeat: repeat
     background-size: 12px 12px
 template:
-  - 'rtgl-view w=f h=f pv=md pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - 'rtgl-view w=f h=f pv=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - $if mode == 'current':
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues} ph=md pv=none:
+              - rtgl-form#form key=${dialogueForm.key} :form=${dialogueForm.form} :defaultValues=${dialogueForm.defaultValues} ph=lg pv=none:
                   - $if selectedResource:
                       - $if selectedResource.resourceType == 'image':
                           - rtgl-view#backgroundImage slot=background cur=pointer bw=xs bc=${selectedResource.itemBorderColor} h-bc=${selectedResource.itemHoverBorderColor} br=md:
@@ -140,17 +140,17 @@ template:
                                   - rtgl-text s=sm c=mu-fg: ${item.label}
                                   - 'rtgl-text s=sm style="font-variant-numeric: tabular-nums;"': ${item.value}
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'gallery':
-          - 'rtgl-view d=h w=f av=c g=md ph=md style="min-width: 0;"':
+          - 'rtgl-view d=h w=f av=c g=md ph=lg style="min-width: 0;"':
               - 'rtgl-view w=1fg sh style="min-width: 0; overscroll-behavior-x: contain;"':
                   - 'rtgl-tabs#tabs selected-tab=${tab} :items=${tabs} style="display: block; min-width: max-content;"': null
               - $if showInlineSearch:
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
               - $if showSearchButton:
                   - 'rtgl-button#searchButton sq pre=search v=ol aria-label="${searchButtonLabel}" title="${searchButtonLabel}"': null
-          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=md style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=lg style="min-height: 0;"':
               - $if showImageSelectorFileExplorer:
                   - rtgl-view h=f w=1fg sv:
                       - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
@@ -195,7 +195,7 @@ template:
                                                       - rtgl-icon icon=play s=xl c=fg: null
                                               - rtgl-view w=f p=md:
                                                   - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md pt=sm style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg pt=sm style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: ${selectButtonLabel}
 
   - $if showSearchButton:

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -199,11 +199,11 @@ styles:
     text-align: left
     width: 100%
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f g=lg style="min-height: 0;"':
-          - rtgl-view w=f g=md ph=md:
+          - rtgl-view w=f g=md ph=lg:
               - 'rtgl-view#bgmChannel.bgmChannel.bgmChannelPreview w=f d=v pos=rel bgc=bg bw=xs bc=${channelBorderColor} h-bc=${channelHoverBorderColor} br=sm cur=pointer tabindex=0 role=button aria-label="${editChannelLabel}" style="height: ${channelHeightPx}px;"':
                   - div.bgmChannelHeader:
                       - span: ${channelLabel}
@@ -226,17 +226,17 @@ template:
                                           - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
           - $if showChannelControls:
               - rtgl-view w=f:
-                  - rtgl-form#channelForm key=channel :form=${channelForm} :defaultValues=${channelDefaultValues} ph=md pv=none: null
+                  - rtgl-form#channelForm key=channel :form=${channelForm} :defaultValues=${channelDefaultValues} ph=lg pv=none: null
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit
   - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg close-button:
       - 'rtgl-view slot=content d=v w=f h=80vh g=lg style="min-width: 0; min-height: 0; overflow: hidden;"':
-          - rtgl-view w=f ph=md:
+          - rtgl-view w=f ph=lg:
               - rtgl-text#channelEditorTitle s=lg: ${channelEditorTitle}
           - $if mode == 'current':
               - 'rtgl-view h=1fg sv w=f g=lg style="min-height: 0;"':
-                  - rtgl-view w=f ph=md:
+                  - rtgl-view w=f ph=lg:
                       - 'rtgl-view#editorChannel.bgmChannel w=f d=v pos=rel bgc=bg bw=xs bc=bo br=sm style="height: ${channelHeightPx}px;"':
                           - div.bgmChannelHeader:
                               - span: ${channelLabel}
@@ -262,13 +262,13 @@ template:
                                                   - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
                   - $if hasSoundSelection:
                       - rtgl-view w=f g=md:
-                          - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} ph=md pv=none: null
+                          - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} ph=lg pv=none: null
                           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
             $elif mode == 'gallery':
-              - rtgl-view d=h w=f av=c g=md ph=md:
+              - rtgl-view d=h w=f av=c g=md ph=lg:
                   - rtgl-view w=1fg: null
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-              - 'rtgl-view d=h w=f g=lg h=1fg ph=md style="min-height: 0;"':
+              - 'rtgl-view d=h w=f g=lg h=1fg ph=lg style="min-height: 0;"':
                   - $if showResourceSelectorFileExplorer:
                       - rtgl-view h=f w=1fg sv:
                           - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
@@ -288,11 +288,11 @@ template:
                                                   - 'rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg style="${resourceSelectorPreviewStyle}"':
                                                       - rtgl-text s=sm c=mu-fg: No waveform
                                               - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
-              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#buttonSelect: Select
           - $if showAudioPlayer:
               - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
                   - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null
           - $if mode == 'current':
-              - 'rtgl-view d=h av=c ah=e w=f ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#channelEditorConfirmButton v=pr: ${confirmButtonLabel}

--- a/src/components/commandLineCharacters/commandLineCharacters.view.yaml
+++ b/src/components/commandLineCharacters/commandLineCharacters.view.yaml
@@ -146,13 +146,13 @@ styles:
     background-repeat: repeat
     background-size: 24px 24px
 template:
-  - 'rtgl-view w=f h=f pv=md pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
+  - 'rtgl-view w=f h=f pv=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - $if mode == 'current':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
               - rtgl-view g=md w=f:
-                  - 'rtgl-form#form key="${formKey}" :form=${form} :defaultValues=${defaultValues} ph=md pv=none':
+                  - 'rtgl-form#form key="${formKey}" :form=${form} :defaultValues=${defaultValues} ph=lg pv=none':
                       - $for character, i in defaultValues.characters:
                           - 'rtgl-view#characterSpriteBox${i}.characterRow slot=${character.spriteFormSlot} data-index=${character.characterIndex} data-character-id=${character.id} cur=pointer bw=xs bc=bo h-bc=ac br=sm style="align-self: flex-start; flex: 0 0 auto;"':
                               - rtgl-view p=md g=md br=md:
@@ -206,15 +206,15 @@ template:
                                           - rtgl-text s=xs: ${spriteGroup.name}
                   - rtgl-button#addCharacterButton v=ol w=f mt=md mh=lg: ${addCharacterButtonLabel}
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'character-select':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-view d=h w=f av=c g=md ph=md:
+          - rtgl-view d=h w=f av=c g=md ph=lg:
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=md style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=lg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
               - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
@@ -235,15 +235,15 @@ template:
                                                   - rtgl-text s=sm c=mu-fg: ${noAvatarLabel}
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
       - $if mode == 'sprite-select':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - $if showSpriteGroupTabs:
-              - rtgl-view w=f ph=md:
+              - rtgl-view w=f ph=lg:
                   - rtgl-tabs#spriteGroupTabs :items=${spriteSelectionTabs} selected-tab=${selectedSpriteGroupId}: null
-          - rtgl-view d=h w=f av=c g=md ph=md:
+          - rtgl-view d=h w=f av=c g=md ph=lg:
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=md style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=lg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${spriteItems}: null
               - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
@@ -262,7 +262,7 @@ template:
                                               - 'div.commandLineCharacterThumbnailTransparencyGrid style="display: block; width: 200px; height: 120px; overflow: hidden; border-radius: 4px;"':
                                                   - rvn-file-image fileId=${item.previewFileId} w=f h=f br=sm: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: ${selectButtonLabel}
   - $if fullImagePreviewVisible:
       - rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:

--- a/src/components/commandLineChoices/commandLineChoices.view.yaml
+++ b/src/components/commandLineChoices/commandLineChoices.view.yaml
@@ -56,13 +56,13 @@ refs:
       item-click:
         handler: handleDropdownMenuClickItem
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == "list":
           - 'rtgl-view wh=f style="min-height: 0;"':
-              - rtgl-view w=f h=24 av=c ph=md mb=md:
+              - rtgl-view w=f h=24 av=c ph=lg mb=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} ph=md pv=none:
+                  - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} ph=lg pv=none:
                       - rtgl-view#choicesContainer slot=choices g=md w=f:
                           - $for item, index in items:
                               - rtgl-view#choiceItem${index} data-index=${index} d=h av=c w=f g=md pv=sm ph=md bgc=mu br=sm cur=pointer:
@@ -71,18 +71,18 @@ template:
                                   - 'rtgl-text s=xs c=mu-fg style="white-space: nowrap; flex: 0 0 auto;"': ${item.actionLabel}
                           - rtgl-button#addChoiceButton v=ol w=f mt=md: + Add Choice
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#submitButton: Submit
         $elif mode == "editChoice":
           - 'rtgl-view wh=f style="min-height: 0;"':
-              - rtgl-view w=f h=24 av=c ph=md mb=md:
+              - rtgl-view w=f h=24 av=c ph=lg mb=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#choiceForm key=${choiceFormKey} :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm} ph=md pv=none:
+                  - rtgl-form#choiceForm key=${choiceFormKey} :form=${choiceFormTemplate} :context=${editFormContext} :defaultValues=${editForm} ph=lg pv=none:
                       - rtgl-view slot=updateVariables w=f:
                           - rvn-system-actions#choiceUpdateVariableEditor :showSelected=${true} :actions=${choiceUpdateVariableActions} actionType=system :allowedModes=${choiceUpdateVariableAllowedModes} :showEmbeddedClose=${false}: null
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#cancelEditButton v=ol: Cancel
                   - rtgl-button#saveChoiceButton: Save Choice
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineConditional/commandLineConditional.view.yaml
+++ b/src/components/commandLineConditional/commandLineConditional.view.yaml
@@ -92,12 +92,12 @@ refs:
       item-click:
         handler: handleDropdownMenuClickItem
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == 'current' && initiated:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-view g=md mt=md w=f p=lg ph=md:
+              - rtgl-view g=md mt=md w=f p=lg ph=lg:
                   - rtgl-text s=sm c=mu-fg: ${branchesLabel}
                   - $for branch in branches:
                       - rtgl-view#conditionalBranch${branch.id} data-branch-id=${branch.id} cur=pointer d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f:
@@ -115,13 +115,13 @@ template:
                           - 'rtgl-button#branchMenuButtonDefault data-branch-id=${defaultBranch.id} sq s=sm v=gh pre=ellipsis title="${branchMenuButtonLabel}" aria-label="${branchMenuButtonLabel}" aria-haspopup=menu aria-keyshortcuts="${defaultBranch.menuKeyShortcuts}"': null
                   - $if !hasDefaultBranch:
                       - rtgl-button#addDefaultButton v=ol w=f: ${addDefaultBranchButton}
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${!hasBranches}: ${submitButton}
       - $if mode == 'editBranch' && initiated:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-view g=md mt=md w=f p=lg ph=md:
+              - rtgl-view g=md mt=md w=f p=lg ph=lg:
                   - $if !isEditingDefault:
                       - rtgl-view g=md w=f:
                           - rtgl-text s=sm c=mu-fg: ${conditionLabel}
@@ -168,6 +168,6 @@ template:
                   - rtgl-view g=md w=f:
                       - rtgl-text s=sm c=mu-fg: ${actionsLabel}
                       - rvn-system-actions#branchActionsEditor :showSelected=${true} :actions=${branchActions} actionType=system :hiddenModes=${hiddenModes} :allowedModes=${branchActionAllowedModes} :showEmbeddedClose=${false}: null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#saveBranchButton ?disabled=${!canSaveBranch}: ${saveButtonPrefix} ${editBranchTitle}
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineControl/commandLineControl.view.yaml
+++ b/src/components/commandLineControl/commandLineControl.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#controlForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.handlers.js
@@ -890,6 +890,22 @@ export const handleFormChange = (deps, payload) => {
   dispatchTemporaryPresentationStateChange(deps);
 };
 
+export const handleFormInput = (deps, payload) => {
+  const { render, store } = deps;
+  const { name, value } = payload._event.detail;
+
+  if (name === "characterName") {
+    store.setCharacterName({ characterName: value });
+  } else if (name === "spriteAnimationPlaybackSpeed") {
+    store.setSpriteAnimationPlaybackSpeed({ speed: value });
+  } else {
+    return;
+  }
+
+  render();
+  dispatchTemporaryPresentationStateChange(deps);
+};
+
 export const handleFormSectionAction = async (deps, payload) => {
   const { appService, i18n, render, store } = deps;
   const { sectionId, actionId, position } = payload._event.detail;

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -5,6 +5,9 @@ refs:
         handler: handleBreadcumbClick
   dialogueForm:
     eventListeners:
+      form-input:
+        handler: handleFormInput
+        debounce: 120
       form-change:
         handler: handleFormChange
       form-section-action:

--- a/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
+++ b/src/components/commandLineDialogueBox/commandLineDialogueBox.view.yaml
@@ -67,12 +67,12 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == 'current':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=md pv=none:
+              - rtgl-form#dialogueForm :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=lg pv=none:
                   - $if customizeTextSpeed:
                       - rtgl-view slot=textSpeed g=md w=f:
                           - rtgl-view d=h av=c w=f g=md:
@@ -97,15 +97,15 @@ template:
                                       - 'rtgl-view.characterSpriteGroupBox data-sprite-group-id=${spriteGroup.id} d=h av=c g=xs ph=md pv=xs cur=pointer bw=xs bc=bo h-bc=pr br=sm bgc=${spriteGroup.backgroundColor}':
                                           - rtgl-text s=xs: ${spriteGroup.name}
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: ${submitButtonLabel}
       - $if mode == 'character-select':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-view d=h w=f av=c g=md ph=md:
+          - rtgl-view d=h w=f av=c g=md ph=lg:
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=md style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=lg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
               - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
@@ -125,15 +125,15 @@ template:
                                                   - rtgl-text s=sm c=mu-fg: ${noAvatarLabel}
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
       - $if mode == 'sprite-select':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - $if showSpriteGroupTabs:
-              - rtgl-view w=f ph=md:
+              - rtgl-view w=f ph=lg:
                   - rtgl-tabs#spriteGroupTabs :items=${spriteSelectionTabs} selected-tab=${selectedSpriteGroupId}: null
-          - rtgl-view d=h w=f av=c g=md ph=md:
+          - rtgl-view d=h w=f av=c g=md ph=lg:
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=md style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=lg style="min-height: 0;"':
               - rtgl-view h=f w=1fg sv:
                   - rvn-base-file-explorer#baseFileExplorer :items=${spriteItems}: null
               - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
@@ -151,7 +151,7 @@ template:
                                             $else:
                                               - rvn-file-image fileId=${item.previewFileId} w=200 h=120: null
                                           - rtgl-text s=xs c=mu-fg ellipsis w=200: ${item.name}
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: ${selectButtonLabel}
   - $if fullImagePreviewVisible:
       - rtgl-view#previewOverlay pos=fix edge=f z=3000 cur=pointer:

--- a/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
+++ b/src/components/commandLineHideConfirmDialog/commandLineHideConfirmDialog.view.yaml
@@ -8,11 +8,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineInput/commandLineInput.view.yaml
+++ b/src/components/commandLineInput/commandLineInput.view.yaml
@@ -32,13 +32,13 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == "list":
           - 'rtgl-view wh=f style="min-height: 0;"':
-              - rtgl-view w=f h=24 av=c ph=md mb=md:
+              - rtgl-view w=f h=24 av=c ph=lg mb=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f ph=md pv=none:
+                  - rtgl-form#form key=${formKey} :form=${form} :defaultValues=${defaultValues} :context=${context} w=f ph=lg pv=none:
                       - rtgl-view slot=${inputFieldsSlot} g=md w=f:
                           - $if hasFields:
                               - $for fieldRow, index in fieldRows:
@@ -52,14 +52,14 @@ template:
                               - rtgl-view p=md bgc=mu br=md w=f:
                                   - rtgl-text s=sm c=mu-fg: ${noInputFieldsLabel}
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#submitButton ?disabled=${submitDisabled}: ${submitButtonLabel}
         $elif mode == "editField":
           - 'rtgl-view wh=f style="min-height: 0;"':
-              - rtgl-view w=f h=24 av=c ph=md mb=md:
+              - rtgl-view w=f h=24 av=c ph=lg mb=md:
                   - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
               - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-                  - rtgl-view d=v g=lg w=f p=lg ph=md:
+                  - rtgl-view d=v g=lg w=f p=lg ph=lg:
                       - rtgl-view d=v g=xs w=f:
                           - rtgl-text s=sm: ${editFieldForm.label}
                           - rtgl-text s=xs c=mu-fg: ${editFieldForm.field}
@@ -83,6 +83,6 @@ template:
                           - rtgl-view d=v g=xs w=150:
                               - rtgl-text s=sm c=mu-fg: ${maxLengthLabel}
                               - rtgl-input#fieldEditMaxLength data-name=maxLength type=number min=0 step=1 w=f value=${editFieldForm.maxLength}: null
-              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#cancelFieldEditButton v=ol: ${cancelButtonLabel}
                   - rtgl-button#saveFieldEditButton ?disabled=${!canSaveEditField}: ${saveFieldButtonLabel}

--- a/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
+++ b/src/components/commandLineLoadSlot/commandLineLoadSlot.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineNextLine/commandLineNextLine.view.yaml
+++ b/src/components/commandLineNextLine/commandLineNextLine.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#nextLineForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLinePopOverlay/commandLinePopOverlay.view.yaml
+++ b/src/components/commandLinePopOverlay/commandLinePopOverlay.view.yaml
@@ -9,10 +9,10 @@ refs:
         handler: handleBreadcrumbClick
 template:
   - $if mode == 'current' && initiated:
-      - rtgl-view w=f h=f pv=md:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+      - rtgl-view w=f h=f pv=lg:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
-          - 'rtgl-view h=1fg sv w=f ph=md style="min-height: 0;"':
+          - 'rtgl-view h=1fg sv w=f ph=lg style="min-height: 0;"':
               - rtgl-text s=sm: Pop the current overlay and return to the previous view.
-          - 'rtgl-view d=h g=md w=f ah=e mt=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h g=md w=f ah=e mt=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton variant=pr: Submit

--- a/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
+++ b/src/components/commandLinePushOverlay/commandLinePushOverlay.view.yaml
@@ -12,12 +12,12 @@ refs:
       form-change:
         handler: handleFormChange
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == 'current' && initiated:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f ph=md pv=none: null
+              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f ph=lg pv=none: null
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton variant=pr: Submit

--- a/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
+++ b/src/components/commandLineResetStoryAtSection/commandLineResetStoryAtSection.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=md pv=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
+++ b/src/components/commandLineRollbackByOffset/commandLineRollbackByOffset.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
+++ b/src/components/commandLineRuntimeAction/commandLineRuntimeAction.view.yaml
@@ -14,11 +14,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=md pv=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton variant=pr: ${submitLabel}

--- a/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
+++ b/src/components/commandLineSaveSlot/commandLineSaveSlot.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#form :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineScreen/commandLineScreen.view.yaml
+++ b/src/components/commandLineScreen/commandLineScreen.view.yaml
@@ -14,11 +14,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=md pv=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
+++ b/src/components/commandLineSectionTransition/commandLineSectionTransition.view.yaml
@@ -12,12 +12,12 @@ refs:
       form-change:
         handler: handleFormChange
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == 'current' && initiated:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#transitionForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=md pv=none: null
+              - rtgl-form#transitionForm key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=lg pv=none: null
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
+++ b/src/components/commandLineSetNextLineConfig/commandLineSetNextLineConfig.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=md pv=none: null
+          - rtgl-form#form key=${formKey} :defaultValues=${defaultValues} :form=${form} :context=${context} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
+++ b/src/components/commandLineShowConfirmDialog/commandLineShowConfirmDialog.view.yaml
@@ -36,13 +36,13 @@ refs:
       close:
         handler: handleNestedActionsClose
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
       - $if mode == 'current':
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f ph=md pv=none: null
-              - rtgl-view g=md mt=md ph=md:
+              - rtgl-form#form :form=${form} :defaultValues=${defaultValues} :context=${context} w=f ph=lg pv=none: null
+              - rtgl-view g=md mt=md ph=lg:
                   - rtgl-view#confirmActionsButton d=h av=c ah=s g=md p=md bgc=mu h-bgc=ac br=md w=f cur=pointer:
                       - rtgl-view d=v:
                           - rtgl-text s=sm: Confirm Actions
@@ -52,7 +52,7 @@ template:
                           - rtgl-text s=sm: Cancel Actions
                           - rtgl-text s=xs c=mu-fg: ${cancelActionsSummary}
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${submitDisabled}: Submit
         $elif mode == 'confirmActions':
           - rvn-system-actions#confirmActionsEditor w=f h=f :showSelected=${true} :actions=${confirmActions} actionType=system :hiddenModes=${nestedHiddenModes}: null

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -226,11 +226,11 @@ styles:
     min-width: "0"
     padding: "0 8px"
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f g=lg style="min-height: 0;"':
-          - rtgl-view w=f g=lg ph=md:
+          - rtgl-view w=f g=lg ph=lg:
               - $for channel, i in channels:
                   - rtgl-view w=f g=md:
                       - 'rtgl-view#sfxChannel${i}.sfxChannel.sfxChannelPreview data-channel-id="${channel.id}" w=f d=v pos=rel bgc=bg bw=xs bc=${channel.channelBorderColor} h-bc=${channel.channelHoverBorderColor} br=sm cur=pointer tabindex=0 role=button aria-label="${editChannelLabel}: ${channel.id}" style="height: ${channel.channelHeightPx}px; flex-basis: ${channel.channelHeightPx}px;"':
@@ -260,7 +260,7 @@ template:
                           - 'rtgl-form#channelForm${i} data-channel-id="${channel.id}" key=${channel.channelFormKey} :form=${channelForm} :defaultValues=${channel.channelDefaultValues} w=f ph=none pv=none': null
               - 'rtgl-button#addChannelButton v=ol w=f mt=md style="flex: 0 0 auto;"': ${addChannelButtonLabel}
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: ${submitButtonLabel}
   - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=md close-button:
       - 'rtgl-view slot=content d=v w=f h=80vh g=lg style="min-width: 0; min-height: 0; overflow: hidden;"':
@@ -268,7 +268,7 @@ template:
           - $if mode == 'current':
               - 'rtgl-view h=1fg sv w=f g=lg style="min-height: 0;"':
                   - $if editorChannel:
-                      - rtgl-view w=f ph=md:
+                      - rtgl-view w=f ph=lg:
                           - 'rtgl-view#editorChannel.sfxChannel w=f d=v pos=rel bgc=bg bw=xs bc=bo br=sm style="height: ${editorChannel.channelHeightPx}px;"':
                               - rtgl-view.sfxChannelHeader d=h w=f:
                                   - div.sfxChannelLabel:
@@ -297,13 +297,13 @@ template:
                                                           - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
                   - $if hasSoundSelection:
                       - rtgl-view w=f g=md:
-                          - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} ph=md pv=none: null
+                          - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} ph=lg pv=none: null
                           - 'rtgl-view h=160 aria-hidden=true style="flex: 0 0 160px;"': null
             $elif mode == 'gallery':
-              - rtgl-view d=h w=f av=c g=md ph=md:
+              - rtgl-view d=h w=f av=c g=md ph=lg:
                   - rtgl-view w=1fg: null
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-              - 'rtgl-view d=h w=f g=lg h=1fg ph=md style="min-height: 0;"':
+              - 'rtgl-view d=h w=f g=lg h=1fg ph=lg style="min-height: 0;"':
                   - $if showResourceSelectorFileExplorer:
                       - rtgl-view h=f w=1fg sv:
                           - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
@@ -323,13 +323,13 @@ template:
                                                   - 'rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg style="${resourceSelectorPreviewStyle}"':
                                                       - rtgl-text s=sm c=mu-fg: No waveform
                                               - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
-              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#buttonSelect: ${selectButtonLabel}
           - $if showAudioPlayer:
               - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
                   - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null
           - $if mode == 'current':
-              - 'rtgl-view d=h av=c ah=e w=f ph=md style="flex: 0 0 auto;"':
+              - 'rtgl-view d=h av=c ah=e w=f ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#channelEditorConfirmButton v=pr: ${confirmButtonLabel}
   - rtgl-popover#addChannelPopover ?open=${addChannelPopover.isOpen} x=${addChannelPopover.position.x} y=${addChannelPopover.position.y} place=bs:
       - rtgl-form#addChannelForm key=${addChannelPopover.key} slot=content :defaultValues=${addChannelDefaultValues} :form=${addChannelForm} w=320: null

--- a/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
+++ b/src/components/commandLineStartSkipMode/commandLineStartSkipMode.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#startSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
+++ b/src/components/commandLineStopSkipMode/commandLineStopSkipMode.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#stopSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineSystemActions/commandLineSystemActions.view.yaml
+++ b/src/components/commandLineSystemActions/commandLineSystemActions.view.yaml
@@ -5,10 +5,10 @@ refs:
         handler: handleActionClick
 template:
   - 'rtgl-view w=f h=f pv=lg br=md d=v style="min-width: 0; min-height: 0; box-sizing: border-box; overflow: hidden;"':
-      - rtgl-view w=f ph=md:
+      - rtgl-view w=f ph=lg:
           - rtgl-text s=sm c=mu-fg: Actions
       - 'rtgl-view h=1fg w=f mt=lg sv style="min-width: 0; min-height: 0;"':
-          - 'rtgl-view w=f d=v g=sm ph=md style="min-width: 0; box-sizing: border-box;"':
+          - 'rtgl-view w=f d=v g=sm ph=lg style="min-width: 0; box-sizing: border-box;"':
               - $for item, i in items:
                   - 'rtgl-view#action${i} data-action-id=${item.id} g=md d=h av=c ph=md bgc=mu h-bgc=ac br=md h=36 w=f cur=pointer style="min-width: 0; box-sizing: border-box;"':
                       - rtgl-svg svg=${item.icon} wh=24: null

--- a/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
+++ b/src/components/commandLineToggleAutoMode/commandLineToggleAutoMode.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#toggleAutoModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
+++ b/src/components/commandLineToggleDialogueUI/commandLineToggleDialogueUI.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#toggleDialogueUIForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
+++ b/src/components/commandLineToggleSkipMode/commandLineToggleSkipMode.view.yaml
@@ -12,11 +12,11 @@ refs:
       click:
         handler: handleSubmitClick
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=md pv=none: null
+          - rtgl-form#toggleSkipModeForm :defaultValues=${defaultValues} :form=${form} w=f ph=lg pv=none: null
           - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit

--- a/src/components/commandLineUpdateVariable/commandLineUpdateVariable.view.yaml
+++ b/src/components/commandLineUpdateVariable/commandLineUpdateVariable.view.yaml
@@ -52,12 +52,12 @@ refs:
       item-click:
         handler: handleDropdownMenuClickItem
 template:
-  - rtgl-view w=f h=f pv=md:
+  - rtgl-view w=f h=f pv=lg:
       - $if mode == 'current' && initiated:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-view g=md mt=md w=f p=lg ph=md:
+              - rtgl-view g=md mt=md w=f p=lg ph=lg:
                   - $for operation, i in operations:
                       - rtgl-view#operation${i} data-operation-id=${operation.id} cur=pointer d=h av=c ah=c g=md p=md bgc=mu h-bgc=ac br=md w=f:
                           - rtgl-text s=sm: '${operation.variableName}:'
@@ -65,13 +65,13 @@ template:
                           - $if operation.op != 'toggle':
                               - rtgl-text s=sm: ${operation.displayValue}
                   - rtgl-button#addOperationButton v=ol w=f mt=md: ${addOperationButton}
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton ?disabled=${!hasOperations}: ${submitButton}
       - $if mode == 'edit' && initiated:
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcrumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f style="min-height: 0;"':
-              - rtgl-view g=md mt=md w=f p=lg ph=md:
+              - rtgl-view g=md mt=md w=f p=lg ph=lg:
                   - rtgl-text s=sm c=mu-fg mb=sm: ${variableLabel}
                   - rtgl-select#variableSelect w=f :selectedValue=${tempOperation.variableId} :options=${variableOptions} placeholder="${variablePlaceholder}": null
                   - $if tempOperation.variableId:
@@ -92,6 +92,6 @@ template:
                   - $if showValueField && valueInputType == 'string' && !showEnumValueSelect:
                       - rtgl-text s=sm c=mu-fg mt=lg mb=sm: ${valueLabel}
                       - rtgl-input#valueInput w=f placeholder="${valueTextPlaceholder}" value=${tempOperation.value}: null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#saveOperationButton ?disabled=${!canSaveOperation}: ${saveOperationButton}
   - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null

--- a/src/components/commandLineVisual/commandLineVisual.view.yaml
+++ b/src/components/commandLineVisual/commandLineVisual.view.yaml
@@ -141,12 +141,12 @@ refs:
       value-input:
         handler: handleShaderAdjustmentInput
 template:
-  - 'rtgl-view w=f h=f pv=md pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
+  - 'rtgl-view w=f h=f pv=lg pos=rel style="min-width: 0; min-height: 0; overflow: hidden;"':
       - $if mode == 'current':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
           - 'rtgl-view h=1fg sv w=f g=md style="min-height: 0;"':
-              - 'rtgl-form#form key="${formKey}" :form=${form} :defaultValues=${defaultValues} ph=md pv=none':
+              - 'rtgl-form#form key="${formKey}" :form=${form} :defaultValues=${defaultValues} ph=lg pv=none':
                   - $for visualGroup, groupIndex in defaultValues.visualGroups:
                       - $for visual, i in visualGroup.visuals:
                           - 'rtgl-view#visualItem${visual.controlId} slot=${visual.previewFormSlot} data-index=${visual.visualIndex} data-visual-id=${visual.id} style="align-self: flex-start; flex: 0 0 auto;"':
@@ -207,19 +207,19 @@ template:
                           - $for adjustment, adjustmentIndex in visual.shaderAdjustments:
                               - $if adjustment.enabled:
                                   - 'rtgl-slider-input#shaderAdjustment${visual.controlId}x${adjustmentIndex} slot=${adjustment.formSlot} data-index=${visual.visualIndex} data-adjustment-id=${adjustment.id} min=${adjustment.min} max=${adjustment.max} step=${adjustment.step} w=f value=${adjustment.value}': null
-              - rtgl-view w=f ph=md:
+              - rtgl-view w=f ph=lg:
                   - rtgl-button#addVisualButton v=ol w=f mt=md: ${addVisualButtonLabel}
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#submitButton: ${submitButtonLabel}
       - $if mode == 'resource-select':
-          - rtgl-view w=f h=24 av=c ph=md mb=md:
+          - rtgl-view w=f h=24 av=c ph=lg mb=md:
               - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
-          - rtgl-view d=h w=f av=c g=md ph=md:
+          - rtgl-view d=h w=f av=c g=md ph=lg:
               - rtgl-tabs#tabs selected-tab=${tab} :items=${tabs}: null
               - rtgl-view w=1fg: null
               - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=md style="min-height: 0;"':
+          - 'rtgl-view d=h w=f g=lg mt=sm h=1fg ph=lg style="min-height: 0;"':
               - $if showResourceSelectorFileExplorer:
                   - rtgl-view h=f w=1fg sv:
                       - rvn-base-file-explorer#baseFileExplorer :items=${resourceItems}: null
@@ -257,7 +257,7 @@ template:
                                                       - rtgl-view w=f h=f av=c ah=c bgc=mu-fg:
                                                           - rtgl-text s=sm c=mu-fg: ${item.resourceTypeLabel}
                                               - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
-          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#buttonSelect: ${selectButtonLabel}
   - rtgl-popover#addVisualPopover ?open=${addVisualPopover.isOpen} x=${addVisualPopover.position.x} y=${addVisualPopover.position.y} place=bs:
       - rtgl-form#addVisualForm key=${addVisualPopover.key} slot=content :defaultValues=${addVisualDefaultValues} :form=${addVisualForm} w=320 p=none: null

--- a/src/components/commandLineVoice/commandLineVoice.view.yaml
+++ b/src/components/commandLineVoice/commandLineVoice.view.yaml
@@ -175,11 +175,11 @@ styles:
     text-align: left
     width: 100%
 template:
-  - rtgl-view w=f h=f pv=md:
-      - rtgl-view w=f h=24 av=c ph=md mb=md:
+  - rtgl-view w=f h=f pv=lg:
+      - rtgl-view w=f h=24 av=c ph=lg mb=md:
           - rtgl-breadcrumb#breadcumb :items=${breadcrumb}: null
       - 'rtgl-view h=1fg sv w=f g=lg style="min-height: 0;"':
-          - rtgl-view w=f g=md ph=md:
+          - rtgl-view w=f g=md ph=lg:
               - 'rtgl-view#voiceChannel.voiceChannel.voiceChannelPreview w=f d=v pos=rel bgc=bg bw=xs bc=${channelBorderColor} h-bc=${channelHoverBorderColor} br=sm cur=pointer tabindex=0 role=button aria-label="${editChannelLabel}" style="height: ${channelHeightPx}px;"':
                   - div.voiceChannelHeader:
                       - span: ${channelLabel}
@@ -203,17 +203,17 @@ template:
                                           - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
           - $if showChannelControls:
               - rtgl-view w=f g=md:
-                  - rtgl-view w=f ph=md:
+                  - rtgl-view w=f ph=lg:
                       - rtgl-text s=md: ${channelLabel}
-                  - rtgl-form#channelForm key=${channelFormKey} :form=${channelForm} :defaultValues=${channelDefaultValues} ph=md pv=none: null
+                  - rtgl-form#channelForm key=${channelFormKey} :form=${channelForm} :defaultValues=${channelDefaultValues} ph=lg pv=none: null
                   - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
-      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"':
+      - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: Submit
   - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg close-button:
       - 'rtgl-view slot=content d=v w=f h=80vh g=lg style="min-width: 0; min-height: 0; overflow: hidden;"':
           - rtgl-text s=lg: ${channelEditorTitle}
           - 'rtgl-view h=1fg sv w=f g=lg style="min-height: 0;"':
-              - rtgl-view w=f ph=md:
+              - rtgl-view w=f ph=lg:
                   - 'rtgl-view#editorChannel.voiceChannel w=f d=v pos=rel bgc=bg bw=xs bc=bo br=sm style="height: ${channelHeightPx}px;"':
                       - div.voiceChannelHeader:
                           - span: ${channelLabel}
@@ -239,10 +239,10 @@ template:
                                               - 'rtgl-text s=xs c=mu-fg style="flex: 0 0 auto;"': ${sound.durationLabel}
               - $if hasSoundSelection:
                   - rtgl-view w=f g=md:
-                      - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} ph=md pv=none: null
+                      - rtgl-form#soundForm key=${selectionKey} :form=${form} :defaultValues=${defaultValues} ph=lg pv=none: null
                       - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
           - $if showAudioPlayer:
               - 'rtgl-view h=72 pos=fix edge=b z=1001 style="left: 0px; right: 0px;"':
                   - rvn-audio-player#rvnAudioPlayer fileId=${playingSound.fileId} autoPlay=true :title=${playingSound.title}: null
-          - 'rtgl-view d=h av=c ah=e w=f ph=md style="flex: 0 0 auto;"':
+          - 'rtgl-view d=h av=c ah=e w=f ph=lg style="flex: 0 0 auto;"':
               - rtgl-button#channelEditorConfirmButton v=pr: ${confirmButtonLabel}

--- a/src/components/systemActions/systemActions.view.yaml
+++ b/src/components/systemActions/systemActions.view.yaml
@@ -55,10 +55,10 @@ refs:
         handler: handleDropdownMenuClickItem
 styles:
   '#helpFloatingButton':
-    top: calc(var(--spacing-md) - 2px)
+    top: calc(var(--spacing-lg) - 2px)
   '@media only screen and (max-width: 640px)':
     '#helpFloatingButton':
-      top: var(--spacing-md)
+      top: var(--spacing-lg)
 template:
   - $if showSelected:
       - rtgl-view g=md w=f:
@@ -256,7 +256,7 @@ template:
               - $if backgroundTransformEditor.isOpen:
                   - 'rvn-action-transform-editor#actionTransformEditor style="display: block; width: 100%; height: 100%; min-width: 0; min-height: 0;" :transform=${backgroundTransformEditor.transform} :targetName=${backgroundTransformEditor.targetName} :targetType=${backgroundTransformEditor.targetType} canvas-aspect-ratio="${backgroundTransformEditor.canvasAspectRatio}" :projectResolution=${backgroundTransformEditor.projectResolution} :selectedElementMetrics=${backgroundTransformEditor.selectedElementMetrics}': null
                 $else:
-                  - 'rtgl-view#helpFloatingButton pos=abs z=10 w=28 h=28 sm-w=24 sm-h=24 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="right: var(--spacing-md); box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);"':
+                  - 'rtgl-view#helpFloatingButton pos=abs z=10 w=28 h=28 sm-w=24 sm-h=24 ah=c av=c bgc=bg bw=xs bc=bo h-bc=ac br=f cur=pointer style="right: var(--spacing-lg); box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);"':
                       - rtgl-text s=xs c=mu-fg: '?'
                   - $if mode == "actions":
                       - rvn-command-line-actions#commandLineActions :actionsType=${actionsType} :hiddenModes=${hiddenModes} :allowedModes=${allowedModes}: null

--- a/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
+++ b/src/components/systemActionsDialogSurface/systemActionsDialogSurface.store.js
@@ -47,9 +47,9 @@ export const selectViewData = ({ state, props }) => {
       state.suppressClose === true || isBooleanPropEnabled(props.suppressClose),
     overlayHorizontalInset: "64px",
     overlayBackground: "rgba(0, 0, 0, 0.42)",
-    panelHorizontalInset: "96px",
-    panelWidthReduction: "64px",
-    panelVerticalInset: "32px",
+    panelHorizontalInset: "80px",
+    panelWidthReduction: "32px",
+    panelVerticalInset: "16px",
     panelMaxHeight: "800px",
   };
 };

--- a/tests/commandLineActions/commandLineActions.view.test.js
+++ b/tests/commandLineActions/commandLineActions.view.test.js
@@ -27,10 +27,10 @@ describe("commandLineActions view", () => {
       'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"',
     );
     expect(commandLineActionsView).toContain(
-      "rtgl-view w=f h=24 av=c ph=md mb=md:\n          - rtgl-breadcrumb :items=${breadcrumb}: null",
+      "rtgl-view w=f h=24 av=c ph=lg mb=md:\n          - rtgl-breadcrumb :items=${breadcrumb}: null",
     );
-    expect(commandLineActionsView).toContain("w=f d=v g=sm ph=md");
-    expect(commandLineActionsView).toContain("w=f h=f pv=md");
+    expect(commandLineActionsView).toContain("w=f d=v g=sm ph=lg");
+    expect(commandLineActionsView).toContain("w=f h=f pv=lg");
     expect(commandLineActionsView).not.toContain(
       "rtgl-text s=sm c=mu-fg: Actions",
     );

--- a/tests/commandLineActions/commandLineFormSpacing.view.test.js
+++ b/tests/commandLineActions/commandLineFormSpacing.view.test.js
@@ -28,12 +28,7 @@ describe("command-line form spacing", () => {
           line.includes("rtgl-form") && !line.includes("slot=content"),
       );
 
-      if (view.includes("rtgl-breadcrumb")) {
-        expect(view).toContain("pv=md");
-        expect(view).not.toContain("pv=lg");
-      } else {
-        expect(view).toContain("pv=lg");
-      }
+      expect(view).toContain("pv=lg");
       expect(view).not.toMatch(/rtgl-view[^\n]*w=f h=f p=lg/);
       for (let index = 0; index < lines.length; index += 1) {
         const formLine = lines[index];
@@ -57,10 +52,10 @@ describe("command-line form spacing", () => {
           ancestorIndent = currentIndent;
         }
 
-        if (ancestorLines.some((line) => line.includes("ph=md"))) {
+        if (ancestorLines.some((line) => line.includes("ph=lg"))) {
           expect(formLine).toContain("ph=none");
         } else {
-          expect(formLine).toContain("ph=md");
+          expect(formLine).toContain("ph=lg");
         }
         expect(formLine).toContain("pv=none");
         expect(formLine).not.toContain("p=none");
@@ -81,7 +76,7 @@ describe("command-line form spacing", () => {
               line.includes("- rtgl-view"),
           );
         expect(containerLine.trim()).toBe(
-          "- rtgl-view w=f h=24 av=c ph=md mb=md:",
+          "- rtgl-view w=f h=24 av=c ph=lg mb=md:",
         );
       }
 

--- a/tests/commandLineAudioChannels/commandLineAudioChannels.view.test.js
+++ b/tests/commandLineAudioChannels/commandLineAudioChannels.view.test.js
@@ -86,7 +86,7 @@ describe("command-line audio channel views", () => {
       "utf8",
     );
 
-    expect(view).toContain("rtgl-view w=f ph=md:");
+    expect(view).toContain("rtgl-view w=f ph=lg:");
     expect(view).toContain(
       "rtgl-text#channelEditorTitle s=lg: ${channelEditorTitle}",
     );

--- a/tests/commandLineBackground/commandLineBackground.view.test.js
+++ b/tests/commandLineBackground/commandLineBackground.view.test.js
@@ -41,9 +41,9 @@ describe("commandLineBackground view", () => {
       "rtgl-popover#searchPopover ?open=${searchPopover.isOpen}",
     );
     expect(view).toContain(
-      'rtgl-view d=h av=c ah=e w=f g=lg ph=md pt=sm style="flex: 0 0 auto;"',
+      'rtgl-view d=h av=c ah=e w=f g=lg ph=lg pt=sm style="flex: 0 0 auto;"',
     );
-    expect(view).toContain("w=f h=f pv=md");
-    expect(view).toContain("rtgl-view w=f h=24 av=c ph=md mb=md:");
+    expect(view).toContain("w=f h=f pv=lg");
+    expect(view).toContain("rtgl-view w=f h=24 av=c ph=lg mb=md:");
   });
 });

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -212,13 +212,13 @@ describe("commandLineDialogueBox.handlers", () => {
     expect(view).toContain("handler: handleRemoveCustomTextSpeedClick");
     expect(view).toContain("rtgl-slider-input#textSpeed");
     expect(view).toContain("handler: handleTextSpeedChange");
-    expect(view).toContain("rtgl-view w=f h=f pv=md:");
-    expect(view).toContain("rtgl-view w=f ph=md:");
+    expect(view).toContain("rtgl-view w=f h=f pv=lg:");
+    expect(view).toContain("rtgl-view w=f ph=lg:");
     expect(view).toContain(
-      'rtgl-view d=h av=c ah=e w=f g=lg ph=md style="flex: 0 0 auto;"',
+      'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"',
     );
     expect(view).toContain("rtgl-form#dialogueForm");
-    expect(view).toContain("w=f ph=md pv=none:");
+    expect(view).toContain("w=f ph=lg pv=none:");
     expect(view).toContain(
       'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"',
     );

--- a/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
+++ b/tests/commandLineDialogueBox/commandLineDialogueBox.handlers.test.js
@@ -8,6 +8,7 @@ import {
   handleCharacterSpriteBoxContextMenu,
   handleCharacterSpriteMenuButtonClick,
   handleFormChange,
+  handleFormInput,
   handleFormSectionAction,
   handleRemoveCustomTextSpeedClick,
   handleSpriteGroupTabClick,
@@ -208,6 +209,8 @@ describe("commandLineDialogueBox.handlers", () => {
     expect(view).toContain("handler: handleCharacterSpriteBoxClick");
     expect(view).toContain("form-section-action:");
     expect(view).toContain("handler: handleFormSectionAction");
+    expect(view).toContain("form-input:");
+    expect(view).toContain("handler: handleFormInput");
     expect(view).toContain("rtgl-button#removeCustomTextSpeedButton");
     expect(view).toContain("handler: handleRemoveCustomTextSpeedClick");
     expect(view).toContain("rtgl-slider-input#textSpeed");
@@ -1015,6 +1018,64 @@ describe("commandLineDialogueBox.handlers", () => {
         },
       },
     });
+  });
+
+  it("does not replay stale form values from debounced input", () => {
+    const state = createInitialState();
+    const render = vi.fn();
+    const dispatchEvent = vi.fn();
+    const store = createStore(state);
+    setCustomCharacterName({ state }, { customCharacterName: true });
+    setCharacterName({ state }, { characterName: "Old name" });
+
+    handleFormChange(
+      {
+        props: { layouts, characters },
+        refs: createFormRefs(),
+        render,
+        store,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            values: {
+              resourceId: "layout-adv",
+              characterId: "",
+              customCharacterName: false,
+              characterName: "",
+              persistCharacter: false,
+              clearPage: false,
+            },
+          },
+        },
+      },
+    );
+
+    handleFormInput(
+      {
+        props: { layouts, characters },
+        render,
+        store,
+        dispatchEvent,
+      },
+      {
+        _event: {
+          detail: {
+            name: "characterName",
+            value: "Typed name",
+            values: {
+              customCharacterName: true,
+              characterName: "Typed name",
+            },
+          },
+        },
+      },
+    );
+
+    expect(state.customCharacterName).toBe(false);
+    expect(state.characterName).toBe("Typed name");
+    expect(selectDialogueBuildState({ state }).customCharacterName).toBe(false);
   });
 
   it("emits temporary presentation state changes with customized text speed", () => {

--- a/tests/systemActions/systemActions.view.test.js
+++ b/tests/systemActions/systemActions.view.test.js
@@ -149,10 +149,10 @@ describe("systemActions view", () => {
     expect(systemActionsView).toContain("overflow-y: auto");
     expect(systemActionsView).toContain("overscroll-behavior: contain");
     expect(systemActionsView).toContain(
-      "top: calc(var(--spacing-md) - 2px)",
+      "top: calc(var(--spacing-lg) - 2px)",
     );
-    expect(systemActionsView).toContain("top: var(--spacing-md)");
-    expect(systemActionsView).toContain("right: var(--spacing-md);");
+    expect(systemActionsView).toContain("top: var(--spacing-lg)");
+    expect(systemActionsView).toContain("right: var(--spacing-lg);");
     expect(systemActionsView).toContain(
       "w=28 h=28 sm-w=24 sm-h=24",
     );

--- a/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
+++ b/tests/systemActionsDialogSurface/systemActionsDialogSurface.store.test.js
@@ -28,9 +28,9 @@ describe("systemActionsDialogSurface.store", () => {
       suppressClose: false,
       overlayHorizontalInset: "64px",
       overlayBackground: "rgba(0, 0, 0, 0.42)",
-      panelHorizontalInset: "96px",
-      panelWidthReduction: "64px",
-      panelVerticalInset: "32px",
+      panelHorizontalInset: "80px",
+      panelWidthReduction: "32px",
+      panelVerticalInset: "16px",
       panelMaxHeight: "800px",
     });
   });
@@ -77,9 +77,9 @@ describe("systemActionsDialogSurface.store", () => {
       suppressClose: true,
       overlayHorizontalInset: "64px",
       overlayBackground: "rgba(0, 0, 0, 0.42)",
-      panelHorizontalInset: "96px",
-      panelWidthReduction: "64px",
-      panelVerticalInset: "32px",
+      panelHorizontalInset: "80px",
+      panelWidthReduction: "32px",
+      panelVerticalInset: "16px",
       panelMaxHeight: "800px",
     });
   });


### PR DESCRIPTION
## Summary
- widen and vertically expand the desktop Scene Editor command-line dialog to a 16px inset
- standardize all command-line dialog content on a 16px outer inset
- align the floating help icon with the new inset
- preserve 8px internal row and card padding

## Validation
- `bun run lint`
- command-line spacing/view tests
- system-actions and dialog-surface layout tests