### PR TITLE
Sync Android build version to 1.12.1

### DIFF
--- a/android/routevn/app/build.gradle.kts
+++ b/android/routevn/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.routevn.creator"
         minSdk = 24
         targetSdk = 37
-        versionCode = 1
-        versionName = "0.0.1"
+        versionCode = 2
+        versionName = "1.12.1"
         manifestPlaceholders["usesCleartextTraffic"] = "false"
     }
 


### PR DESCRIPTION
## Summary

- set Android `versionName` to `1.12.1` to match the desktop application version
- increment Android `versionCode` from `1` to `2`

## Validation

- `./gradlew :app:processDebugMainManifest`
- push-hook lint and formatting checks passed

## Scope

- contains only `android/routevn/app/build.gradle.kts`
- existing uncommitted versions-page work and the temporary Android audit roadmap are excluded