### PR TITLE
Polish scene custom-transform scale display and canvas styling

### DIFF
--- a/src/components/actionTransformEditor/actionTransformEditor.view.yaml
+++ b/src/components/actionTransformEditor/actionTransformEditor.view.yaml
@@ -19,8 +19,8 @@ template:
           - rtgl-button#doneButton v=pr: ${doneButton}
       - $if isTouchMode:
           - 'rtgl-view w=f h=1fg d=v style="min-width: 0; min-height: 0;"':
-              - 'rtgl-view w=f p=md bgc=bg ah=c style="flex: 0 0 auto; min-width: 0;"':
-                  - 'div style="position: relative; width: ${canvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto; overflow: hidden;"':
+              - 'rtgl-view#actionTransformCanvasBackground w=f p=md bgc=bg ah=c style="flex: 0 0 auto; min-width: 0; background-image: radial-gradient(circle, var(--input) 1px, transparent 1px); background-size: 24px 24px;"':
+                  - 'rtgl-view#actionTransformCanvasFrame bwl=xs bwr=xs bc=bo style="position: relative; width: ${canvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto; overflow: hidden;"':
                       - 'rvn-scene-editor-preview-canvas#actionTransformCanvasHost style="display: block; width: 100%;" canvas-aspect-ratio="${canvasAspectRatio}"': null
               - 'rtgl-view w=f h=1fg sv pv=md style="min-height: 0;"':
                   - rvn-layout-edit-panel#transformInspector mode=transform :projectResolution=${projectResolution} :selectedElementMetrics=${selectedElementMetrics} :values=${inspectorValues}: null
@@ -33,8 +33,8 @@ template:
                       - 'rtgl-view w=f p=md g=xs bw=xs bc=bo br=md bgc=mu style="box-sizing: border-box;"':
                           - rtgl-text s=xs c=mu-fg: ${targetTypeLabel}
                           - rtgl-text s=sm w=f ellipsis=true: ${targetName}
-              - 'rtgl-view w=1fg h=f bgc=bg av=s ah=c style="min-width: 0; min-height: 0; overflow: auto; box-sizing: border-box;"':
-                  - 'div style="position: relative; width: ${canvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto; overflow: hidden;"':
+              - 'rtgl-view#actionTransformCanvasBackground w=1fg h=f bgc=bg av=s ah=c style="min-width: 0; min-height: 0; overflow: auto; box-sizing: border-box; background-image: radial-gradient(circle, var(--input) 1px, transparent 1px); background-size: 24px 24px;"':
+                  - 'rtgl-view#actionTransformCanvasFrame bwl=xs bwr=xs bc=bo style="position: relative; width: ${canvasMaxWidth}; max-width: 100%; margin-left: auto; margin-right: auto; overflow: hidden;"':
                       - 'rvn-scene-editor-preview-canvas#actionTransformCanvasHost style="display: block; width: 100%;" canvas-aspect-ratio="${canvasAspectRatio}"': null
               - rvn-resizable-panel panel-type=transform-editor w=300 min-w=240 max-w=500 resize-side=left:
                   - 'rtgl-view slot=content w=f h=f d=v style="min-width: 0; min-height: 0;"':

--- a/src/components/layoutEditPanel/layoutEditPanel.store.js
+++ b/src/components/layoutEditPanel/layoutEditPanel.store.js
@@ -877,6 +877,8 @@ export const updateValueProperty = ({ state }, { value, name } = {}) => {
   }
 };
 
+const roundScaleForDisplay = (value) => Number(Number(value ?? 1).toFixed(2));
+
 export const openPopoverForm = (
   { state },
   { x, y, name, form, projectResolution, copy } = {},
@@ -885,7 +887,11 @@ export const openPopoverForm = (
     return;
   }
 
-  const value = getValueAtPath(state.values, name);
+  const fieldValue = getValueAtPath(state.values, name);
+  const value =
+    name === "scaleX" || name === "scaleY"
+      ? roundScaleForDisplay(fieldValue)
+      : fieldValue;
   const popoverFormValues = {
     value,
   };
@@ -1675,6 +1681,8 @@ export const selectViewData = ({ state, props, constants, i18n }) => {
     variablesData: state.variablesData,
     copy,
   });
