### PR TITLE
fix(scenes): preserve explorer reorder target

### DIFF
--- a/src/internal/ui/fileExplorer.js
+++ b/src/internal/ui/fileExplorer.js
@@ -1185,6 +1185,7 @@ export const createScenesFileExplorerHandlers = ({
         sceneId: move.itemId,
         parentId: move.parentId,
         position: move.repositoryPosition,
+        positionTargetId: move.repositoryPositionTargetId,
       });
 
       await refresh(deps);

--- a/tests/scenes/scenes.fileExplorer.test.js
+++ b/tests/scenes/scenes.fileExplorer.test.js
@@ -2,6 +2,53 @@ import { describe, expect, it, vi } from "vitest";
 import { createScenesFileExplorerHandlers } from "../../src/internal/ui/fileExplorer.js";
 
 describe("scenes file explorer", () => {
+  it.each([
+    {
+      explorerPosition: "above",
+      repositoryPosition: "before",
+    },
+    {
+      explorerPosition: "below",
+      repositoryPosition: "after",
+    },
+  ])(
+    "preserves the drop target when moving a scene $explorerPosition a sibling",
+    async ({ explorerPosition, repositoryPosition }) => {
+      const refresh = vi.fn(async () => {});
+      const reorderSceneItem = vi.fn(async () => {});
+      const deps = {
+        projectService: {
+          ensureRepository: vi.fn(async () => {}),
+          reorderSceneItem,
+        },
+      };
+      const handlers = createScenesFileExplorerHandlers({ refresh });
+
+      await handlers.handleFileExplorerTargetChanged(deps, {
+        _event: {
+          detail: {
+            source: {
+              id: "scene-3",
+            },
+            target: {
+              id: "scene-1",
+              parentId: "folder-1",
+            },
+            position: explorerPosition,
+          },
+        },
+      });
+
+      expect(reorderSceneItem).toHaveBeenCalledWith({
+        sceneId: "scene-3",
+        parentId: "folder-1",
+        position: repositoryPosition,
+        positionTargetId: "scene-1",
+      });
+      expect(refresh).toHaveBeenCalledWith(deps);
+    },
+  );
+
   it("shows an error when creating a folder fails", async () => {
     const refresh = vi.fn(async () => {});
     const deps = {


### PR DESCRIPTION
## Summary

- forward the scene explorer sibling drop target to the scene reorder command
- preserve correct before/after placement when dragging scenes within a folder
- add regression coverage for both above and below sibling drops

## Validation

- `bunx vitest run tests/scenes` — 35 passed
- all file explorer tests — 71 passed
- `bun run test:smoke` — passed
- `bun run lint` — passed
- live browser validation: moved the third child to first, then moved it back below the last sibling

The complete Vitest suite was also run: 3,382 tests passed and 41 unrelated existing tests failed in other modules, primarily stale i18n fixtures and test mocks.