### PR TITLE
Fix audio effect property menu and bump version to 1.12.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "discord-rich-presence",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.12.0"
+version = "1.12.1"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.12.0" date="2026-08-14"/>
+    <release version="1.12.1" date="2026-08-15"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",

--- a/src/pages/audioEffectsEditor/audioEffectsEditor.handlers.js
+++ b/src/pages/audioEffectsEditor/audioEffectsEditor.handlers.js
@@ -351,15 +351,45 @@ export const handleConfirmSoundSelection = (deps) => {
   render();
 };
 
-export const handleAddPropertyClick = (deps, payload) => {
+const openAddPropertyDialog = (deps, { side } = {}) => {
   const { refs, render, store } = deps;
-  const { side } = payload._event.currentTarget.dataset;
   store.openAddPropertyDialog({ side });
   render();
   refs.addPropertyForm.reset();
   refs.addPropertyForm.setValues({
     values: store.selectViewData().addPropertyFormDefaults,
   });
+};
+
+export const handleAddPropertyClick = (deps, payload) => {
+  const { render, store } = deps;
+  const event = payload._event;
+  const { side } = event.currentTarget.dataset;
+  if (side) {
+    openAddPropertyDialog(deps, { side });
+    return;
+  }
+
+  store.openAddPropertySideMenu({
+    x: event.clientX,
+    y: event.clientY,
+  });
+  render();
+};
+
+export const handleAddPropertySideMenuItemClick = (deps, payload) => {
+  const side = payload._event.detail.item.value;
+  if (side !== "prev" && side !== "next") {
+    return;
+  }
+
+  openAddPropertyDialog(deps, { side });
+};
+
+export const handleAddPropertySideMenuClose = (deps) => {
+  const { render, store } = deps;
+  store.closeAddPropertySideMenu();
+  render();
 };
 
 export const handleAddPropertyDialogClose = (deps) => {

--- a/src/pages/audioEffectsEditor/audioEffectsEditor.store.js
+++ b/src/pages/audioEffectsEditor/audioEffectsEditor.store.js
@@ -295,6 +295,11 @@ export const createInitialState = () => ({
   },
   addPropertyDialogOpen: false,
   addPropertySide: "update",
+  addPropertySideMenu: {
+    open: false,
+    x: undefined,
+    y: undefined,
+  },
   keyframeDialog: {
     open: false,
     side: undefined,
@@ -338,6 +343,9 @@ export const loadAudioEffect = ({ state }, { item } = {}) => {
   state.selectedKeyframeAddMenu.open = false;
   state.selectedKeyframeAddMenu.x = undefined;
   state.selectedKeyframeAddMenu.y = undefined;
+  state.addPropertySideMenu.open = false;
+  state.addPropertySideMenu.x = undefined;
+  state.addPropertySideMenu.y = undefined;
   closeKeyframeMenu({ state });
   state.dirty = false;
 };
@@ -667,6 +675,9 @@ export const openAddPropertyDialog = ({ state }, { side = "update" } = {}) => {
   if (!validSide) {
     return;
   }
+  state.addPropertySideMenu.open = false;
+  state.addPropertySideMenu.x = undefined;
+  state.addPropertySideMenu.y = undefined;
   state.addPropertySide = side;
   state.addPropertyDialogOpen = true;
 };
@@ -676,6 +687,18 @@ export const closeAddPropertyDialog = ({ state }) => {
 };
 
 export const selectAddPropertySide = ({ state }) => state.addPropertySide;
+
+export const openAddPropertySideMenu = ({ state }, { x, y } = {}) => {
+  state.addPropertySideMenu.open = true;
+  state.addPropertySideMenu.x = x;
+  state.addPropertySideMenu.y = y;
+};
+
+export const closeAddPropertySideMenu = ({ state }) => {
+  state.addPropertySideMenu.open = false;
+  state.addPropertySideMenu.x = undefined;
+  state.addPropertySideMenu.y = undefined;
+};
 
 export const addAudioEffectProperty = (
   { state },
@@ -1375,6 +1398,27 @@ export const selectViewData = ({ state, i18n }) => {
   const availableProperties = AUDIO_EFFECT_PROPERTY_KEYS.filter(
     (property) => !addPropertyTracks[property],
   );
+  const canAddPreviousProperty =
+    Object.keys(state.definition.prev ?? {}).length <
+    AUDIO_EFFECT_PROPERTY_KEYS.length;
+  const canAddNextProperty =
+    Object.keys(state.definition.next ?? {}).length <
+    AUDIO_EFFECT_PROPERTY_KEYS.length;
+  const addPropertySideMenuItems = [];
+  if (canAddPreviousProperty) {
+    addPropertySideMenuItems.push({
+      label: copy.outgoingLabel ?? "Outgoing",
+      type: "item",
+      value: "prev",
+    });
+  }
+  if (canAddNextProperty) {
+    addPropertySideMenuItems.push({
+      label: copy.incomingLabel ?? "Incoming",
+      type: "item",
+      value: "next",
+    });
+  }
   const dialogProperty = state.keyframeDialog.property;
   const dialogSide = state.keyframeDialog.side;
   const dialogKeyframes =
@@ -1615,12 +1659,9 @@ export const selectViewData = ({ state, i18n }) => {
     outgoingTimelineLabel: copy.outgoingLabel ?? "Outgoing",
     incomingTimelineLabel: copy.incomingLabel ?? "Incoming",
     canAddProperty: availableProperties.length > 0,
-    canAddPreviousProperty:
-      Object.keys(state.definition.prev ?? {}).length <
-      AUDIO_EFFECT_PROPERTY_KEYS.length,
-    canAddNextProperty:
-      Object.keys(state.definition.next ?? {}).length <
-      AUDIO_EFFECT_PROPERTY_KEYS.length,
+    canAddTransitionProperty: addPropertySideMenuItems.length > 0,
+    addPropertySideMenu: state.addPropertySideMenu,
+    addPropertySideMenuItems,
     addPropertyButton: copy.addPropertyButton ?? "Add Property",
     addKeyframeButton: copy.addKeyframeButton ?? "Add Keyframe",
     removePropertyButton: copy.removePropertyButton ?? "Remove Property",

--- a/src/pages/audioEffectsEditor/audioEffectsEditor.view.yaml
+++ b/src/pages/audioEffectsEditor/audioEffectsEditor.view.yaml
@@ -73,14 +73,12 @@ refs:
     eventListeners:
       click:
         handler: handleAddPropertyClick
-  addPreviousPropertyButton:
+  addPropertySideMenu:
     eventListeners:
-      click:
-        handler: handleAddPropertyClick
-  addNextPropertyButton:
-    eventListeners:
-      click:
-        handler: handleAddPropertyClick
+      close:
+        handler: handleAddPropertySideMenuClose
+      item-click:
+        handler: handleAddPropertySideMenuItemClick
   removePropertyButton:
     eventListeners:
       click:
@@ -249,11 +247,8 @@ template:
                           - $if canAddProperty:
                               - 'rtgl-button#addPropertyButton data-side=update pre=plus s=sm': ${addPropertyButton}
                       - $if selectedEditorTab == 'timeline' && isTransition:
-                          - rtgl-view d=h av=c g=sm:
-                              - $if canAddPreviousProperty:
-                                  - 'rtgl-button#addPreviousPropertyButton data-side=prev pre=plus s=sm': ${outgoingTimelineLabel}
-                              - $if canAddNextProperty:
-                                  - 'rtgl-button#addNextPropertyButton data-side=next pre=plus s=sm': ${incomingTimelineLabel}
+                          - $if canAddTransitionProperty:
+                              - 'rtgl-button#addPropertyButton pre=plus s=sm aria-haspopup=menu aria-expanded="${addPropertySideMenu.open}"': ${addPropertyButton}
                       - $if selectedEditorTab == 'preview':
                           - 'rtgl-button#savePreviewButton s=sm ?disabled=${saving}': ${saveButton}
                   - $if selectedEditorTab == 'timeline':
@@ -375,5 +370,6 @@ template:
               - rtgl-view d=h g=sm w=f ah=e:
                   - 'rtgl-button#confirmSoundSelection variant=pr ?disabled=${soundSelectionConfirmDisabled}': ${confirmSoundSelectionButton}
   - rtgl-dropdown-menu#keyframeDropdownMenu :items=${keyframeMenuItems} ?open=${keyframeMenu.open} x=${keyframeMenu.x} y=${keyframeMenu.y}: null
+  - rtgl-dropdown-menu#addPropertySideMenu :items=${addPropertySideMenuItems} ?open=${addPropertySideMenu.open} x=${addPropertySideMenu.x} y=${addPropertySideMenu.y}: null
   - rtgl-dropdown-menu#selectedKeyframeAddMenu :items=${selectedKeyframeAddMenuItems} ?open=${selectedKeyframeAddMenu.open} x=${selectedKeyframeAddMenu.x} y=${selectedKeyframeAddMenu.y}: null
   - rtgl-tooltip ?open=${playButtonTooltip.open} x=${playButtonTooltip.x} y=${playButtonTooltip.y} place="b" content="${playButtonDisabledReason}": null

--- a/tests/audioEffectsEditor/audioEffectsEditor.handlers.test.js
+++ b/tests/audioEffectsEditor/audioEffectsEditor.handlers.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   handleAddPropertyClick,
+  handleAddPropertySideMenuClose,
+  handleAddPropertySideMenuItemClick,
   handleAddKeyframeFromTimeline,
   handleBackClick,
   handleEditorTabClick,
@@ -34,7 +36,29 @@ import {
 import { EN_I18N } from "../support/i18n.js";
 
 describe("audioEffectsEditor.handlers", () => {
-  it("opens property creation for the requested transition side", () => {
+  it("opens the transition-side menu from the shared add button", () => {
+    const store = { openAddPropertySideMenu: vi.fn() };
+    const render = vi.fn();
+
+    handleAddPropertyClick(
+      { render, store },
+      {
+        _event: {
+          clientX: 120,
+          clientY: 48,
+          currentTarget: { dataset: {} },
+        },
+      },
+    );
+
+    expect(store.openAddPropertySideMenu).toHaveBeenCalledWith({
+      x: 120,
+      y: 48,
+    });
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("opens property creation for the selected transition side", () => {
     const refs = {
       addPropertyForm: { reset: vi.fn(), setValues: vi.fn() },
     };
@@ -46,9 +70,9 @@ describe("audioEffectsEditor.handlers", () => {
     };
     const render = vi.fn();
 
-    handleAddPropertyClick(
+    handleAddPropertySideMenuItemClick(
       { refs, render, store },
-      { _event: { currentTarget: { dataset: { side: "next" } } } },
+      { _event: { detail: { item: { value: "next" } } } },
     );
 
     expect(store.openAddPropertyDialog).toHaveBeenCalledWith({ side: "next" });
@@ -56,6 +80,16 @@ describe("audioEffectsEditor.handlers", () => {
     expect(refs.addPropertyForm.setValues).toHaveBeenCalledWith({
       values: { property: "pan" },
     });
+    expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("closes the transition-side menu", () => {
+    const store = { closeAddPropertySideMenu: vi.fn() };
+    const render = vi.fn();
+
+    handleAddPropertySideMenuClose({ render, store });
+
+    expect(store.closeAddPropertySideMenu).toHaveBeenCalledOnce();
     expect(render).toHaveBeenCalledOnce();
   });
 

--- a/tests/audioEffectsEditor/audioEffectsEditor.store.test.js
+++ b/tests/audioEffectsEditor/audioEffectsEditor.store.test.js
@@ -825,6 +825,48 @@ describe("audioEffectsEditor.store", () => {
     expect(Object.keys(state.definition.next)).toEqual(["playbackRate"]);
   });
 
+  it("offers transition sides from one add-property menu", () => {
+    const state = createInitialState();
+    loadAudioEffect(
+      { state },
+      {
+        item: {
+          id: "transition-properties",
+          name: "Transition Properties",
+          audioEffect: {
+            type: "transition",
+            prev: {
+              volume: {
+                keyframes: [{ value: 0, duration: 300, easing: "linear" }],
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      canAddTransitionProperty: true,
+      addPropertySideMenuItems: [
+        { label: "Outgoing", type: "item", value: "prev" },
+        { label: "Incoming", type: "item", value: "next" },
+      ],
+    });
+
+    addAudioEffectProperty({ state }, { side: "prev", property: "pan" });
+    addAudioEffectProperty(
+      { state },
+      { side: "prev", property: "playbackRate" },
+    );
+
+    expect(selectViewData({ state, i18n: EN_I18N })).toMatchObject({
+      canAddTransitionProperty: true,
+      addPropertySideMenuItems: [
+        { label: "Incoming", type: "item", value: "next" },
+      ],
+    });
+  });
+
   it("keeps relative start-value deltas outside absolute slider bounds", () => {
     const state = createInitialState();
     loadAudioEffect(

--- a/tests/audioEffectsEditor/audioEffectsEditor.view.test.js
+++ b/tests/audioEffectsEditor/audioEffectsEditor.view.test.js
@@ -15,6 +15,12 @@ describe("audioEffectsEditor view", () => {
     expect(view).toContain("rvn-keyframe-timeline#nextTimeline");
     expect(view).toContain("${outgoingTimelineLabel}");
     expect(view).toContain("${incomingTimelineLabel}");
+    expect(view).toContain(
+      "rtgl-button#addPropertyButton pre=plus s=sm aria-haspopup=menu",
+    );
+    expect(view).toContain("rtgl-dropdown-menu#addPropertySideMenu");
+    expect(view).not.toContain("#addPreviousPropertyButton");
+    expect(view).not.toContain("#addNextPropertyButton");
     expect(view).not.toContain("${previousTimelineLabel}");
     expect(view).not.toContain("${nextTimelineLabel}");
     expect(view).toContain("rvn-detail-view#selectedKeyframeDetails");


### PR DESCRIPTION
## Summary

- replace the separate Outgoing and Incoming property buttons with one Add Property menu
- show only transition sides that still have available audio properties
- bump the Creator release version from 1.12.0 to 1.12.1 across Tauri, Cargo, and AppStream metadata

## Testing

- bunx vitest run tests/audioEffectsEditor/audioEffectsEditor.store.test.js tests/audioEffectsEditor/audioEffectsEditor.handlers.test.js tests/audioEffectsEditor/audioEffectsEditor.view.test.js
- bun run lint
- node scripts/validate-linux-packaging.js
- cargo metadata --locked --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml