### PR TITLE
Fix BGM restarts across sections by deriving sound ids from the resource

### DIFF
--- a/src/components/commandLineBgm/commandLineBgm.handlers.js
+++ b/src/components/commandLineBgm/commandLineBgm.handlers.js
@@ -1,5 +1,4 @@
 import { toFlatItems } from "../../internal/project/tree.js";
-import { generateId } from "../../internal/id.js";
 import {
   finishAudioTimelineDrag,
   mountAudioTimelineDragSubscriptions,
@@ -463,8 +462,11 @@ export const handleButtonSelectClick = (deps) => {
       resourceId,
     });
   } else {
+    // The sound id is the runtime playback identity: re-authoring the same
+    // resource in another section must reuse it so the track continues
+    // instead of restarting. insertSound suffixes repeated resources.
     store.insertSound({
-      id: generateId(),
+      id: resourceId,
       resourceId,
       index: store.selectPendingInsertIndex(),
     });

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -819,7 +819,7 @@ export const finishSoundDrag = (
 
 export const insertSound = (
   { state },
-  { id, resourceId, index = state.bgm.sounds.length } = {},
+  { resourceId, id = resourceId, index = state.bgm.sounds.length } = {},
 ) => {
   // Resource-derived ids collide when the same resource is inserted twice;
   // suffix them like normalizeSounds so channel ids stay unique.

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -821,9 +821,18 @@ export const insertSound = (
   { state },
   { id, resourceId, index = state.bgm.sounds.length } = {},
 ) => {
+  // Resource-derived ids collide when the same resource is inserted twice;
+  // suffix them like normalizeSounds so channel ids stay unique.
+  const existingIds = new Set(state.bgm.sounds.map((sound) => sound.id));
+  let uniqueId = id;
+  let duplicateIndex = 2;
+  while (existingIds.has(uniqueId)) {
+    uniqueId = `${id}-${duplicateIndex}`;
+    duplicateIndex += 1;
+  }
   const sound = normalizeSounds([
     {
-      id,
+      id: uniqueId,
       resourceId,
       volume: DEFAULT_SOUND_VOLUME,
     },

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -604,6 +604,24 @@ describe("commandLineBgm.handlers", () => {
   });
 
   it("reuses the resource id so the same track keeps a stable playback identity", () => {
+    const render = vi.fn();
+    const authorChannel = () => {
+      const state = createState();
+      const store = createStore(state);
+      store.setPendingInsertIndex({ index: 0 });
+      store.setTempSelectedResource({ resourceId: "intro" });
+      store.setMode({ mode: "gallery" });
+      handleButtonSelectClick({ store, render });
+      return state.bgm.sounds[0].id;
+    };
+
+    // Two independently authored channels (e.g. one per section) must agree
+    // on the id or the runtime restarts the track at the section boundary.
+    expect(authorChannel()).toBe("intro");
+    expect(authorChannel()).toBe("intro");
+  });
+
+  it("suffixes clip ids when the same resource is inserted twice", () => {
     const state = createState();
     const store = createStore(state);
     const render = vi.fn();

--- a/tests/commandLineBgm/commandLineBgm.handlers.test.js
+++ b/tests/commandLineBgm/commandLineBgm.handlers.test.js
@@ -435,6 +435,7 @@ describe("commandLineBgm.handlers", () => {
     handleButtonSelectClick({ store, render });
 
     expect(state.bgm.sounds).toHaveLength(1);
+    expect(state.bgm.sounds[0].id).toBe("intro");
     expect(state.bgm.sounds[0].resourceId).toBe("intro");
     expect(state.isChannelEditorOpen).toBe(false);
     expect(state.mode).toBe("current");
@@ -593,12 +594,36 @@ describe("commandLineBgm.handlers", () => {
     expect(state.mode).toBe("current");
     expect(state.bgm.sounds).toHaveLength(1);
     expect(state.bgm.sounds[0]).toMatchObject({
+      id: "intro",
       resourceId: "intro",
       volume: 100,
       startDelayMs: 0,
     });
     expect(state.selectedSoundId).toBe(state.bgm.sounds[0].id);
     expect(render).toHaveBeenCalledOnce();
+  });
+
+  it("reuses the resource id so the same track keeps a stable playback identity", () => {
+    const state = createState();
+    const store = createStore(state);
+    const render = vi.fn();
+    store.setPendingInsertIndex({ index: 0 });
+    store.setTempSelectedResource({ resourceId: "intro" });
+    store.setMode({ mode: "gallery" });
+
+    handleButtonSelectClick({ store, render });
+
+    expect(state.bgm.sounds.map((sound) => sound.id)).toEqual(["intro"]);
+
+    store.setPendingInsertIndex({ index: 1 });
+    store.setTempSelectedResource({ resourceId: "intro" });
+    store.setMode({ mode: "gallery" });
+    handleButtonSelectClick({ store, render });
+
+    expect(state.bgm.sounds.map((sound) => sound.id)).toEqual([
+      "intro",
+      "intro-2",
+    ]);
   });
 
   it("selects and removes an individual clip from its context menu", async () => {

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -718,6 +718,66 @@ describe("commandLineBgm.store", () => {
     expect(selectSelectedSoundId({ state })).toBeUndefined();
   });
 
+  it("derives clip ids from the resource and suffixes channel duplicates", () => {
+    const state = createInitialState();
+    setRepositoryState({ state }, { sounds });
+
+    insertSound({ state }, { resourceId: "intro" });
+    insertSound({ state }, { resourceId: "intro" });
+    insertSound({ state }, { resourceId: "intro" });
+
+    expect(selectBgm({ state }).sounds.map((sound) => sound.id)).toEqual([
+      "intro",
+      "intro-2",
+      "intro-3",
+    ]);
+  });
+
+  it("keeps explicit clip ids and only suffixes on collision", () => {
+    const state = createInitialState();
+    setRepositoryState({ state }, { sounds });
+
+    insertSound({ state }, { id: "intro-clip", resourceId: "intro" });
+    insertSound({ state }, { resourceId: "theme" });
+
+    expect(selectBgm({ state }).sounds.map((sound) => sound.id)).toEqual([
+      "intro-clip",
+      "theme",
+    ]);
+  });
+
+  it("skips suffix ids already owned by other clips", () => {
+    const state = createInitialState();
+    setRepositoryState({ state }, { sounds });
+
+    insertSound({ state }, { id: "intro-2", resourceId: "theme" });
+    insertSound({ state }, { resourceId: "intro" });
+    insertSound({ state }, { resourceId: "intro" });
+
+    expect(selectBgm({ state }).sounds.map((sound) => sound.id)).toEqual([
+      "intro-2",
+      "intro",
+      "intro-3",
+    ]);
+  });
+
+  it("reuses freed ids when clips are removed", () => {
+    const state = createInitialState();
+    setRepositoryState({ state }, { sounds });
+
+    insertSound({ state }, { resourceId: "intro" });
+    insertSound({ state }, { resourceId: "intro" });
+    removeSound({ state }, { soundId: "intro" });
+    insertSound({ state }, { resourceId: "intro" });
+
+    // The replacement clip is appended after the survivor, but reclaims the
+    // freed base id.
+    expect(selectBgm({ state }).sounds.map((sound) => sound.id)).toEqual([
+      "intro-2",
+      "intro",
+    ]);
+  });
+
   it("connects a sound to the exact end of the previous sound", () => {
     const state = createInitialState();
     setRepositoryState({ state }, { sounds });


### PR DESCRIPTION
## Problem

Authoring the same track as BGM in section 1 and section 2 caused the track to stop and replay from the beginning when the player crossed into section 2, instead of continuing seamlessly.

## Root cause

Every BGM insertion minted a fresh nanoid as the sound id (`generateId()` in `handleButtonSelectClick`). The runtime treats that id as the playback identity:

- route-engine derives the render id `bgm:<soundId>` from the authored sound id, and rebuilds the presentation state from the new section's lines on entry (`constructRenderState.js` → `createBgmChannelNode`).
- route-graphics diffs sounds by id (`AudioStage.renderGraph`): a changed id means the old sound is finished and the new one starts at position 0. Same id + same `src`/`startAt`/`endAt`/`startDelayMs` continues in place (documented in `route-graphics/docs/audio-effects.md`, "Sound Identity and Replay").

So the same resource authored in two sections produced two different ids and an audible restart. The engine's audio-effect handoff path even assumes stability (`resolveAudioEffects.js` throws "Audio effects require a stable BGM sound id across a handoff").

## Fix

- Insert BGM clips with `id: resourceId` instead of a generated id, so re-authoring the same resource anywhere in the story yields the same playback identity and the track continues. This matches the `normalizeSounds` fallback, which already uses `resourceId` as the id when missing.
- `insertSound` defaults the id to the resource id and suffixes `-2`, `-3`, ... when that id is already taken in the channel, keeping channel ids unique (the engine rejects duplicate BGM sound ids). The suffix scan skips ids owned by other clips, and freed ids are reused after removal.
- Voice and SFX insertions keep generated ids: one-shot sounds are supposed to replay, which per the graphics contract requires a fresh id.

No data migration: clips authored before this change keep their existing random ids (re-authored sections pick up stable ids from now on).

## Tests

Handler level:
- Two independently authored channels (the two-section scenario) produce the same id for the same resource — the direct regression test for this bug.
- Repeat insertion of one resource suffixes (`intro`, `intro-2`); existing tests assert insertion, selection, and replace-keeps-id behavior.

Store level:
- Suffix chaining across three insertions (`intro`, `intro-2`, `intro-3`).
- Explicit ids pass through untouched.
- Suffix ids already owned by other clips are skipped (`intro-2` taken → next insert takes `intro-3`).
- Freed ids are reclaimed after removal.

## Verification

- `tests/commandLineBgm/`: 42 passed.
- `tests/sceneEditor` + `tests/sceneEditorLexical`: 281 passed.
- `bun run test:smoke`: PASS.
- Adjacent suites (`commandLineAudioChannels`, `commandLineSoundEffects`, `commandLineVoice`, `systemActions`): only pre-existing failures in `commandLineShowConfirmDialog.handlers.test.js`, reproduced on clean `main`.
- `bun run lint` clean.