+  values.scaleX = roundScaleForDisplay(values.scaleX);
+  values.scaleY = roundScaleForDisplay(values.scaleY);
   values.textRevealIndicatorItems = values.textRevealIndicatorItems.map(
     (item) => hydrateTextRevealIndicatorItem(item, state.spritesheetsData),
   );

--- a/tests/actionTransformEditor/actionTransformEditor.view.test.js
+++ b/tests/actionTransformEditor/actionTransformEditor.view.test.js
@@ -1,7 +1,45 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import yaml from "js-yaml";
+import { parseAndRender } from "jempl";
+import {
+  createInitialState,
+  selectViewData,
+} from "../../src/components/actionTransformEditor/actionTransformEditor.store.js";
 
 describe("actionTransformEditor view", () => {
+  it.each([false, true])(
+    "uses layout-editor canvas framing in touch mode %s",
+    (isTouchMode) => {
+      const view = yaml.load(
+        readFileSync(
+          new URL(
+            "../../src/components/actionTransformEditor/actionTransformEditor.view.yaml",
+            import.meta.url,
+          ),
+          "utf8",
+        ),
+      );
+      const viewData = selectViewData({
+        state: { ...createInitialState(), isTouchMode },
+        props: {},
+      });
+      const template = JSON.stringify(parseAndRender(view.template, viewData));
+
+      expect(template).toContain("#actionTransformCanvasBackground");
+      expect(template).toContain(
+        "background-image: radial-gradient(circle, var(--input) 1px, transparent 1px)",
+      );
+      expect(template).toContain("background-size: 24px 24px");
+      expect(template).toContain(
+        "#actionTransformCanvasFrame bwl=xs bwr=xs bc=bo",
+      );
+      expect(template).toContain(
+        "rvn-scene-editor-preview-canvas#actionTransformCanvasHost",
+      );
+    },
+  );
+
   it("leaves canvas pointer interaction to the graphics selection chrome", () => {
     const view = readFileSync(
       new URL(

--- a/tests/layoutEditPanel/layoutEditPanel.transformMode.test.js
+++ b/tests/layoutEditPanel/layoutEditPanel.transformMode.test.js
@@ -3,6 +3,7 @@ import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 import {
   createInitialState,
+  openPopoverForm,
   selectViewData,
   setValues,
 } from "../../src/components/layoutEditPanel/layoutEditPanel.store.js";
@@ -20,6 +21,42 @@ const CONSTANTS = yaml.load(
 );
 
 describe("layoutEditPanel transform mode", () => {
+  it.each([
+    [1.23456789, 0.98765432, 1.23, 0.99],
+    [0.1 + 0.2, 1.2 + 0.01, 0.3, 1.21],
+    [-1.236, -0.994, -1.24, -0.99],
+    [0, 1, 0, 1],
+  ])(
+    "rounds scale readouts and popovers without changing the transform (%s, %s)",
+    (scaleX, scaleY, expectedX, expectedY) => {
+      const state = createInitialState();
+      setValues({ state }, { values: { scaleX, scaleY } });
+      const viewData = selectViewData({
+        state,
+        props: {
+          mode: "transform",
+          projectResolution: { width: 1920, height: 1080 },
+          layoutsData: EMPTY_TREE,
+          charactersData: EMPTY_TREE,
+        },
+        constants: CONSTANTS,
+        i18n: EN_I18N,
+      });
+      const fields = viewData.config.sections[0].items[1].fields;
+
+      expect(fields.map(({ value }) => value)).toEqual([expectedX, expectedY]);
+      for (const field of fields) {
+        openPopoverForm(
+          { state },
+          { name: field.name, form: field.popoverForm },
+        );
+        expect(state.popover.defaultValues.value).toBe(field.value);
+      }
+      expect(state.values).toMatchObject({ scaleX, scaleY });
+      expect(viewData.values).toMatchObject({ scaleX, scaleY });
+    },
+  );
+
   it("exposes only action-transform controls", () => {
     const state = createInitialState();
     setValues(

--- a/vt/specs/project/action-transform-editor.yaml
+++ b/vt/specs/project/action-transform-editor.yaml
@@ -135,6 +135,28 @@ steps:
     type: js
     fn: eval
     args:
+      - |
+        (() => {
+          const deepQuery = (root, selector) => {
+            const direct = root?.querySelector?.(selector);
+            if (direct) return direct;
+            for (const node of root?.querySelectorAll?.('*') ?? []) {
+              const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined;
+              if (found) return found;
+            }
+          };
+          const editor = deepQuery(document, 'rvn-action-transform-editor#actionTransformEditor');
+          const background = getComputedStyle(deepQuery(editor.shadowRoot, '#actionTransformCanvasBackground'));
+          const frame = getComputedStyle(deepQuery(editor.shadowRoot, '#actionTransformCanvasFrame'));
+          return String(background.backgroundImage.includes('radial-gradient') &&
+            background.backgroundSize === '24px 24px' &&
+            frame.borderLeftWidth === '1px' && frame.borderRightWidth === '1px');
+        })()
+    value: "true"
+  - action: assert
+    type: js
+    fn: eval
+    args:
       - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const sceneEditor = deepQuery(document, 'rvn-scene-editor-lexical'); const metrics = sceneEditor?.store?.selectBackgroundTransformEditor?.()?.selectedElementMetrics; return `${metrics?.width}x${metrics?.height}`; })()"
     value: "1920x1080"
   - action: select
@@ -220,6 +242,52 @@ steps:
     fn: eval
     args:
       - "(() => { const deepQuery = (root, selector) => { const direct = root?.querySelector?.(selector); if (direct) return direct; for (const node of root?.querySelectorAll?.('*') ?? []) { const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined; if (found) return found; } return undefined; }; const editor = deepQuery(document, 'rvn-action-transform-editor#actionTransformEditor'); const yField = deepQuery(editor?.shadowRoot, '#groupItem0x0x1'); return String(Number(yField?.textContent?.trim()) === window.__vtActionTransformY + 1); })()"
+    value: "true"
+  - action: assert
+    type: js
+    fn: eval
+    args:
+      - |
+        (async () => {
+          const deepQuery = (root, selector) => {
+            const direct = root?.querySelector?.(selector);
+            if (direct) return direct;
+            for (const node of root?.querySelectorAll?.('*') ?? []) {
+              const found = node.shadowRoot ? deepQuery(node.shadowRoot, selector) : undefined;
+              if (found) return found;
+            }
+          };
+          const waitUntil = async (condition) => {
+            const deadline = Date.now() + 5000;
+            while (!condition()) {
+              if (Date.now() >= deadline) throw new Error('Scale display did not update');
+              await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+          };
+          const editor = deepQuery(document, 'rvn-action-transform-editor#actionTransformEditor');
+          const inspector = () => deepQuery(editor.shadowRoot, '#transformInspector');
+          const original = editor.props.transform;
+          const update = (formValues) => editor.transformedHandlers.handleInspectorUpdate({
+            _event: { detail: { formValues } },
+          });
+          try {
+            update({ ...original, scaleX: 1.23456789, scaleY: 0.98765432 });
+            for (const [name, expected] of [['scaleX', '1.23'], ['scaleY', '0.99']]) {
+              const field = () => deepQuery(inspector().shadowRoot, `[data-name='${name}']`);
+              await waitUntil(() => field()?.textContent.trim() === expected);
+              field().click();
+              await waitUntil(() => {
+                const form = deepQuery(inspector().shadowRoot, '#popoverForm');
+                return deepQuery(form, 'input')?.value === expected;
+              });
+              inspector().transformedHandlers.handlePopverFormClose({});
+            }
+            return String(editor.props.transform.scaleX === 1.23456789 && editor.props.transform.scaleY === 0.98765432);
+          } finally {
+            inspector().transformedHandlers.handlePopverFormClose({});
+            update(original);
+          }
+        })()
     value: "true"
   - action: select
     selector: "rvn-action-transform-editor#actionTransformEditor #doneButton"


### PR DESCRIPTION
## Summary

- Round Scale X and Scale Y readouts and edit-popover defaults to two decimal places without changing the underlying transform until it is edited.
- Match the layout editor's 24px dot background and thin canvas side borders in the scene editor's custom-transform view, on desktop and touch layouts.
- Leave the normal scene preview unchanged and add regression coverage for precision and canvas styling.

## Validation

- `bun run lint` and formatting checks pass.
- 24 targeted tests pass across the transform inspector, popovers, action-transform editor, and background-transform helpers.
- Executed the new VT assertions in Chromium against an isolated test project, on both desktop and touch layouts; scale readouts/popovers and canvas framing passed.
- Visually inspected desktop and touch screenshots. Full VT screenshot generation was not run.
