### PR TITLE
Fix audio effect icon in file explorer

### DIFF
--- a/src/components/baseFileExplorer/baseFileExplorer.store.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.store.js
@@ -457,6 +457,8 @@ export const selectViewData = ({ state, props, props: attrs }) => {
         svg = "spritesheets";
       } else if (item.type === "sound") {
         svg = "audio";
+      } else if (item.type === "audioEffect") {
+        svg = "audioEffects";
       } else if (item.type.startsWith("text")) {
         svg = "text";
       } else if (item.type.startsWith("container")) {

--- a/svg/audioEffects.svg
+++ b/svg/audioEffects.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2.25 8C4 8 4 4.5 5.75 4.5C7.5 4.5 7.5 11.5 9.25 11.5C11 11.5 11 4.5 12.75 4.5C14.5 4.5 14.5 8 16.25 8" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.75 16C9.5 16 9.5 12.5 11.25 12.5C13 12.5 13 19.5 14.75 19.5C16.5 19.5 16.5 12.5 18.25 12.5C20 12.5 20 16 21.75 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 7H3.5L4.5 5L5.75 9L7.25 3L8.75 11L10.25 5L11.5 9L12.75 4L14.25 10L15.75 5.5L17 8.5L18.25 6L19.5 8H22" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 17H4L5.25 15L6.5 19L8 13L9.5 21L11 14.5L12.5 19.5L14 14L15.5 20L17 15.5L18.25 18.5L19.5 16H22" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/tests/baseFileExplorer/baseFileExplorer.store.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.store.test.js
@@ -72,6 +72,28 @@ describe("baseFileExplorer.store", () => {
     expect(viewData.items[0].svg).toBe("audio");
   });
 
+  it("uses the audio effects icon for audio effects", () => {
+    const state = createInitialState();
+    const viewData = selectViewData({
+      state,
+      props: {
+        items: [
+          {
+            id: "audio-effect-1",
+            type: "audioEffect",
+            name: "Fade In",
+            _level: 0,
+            hasChildren: false,
+            parentId: null,
+          },
+        ],
+      },
+    });
+
+    expect(viewData.items).toHaveLength(1);
+    expect(viewData.items[0].svg).toBe("audioEffects");
+  });
+
   it("preserves an explicit item icon", () => {
     const state = createInitialState();
     const viewData = selectViewData({


### PR DESCRIPTION
## Summary

- show the dedicated audio-effects icon for audio effect items in the base file explorer
- refine the icon artwork with a clearer waveform treatment
- add regression coverage for the audio effect item mapping

## Tests

- `bunx vitest run tests/baseFileExplorer/baseFileExplorer.store.test.js`
- `bun run lint`