### PR TITLE
Improve mobile file explorer actions and BGM selector

### DIFF
--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -44,6 +44,7 @@ export const handleBeforeMount = (deps) => {
   const cleanupSubscriptions = mountSubscriptions(deps);
   return () => {
     clearTouchDragTimer(deps.store);
+    cancelEmptyLongPress(deps.store);
     clearDragAutoScrollTimer(deps.store);
     cleanupSubscriptions();
   };
@@ -86,6 +87,19 @@ const isFileExplorerControlEvent = (event) => {
         event.target.closest("[data-file-explorer-action]"),
     )
   );
+};
+
+const isFileExplorerItemEvent = (event) => {
+  return (
+    typeof event?.target?.closest === "function" &&
+    Boolean(event.target.closest("[data-file-explorer-item='true']"))
+  );
+};
+
+const getEmptyContextMenuItems = (props) => {
+  return Array.isArray(props.emptyContextMenuItems)
+    ? props.emptyContextMenuItems
+    : undefined;
 };
 
 const calculateForbiddenTargets = (sourceItem, allItems) => {
@@ -672,6 +686,21 @@ const clearTouchDragTimer = (store) => {
   store.setTouchDragTimerId({ timerId: undefined });
 };
 
+const clearEmptyLongPressTimer = (store) => {
+  const timerId = store.selectEmptyLongPressTimerId();
+  if (timerId === undefined) {
+    return;
+  }
+
+  clearTimeout(timerId);
+  store.setEmptyLongPressTimerId({ timerId: undefined });
+};
+
+const cancelEmptyLongPress = (store) => {
+  clearEmptyLongPressTimer(store);
+  store.clearEmptyLongPress();
+};
+
 const cancelPendingTouchDrag = (deps) => {
   const { store } = deps;
   clearTouchDragTimer(store);
@@ -805,6 +834,44 @@ const startMobileLongPressTimer = (deps, { point } = {}) => {
   store.setTouchDragTimerId({ timerId });
 };
 
+const startEmptyLongPressTimer = (deps, { point } = {}) => {
+  const { props, render, store } = deps;
+  const emptyContextMenuItems = getEmptyContextMenuItems(props);
+  if (!emptyContextMenuItems?.length) {
+    return false;
+  }
+
+  store.setEmptyLongPressStartPoint({ point });
+
+  const timerId = setTimeout(() => {
+    store.setEmptyLongPressTimerId({ timerId: undefined });
+    store.setSuppressNextClick({ suppress: true });
+    suppressTouchContextMenu(store);
+    store.showDropdownMenuFileExplorerEmpty({
+      position: point,
+      emptyContextMenuItems,
+    });
+    render();
+  }, TOUCH_LONG_PRESS_DELAY_MS);
+
+  store.setEmptyLongPressTimerId({ timerId });
+  return true;
+};
+
+const handleEmptyLongPressPointMove = (store, { point } = {}) => {
+  const startPoint = store.selectEmptyLongPressStartPoint();
+  if (!startPoint) {
+    return false;
+  }
+
+  const distance = Math.hypot(point.x - startPoint.x, point.y - startPoint.y);
+  if (distance > TOUCH_SCROLL_CANCEL_DISTANCE) {
+    cancelEmptyLongPress(store);
+  }
+
+  return true;
+};
+
 const updateDragTarget = (deps, { clientY } = {}) => {
   const { store, render, props } = deps;
 
@@ -890,6 +957,54 @@ export const handleItemMouseDown = (deps, payload) => {
     event,
     clientX: event.clientX,
     clientY: event.clientY,
+  });
+};
+
+export const handleContainerPointerDown = (deps, payload) => {
+  const { store } = deps;
+  const event = payload?._event;
+  if (
+    event?.pointerType === "mouse" ||
+    event?.isPrimary === false ||
+    isFileExplorerItemEvent(event)
+  ) {
+    return;
+  }
+
+  const point = getPointerPoint(event);
+  if (!point) {
+    return;
+  }
+
+  cancelEmptyLongPress(store);
+  if (!startEmptyLongPressTimer(deps, { point })) {
+    return;
+  }
+
+  store.setEmptyLongPressPointerId({ pointerId: event.pointerId });
+};
+
+export const handleContainerTouchStart = (deps, payload) => {
+  const { store } = deps;
+  const event = payload?._event;
+  if (
+    store.selectEmptyLongPressPointerId() !== undefined ||
+    isFileExplorerItemEvent(event)
+  ) {
+    return;
+  }
+
+  const touchPoint = getTouchPoint(event);
+  if (!touchPoint || event?.touches?.length !== 1) {
+    return;
+  }
+
+  cancelEmptyLongPress(store);
+  startEmptyLongPressTimer(deps, {
+    point: {
+      x: touchPoint.clientX,
+      y: touchPoint.clientY,
+    },
   });
 };
 
@@ -1135,8 +1250,22 @@ const handleMobilePointMove = (deps, payload, { point } = {}) => {
 };
 
 export const handleWindowTouchMove = (deps, payload) => {
+  const { store } = deps;
   const touchPoint = getTouchPoint(payload?._event);
   if (!touchPoint) {
+    return;
+  }
+
+  if (
+    store.selectEmptyLongPressStartPoint() !== undefined &&
+    store.selectEmptyLongPressPointerId() === undefined
+  ) {
+    handleEmptyLongPressPointMove(store, {
+      point: {
+        x: touchPoint.clientX,
+        y: touchPoint.clientY,
+      },
+    });
     return;
   }
 
@@ -1151,6 +1280,19 @@ export const handleWindowTouchMove = (deps, payload) => {
 export const handleWindowPointerMove = (deps, payload) => {
   const { store } = deps;
   const event = payload?._event;
+  const emptyLongPressPointerId = store.selectEmptyLongPressPointerId();
+  if (
+    emptyLongPressPointerId !== undefined &&
+    event?.pointerId === emptyLongPressPointerId &&
+    event?.pointerType !== "mouse"
+  ) {
+    const point = getPointerPoint(event);
+    if (point) {
+      handleEmptyLongPressPointMove(store, { point });
+    }
+    return;
+  }
+
   const pointerId = store.selectTouchDragPointerId();
 
   if (
@@ -1216,6 +1358,15 @@ const handleMobilePointEnd = (deps, payload, { point } = {}) => {
 };
 
 export const handleWindowTouchEnd = (deps, payload) => {
+  const { store } = deps;
+  if (
+    store.selectEmptyLongPressStartPoint() !== undefined &&
+    store.selectEmptyLongPressPointerId() === undefined
+  ) {
+    cancelEmptyLongPress(store);
+    return;
+  }
+
   const touchPoint = getTouchPoint(payload?._event);
   handleMobilePointEnd(deps, payload, {
     point: touchPoint
@@ -1230,6 +1381,16 @@ export const handleWindowTouchEnd = (deps, payload) => {
 export const handleWindowPointerUp = (deps, payload) => {
   const { store } = deps;
   const event = payload?._event;
+  const emptyLongPressPointerId = store.selectEmptyLongPressPointerId();
+  if (
+    emptyLongPressPointerId !== undefined &&
+    event?.pointerId === emptyLongPressPointerId &&
+    event?.pointerType !== "mouse"
+  ) {
+    cancelEmptyLongPress(store);
+    return;
+  }
+
   const pointerId = store.selectTouchDragPointerId();
 
   if (
@@ -1247,6 +1408,13 @@ export const handleWindowPointerUp = (deps, payload) => {
 
 export const handleWindowTouchCancel = (deps, payload) => {
   const { store, render } = deps;
+
+  if (store.selectEmptyLongPressStartPoint() !== undefined) {
+    if (store.selectEmptyLongPressPointerId() === undefined) {
+      cancelEmptyLongPress(store);
+    }
+    return;
+  }
 
   payload?._event?.preventDefault?.();
   payload?._event?.stopPropagation?.();
@@ -1269,6 +1437,16 @@ export const handleWindowTouchCancel = (deps, payload) => {
 export const handleWindowPointerCancel = (deps, payload) => {
   const { store } = deps;
   const event = payload?._event;
+  const emptyLongPressPointerId = store.selectEmptyLongPressPointerId();
+  if (
+    emptyLongPressPointerId !== undefined &&
+    event?.pointerId === emptyLongPressPointerId &&
+    event?.pointerType !== "mouse"
+  ) {
+    cancelEmptyLongPress(store);
+    return;
+  }
+
   const pointerId = store.selectTouchDragPointerId();
 
   if (
@@ -1329,6 +1507,13 @@ const subscriptions = (deps) => {
 
 const shouldSuppressTouchContextMenu = (deps, event) => {
   const { store, props: attrs } = deps;
+  if (
+    store.selectEmptyLongPressStartPoint() !== undefined ||
+    store.selectTouchContextMenuSuppressUntil() > Date.now()
+  ) {
+    return true;
+  }
+
   if (!isDragEnabledForAttrs(attrs)) {
     return false;
   }
@@ -1337,8 +1522,7 @@ const shouldSuppressTouchContextMenu = (deps, event) => {
     event?.sourceCapabilities?.firesTouchEvents === true ||
     store.selectTouchDragActive() ||
     store.selectTouchScrollActive() ||
-    store.selectTouchDragStartPoint() !== undefined ||
-    store.selectTouchContextMenuSuppressUntil() > Date.now()
+    store.selectTouchDragStartPoint() !== undefined
   );
 };
 
@@ -1351,11 +1535,7 @@ export const handleContainerClick = (deps, payload) => {
     return;
   }
 
-  const target = payload?._event?.target;
-  if (
-    typeof target?.closest === "function" &&
-    target.closest("[data-file-explorer-item='true']")
-  ) {
+  if (isFileExplorerItemEvent(payload?._event)) {
     return;
   }
 
@@ -1382,9 +1562,7 @@ export const handleContainerContextMenu = (deps, payload) => {
 
   payload._event.preventDefault();
 
-  const emptyContextMenuItems = Array.isArray(props.emptyContextMenuItems)
-    ? props.emptyContextMenuItems
-    : undefined;
+  const emptyContextMenuItems = getEmptyContextMenuItems(props);
   if (!emptyContextMenuItems?.length) {
     return;
   }
@@ -1401,9 +1579,13 @@ export const handleEmptyMessageClick = (deps, payload) => {
   const { store, render, props } = deps;
   payload._event.preventDefault();
 
-  const emptyContextMenuItems = Array.isArray(props.emptyContextMenuItems)
-    ? props.emptyContextMenuItems
-    : undefined;
+  if (store.selectSuppressNextClick()) {
+    payload._event.stopPropagation();
+    store.setSuppressNextClick({ suppress: false });
+    return;
+  }
+
+  const emptyContextMenuItems = getEmptyContextMenuItems(props);
   if (!emptyContextMenuItems?.length) {
     return;
   }
@@ -1417,8 +1599,61 @@ export const handleEmptyMessageClick = (deps, payload) => {
   render();
 };
 
+const openItemDropdownMenu = (
+  deps,
+  { itemId, position, emitSelectionEvent = true, hideDeleteIcon = false } = {},
+) => {
+  const { dispatchEvent, props, render, store } = deps;
+  const item = props.items?.find((entry) => entry.id === itemId);
+  if (!item) {
+    return;
+  }
+
+  const contextMenuItems = Array.isArray(props.contextMenuItems)
+    ? props.contextMenuItems
+    : undefined;
+  const folderContextMenuItems = Array.isArray(props.folderContextMenuItems)
+    ? props.folderContextMenuItems
+    : undefined;
+  const itemContextMenuItems = Array.isArray(props.itemContextMenuItems)
+    ? props.itemContextMenuItems
+    : undefined;
+  const resolvedContextMenuItems = Array.isArray(item.contextMenuItems)
+    ? item.contextMenuItems
+    : item.type === "folder"
+      ? (folderContextMenuItems ?? contextMenuItems)
+      : (itemContextMenuItems ?? contextMenuItems);
+  if (!resolvedContextMenuItems?.length) {
+    return;
+  }
+
+  const dropdownMenuItems = hideDeleteIcon
+    ? resolvedContextMenuItems.map((menuItem) => {
+        if (menuItem.value !== "delete-item" || menuItem.icon === undefined) {
+          return menuItem;
+        }
+
+        const itemWithoutDeleteIcon = { ...menuItem };
+        delete itemWithoutDeleteIcon.icon;
+        return itemWithoutDeleteIcon;
+      })
+    : resolvedContextMenuItems;
+
+  store.showDropdownMenuFileExplorerItem({
+    position,
+    id: itemId,
+    type: item.type,
+    contextMenuItems: dropdownMenuItems,
+  });
+  store.clearPendingDrag();
+  store.setSelectedItemId({ itemId });
+  render();
+  if (emitSelectionEvent) {
+    emitItemClick({ dispatchEvent, item });
+  }
+};
+
 export const handleItemContextMenu = (deps, payload) => {
-  const { store, render, props } = deps;
   payload._event.preventDefault();
   payload._event.stopPropagation();
 
@@ -1431,39 +1666,32 @@ export const handleItemContextMenu = (deps, payload) => {
     return;
   }
 
-  // Find the item to get its type
-  const item = props.items?.find((item) => item.id === itemId);
-  const contextMenuItems = Array.isArray(props.contextMenuItems)
-    ? props.contextMenuItems
-    : undefined;
-  const folderContextMenuItems = Array.isArray(props.folderContextMenuItems)
-    ? props.folderContextMenuItems
-    : undefined;
-  const itemContextMenuItems = Array.isArray(props.itemContextMenuItems)
-    ? props.itemContextMenuItems
-    : undefined;
-  const resolvedContextMenuItems = Array.isArray(item?.contextMenuItems)
-    ? item.contextMenuItems
-    : item?.type === "folder"
-      ? (folderContextMenuItems ?? contextMenuItems)
-      : (itemContextMenuItems ?? contextMenuItems);
-  if (!resolvedContextMenuItems?.length) {
+  openItemDropdownMenu(deps, {
+    position: { x: payload._event.clientX, y: payload._event.clientY },
+    itemId,
+  });
+};
+
+export const handleItemMenuClick = (deps, payload) => {
+  const event = payload._event;
+  event.preventDefault();
+  event.stopPropagation();
+
+  const itemId = getItemIdFromEvent(event);
+  if (!itemId) {
     return;
   }
 
-  // Show dropdown menu for item
-  store.showDropdownMenuFileExplorerItem({
-    position: { x: payload._event.clientX, y: payload._event.clientY },
-    id: itemId,
-    type: item?.type,
-    contextMenuItems: resolvedContextMenuItems,
-    folderContextMenuItems,
-    itemContextMenuItems,
+  const rect = event.currentTarget.getBoundingClientRect();
+  openItemDropdownMenu(deps, {
+    itemId,
+    emitSelectionEvent: false,
+    hideDeleteIcon: true,
+    position: {
+      x: Math.round(rect.right),
+      y: Math.round(rect.bottom),
+    },
   });
-  store.clearPendingDrag();
-  store.setSelectedItemId({ itemId });
-  render();
-  emitItemClick({ dispatchEvent: deps.dispatchEvent, item });
 };
 
 export const handleItemClick = (deps, payload) => {
@@ -1714,6 +1942,7 @@ export const handleSetFolderCollapsed = (deps, payload) => {
 
 export const handleDropdownMenuClickOverlay = (deps) => {
   const { store, render } = deps;
+  store.setSuppressNextClick({ suppress: false });
   store.hideDropdownMenu();
   render();
 };
@@ -1730,6 +1959,7 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
   const position = store.selectDropdownMenuPosition();
 
   // Hide dropdown
+  store.setSuppressNextClick({ suppress: false });
   store.hideDropdownMenu();
   render();
 

--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -963,11 +963,16 @@ export const handleItemMouseDown = (deps, payload) => {
 export const handleContainerPointerDown = (deps, payload) => {
   const { store } = deps;
   const event = payload?._event;
-  if (
-    event?.pointerType === "mouse" ||
-    event?.isPrimary === false ||
-    isFileExplorerItemEvent(event)
-  ) {
+  if (event?.pointerType === "mouse") {
+    return;
+  }
+
+  if (event?.isPrimary === false || event?.button !== 0) {
+    cancelEmptyLongPress(store);
+    return;
+  }
+
+  if (isFileExplorerItemEvent(event)) {
     return;
   }
 
@@ -987,15 +992,21 @@ export const handleContainerPointerDown = (deps, payload) => {
 export const handleContainerTouchStart = (deps, payload) => {
   const { store } = deps;
   const event = payload?._event;
-  if (
-    store.selectEmptyLongPressPointerId() !== undefined ||
-    isFileExplorerItemEvent(event)
-  ) {
+  if (event?.touches?.length !== 1) {
+    cancelEmptyLongPress(store);
+    return;
+  }
+
+  if (store.selectEmptyLongPressPointerId() !== undefined) {
+    return;
+  }
+
+  if (isFileExplorerItemEvent(event)) {
     return;
   }
 
   const touchPoint = getTouchPoint(event);
-  if (!touchPoint || event?.touches?.length !== 1) {
+  if (!touchPoint) {
     return;
   }
 

--- a/src/components/baseFileExplorer/baseFileExplorer.handlers.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.handlers.js
@@ -1953,13 +1953,22 @@ export const handleSetFolderCollapsed = (deps, payload) => {
 
 export const handleDropdownMenuClickOverlay = (deps) => {
   const { store, render } = deps;
-  store.setSuppressNextClick({ suppress: false });
+  if (store.selectSuppressNextClick()) {
+    store.setSuppressNextClick({ suppress: false });
+    return;
+  }
+
   store.hideDropdownMenu();
   render();
 };
 
 export const handleDropdownMenuClickItem = (deps, payload) => {
   const { store, dispatchEvent, render } = deps;
+  if (store.selectSuppressNextClick()) {
+    store.setSuppressNextClick({ suppress: false });
+    return;
+  }
+
   const detail = payload._event.detail;
   const itemId = store.selectDropdownMenuItemId();
 
@@ -1970,7 +1979,6 @@ export const handleDropdownMenuClickItem = (deps, payload) => {
   const position = store.selectDropdownMenuPosition();
 
   // Hide dropdown
-  store.setSuppressNextClick({ suppress: false });
   store.hideDropdownMenu();
   render();
 

--- a/src/components/baseFileExplorer/baseFileExplorer.schema.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.schema.yaml
@@ -71,6 +71,9 @@ propsSchema:
     dropdownMenu:
       type: boolean
       description: Enable context menu dropdown on right-click
+    showItemMenuActions:
+      type: boolean
+      description: Show a trailing action menu button for each item with context-menu actions
     no-empty-message:
       type: boolean
       description: Whether to show the empty message when there are no items

--- a/src/components/baseFileExplorer/baseFileExplorer.store.js
+++ b/src/components/baseFileExplorer/baseFileExplorer.store.js
@@ -37,6 +37,9 @@ export const createInitialState = () => ({
   touchDragActive: false,
   touchScrollActive: false,
   touchScrollLastPoint: undefined,
+  emptyLongPressTimerId: undefined,
+  emptyLongPressStartPoint: undefined,
+  emptyLongPressPointerId: undefined,
   touchContextMenuSuppressUntil: 0,
   suppressNextClick: false,
   dragAutoScrollTimerId: undefined,
@@ -146,6 +149,24 @@ export const clearTouchDrag = ({ state }, _payload = {}) => {
   state.touchScrollLastPoint = undefined;
 };
 
+export const setEmptyLongPressTimerId = ({ state }, { timerId } = {}) => {
+  state.emptyLongPressTimerId = timerId;
+};
+
+export const setEmptyLongPressStartPoint = ({ state }, { point } = {}) => {
+  state.emptyLongPressStartPoint = point;
+};
+
+export const setEmptyLongPressPointerId = ({ state }, { pointerId } = {}) => {
+  state.emptyLongPressPointerId = pointerId;
+};
+
+export const clearEmptyLongPress = ({ state }, _payload = {}) => {
+  state.emptyLongPressTimerId = undefined;
+  state.emptyLongPressStartPoint = undefined;
+  state.emptyLongPressPointerId = undefined;
+};
+
 export const setTouchContextMenuSuppressUntil = (
   { state },
   { suppressUntil } = {},
@@ -237,6 +258,18 @@ export const selectTouchScrollActive = ({ state }) => {
 
 export const selectTouchScrollLastPoint = ({ state }) => {
   return state.touchScrollLastPoint;
+};
+
+export const selectEmptyLongPressTimerId = ({ state }) => {
+  return state.emptyLongPressTimerId;
+};
+
+export const selectEmptyLongPressStartPoint = ({ state }) => {
+  return state.emptyLongPressStartPoint;
+};
+
+export const selectEmptyLongPressPointerId = ({ state }) => {
+  return state.emptyLongPressPointerId;
 };
 
 export const selectTouchContextMenuSuppressUntil = ({ state }) => {
@@ -389,7 +422,7 @@ export const selectPopoverItemId = ({ state }) => {
   return state.popover.itemId;
 };
 
-export const selectViewData = ({ state, props, props: attrs }) => {
+export const selectViewData = ({ state, props, props: attrs, i18n = {} }) => {
   let items = props.items || [];
 
   // Filter items based on collapsed state
@@ -417,6 +450,20 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     getBooleanAttr(attrs, "allowDrag", "allow-drag") ||
     getBooleanAttr(attrs, "draggable", "draggable");
   const touchAction = dragEnabled ? "none" : "pan-y";
+  const showItemMenuActions = getBooleanAttr(
+    attrs,
+    "showItemMenuActions",
+    "show-item-menu-actions",
+  );
+  const contextMenuItems = Array.isArray(props.contextMenuItems)
+    ? props.contextMenuItems
+    : undefined;
+  const folderContextMenuItems = Array.isArray(props.folderContextMenuItems)
+    ? props.folderContextMenuItems
+    : undefined;
+  const itemContextMenuItems = Array.isArray(props.itemContextMenuItems)
+    ? props.itemContextMenuItems
+    : undefined;
 
   // Map items with additional UI properties
   const processedItems = visibleItems.map((item) => {
@@ -466,6 +513,12 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       }
     }
 
+    const resolvedContextMenuItems = Array.isArray(item.contextMenuItems)
+      ? item.contextMenuItems
+      : item.type === "folder"
+        ? (folderContextMenuItems ?? contextMenuItems)
+        : (itemContextMenuItems ?? contextMenuItems);
+
     return {
       ...item,
       ml: item._level * 16,
@@ -478,6 +531,8 @@ export const selectViewData = ({ state, props, props: attrs }) => {
       iconColor: item.iconColor ?? "fg",
       iconCssColor: item.iconCssColor ?? "var(--foreground)",
       textColor: item.textColor ?? "fg",
+      showMenuAction:
+        showItemMenuActions && resolvedContextMenuItems?.length > 0,
     };
   });
 
@@ -544,6 +599,7 @@ export const selectViewData = ({ state, props, props: attrs }) => {
     ),
     noEmptyMessage: getBooleanAttr(attrs, "noEmptyMessage", "no-empty-message"),
     shrinkable: getBooleanAttr(attrs, "shrinkable", "shrinkable"),
+    itemActionsLabel: i18n.resourcePages?.actionsLabel ?? "Actions",
   };
 
   return viewData;

--- a/src/components/baseFileExplorer/baseFileExplorer.view.yaml
+++ b/src/components/baseFileExplorer/baseFileExplorer.view.yaml
@@ -3,6 +3,10 @@ refs:
     eventListeners:
       click:
         handler: handleContainerClick
+      pointerdown:
+        handler: handleContainerPointerDown
+      touchstart:
+        handler: handleContainerTouchStart
       contextmenu:
         handler: handleContainerContextMenu
   item*:
@@ -28,6 +32,10 @@ refs:
     eventListeners:
       click:
         handler: handleVisibilityToggleClick
+  itemMenu*:
+    eventListeners:
+      click:
+        handler: handleItemMenuClick
   emptyMessage:
     eventListeners:
       click:
@@ -99,6 +107,8 @@ template:
                               - $if item.visibilityToggle:
                                   - 'button#visibilityRef${i}.visibilityAction type=button data-item-id=${item.id} data-file-explorer-action=true data-always-visible="${item.visibilityToggleAlwaysVisible}" aria-label="${item.visibilityLabel}" title="${item.visibilityLabel}" style="color: ${item.iconCssColor};"':
                                       - rtgl-svg svg=${item.visibilityIcon} wh=16 c=${item.iconColor} aria-hidden=true: null
+                              - $if item.showMenuAction:
+                                  - 'rtgl-button#itemMenuRef${i} data-item-id=${item.id} data-file-explorer-action=true sq s=sm v=gh pre=ellipsis aria-label="${itemActionsLabel}" title="${itemActionsLabel}" aria-haspopup=menu': null
                   - 'div#container style="width: 100%; height: ${bottomEmptySpaceHeight}; min-height: ${bottomEmptySpaceHeight}; flex: 0 0 ${bottomEmptySpaceHeight}; pointer-events: none;"': null
           - $if targetDragIndex != -2 && targetDropPosition != 'inside':
               - 'rtgl-view pos=abs bgc=fg h=2 style="top: ${targetDragPosition}px; left: ${targetDragLeftOffset}px; width: calc(100% - ${targetDragLeftOffset}px); z-index: 1000;"': null

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -535,9 +535,10 @@ export const selectViewData = ({ state, i18n }) => {
     showResourceSelectorFileExplorer: resourceSelectorLayout.showFileExplorer,
     resourceSelectorColumns: resourceSelectorLayout.columns,
     resourceSelectorGridStyle: resourceSelectorLayout.gridStyle,
-    resourceSelectorItemStyle: resourceSelectorLayout.itemStyle,
-    resourceSelectorCardStyle: resourceSelectorLayout.cardStyle,
-    resourceSelectorPreviewStyle: resourceSelectorLayout.previewStyle,
+    resourceSelectorHorizontalPadding: state.isTouchMode ? "none" : "lg",
+    resourceSelectorCardStyle:
+      resourceSelectorLayout.cardStyle ||
+      "width: 200px; min-width: 0; max-width: 100%; box-sizing: border-box;",
     sounds,
     showChannelControls: sounds.length > 0,
     isChannelEditorOpen: state.isChannelEditorOpen,

--- a/src/components/commandLineBgm/commandLineBgm.view.yaml
+++ b/src/components/commandLineBgm/commandLineBgm.view.yaml
@@ -268,26 +268,28 @@ template:
               - rtgl-view d=h w=f av=c g=md ph=lg:
                   - rtgl-view w=1fg: null
                   - rtgl-input#searchInput s=sm placeholder=${searchPlaceholder} value=${searchQuery} h=1fg: null
-              - 'rtgl-view d=h w=f g=lg h=1fg ph=lg style="min-height: 0;"':
+              - 'rtgl-view d=h w=f g=lg h=1fg ph=${resourceSelectorHorizontalPadding} style="min-height: 0;"':
                   - $if showResourceSelectorFileExplorer:
                       - rtgl-view h=f w=1fg sv:
                           - rvn-base-file-explorer#baseFileExplorer :items=${items}: null
                   - rtgl-view#galleryScroll h=f w=2fg sv g=lg:
                       - $for group, i in groups:
-                          - rtgl-view data-group-id=${group.id} g=md:
+                          - rtgl-view data-group-id=${group.id} w=f g=md:
                               - rtgl-view d=h av=c g=md:
                                   - rtgl-svg svg=folder wh=16: null
                                   - rtgl-text: ${group.fullLabel}
-                              - 'rtgl-view d=h w=f wrap g=lg style="${resourceSelectorGridStyle}"':
+                              - 'rtgl-view d=h w=f wrap g=md style="${resourceSelectorGridStyle}"':
                                   - $for item, j in group.children:
-                                      - 'rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=sm style="${resourceSelectorItemStyle}"':
-                                          - 'rtgl-view p=md g=md br=md style="${resourceSelectorCardStyle}"':
-                                              - $if item.waveformDataFileId:
-                                                  - 'rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=200 h=120 style="${resourceSelectorPreviewStyle}"': null
-                                                $else:
-                                                  - 'rtgl-view w=200 h=120 av=c ah=c bgc=mu-fg style="${resourceSelectorPreviewStyle}"':
-                                                      - rtgl-text s=sm c=mu-fg: No waveform
-                                              - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
+                                      - rtgl-view#resourceItem${i}x${j} data-resource-id=${item.id} cur=pointer bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md:
+                                          - 'rtgl-view br=md pos=rel overflow=hidden style="${resourceSelectorCardStyle}"':
+                                              - 'rtgl-view w=f style="aspect-ratio: 16 / 9; overflow: hidden;"':
+                                                  - $if item.waveformDataFileId:
+                                                      - rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=f h=f: null
+                                                    $else:
+                                                      - rtgl-view w=f h=f av=c ah=c bgc=mu-fg:
+                                                          - rtgl-text s=sm c=mu-fg: No waveform
+                                              - rtgl-view w=f p=md:
+                                                  - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
               - 'rtgl-view d=h av=c ah=e w=f g=lg ph=lg style="flex: 0 0 auto;"':
                   - rtgl-button#buttonSelect: Select
           - $if showAudioPlayer:

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -479,6 +479,7 @@ webServerPage:
   urlLabel: "URL"
   warningTitle: "Warning"
 resourcePages:
+  actionsLabel: "Actions"
   addTagOption: "Add tag"
   addTagPlaceholder: "Add tag"
   addText: "Add"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -479,6 +479,7 @@ webServerPage:
   urlLabel: "URL"
   warningTitle: "警告"
 resourcePages:
+  actionsLabel: "アクション"
   addTagOption: "タグを追加"
   addTagPlaceholder: "タグを追加"
   addText: "追加"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -479,6 +479,7 @@ webServerPage:
   urlLabel: "URL"
   warningTitle: "警告"
 resourcePages:
+  actionsLabel: "操作"
   addTagOption: "添加标签"
   addTagPlaceholder: "添加标签"
   addText: "添加"

--- a/src/pages/animations/animations.view.yaml
+++ b/src/pages/animations/animations.view.yaml
@@ -178,7 +178,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/audioEffects/audioEffects.view.yaml
+++ b/src/pages/audioEffects/audioEffects.view.yaml
@@ -174,7 +174,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/characterSprites/characterSprites.view.yaml
+++ b/src/pages/characterSprites/characterSprites.view.yaml
@@ -306,7 +306,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/characters/characters.view.yaml
+++ b/src/pages/characters/characters.view.yaml
@@ -210,7 +210,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/colors/colors.view.yaml
+++ b/src/pages/colors/colors.view.yaml
@@ -165,7 +165,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/controls/controls.view.yaml
+++ b/src/pages/controls/controls.view.yaml
@@ -193,7 +193,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/fonts/fonts.view.yaml
+++ b/src/pages/fonts/fonts.view.yaml
@@ -160,7 +160,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/images/images.view.yaml
+++ b/src/pages/images/images.view.yaml
@@ -252,7 +252,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag bottom-empty-space-height=80vh start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions bottom-empty-space-height=80vh start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/layoutEditor/layoutEditor.view.yaml
+++ b/src/pages/layoutEditor/layoutEditor.view.yaml
@@ -123,4 +123,4 @@ template:
               - rtgl-text w=1fg s=md: ${nodeExplorerTitle}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag bottom-empty-space-height=80vh :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions bottom-empty-space-height=80vh :contextMenuItems=${contextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null

--- a/src/pages/layouts/layouts.view.yaml
+++ b/src/pages/layouts/layouts.view.yaml
@@ -163,7 +163,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/particles/particles.view.yaml
+++ b/src/pages/particles/particles.view.yaml
@@ -204,7 +204,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -185,7 +185,7 @@ template:
                   - rtgl-text w=1fg s=md: ${filesLabel}
                   - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
               - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-                  - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+                  - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
       - $if showMapAddHint:
           - 'rtgl-view pos=abs z=150 style="left: 50%; bottom: 24px; transform: translateX(-50%);"':
               - rtgl-view d=h av=c g=sm bgc=mu bc=bo bw=xs br=sm pv=md ph=md:

--- a/src/pages/sounds/sounds.view.yaml
+++ b/src/pages/sounds/sounds.view.yaml
@@ -188,7 +188,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/spritesheets/spritesheets.view.yaml
+++ b/src/pages/spritesheets/spritesheets.view.yaml
@@ -190,7 +190,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions start-collapsed=${startCollapsedFileExplorer} :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/textStyles/textStyles.view.yaml
+++ b/src/pages/textStyles/textStyles.view.yaml
@@ -201,7 +201,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/transforms/transforms.view.yaml
+++ b/src/pages/transforms/transforms.view.yaml
@@ -219,7 +219,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/variables/variables.view.yaml
+++ b/src/pages/variables/variables.view.yaml
@@ -121,7 +121,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/src/pages/videos/videos.view.yaml
+++ b/src/pages/videos/videos.view.yaml
@@ -179,7 +179,7 @@ template:
               - rtgl-text w=1fg s=md: ${filesLabel}
               - rtgl-button#mobileFileExplorerClose sq pre=x v=ol: null
           - 'rtgl-view w=f h=1fg style="min-height: 0;"':
-              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
+              - rvn-base-file-explorer#fileExplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
   - $if showMobileDetailSheet:
       - rvn-mobile-sheet#mobileDetailSheet ?open=${showMobileDetailSheet}:
           - rtgl-view slot=content d=v w=f h=f:

--- a/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
@@ -2,12 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   handleClearSelection,
   handleContainerClick,
+  handleContainerContextMenu,
+  handleContainerPointerDown,
+  handleContainerTouchStart,
+  handleDropdownMenuClickOverlay,
   handleItemContextMenu,
+  handleItemMenuClick,
   handleItemPointerDown,
   handleItemTouchStart,
   handleVisibilityToggleClick,
   handleNavigateSelection,
   handleWindowMouseUp,
+  handleWindowPointerCancel,
   handleWindowPointerMove,
   handleWindowPointerUp,
   handleWindowTouchCancel,
@@ -104,9 +110,14 @@ const createTouchEvent = ({
   };
 };
 
-const createContextMenuEvent = ({ currentTarget, firesTouchEvents } = {}) => {
+const createContextMenuEvent = ({
+  currentTarget,
+  target = currentTarget,
+  firesTouchEvents,
+} = {}) => {
   return {
     currentTarget,
+    target,
     clientX: 10,
     clientY: 16,
     preventDefault: vi.fn(),
@@ -129,6 +140,7 @@ const createDragDeps = ({ itemCount = 4, rootHeight = 128 } = {}) => {
     items,
     allowDrag: true,
     contextMenuItems: [{ label: "Rename", value: "rename-item" }],
+    emptyContextMenuItems: [{ label: "New Folder", value: "new-item" }],
   };
   const state = baseFileExplorerStore.createInitialState();
   const store = createBoundStore({ state, props });
@@ -310,6 +322,163 @@ describe("baseFileExplorer handlers", () => {
     expect(deps.dispatchEvent).not.toHaveBeenCalled();
   });
 
+  it("opens the empty-space menu after a stationary pointer long press", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    const event = createPointerEvent({
+      currentTarget: deps.refs.root,
+      x: 24,
+      y: 112,
+      pointerId: 7,
+    });
+
+    handleContainerPointerDown(deps, { _event: event });
+    vi.advanceTimersByTime(359);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+
+    vi.advanceTimersByTime(1);
+
+    expect(state.dropdownMenu).toEqual({
+      isOpen: true,
+      position: { x: 24, y: 112 },
+      itemId: null,
+      items: [{ label: "New Folder", value: "new-item" }],
+    });
+    expect(deps.store.selectSuppressNextClick()).toBe(true);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+
+    const contextMenuEvent = createContextMenuEvent({
+      currentTarget: deps.refs.root,
+      target: { closest: vi.fn(() => undefined) },
+      firesTouchEvents: true,
+    });
+    handleContainerContextMenu(deps, { _event: contextMenuEvent });
+
+    expect(contextMenuEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(contextMenuEvent.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+
+    handleWindowPointerUp(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 112,
+        pointerId: 7,
+      }),
+    });
+
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+    expect(deps.store.selectEmptyLongPressPointerId()).toBeUndefined();
+
+    handleDropdownMenuClickOverlay(deps);
+
+    expect(deps.store.selectSuppressNextClick()).toBe(false);
+  });
+
+  it("cancels an empty-space long press when touch movement becomes a scroll", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 80,
+        pointerId: 7,
+      }),
+    });
+    const moveEvent = createPointerEvent({
+      currentTarget: deps.refs.root,
+      x: 24,
+      y: 89,
+      pointerId: 7,
+    });
+
+    handleWindowPointerMove(deps, { _event: moveEvent });
+    vi.advanceTimersByTime(400);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+    expect(moveEvent.preventDefault).not.toHaveBeenCalled();
+    expect(moveEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("ignores container long-press handling when the touch starts on an item", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    const itemTarget = {
+      closest: (selector) =>
+        selector === "[data-file-explorer-item='true']" ? {} : undefined,
+    };
+
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        target: itemTarget,
+        x: 24,
+        y: 16,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.store.selectEmptyLongPressTimerId()).toBeUndefined();
+  });
+
+  it("supports the touch-event fallback for empty-space long press", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    handleContainerTouchStart(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.root,
+        x: 30,
+        y: 100,
+      }),
+    });
+
+    vi.advanceTimersByTime(360);
+
+    expect(state.dropdownMenu.isOpen).toBe(true);
+    expect(state.dropdownMenu.position).toEqual({ x: 30, y: 100 });
+
+    handleWindowTouchEnd(deps, {
+      _event: createTouchEvent({
+        currentTarget: deps.refs.root,
+        x: 30,
+        y: 100,
+        ended: true,
+      }),
+    });
+
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+  });
+
+  it("cancels a pointer-backed empty long press when the pointer is cancelled", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 80,
+        pointerId: 7,
+      }),
+    });
+
+    handleWindowPointerCancel(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 80,
+        pointerId: 7,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+  });
+
   it("emits visibility changes without selecting or dragging the row", () => {
     const { deps } = createDragDeps({ itemCount: 1 });
     deps.props.items[0].visibilityToggle = true;
@@ -352,6 +521,53 @@ describe("baseFileExplorer handlers", () => {
         }),
       }),
     );
+  });
+
+  it("opens the item context menu from the trailing action button without dragging or navigating", () => {
+    const { deps, state } = createDragDeps({ itemCount: 1 });
+    deps.props.contextMenuItems = [
+      { label: "Rename", value: "rename-item" },
+      { label: "Delete", icon: "trash", value: "delete-item" },
+    ];
+    const actionTarget = {
+      closest: (selector) =>
+        selector === "[data-file-explorer-action]" ? actionTarget : undefined,
+    };
+    const currentTarget = {
+      getAttribute: (name) => (name === "data-item-id" ? "item-1" : undefined),
+      getBoundingClientRect: () => ({ right: 312.4, bottom: 84.6 }),
+    };
+    const event = {
+      currentTarget,
+      target: actionTarget,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+
+    handleItemPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.itemRef0,
+        target: actionTarget,
+        x: 300,
+        y: 72,
+      }),
+    });
+    handleItemMenuClick(deps, { _event: event });
+
+    expect(deps.store.selectPendingDrag()).toBeNull();
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    expect(state.dropdownMenu).toEqual({
+      isOpen: true,
+      position: { x: 312, y: 85 },
+      itemId: "item-1",
+      items: [
+        { label: "Rename", value: "rename-item" },
+        { label: "Delete", value: "delete-item" },
+      ],
+    });
+    expect(deps.store.selectSelectedItemId()).toBe("item-1");
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
   });
 
   it("jumps selection by distance and clamps to the visible list bounds", () => {
@@ -845,7 +1061,10 @@ describe("baseFileExplorer handlers", () => {
     expect(touchContextMenuEvent.stopPropagation).toHaveBeenCalled();
     expect(deps.store.selectDropdownMenuItemId()).toBeNull();
 
-    const { deps: desktopDeps } = createDragDeps();
+    const { deps: desktopDeps, state: desktopState } = createDragDeps();
+    desktopDeps.props.contextMenuItems = [
+      { label: "Delete", icon: "trash", value: "delete-item" },
+    ];
     const mouseContextMenuEvent = createContextMenuEvent({
       currentTarget: desktopDeps.refs.itemRef0,
     });
@@ -854,6 +1073,9 @@ describe("baseFileExplorer handlers", () => {
 
     expect(desktopDeps.store.selectDropdownMenuItemId()).toBe("item-1");
     expect(desktopDeps.store.selectSelectedItemId()).toBe("item-1");
+    expect(desktopState.dropdownMenu.items).toEqual([
+      { label: "Delete", icon: "trash", value: "delete-item" },
+    ]);
     expect(desktopDeps.dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "item-click",

--- a/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
@@ -5,6 +5,7 @@ import {
   handleContainerContextMenu,
   handleContainerPointerDown,
   handleContainerTouchStart,
+  handleDropdownMenuClickItem,
   handleDropdownMenuClickOverlay,
   handleItemContextMenu,
   handleItemMenuClick,
@@ -378,6 +379,52 @@ describe("baseFileExplorer handlers", () => {
     handleDropdownMenuClickOverlay(deps);
 
     expect(deps.store.selectSuppressNextClick()).toBe(false);
+    expect(state.dropdownMenu.isOpen).toBe(true);
+    expect(deps.render).toHaveBeenCalledTimes(1);
+
+    handleDropdownMenuClickOverlay(deps);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.render).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not activate a menu item from the touch release that opened it", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 112,
+        pointerId: 7,
+      }),
+    });
+    vi.advanceTimersByTime(360);
+
+    const payload = {
+      _event: {
+        detail: {
+          item: { label: "New Folder", value: "new-item" },
+        },
+      },
+    };
+    handleDropdownMenuClickItem(deps, payload);
+
+    expect(deps.store.selectSuppressNextClick()).toBe(false);
+    expect(state.dropdownMenu.isOpen).toBe(true);
+    expect(deps.dispatchEvent).not.toHaveBeenCalled();
+
+    handleDropdownMenuClickItem(deps, payload);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "file-action",
+        detail: expect.objectContaining({
+          itemId: null,
+        }),
+      }),
+    );
   });
 
   it("cancels an empty-space long press when touch movement becomes a scroll", () => {

--- a/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.handlers.test.js
@@ -78,13 +78,17 @@ const createPointerEvent = ({
   x,
   y,
   pointerId = 1,
+  pointerType = "touch",
+  isPrimary = true,
+  button = 0,
 } = {}) => {
   return {
     currentTarget,
     target,
     pointerId,
-    pointerType: "touch",
-    isPrimary: true,
+    pointerType,
+    isPrimary,
+    button,
     clientX: x,
     clientY: y,
     preventDefault: vi.fn(),
@@ -403,6 +407,64 @@ describe("baseFileExplorer handlers", () => {
     expect(moveEvent.stopPropagation).not.toHaveBeenCalled();
   });
 
+  it("preserves the normal context menu for a pen barrel-button press", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 80,
+        pointerType: "pen",
+        button: 2,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(deps.store.selectEmptyLongPressTimerId()).toBeUndefined();
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+
+    const contextMenuEvent = createContextMenuEvent({
+      currentTarget: deps.refs.root,
+      target: { closest: vi.fn(() => undefined) },
+    });
+    handleContainerContextMenu(deps, { _event: contextMenuEvent });
+
+    expect(state.dropdownMenu.isOpen).toBe(true);
+    expect(contextMenuEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(contextMenuEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("cancels an empty-space long press when another pointer touches", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 24,
+        y: 80,
+        pointerId: 7,
+      }),
+    });
+    handleContainerPointerDown(deps, {
+      _event: createPointerEvent({
+        currentTarget: deps.refs.root,
+        x: 40,
+        y: 80,
+        pointerId: 8,
+        isPrimary: false,
+      }),
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.store.selectEmptyLongPressTimerId()).toBeUndefined();
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+    expect(deps.store.selectEmptyLongPressPointerId()).toBeUndefined();
+  });
+
   it("ignores container long-press handling when the touch starts on an item", () => {
     vi.useFakeTimers();
     const { deps, state } = createDragDeps();
@@ -450,6 +512,32 @@ describe("baseFileExplorer handlers", () => {
       }),
     });
 
+    expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
+  });
+
+  it("cancels the touch-event fallback when another touch starts", () => {
+    vi.useFakeTimers();
+    const { deps, state } = createDragDeps();
+    const firstTouch = createTouchEvent({
+      currentTarget: deps.refs.root,
+      x: 30,
+      y: 100,
+    });
+
+    handleContainerTouchStart(deps, { _event: firstTouch });
+    handleContainerTouchStart(deps, {
+      _event: {
+        ...firstTouch,
+        touches: [
+          { clientX: 30, clientY: 100 },
+          { clientX: 50, clientY: 100 },
+        ],
+      },
+    });
+    vi.advanceTimersByTime(400);
+
+    expect(state.dropdownMenu.isOpen).toBe(false);
+    expect(deps.store.selectEmptyLongPressTimerId()).toBeUndefined();
     expect(deps.store.selectEmptyLongPressStartPoint()).toBeUndefined();
   });
 

--- a/tests/baseFileExplorer/baseFileExplorer.store.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.store.test.js
@@ -180,4 +180,38 @@ describe("baseFileExplorer.store", () => {
     expect(disabledViewData.items[0].touchAction).toBe("pan-y");
     expect(enabledViewData.items[0].touchAction).toBe("none");
   });
+
+  it("shows localized item menu actions only when explicitly enabled", () => {
+    const state = createInitialState();
+    const item = {
+      id: "item-1",
+      type: "image",
+      name: "Image 1",
+      _level: 0,
+      hasChildren: false,
+      parentId: null,
+    };
+    const baseProps = {
+      items: [item],
+      itemContextMenuItems: [{ label: "Rename", value: "rename-item" }],
+    };
+
+    const disabledViewData = selectViewData({
+      state,
+      props: baseProps,
+      i18n: { resourcePages: { actionsLabel: "Item actions" } },
+    });
+    const enabledViewData = selectViewData({
+      state,
+      props: {
+        ...baseProps,
+        showItemMenuActions: true,
+      },
+      i18n: { resourcePages: { actionsLabel: "Item actions" } },
+    });
+
+    expect(disabledViewData.items[0].showMenuAction).toBe(false);
+    expect(enabledViewData.items[0].showMenuAction).toBe(true);
+    expect(enabledViewData.itemActionsLabel).toBe("Item actions");
+  });
 });

--- a/tests/baseFileExplorer/baseFileExplorer.view.test.js
+++ b/tests/baseFileExplorer/baseFileExplorer.view.test.js
@@ -40,6 +40,13 @@ describe("baseFileExplorer view", () => {
     expect(view).toContain("data-file-explorer-arrow=true");
   });
 
+  it("wires background pointer and touch starts for empty-space menus", () => {
+    const view = readView();
+
+    expect(view).toContain("handler: handleContainerPointerDown");
+    expect(view).toContain("handler: handleContainerTouchStart");
+  });
+
   it("renders special-item badges in the bottom-right corner of the item icon", () => {
     const view = readView();
 
@@ -68,5 +75,18 @@ describe("baseFileExplorer view", () => {
       "[data-file-explorer-item='true']:hover .visibilityAction",
     );
     expect(view).toContain("data-always-visible='true'");
+  });
+
+  it("renders opt-in trailing item menu actions", () => {
+    const view = readView();
+
+    expect(view).toContain("itemMenu*:");
+    expect(view).toContain("handler: handleItemMenuClick");
+    expect(view).toContain("$if item.showMenuAction");
+    expect(view).toContain("rtgl-button#itemMenuRef${i}");
+    expect(view).toContain("data-file-explorer-action=true");
+    expect(view).toContain("pre=ellipsis");
+    expect(view).toContain('aria-label="${itemActionsLabel}"');
+    expect(view).toContain("aria-haspopup=menu");
   });
 });

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -109,6 +109,9 @@ describe("commandLineBgm.store", () => {
       showResourceSelectorFileExplorer: true,
       resourceSelectorColumns: undefined,
       resourceSelectorGridStyle: "",
+      resourceSelectorHorizontalPadding: "lg",
+      resourceSelectorCardStyle:
+        "width: 200px; min-width: 0; max-width: 100%; box-sizing: border-box;",
     });
 
     setUiConfig({ state }, { uiConfig: { inputMode: "touch" } });
@@ -118,6 +121,9 @@ describe("commandLineBgm.store", () => {
       resourceSelectorColumns: 2,
       resourceSelectorGridStyle:
         "display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));",
+      resourceSelectorHorizontalPadding: "none",
+      resourceSelectorCardStyle:
+        "width: 100%; min-width: 0; max-width: 100%; box-sizing: border-box;",
     });
   });
 

--- a/tests/commandLineBgm/commandLineBgm.view.test.js
+++ b/tests/commandLineBgm/commandLineBgm.view.test.js
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+const readView = () =>
+  readFileSync(
+    new URL(
+      "../../src/components/commandLineBgm/commandLineBgm.view.yaml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+
+describe("commandLineBgm view", () => {
+  it("has valid YAML", () => {
+    expect(() => yaml.load(readView())).not.toThrow();
+  });
+
+  it("uses the Sounds card treatment in a responsive two-column grid", () => {
+    const view = readView();
+
+    expect(view).toContain(
+      'rtgl-view d=h w=f wrap g=md style="${resourceSelectorGridStyle}"',
+    );
+    expect(view).toContain("ph=${resourceSelectorHorizontalPadding}");
+    expect(view).toContain("data-group-id=${group.id} w=f g=md");
+    expect(view).toContain(
+      'rtgl-view br=md pos=rel overflow=hidden style="${resourceSelectorCardStyle}"',
+    );
+    expect(view).not.toContain("resourceSelectorItemStyle");
+    expect(view).not.toContain("resourceSelectorCardWidth");
+    expect(view).toContain("aspect-ratio: 16 / 9");
+    expect(view).toContain(
+      "rvn-waveform-visualizer waveformDataFileId=${item.waveformDataFileId} w=f h=f",
+    );
+    expect(view).toContain("rtgl-view w=f h=f av=c ah=c bgc=mu-fg");
+    expect(view).toContain("rtgl-view w=f p=md");
+    expect(view).not.toContain("rtgl-view p=md g=md br=md");
+    expect(view).not.toContain(
+      "waveformDataFileId=${item.waveformDataFileId} w=200 h=120",
+    );
+  });
+});

--- a/tests/images/images.view.test.js
+++ b/tests/images/images.view.test.js
@@ -109,6 +109,35 @@ describe("images view", () => {
     expect(mobileExplorerBranch).toContain("bottom-empty-space-height=80vh");
   });
 
+  it("enables per-item action menus only in the mobile file explorer", () => {
+    const imagesView = readFileSync(
+      new URL("../../src/pages/images/images.view.yaml", import.meta.url),
+      "utf8",
+    );
+
+    const mobileExplorerStart = imagesView.indexOf(
+      "$if showMobileFileExplorer",
+    );
+    const mobileDetailSheetStart = imagesView.indexOf(
+      "$if showMobileDetailSheet",
+      mobileExplorerStart,
+    );
+    const mobileExplorerBranch = imagesView.slice(
+      mobileExplorerStart,
+      mobileDetailSheetStart,
+    );
+    const desktopExplorerBranch = imagesView.slice(0, mobileExplorerStart);
+
+    expect(mobileExplorerBranch).toContain("show-item-menu-actions");
+    expect(mobileExplorerBranch).toContain(
+      ":folderContextMenuItems=${folderContextMenuItems}",
+    );
+    expect(mobileExplorerBranch).toContain(
+      ":itemContextMenuItems=${itemContextMenuItems}",
+    );
+    expect(desktopExplorerBranch).not.toContain("show-item-menu-actions");
+  });
+
   it("keeps the mobile file explorer clear of iOS safe areas", () => {
     const imagesView = readFileSync(
       new URL("../../src/pages/images/images.view.yaml", import.meta.url),

--- a/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
+++ b/tests/resourcePages/mobileFileExplorerNavbar.view.test.js
@@ -8,6 +8,11 @@ const mobileFileExplorerPages = [
     "$if showMobileFileExplorer",
   ],
   [
+    "audio effects",
+    "audioEffects/audioEffects.view.yaml",
+    "$if showMobileFileExplorer",
+  ],
+  [
     "character sprites",
     "characterSprites/characterSprites.view.yaml",
     "$if showMobileFileExplorer",
@@ -28,6 +33,7 @@ const mobileFileExplorerPages = [
   ],
   ["layouts", "layouts/layouts.view.yaml", "$if showMobileFileExplorer"],
   ["particles", "particles/particles.view.yaml", "$if showMobileFileExplorer"],
+  ["scenes", "scenes/scenes.view.yaml", "$if showMobileFileExplorer"],
   ["sounds", "sounds/sounds.view.yaml", "$if showMobileFileExplorer"],
   [
     "spritesheets",
@@ -87,6 +93,27 @@ describe("mobile file explorer navbar", () => {
       expect(view).not.toContain(
         "rtgl-view h=56 w=f d=h av=c ph=md bgc=bg bwb=xs g=md",
       );
+    },
+  );
+
+  it.each(mobileFileExplorerPages)(
+    "exposes the empty-space menu in the mobile explorer for %s",
+    (_name, relativePath, explorerCondition) => {
+      const view = readFileSync(
+        new URL(`../../src/pages/${relativePath}`, import.meta.url),
+        "utf8",
+      );
+      const mobileBranch = view.slice(view.indexOf(explorerCondition));
+      const explorerLine = mobileBranch
+        .split("\n")
+        .find((line) => line.includes("rvn-base-file-explorer#file"));
+
+      expect(explorerLine).toContain("dropdown-menu");
+      expect(explorerLine).toContain("show-item-menu-actions");
+      expect(explorerLine).toContain(
+        ":emptyContextMenuItems=${emptyContextMenuItems}",
+      );
+      expect(view.match(/show-item-menu-actions/g)).toHaveLength(1);
     },
   );
 });


### PR DESCRIPTION
## Summary

- open file explorer context actions by long-pressing empty space on touch devices
- add per-item overflow actions across resource explorer pages without triggering item navigation
- keep drag interactions intact and omit the delete icon from the mobile overflow menu
- limit empty-space long press to primary-button input and cancel it when additional contacts start
- keep newly opened long-press menus from closing or activating an item on the synthesized release-click
- render BGM sound cards as a full-width two-column grid with fixed 16:9 waveforms

## Validation

- `bun run lint`
- 158 affected Vitest tests passed across 10 test files
- `git diff --check`
- manually verified on a Vivo V2309A running Android 16:
  - BGM gallery renders two 143px columns in a 294px content area
  - Layout Editor empty-space long press remains open after finger release
  - the release-click is consumed without activating a menu item

## Repository check note

`bun run check:contracts` currently reports the existing repository-wide baseline of 504 errors and 3 warnings, including legacy component naming and unsupported attribute diagnostics unrelated to this change.