### PR TITLE
Fix fullscreen scene preview borders

### DIFF
--- a/src/components/vnPreview/vnPreview.view.yaml
+++ b/src/components/vnPreview/vnPreview.view.yaml
@@ -14,6 +14,8 @@ refs:
           width: ${_event.target.innerWidth}
           height: ${_event.target.innerHeight}
 styles:
+  "#previewSurface:focus-visible":
+    --focus-ring-box-shadow: none
   "#canvas > canvas":
     transform: none
     transform-origin: center
@@ -23,7 +25,7 @@ template:
   - 'rtgl-view#previewSurface pos=fix edge=f tabindex=-1 style="display: flex; justify-content: center; align-items: center; overflow: hidden; background: black; outline: none; min-width: 0; min-height: 0;" z=3500 data-preview-ready=${isPreviewReady}':
       - 'rtgl-view style="${previewStageStyle}"':
           - 'div#canvas data-preview-rotated=${isRotated} style="${previewCanvasHostStyle}"': null
-          - 'rtgl-view bwb=xs style="${previewFrameStyle}"': null
+          - 'rtgl-view style="${previewFrameStyle}"': null
           - $if isAssetLoading:
               - rtgl-view pos=abs edge=f w=f h=f bgc=bg op=0.6 av=c ah=c z=2:
                   - rtgl-text s=h3: Loading preview...

--- a/tests/vnPreview/vnPreview.view.test.js
+++ b/tests/vnPreview/vnPreview.view.test.js
@@ -1,7 +1,37 @@
 import { readFileSync } from "node:fs";
+import { load } from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 describe("vnPreview view", () => {
+  it("does not draw decorative borders around the fullscreen canvas", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/vnPreview/vnPreview.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(view).not.toMatch(/\bbw[trblxy]?=/);
+  });
+
+  it("hides the fullscreen surface focus ring while keeping keyboard focus", () => {
+    const view = readFileSync(
+      new URL(
+        "../../src/components/vnPreview/vnPreview.view.yaml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(load(view).styles["#previewSurface:focus-visible"]).toEqual({
+      "--focus-ring-box-shadow": "none",
+    });
+    expect(view).toContain(
+      "rtgl-view#previewSurface pos=fix edge=f tabindex=-1",
+    );
+  });
+
   it("rotates only the renderer canvas and leaves its input bridge host untransformed", () => {
     const view = readFileSync(
       new URL(


### PR DESCRIPTION
## Summary

- Remove the decorative bottom border over the fullscreen preview canvas.
- Hide the fullscreen surface's focus ring without disabling keyboard focus or changing focus styling on other controls.
- Keep canvas sizing and aspect-ratio letterboxing unchanged, and add regression coverage.

## Validation

- `bun run lint`
- `bunx vitest run tests/vnPreview` — 23 tests passed
- `bunx prettier --check tests/vnPreview/vnPreview.view.test.js`
- `git diff --check`
- Playwright browser validation: confirmed the bottom border changed from 1px to 0px and the focused surface's 2px inset ring was removed. Canvas stayed 1440 × 810 in a 1440 × 900 viewport; keyboard focus and Escape-to-close still work.
