### PR TITLE
Bump RouteVN Creator to 1.12.2

### DIFF
--- a/android/routevn/app/build.gradle.kts
+++ b/android/routevn/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.routevn.creator"
         minSdk = 24
         targetSdk = 37
-        versionCode = 2
-        versionName = "1.12.1"
+        versionCode = 3
+        versionName = "1.12.2"
         manifestPlaceholders["usesCleartextTraffic"] = "false"
     }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "routevn-creator"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "discord-rich-presence",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routevn-creator"
-version = "1.12.1"
+version = "1.12.2"
 description = "RouteVN Creator. Follow us on social media to stay updated."
 authors = ["Yuusoft"]
 license = "MIT"

--- a/src-tauri/assets/com.routevn.creator.metainfo.xml
+++ b/src-tauri/assets/com.routevn.creator.metainfo.xml
@@ -23,6 +23,6 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.12.1" date="2026-08-15"/>
+    <release version="1.12.2" date="2026-08-18"/>
   </releases>
 </component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "RouteVN Creator",
   "mainBinaryName": "routevn-creator",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "identifier": "com.routevn.creator",
   "build": {
     "frontendDist": "../_site",


### PR DESCRIPTION
Patch release bump `1.12.1` → `1.12.2`, shipping the BGM continuity fix from #1108.

Note: the request said 1.21.1 → 1.21.2, but the app version in the repo is 1.12.1 (the only 1.21.x reference anywhere is the unrelated `@rettangoli/ui` dependency pin, and 1.21.2 does not exist on npm). Interpreted as a digit transposition of the actual patch bump — flag here if a different version was intended.

Updated locations, matching the convention of #1099 and #1105:

- `src-tauri/Cargo.toml` — crate version
- `src-tauri/tauri.conf.json` — app version
- `src-tauri/Cargo.lock` — `routevn-creator` package entry
- `src-tauri/assets/com.routevn.creator.metainfo.xml` — release entry with today's date
- `android/routevn/app/build.gradle.kts` — `versionName` + `versionCode` 2 → 3

iOS `MARKETING_VERSION` is stale at 1.8.2 and was left untouched, consistent with the previous two version bumps.