### PR TITLE
Fix mobile scene hint layout and clipped small text

### DIFF
--- a/src/pages/scenes/scenes.view.yaml
+++ b/src/pages/scenes/scenes.view.yaml
@@ -187,9 +187,9 @@ template:
               - 'rtgl-view w=f h=1fg style="min-height: 0;"':
                   - rvn-base-file-explorer#fileexplorer :items=${flatItems} shrinkable dropdown-menu allowDrag show-item-menu-actions :folderContextMenuItems=${folderContextMenuItems} :itemContextMenuItems=${itemContextMenuItems} :emptyContextMenuItems=${emptyContextMenuItems}: null
       - $if showMapAddHint:
-          - 'rtgl-view pos=abs z=150 style="left: 50%; bottom: 24px; transform: translateX(-50%);"':
+          - 'rtgl-view pos=abs z=1201 style="left: 50%; bottom: 24px; width: max-content; max-width: calc(100% - 32px); transform: translateX(-50%);"':
               - rtgl-view d=h av=c g=sm bgc=mu bc=bo bw=xs br=sm pv=md ph=md:
-                  - rtgl-text c=fg s=sm mh=xl: ${mapAddHint}
+                  - rtgl-text c=fg s=sm w=1fg: ${mapAddHint}
                   - rtgl-view#mapAddHintClose d=h av=c ah=c w=20 h=20 cur=pointer:
                       - rtgl-svg svg=x wh=14 c=mu-fg: null
   - $if previewVisible:

--- a/static/public/theme.css
+++ b/static/public/theme.css
@@ -128,12 +128,12 @@ body {
 
   --sm-font-size: 0.875rem;
   --sm-font-weight: 400;
-  --sm-line-height: 1;
+  --sm-line-height: 1.25rem;
   --sm-letter-spacing: normal;
 
   --xs-font-size: 0.75rem;
   --xs-font-weight: normal;
-  --xs-line-height: 1;
+  --xs-line-height: 1rem;
   --xs-letter-spacing: normal;
 
   --primary: oklch(0.32 0.018 250);


### PR DESCRIPTION
The scene-map hint wrapped onto four lines on narrow Android screens, and the floating help button could cover its close control. Let the hint use its content width within the viewport, remove the extra text margins, and place it above the help button.

Small labels such as “Light” used a line height equal to the font size. On the Vivo WebView, font bounds extended below those boxes and ellipsis styling clipped the descenders. Increase the shared theme line heights to 16px for 12px text and 20px for 14px text.

Validation:
- `bun run lint`
- `bunx prettier --check static/public/theme.css`
- `git diff --check`
- Verified the scene-map hint and Appearance label on a Vivo V2309A; the hint fits on one line above the help button, and “Light” has visible descenders. The user confirmed the text fix works on the phone.
