### PR TITLE
Prepare Creator 1.12.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "discord-rich-presence",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.11.1"
+version = "1.12.0"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.11.1" date="2026-08-10"/>
+    <release version="1.12.0" date="2026-08-14"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
## Summary

- bump the Creator feature version from `1.11.1` to `1.12.0`
- align the Tauri config, Rust manifest, Rust lockfile, and Linux AppStream release metadata
- set the AppStream release date to `2026-08-14`

## Validation

- `bun run tauri:validate:linux-packaging`
- `cargo metadata --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml`
- push hook: `oxlint && bun prettier --check src`