### PR TITLE
Harden Android storage and WebView security, align mobile scene dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Browser builds persist project data through IndexedDB-backed stores.
 
 Desktop builds persist project data through Tauri/SQLite-backed stores.
 
-Android builds run the web app inside a native WebView shell and persist project
-data through the web/IndexedDB-backed stores. Tauri is not used for mobile.
+Android builds run the web app inside a native WebView shell and persist app and
+project data through native SQLite-backed stores. Tauri is not used for mobile.
 
 ## Frameworks used
 

--- a/README.md
+++ b/README.md
@@ -128,22 +128,29 @@ Open: http://localhost:3001/project
 
 ### Android Application
 
-Install the debug shell once after native Android changes:
+Build and install the debug app with packaged local JavaScript:
 
 ```shell
 bun run android:install
 ```
 
-Start the Android JS dev server:
+For explicit watch-mode development, start the Android JS dev server:
 
 ```shell
 bun run watch:android
 ```
 
-The debug app loads `http://127.0.0.1:3001/android/index.html`. The watch
-script prepares `_site`, configures `adb reverse tcp:3001 tcp:3001` when a
-device is connected, and serves `src/setup.android.js` so frontend changes can
-be refreshed without reinstalling the APK.
+The watch script prepares `_site`, configures
+`adb reverse tcp:3001 tcp:3001` when a device is connected, and serves
+`src/setup.android.js`. After it is ready, explicitly relaunch the debug app
+against the server:
+
+```shell
+adb shell am start -S -n com.routevn.creator/.MainActivity \
+  --ez routevnUseDevServer true
+```
+
+Normal launches omit this extra and always use packaged local JavaScript.
 
 ### Desktop Application (Tauri)
 

--- a/android/routevn/app/proguard-rules.pro
+++ b/android/routevn/app/proguard-rules.pro
@@ -1,3 +1,0 @@
--keepclassmembers class com.routevn.creator.MainActivity$AndroidBridge {
-    @android.webkit.JavascriptInterface <methods>;
-}

