### PR TITLE
Fix layout editor drag jumps and snapbacks

### DIFF
--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -1751,12 +1751,12 @@ export const handleOnUpdate = async (deps, changes) => {
 
   const nextSelectedItem = getSelectedItem(newProps);
   if (
-    !deps.store.selectDragging().isDragging &&
     areCanvasItemsEquivalent(
       nextSelectedItem,
       deps.store.selectPendingUpdatedItem(),
     )
   ) {
+    // Accept refreshed item fields; the gesture's render snapshot stays separate.
     deps.store.clearPendingUpdatedItem();
   }
 

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.handlers.js
@@ -689,14 +689,22 @@ const createTransientCanvasItemUpdater = ({ updatedItem, dragging } = {}) => {
 };
 
 const renderTransientCanvasItem = (deps, updatedItem) => {
-  const { baseElements, parsedElements, canvasUnitsPerCssPixel } =
-    deps.store.selectCanvasRenderState();
-  const { occurrencesById, occurrenceIdsByOwner } =
-    deps.store.selectSelectionOccurrenceState();
+  const { store, props, graphicsService } = deps;
+  const dragRenderState = store.selectDragRenderState();
+  if (!dragRenderState) {
+    return false;
+  }
+  const {
+    baseElements,
+    parsedElements,
+    occurrencesById,
+    occurrenceIdsByOwner,
+  } = dragRenderState;
+  const { canvasUnitsPerCssPixel } = store.selectCanvasRenderState();
   const occurrenceIds = new Set(occurrenceIdsByOwner[updatedItem.id] ?? []);
   const updateElement = createTransientCanvasItemUpdater({
     updatedItem,
-    dragging: deps.store.selectDragging(),
+    dragging: store.selectDragging(),
   });
   if (
     baseElements.length === 0 ||
@@ -726,14 +734,22 @@ const renderTransientCanvasItem = (deps, updatedItem) => {
       baseElements: nextBaseState.elements,
       parsedElements: nextParsedState.elements,
       selectedItemId: updatedItem.id,
-      selectedOccurrenceId: deps.store.selectSelectedOccurrenceId(),
+      selectedOccurrenceId: store.selectSelectedOccurrenceId(),
       occurrencesById,
       occurrenceIdsByOwner,
       selectedItem: updatedItem,
-      disableMoveDrag: deps.props.disableMoveDrag === true,
+      disableMoveDrag: props.disableMoveDrag === true,
       canvasUnitsPerCssPixel,
     });
-  deps.graphicsService.render({ elements, animations: [] });
+  // A full render awaiting assets must not paint over this newer position.
+  store.setActiveRenderRequestId({ requestId: undefined });
+  graphicsService.render({ elements, animations: [] });
+  store.setCanvasRenderState({
+    elements,
+    baseElements: nextBaseState.elements,
+    parsedElements: nextParsedState.elements,
+    canvasUnitsPerCssPixel,
+  });
   dispatchSelectedElementMetrics(deps, {
     itemId: updatedItem.id,
     metrics: selectedElementMetrics,
@@ -825,7 +841,11 @@ const startCanvasPointerSelectionDrag = (
   }
 
   dispatchCanvasSelection(deps, selection);
-  const currentItem = getLayoutItemById(deps.props, selection.itemId);
+  const pendingUpdatedItem = deps.store.selectPendingUpdatedItem();
+  const currentItem =
+    pendingUpdatedItem?.id === selection.itemId
+      ? pendingUpdatedItem
+      : getLayoutItemById(deps.props, selection.itemId);
   const canMove =
     currentItem &&
     Number.isFinite(currentItem.x) &&
@@ -1485,13 +1505,13 @@ const handleBorderDragMove = async (deps, payload = {}) => {
   }
 
   deps.store.setPendingUpdatedItem({ updatedItem });
+  dispatchCanvasItemEvent(deps, "drag-update", updatedItem);
   if (!renderTransientCanvasItem(deps, updatedItem)) {
     await renderLayoutEditorCanvas(deps, deps.props, {
       updatedItem,
       reason: "border-drag-move",
     });
   }
-  dispatchCanvasItemEvent(deps, "drag-update", updatedItem);
 };
 
 const handleBorderDragEnd = async (deps) => {
@@ -1507,11 +1527,11 @@ const handleBorderDragEnd = async (deps) => {
     return;
   }
 
+  dispatchCanvasItemEvent(deps, "update", pendingUpdatedItem);
   await renderLayoutEditorCanvas(deps, deps.props, {
     updatedItem: pendingUpdatedItem,
     reason: "border-drag-end",
   });
-  dispatchCanvasItemEvent(deps, "update", pendingUpdatedItem);
 };
 
 const subscriptions = (deps) => {
@@ -1731,6 +1751,7 @@ export const handleOnUpdate = async (deps, changes) => {
 
   const nextSelectedItem = getSelectedItem(newProps);
   if (
+    !deps.store.selectDragging().isDragging &&
     areCanvasItemsEquivalent(
       nextSelectedItem,
       deps.store.selectPendingUpdatedItem(),

--- a/src/components/layoutEditorCanvas/layoutEditorCanvas.store.js
+++ b/src/components/layoutEditorCanvas/layoutEditorCanvas.store.js
@@ -10,6 +10,7 @@ export const createInitialState = () => ({
   isDragging: false,
   dragMode: "move",
   dragStartPosition: undefined,
+  dragRenderState: undefined,
   pendingUpdatedItem: undefined,
   fileContentCacheById: {},
   activeRenderRequestId: undefined,
@@ -37,6 +38,14 @@ export const setGraphicsReady = ({ state }, { value = false } = {}) => {
 export const startDragging = ({ state }, { dragMode = "move" } = {}) => {
   state.isDragging = true;
   state.dragMode = dragMode;
+  state.activeRenderRequestId = undefined;
+  // Pointer deltas stay relative to this snapshot for the entire gesture.
+  state.dragRenderState = {
+    baseElements: state.canvasBaseElements,
+    parsedElements: state.canvasParsedElements,
+    occurrencesById: state.selectionOccurrencesById,
+    occurrenceIdsByOwner: state.selectionOccurrenceIdsByOwner,
+  };
 };
 
 export const setDragStartPosition = (
@@ -96,6 +105,7 @@ export const stopDragging = ({ state }, _payload = {}) => {
   state.isDragging = false;
   state.dragMode = "move";
   state.dragStartPosition = undefined;
+  state.dragRenderState = undefined;
 };
 
 export const setPendingUpdatedItem = ({ state }, { updatedItem } = {}) => {
@@ -312,6 +322,10 @@ export const selectCanvasRenderState = ({ state }) => {
     parsedElements: state.canvasParsedElements,
     canvasUnitsPerCssPixel: state.canvasUnitsPerCssPixel,
   };
+};
+
+export const selectDragRenderState = ({ state }) => {
+  return state.dragRenderState;
 };
 
 export const selectViewData = ({ state, props }) => {

--- a/src/pages/layoutEditor/layoutEditor.handlers.js
+++ b/src/pages/layoutEditor/layoutEditor.handlers.js
@@ -1711,6 +1711,10 @@ async function handleDebouncedUpdate(deps, payload) {
         };
       }
 
+      // Only edits newer than this acknowledged save should overlay repository data.
+      store.clearPendingPersistPayload({
+        persistenceRequestId: payload.persistenceRequestId,
+      });
       const currentPayload = getEditorPayload(appService);
       store.syncRepositoryState(
         createLayoutEditorRepositoryStoreData({
@@ -1719,9 +1723,6 @@ async function handleDebouncedUpdate(deps, payload) {
           resourceType: currentPayload.resourceType || resourceType,
         }),
       );
-      store.clearPendingPersistPayload({
-        persistenceRequestId: payload.persistenceRequestId,
-      });
       return {
         ok: true,
         didPersist: true,
@@ -1989,26 +1990,21 @@ export const handleLayoutEditPanelUpdateHandler = async (deps, payload) => {
     updatedItem: updatedItem,
   });
 
+  const pendingPayload = queuePendingLayoutEditorPersist(store, {
+    layoutId,
+    resourceType,
+    selectedItemId,
+    updatedItem,
+  });
   if (
     shouldPersistLayoutEditorFieldImmediately({
       name: detail.name,
       itemType: currentItem.type,
     })
   ) {
-    await handleDebouncedUpdate(deps, {
-      layoutId,
-      resourceType,
-      selectedItemId,
-      updatedItem,
-    });
+    await handleDebouncedUpdate(deps, pendingPayload);
   } else {
     const { subject } = deps;
-    const pendingPayload = queuePendingLayoutEditorPersist(store, {
-      layoutId,
-      resourceType,
-      selectedItemId,
-      updatedItem,
-    });
     subject.dispatch("layoutEditor.updateElement", pendingPayload);
   }
 

--- a/src/pages/layoutEditor/layoutEditor.store.js
+++ b/src/pages/layoutEditor/layoutEditor.store.js
@@ -387,6 +387,19 @@ export const syncRepositoryState = ({ state }, payload = {}) => {
     resourceType,
   });
   state.layoutData = layoutData ?? { items: {}, tree: [] };
+  const pending = state.pendingPersistPayload;
+  if (
+    pending &&
+    pending.layoutId === layoutId &&
+    pending.resourceType === resourceType &&
+    state.layoutData.items[pending.selectedItemId]
+  ) {
+    // An earlier save can finish while a newer drag position is still queued.
+    // Copy the item map so preserving the draft never mutates repository data.
+    const items = Object.assign({}, state.layoutData.items);
+    items[pending.selectedItemId] = pending.updatedItem;
+    state.layoutData = { tree: state.layoutData.tree, items };
+  }
   state.images = images ?? { items: {}, tree: [] };
   state.soundsData = soundsData ?? { items: {}, tree: [] };
   state.spritesheetsData = spritesheetsData ?? { items: {}, tree: [] };

--- a/tests/layoutEditor/layoutEditor.handlers.test.js
+++ b/tests/layoutEditor/layoutEditor.handlers.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { produce } from "immer";
 import { EN_I18N } from "../support/i18n.js";
+import * as layoutEditorStore from "../../src/pages/layoutEditor/layoutEditor.store.js";
+import { createLayoutEditorRepositoryStoreData } from "../../src/pages/layoutEditor/support/layoutEditorRepositoryState.js";
 import {
   handleBackClick,
   handleFileExplorerAction,
@@ -132,6 +135,162 @@ const createLayoutEditorDeps = ({
     i18n: EN_I18N,
   };
 };
+
+const createDraftReconciliationHarness = (resourceType) => {
+  const deps = createLayoutEditorDeps({ resourceType });
+  let repositoryState = {
+    project: { resolution: { width: 1920, height: 1080 } },
+    [resourceType]: {
+      items: {
+        "layout-1": {
+          elements: {
+            tree: [{ id: "item-1" }],
+            items: {
+              "item-1": {
+                type: "container-ref-save-load-slot",
+                name: "Container One",
+                x: 0,
+                y: 0,
+                paginationMode: "continuous",
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  let state = layoutEditorStore.createInitialState();
+  for (const name of [
+    "syncRepositoryState",
+    "setSelectedItemId",
+    "updateSelectedItem",
+    "setPendingPersistPayload",
+    "clearPendingPersistPayload",
+  ]) {
+    deps.store[name] = vi.fn((payload) => {
+      state = produce(state, (draft) => {
+        layoutEditorStore[name]({ state: draft }, payload);
+      });
+    });
+  }
+  for (const name of [
+    "selectSelectedItemId",
+    "selectSelectedItemData",
+    "selectItemDataById",
+    "selectImages",
+    "selectPendingPersistPayload",
+  ]) {
+    deps.store[name] = (payload) => layoutEditorStore[name]({ state }, payload);
+  }
+  const updateElement = vi.fn(async ({ elementId, data, replace }) => {
+    repositoryState = produce(repositoryState, (draft) => {
+      const items = draft[resourceType].items["layout-1"].elements.items;
+      if (replace) {
+        items[elementId] = data;
+      } else {
+        Object.assign(items[elementId], data);
+      }
+    });
+    return { valid: true };
+  });
+  deps.projectService.updateLayoutElement = updateElement;
+  deps.projectService.updateControlElement = updateElement;
+  deps.projectService.getRepositoryState = () => repositoryState;
+  deps.appService.getPayload = () => ({
+    p: "project-1",
+    [resourceType === "controls" ? "c" : "l"]: "layout-1",
+  });
+  deps.store.syncRepositoryState(
+    createLayoutEditorRepositoryStoreData({
+      repositoryState,
+      layoutId: "layout-1",
+      resourceType,
+    }),
+  );
+  deps.store.setSelectedItemId({ itemId: "item-1" });
+  return {
+    deps,
+    updateElement,
+    savedItem: () =>
+      repositoryState[resourceType].items["layout-1"].elements.items["item-1"],
+    edit: (name, value) =>
+      handleLayoutEditPanelUpdateHandler(deps, {
+        _event: { detail: { name, value } },
+      }),
+  };
+};
+
+describe.each(["layouts", "controls"])(
+  "layoutEditor %s draft reconciliation",
+  (resourceType) => {
+    it("supersedes a debounced draft when a newer field is saved immediately", async () => {
+      const { deps, edit, savedItem } =
+        createDraftReconciliationHarness(resourceType);
+      await edit("x", 10);
+      await edit("paginationMode", "paginated");
+
+      expect(savedItem()).toMatchObject({ x: 10, paginationMode: "paginated" });
+      expect(deps.store.selectSelectedItemData()).toMatchObject({
+        x: 10,
+        paginationMode: "paginated",
+      });
+      expect(deps.store.selectPendingPersistPayload()).toBeUndefined();
+
+      await edit("x", 20);
+      await handleBackClick(deps);
+      expect(savedItem()).toMatchObject({ x: 20, paginationMode: "paginated" });
+    });
+
+    it("retains edits made while an immediate save is in flight", async () => {
+      const { deps, edit, savedItem, updateElement } =
+        createDraftReconciliationHarness(resourceType);
+      const persist = updateElement.getMockImplementation();
+      let release;
+      const saveReady = new Promise((resolve) => {
+        release = resolve;
+      });
+      updateElement.mockImplementationOnce(async (payload) => {
+        await saveReady;
+        return persist(payload);
+      });
+      await edit("x", 10);
+      const saving = edit("paginationMode", "paginated");
+      await vi.waitFor(() => expect(updateElement).toHaveBeenCalledTimes(1));
+      await edit("x", 20);
+      const pending = deps.store.selectPendingPersistPayload();
+      release();
+      await saving;
+
+      expect(savedItem()).toMatchObject({ x: 10, paginationMode: "paginated" });
+      expect(deps.store.selectSelectedItemData()).toMatchObject({
+        x: 20,
+        paginationMode: "paginated",
+      });
+      expect(deps.store.selectPendingPersistPayload()).toEqual(pending);
+      await handleBackClick(deps);
+      expect(savedItem()).toMatchObject({ x: 20, paginationMode: "paginated" });
+    });
+
+    it("accepts refreshed fields once the pending save is acknowledged", async () => {
+      const { deps, edit, savedItem, updateElement } =
+        createDraftReconciliationHarness(resourceType);
+      const persist = updateElement.getMockImplementation();
+      updateElement.mockImplementationOnce(async (payload) => {
+        const result = await persist(payload);
+        await persist({ elementId: "item-1", data: { name: "Container Two" } });
+        return result;
+      });
+      await edit("x", 10);
+      await handleBackClick(deps);
+
+      expect(deps.store.selectPendingPersistPayload()).toBeUndefined();
+      expect(deps.store.selectSelectedItemData().name).toBe("Container Two");
+      await edit("x", 20);
+      await handleBackClick(deps);
+      expect(savedItem()).toMatchObject({ x: 20, name: "Container Two" });
+    });
+  },
+);
 
 describe("layoutEditor.handleFileExplorerVisibilityToggle", () => {
   it("optimistically updates and persists element visibility", async () => {

--- a/tests/layoutEditor/layoutEditor.store.test.js
+++ b/tests/layoutEditor/layoutEditor.store.test.js
@@ -11,6 +11,8 @@ import {
   setDetailPanelSelectedItemId,
   setPreviewData,
   setUiConfig,
+  setPendingPersistPayload,
+  clearPendingPersistPayload,
 } from "../../src/pages/layoutEditor/layoutEditor.store.js";
 
 const TEST_CONSTANTS = {
@@ -48,6 +50,83 @@ const LAYOUT_EDITOR_CONSTANTS = yaml.load(
 );
 
 describe("layoutEditor.store", () => {
+  it.each(["layouts", "controls"])(
+    "preserves the latest unsaved position when an older %s save is reconciled",
+    (resourceType) => {
+      const state = createInitialState();
+      const committedItem = Object.freeze({ type: "rect", x: 10, y: 0 });
+      const layoutData = {
+        items: Object.freeze({ "item-one": committedItem }),
+        tree: [{ id: "item-one" }],
+      };
+      const payload = {
+        projectResolution: { width: 1920, height: 1080 },
+        layoutId: "layout-one",
+        resourceType,
+        layoutData,
+      };
+      const updatedItem = { type: "rect", x: 20, y: 0 };
+      setPendingPersistPayload(
+        { state },
+        {
+          payload: {
+            layoutId: "layout-one",
+            resourceType,
+            selectedItemId: "item-one",
+            updatedItem,
+            persistenceRequestId: "save-two",
+          },
+        },
+      );
+
+      syncRepositoryState({ state }, payload);
+      clearPendingPersistPayload(
+        { state },
+        { persistenceRequestId: "save-one" },
+      );
+      expect(state.layoutData.items["item-one"].x).toBe(20);
+      expect(layoutData.items["item-one"].x).toBe(10);
+      expect(state.pendingPersistPayload.updatedItem).toEqual(updatedItem);
+
+      clearPendingPersistPayload(
+        { state },
+        { persistenceRequestId: "save-two" },
+      );
+      syncRepositoryState({ state }, payload);
+      expect(state.layoutData.items["item-one"].x).toBe(10);
+    },
+  );
+
+  it.each([
+    { layoutId: "layout-two", resourceType: "layouts" },
+    { layoutId: "layout-one", resourceType: "controls" },
+  ])("does not carry a pending drag into another owner: %j", (owner) => {
+    const state = createInitialState();
+    setPendingPersistPayload(
+      { state },
+      {
+        payload: {
+          layoutId: "layout-one",
+          resourceType: "layouts",
+          selectedItemId: "item-one",
+          updatedItem: { type: "rect", x: 20, y: 0 },
+        },
+      },
+    );
+    syncRepositoryState(
+      { state },
+      {
+        ...owner,
+        projectResolution: { width: 1920, height: 1080 },
+        layoutData: {
+          items: { "item-one": { type: "rect", x: 10, y: 0 } },
+          tree: [{ id: "item-one" }],
+        },
+      },
+    );
+    expect(state.layoutData.items["item-one"].x).toBe(10);
+  });
+
   it("marks selected descendants of hidden parents as effectively hidden", () => {
     const state = createInitialState();
 
@@ -289,10 +368,7 @@ describe("layoutEditor.store", () => {
     const roleLabels = {
       "choice-item": ["container-ref-choice-item", "Choice Item"],
       "choice-item-text": ["text-ref-choice-item-content", "Choice Item Text"],
-      "dialogue-text": [
-        "text-revealing-ref-dialogue-content",
-        "Dialogue Text",
-      ],
+      "dialogue-text": ["text-revealing-ref-dialogue-content", "Dialogue Text"],
       "nvl-line": ["container-ref-dialogue-line", "NVL Line"],
       "nvl-line-speaker-name": [
         "text-ref-dialogue-line-character-name",

--- a/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
+++ b/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
@@ -337,6 +337,51 @@ const delayNextAssetLoad = (deps) => {
 };
 
 describe("layoutEditorCanvas drag rendering", () => {
+  it.each(["move", "release"])(
+    "retains collaborator fields on %s after a drag draft is acknowledged",
+    async (nextAction) => {
+      const drag = createDragHarness();
+      drag.start();
+      await drag.move(10);
+      const dragRenderState = drag.deps.store.selectDragRenderState();
+      await drag.renderParentDraft();
+
+      const oldProps = { ...drag.deps.props };
+      const layoutState = drag.deps.props.layoutState;
+      const updatedItem = {
+        ...layoutState.elements.items.parent,
+        name: "Container Two",
+        opacity: 0.5,
+      };
+      drag.deps.props.layoutState = {
+        ...layoutState,
+        elements: {
+          ...layoutState.elements,
+          items: { ...layoutState.elements.items, parent: updatedItem },
+        },
+      };
+      await handleOnUpdate(drag.deps, {
+        oldProps,
+        newProps: drag.deps.props,
+      });
+      expect(drag.deps.store.selectDragRenderState()).toBe(dragRenderState);
+
+      if (nextAction === "move") {
+        await drag.move(20);
+        expect(drag.renderedParent().x).toBe(20);
+      }
+      await drag.end();
+      const updates = drag.deps.dispatchEvent.mock.calls
+        .map(([event]) => event)
+        .filter(({ type }) => type === "update");
+      expect(updates.at(-1).detail.updatedItem).toMatchObject({
+        x: nextAction === "move" ? 20 : 10,
+        name: "Container Two",
+        opacity: 0.5,
+      });
+    },
+  );
+
   it("keeps movement relative to drag start across parent redraws", async () => {
     const drag = createDragHarness();
     drag.start();

--- a/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
+++ b/tests/layoutEditor/layoutEditorCanvas.handlers.test.js
@@ -102,6 +102,7 @@ const createStore = (props) => {
     selectHoverFrameId: bindSelector(canvasStore.selectHoverFrameId),
     setCanvasRenderState: bindAction(canvasStore.setCanvasRenderState),
     selectCanvasRenderState: bindSelector(canvasStore.selectCanvasRenderState),
+    selectDragRenderState: bindSelector(canvasStore.selectDragRenderState),
     selectPendingUpdatedItem: bindSelector(
       canvasStore.selectPendingUpdatedItem,
     ),
@@ -266,6 +267,141 @@ const runClick = (deps, { clickCount = 1, metaKey = false } = {}) => {
 
   return event;
 };
+
+const createDragHarness = () => {
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn(() => 1),
+  );
+  const deps = createDeps({ selectedItemId: "parent" });
+  const { parsedElements } = deps.store.selectCanvasRenderState();
+  deps.store.setCanvasRenderState({
+    elements: parsedElements,
+    baseElements: parsedElements,
+    parsedElements,
+    canvasUnitsPerCssPixel: 1,
+  });
+  const pointer = {
+    button: 0,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: "mouse",
+    clientX: 30,
+    clientY: 30,
+    currentTarget: {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+    },
+  };
+  return {
+    deps,
+    start: () => handleCanvasPointerDown(deps, { _event: pointer }),
+    move: (deltaX) =>
+      handleCanvasPointerMove(deps, {
+        _event: { ...pointer, clientX: pointer.clientX + deltaX },
+      }),
+    end: () => handleCanvasPointerUp(deps, { _event: pointer }),
+    renderedParent: () =>
+      deps.graphicsService.render.mock.calls.at(-1)[0].elements[0],
+    renderParentDraft: () => {
+      const oldProps = { ...deps.props };
+      const elements = deps.props.layoutState.elements;
+      deps.props.layoutState = {
+        ...deps.props.layoutState,
+        elements: {
+          ...elements,
+          items: {
+            ...elements.items,
+            parent: deps.store.selectPendingUpdatedItem(),
+          },
+        },
+      };
+      return handleOnUpdate(deps, { oldProps, newProps: deps.props });
+    },
+  };
+};
+
+const delayNextAssetLoad = (deps) => {
+  let release;
+  let notifyStarted;
+  const started = new Promise((resolve) => {
+    notifyStarted = resolve;
+  });
+  deps.graphicsService.loadAssets.mockImplementationOnce(() => {
+    notifyStarted();
+    return new Promise((resolve) => {
+      release = resolve;
+    });
+  });
+  return { started, release: () => release() };
+};
+
+describe("layoutEditorCanvas drag rendering", () => {
+  it("keeps movement relative to drag start across parent redraws", async () => {
+    const drag = createDragHarness();
+    drag.start();
+    await drag.move(10);
+    await drag.renderParentDraft();
+    await drag.move(20);
+    expect(drag.renderedParent()).toMatchObject({ x: 20, y: 0 });
+    await drag.move(25);
+    expect(drag.renderedParent()).toMatchObject({ x: 25, y: 0 });
+    await drag.end();
+    expect(drag.renderedParent()).toMatchObject({ x: 25, y: 0 });
+  });
+
+  it("does not let a delayed full redraw overwrite newer movement", async () => {
+    const drag = createDragHarness();
+    drag.start();
+    await drag.move(10);
+    const assets = delayNextAssetLoad(drag.deps);
+    const redraw = drag.renderParentDraft();
+    await assets.started;
+    await drag.move(20);
+    expect(drag.renderedParent().x).toBe(20);
+    assets.release();
+    await redraw;
+    expect(drag.renderedParent().x).toBe(20);
+    await drag.move(25);
+    expect(drag.renderedParent().x).toBe(25);
+  });
+
+  it("starts the next drag from the latest position before the release redraw finishes", async () => {
+    const drag = createDragHarness();
+    drag.start();
+    await drag.move(10);
+    const assets = delayNextAssetLoad(drag.deps);
+    const released = drag.end();
+    await assets.started;
+    drag.start();
+    await drag.move(10);
+    expect(drag.deps.store.selectPendingUpdatedItem().x).toBe(20);
+    expect(drag.renderedParent().x).toBe(20);
+    assets.release();
+    await released;
+    expect(drag.renderedParent().x).toBe(20);
+    await drag.end();
+    const updates = drag.deps.dispatchEvent.mock.calls
+      .map(([event]) => event)
+      .filter(({ type }) => type === "update");
+    expect(updates.map(({ detail }) => detail.updatedItem.x)).toEqual([10, 20]);
+    const eventTypes = drag.deps.dispatchEvent.mock.calls.map(
+      ([event]) => event.type,
+    );
+    expect(eventTypes.indexOf("update")).toBeLessThan(
+      eventTypes.lastIndexOf("drag-update"),
+    );
+  });
+
+  it("keeps the current position when canvas chrome resizes during a drag", async () => {
+    const drag = createDragHarness();
+    drag.start();
+    await drag.move(10);
+    drag.deps.canvasBounds.width = 200;
+    handleCanvasResize(drag.deps);
+    expect(drag.renderedParent().x).toBe(10);
+  });
+});
 
 describe("layoutEditorCanvas pointer selection", () => {
   it("renders hover with Route Graphics rects and a one-CSS-pixel light-gray line", () => {

--- a/vt/specs/project/layouts.yaml
+++ b/vt/specs/project/layouts.yaml
@@ -307,16 +307,75 @@ steps:
     type: js
     fn: eval
     args:
+      - |
+        (async () => {
+          const deepQuery = (root, selector) => {
+            const direct = root?.querySelector?.(selector);
+            if (direct) return direct;
+            for (const node of root?.querySelectorAll?.('*') ?? []) {
+              const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined;
+              if (found) return found;
+            }
+          };
+          const findById = (elements, id) => {
+            for (const element of elements ?? []) {
+              if (element.id === id) return element;
+              const child = findById(element.children, id);
+              if (child) return child;
+            }
+          };
+          const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas');
+          await canvas.transformedHandlers.restartPreview({});
+          canvas.deps.subject.dispatch('border-drag-move', { x: 30, y: 15 });
+          const moved = findById(window.__vtFragmentDragElements, 'wTne3pvWw7ui');
+          const expected = window.__vtFragmentDragExpected;
+          const stayedUnderPointer = moved.x === expected.x + 10 && moved.y === expected.y + 5;
+          canvas.deps.subject.dispatch('border-drag-move', { x: 20, y: 10 });
+          return String(stayedUnderPointer);
+        })()
+    value: "true"
+  - action: assert
+    type: js
+    fn: eval
+    args:
       - "(() => { const findById = (elements, id) => { for (const element of Array.isArray(elements) ? elements : []) { if (element?.id === id) return element; const child = findById(element?.children, id); if (child) return child; } }; const root = findById(window.__vtFragmentDragElements, 'wTne3pvWw7ui'); const fields = ['x', 'y', 'width', 'height', 'rotation']; const descendantsStayedLocal = window.__vtFragmentDragBaseline.every((before) => { const after = findById(window.__vtFragmentDragElements, before.id); return after && fields.every((field) => Object.is(after[field], before[field])); }); return String(root?.x === window.__vtFragmentDragExpected.x && root?.y === window.__vtFragmentDragExpected.y && descendantsStayedLocal); })()"
     value: "true"
   - action: assert
     type: js
     fn: eval
     args:
-      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas'); if (!canvas || !window.__vtFragmentOriginalRender) return 'missing-drag'; canvas.deps.graphicsService.render = window.__vtFragmentOriginalRender; canvas.deps.subject.dispatch('border-drag-end'); delete window.__vtFragmentOriginalRender; delete window.__vtFragmentDragElements; delete window.__vtFragmentDragBaseline; delete window.__vtFragmentDragExpected; return 'released'; })()"
+      - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas'); if (!canvas || !window.__vtFragmentOriginalRender) return 'missing-drag'; canvas.deps.graphicsService.render = window.__vtFragmentOriginalRender; canvas.deps.subject.dispatch('border-drag-end'); delete window.__vtFragmentOriginalRender; delete window.__vtFragmentDragElements; delete window.__vtFragmentDragBaseline; return 'released'; })()"
     value: "released"
   - action: wait
     ms: 500
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - |
+        (() => {
+          const deepQuery = (root, selector) => {
+            const direct = root?.querySelector?.(selector);
+            if (direct) return direct;
+            for (const node of root?.querySelectorAll?.('*') ?? []) {
+              const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined;
+              if (found) return found;
+            }
+          };
+          const findById = (elements, id) => {
+            for (const element of elements ?? []) {
+              if (element.id === id) return element;
+              const child = findById(element.children, id);
+              if (child) return child;
+            }
+          };
+          const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas');
+          const root = findById(canvas.store.selectCanvasRenderState().baseElements, 'wTne3pvWw7ui');
+          const expected = window.__vtFragmentDragExpected;
+          delete window.__vtFragmentDragExpected;
+          return String(root.x === expected.x && root.y === expected.y);
+        })()
+    value: "true"
   - action: assert
     type: js
     fn: eval

--- a/vt/specs/project/layouts.yaml
+++ b/vt/specs/project/layouts.yaml
@@ -338,6 +338,49 @@ steps:
     type: js
     fn: eval
     args:
+      - |
+        (async () => {
+          const deepQuery = (root, selector) => {
+            const direct = root?.querySelector?.(selector);
+            if (direct) return direct;
+            for (const node of root?.querySelectorAll?.('*') ?? []) {
+              const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined;
+              if (found) return found;
+            }
+          };
+          const canvas = deepQuery(document, 'rvn-layout-editor-canvas#layoutEditorCanvas');
+          const editor = deepQuery(document, 'rvn-layout-editor');
+          const waitUntil = async (condition) => {
+            const deadline = Date.now() + 10000;
+            while (!condition()) {
+              if (Date.now() >= deadline) throw new Error('Timed out waiting for draft reconciliation');
+              await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+          };
+          await waitUntil(() => !editor.store.selectPendingPersistPayload());
+          const dragStart = canvas.store.selectDragging().dragStartPosition;
+          // Simulate a collaborator edit after the paused drag has autosaved.
+          const result = await editor.deps.projectService.updateLayoutElement({
+            layoutId: editor.store.selectLayoutId(),
+            elementId: 'wTne3pvWw7ui',
+            data: { name: 'Fragment Two' },
+            replace: false,
+          });
+          if (result.valid === false) return 'save-rejected';
+          await editor.transformedHandlers.handleDataChanged({});
+          await waitUntil(() => canvas.props.layoutState.elements.items.wTne3pvWw7ui.name === 'Fragment Two');
+          canvas.deps.subject.dispatch('border-drag-move', { x: 30, y: 15 });
+          const updatedItem = canvas.store.selectPendingUpdatedItem();
+          const retainedFields = updatedItem?.name === 'Fragment Two';
+          const retainedDragStart = canvas.store.selectDragging().dragStartPosition === dragStart;
+          canvas.deps.subject.dispatch('border-drag-move', { x: 20, y: 10 });
+          return String(retainedFields && retainedDragStart);
+        })()
+    value: "true"
+  - action: assert
+    type: js
+    fn: eval
+    args:
       - "(() => { const findById = (elements, id) => { for (const element of Array.isArray(elements) ? elements : []) { if (element?.id === id) return element; const child = findById(element?.children, id); if (child) return child; } }; const root = findById(window.__vtFragmentDragElements, 'wTne3pvWw7ui'); const fields = ['x', 'y', 'width', 'height', 'rotation']; const descendantsStayedLocal = window.__vtFragmentDragBaseline.every((before) => { const after = findById(window.__vtFragmentDragElements, before.id); return after && fields.every((field) => Object.is(after[field], before[field])); }); return String(root?.x === window.__vtFragmentDragExpected.x && root?.y === window.__vtFragmentDragExpected.y && descendantsStayedLocal); })()"
     value: "true"
   - action: assert
@@ -373,7 +416,10 @@ steps:
           const root = findById(canvas.store.selectCanvasRenderState().baseElements, 'wTne3pvWw7ui');
           const expected = window.__vtFragmentDragExpected;
           delete window.__vtFragmentDragExpected;
-          return String(root.x === expected.x && root.y === expected.y);
+          const editor = deepQuery(document, 'rvn-layout-editor');
+          const savedItem = editor.deps.projectService.getRepositoryState()
+            .layouts.items[editor.store.selectLayoutId()].elements.items.wTne3pvWw7ui;
+          return String(root.x === expected.x && root.y === expected.y && savedItem.name === 'Fragment Two');
         })()
     value: "true"
   - action: assert


### PR DESCRIPTION
Canvas items could jump ahead during dragging and snap back on release when a redraw or an earlier save completed. A 20-unit move could display as 30 units because the redraw replaced the position baseline partway through the gesture.

Keep a fixed render snapshot for each drag, invalidate asynchronous redraws when newer movement occurs, and keep the displayed canvas cache current. Submit updates before awaiting redraws so consecutive drags use the latest position. Preserve the latest queued edit when reconciling older saves for layouts and controls.

Reconcile drafts by save request: immediate field saves supersede older debounced drafts, and acknowledged drafts are cleared before repository synchronization. Accept refreshed non-transform fields during an acknowledged drag without resetting its gesture baseline, so continued movement and release preserve collaborator edits.

Validation:

- `bun run lint` passes.
- 92 targeted tests pass across canvas handlers, page state/handlers, persistence, selection, and rotation; new regressions failed before the fixes.
- Verified real mouse dragging, redraws during dragging, delayed redraw completion, release, and persisted positions in Chromium using the web setup and an isolated test project.
- Verified position → immediate pagination mode → subsequent position edits against real saved data in Chromium.
- Extended the fragment-drag visual workflow with a simulated collaborator rename after autosave; its exact updated assertions pass in Chromium, including continued movement and release.
- The broader `tests/layoutEditor` and `tests/layoutEditPanel` run has 10 failures in untouched tests involving preview selector mocks, missing i18n fixtures, and a slider range expectation.
