### PR TITLE
Streamline initial audio selection

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -11,10 +11,18 @@ import {
   selectCommandLineCopy,
 } from "../../internal/ui/sceneEditor/commandLineCopy.js";
 
-const openBgmGallery = ({ store, render, index }) => {
+const openBgmGallery = ({
+  store,
+  render,
+  index,
+  closeEditorAfterSelection = false,
+}) => {
   store.setPendingReplacement({ soundId: undefined });
   store.setPendingInsertIndex({ index });
   store.setTempSelectedResource({ resourceId: undefined });
+  store.setCloseEditorAfterSoundSelection({
+    close: closeEditorAfterSelection,
+  });
   store.setMode({ mode: "gallery" });
   render();
 };
@@ -85,6 +93,16 @@ export const handleChannelClick = (deps, payload) => {
   event.stopPropagation();
   appService.blurActiveElement();
   store.openChannelEditor();
+  if (!store.selectHasBgmSounds()) {
+    openBgmGallery({
+      store,
+      render,
+      index: 0,
+      closeEditorAfterSelection: true,
+    });
+    return;
+  }
+
   render();
 };
 
@@ -425,6 +443,7 @@ export const handleBreadcumbActionsClick = (deps, payload) => {
 
   store.setMode({ mode: id });
   store.setTempSelectedResource({ resourceId: undefined });
+  store.setCloseEditorAfterSoundSelection({ close: false });
   render();
 };
 
@@ -436,6 +455,8 @@ export const handleButtonSelectClick = (deps) => {
   }
 
   const replacementSoundId = store.selectPendingReplacementSoundId();
+  const closeEditorAfterSelection =
+    store.selectCloseEditorAfterSoundSelection();
   if (replacementSoundId) {
     store.replaceSoundResource({
       soundId: replacementSoundId,
@@ -448,6 +469,10 @@ export const handleButtonSelectClick = (deps) => {
       index: store.selectPendingInsertIndex(),
     });
   }
-  store.setMode({ mode: "current" });
+  if (closeEditorAfterSelection) {
+    store.closeChannelEditor();
+  } else {
+    store.setMode({ mode: "current" });
+  }
   render();
 };

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -317,6 +317,7 @@ export const createInitialState = () => ({
   tempSelectedResourceId: undefined,
   pendingInsertIndex: 0,
   pendingReplacementSoundId: undefined,
+  closeEditorAfterSoundSelection: false,
   channelSelected: false,
   isChannelEditorOpen: false,
   selectedSoundId: undefined,
@@ -337,6 +338,10 @@ export const setUiConfig = ({ state }, { uiConfig } = {}) => {
 };
 
 export const selectBgm = ({ state }) => state.bgm;
+
+export const selectHasBgmSounds = ({ state }) => {
+  return state.bgm.sounds.length > 0;
+};
 
 export const selectSelectedSoundId = ({ state }) => state.selectedSoundId;
 
@@ -366,6 +371,10 @@ export const selectPendingInsertIndex = ({ state }) => {
 
 export const selectPendingReplacementSoundId = ({ state }) => {
   return state.pendingReplacementSoundId;
+};
+
+export const selectCloseEditorAfterSoundSelection = ({ state }) => {
+  return state.closeEditorAfterSoundSelection;
 };
 
 export const selectTempSelectedResourceId = ({ state }) => {
@@ -585,6 +594,7 @@ export const setBgm = ({ state }, { bgm } = {}) => {
   state.isChannelEditorOpen = false;
   state.selectedSoundId = undefined;
   state.pendingReplacementSoundId = undefined;
+  state.closeEditorAfterSoundSelection = false;
 };
 
 export const clearBgm = ({ state }, _payload = {}) => {
@@ -597,6 +607,7 @@ export const clearBgm = ({ state }, _payload = {}) => {
   state.pendingInsertIndex = 0;
   state.tempSelectedResourceId = undefined;
   state.pendingReplacementSoundId = undefined;
+  state.closeEditorAfterSoundSelection = false;
   closeAudioPlayer({ state });
 };
 
@@ -622,6 +633,7 @@ export const openChannelEditor = ({ state }, _payload = {}) => {
   state.channelSelected = false;
   state.isChannelEditorOpen = true;
   state.selectedSoundId = undefined;
+  state.closeEditorAfterSoundSelection = false;
 };
 
 export const closeChannelEditor = ({ state }, _payload = {}) => {
@@ -632,6 +644,7 @@ export const closeChannelEditor = ({ state }, _payload = {}) => {
   state.soundDrag = undefined;
   state.tempSelectedResourceId = undefined;
   state.pendingReplacementSoundId = undefined;
+  state.closeEditorAfterSoundSelection = false;
   closeAudioPlayer({ state });
 };
 
@@ -867,6 +880,13 @@ export const setPendingInsertIndex = ({ state }, { index } = {}) => {
 
 export const setPendingReplacement = ({ state }, { soundId } = {}) => {
   state.pendingReplacementSoundId = soundId;
+};
+
+export const setCloseEditorAfterSoundSelection = (
+  { state },
+  { close } = {},
+) => {
+  state.closeEditorAfterSoundSelection = close ?? false;
 };
 
 export const setTempSelectedResource = ({ state }, { resourceId } = {}) => {

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.handlers.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.handlers.js
@@ -41,10 +41,19 @@ const syncSelectedSoundForm = ({ refs, store }) => {
   });
 };
 
-const openSfxGallery = ({ store, render, channelId, index }) => {
+const openSfxGallery = ({
+  store,
+  render,
+  channelId,
+  index,
+  closeEditorAfterSelection = false,
+}) => {
   store.setPendingReplacement({ channelId: undefined, soundId: undefined });
   store.setPendingInsertion({ channelId, index });
   store.setTempSelectedResource({ resourceId: undefined });
+  store.setCloseEditorAfterSoundSelection({
+    close: closeEditorAfterSelection,
+  });
   store.setMode({ mode: "gallery" });
   render();
 };
@@ -142,6 +151,18 @@ export const handleChannelClick = (deps, payload) => {
   appService.blurActiveElement();
   const channelId = event.currentTarget.dataset.channelId;
   store.openChannelEditor({ channelId });
+  const channel = store.selectChannelById({ channelId });
+  if (channel.sounds.length === 0) {
+    openSfxGallery({
+      store,
+      render,
+      channelId,
+      index: 0,
+      closeEditorAfterSelection: true,
+    });
+    return;
+  }
+
   render();
 };
 
@@ -512,6 +533,7 @@ export const handleBreadcumbClick = (deps, payload) => {
 
   store.setMode({ mode: id });
   store.setTempSelectedResource({ resourceId: undefined });
+  store.setCloseEditorAfterSoundSelection({ close: false });
   render();
 };
 
@@ -524,6 +546,8 @@ export const handleButtonSelectClick = (deps) => {
   }
 
   const replacementSoundId = store.selectPendingReplacementSoundId();
+  const closeEditorAfterSelection =
+    store.selectCloseEditorAfterSoundSelection();
   if (replacementSoundId) {
     store.replaceSoundResource({
       channelId,
@@ -538,6 +562,10 @@ export const handleButtonSelectClick = (deps) => {
       index: store.selectPendingInsertIndex(),
     });
   }
-  store.setMode({ mode: "current" });
+  if (closeEditorAfterSelection) {
+    store.closeChannelEditor();
+  } else {
+    store.setMode({ mode: "current" });
+  }
   render();
 };

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.store.js
@@ -265,6 +265,7 @@ export const createInitialState = () => ({
   pendingChannelId: undefined,
   pendingInsertIndex: 0,
   pendingReplacementSoundId: undefined,
+  closeEditorAfterSoundSelection: false,
   tempSelectedResourceId: undefined,
   searchQuery: "",
   addChannelPopover: {
@@ -327,6 +328,10 @@ export const selectPendingInsertIndex = ({ state }) => {
 
 export const selectPendingReplacementSoundId = ({ state }) => {
   return state.pendingReplacementSoundId;
+};
+
+export const selectCloseEditorAfterSoundSelection = ({ state }) => {
+  return state.closeEditorAfterSoundSelection;
 };
 
 export const selectTempSelectedResourceId = ({ state }) => {
@@ -577,6 +582,7 @@ export const setSfx = ({ state }, { sfx } = {}) => {
   state.selectedSoundId = undefined;
   state.pendingChannelId = undefined;
   state.pendingReplacementSoundId = undefined;
+  state.closeEditorAfterSoundSelection = false;
 };
 
 export const addChannel = ({ state }, { id } = {}) => {
@@ -652,6 +658,7 @@ export const openChannelEditor = ({ state }, { channelId } = {}) => {
   state.editingChannelId = channelId;
   state.selectedSoundId = undefined;
   state.addChannelPopover.isOpen = false;
+  state.closeEditorAfterSoundSelection = false;
 };
 
 export const closeChannelEditor = ({ state }, _payload = {}) => {
@@ -662,6 +669,7 @@ export const closeChannelEditor = ({ state }, _payload = {}) => {
   state.pendingChannelId = undefined;
   state.tempSelectedResourceId = undefined;
   state.pendingReplacementSoundId = undefined;
+  state.closeEditorAfterSoundSelection = false;
   closeAudioPlayer({ state });
 };
 
@@ -903,6 +911,13 @@ export const setPendingReplacement = (
 ) => {
   state.pendingChannelId = channelId;
   state.pendingReplacementSoundId = soundId;
+};
+
+export const setCloseEditorAfterSoundSelection = (
+  { state },
+  { close } = {},
+) => {
+  state.closeEditorAfterSoundSelection = close ?? false;
 };
 
 export const setTempSelectedResource = ({ state }, { resourceId } = {}) => {

--- a/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
+++ b/src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml
@@ -262,7 +262,7 @@ template:
               - 'rtgl-view h=240 aria-hidden=true style="flex: 0 0 240px;"': null
       - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
           - rtgl-button#submitButton: ${submitButtonLabel}
-  - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=md close-button:
+  - rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg close-button:
       - 'rtgl-view slot=content d=v w=f h=80vh g=lg style="min-width: 0; min-height: 0; overflow: hidden;"':
           - rtgl-text s=lg: ${channelEditorTitle}
           - $if mode == 'current':

--- a/src/components/commandLineVoice/commandLineVoice.handlers.js
+++ b/src/components/commandLineVoice/commandLineVoice.handlers.js
@@ -186,7 +186,7 @@ export const handleAfterMount = async (deps) => {
   render();
 };
 
-export const handleChannelClick = (deps, payload) => {
+export const handleChannelClick = async (deps, payload) => {
   const { store, render, appService } = deps;
   const { _event: event } = payload;
   if (
@@ -198,18 +198,23 @@ export const handleChannelClick = (deps, payload) => {
   }
   event.stopPropagation();
   appService.blurActiveElement();
+  if (!store.selectHasVoiceSounds()) {
+    await pickAndInsertVoice(deps, 0);
+    return;
+  }
+
   store.openChannelEditor();
   render();
 };
 
-export const handleChannelKeyDown = (deps, payload) => {
+export const handleChannelKeyDown = async (deps, payload) => {
   const { _event: event } = payload;
   if (!isSelectionKey(event) || event.target !== event.currentTarget) {
     return;
   }
 
   event.preventDefault();
-  handleChannelClick(deps, payload);
+  await handleChannelClick(deps, payload);
 };
 
 export const handleChannelEditorClose = (deps) => {

--- a/src/components/commandLineVoice/commandLineVoice.store.js
+++ b/src/components/commandLineVoice/commandLineVoice.store.js
@@ -187,6 +187,10 @@ export const createInitialState = () => ({
 
 export const selectVoice = ({ state }) => state.voice;
 
+export const selectHasVoiceSounds = ({ state }) => {
+  return state.voice.sounds.length > 0;
+};
+
 export const selectVoicePayload = ({ state }) => {
   return normalizeVoice(state.voice);
 };
@@ -298,7 +302,6 @@ export const selectViewData = ({ state, i18n }) => {
     channelEditorTitle: channelName,
     confirmButtonLabel: localizeCommandLineText("Confirm", copy),
     editChannelLabel: localizeCommandLineText("Edit Channel", copy),
-    emptyAudioLabel: localizeCommandLineText("No audio", copy),
     addAudioLabel: localizeCommandLineText("Add voice audio", copy),
     addBeforeLabel: localizeCommandLineText("Add audio before", copy),
     addAfterLabel: localizeCommandLineText("Add audio after", copy),

--- a/src/components/commandLineVoice/commandLineVoice.view.yaml
+++ b/src/components/commandLineVoice/commandLineVoice.view.yaml
@@ -141,6 +141,7 @@ styles:
   ".voiceInsertAfter":
     right: "0"
   ".voiceEmptyAdd":
+    align-items: center
     appearance: none
     background: var(--background)
     border: "0"
@@ -148,10 +149,12 @@ styles:
     box-sizing: border-box
     color: var(--muted-foreground)
     cursor: pointer
+    display: flex
     flex: "0 0 126px"
     font-family: inherit
     font-size: 30px
     height: 100%
+    justify-content: center
     padding: "0"
     width: 100%
   ".voiceEmptyAdd:hover":
@@ -185,8 +188,7 @@ template:
                       - span: ${channelLabel}
                       - span: ${channelDurationLabel}
                   - $if sounds.length == 0:
-                      - rtgl-view w=f h=126 bwb=xs bc=bo av=c ah=c:
-                          - rtgl-text s=sm c=mu-fg: ${emptyAudioLabel}
+                      - 'div.voiceEmptyAdd aria-hidden=true': "+"
                     $else:
                       - 'rtgl-view.voiceTimelineTrack w=f pos=rel style="height: ${timelineHeightPx}px; min-width: 100%;"':
                           - $for sound, i in sounds:

--- a/tests/commandLineAudioChannels/commandLineAudioChannels.view.test.js
+++ b/tests/commandLineAudioChannels/commandLineAudioChannels.view.test.js
@@ -118,6 +118,32 @@ describe("command-line audio channel views", () => {
     expect(emptyAddStyles).toContain("justify-content: center");
   });
 
+  it("shows a centered plus in an empty Voice channel preview", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/commandLineVoice/commandLineVoice.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const templateStart = view.indexOf("template:");
+    const editorStart = view.indexOf(
+      "  - rtgl-dialog#channelEditorDialog",
+      templateStart,
+    );
+    const mainView = view.slice(templateStart, editorStart);
+    const emptyAddStyleStart = view.indexOf('  ".voiceEmptyAdd":');
+    const emptyAddStyles = view.slice(
+      emptyAddStyleStart,
+      view.indexOf('  ".voiceEmptyAdd:hover":', emptyAddStyleStart),
+    );
+
+    expect(mainView).toContain('div.voiceEmptyAdd aria-hidden=true\': "+"');
+    expect(mainView).not.toContain("${emptyAudioLabel}");
+    expect(emptyAddStyles).toContain("align-items: center");
+    expect(emptyAddStyles).toContain("justify-content: center");
+  });
+
   it("remounts audio channel forms from their state-derived keys", () => {
     const bgmView = readFileSync(
       new URL(

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -411,6 +411,37 @@ describe("commandLineBgm.handlers", () => {
     expect(render).toHaveBeenCalledOnce();
   });
 
+  it("opens the gallery from an empty channel and closes after adding", () => {
+    const state = createState();
+    const store = createStore(state);
+    const render = vi.fn();
+    const stopPropagation = vi.fn();
+    const blurActiveElement = vi.fn();
+
+    handleChannelClick(
+      { store, render, appService: { blurActiveElement } },
+      { _event: { stopPropagation } },
+    );
+
+    expect(state.isChannelEditorOpen).toBe(true);
+    expect(state.mode).toBe("gallery");
+    expect(state.pendingInsertIndex).toBe(0);
+    expect(state.closeEditorAfterSoundSelection).toBe(true);
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(blurActiveElement).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledOnce();
+
+    store.setTempSelectedResource({ resourceId: "intro" });
+    handleButtonSelectClick({ store, render });
+
+    expect(state.bgm.sounds).toHaveLength(1);
+    expect(state.bgm.sounds[0].resourceId).toBe("intro");
+    expect(state.isChannelEditorOpen).toBe(false);
+    expect(state.mode).toBe("current");
+    expect(state.closeEditorAfterSoundSelection).toBe(false);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
   it("opens the channel editor when a channel descendant is clicked", () => {
     const state = createState();
     const store = createStore(state);

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.handlers.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.handlers.test.js
@@ -79,7 +79,7 @@ const createState = () => {
 };
 
 describe("commandLineSoundEffects.handlers", () => {
-  it("opens a channel editor when any part of the channel is clicked", () => {
+  it("opens the gallery from an empty channel and closes after adding", () => {
     const state = createState();
     const store = createStore(state);
     const render = vi.fn();
@@ -101,8 +101,51 @@ describe("commandLineSoundEffects.handlers", () => {
 
     expect(state.selectedChannelId).toBe("Channel One");
     expect(state.editingChannelId).toBe("Channel One");
+    expect(state.mode).toBe("gallery");
+    expect(state.pendingChannelId).toBe("Channel One");
+    expect(state.pendingInsertIndex).toBe(0);
+    expect(state.closeEditorAfterSoundSelection).toBe(true);
     expect(stopPropagation).toHaveBeenCalledOnce();
     expect(blurActiveElement).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledOnce();
+
+    store.setTempSelectedResource({ resourceId: "rain" });
+    handleButtonSelectClick({ store, render });
+
+    expect(state.channels[0].sounds).toHaveLength(1);
+    expect(state.channels[0].sounds[0].resourceId).toBe("rain");
+    expect(state.editingChannelId).toBeUndefined();
+    expect(state.mode).toBe("current");
+    expect(state.closeEditorAfterSoundSelection).toBe(false);
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens the channel editor for a populated channel", () => {
+    const state = createState();
+    const store = createStore(state);
+    const render = vi.fn();
+    const blurActiveElement = vi.fn();
+    store.addChannel({ id: "Weather" });
+    store.insertSound({
+      channelId: "Weather",
+      id: "rain-clip",
+      resourceId: "rain",
+      index: 0,
+    });
+
+    handleChannelClick(
+      { store, render, appService: { blurActiveElement } },
+      {
+        _event: {
+          currentTarget: { dataset: { channelId: "Weather" } },
+          stopPropagation: vi.fn(),
+        },
+      },
+    );
+
+    expect(state.editingChannelId).toBe("Weather");
+    expect(state.mode).toBe("current");
+    expect(state.closeEditorAfterSoundSelection).toBe(false);
     expect(render).toHaveBeenCalledOnce();
   });
 

--- a/tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js
+++ b/tests/commandLineSoundEffects/commandLineSoundEffects.view.test.js
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("commandLineSoundEffects view", () => {
-  it("uses the medium size for the sound effect editor dialog", () => {
+  it("uses the large size for the sound effect editor dialog", () => {
     const view = readFileSync(
       new URL(
         "../../src/components/commandLineSoundEffects/commandLineSoundEffects.view.yaml",
@@ -12,10 +12,10 @@ describe("commandLineSoundEffects view", () => {
     );
 
     expect(view).toContain(
-      "rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=md close-button:",
+      "rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg close-button:",
     );
     expect(view).not.toContain(
-      "rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=lg",
+      "rtgl-dialog#channelEditorDialog ?open=${isChannelEditorOpen} s=md",
     );
   });
 

--- a/tests/commandLineVoice/commandLineVoice.handlers.test.js
+++ b/tests/commandLineVoice/commandLineVoice.handlers.test.js
@@ -78,6 +78,7 @@ const createUploadHarness = () => {
     })),
     showAlert: vi.fn(),
     showDropdownMenu: vi.fn(),
+    blurActiveElement: vi.fn(),
   };
 
   return { appService, projectService, uploadResult };
@@ -207,14 +208,14 @@ describe("commandLineVoice.handlers", () => {
     expect(render).toHaveBeenCalledTimes(2);
   });
 
-  it("opens the Voice channel editor from its channel", () => {
+  it("opens the Voice channel editor from a populated channel", async () => {
     const state = voiceStore.createInitialState();
     const store = createStore(state);
     const render = vi.fn();
     const blurActiveElement = vi.fn();
     store.insertSound({ id: "clip", resourceId: "voice-1", index: 0 });
 
-    handleChannelClick(
+    await handleChannelClick(
       { store, render, appService: { blurActiveElement } },
       { _event: { stopPropagation: vi.fn() } },
     );
@@ -224,6 +225,37 @@ describe("commandLineVoice.handlers", () => {
     expect(state.selectedSoundId).toBeUndefined();
     expect(blurActiveElement).toHaveBeenCalledOnce();
     expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("picks and adds Voice audio directly from an empty channel", async () => {
+    const state = voiceStore.createInitialState();
+    const { deps, appService, render } = createUploadDeps(state);
+    const stopPropagation = vi.fn();
+
+    await handleChannelClick(deps, {
+      _event: { stopPropagation },
+    });
+
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(appService.blurActiveElement).toHaveBeenCalledOnce();
+    expect(appService.pickFiles).toHaveBeenCalledOnce();
+    expect(state.voice.sounds).toHaveLength(1);
+    expect(state.isChannelEditorOpen).toBe(false);
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("leaves an empty Voice channel unchanged when picking is cancelled", async () => {
+    const state = voiceStore.createInitialState();
+    const { deps, appService, render } = createUploadDeps(state);
+    appService.pickFiles.mockResolvedValueOnce(undefined);
+
+    await handleChannelClick(deps, {
+      _event: { stopPropagation: vi.fn() },
+    });
+
+    expect(state.voice.sounds).toEqual([]);
+    expect(state.isChannelEditorOpen).toBe(false);
+    expect(render).not.toHaveBeenCalled();
   });
 
   it("removes a Voice clip from its context menu", async () => {


### PR DESCRIPTION
## Summary

- show a consistent plus affordance for empty Voice, BGM, and Sound Effects channels
- open the audio selector directly when an empty channel is clicked
- add the first selected audio immediately and return to the main page
- keep populated-channel clicks and subsequent edits in the channel editor
- preserve cancel behavior without creating audio

## Validation

- bun run lint
- bun run test:smoke
- 96 focused Voice, BGM, Sound Effects, and shared audio-channel tests