### PR TITLE
Fix Android project imports to use fresh identities

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -2705,10 +2705,7 @@ public class MainActivity extends Activity {
         );
 
         File importRoot = new File(getCacheDir(), "project-import");
-        File importWorkDir = new File(
-            importRoot,
-            UUID.randomUUID().toString()
-        );
+        File importWorkDir = new File(importRoot, projectId);
         deleteRecursively(importWorkDir);
 
         try {
@@ -3911,10 +3908,6 @@ public class MainActivity extends Activity {
                         "id = ?",
                         new String[] { sourceCreateEventId }
                     );
-                }
-
-                if (hasTable(database, "materialized_view_state")) {
-                    database.delete("materialized_view_state", null, null);
                 }
 
                 database.setTransactionSuccessful();

--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -1417,7 +1417,8 @@ public class MainActivity extends Activity {
             try {
                 JSONObject payload = new JSONObject(payloadJson);
                 JSONObject result = importProjectFolderFromTreeUri(
-                    payload.getString("uri")
+                    payload.getString("uri"),
+                    payload.getString("projectId")
                 );
                 return bridgeSuccess(result);
             } catch (Exception error) {
@@ -2669,11 +2670,21 @@ public class MainActivity extends Activity {
         }
     }
 
-    private JSONObject importProjectFolderFromTreeUri(String uriString)
+    private JSONObject importProjectFolderFromTreeUri(
+        String uriString,
+        String requestedProjectId
+    )
         throws Exception {
         String normalizedUri = uriString == null ? "" : uriString.trim();
         if (normalizedUri.isEmpty()) {
             throw new IllegalArgumentException("Project folder is required.");
+        }
+        String projectId = safePathSegment(requestedProjectId);
+        File projectRoot = getProjectRoot(projectId);
+        if (projectRoot.exists()) {
+            throw new IllegalArgumentException(
+                "Generated Android project storage already exists."
+            );
         }
 
         Uri treeUri = Uri.parse(normalizedUri);
@@ -2696,7 +2707,7 @@ public class MainActivity extends Activity {
         File importRoot = new File(getCacheDir(), "project-import");
         File importWorkDir = new File(
             importRoot,
-            String.valueOf(System.currentTimeMillis())
+            UUID.randomUUID().toString()
         );
         deleteRecursively(importWorkDir);
 
@@ -2717,59 +2728,21 @@ public class MainActivity extends Activity {
             }
 
             JSONObject projectInfo = readProjectInfoFromDatabaseFile(tempDbFile);
-            String projectId = safePathSegment(projectInfo.optString("id", ""));
-            String projectDbPath = getProjectDatabasePath(projectId);
-            File targetDbFile = getProjectDatabaseFile(projectId);
-            File targetDbDirectory = targetDbFile.getParentFile();
-            File projectRoot = getProjectRoot(projectId);
-            File targetFilesRoot = new File(projectRoot, "files");
-            File targetMetadataRoot = new File(projectRoot, "file-metadata");
-            boolean alreadyImported = targetDbFile.isFile() && targetFilesRoot.isDirectory();
+            String sourceProjectId = safePathSegment(
+                projectInfo.optString("id", "")
+            );
+            rewriteImportedProjectIdentity(
+                tempDbFile,
+                sourceProjectId,
+                projectId
+            );
+            projectInfo.put("id", projectId);
 
-            if (!alreadyImported) {
-                closeDatabase(projectDbPath);
-                try {
-                    deleteRecursively(projectRoot);
-
-                    copyFile(tempDbFile, targetDbFile);
-                    File tempWalFile = new File(importWorkDir, "project.db-wal");
-                    if (tempWalFile.isFile()) {
-                        copyFile(
-                            tempWalFile,
-                            new File(targetDbDirectory, "project.db-wal")
-                        );
-                    }
-                    File tempShmFile = new File(importWorkDir, "project.db-shm");
-                    if (tempShmFile.isFile()) {
-                        copyFile(
-                            tempShmFile,
-                            new File(targetDbDirectory, "project.db-shm")
-                        );
-                    }
-                    File tempJournalFile = new File(
-                        importWorkDir,
-                        "project.db-journal"
-                    );
-                    if (tempJournalFile.isFile()) {
-                        copyFile(
-                            tempJournalFile,
-                            new File(targetDbDirectory, "project.db-journal")
-                        );
-                    }
-
-                    copyDocumentDirectoryContents(filesUri, targetFilesRoot);
-                    if (metadataUri != null) {
-                        copyDocumentDirectoryContents(metadataUri, targetMetadataRoot);
-                    }
-                } catch (Exception importError) {
-                    try {
-                        closeDatabase(projectDbPath);
-                        deleteRecursively(projectRoot);
-                    } catch (Exception cleanupError) {
-                        importError.addSuppressed(cleanupError);
-                    }
-                    throw importError;
-                }
+            File stagedFilesRoot = new File(importWorkDir, "files");
+            File stagedMetadataRoot = new File(importWorkDir, "file-metadata");
+            copyDocumentDirectoryContents(filesUri, stagedFilesRoot);
+            if (metadataUri != null) {
+                copyDocumentDirectoryContents(metadataUri, stagedMetadataRoot);
             }
 
             JSONObject result = new JSONObject();
@@ -2787,11 +2760,32 @@ public class MainActivity extends Activity {
                 "sourceName",
                 resolveDocumentDisplayName(rootDocumentUri, "Selected Folder")
             );
-            result.put("alreadyImported", alreadyImported);
+
+            promoteImportedProject(importWorkDir, projectRoot);
             return result;
         } finally {
             deleteRecursively(importWorkDir);
         }
+    }
+
+    private void promoteImportedProject(File stagedRoot, File projectRoot)
+        throws Exception {
+        File projectsRoot = projectRoot.getParentFile();
+        if (
+            projectsRoot == null ||
+            (!projectsRoot.exists() && !projectsRoot.mkdirs())
+        ) {
+            throw new IllegalStateException(
+                "Failed to create Android projects directory."
+            );
+        }
+        if (projectRoot.exists()) {
+            throw new IllegalArgumentException(
+                "Generated Android project storage already exists."
+            );
+        }
+
+        Os.rename(stagedRoot.getAbsolutePath(), projectRoot.getAbsolutePath());
     }
 
     private JSONObject exportProjectFolderToTreeUri(
@@ -3809,6 +3803,189 @@ public class MainActivity extends Activity {
             return projectInfo;
         } finally {
             database.close();
+        }
+    }
+
+    private void rewriteImportedProjectIdentity(
+        File databaseFile,
+        String sourceProjectId,
+        String targetProjectId
+    ) throws Exception {
+        if (sourceProjectId.equals(targetProjectId)) {
+            throw new IllegalArgumentException(
+                "Imported project must use a new project id."
+            );
+        }
+
+        SQLiteDatabase database = SQLiteDatabase.openDatabase(
+            databaseFile.getAbsolutePath(),
+            null,
+            SQLiteDatabase.OPEN_READWRITE
+        );
+
+        try {
+            assertDatabaseIntegrity(database);
+            if (!hasTable(database, "app_state")) {
+                throw new IllegalArgumentException(
+                    "Selected project uses an unsupported database format."
+                );
+            }
+
+            String rawProjectInfo = readKeyValueTableValue(
+                database,
+                "app_state",
+                "projectInfo"
+            );
+            if (rawProjectInfo == null || rawProjectInfo.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Selected project is missing project information."
+                );
+            }
+            JSONObject projectInfo = new JSONObject(rawProjectInfo);
+            String storedProjectId = safePathSegment(
+                projectInfo.optString("id", "")
+            );
+            if (!sourceProjectId.equals(storedProjectId)) {
+                throw new IllegalArgumentException(
+                    "Selected project identity does not match."
+                );
+            }
+
+            assertCommittedProjectIdentity(database, sourceProjectId);
+
+            database.beginTransaction();
+            try {
+                projectInfo.put("id", targetProjectId);
+                ContentValues projectInfoValues = new ContentValues();
+                projectInfoValues.put("value", projectInfo.toString());
+                int updatedProjectInfo = database.update(
+                    "app_state",
+                    projectInfoValues,
+                    "key = ?",
+                    new String[] { "projectInfo" }
+                );
+                if (updatedProjectInfo != 1) {
+                    throw new IllegalArgumentException(
+                        "Selected project is missing project information."
+                    );
+                }
+                database.delete(
+                    "app_state",
+                    "key = ?",
+                    new String[] {
+                        "collab.lastCommittedId:" + sourceProjectId,
+                    }
+                );
+
+                String sourceCreateEventId =
+                    "project-create:" + sourceProjectId;
+                String targetCreateEventId =
+                    "project-create:" + targetProjectId;
+
+                if (hasTable(database, "committed_events")) {
+                    ContentValues committedIdentity = new ContentValues();
+                    committedIdentity.put("project_id", targetProjectId);
+                    database.update(
+                        "committed_events",
+                        committedIdentity,
+                        null,
+                        null
+                    );
+
+                    ContentValues committedCreateId = new ContentValues();
+                    committedCreateId.put("id", targetCreateEventId);
+                    database.update(
+                        "committed_events",
+                        committedCreateId,
+                        "id = ?",
+                        new String[] { sourceCreateEventId }
+                    );
+                }
+
+                if (hasTable(database, "local_drafts")) {
+                    ContentValues draftCreateId = new ContentValues();
+                    draftCreateId.put("id", targetCreateEventId);
+                    database.update(
+                        "local_drafts",
+                        draftCreateId,
+                        "id = ?",
+                        new String[] { sourceCreateEventId }
+                    );
+                }
+
+                if (hasTable(database, "materialized_view_state")) {
+                    database.delete("materialized_view_state", null, null);
+                }
+
+                database.setTransactionSuccessful();
+            } finally {
+                database.endTransaction();
+            }
+
+            try (
+                Cursor checkpoint = database.rawQuery(
+                    "PRAGMA wal_checkpoint(TRUNCATE)",
+                    null
+                )
+            ) {
+                if (!checkpoint.moveToFirst()) {
+                    throw new IllegalStateException(
+                        "Failed to checkpoint imported project database."
+                    );
+                }
+            }
+            assertDatabaseIntegrity(database);
+        } finally {
+            database.close();
+        }
+
+        deleteTemporaryFile(
+            new File(databaseFile.getAbsolutePath() + "-wal")
+        );
+        deleteTemporaryFile(
+            new File(databaseFile.getAbsolutePath() + "-shm")
+        );
+        deleteTemporaryFile(
+            new File(databaseFile.getAbsolutePath() + "-journal")
+        );
+    }
+
+    private void assertCommittedProjectIdentity(
+        SQLiteDatabase database,
+        String sourceProjectId
+    ) throws Exception {
+        if (!hasTable(database, "committed_events")) {
+            return;
+        }
+
+        try (
+            Cursor cursor = database.rawQuery(
+                "SELECT project_id FROM committed_events " +
+                "WHERE project_id IS NOT NULL AND project_id <> ? LIMIT 1",
+                new String[] { sourceProjectId }
+            )
+        ) {
+            if (cursor.moveToFirst()) {
+                throw new IllegalArgumentException(
+                    "Selected project contains mismatched repository history."
+                );
+            }
+        }
+    }
+
+    private void assertDatabaseIntegrity(SQLiteDatabase database)
+        throws Exception {
+        try (
+            Cursor cursor = database.rawQuery("PRAGMA integrity_check", null)
+        ) {
+            if (
+                !cursor.moveToFirst() ||
+                !"ok".equalsIgnoreCase(cursor.getString(0))
+            ) {
+                throw new IllegalArgumentException(
+                    "Selected project database is corrupted."
+                );
+            }
         }
     }
 

--- a/src/deps/services/android/appService.js
+++ b/src/deps/services/android/appService.js
@@ -122,12 +122,13 @@ export const createAppService = (params) => {
         throw new Error("Project folder is required.");
       }
 
+      const projectId = generateId();
       const importedProject = await callAndroidBridge("importProjectFolder", {
         uri: folderSelection.uri,
+        projectId,
       });
-      const projectId = importedProject.id;
-      if (!projectId) {
-        throw new Error("Imported project is missing an id.");
+      if (importedProject.id !== projectId) {
+        throw new Error("Imported project identity does not match.");
       }
 
       const importedName = importedProject.name?.trim?.() ?? "";

--- a/tests/android/projectImportIdentity.test.js
+++ b/tests/android/projectImportIdentity.test.js
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path) =>
+  readFile(new URL(`../../${path}`, import.meta.url), "utf8");
+
+describe("Android project import identity", () => {
+  it("installs every import under a newly assigned project id", async () => {
+    const activity = await readRepoFile(
+      "android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java",
+    );
+
+    expect(activity).toContain('payload.getString("projectId")');
+    expect(activity).toContain("rewriteImportedProjectIdentity(");
+    expect(activity).toContain('projectInfo.put("id", targetProjectId)');
+    expect(activity).toContain(
+      'committedIdentity.put("project_id", targetProjectId)',
+    );
+    expect(activity).toContain('"collab.lastCommittedId:" + sourceProjectId');
+    expect(activity).toContain(
+      'database.delete("materialized_view_state", null, null)',
+    );
+    expect(activity).toContain("assertDatabaseIntegrity(database)");
+    expect(activity).toContain(
+      "Os.rename(stagedRoot.getAbsolutePath(), projectRoot.getAbsolutePath())",
+    );
+    expect(activity).not.toContain('result.put("alreadyImported"');
+  });
+});

--- a/tests/android/projectImportIdentity.test.js
+++ b/tests/android/projectImportIdentity.test.js
@@ -19,11 +19,14 @@ describe("Android project import identity", () => {
     );
     expect(activity).toContain('"collab.lastCommittedId:" + sourceProjectId');
     expect(activity).toContain(
-      'database.delete("materialized_view_state", null, null)',
+      "File importWorkDir = new File(importRoot, projectId)",
     );
     expect(activity).toContain("assertDatabaseIntegrity(database)");
     expect(activity).toContain(
       "Os.rename(stagedRoot.getAbsolutePath(), projectRoot.getAbsolutePath())",
+    );
+    expect(activity).not.toContain(
+      'database.delete("materialized_view_state", null, null)',
     );
     expect(activity).not.toContain('result.put("alreadyImported"');
   });

