### PR TITLE
Fix Android scene editor help button position

### DIFF
--- a/src/pages/app/app.store.js
+++ b/src/pages/app/app.store.js
@@ -17,6 +17,7 @@ const MOBILE_TAB_BAR_HEIGHT_PX = 64;
 const HELP_BUTTON_BOTTOM_OFFSET_PX = 24;
 const HELP_BUTTON_TOUCH_BOTTOM_OFFSET_PX = 28;
 const HELP_BUTTON_IOS_EXTRA_BOTTOM_OFFSET_PX = 36;
+const SCENE_EDITOR_ANDROID_HELP_BUTTON_EXTRA_BOTTOM_OFFSET_PX = 48;
 const MOBILE_TAB_BAR_ACTIVE_COLOR = "white";
 const MOBILE_TAB_BAR_INACTIVE_COLOR = "mu-fg";
 
@@ -280,8 +281,15 @@ const selectRepositoryLoadingProgressPercent = ({ state }) => {
 
 export const selectViewData = ({ state, i18n }) => {
   const copy = selectAppCopy(i18n);
+  const currentRoutePattern = selectCurrentRoutePattern({ state });
   const showSidebar = selectShowSidebar({ state });
   const showMobileTabBar = selectShowMobileTabBar({ state });
+  const sceneEditorAndroidHelpButtonExtraBottomOffset =
+    state.isTouchMode &&
+    state.platform === "android" &&
+    currentRoutePattern === "/project/scene-editor"
+      ? SCENE_EDITOR_ANDROID_HELP_BUTTON_EXTRA_BOTTOM_OFFSET_PX
+      : 0;
   const repositoryLoadingProgressPercent =
     selectRepositoryLoadingProgressPercent({
       state,
@@ -292,7 +300,7 @@ export const selectViewData = ({ state, i18n }) => {
 
   return {
     ...state,
-    currentRoutePattern: selectCurrentRoutePattern({ state }),
+    currentRoutePattern,
     showSidebar,
     showMobileTabBar,
     mobileTabBarItems: selectMobileTabBarItems({ state, i18n }),
@@ -308,7 +316,8 @@ export const selectViewData = ({ state, i18n }) => {
           HELP_BUTTON_TOUCH_BOTTOM_OFFSET_PX +
           (state.platform === "ios"
             ? HELP_BUTTON_IOS_EXTRA_BOTTOM_OFFSET_PX
-            : 0)
+            : 0) +
+          sceneEditorAndroidHelpButtonExtraBottomOffset
         }px`
       : `${HELP_BUTTON_BOTTOM_OFFSET_PX}px`,
     repositoryLoadingProgressPercent,

--- a/tests/app/app.store.test.js
+++ b/tests/app/app.store.test.js
@@ -276,4 +276,63 @@ describe("app.store floating help button", () => {
     );
     expect(selectViewData({ state: iosState }).helpButtonBottom).toBe("128px");
   });
+
+  it("raises the Android touch help button only on the scene editor", () => {
+    const androidState = createInitialState();
+    setPlatform({ state: androidState }, { platform: "android" });
+    setUiConfig(
+      { state: androidState },
+      { uiConfig: { id: "touch", inputMode: "touch" } },
+    );
+    setCurrentRoute(
+      { state: androidState },
+      {
+        route: "/project/scene-editor",
+        payload: { p: "project-1", s: "scene-1" },
+      },
+    );
+
+    expect(selectViewData({ state: androidState }).helpButtonBottom).toBe(
+      "140px",
+    );
+
+    setCurrentRoute(
+      { state: androidState },
+      { route: "/project/scenes", payload: { p: "project-1" } },
+    );
+
+    expect(selectViewData({ state: androidState }).helpButtonBottom).toBe(
+      "92px",
+    );
+
+    const iosState = createInitialState();
+    setPlatform({ state: iosState }, { platform: "ios" });
+    setUiConfig(
+      { state: iosState },
+      { uiConfig: { id: "touch", inputMode: "touch" } },
+    );
+    setCurrentRoute(
+      { state: iosState },
+      {
+        route: "/project/scene-editor",
+        payload: { p: "project-1", s: "scene-1" },
+      },
+    );
+
+    expect(selectViewData({ state: iosState }).helpButtonBottom).toBe("128px");
+
+    const desktopState = createInitialState();
+    setPlatform({ state: desktopState }, { platform: "android" });
+    setCurrentRoute(
+      { state: desktopState },
+      {
+        route: "/project/scene-editor",
+        payload: { p: "project-1", s: "scene-1" },
+      },
+    );
+
+    expect(selectViewData({ state: desktopState }).helpButtonBottom).toBe(
+      "24px",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- raise the floating help button by 48px on the Android touch scene editor
- keep Android offsets unchanged on other routes
- keep iOS and non-touch positioning unchanged
- add regression coverage for each positioning boundary

## Validation

- bunx vitest run tests/app/app.store.test.js
- bun run lint
- bun run build:android