### PR TITLE
Update Rettangoli UI to 1.21.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@lexical/selection": "0.22.0",
         "@lexical/utils": "0.22.0",
         "@rettangoli/fe": "1.4.1",
-        "@rettangoli/ui": "1.20.0",
+        "@rettangoli/ui": "1.21.1",
         "@rettangoli/vt": "1.1.0",
         "@routevn/creator-model": "1.13.2",
         "@tauri-apps/api": "2.11.0",
@@ -315,7 +315,7 @@
 
     "@rettangoli/sites": ["@rettangoli/sites@1.3.0", "", { "dependencies": { "gray-matter": "^4.0.3", "jempl": "^0.3.1-rc1", "js-yaml": "^4.1.0", "markdown-it": "^14.1.0", "shiki": "^3.13.0", "ws": "^8.18.0", "yahtml": "0.0.4" } }, "sha512-K2l0SaJ/xQ+QLmGq+Oa4f0p0V+02J8Tea4NOlkfQWZ/QVGpyWrJUZDTHxlxlS9XoEMpTCtztBBo8JMMbtKrYcA=="],
 
-    "@rettangoli/ui": ["@rettangoli/ui@1.20.0", "", { "dependencies": { "@rettangoli/fe": "1.4.1", "jempl": "1.0.1" } }, "sha512-aADOCtXA2ogSAYo6G+5mb1iQ+tZiMs/k2ZjpWx5KY72IQt2GQDUOvvSaDuP5t7+9grYpvU/vQpFeVFJuNXl5Fw=="],
+    "@rettangoli/ui": ["@rettangoli/ui@1.21.1", "", { "dependencies": { "@rettangoli/fe": "1.4.1", "jempl": "1.0.1" } }, "sha512-4OPTF+PhJ9IwbhtmY62qEIgcBuU+vxEiamiRqT5g5PEKFuCzh3Lnod0C71YO+ULloMKO5e/X6cPjjOGwrEoOSw=="],
 
     "@rettangoli/vt": ["@rettangoli/vt@1.1.0", "", { "dependencies": { "commander": "^13.1.0", "js-yaml": "^4.1.0", "liquidjs": "^10.21.0", "parse5": "^7.3.0", "pixelmatch": "^7.1.0", "playwright": "1.57.0", "sharp": "^0.34.5", "shiki": "^3.3.0" } }, "sha512-0sT8M7hKH/S+IHzogpwUS6o59Q6Fdd6JswQLAn0ANGVHQDvDYsh4jMeXhXhMUXfa4tFQ9epvNDwS5eFRtuFmZw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@lexical/selection": "0.22.0",
     "@lexical/utils": "0.22.0",
     "@rettangoli/fe": "1.4.1",
-    "@rettangoli/ui": "1.20.0",
+    "@rettangoli/ui": "1.21.1",
     "@rettangoli/vt": "1.1.0",
     "@routevn/creator-model": "1.13.2",
     "@tauri-apps/api": "2.11.0",

--- a/src/pages/project/support/projectAnalytics.js
+++ b/src/pages/project/support/projectAnalytics.js
@@ -8,7 +8,7 @@ export const PROJECT_ANALYTICS_RESOURCE_GROUPS = Object.freeze([
   },
   {
     key: "animatedAssets",
-    resourceKeys: ["audioEffects", "animations", "particles", "spritesheets"],
+    resourceKeys: ["animations", "audioEffects", "particles", "spritesheets"],
   },
   {
     key: "userInterface",

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -14,7 +14,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/authenticate/index.html
+++ b/static/authenticate/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js?v=20260224-collab-debug-v2"></script>
     <script type="module" src="/public/main.js?v=20260224-collab-debug-v2"></script>
   </head>
   <body class="dark">

--- a/static/ios/index.html
+++ b/static/ios/index.html
@@ -43,7 +43,7 @@
     </script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
     <script>
       window.addEventListener("load", () => {

--- a/static/project/cgs/index.html
+++ b/static/project/cgs/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/index.html
+++ b/static/project/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/index.html
+++ b/static/project/releases/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/releases/versions/index.html
+++ b/static/project/releases/versions/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/animations/index.html
+++ b/static/project/resources/animations/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/audio/index.html
+++ b/static/project/resources/audio/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/character-sprites/index.html
+++ b/static/project/resources/character-sprites/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/characters/index.html
+++ b/static/project/resources/characters/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/colors/index.html
+++ b/static/project/resources/colors/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/component-editor/index.html
+++ b/static/project/resources/component-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/fonts/index.html
+++ b/static/project/resources/fonts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/images/index.html
+++ b/static/project/resources/images/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/index.html
+++ b/static/project/resources/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layout-editor/index.html
+++ b/static/project/resources/layout-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/layouts/index.html
+++ b/static/project/resources/layouts/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/sounds/index.html
+++ b/static/project/resources/sounds/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/transforms/index.html
+++ b/static/project/resources/transforms/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/tweens/index.html
+++ b/static/project/resources/tweens/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/typography/index.html
+++ b/static/project/resources/typography/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/variables/index.html
+++ b/static/project/resources/variables/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/resources/videos/index.html
+++ b/static/project/resources/videos/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scene-editor/index.html
+++ b/static/project/scene-editor/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/scenes/index.html
+++ b/static/project/scenes/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/about/index.html
+++ b/static/project/settings/about/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/general/index.html
+++ b/static/project/settings/general/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/project/settings/user/index.html
+++ b/static/project/settings/user/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/static/projects/index.html
+++ b/static/projects/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/windowChrome.js" defer></script>
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.20.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
   </head>
   <body class="dark">

--- a/tests/projectPage/projectAnalytics.test.js
+++ b/tests/projectPage/projectAnalytics.test.js
@@ -110,8 +110,8 @@ describe("project analytics", () => {
       {
         key: "animatedAssets",
         resources: [
-          { key: "audioEffects", count: 0 },
           { key: "animations", count: 0 },
+          { key: "audioEffects", count: 0 },
           { key: "particles", count: 0 },
           { key: "spritesheets", count: 0 },
         ],

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -6,7 +6,7 @@
     <title>VT E2E Runner</title>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
-    <script src="/public/@rettangoli/ui@1.19.0/dist/rettangoli-iife-ui.min.js"></script>
+    <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module">
       const VT_RESET_KEY = "routevn.vt.indexeddb-reset-done";
 


### PR DESCRIPTION
## Summary

- update `@rettangoli/ui` from `1.20.0` to `1.21.1`
- align all 32 HTML entry-point and VT script references with `1.21.1`
- place Audio Effects after Animations on the project dashboard

## Validation

- `bun run test:smoke`
- `bunx vitest run tests/projectPage/projectAnalytics.test.js`
- `bunx vitest run tests/windowChrome/windowChrome.test.js tests/buildScripts/rettangoliUiPackage.test.js`
- push hook: `oxlint && bun prettier --check src`

## Known validation limitation

- `bun run check:contracts` currently reports 500 repository-wide component/schema diagnostics; this PR does not expand scope to address them.