--- a/tests/appService/projectEntryLanguagePlatforms.test.js
+++ b/tests/appService/projectEntryLanguagePlatforms.test.js
@@ -308,6 +308,63 @@ describe("project-entry language platform propagation", () => {
     ]);
   });
 
+  it("assigns a fresh local id when importing an Android project", async () => {
+    let importPayload;
+    mocked.androidBridge.mockImplementation((method, payload) => {
+      if (method !== "importProjectFolder") {
+        throw new Error(`Unexpected Android bridge method: ${method}`);
+      }
+
+      importPayload = payload;
+      return {
+        id: payload.projectId,
+        name: "Imported Project",
+        description: "Imported description",
+        language: "en",
+        iconFileId: null,
+      };
+    });
+    const db = createDb();
+    const appService = createAndroidAppService(
+      createParams({ db, projectService: createProjectService() }),
+    );
+
+    const project = await appService.openExistingProject({
+      uri: "content://projects/imported-project",
+      name: "Imported Project",
+    });
+
+    expect(importPayload).toEqual({
+      uri: "content://projects/imported-project",
+      projectId: project.id,
+    });
+    expect(project.id).toMatch(/^[1-9A-HJ-NP-Za-km-z]{12}$/);
+    await expect(db.get("projectEntries")).resolves.toEqual([
+      expect.objectContaining({
+        id: project.id,
+        name: "Imported Project",
+      }),
+    ]);
+  });
+
+  it("rejects an Android import that returns a different project id", async () => {
+    mocked.androidBridge.mockResolvedValue({
+      id: "unexpected-project-id",
+      name: "Imported Project",
+    });
+    const db = createDb();
+    const appService = createAndroidAppService(
+      createParams({ db, projectService: createProjectService() }),
+    );
+
+    await expect(
+      appService.openExistingProject({
+        uri: "content://projects/imported-project",
+      }),
+    ).rejects.toThrow("Imported project identity does not match.");
+    await expect(db.get("projectEntries")).resolves.toEqual([]);
+  });
+
   it.each([
     ["android", createAndroidAppService, mocked.androidBridge],
     ["ios", createIOSAppService, mocked.iosBridge],


### PR DESCRIPTION
## Summary

- generate a fresh NanoID-style local project ID for every Android folder import
- use that generated project ID for both native staging and final storage
- rewrite staged project metadata, repository ownership, bootstrap event identity, and stale collaboration cursor state
- preserve materialized checkpoints, including checkpoint-backed local project histories
- stage the complete project and atomically promote it without overwriting installed projects
- preserve browser and native application identities for release/save continuity

## Validation

- bunx vitest run tests/android tests/appService/projectEntryLanguagePlatforms.test.js (47 tests passed)
- ./gradlew :app:compileDebugJavaWithJavac
- bun run build:android
- ./gradlew :app:assembleDebug

Device installation was attempted twice but Android rejected the on-device installation permission prompt, so repeated-import device validation remains pending.