--- a/android/routevn/app/src/main/AndroidManifest.xml
+++ b/android/routevn/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -89,6 +89,8 @@ public class MainActivity extends Activity {
     private static final String APP_ORIGIN = "https://" + APP_ASSET_HOST;
     private static final String DEV_SERVER_ORIGIN =
         "http://" + DEV_SERVER_HOST + ":" + DEV_SERVER_PORT;
+    private static final String DEV_SERVER_INTENT_EXTRA =
+        "routevnUseDevServer";
     private static final String ANDROID_BRIDGE_NAME = "RouteVNAndroid";
     private static final int ANDROID_BRIDGE_PROTOCOL_VERSION = 1;
     private static final int FILE_CHOOSER_REQUEST_CODE = 3711;
@@ -468,7 +470,7 @@ public class MainActivity extends Activity {
             settings.setSafeBrowsingEnabled(true);
         }
 
-        if (BuildConfig.DEBUG) {
+        if (shouldUseDebugDevServer()) {
             settings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
         } else {
             settings.setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
@@ -517,7 +519,7 @@ public class MainActivity extends Activity {
 
         Set<String> allowedOriginRules = new HashSet<>();
         allowedOriginRules.add(APP_ORIGIN);
-        if (BuildConfig.DEBUG) {
+        if (shouldUseDebugDevServer()) {
             allowedOriginRules.add(DEV_SERVER_ORIGIN);
         }
 
@@ -592,7 +594,7 @@ public class MainActivity extends Activity {
 
         String origin = sourceOrigin.toString();
         return APP_ORIGIN.equals(origin) ||
-            (BuildConfig.DEBUG && DEV_SERVER_ORIGIN.equals(origin));
+            (shouldUseDebugDevServer() && DEV_SERVER_ORIGIN.equals(origin));
     }
 
     private void postBridgeResponse(
@@ -607,12 +609,18 @@ public class MainActivity extends Activity {
     }
 
     private String getInitialAppUrl() {
-        if (BuildConfig.DEBUG) {
+        if (shouldUseDebugDevServer()) {
             Log.i(TAG, "Loading Android dev server URL: " + DEV_SERVER_URL);
             return DEV_SERVER_URL;
         }
 
+        Log.i(TAG, "Loading packaged Android app URL: " + APP_URL);
         return APP_URL;
+    }
+
+    private boolean shouldUseDebugDevServer() {
+        return BuildConfig.DEBUG &&
+            getIntent().getBooleanExtra(DEV_SERVER_INTENT_EXTRA, false);
     }
 
     private boolean isAppAssetUrl(Uri uri) {
@@ -625,7 +633,7 @@ public class MainActivity extends Activity {
 
     private boolean isDebugDevServerUrl(Uri uri) {
         return (
-            BuildConfig.DEBUG &&
+            shouldUseDebugDevServer() &&
             uri != null &&
             "http".equals(uri.getScheme()) &&
             DEV_SERVER_HOST.equals(uri.getHost()) &&
@@ -878,14 +886,14 @@ public class MainActivity extends Activity {
         Map<String, String> headers = new HashMap<>();
         headers.put(
             "Access-Control-Allow-Origin",
-            BuildConfig.DEBUG ? DEV_SERVER_ORIGIN : APP_ORIGIN
+            shouldUseDebugDevServer() ? DEV_SERVER_ORIGIN : APP_ORIGIN
         );
         headers.put("Access-Control-Allow-Methods", "GET, OPTIONS");
         headers.put("Access-Control-Allow-Headers", "Origin, Range, Accept, Content-Type");
         headers.put("Access-Control-Expose-Headers", "Content-Length, Content-Range, Accept-Ranges");
         headers.put(
             "Cross-Origin-Resource-Policy",
-            BuildConfig.DEBUG ? "cross-origin" : "same-origin"
+            shouldUseDebugDevServer() ? "cross-origin" : "same-origin"
         );
         headers.put("Content-Security-Policy", "default-src 'none'; sandbox");
         headers.put("X-Content-Type-Options", "nosniff");
@@ -1851,6 +1859,10 @@ public class MainActivity extends Activity {
         }
         if (
             upperSql.matches("PRAGMA\\s+USER_VERSION") ||
+            upperSql.matches("PRAGMA\\s+JOURNAL_MODE\\s*=\\s*WAL") ||
+            upperSql.matches("PRAGMA\\s+SYNCHRONOUS\\s*=\\s*(FULL|NORMAL)") ||
+            upperSql.matches("PRAGMA\\s+BUSY_TIMEOUT\\s*=\\s*[0-9]+") ||
+            upperSql.matches("PRAGMA\\s+USER_VERSION\\s*=\\s*[0-9]+") ||
             upperSql.matches(
                 "PRAGMA\\s+TABLE_INFO\\([A-Z_][A-Z0-9_]*\\)"
             )

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -21,6 +21,8 @@ import android.os.Looper;
 import android.provider.OpenableColumns;
 import android.provider.MediaStore;
 import android.provider.DocumentsContract;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
 import android.system.Os;
 import android.util.Base64;
 import android.util.Log;
@@ -29,7 +31,6 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.webkit.ConsoleMessage;
 import android.webkit.CookieManager;
-import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
@@ -39,12 +40,17 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.view.View;
+import android.view.Gravity;
 import android.widget.Toast;
 import android.widget.FrameLayout;
+import android.widget.TextView;
 import android.window.OnBackInvokedCallback;
 import android.window.OnBackInvokedDispatcher;
 import androidx.core.splashscreen.SplashScreen;
+import androidx.webkit.JavaScriptReplyProxy;
 import androidx.webkit.WebViewAssetLoader;
+import androidx.webkit.WebViewCompat;
+import androidx.webkit.WebViewFeature;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -53,13 +59,22 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -71,6 +86,11 @@ public class MainActivity extends Activity {
     private static final int DEV_SERVER_PORT = 3001;
     private static final String DEV_SERVER_URL =
         "http://" + DEV_SERVER_HOST + ":" + DEV_SERVER_PORT + "/android/index.html";
+    private static final String APP_ORIGIN = "https://" + APP_ASSET_HOST;
+    private static final String DEV_SERVER_ORIGIN =
+        "http://" + DEV_SERVER_HOST + ":" + DEV_SERVER_PORT;
+    private static final String ANDROID_BRIDGE_NAME = "RouteVNAndroid";
+    private static final int ANDROID_BRIDGE_PROTOCOL_VERSION = 1;
     private static final int FILE_CHOOSER_REQUEST_CODE = 3711;
     private static final int ANDROID_FILE_PICKER_REQUEST_CODE = 3712;
     private static final int ANDROID_SAVE_FILE_PICKER_REQUEST_CODE = 3713;
@@ -90,6 +110,13 @@ public class MainActivity extends Activity {
     private static final String PROJECT_FILE_WRITE_TEMP_PREFIX =
         ".routevn-project-write-";
     private static final String APP_DATABASE_NAME = "app.db";
+    private static final String USER_CONFIG_DB_KEY = "userConfig";
+    private static final String AUTH_CONFIG_KEY = "auth";
+    private static final String AUTH_SESSION_CONFIG_KEY = "session";
+    private static final String AUTH_SECRET_PREFERENCES = "auth-secrets";
+    private static final String AUTH_SECRET_VALUE_KEY = "session";
+    private static final String AUTH_SECRET_KEY_ALIAS =
+        "routevn.auth.session";
     private static final String PROJECT_DATABASE_NAME = "project.db";
     private static final String PROJECTS_DIRECTORY_NAME = "projects";
 
@@ -136,13 +163,15 @@ public class MainActivity extends Activity {
     private boolean systemInsetsApplied = false;
     private WebViewAssetLoader assetLoader;
     private ValueCallback<Uri[]> fileChooserCallback;
-    private boolean canGoBackInWebApp = false;
+    private volatile boolean canGoBackInWebApp = false;
     private Object backInvokedCallback;
     private String pendingAndroidFilePickerRequestId;
     private boolean pendingAndroidFilePickerMultiple = false;
     private String pendingAndroidSaveFilePickerRequestId;
     private String pendingAndroidFolderPickerRequestId;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final ExecutorService bridgeExecutor =
+        Executors.newSingleThreadExecutor();
     private final Runnable finishSplashRunnable = this::finishSplash;
     private final Map<String, SQLiteDatabase> sqliteDatabases = new HashMap<>();
     private final Map<String, ProjectFileWriteSession> projectFileWriteSessions =
@@ -375,9 +404,12 @@ public class MainActivity extends Activity {
             )
         );
         webView.setBackgroundColor(Color.BLACK);
-        webView.addJavascriptInterface(new AndroidBridge(), "RouteVNAndroid");
         configureWebSettings(webView.getSettings());
         configureCookies();
+        if (!configureSecureAndroidBridge()) {
+            showUnsupportedWebViewError();
+            return;
+        }
 
         webView.setWebViewClient(new RouteVNWebViewClient());
         webView.setWebChromeClient(new RouteVNWebChromeClient());
@@ -425,9 +457,10 @@ public class MainActivity extends Activity {
         settings.setDatabaseEnabled(true);
         settings.setMediaPlaybackRequiresUserGesture(false);
         settings.setAllowFileAccess(false);
-        settings.setAllowContentAccess(true);
+        settings.setAllowContentAccess(false);
         settings.setAllowFileAccessFromFileURLs(false);
         settings.setAllowUniversalAccessFromFileURLs(false);
+        settings.setJavaScriptCanOpenWindowsAutomatically(false);
         settings.setSupportMultipleWindows(false);
         settings.setTextZoom(100);
 
@@ -474,7 +507,103 @@ public class MainActivity extends Activity {
     private void configureCookies() {
         CookieManager cookieManager = CookieManager.getInstance();
         cookieManager.setAcceptCookie(true);
-        cookieManager.setAcceptThirdPartyCookies(webView, true);
+        cookieManager.setAcceptThirdPartyCookies(webView, false);
+    }
+
+    private boolean configureSecureAndroidBridge() {
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+            return false;
+        }
+
+        Set<String> allowedOriginRules = new HashSet<>();
+        allowedOriginRules.add(APP_ORIGIN);
+        if (BuildConfig.DEBUG) {
+            allowedOriginRules.add(DEV_SERVER_ORIGIN);
+        }
+
+        WebViewCompat.addWebMessageListener(
+            webView,
+            ANDROID_BRIDGE_NAME,
+            allowedOriginRules,
+            (view, message, sourceOrigin, isMainFrame, replyProxy) -> {
+                if (!isMainFrame || !isAllowedBridgeOrigin(sourceOrigin)) {
+                    Log.w(TAG, "Rejected Android bridge message from " + sourceOrigin);
+                    return;
+                }
+
+                String messageData = message.getData();
+                if (messageData == null) {
+                    postBridgeResponse(
+                        replyProxy,
+                        bridgeFailure(
+                            new IllegalArgumentException(
+                                "Android bridge message is invalid."
+                            )
+                        )
+                    );
+                    return;
+                }
+
+                bridgeExecutor.execute(() -> {
+                    String response = dispatchAndroidBridgeMessage(messageData);
+                    postBridgeResponse(replyProxy, response);
+                });
+            }
+        );
+        return true;
+    }
+
+    private void showUnsupportedWebViewError() {
+        if (webView != null) {
+            webView.destroy();
+            webView = null;
+        }
+
+        TextView message = new TextView(this);
+        message.setText(
+            "RouteVN Creator needs a newer Android System WebView. " +
+            "Update Android System WebView or Google Chrome, then reopen the app."
+        );
+        message.setTextColor(Color.WHITE);
+        message.setTextSize(18);
+        message.setGravity(Gravity.CENTER);
+        message.setPadding(48, 48, 48, 48);
+
+        FrameLayout rootView = new FrameLayout(this);
+        rootView.setBackgroundColor(Color.BLACK);
+        rootView.addView(
+            message,
+            new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        );
+        applySystemBarInsets(rootView);
+        setContentView(rootView);
+        rootView.requestApplyInsets();
+        requestSplashDismiss();
+        mainHandler.postDelayed(finishSplashRunnable, SPLASH_MAX_VISIBLE_MS);
+    }
+
+    private boolean isAllowedBridgeOrigin(Uri sourceOrigin) {
+        if (sourceOrigin == null) {
+            return false;
+        }
+
+        String origin = sourceOrigin.toString();
+        return APP_ORIGIN.equals(origin) ||
+            (BuildConfig.DEBUG && DEV_SERVER_ORIGIN.equals(origin));
+    }
+
+    private void postBridgeResponse(
+        JavaScriptReplyProxy replyProxy,
+        String response
+    ) {
+        mainHandler.post(() -> {
+            if (webView != null) {
+                replyProxy.postMessage(response);
+            }
+        });
     }
 
     private String getInitialAppUrl() {
@@ -502,6 +631,14 @@ public class MainActivity extends Activity {
             DEV_SERVER_HOST.equals(uri.getHost()) &&
             uri.getPort() == DEV_SERVER_PORT
         );
+    }
+
+    private boolean isTrustedAppDocumentUrl(Uri uri) {
+        if (isAppAssetUrl(uri)) {
+            return "/web/index.html".equals(uri.getPath());
+        }
+        return isDebugDevServerUrl(uri) &&
+            "/android/index.html".equals(uri.getPath());
     }
 
     private boolean openExternalUri(Uri uri) {
@@ -555,6 +692,7 @@ public class MainActivity extends Activity {
 
         closeSqliteDatabases();
         closeProjectFileWriteSessions();
+        bridgeExecutor.shutdownNow();
 
         if (webView != null) {
             webView.destroy();
@@ -612,22 +750,32 @@ public class MainActivity extends Activity {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
             Uri uri = request.getUrl();
-            if (isAppAssetUrl(uri) || isDebugDevServerUrl(uri)) {
+            if (isTrustedAppDocumentUrl(uri)) {
                 return false;
             }
 
-            return openExternalUri(uri);
+            if (isAppAssetUrl(uri) || isDebugDevServerUrl(uri)) {
+                return true;
+            }
+
+            openExternalUri(uri);
+            return true;
         }
 
         @Override
         @SuppressWarnings("deprecation")
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
             Uri uri = Uri.parse(url);
-            if (isAppAssetUrl(uri) || isDebugDevServerUrl(uri)) {
+            if (isTrustedAppDocumentUrl(uri)) {
                 return false;
             }
 
-            return openExternalUri(uri);
+            if (isAppAssetUrl(uri) || isDebugDevServerUrl(uri)) {
+                return true;
+            }
+
+            openExternalUri(uri);
+            return true;
         }
 
         @Override
@@ -728,55 +876,265 @@ public class MainActivity extends Activity {
 
     private Map<String, String> createInternalFileResponseHeaders() {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Access-Control-Allow-Origin", "*");
+        headers.put(
+            "Access-Control-Allow-Origin",
+            BuildConfig.DEBUG ? DEV_SERVER_ORIGIN : APP_ORIGIN
+        );
         headers.put("Access-Control-Allow-Methods", "GET, OPTIONS");
         headers.put("Access-Control-Allow-Headers", "Origin, Range, Accept, Content-Type");
         headers.put("Access-Control-Expose-Headers", "Content-Length, Content-Range, Accept-Ranges");
-        headers.put("Cross-Origin-Resource-Policy", "cross-origin");
+        headers.put(
+            "Cross-Origin-Resource-Policy",
+            BuildConfig.DEBUG ? "cross-origin" : "same-origin"
+        );
+        headers.put("Content-Security-Policy", "default-src 'none'; sandbox");
+        headers.put("X-Content-Type-Options", "nosniff");
         return headers;
     }
 
+    private String dispatchAndroidBridgeMessage(String messageData) {
+        String requestId = "";
+        try {
+            JSONObject request = new JSONObject(messageData);
+            requestId = request.getString("id");
+            if (requestId.isEmpty() || requestId.length() > 64) {
+                throw new IllegalArgumentException(
+                    "Android bridge request id is invalid."
+                );
+            }
+            if (
+                request.getInt("version") != ANDROID_BRIDGE_PROTOCOL_VERSION
+            ) {
+                throw new IllegalArgumentException(
+                    "Unsupported Android bridge protocol version."
+                );
+            }
+
+            String method = request.getString("method");
+            JSONObject payload = request.optJSONObject("payload");
+            if (payload == null) {
+                payload = new JSONObject();
+            }
+
+            String result = dispatchAndroidBridgeMethod(
+                method,
+                payload.toString()
+            );
+            return attachBridgeResponseMetadata(requestId, result);
+        } catch (Throwable error) {
+            return attachBridgeResponseMetadata(
+                requestId,
+                bridgeFailure(error)
+            );
+        }
+    }
+
+    private String dispatchAndroidBridgeMethod(
+        String method,
+        String payloadJson
+    ) throws Exception {
+        JSONObject payload = new JSONObject(payloadJson);
+        AndroidBridge bridge = new AndroidBridge();
+        switch (method) {
+            case "isDebugBuild":
+                return bridgeSuccess(bridge.isDebugBuild());
+            case "updateBackState":
+                bridge.updateBackState(payload.getBoolean("canGoBack"));
+                return bridgeSuccess(true);
+            case "openExternalUrl":
+                bridge.openExternalUrl(payload.getString("url"));
+                return bridgeSuccess(true);
+            case "markSplashReady":
+                bridge.markSplashReady();
+                return bridgeSuccess(true);
+            case "appDbInit":
+                return bridge.appDbInit(payloadJson);
+            case "appDbGet":
+                return bridge.appDbGet(payloadJson);
+            case "appDbSet":
+                return bridge.appDbSet(payloadJson);
+            case "appDbRemove":
+                return bridge.appDbRemove(payloadJson);
+            case "appDbGetEvents":
+                return bridge.appDbGetEvents(payloadJson);
+            case "appDbAppendEvent":
+                return bridge.appDbAppendEvent(payloadJson);
+            case "sqliteOpen":
+                return bridge.sqliteOpen(payloadJson);
+            case "sqliteQuery":
+                return bridge.sqliteQuery(payloadJson);
+            case "sqliteExec":
+                return bridge.sqliteExec(payloadJson);
+            case "sqliteClose":
+                return bridge.sqliteClose(payloadJson);
+            case "ensureProjectStorage":
+                return bridge.ensureProjectStorage(payloadJson);
+            case "getProjectStorageStatus":
+                return bridge.getProjectStorageStatus(payloadJson);
+            case "listProjectFolders":
+                return bridge.listProjectFolders(payloadJson);
+            case "beginProjectFileWrite":
+                return bridge.beginProjectFileWrite(payloadJson);
+            case "appendProjectFileWrite":
+                return bridge.appendProjectFileWrite(payloadJson);
+            case "finishProjectFileWrite":
+                return bridge.finishProjectFileWrite(payloadJson);
+            case "abortProjectFileWrite":
+                return bridge.abortProjectFileWrite(payloadJson);
+            case "writeProjectFile":
+                return bridge.writeProjectFile(payloadJson);
+            case "deleteProjectFile":
+                return bridge.deleteProjectFile(payloadJson);
+            case "readProjectFile":
+                return bridge.readProjectFile(payloadJson);
+            case "readProjectFileMetadata":
+                return bridge.readProjectFileMetadata(payloadJson);
+            case "writeDownloadFile":
+                return bridge.writeDownloadFile(payloadJson);
+            case "writeFileToUri":
+                return bridge.writeFileToUri(payloadJson);
+            case "createDistributionZipStreamedToUri":
+                return bridge.createDistributionZipStreamedToUri(payloadJson);
+            case "openFilePicker":
+                return bridge.openFilePicker(payloadJson);
+            case "openSaveFilePicker":
+                return bridge.openSaveFilePicker(payloadJson);
+            case "openFolderPicker":
+                return bridge.openFolderPicker(payloadJson);
+            case "importProjectFolder":
+                return bridge.importProjectFolder(payloadJson);
+            case "exportProjectFolder":
+                return bridge.exportProjectFolder(payloadJson);
+            case "deletePickerRequest":
+                return bridge.deletePickerRequest(payloadJson);
+            default:
+                throw new IllegalArgumentException(
+                    "Unsupported Android bridge method."
+                );
+        }
+    }
+
+    private String attachBridgeResponseMetadata(
+        String requestId,
+        String resultJson
+    ) {
+        try {
+            JSONObject result = new JSONObject(resultJson);
+            result.put("version", ANDROID_BRIDGE_PROTOCOL_VERSION);
+            result.put("id", requestId);
+            return result.toString();
+        } catch (Exception error) {
+            return "{\"version\":1,\"id\":\"\",\"ok\":false," +
+                "\"error\":{\"message\":\"Android bridge response failed\"}}";
+        }
+    }
+
     private final class AndroidBridge {
-        @JavascriptInterface
         public boolean isDebugBuild() {
             return BuildConfig.DEBUG;
         }
 
-        @JavascriptInterface
         public void updateBackState(boolean canGoBack) {
             canGoBackInWebApp = canGoBack;
         }
 
-        @JavascriptInterface
         public void openExternalUrl(String url) {
             runOnUiThread(() -> openExternalUri(Uri.parse(url)));
         }
 
-        @JavascriptInterface
         public void markSplashReady() {
             runOnUiThread(MainActivity.this::requestSplashDismiss);
         }
 
-        @JavascriptInterface
-        public String sqliteOpen(String payloadJson) {
+        public String appDbInit(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
-                String dbPath = payload.getString("dbPath");
-                openDatabase(dbPath);
+                initializeAppDatabase(payload.optBoolean("withEvents", false));
                 return bridgeSuccess(true);
             } catch (Exception error) {
                 return bridgeFailure(error);
             }
         }
 
-        @JavascriptInterface
+        public String appDbGet(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                return bridgeSuccess(readAppDatabaseValue(payload.getString("key")));
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        public String appDbSet(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                writeAppDatabaseValue(
+                    payload.getString("key"),
+                    payload.getString("valueJson")
+                );
+                return bridgeSuccess(true);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        public String appDbRemove(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                removeAppDatabaseValue(payload.getString("key"));
+                return bridgeSuccess(true);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        public String appDbGetEvents(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                Long since = payload.has("since") && !payload.isNull("since")
+                    ? payload.getLong("since")
+                    : null;
+                return bridgeSuccess(readAppDatabaseEvents(since));
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        public String appDbAppendEvent(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                appendAppDatabaseEvent(
+                    payload.getString("type"),
+                    payload.getString("payloadJson")
+                );
+                return bridgeSuccess(true);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
+        public String sqliteOpen(String payloadJson) {
+            try {
+                JSONObject payload = new JSONObject(payloadJson);
+                String dbPath = payload.getString("dbPath");
+                openProjectDatabaseForBridge(dbPath);
+                return bridgeSuccess(true);
+            } catch (Exception error) {
+                return bridgeFailure(error);
+            }
+        }
+
         public String sqliteQuery(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
-                SQLiteDatabase database = openDatabase(payload.getString("dbPath"));
+                SQLiteDatabase database = openProjectDatabaseForBridge(
+                    payload.getString("dbPath")
+                );
+                String sql = payload.getString("sql");
+                validateBridgeQuerySql(sql);
                 JSONArray rows = queryDatabase(
                     database,
-                    payload.getString("sql"),
+                    sql,
                     payload.optJSONArray("args")
                 );
                 return bridgeSuccess(rows);
@@ -785,14 +1143,17 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String sqliteExec(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
-                SQLiteDatabase database = openDatabase(payload.getString("dbPath"));
+                SQLiteDatabase database = openProjectDatabaseForBridge(
+                    payload.getString("dbPath")
+                );
+                String sql = payload.getString("sql");
+                validateBridgeExecuteSql(sql);
                 int rowsAffected = executeDatabaseStatement(
                     database,
-                    payload.getString("sql"),
+                    sql,
                     payload.optJSONArray("args")
                 );
                 JSONObject result = new JSONObject();
@@ -803,18 +1164,18 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String sqliteClose(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
-                closeDatabase(payload.getString("dbPath"));
+                String dbPath = payload.getString("dbPath");
+                resolveProjectDatabaseFileForBridge(dbPath);
+                closeDatabase(dbPath);
                 return bridgeSuccess(true);
             } catch (Exception error) {
                 return bridgeFailure(error);
             }
         }
 
-        @JavascriptInterface
         public String ensureProjectStorage(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -825,7 +1186,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String getProjectStorageStatus(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -839,7 +1199,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String listProjectFolders(String payloadJson) {
             try {
                 return bridgeSuccess(MainActivity.this.listProjectFolders());
@@ -848,7 +1207,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String beginProjectFileWrite(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -868,7 +1226,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String appendProjectFileWrite(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -884,7 +1241,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String finishProjectFileWrite(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -898,7 +1254,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String abortProjectFileWrite(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -909,7 +1264,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String writeProjectFile(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -925,7 +1279,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String deleteProjectFile(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -940,7 +1293,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String readProjectFile(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -954,7 +1306,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String readProjectFileMetadata(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -968,7 +1319,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String writeDownloadFile(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -983,7 +1333,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String writeFileToUri(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -997,7 +1346,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String createDistributionZipStreamedToUri(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1009,7 +1357,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String openFilePicker(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1026,7 +1373,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String openSaveFilePicker(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1046,7 +1392,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String openFolderPicker(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1060,7 +1405,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String importProjectFolder(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1073,7 +1417,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String exportProjectFolder(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1108,7 +1451,6 @@ public class MainActivity extends Activity {
             }
         }
 
-        @JavascriptInterface
         public String deletePickerRequest(String payloadJson) {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
@@ -1145,6 +1487,287 @@ public class MainActivity extends Activity {
         }
     }
 
+    private void initializeAppDatabase(boolean withEvents) throws Exception {
+        SQLiteDatabase database = openDatabase(APP_DATABASE_NAME);
+        database.execSQL(
+            "CREATE TABLE IF NOT EXISTS kv (" +
+            "key TEXT PRIMARY KEY, value TEXT)"
+        );
+        if (withEvents) {
+            database.execSQL(
+                "CREATE TABLE IF NOT EXISTS events (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "type TEXT NOT NULL, payload TEXT, " +
+                "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+            );
+        }
+    }
+
+    private String readAppDatabaseValue(String key) throws Exception {
+        String safeKey = validateAppDatabaseKey(key);
+        SQLiteDatabase database = openDatabase(APP_DATABASE_NAME);
+        String valueJson = null;
+        try (
+            Cursor cursor = database.query(
+                "kv",
+                new String[] { "value" },
+                "key = ?",
+                new String[] { safeKey },
+                null,
+                null,
+                null,
+                "1"
+            )
+        ) {
+            if (cursor.moveToFirst()) {
+                valueJson = cursor.getString(0);
+            }
+        }
+
+        if (!USER_CONFIG_DB_KEY.equals(safeKey)) {
+            return valueJson;
+        }
+
+        JSONObject userConfig = valueJson == null
+            ? new JSONObject()
+            : new JSONObject(valueJson);
+        String authSessionJson = readSecureAuthSession();
+        if (authSessionJson != null) {
+            JSONObject auth = userConfig.optJSONObject(AUTH_CONFIG_KEY);
+            if (auth == null) {
+                auth = new JSONObject();
+                userConfig.put(AUTH_CONFIG_KEY, auth);
+            }
+            auth.put(
+                AUTH_SESSION_CONFIG_KEY,
+                new JSONObject(authSessionJson)
+            );
+        }
+        return userConfig.toString();
+    }
+
+    private void writeAppDatabaseValue(String key, String valueJson)
+        throws Exception {
+        String safeKey = validateAppDatabaseKey(key);
+        String persistedValueJson = valueJson;
+        if (USER_CONFIG_DB_KEY.equals(safeKey)) {
+            JSONObject userConfig = new JSONObject(valueJson);
+            JSONObject auth = userConfig.optJSONObject(AUTH_CONFIG_KEY);
+            Object authSession = auth == null
+                ? null
+                : auth.opt(AUTH_SESSION_CONFIG_KEY);
+            if (authSession instanceof JSONObject) {
+                writeSecureAuthSession(authSession.toString());
+            } else {
+                clearSecureAuthSession();
+            }
+            if (auth != null) {
+                auth.remove(AUTH_SESSION_CONFIG_KEY);
+                if (auth.length() == 0) {
+                    userConfig.remove(AUTH_CONFIG_KEY);
+                }
+            }
+            persistedValueJson = userConfig.toString();
+        }
+
+        ContentValues values = new ContentValues();
+        values.put("key", safeKey);
+        values.put("value", persistedValueJson);
+        openDatabase(APP_DATABASE_NAME).insertWithOnConflict(
+            "kv",
+            null,
+            values,
+            SQLiteDatabase.CONFLICT_REPLACE
+        );
+    }
+
+    private void removeAppDatabaseValue(String key) throws Exception {
+        String safeKey = validateAppDatabaseKey(key);
+        if (USER_CONFIG_DB_KEY.equals(safeKey)) {
+            clearSecureAuthSession();
+        }
+        openDatabase(APP_DATABASE_NAME).delete(
+            "kv",
+            "key = ?",
+            new String[] { safeKey }
+        );
+    }
+
+    private JSONArray readAppDatabaseEvents(Long since) throws Exception {
+        SQLiteDatabase database = openDatabase(APP_DATABASE_NAME);
+        JSONArray events = new JSONArray();
+        String selection = since == null ? null : "id > ?";
+        String[] selectionArgs = since == null
+            ? null
+            : new String[] { String.valueOf(since) };
+        try (
+            Cursor cursor = database.query(
+                "events",
+                new String[] { "id", "type", "payload" },
+                selection,
+                selectionArgs,
+                null,
+                null,
+                "id"
+            )
+        ) {
+            while (cursor.moveToNext()) {
+                JSONObject event = new JSONObject();
+                event.put("id", cursor.getLong(0));
+                event.put("type", cursor.getString(1));
+                event.put("payloadJson", cursor.getString(2));
+                events.put(event);
+            }
+        }
+        return events;
+    }
+
+    private void appendAppDatabaseEvent(String type, String payloadJson)
+        throws Exception {
+        if (type == null || type.isEmpty() || type.length() > 256) {
+            throw new IllegalArgumentException("App event type is invalid.");
+        }
+        ContentValues values = new ContentValues();
+        values.put("type", type);
+        values.put("payload", payloadJson);
+        openDatabase(APP_DATABASE_NAME).insertOrThrow("events", null, values);
+    }
+
+    private String validateAppDatabaseKey(String key) {
+        if (key == null || key.isEmpty() || key.length() > 256) {
+            throw new IllegalArgumentException("App database key is invalid.");
+        }
+        return key;
+    }
+
+    private SecretKey getOrCreateAuthSecretKey() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        keyStore.load(null);
+        java.security.Key storedKey = keyStore.getKey(
+            AUTH_SECRET_KEY_ALIAS,
+            null
+        );
+        if (storedKey instanceof SecretKey) {
+            return (SecretKey) storedKey;
+        }
+
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            "AndroidKeyStore"
+        );
+        keyGenerator.init(
+            new KeyGenParameterSpec.Builder(
+                AUTH_SECRET_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT |
+                    KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(
+                    KeyProperties.ENCRYPTION_PADDING_NONE
+                )
+                .build()
+        );
+        return keyGenerator.generateKey();
+    }
+
+    private void writeSecureAuthSession(String authSessionJson)
+        throws Exception {
+        String encodedValue;
+        try {
+            encodedValue = encryptAuthSession(authSessionJson);
+        } catch (Exception error) {
+            deleteAuthSecretKey();
+            encodedValue = encryptAuthSession(authSessionJson);
+        }
+        boolean committed = getSharedPreferences(
+            AUTH_SECRET_PREFERENCES,
+            MODE_PRIVATE
+        )
+            .edit()
+            .putString(AUTH_SECRET_VALUE_KEY, encodedValue)
+            .commit();
+        if (!committed) {
+            throw new IllegalStateException("Failed to store auth session.");
+        }
+    }
+
+    private String encryptAuthSession(String authSessionJson)
+        throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateAuthSecretKey());
+        byte[] ciphertext = cipher.doFinal(
+            authSessionJson.getBytes(StandardCharsets.UTF_8)
+        );
+        return Base64.encodeToString(cipher.getIV(), Base64.NO_WRAP) +
+            ":" +
+            Base64.encodeToString(ciphertext, Base64.NO_WRAP);
+    }
+
+    private String readSecureAuthSession() {
+        SharedPreferences preferences = getSharedPreferences(
+            AUTH_SECRET_PREFERENCES,
+            MODE_PRIVATE
+        );
+        String encodedValue = preferences.getString(
+            AUTH_SECRET_VALUE_KEY,
+            null
+        );
+        if (encodedValue == null) {
+            return null;
+        }
+
+        try {
+            String[] parts = encodedValue.split(":", -1);
+            if (parts.length != 2) {
+                throw new IllegalArgumentException(
+                    "Stored auth session is invalid."
+                );
+            }
+            byte[] iv = Base64.decode(parts[0], Base64.NO_WRAP);
+            byte[] ciphertext = Base64.decode(parts[1], Base64.NO_WRAP);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                getOrCreateAuthSecretKey(),
+                new GCMParameterSpec(128, iv)
+            );
+            return new String(
+                cipher.doFinal(ciphertext),
+                StandardCharsets.UTF_8
+            );
+        } catch (Exception error) {
+            Log.e(TAG, "Stored auth session could not be decrypted.", error);
+            preferences.edit().remove(AUTH_SECRET_VALUE_KEY).commit();
+            deleteAuthSecretKey();
+            return null;
+        }
+    }
+
+    private void deleteAuthSecretKey() {
+        try {
+            KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+            keyStore.load(null);
+            if (keyStore.containsAlias(AUTH_SECRET_KEY_ALIAS)) {
+                keyStore.deleteEntry(AUTH_SECRET_KEY_ALIAS);
+            }
+        } catch (Exception error) {
+            Log.e(TAG, "Failed to reset the auth secret key.", error);
+        }
+    }
+
+    private void clearSecureAuthSession() {
+        boolean committed = getSharedPreferences(
+            AUTH_SECRET_PREFERENCES,
+            MODE_PRIVATE
+        )
+            .edit()
+            .remove(AUTH_SECRET_VALUE_KEY)
+            .commit();
+        if (!committed) {
+            throw new IllegalStateException("Failed to clear auth session.");
+        }
+    }
+
     private synchronized SQLiteDatabase openDatabase(String dbPath) throws Exception {
         SQLiteDatabase cachedDatabase = sqliteDatabases.get(dbPath);
         if (cachedDatabase != null && cachedDatabase.isOpen()) {
@@ -1167,6 +1790,107 @@ public class MainActivity extends Activity {
         }
         sqliteDatabases.put(dbPath, database);
         return database;
+    }
+
+    private SQLiteDatabase openProjectDatabaseForBridge(String dbPath)
+        throws Exception {
+        resolveProjectDatabaseFileForBridge(dbPath);
+        return openDatabase(dbPath);
+    }
+
+    private File resolveProjectDatabaseFileForBridge(String dbPath)
+        throws Exception {
+        String normalizedPath = dbPath == null ? "" : dbPath;
+        String[] parts = normalizedPath.split("/", -1);
+        if (
+            parts.length != 3 ||
+            !PROJECTS_DIRECTORY_NAME.equals(parts[0]) ||
+            !PROJECT_DATABASE_NAME.equals(parts[2])
+        ) {
+            throw new IllegalArgumentException(
+                "The SQLite bridge only supports project databases."
+            );
+        }
+
+        String projectId = safePathSegment(parts[1]);
+        if (!projectId.equals(parts[1])) {
+            throw new IllegalArgumentException(
+                "Unsupported Android project database path."
+            );
+        }
+        return getProjectDatabaseFile(projectId);
+    }
+
+    private String normalizeSingleBridgeSqlStatement(String sql) {
+        String normalizedSql = sql == null ? "" : sql.trim();
+        while (normalizedSql.endsWith(";")) {
+            normalizedSql = normalizedSql.substring(
+                0,
+                normalizedSql.length() - 1
+            ).trim();
+        }
+        if (
+            normalizedSql.isEmpty() ||
+            normalizedSql.contains(";") ||
+            normalizedSql.contains("--") ||
+            normalizedSql.contains("/*") ||
+            normalizedSql.contains("*/")
+        ) {
+            throw new IllegalArgumentException(
+                "Android SQLite accepts one uncommented statement."
+            );
+        }
+        return normalizedSql;
+    }
+
+    private void validateBridgeQuerySql(String sql) {
+        String upperSql = normalizeSingleBridgeSqlStatement(sql)
+            .toUpperCase(Locale.ROOT);
+        if (upperSql.matches("SELECT\\s+[\\s\\S]*")) {
+            return;
+        }
+        if (
+            upperSql.matches("PRAGMA\\s+USER_VERSION") ||
+            upperSql.matches(
+                "PRAGMA\\s+TABLE_INFO\\([A-Z_][A-Z0-9_]*\\)"
+            )
+        ) {
+            return;
+        }
+        throw new IllegalArgumentException(
+            "Unsupported Android SQLite query."
+        );
+    }
+
+    private void validateBridgeExecuteSql(String sql) {
+        String upperSql = normalizeSingleBridgeSqlStatement(sql)
+            .toUpperCase(Locale.ROOT);
+        if (
+            upperSql.matches("PRAGMA\\s+JOURNAL_MODE\\s*=\\s*WAL") ||
+            upperSql.matches("PRAGMA\\s+SYNCHRONOUS\\s*=\\s*(FULL|NORMAL)") ||
+            upperSql.matches("PRAGMA\\s+BUSY_TIMEOUT\\s*=\\s*[0-9]+") ||
+            upperSql.matches("PRAGMA\\s+USER_VERSION\\s*=\\s*[0-9]+")
+        ) {
+            return;
+        }
+
+        if (
+            upperSql.startsWith("CREATE TABLE IF NOT EXISTS ") ||
+            upperSql.startsWith("CREATE INDEX IF NOT EXISTS ") ||
+            upperSql.startsWith("INSERT ") ||
+            upperSql.startsWith("UPDATE ") ||
+            upperSql.startsWith("DELETE ") ||
+            upperSql.equals("BEGIN") ||
+            upperSql.equals("BEGIN IMMEDIATE") ||
+            upperSql.equals("COMMIT") ||
+            upperSql.equals("ROLLBACK")
+        ) {
+            return;
+        }
+
+        throw new IllegalArgumentException(
+            "Unsupported Android SQLite statement."
+        );
     }
 
     private File resolveDatabaseFile(String dbPath) throws Exception {

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -89,6 +89,9 @@ public class MainActivity extends Activity {
         60 * 60 * 1000L;
     private static final String PROJECT_FILE_WRITE_TEMP_PREFIX =
         ".routevn-project-write-";
+    private static final String APP_DATABASE_NAME = "app.db";
+    private static final String PROJECT_DATABASE_NAME = "project.db";
+    private static final String PROJECTS_DIRECTORY_NAME = "projects";
 
     private static final class ProjectFileWriteSession {
         private final String writeId;
@@ -1148,8 +1151,7 @@ public class MainActivity extends Activity {
             return cachedDatabase;
         }
 
-        File databasesRoot = new File(getFilesDir(), "databases");
-        File databaseFile = resolveSafeRelativeFile(databasesRoot, dbPath);
+        File databaseFile = resolveDatabaseFile(dbPath);
         File parentFile = databaseFile.getParentFile();
         if (parentFile != null && !parentFile.exists() && !parentFile.mkdirs()) {
             throw new IllegalStateException("Failed to create database directory.");
@@ -1165,6 +1167,30 @@ public class MainActivity extends Activity {
         }
         sqliteDatabases.put(dbPath, database);
         return database;
+    }
+
+    private File resolveDatabaseFile(String dbPath) throws Exception {
+        String normalizedPath = dbPath == null ? "" : dbPath;
+        if (APP_DATABASE_NAME.equals(normalizedPath)) {
+            return getDatabasePath(APP_DATABASE_NAME).getCanonicalFile();
+        }
+
+        String[] parts = normalizedPath.split("/", -1);
+        if (
+            parts.length == 3 &&
+            PROJECTS_DIRECTORY_NAME.equals(parts[0]) &&
+            PROJECT_DATABASE_NAME.equals(parts[2])
+        ) {
+            String projectId = safePathSegment(parts[1]);
+            if (!projectId.equals(parts[1])) {
+                throw new IllegalArgumentException(
+                    "Unsupported Android database path."
+                );
+            }
+            return getProjectDatabaseFile(projectId);
+        }
+
+        throw new IllegalArgumentException("Unsupported Android database path.");
     }
 
     private synchronized void closeDatabase(String dbPath) {
@@ -1967,7 +1993,6 @@ public class MainActivity extends Activity {
             if (!alreadyImported) {
                 closeDatabase(projectDbPath);
                 try {
-                    deleteRecursively(targetDbDirectory);
                     deleteRecursively(projectRoot);
 
                     copyFile(tempDbFile, targetDbFile);
@@ -2003,7 +2028,6 @@ public class MainActivity extends Activity {
                 } catch (Exception importError) {
                     try {
                         closeDatabase(projectDbPath);
-                        deleteRecursively(targetDbDirectory);
                         deleteRecursively(projectRoot);
                     } catch (Exception cleanupError) {
                         importError.addSuppressed(cleanupError);
@@ -2117,23 +2141,24 @@ public class MainActivity extends Activity {
     }
 
     private String getProjectDatabasePath(String projectId) {
-        return "projects/" + safePathSegment(projectId) + "/project.db";
+        return PROJECTS_DIRECTORY_NAME +
+            "/" +
+            safePathSegment(projectId) +
+            "/" +
+            PROJECT_DATABASE_NAME;
     }
 
     private File getProjectDatabaseFile(String projectId) throws Exception {
-        return resolveSafeRelativeFile(
-            new File(getFilesDir(), "databases"),
-            getProjectDatabasePath(projectId)
-        );
+        return new File(
+            getProjectRoot(projectId),
+            PROJECT_DATABASE_NAME
+        ).getCanonicalFile();
     }
 
     private JSONArray listProjectFolders() throws Exception {
         JSONArray projects = new JSONArray();
-        File projectDatabasesRoot = new File(
-            new File(getFilesDir(), "databases"),
-            "projects"
-        );
-        File[] projectDirectories = projectDatabasesRoot.listFiles();
+        File projectsRoot = new File(getFilesDir(), PROJECTS_DIRECTORY_NAME);
+        File[] projectDirectories = projectsRoot.listFiles();
         if (projectDirectories == null) {
             return projects;
         }
@@ -2150,8 +2175,11 @@ public class MainActivity extends Activity {
                 continue;
             }
 
-            File projectDbFile = new File(projectDirectory, "project.db");
-            File projectFilesRoot = new File(getProjectRoot(projectId), "files");
+            File projectDbFile = new File(
+                projectDirectory,
+                PROJECT_DATABASE_NAME
+            );
+            File projectFilesRoot = new File(projectDirectory, "files");
             if (!projectDbFile.isFile() || !projectFilesRoot.isDirectory()) {
                 continue;
             }
@@ -2198,7 +2226,7 @@ public class MainActivity extends Activity {
 
     private File getProjectRoot(String projectId) throws Exception {
         return resolveSafeRelativeFile(
-            new File(getFilesDir(), "projects"),
+            new File(getFilesDir(), PROJECTS_DIRECTORY_NAME),
             safePathSegment(projectId)
         );
     }
@@ -2317,14 +2345,38 @@ public class MainActivity extends Activity {
     private File resolveInternalStorageFileForPath(String normalizedPath)
         throws Exception {
         String[] parts = normalizeInternalStoragePath(normalizedPath).split("/");
-        if (isTypedProjectFilePath(parts)) {
+        if (
+            parts.length == 4 &&
+            PROJECTS_DIRECTORY_NAME.equals(parts[0]) &&
+            "files".equals(parts[2])
+        ) {
             String safeProjectId = safePathSegment(parts[1]);
-            String safeFileId = safePathSegment(parts[3]);
-            File projectRoot = getProjectRoot(safeProjectId);
-            return resolveSafeRelativeFile(new File(projectRoot, "files"), safeFileId);
+            return resolveSafeRelativeFile(
+                new File(getProjectRoot(safeProjectId), "files"),
+                safePathSegment(parts[3])
+            );
         }
 
-        return resolveSafeRelativeFile(getFilesDir(), normalizedPath);
+        if (isTypedProjectFilePath(parts)) {
+            String safeProjectId = safePathSegment(parts[1]);
+            return resolveSafeRelativeFile(
+                new File(getProjectRoot(safeProjectId), "files"),
+                safePathSegment(parts[3])
+            );
+        }
+
+        if (
+            parts.length == 4 &&
+            "picker".equals(parts[0]) &&
+            "files".equals(parts[2])
+        ) {
+            return resolveSafeRelativeFile(
+                new File(getPickerRoot(safePathSegment(parts[1])), "files"),
+                safePathSegment(parts[3])
+            );
+        }
+
+        throw new SecurityException("Unsupported Android internal file path.");
     }
 
     private boolean isTypedProjectFilePath(String[] parts) {

--- a/android/routevn/app/src/main/res/xml-v28/backup_rules.xml
+++ b/android/routevn/app/src/main/res/xml-v28/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include
+        domain="file"
+        path="projects/"
+        requireFlags="deviceToDeviceTransfer" />
+</full-backup-content>

--- a/android/routevn/app/src/main/res/xml/backup_rules.xml
+++ b/android/routevn/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
+    <exclude domain="root" path="." />
+    <exclude domain="file" path="." />
     <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="device_root" path="." />
+    <exclude domain="device_file" path="." />
+    <exclude domain="device_database" path="." />
+    <exclude domain="device_sharedpref" path="." />
 </full-backup-content>

--- a/android/routevn/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/routevn/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
         <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
     </cloud-backup>
     <device-transfer>
-        <exclude domain="database" path="." />
+        <include domain="file" path="projects/" />
     </device-transfer>
 </data-extraction-rules>

--- a/docs/android.md
+++ b/docs/android.md
@@ -88,8 +88,8 @@ This gives the local bundle an HTTPS origin while serving packaged app files.
 
 ### Android JS Watch Mode
 
-Debug Android builds load the local Android dev server instead of packaged
-assets:
+Debug Android builds use packaged assets by default, just like release builds.
+The local Android dev server is an explicit launch-time opt-in:
 
 ```text
 http://127.0.0.1:3001/android/index.html
@@ -109,8 +109,17 @@ bun run watch:android
 
 `watch:android` prepares `_site`, runs `adb reverse tcp:3001 tcp:3001` when a
 device is connected, and starts `rtgl fe watch` with `src/setup.android.js`.
-After that, JS, YAML view, store, handler, i18n, and setup changes are served
-from the dev server. Refresh or relaunch the app without reinstalling the APK.
+After the server is ready, launch the installed debug app with the explicit
+development extra:
+
+```bash
+adb shell am start -S -n com.routevn.creator/.MainActivity \
+  --ez routevnUseDevServer true
+```
+
+JS, YAML view, store, handler, i18n, and setup changes are then served from the
+dev server. A normal launcher start does not set this extra and uses packaged
+JavaScript instead.
 
 If multiple Android devices are connected, set `ANDROID_SERIAL` before running
 the watch command:
@@ -119,8 +128,7 @@ the watch command:
 ANDROID_SERIAL=<device-serial> bun run watch:android
 ```
 
-Release builds still load packaged assets through `WebViewAssetLoader`. Debug
-builds are dev-server shells by default.
+Release builds always load packaged assets through `WebViewAssetLoader`.
 
 ### Native Shell And Packaged Assets
 
@@ -130,8 +138,8 @@ Build Android web assets:
 bun run build:android
 ```
 
-Build the debug APK. Debug builds load the dev server and use these packaged
-assets only as fallback development artifacts:
+Build the debug APK. Debug builds use these packaged assets unless explicitly
+launched with the development intent extra described above:
 
 ```bash
 cd android/routevn
@@ -246,7 +254,8 @@ provided through AndroidX `addWebMessageListener` with a versioned asynchronous
 request protocol. The native listener accepts only main-frame messages from:
 
 - `https://appassets.androidplatform.net` in every build
-- `http://127.0.0.1:3001` additionally in debug builds
+- `http://127.0.0.1:3001` only when a debug build is explicitly launched with
+  `routevnUseDevServer=true`
 
 There is no wildcard-origin or compatibility fallback. A WebView without the
 origin-scoped message-listener feature fails closed instead of exposing a less
@@ -356,9 +365,9 @@ can miss Android-specific parser, layout, asset, and bridge behavior.
 - For packaged-asset validation, build a release bundle with `bun run
 android:bundle`. A native release build without rebuilding Android web assets
   can package stale JavaScript.
-- If a debug app shows a WebView network error on launch, start
-  `bun run watch:android` and confirm `adb reverse tcp:3001 tcp:3001` is active
-  for the device.
+- If an explicitly dev-server-launched app shows a WebView network error,
+  confirm `bun run watch:android` is running and
+  `adb reverse tcp:3001 tcp:3001` is active for the device.
 - Android builds must use the local `rtgl` dev dependency through
   `scripts/build.sh`, not a globally installed `rtgl` CLI. The local build
   preserves the repo's `rettangoli.config.yaml` options, including `i18n`.

--- a/docs/android.md
+++ b/docs/android.md
@@ -191,6 +191,35 @@ The native bridge in `MainActivity.java` handles:
 - download writes
 - Android document picker results
 
+## Private Storage Layout
+
+The global app database uses Android's standard database directory, while every
+project is one self-contained directory under the app-private files directory:
+
+```text
+databases/app.db
+
+files/projects/<projectId>/
+  project.db
+  project.db-wal
+  project.db-shm
+  files/<fileId>
+  file-metadata/<fileId>.mime
+```
+
+`databases/` and `files/` in this diagram are Android backup domains, not
+sibling directories returned by the same API. `app.db` is resolved with
+`getDatabasePath("app.db")`; project roots are resolved below `getFilesDir()`.
+
+The JavaScript SQLite path contract remains deliberately narrow:
+
+- `app.db` resolves only to the global app database.
+- `projects/<projectId>/project.db` resolves only to that project's database.
+- all other database paths are rejected by the native bridge.
+
+Project discovery requires both `project.db` and `files/`, so incomplete
+directories are not listed as valid projects.
+
 Project files are stored in app-private storage and served back through
 `/android-files/`. For media assets, Android returns typed URLs such as:
 
@@ -200,6 +229,32 @@ Project files are stored in app-private storage and served back through
 
 The typed filename lets Pixi choose the right image/video parser while the
 native handler maps the request back to the extensionless stored project file.
+The file handler accepts only project-asset and picker-file routes; database,
+WAL, metadata, staging, and unrelated private paths are not served.
+
+## Backup And Device Transfer
+
+`android:allowBackup` is enabled as the master switch, but RouteVN does not use
+Android Auto Backup for cloud project recovery. Projects commonly contain media
+and can exceed Auto Backup's 25 MB per-app cloud quota.
+
+The configured policy is:
+
+- cloud backup contains no current RouteVN app data
+- Android 12+ device-to-device transfer includes only the complete `projects/`
+  root
+- Android 9–11 includes `projects/` only when the backup transport declares a
+  device-to-device transfer
+- Android 7–8 backs up no RouteVN app data because those versions cannot apply
+  the device-to-device-only condition
+- the global `app.db`, including authentication tokens, is never backed up or
+  transferred
+- picker files, staging files, preferences, and other private files are not
+  backed up or transferred
+
+Manual project export remains the recovery mechanism until RouteVN provides a
+project-aware cloud backup or synchronization service. Android device transfer
+is a convenience and must not be presented as the user's only backup.
 
 ## Android Back
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -53,7 +53,7 @@ sdk.dir=/Users/<user>/Android/Sdk
 
 ## Endpoint Configuration
 
-`static/android/index.html` defines Android runtime endpoints through
+`static/public/android-env.js` defines Android runtime endpoints through
 `window.env`:
 
 - `ROUTEVN_API_ENDPOINT`
@@ -186,7 +186,8 @@ The native bridge in `MainActivity.java` handles:
 
 - route back-state updates and Android back dispatch
 - external URL opening
-- SQLite open/query/exec/close
+- named global app-database operations
+- project-only SQLite open/query/exec/close
 - project file read/write/metadata
 - download writes
 - Android document picker results
@@ -214,11 +215,14 @@ files/projects/<projectId>/
 sibling directories returned by the same API. `app.db` is resolved with
 `getDatabasePath("app.db")`; project roots are resolved below `getFilesDir()`.
 
-The JavaScript SQLite path contract remains deliberately narrow:
+The native database contract remains deliberately narrow:
 
-- `app.db` resolves only to the global app database.
-- `projects/<projectId>/project.db` resolves only to that project's database.
-- all other database paths are rejected by the native bridge.
+- the global `app.db` is accessed only through named key/value and event
+  operations
+- the raw SQLite bridge accepts only
+  `projects/<projectId>/project.db`, one statement per request, and the query,
+  schema, transaction, and write statement classes used by the project store
+- all other database paths and statement classes are rejected
 
 Project discovery requires both `project.db` and `files/`, so incomplete
 directories are not listed as valid projects.
@@ -235,6 +239,31 @@ native handler maps the request back to the extensionless stored project file.
 The file handler accepts only project-asset and picker-file routes; database,
 WAL, metadata, staging, and unrelated private paths are not served.
 
+## WebView Security Boundary
+
+The WebView does not use `addJavascriptInterface`. Native operations are
+provided through AndroidX `addWebMessageListener` with a versioned asynchronous
+request protocol. The native listener accepts only main-frame messages from:
+
+- `https://appassets.androidplatform.net` in every build
+- `http://127.0.0.1:3001` additionally in debug builds
+
+There is no wildcard-origin or compatibility fallback. A WebView without the
+origin-scoped message-listener feature fails closed instead of exposing a less
+safe bridge.
+
+The Android document uses a restrictive Content Security Policy: scripts must
+come from the document origin, frames and objects are disabled, and inline
+scripts are not permitted. Internal-file CORS responses name the one expected
+origin for the build. Direct `file://` and `content://` access, automatic
+JavaScript windows, and third-party cookies are disabled.
+
+Authentication and refresh tokens are removed from the serialized
+`userConfig` value before `app.db` is written. The opaque session JSON is
+encrypted with an AES-GCM key generated in Android Keystore; only ciphertext is
+stored in the excluded `auth-secrets` preferences file. The session is merged
+back into the in-memory config only when the app reads its named global state.
+
 ## Backup And Device Transfer
 
 `android:allowBackup` is enabled as the master switch, but RouteVN does not use
@@ -250,8 +279,8 @@ The configured policy is:
   device-to-device transfer
 - Android 7–8 backs up no RouteVN app data because those versions cannot apply
   the device-to-device-only condition
-- the global `app.db`, including authentication tokens, is never backed up or
-  transferred
+- the global `app.db` and Keystore-encrypted authentication secret are never
+  backed up or transferred
 - picker files, staging files, preferences, and other private files are not
   backed up or transferred
 
@@ -325,7 +354,7 @@ can miss Android-specific parser, layout, asset, and bridge behavior.
   changes should refresh from `http://127.0.0.1:3001/android/index.html`
   without reinstalling the APK.
 - For packaged-asset validation, build a release bundle with `bun run
-  android:bundle`. A native release build without rebuilding Android web assets
+android:bundle`. A native release build without rebuilding Android web assets
   can package stale JavaScript.
 - If a debug app shows a WebView network error on launch, start
   `bun run watch:android` and confirm `adb reverse tcp:3001 tcp:3001` is active
@@ -337,7 +366,7 @@ can miss Android-specific parser, layout, asset, and bridge behavior.
   blank screens were caused by frontend render errors such as missing i18n
   catalogs or Rettangoli parser failures, not native Activity failures.
 - The Android build log should show `Building frontend bundle with
-  src/setup.android.js` and include the configured `i18n` block. If it does not,
+src/setup.android.js` and include the configured `i18n` block. If it does not,
   the APK may not match the web bundle contract expected by the app.
 
 ### WebView Validation
@@ -454,6 +483,7 @@ same device, same project, and same navigation path. Otherwise it is easy to
   An unquoted value such as `h=${scrollBottomPadding}` can expand to
   `h=calc(96px + env(safe-area-inset-bottom))`, which the Rettangoli selector
   parser treats as invalid separate tokens.
+
 - A `style="height: ${scrollBottomPadding};"` spacer can collapse in some
   nested resource scroll layouts. The `h` attribute path matches established
   app spacer usage and produced a real measured `96px` spacer on Android.

--- a/docs/android.md
+++ b/docs/android.md
@@ -196,6 +196,9 @@ The native bridge in `MainActivity.java` handles:
 The global app database uses Android's standard database directory, while every
 project is one self-contained directory under the app-private files directory:
 
+This is RouteVN Creator's first supported Android storage layout. No released
+Android build used another storage root, so there is no upgrade migration.
+
 ```text
 databases/app.db
 

--- a/docs/platform/05-storage.md
+++ b/docs/platform/05-storage.md
@@ -46,6 +46,8 @@ event store.
 Storage location:
 
 - desktop: project-specific SQLite `project.db`
+- Android: app-private `files/projects/<projectId>/project.db`, beside the
+  project's `files/` asset directory
 - web: project-specific IndexedDB project DB
 
 Current app-owned keys:
@@ -130,7 +132,8 @@ For the complete contract, see
 `11-windows-player-runtime-persistence.md`.
 
 The global app DB separately owns app-level cached project listing data and the
-shared `userConfig` object.
+shared `userConfig` object. On Android it uses the platform-standard
+`getDatabasePath("app.db")` location and is not part of a project directory.
 
 For the agreed persisted key catalog across global app DB, project-specific DB
 `app` store, and non-persisted runtime-only values, see

--- a/src/deps/clients/android/bridge.js
+++ b/src/deps/clients/android/bridge.js
@@ -3,9 +3,16 @@ import {
   logAndroidBridgeTiming,
 } from "../../../internal/navigationTiming.js";
 
+const BRIDGE_PROTOCOL_VERSION = 1;
+const BRIDGE_RESPONSE_TIMEOUT_MS = 30 * 60 * 1000;
+
+let nextBridgeRequestId = 1;
+let configuredBridge;
+const pendingBridgeRequests = new Map();
+
 const getAndroidBridge = () => {
   const bridge = window.RouteVNAndroid;
-  if (!bridge) {
+  if (typeof bridge?.postMessage !== "function") {
     throw new Error("Android bridge is not available.");
   }
   return bridge;
@@ -23,39 +30,93 @@ const getBridgeResultSize = (value) => {
   return undefined;
 };
 
-export const callAndroidBridge = (method, payload = {}) => {
-  const startedAt = getNavigationTimingNow();
-  const bridge = getAndroidBridge();
-  const fn = bridge[method];
-  if (typeof fn !== "function") {
-    throw new Error(`Android bridge method is not available: ${method}`);
+const handleAndroidBridgeMessage = (event) => {
+  let response;
+  try {
+    response = JSON.parse(event.data);
+  } catch {
+    return;
   }
+
+  if (response?.version !== BRIDGE_PROTOCOL_VERSION) {
+    return;
+  }
+
+  const pending = pendingBridgeRequests.get(response.id);
+  if (!pending) {
+    return;
+  }
+
+  pendingBridgeRequests.delete(response.id);
+  clearTimeout(pending.timeoutId);
+
+  if (response.ok === true) {
+    pending.resolve(response.value);
+    return;
+  }
+
+  const error = new Error(
+    response.error?.message ?? `Android bridge call failed: ${pending.method}`,
+  );
+  error.code = response.error?.code;
+  pending.reject(error);
+};
+
+const ensureAndroidBridgeListener = () => {
+  const bridge = getAndroidBridge();
+  if (configuredBridge !== bridge) {
+    bridge.onmessage = handleAndroidBridgeMessage;
+    configuredBridge = bridge;
+  }
+  return bridge;
+};
+
+export const callAndroidBridge = async (method, payload = {}) => {
+  const startedAt = getNavigationTimingNow();
+  const bridge = ensureAndroidBridgeListener();
 
   let ok = false;
   let errorCode;
   let resultSize;
   try {
-    const rawResult = fn.call(bridge, JSON.stringify(payload));
-    let result;
-    try {
-      result = JSON.parse(rawResult);
-    } catch {
-      throw new Error(`Android bridge returned invalid JSON for ${method}.`);
-    }
+    const requestId = String(nextBridgeRequestId);
+    nextBridgeRequestId += 1;
 
-    ok = !!result?.ok;
-    if (!ok) {
-      const error = new Error(
-        result?.error?.message || `Android bridge call failed: ${method}`,
-      );
-      error.code = result?.error?.code;
-      error.details = result?.error?.details;
-      errorCode = error.code;
-      throw error;
-    }
+    const value = await new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        pendingBridgeRequests.delete(requestId);
+        reject(new Error(`Android bridge call timed out: ${method}`));
+      }, BRIDGE_RESPONSE_TIMEOUT_MS);
 
-    resultSize = getBridgeResultSize(result.value);
-    return result.value;
+      pendingBridgeRequests.set(requestId, {
+        method,
+        resolve,
+        reject,
+        timeoutId,
+      });
+
+      try {
+        bridge.postMessage(
+          JSON.stringify({
+            version: BRIDGE_PROTOCOL_VERSION,
+            id: requestId,
+            method,
+            payload,
+          }),
+        );
+      } catch (error) {
+        pendingBridgeRequests.delete(requestId);
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    });
+
+    ok = true;
+    resultSize = getBridgeResultSize(value);
+    return value;
+  } catch (error) {
+    errorCode = error?.code;
+    throw error;
   } finally {
     logAndroidBridgeTiming({
       method,

--- a/src/deps/clients/android/db.js
+++ b/src/deps/clients/android/db.js
@@ -1,4 +1,5 @@
 import { createAndroidSqliteConnection } from "./sqlite.js";
+import { callAndroidBridge } from "./bridge.js";
 
 const stripSqlitePrefix = (value) =>
   String(value || "").replace(/^sqlite:/, "");
@@ -19,7 +20,10 @@ const resolveDbPath = ({ path, projectPath }) => {
 
 export const createDb = ({ path, projectPath, withEvents = false }) => {
   const dbPath = resolveDbPath({ path, projectPath });
-  const db = createAndroidSqliteConnection({ dbPath });
+  const isAppDatabase = !projectPath && dbPath === "app.db";
+  const db = isAppDatabase
+    ? undefined
+    : createAndroidSqliteConnection({ dbPath });
   let initialized = false;
   let operationQueue = Promise.resolve();
 
@@ -38,6 +42,12 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
   const instance = {
     async init() {
       return queueDbOperation(async () => {
+        if (isAppDatabase) {
+          await callAndroidBridge("appDbInit", { withEvents });
+          initialized = true;
+          return;
+        }
+
         await db.init();
         await db.execute(`
           CREATE TABLE IF NOT EXISTS kv (
@@ -64,6 +74,13 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
     async get(key) {
       return queueDbOperation(async () => {
         ensureInitialized();
+        if (isAppDatabase) {
+          const valueJson = await callAndroidBridge("appDbGet", { key });
+          return valueJson === undefined || valueJson === null
+            ? null
+            : JSON.parse(valueJson);
+        }
+
         const rows = await db.select("SELECT value FROM kv WHERE key = ?", [
           key,
         ]);
@@ -83,6 +100,14 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
     async set(key, value) {
       return queueDbOperation(async () => {
         ensureInitialized();
+        if (isAppDatabase) {
+          await callAndroidBridge("appDbSet", {
+            key,
+            valueJson: JSON.stringify(value) ?? "null",
+          });
+          return;
+        }
+
         await db.execute(
           "INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)",
           [key, JSON.stringify(value)],
@@ -93,6 +118,11 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
     async remove(key) {
       return queueDbOperation(async () => {
         ensureInitialized();
+        if (isAppDatabase) {
+          await callAndroidBridge("appDbRemove", { key });
+          return;
+        }
+
         await db.execute("DELETE FROM kv WHERE key = ?", [key]);
       });
     },
@@ -102,6 +132,14 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
     instance.getEvents = async ({ since } = {}) => {
       return queueDbOperation(async () => {
         ensureInitialized();
+        if (isAppDatabase) {
+          const events = await callAndroidBridge("appDbGetEvents", { since });
+          return events.map((event) => ({
+            type: event.type,
+            payload: event.payloadJson ? JSON.parse(event.payloadJson) : null,
+          }));
+        }
+
         const rows =
           since === undefined
             ? await db.select(
@@ -121,6 +159,14 @@ export const createDb = ({ path, projectPath, withEvents = false }) => {
     instance.appendEvent = async (event) => {
       return queueDbOperation(async () => {
         ensureInitialized();
+        if (isAppDatabase) {
+          await callAndroidBridge("appDbAppendEvent", {
+            type: event.type,
+            payloadJson: JSON.stringify(event.payload) ?? "null",
+          });
+          return;
+        }
+
         await db.execute("INSERT INTO events (type, payload) VALUES (?, ?)", [
           event.type,
           JSON.stringify(event.payload),

--- a/src/deps/clients/android/filePicker.js
+++ b/src/deps/clients/android/filePicker.js
@@ -241,16 +241,16 @@ const requestNativeAndroidFilePicker = (options = {}) => {
   return new Promise((resolve, reject) => {
     pendingAndroidFilePickers.set(requestId, { resolve, reject });
 
-    try {
+    void Promise.resolve(
       callAndroidBridge("openFilePicker", {
         requestId,
         multiple: options.multiple ?? false,
         accept: resolveAccept(options),
-      });
-    } catch (error) {
+      }),
+    ).catch((error) => {
       pendingAndroidFilePickers.delete(requestId);
       reject(error);
-    }
+    });
   });
 };
 
@@ -265,16 +265,16 @@ const requestNativeAndroidFolderPicker = (options = {}) => {
   return new Promise((resolve, reject) => {
     pendingAndroidFolderPickers.set(requestId, { resolve, reject });
 
-    try {
+    void Promise.resolve(
       callAndroidBridge("openFolderPicker", {
         requestId,
         title: options.title || "Select Folder",
         writable: options.writable === true,
-      });
-    } catch (error) {
+      }),
+    ).catch((error) => {
       pendingAndroidFolderPickers.delete(requestId);
       reject(error);
-    }
+    });
   });
 };
 
@@ -289,16 +289,16 @@ const requestNativeAndroidSaveFilePicker = (options = {}) => {
   return new Promise((resolve, reject) => {
     pendingAndroidSaveFilePickers.set(requestId, { resolve, reject });
 
-    try {
+    void Promise.resolve(
       callAndroidBridge("openSaveFilePicker", {
         requestId,
         filename: resolveSaveFilename(options),
         mimeType: resolveSaveMimeType(options),
-      });
-    } catch (error) {
+      }),
+    ).catch((error) => {
       pendingAndroidSaveFilePickers.delete(requestId);
       reject(error);
-    }
+    });
   });
 };
 
@@ -323,7 +323,7 @@ const resolvePickerRequestId = (descriptor = {}) => {
   return match?.[1];
 };
 
-const cleanupNativePickedFiles = (descriptors = []) => {
+const cleanupNativePickedFiles = async (descriptors = []) => {
   const requestIds = new Set();
   for (const descriptor of descriptors) {
     const requestId = resolvePickerRequestId(descriptor);
@@ -334,7 +334,7 @@ const cleanupNativePickedFiles = (descriptors = []) => {
 
   for (const requestId of requestIds) {
     try {
-      callAndroidBridge("deletePickerRequest", { requestId });
+      await callAndroidBridge("deletePickerRequest", { requestId });
     } catch (error) {
       console.warn("[android.filePicker] Failed to clean picker files", {
         requestId,
@@ -351,7 +351,7 @@ const readNativePickedFiles = async (descriptors) => {
       files.push(await readNativePickedFile(descriptor));
     }
   } finally {
-    cleanupNativePickedFiles(descriptors);
+    await cleanupNativePickedFiles(descriptors);
   }
   return files;
 };

--- a/src/deps/clients/android/sqlite.js
+++ b/src/deps/clients/android/sqlite.js
@@ -86,7 +86,7 @@ export const createAndroidSqliteConnection = ({ dbPath }) => {
 
   return {
     async init() {
-      callAndroidBridge("sqliteOpen", { dbPath });
+      await callAndroidBridge("sqliteOpen", { dbPath });
     },
 
     async select(sql, args = []) {
@@ -94,7 +94,7 @@ export const createAndroidSqliteConnection = ({ dbPath }) => {
       let ok = false;
       let resultSize;
       try {
-        const rows = callAndroidBridge("sqliteQuery", {
+        const rows = await callAndroidBridge("sqliteQuery", {
           dbPath,
           sql,
           args: normalizeArgs(args),
@@ -124,7 +124,7 @@ export const createAndroidSqliteConnection = ({ dbPath }) => {
     },
 
     async close() {
-      callAndroidBridge("sqliteClose", { dbPath });
+      await callAndroidBridge("sqliteClose", { dbPath });
     },
   };
 };

--- a/src/deps/services/android/appService.js
+++ b/src/deps/services/android/appService.js
@@ -21,9 +21,9 @@ const normalizeFolderSelection = (selection) => {
   };
 };
 
-const listAndroidProjectFolders = () => {
+const listAndroidProjectFolders = async () => {
   try {
-    const projects = callAndroidBridge("listProjectFolders");
+    const projects = await callAndroidBridge("listProjectFolders");
     return Array.isArray(projects) ? projects : [];
   } catch {
     return undefined;
@@ -55,7 +55,7 @@ export const createAppService = (params) => {
   const appDb = params.db;
 
   const syncAndroidProjectEntriesFromStorage = async () => {
-    const discoveredProjects = listAndroidProjectFolders();
+    const discoveredProjects = await listAndroidProjectFolders();
     if (!discoveredProjects) {
       return;
     }
@@ -122,7 +122,7 @@ export const createAppService = (params) => {
         throw new Error("Project folder is required.");
       }
 
-      const importedProject = callAndroidBridge("importProjectFolder", {
+      const importedProject = await callAndroidBridge("importProjectFolder", {
         uri: folderSelection.uri,
       });
       const projectId = importedProject.id;

--- a/src/deps/services/android/projectService.js
+++ b/src/deps/services/android/projectService.js
@@ -42,16 +42,16 @@ const requestNativeAndroidProjectExport = ({ projectId, destinationUri }) => {
   return new Promise((resolve, reject) => {
     pendingAndroidProjectExports.set(requestId, { resolve, reject });
 
-    try {
+    void Promise.resolve(
       callAndroidBridge("exportProjectFolder", {
         requestId,
         projectId,
         destinationUri,
-      });
-    } catch (error) {
+      }),
+    ).catch((error) => {
       pendingAndroidProjectExports.delete(requestId);
       reject(error);
-    }
+    });
   });
 };
 

--- a/src/deps/services/android/projectServiceAdapters.js
+++ b/src/deps/services/android/projectServiceAdapters.js
@@ -280,16 +280,16 @@ const createLocalOnlyProjectCollabSession = ({
   };
 };
 
-const ensureAndroidProjectStorage = (projectId) => {
-  callAndroidBridge("ensureProjectStorage", {
+const ensureAndroidProjectStorage = async (projectId) => {
+  await callAndroidBridge("ensureProjectStorage", {
     projectId: assertSafeAndroidStorageSegment(projectId, {
       label: "Android project id",
     }),
   });
 };
 
-const assertUnusedAndroidProjectStorage = (projectId) => {
-  const status = callAndroidBridge("getProjectStorageStatus", {
+const assertUnusedAndroidProjectStorage = async (projectId) => {
+  const status = await callAndroidBridge("getProjectStorageStatus", {
     projectId: assertSafeAndroidStorageSegment(projectId, {
       label: "Android project id",
     }),
@@ -312,7 +312,7 @@ const writeAndroidProjectFile = async ({
   const safeProjectId = assertSafeAndroidStorageSegment(projectId, {
     label: "Android project id",
   });
-  const { writeId } = callAndroidBridge("beginProjectFileWrite", {
+  const { writeId } = await callAndroidBridge("beginProjectFileWrite", {
     projectId: safeProjectId,
     fileId,
     mimeType: resolveProjectFileMimeType({ mimeType, bytes }),
@@ -329,7 +329,7 @@ const writeAndroidProjectFile = async ({
         offset + PROJECT_FILE_WRITE_CHUNK_SIZE_BYTES,
         bytes.byteLength,
       );
-      const result = callAndroidBridge("appendProjectFileWrite", {
+      const result = await callAndroidBridge("appendProjectFileWrite", {
         writeId,
         offset,
         base64: uint8ArrayToBase64(bytes.subarray(offset, chunkEnd)),
@@ -346,7 +346,7 @@ const writeAndroidProjectFile = async ({
     return callAndroidBridge("finishProjectFileWrite", { writeId });
   } catch (error) {
     try {
-      callAndroidBridge("abortProjectFileWrite", { writeId });
+      await callAndroidBridge("abortProjectFileWrite", { writeId });
     } catch (abortError) {
       console.warn("Failed to abort Android project file write.", abortError);
     }
@@ -354,11 +354,11 @@ const writeAndroidProjectFile = async ({
   }
 };
 
-const readAndroidProjectFile = ({ projectId, fileId }) => {
+const readAndroidProjectFile = async ({ projectId, fileId }) => {
   const safeProjectId = assertSafeAndroidStorageSegment(projectId, {
     label: "Android project id",
   });
-  const result = callAndroidBridge("readProjectFile", {
+  const result = await callAndroidBridge("readProjectFile", {
     projectId: safeProjectId,
     fileId,
   });
@@ -368,12 +368,12 @@ const readAndroidProjectFile = ({ projectId, fileId }) => {
   };
 };
 
-const readAndroidProjectFileMetadata = ({ projectId, fileId }) => {
+const readAndroidProjectFileMetadata = async ({ projectId, fileId }) => {
   const safeProjectId = assertSafeAndroidStorageSegment(projectId, {
     label: "Android project id",
   });
   const safeFileId = assertSafeProjectFileId(fileId);
-  const result = callAndroidBridge("readProjectFileMetadata", {
+  const result = await callAndroidBridge("readProjectFileMetadata", {
     projectId: safeProjectId,
     fileId: safeFileId,
   });
@@ -422,14 +422,14 @@ const resolveKnownFileMetadata = (fileMetadata) => {
   };
 };
 
-const resolveAndroidProjectFileMetadata = ({
+const resolveAndroidProjectFileMetadata = async ({
   projectId,
   fileId,
   fileMetadata,
 }) => {
   return (
     resolveKnownFileMetadata(fileMetadata) ??
-    readAndroidProjectFileMetadata({ projectId, fileId })
+    (await readAndroidProjectFileMetadata({ projectId, fileId }))
   );
 };
 
@@ -491,7 +491,7 @@ const collectDistributionZipAssets = async ({
   for (const fileEntry of normalizeExportFileEntries(fileEntries)) {
     const safeFileId = assertSafeProjectFileId(fileEntry.id);
     try {
-      const { bytes, mimeType } = readAndroidProjectFile({
+      const { bytes, mimeType } = await readAndroidProjectFile({
         projectId,
         fileId: safeFileId,
       });
@@ -589,7 +589,7 @@ const createNativeDistributionZipStreamedToPath = async ({
     payload.webIconFileId = staticFiles.webIconFileId;
   }
 
-  const result = callAndroidBridge(
+  const result = await callAndroidBridge(
     "createDistributionZipStreamedToUri",
     payload,
   );
@@ -664,9 +664,9 @@ export const createAndroidProjectServiceAdapters = ({
         throw new Error("Template is required for project initialization");
       }
 
-      assertUnusedAndroidProjectStorage(safeProjectId);
+      await assertUnusedAndroidProjectStorage(safeProjectId);
 
-      ensureAndroidProjectStorage(safeProjectId);
+      await ensureAndroidProjectStorage(safeProjectId);
 
       const loadedTemplateData = await loadTemplate(template);
       const languageTemplateData = resolveTemplateFontsForLanguage({
@@ -740,7 +740,7 @@ export const createAndroidProjectServiceAdapters = ({
         bytes: fileBytes,
       });
 
-      ensureAndroidProjectStorage(resolvedProjectId);
+      await ensureAndroidProjectStorage(resolvedProjectId);
       await writeAndroidProjectFile({
         projectId: resolvedProjectId,
         fileId: safeFileId,
@@ -766,7 +766,7 @@ export const createAndroidProjectServiceAdapters = ({
       const reference = projectReference ?? getCurrentReference();
       const projectId = reference?.repositoryProjectId || reference?.projectId;
       for (const fileId of fileIds) {
-        callAndroidBridge("deleteProjectFile", {
+        await callAndroidBridge("deleteProjectFile", {
           projectId,
           fileId: assertSafeProjectFileId(fileId),
         });
@@ -777,7 +777,7 @@ export const createAndroidProjectServiceAdapters = ({
       const reference = getCurrentReference();
       const projectId = reference?.repositoryProjectId || reference?.projectId;
       const safeFileId = assertSafeProjectFileId(fileId);
-      const metadata = resolveAndroidProjectFileMetadata({
+      const metadata = await resolveAndroidProjectFileMetadata({
         projectId,
         fileId: safeFileId,
         fileMetadata,
@@ -807,7 +807,7 @@ export const createAndroidProjectServiceAdapters = ({
 
     getFileByProjectId: async ({ projectId, fileId }) => {
       const safeFileId = assertSafeProjectFileId(fileId);
-      const { bytes, mimeType } = readAndroidProjectFile({
+      const { bytes, mimeType } = await readAndroidProjectFile({
         projectId,
         fileId: safeFileId,
       });

--- a/src/internal/navigationTiming.js
+++ b/src/internal/navigationTiming.js
@@ -4,7 +4,11 @@ const ACTIVE_TRACE_TTL_MS = 2000;
 let nextTraceId = 0;
 let activeTraceId;
 let activeTraceClearTimer;
-let cachedAndroidDebugBuild;
+let cachedAndroidDebugBuild = false;
+
+export const setAndroidDebugBuild = (isDebugBuild) => {
+  cachedAndroidDebugBuild = isDebugBuild === true;
+};
 
 export const getNavigationTimingNow = () => {
   if (
@@ -20,23 +24,6 @@ export const getNavigationTimingNow = () => {
 const roundMs = (value) => Number(value.toFixed(2));
 
 const isAndroidDebugBuild = () => {
-  if (cachedAndroidDebugBuild !== undefined) {
-    return cachedAndroidDebugBuild;
-  }
-
-  const bridge =
-    typeof window !== "undefined" ? window.RouteVNAndroid : undefined;
-  if (typeof bridge?.isDebugBuild === "function") {
-    try {
-      cachedAndroidDebugBuild = bridge.isDebugBuild() === true;
-      return cachedAndroidDebugBuild;
-    } catch {
-      cachedAndroidDebugBuild = false;
-      return cachedAndroidDebugBuild;
-    }
-  }
-
-  cachedAndroidDebugBuild = false;
   return cachedAndroidDebugBuild;
 };
 

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -168,11 +168,12 @@ template:
           - rtgl-popover#sceneFormPopover ?open=${showSceneFormPopover} x=${sceneFormPosition.x} y=${sceneFormPosition.y}:
               - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=320: null
       - $if showSceneFormDialog:
-          - rtgl-dialog#sceneFormDialog ?open=${showSceneFormDialog} s=sm:
-              - rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=f: null
-      - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md:
-          - rtgl-view slot=content g=md:
-              - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} w=f: null
+          - rtgl-dialog#sceneFormDialog ?open=${showSceneFormDialog} s=md md-layout=fixed-top:
+              - rtgl-view slot=content d=v w=f h=f overflow=hidden:
+                  - rtgl-form#sceneForm key=${sceneFormKey} :defaultValues=${sceneFormData} :form=${sceneFormFields} sticky bottom-spacer=96 w=f h=f: null
+      - rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md md-layout=fixed-top:
+          - rtgl-view slot=content d=v w=f h=f overflow=hidden:
+              - rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} sticky bottom-spacer=96 w=f h=f: null
       - rtgl-dropdown-menu#dropdownMenu :items=${dropdownMenu.items} x=${dropdownMenu.position.x} y=${dropdownMenu.position.y} ?open=${dropdownMenu.isOpen}: null
       - rtgl-tooltip ?open=${deadEndTooltip.open} x=${deadEndTooltip.x} y=${deadEndTooltip.y} place="t" content="${deadEndTooltip.content}": null
       - $if showMobileScenesControls:

--- a/src/setup.android.js
+++ b/src/setup.android.js
@@ -1,6 +1,7 @@
 import { createGlobalUI } from "@rettangoli/ui";
 
 import { createDb } from "./deps/clients/android/db.js";
+import { callAndroidBridge } from "./deps/clients/android/bridge.js";
 import { createAndroidFilePicker } from "./deps/clients/android/filePicker.js";
 import AndroidRouter from "./deps/clients/android/router.js";
 import { createBrowserEventsClient } from "./deps/clients/browserEvents.js";
@@ -15,9 +16,18 @@ import Subject from "./deps/subject.js";
 import { createGraphicsService } from "./deps/services/graphicsService.js";
 import { deriveProjectFormatVersionFromAppVersion } from "./internal/projectCompatibility.js";
 import { registerPrimitives } from "./primitives/registerPrimitives.js";
+import { setAndroidDebugBuild } from "./internal/navigationTiming.js";
 import tauriConfig from "../src-tauri/tauri.conf.json";
 
 registerPrimitives();
+
+let isAndroidDebugBuild = false;
+try {
+  isAndroidDebugBuild = await callAndroidBridge("isDebugBuild");
+} catch {
+  // The bridge is absent in browser-only smoke checks.
+}
+setAndroidDebugBuild(isAndroidDebugBuild);
 
 const uiConfig = {
   id: "touch",
@@ -57,11 +67,11 @@ const subject = new Subject();
 let nativeBackInFlight = false;
 
 const notifyAndroidBackState = () => {
-  try {
-    window.RouteVNAndroid?.updateBackState?.(router.canGoBack());
-  } catch {
-    // Android bridge may not be present in browser-based smoke checks.
-  }
+  void callAndroidBridge("updateBackState", {
+    canGoBack: router.canGoBack(),
+  }).catch(() => {
+    // The bridge is absent in browser-only smoke checks.
+  });
 };
 
 router.setOnStackChange(notifyAndroidBackState);
@@ -117,12 +127,12 @@ const projectService = createProjectService({
 });
 
 const openUrl = async (url) => {
-  if (window.RouteVNAndroid?.openExternalUrl) {
-    window.RouteVNAndroid.openExternalUrl(url);
+  try {
+    await callAndroidBridge("openExternalUrl", { url });
     return;
+  } catch {
+    window.open(url, "_blank");
   }
-
-  window.open(url, "_blank");
 };
 
 const appService = createAppService({
@@ -177,14 +187,7 @@ const deps = {
 };
 
 const installAndroidDebugHooks = () => {
-  let isDebugBuild = false;
-  try {
-    isDebugBuild = window.RouteVNAndroid?.isDebugBuild?.() === true;
-  } catch {
-    isDebugBuild = false;
-  }
-
-  if (!isDebugBuild) {
+  if (!isAndroidDebugBuild) {
     return;
   }
 
@@ -208,5 +211,6 @@ const installAndroidDebugHooks = () => {
 
 installAndroidDebugHooks();
 notifyAndroidBackState();
+void callAndroidBridge("markSplashReady").catch(() => {});
 
 export { deps };

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -2,13 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Route Graphics 1.43 embeds Pixi and requires unsafe-eval. Script
+         sources remain restricted to this packaged app origin. -->
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no"
     />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' https: data: blob:; font-src 'self' data:; connect-src 'self' https: ws://127.0.0.1:3001; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' https: data: blob:; font-src 'self' data:; connect-src 'self' https: ws://127.0.0.1:3001; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'"
     />
     <title>RouteVN Creator</title>
     <script src="/public/android-env.js"></script>

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -6,25 +6,16 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' https: data: blob:; font-src 'self' data:; connect-src 'self' https: ws://127.0.0.1:3001; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'"
+    />
     <title>RouteVN Creator</title>
-    <script>
-      window.env = {
-        ROUTEVN_API_ENDPOINT: "https://api.example.invalid",
-      };
-    </script>
+    <script src="/public/android-env.js"></script>
     <link rel="stylesheet" href="/public/theme.css" />
     <script src="/public/rtgl-icons.js"></script>
     <script src="/public/@rettangoli/ui@1.21.1/dist/rettangoli-iife-ui.min.js"></script>
     <script type="module" src="/public/main.js"></script>
-    <script>
-      window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            window.RouteVNAndroid?.markSplashReady?.();
-          });
-        });
-      });
-    </script>
   </head>
   <body class="dark">
     <rvn-app></rvn-app>

--- a/static/android/index.html
+++ b/static/android/index.html
@@ -10,7 +10,7 @@
     />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' https: data: blob:; font-src 'self' data:; connect-src 'self' https: ws://127.0.0.1:3001; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' https: data: blob:; font-src 'self' data: blob: https://appassets.androidplatform.net; connect-src 'self' https: ws://127.0.0.1:3001; worker-src 'self' blob:; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'self'"
     />
     <title>RouteVN Creator</title>
     <script src="/public/android-env.js"></script>

--- a/static/public/android-env.js
+++ b/static/public/android-env.js
@@ -1,0 +1,3 @@
+window.env = {
+  ROUTEVN_API_ENDPOINT: "https://api.example.invalid",
+};

--- a/tests/android/backupRules.test.js
+++ b/tests/android/backupRules.test.js
@@ -1,0 +1,84 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path) =>
+  readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+
+const normalizeXml = (xml) => xml.replace(/\s+/g, " ").trim();
+
+const readXmlSection = (xml, tagName) => {
+  const match = normalizeXml(xml).match(
+    new RegExp(`<${tagName}(?: [^>]*)?>(.*?)</${tagName}>`),
+  );
+  return match?.[1]?.trim() ?? "";
+};
+
+const ALL_BACKUP_DOMAINS = [
+  "root",
+  "file",
+  "database",
+  "sharedpref",
+  "external",
+  "device_root",
+  "device_file",
+  "device_database",
+  "device_sharedpref",
+];
+
+describe("Android backup policy", () => {
+  it("enables controlled Android backup configuration", async () => {
+    const manifest = await readRepoFile(
+      "android/routevn/app/src/main/AndroidManifest.xml",
+    );
+
+    expect(manifest).toContain('android:allowBackup="true"');
+    expect(manifest).toContain(
+      'android:dataExtractionRules="@xml/data_extraction_rules"',
+    );
+    expect(manifest).toContain(
+      'android:fullBackupContent="@xml/backup_rules"',
+    );
+  });
+
+  it("excludes all cloud data and transfers only complete project roots on Android 12+", async () => {
+    const rules = await readRepoFile(
+      "android/routevn/app/src/main/res/xml/data_extraction_rules.xml",
+    );
+    const cloudRules = readXmlSection(rules, "cloud-backup");
+    const transferRules = readXmlSection(rules, "device-transfer");
+
+    for (const domain of ALL_BACKUP_DOMAINS) {
+      expect(cloudRules).toContain(
+        `<exclude domain="${domain}" path="." />`,
+      );
+    }
+    expect(cloudRules).not.toContain("<include");
+    expect(transferRules).toBe(
+      '<include domain="file" path="projects/" />',
+    );
+  });
+
+  it("uses D2D-only project transfer on Android 9-11 and no backup on older devices", async () => {
+    const legacyRules = await readRepoFile(
+      "android/routevn/app/src/main/res/xml/backup_rules.xml",
+    );
+    const d2dRules = normalizeXml(
+      await readRepoFile(
+        "android/routevn/app/src/main/res/xml-v28/backup_rules.xml",
+      ),
+    );
+
+    for (const domain of ALL_BACKUP_DOMAINS) {
+      expect(legacyRules).toContain(
+        `<exclude domain="${domain}" path="." />`,
+      );
+    }
+    expect(legacyRules).not.toContain("<include");
+    expect(d2dRules).toContain('domain="file"');
+    expect(d2dRules).toContain('path="projects/"');
+    expect(d2dRules).toContain(
+      'requireFlags="deviceToDeviceTransfer"',
+    );
+  });
+});

--- a/tests/android/bridge.test.js
+++ b/tests/android/bridge.test.js
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { callAndroidBridge } from "../../src/deps/clients/android/bridge.js";
+
+const originalWindow = globalThis.window;
+
+const installBridge = (respond) => {
+  const bridge = {
+    postMessage: vi.fn((messageData) => {
+      const request = JSON.parse(messageData);
+      queueMicrotask(() => {
+        bridge.onmessage({
+          data: JSON.stringify(respond(request)),
+        });
+      });
+    }),
+  };
+  globalThis.window = { RouteVNAndroid: bridge };
+  return bridge;
+};
+
+afterEach(() => {
+  globalThis.window = originalWindow;
+  vi.restoreAllMocks();
+});
+
+describe("Android WebMessage bridge client", () => {
+  it("uses the versioned asynchronous request and response protocol", async () => {
+    const bridge = installBridge((request) => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      value: { stored: true },
+    }));
+
+    await expect(
+      callAndroidBridge("ensureProjectStorage", { projectId: "project-1" }),
+    ).resolves.toEqual({ stored: true });
+
+    const request = JSON.parse(bridge.postMessage.mock.calls[0][0]);
+    expect(request).toMatchObject({
+      version: 1,
+      method: "ensureProjectStorage",
+      payload: { projectId: "project-1" },
+    });
+    expect(request.id).toEqual(expect.any(String));
+  });
+
+  it("rejects native errors without exposing a synchronous method surface", async () => {
+    const bridge = installBridge((request) => ({
+      version: 1,
+      id: request.id,
+      ok: false,
+      error: {
+        code: "IllegalArgumentException",
+        message: "Unsupported Android bridge method.",
+      },
+    }));
+
+    const error = await callAndroidBridge("notAllowed").catch(
+      (caughtError) => caughtError,
+    );
+
+    expect(error.message).toBe("Unsupported Android bridge method.");
+    expect(error.code).toBe("IllegalArgumentException");
+    expect(Object.keys(bridge)).toEqual(["postMessage", "onmessage"]);
+  });
+});

--- a/tests/android/db.test.js
+++ b/tests/android/db.test.js
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  callAndroidBridge: vi.fn(),
+}));
+
+vi.mock("../../src/deps/clients/android/bridge.js", async () => {
+  const actual = await vi.importActual(
+    "../../src/deps/clients/android/bridge.js",
+  );
+  return {
+    ...actual,
+    callAndroidBridge: mocked.callAndroidBridge,
+  };
+});
+
+import { createDb } from "../../src/deps/clients/android/db.js";
+
+describe("Android global app database", () => {
+  beforeEach(() => {
+    mocked.callAndroidBridge.mockReset();
+  });
+
+  it("uses named app-state operations instead of the raw SQLite bridge", async () => {
+    mocked.callAndroidBridge.mockImplementation(async (method) => {
+      if (method === "appDbGet") {
+        return JSON.stringify({ name: "Project One" });
+      }
+      return true;
+    });
+    const db = createDb({ path: "app.db" });
+
+    await db.init();
+    await expect(db.get("currentProject")).resolves.toEqual({
+      name: "Project One",
+    });
+    await db.set("currentProject", { name: "Project One" });
+    await db.remove("currentProject");
+
+    expect(mocked.callAndroidBridge.mock.calls).toEqual([
+      ["appDbInit", { withEvents: false }],
+      ["appDbGet", { key: "currentProject" }],
+      [
+        "appDbSet",
+        {
+          key: "currentProject",
+          valueJson: '{"name":"Project One"}',
+        },
+      ],
+      ["appDbRemove", { key: "currentProject" }],
+    ]);
+    expect(
+      mocked.callAndroidBridge.mock.calls.some(([method]) =>
+        method.startsWith("sqlite"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/android/securityBoundary.test.js
+++ b/tests/android/securityBoundary.test.js
@@ -15,13 +15,17 @@ describe("Android WebView security boundary", () => {
     expect(activity).toContain("if (!isMainFrame || !isAllowedBridgeOrigin");
     expect(activity).toContain("allowedOriginRules.add(APP_ORIGIN)");
     expect(activity).toContain("allowedOriginRules.add(DEV_SERVER_ORIGIN)");
+    expect(activity).toContain("shouldUseDebugDevServer()");
+    expect(activity).toContain(
+      "getIntent().getBooleanExtra(DEV_SERVER_INTENT_EXTRA, false)",
+    );
     expect(activity).not.toContain("addJavascriptInterface(");
     expect(activity).not.toContain("@JavascriptInterface");
     expect(activity).not.toContain('allowedOriginRules.add("*")');
     expect(activity).toContain("isTrustedAppDocumentUrl(uri)");
-    expect(activity.match(/openExternalUri\(uri\);\s+return true;/g)).toHaveLength(
-      2,
-    );
+    expect(
+      activity.match(/openExternalUri\(uri\);\s+return true;/g),
+    ).toHaveLength(2);
     expect(activity).toContain(
       'headers.put("Content-Security-Policy", "default-src \'none\'; sandbox")',
     );
@@ -40,7 +44,7 @@ describe("Android WebView security boundary", () => {
       'headers.put("Access-Control-Allow-Origin", "*")',
     );
     expect(activity).toContain(
-      "BuildConfig.DEBUG ? DEV_SERVER_ORIGIN : APP_ORIGIN",
+      "shouldUseDebugDevServer() ? DEV_SERVER_ORIGIN : APP_ORIGIN",
     );
   });
 
@@ -55,6 +59,9 @@ describe("Android WebView security boundary", () => {
     );
     expect(activity).toContain("validateBridgeQuerySql(sql)");
     expect(activity).toContain("validateBridgeExecuteSql(sql)");
+    expect(activity.match(/PRAGMA\\\\s\+JOURNAL_MODE/g)).toHaveLength(2);
+    expect(activity.match(/PRAGMA\\\\s\+SYNCHRONOUS/g)).toHaveLength(2);
+    expect(activity.match(/PRAGMA\\\\s\+BUSY_TIMEOUT/g)).toHaveLength(2);
     expect(activity).toContain('KeyStore.getInstance("AndroidKeyStore")');
     expect(activity).toContain('Cipher.getInstance("AES/GCM/NoPadding")');
     expect(activity).toContain("auth.remove(AUTH_SESSION_CONFIG_KEY)");

--- a/tests/android/securityBoundary.test.js
+++ b/tests/android/securityBoundary.test.js
@@ -1,0 +1,73 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path) =>
+  readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+
+describe("Android WebView security boundary", () => {
+  it("exposes native messaging only to exact trusted main-frame origins", async () => {
+    const activity = await readRepoFile(
+      "android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java",
+    );
+
+    expect(activity).toContain("WebViewCompat.addWebMessageListener(");
+    expect(activity).toContain("if (!isMainFrame || !isAllowedBridgeOrigin");
+    expect(activity).toContain("allowedOriginRules.add(APP_ORIGIN)");
+    expect(activity).toContain("allowedOriginRules.add(DEV_SERVER_ORIGIN)");
+    expect(activity).not.toContain("addJavascriptInterface(");
+    expect(activity).not.toContain("@JavascriptInterface");
+    expect(activity).not.toContain('allowedOriginRules.add("*")');
+    expect(activity).toContain("isTrustedAppDocumentUrl(uri)");
+    expect(activity.match(/openExternalUri\(uri\);\s+return true;/g)).toHaveLength(
+      2,
+    );
+    expect(activity).toContain(
+      'headers.put("Content-Security-Policy", "default-src \'none\'; sandbox")',
+    );
+  });
+
+  it("keeps CORS and cookies scoped to the app", async () => {
+    const activity = await readRepoFile(
+      "android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java",
+    );
+
+    expect(activity).toContain(
+      "cookieManager.setAcceptThirdPartyCookies(webView, false)",
+    );
+    expect(activity).toContain("settings.setAllowContentAccess(false)");
+    expect(activity).not.toContain(
+      'headers.put("Access-Control-Allow-Origin", "*")',
+    );
+    expect(activity).toContain(
+      "BuildConfig.DEBUG ? DEV_SERVER_ORIGIN : APP_ORIGIN",
+    );
+  });
+
+  it("limits raw SQLite to project databases and stores auth secrets with Android Keystore", async () => {
+    const activity = await readRepoFile(
+      "android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java",
+    );
+    const androidDb = await readRepoFile("src/deps/clients/android/db.js");
+
+    expect(activity).toContain(
+      '"The SQLite bridge only supports project databases."',
+    );
+    expect(activity).toContain("validateBridgeQuerySql(sql)");
+    expect(activity).toContain("validateBridgeExecuteSql(sql)");
+    expect(activity).toContain('KeyStore.getInstance("AndroidKeyStore")');
+    expect(activity).toContain('Cipher.getInstance("AES/GCM/NoPadding")');
+    expect(activity).toContain("auth.remove(AUTH_SESSION_CONFIG_KEY)");
+    expect(androidDb).toContain('callAndroidBridge("appDbSet"');
+  });
+
+  it("uses a restrictive Android document policy without inline scripts or frames", async () => {
+    const html = await readRepoFile("static/android/index.html");
+
+    expect(html).toContain("script-src 'self' 'wasm-unsafe-eval'");
+    expect(html).toContain("frame-src 'none'");
+    expect(html).toContain("object-src 'none'");
+    expect(html).toContain('src="/public/android-env.js"');
+    expect(html).not.toMatch(/<script(?:\s[^>]*)?>\s*[^<\s]/);
+  });
+});

--- a/tests/android/securityBoundary.test.js
+++ b/tests/android/securityBoundary.test.js
@@ -74,6 +74,9 @@ describe("Android WebView security boundary", () => {
     expect(html).toContain(
       "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'",
     );
+    expect(html).toContain(
+      "font-src 'self' data: blob: https://appassets.androidplatform.net",
+    );
     expect(html).toContain("frame-src 'none'");
     expect(html).toContain("object-src 'none'");
     expect(html).toContain('src="/public/android-env.js"');

--- a/tests/android/securityBoundary.test.js
+++ b/tests/android/securityBoundary.test.js
@@ -68,10 +68,12 @@ describe("Android WebView security boundary", () => {
     expect(androidDb).toContain('callAndroidBridge("appDbSet"');
   });
 
-  it("uses a restrictive Android document policy without inline scripts or frames", async () => {
+  it("keeps Android scripts same-origin while allowing the embedded Pixi renderer", async () => {
     const html = await readRepoFile("static/android/index.html");
 
-    expect(html).toContain("script-src 'self' 'wasm-unsafe-eval'");
+    expect(html).toContain(
+      "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'",
+    );
     expect(html).toContain("frame-src 'none'");
     expect(html).toContain("object-src 'none'");
     expect(html).toContain('src="/public/android-env.js"');

--- a/tests/scenes/scenes.view.test.js
+++ b/tests/scenes/scenes.view.test.js
@@ -41,7 +41,7 @@ describe("scenes view", () => {
     );
   });
 
-  it("uses a popover for desktop scene creation and a dialog form for mobile", () => {
+  it("uses a popover for desktop scene creation", () => {
     const scenesView = readFileSync(
       new URL("../../src/pages/scenes/scenes.view.yaml", import.meta.url),
       "utf8",
@@ -50,11 +50,28 @@ describe("scenes view", () => {
     expect(scenesView).toContain(
       "rtgl-popover#sceneFormPopover ?open=${showSceneFormPopover} x=${sceneFormPosition.x} y=${sceneFormPosition.y}",
     );
+  });
+
+  it("uses image-style mobile dialogs with sticky scene form actions", () => {
+    const scenesView = readFileSync(
+      new URL("../../src/pages/scenes/scenes.view.yaml", import.meta.url),
+      "utf8",
+    );
+
     expect(scenesView).toContain(
-      "rtgl-dialog#sceneFormDialog ?open=${showSceneFormDialog} s=sm",
+      "rtgl-dialog#sceneFormDialog ?open=${showSceneFormDialog} s=md md-layout=fixed-top:",
     );
     expect(scenesView).toContain(
-      "rtgl-form#sceneForm key=${sceneFormKey} slot=content :defaultValues=${sceneFormData} :form=${sceneFormFields} w=f",
+      "rtgl-dialog#editDialog ?open=${isEditDialogOpen} s=md md-layout=fixed-top:",
+    );
+    expect(
+      scenesView.match(/slot=content d=v w=f h=f overflow=hidden:/g),
+    ).toHaveLength(2);
+    expect(scenesView).toContain(
+      "rtgl-form#sceneForm key=${sceneFormKey} :defaultValues=${sceneFormData} :form=${sceneFormFields} sticky bottom-spacer=96 w=f h=f:",
+    );
+    expect(scenesView).toContain(
+      "rtgl-form#editForm key=${isEditDialogOpen} :defaultValues=${editDefaultValues} :form=${editForm} sticky bottom-spacer=96 w=f h=f:",
     );
   });
 


### PR DESCRIPTION
## Summary
- use one app-private directory per Android project and the standard Android location for the global app database
- enable controlled backup with no cloud payload and project-only device-to-device transfer
- replace `addJavascriptInterface` with an asynchronous, main-frame, exact-origin AndroidX WebMessage bridge
- expose the global app database through named operations and limit raw SQL to approved project database paths and statement classes
- encrypt authentication and refresh tokens at rest with an Android Keystore AES-GCM key
- harden Android navigation, internal-file CORS and CSP, content access, and third-party-cookie policy
- make packaged local JavaScript the default for debug and release builds; keep the debug web server as an explicit intent opt-in
- allow only the project-store PRAGMAs required through both native SQLite dispatch paths
- align mobile scene add/edit dialogs with the image edit form layout
- document the permanent Android storage, backup, and WebView security contracts

## Validation
- `bunx vitest run tests/android` (27 tests passed)
- `bun run test`
- `bun run test:smoke`
- `bun run lint`
- `./gradlew :app:compileDebugJavaWithJavac`
- `./gradlew :app:compileReleaseJavaWithJavac`
- `./gradlew :app:assembleDebug`
- installed and launched on Vivo V2309A
- device log confirmed `https://appassets.androidplatform.net/web/index.html` and no unsupported SQLite-query error after the PRAGMA fix
- `git diff --check`
- push hook: oxlint and Prettier passed

## Notes
- Android device-to-device restore still needs validation on a real Android 12+ transfer.
- The temporary Android audit roadmap remains intentionally excluded from this PR.
- The repository-wide contract checker currently reports its existing baseline of 502 registry and attribute diagnostics across 117 components, including the established image-dialog form sizing pattern used here.