### PR TITLE
fix: macos export version prefill

### DIFF
--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -401,6 +401,7 @@ versionsPage:
   macosVerifyingApplicationStatus: "Verifying application..."
   macosVerifyingArchiveStatus: "Verifying application archive..."
   loadingMessage: "Loading..."
+  nameDescription: "Version name can be anything, but it is recommended you use an incremental numbering system (for example 1.0.0)."
   nameLabel: "Name"
   noSelectionLabel: "No selection"
   noVersionsMessage: "No versions"

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -401,6 +401,7 @@ versionsPage:
   macosVerifyingApplicationStatus: "アプリケーションを検証しています..."
   macosVerifyingArchiveStatus: "アプリケーションアーカイブを検証しています..."
   loadingMessage: "読み込み中..."
+  nameDescription: "バージョン名は任意ですが、連番の番号体系（例: 1.0.0）を使用することをお勧めします。"
   nameLabel: "名前"
   noSelectionLabel: "未選択"
   noVersionsMessage: "バージョンはありません"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -401,6 +401,7 @@ versionsPage:
   macosVerifyingApplicationStatus: "正在验证应用..."
   macosVerifyingArchiveStatus: "正在验证应用归档..."
   loadingMessage: "正在加载..."
+  nameDescription: "版本名称可以任意指定，但建议使用递增的版本编号（例如 1.0.0）。"
   nameLabel: "名称"
   noSelectionLabel: "未选择"
   noVersionsMessage: "没有版本"

--- a/src/pages/versions/versions.handlers.js
+++ b/src/pages/versions/versions.handlers.js
@@ -786,7 +786,9 @@ const prepareExportConfirmation = async (
     macosExportForm.reset();
     macosExportForm.setValues({
       values: {
-        version: version.name ?? "",
+        version: isValidMacosApplicationVersion(version?.name)
+          ? version.name
+          : "",
         buildNumber: "",
       },
     });

--- a/src/pages/versions/versions.store.js
+++ b/src/pages/versions/versions.store.js
@@ -30,6 +30,9 @@ const createVersionForm = ({ isEditing, copy = {} } = {}) => ({
       name: "name",
       type: "input-text",
       label: copy.nameLabel ?? "Name",
+      description:
+        copy.nameDescription ??
+        "Version name can be anything, but it is recommended you use an incremental numbering system (for example 1.0.0).",
       required: true,
     },
     {

--- a/tests/versions/versions.handlers.test.js
+++ b/tests/versions/versions.handlers.test.js
@@ -1325,7 +1325,7 @@ describe("versions macOS export handlers", () => {
     expect(deps.refs.macosExportForm.reset).toHaveBeenCalledTimes(1);
     expect(deps.refs.macosExportForm.setValues).toHaveBeenCalledWith({
       values: {
-        version: "Version 1",
+        version: "",
         buildNumber: "",
       },
     });
@@ -1360,6 +1360,35 @@ describe("versions macOS export handlers", () => {
     expect(
       deps.projectService.createMacosApplicationToPath.mock.calls[0][4],
     ).toEqual({ onProgress: expect.any(Function) });
+  });
+
+  it("prefills the version field when the version name is a valid 3-part semver", async () => {
+    const repository = {
+      loadState: vi.fn(async () => structuredClone(initialProjectData)),
+      loadEvents: vi.fn(async () => []),
+      getState: vi.fn(() => structuredClone(initialProjectData)),
+    };
+    const deps = createDeps({
+      repository,
+      version: {
+        id: "version-1",
+        name: "1.2.3",
+        actionIndex: 3,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    await handleDownloadMacosApplicationClick(
+      deps,
+      createVersionClickPayload(),
+    );
+
+    expect(deps.refs.macosExportForm.setValues).toHaveBeenCalledWith({
+      values: {
+        version: "1.2.3",
+        buildNumber: "",
+      },
+    });
   });
 
   it("requires a manually entered build number for every macOS export", async () => {

--- a/tests/versions/versions.store.test.js
+++ b/tests/versions/versions.store.test.js
@@ -31,6 +31,13 @@ describe("versions store form", () => {
     });
 
     expect(viewData.versionForm.title).toBe("New Version");
+    expect(viewData.versionForm.fields[0]).toEqual({
+      name: "name",
+      type: "input-text",
+      label: "Name",
+      description: EN_I18N.versionsPage.nameDescription,
+      required: true,
+    });
     expect(viewData.versionForm.actions).toEqual({
       buttons: [
         {


### PR DESCRIPTION
- If version name is non-numeric, it wouldn't be pre-filled to the macOS bundle version field when exporting to mac. This is because versions can only be numerical. Originally, the app would blindly copy it resulting in an error, unless the user manually removes it.
- Added a short description for naming conventions when creating a new version of an app.
<img width="1200" height="1938" alt="macos-export-changes" src="https://github.com/user-attachments/assets/81afc04f-833a-4501-8d67-921e9e73779d" />
<img width="764" height="427" alt="new-version-name-description" src="https://github.com/user-attachments/assets/48aedcf6-adb8-475b-a487-3fdfa4fa1aaa" />
