### PR TITLE
Show import progress and fix mobile audio and tab feedback

### DIFF
--- a/src/components/mobileSidebar/mobileSidebar.view.yaml
+++ b/src/components/mobileSidebar/mobileSidebar.view.yaml
@@ -7,6 +7,9 @@ refs:
         handler: handleItemPointerUp
       click:
         handler: handleItemClick
+styles:
+  '[data-item-id][bgc="bg"]:active':
+    background-color: var(--muted)
 template:
   - rtgl-view d=v w=${w} h=${h} bgc=bg pb=lg:
       - rtgl-view d=v w=f h=f ph=lg g=lg sv:
@@ -15,6 +18,6 @@ template:
                   - 'rtgl-view h=32 w=f av=c ph=md bgc=bg z=1 style="position: sticky; top: 0;"':
                       - rtgl-text s=xs c=mu-fg: ${section.label}
                   - $for item, itemIndex in section.items:
-                      - 'rtgl-view#mobileSidebarItem${sectionIndex}x${itemIndex} data-item-id=${item.id} w=f h=48 d=h av=c g=sm ph=md br=lg bgc=${item.bgc} h-bgc=mu cur=pointer style="touch-action: manipulation; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; -webkit-tap-highlight-color: transparent;"':
+                      - 'rtgl-view#mobileSidebarItem${sectionIndex}x${itemIndex} data-item-id=${item.id} w=f h=48 d=h av=c g=sm ph=md br=lg bgc=${item.bgc} cur=pointer style="touch-action: manipulation; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; -webkit-tap-highlight-color: transparent;"':
                           - rtgl-svg wh=20 svg=${item.icon} c=fg: null
                           - rtgl-text s=sm: ${item.label}

--- a/src/deps/services/audioService.js
+++ b/src/deps/services/audioService.js
@@ -155,6 +155,8 @@ export const createAudioService = () => {
         return undefined;
       }
 
+      // Replacement players can mount before the previous owner releases.
+      service.stop();
       service.init();
       const context = audioContext;
       const requestId = ++loadRequestId;

--- a/src/i18n/en.yaml
+++ b/src/i18n/en.yaml
@@ -56,6 +56,8 @@ projectsPage:
   fillRequiredFields: "Please fill in all required fields."
   importButton: "Import"
   importedProjectMessage: "Project \"{projectName}\" imported."
+  importingProjectMessage: "Please wait while your project is being imported."
+  importingProjectTitle: "Importing Project…"
   importProjectMenuItem: "Import Project"
   incompatibleProjectTitle: "Incompatible Project"
   invalidProjectEntryImportAgain: "This project entry is invalid. Remove it from the list and import the project again."

--- a/src/i18n/ja.yaml
+++ b/src/i18n/ja.yaml
@@ -56,6 +56,8 @@ projectsPage:
   fillRequiredFields: "必須項目を入力してください。"
   importButton: "取り込む"
   importedProjectMessage: "プロジェクト「{projectName}」を取り込みました。"
+  importingProjectMessage: "プロジェクトを取り込んでいます。しばらくお待ちください。"
+  importingProjectTitle: "プロジェクトを取り込み中…"
   importProjectMenuItem: "プロジェクトを取り込む"
   incompatibleProjectTitle: "互換性のないプロジェクト"
   invalidProjectEntryImportAgain: "このプロジェクト項目は無効です。一覧から削除して、もう一度プロジェクトを取り込んでください。"

--- a/src/i18n/zh-hans.yaml
+++ b/src/i18n/zh-hans.yaml
@@ -56,6 +56,8 @@ projectsPage:
   fillRequiredFields: "请填写所有必填项。"
   importButton: "导入"
   importedProjectMessage: "项目“{projectName}”已导入。"
+  importingProjectMessage: "正在导入项目，请稍候。"
+  importingProjectTitle: "正在导入项目…"
   importProjectMenuItem: "导入项目"
   incompatibleProjectTitle: "项目不兼容"
   invalidProjectEntryImportAgain: "该项目条目无效。请从列表中移除后重新导入项目。"

--- a/src/pages/projects/projects.handlers.js
+++ b/src/pages/projects/projects.handlers.js
@@ -420,10 +420,22 @@ export const handleOpenButtonClick = async (deps) => {
       return;
     }
 
-    const importedProject = await appService.openExistingProject(selectedPath);
-    const projects = await appService.loadAllProjects();
-    store.setProjects({ projects });
-    render();
+    const progressDialog = appService.showProgressDialog({
+      title: copy.importingProjectTitle,
+      message: copy.importingProjectMessage,
+      progress: {},
+    });
+
+    let importedProject;
+    try {
+      await progressDialog.waitForPaint();
+      importedProject = await appService.openExistingProject(selectedPath);
+      const projects = await appService.loadAllProjects();
+      store.setProjects({ projects });
+      render();
+    } finally {
+      progressDialog.close();
+    }
 
     appService.showToast({
       message: formatProjectsPageCopy(copy.importedProjectMessage, {

--- a/tests/projects/projects.handlers.test.js
+++ b/tests/projects/projects.handlers.test.js
@@ -818,6 +818,106 @@ describe("projects app version menu", () => {
 });
 
 describe("projects.handleOpenButtonClick", () => {
+  it.each(["tauri", "android", "ios"])(
+    "keeps progress visible through import and list refresh on %s",
+    async (platform) => {
+      const deps = createDeps({ platform });
+      const paint = Promise.withResolvers();
+      const importing = Promise.withResolvers();
+      const refreshing = Promise.withResolvers();
+      const progressDialog = {
+        waitForPaint: vi.fn(() => paint.promise),
+        close: vi.fn(),
+      };
+      deps.appService.openFolderPicker.mockResolvedValue(
+        "/projects/project-one",
+      );
+      deps.appService.showProgressDialog.mockReturnValue(progressDialog);
+      deps.appService.openExistingProject.mockReturnValue(importing.promise);
+      deps.appService.loadAllProjects.mockReturnValue(refreshing.promise);
+
+      const task = handleOpenButtonClick(deps);
+      await vi.waitFor(() => {
+        expect(progressDialog.waitForPaint).toHaveBeenCalledOnce();
+      });
+      expect(deps.appService.showProgressDialog).toHaveBeenCalledWith({
+        title: "Importing Project…",
+        message: "Please wait while your project is being imported.",
+        progress: {},
+      });
+      expect(deps.appService.openExistingProject).not.toHaveBeenCalled();
+
+      paint.resolve();
+      await vi.waitFor(() => {
+        expect(deps.appService.openExistingProject).toHaveBeenCalledWith(
+          "/projects/project-one",
+        );
+      });
+      expect(progressDialog.close).not.toHaveBeenCalled();
+      const project = { id: "project-one", name: "Project One" };
+      importing.resolve(project);
+      await vi.waitFor(() => {
+        expect(deps.appService.loadAllProjects).toHaveBeenCalledOnce();
+      });
+      expect(progressDialog.close).not.toHaveBeenCalled();
+      expect(deps.appService.showToast).not.toHaveBeenCalled();
+
+      refreshing.resolve([project]);
+      await task;
+      expect(deps.store.setProjects).toHaveBeenCalledWith({
+        projects: [project],
+      });
+      expect(progressDialog.close).toHaveBeenCalledOnce();
+      expect(deps.render.mock.invocationCallOrder[0]).toBeLessThan(
+        progressDialog.close.mock.invocationCallOrder[0],
+      );
+      expect(progressDialog.close.mock.invocationCallOrder[0]).toBeLessThan(
+        deps.appService.showToast.mock.invocationCallOrder[0],
+      );
+    },
+  );
+
+  it("does not show progress when folder selection is cancelled", async () => {
+    const deps = createDeps();
+    deps.appService.openFolderPicker.mockResolvedValue(undefined);
+
+    await handleOpenButtonClick(deps);
+
+    expect(deps.appService.showProgressDialog).not.toHaveBeenCalled();
+    expect(deps.appService.openExistingProject).not.toHaveBeenCalled();
+    expect(deps.appService.showToast).not.toHaveBeenCalled();
+    expect(deps.appService.showAlert).not.toHaveBeenCalled();
+  });
+
+  it.each(["openExistingProject", "loadAllProjects"])(
+    "closes progress before showing an error when %s fails",
+    async (method) => {
+      const deps = createDeps();
+      deps.appService.openFolderPicker.mockResolvedValue(
+        "/projects/project-one",
+      );
+      deps.appService.openExistingProject.mockResolvedValue({
+        id: "project-one",
+        name: "Project One",
+      });
+      deps.appService[method].mockRejectedValue(new Error("Import failed"));
+
+      await handleOpenButtonClick(deps);
+
+      const progressDialog =
+        deps.appService.showProgressDialog.mock.results[0].value;
+      expect(progressDialog.close).toHaveBeenCalledOnce();
+      expect(progressDialog.close.mock.invocationCallOrder[0]).toBeLessThan(
+        deps.appService.showAlert.mock.invocationCallOrder[0],
+      );
+      expect(deps.appService.showAlert).toHaveBeenCalledWith({
+        message: "Import failed",
+      });
+      expect(deps.store.setProjects).not.toHaveBeenCalled();
+      expect(deps.appService.showToast).not.toHaveBeenCalled();
+    },
+  );
+
   it("reloads the project list and shows a toast after a successful import", async () => {
     const deps = createDeps();
     deps.appService.openFolderPicker.mockResolvedValue(

--- a/tests/services/audioService.test.js
+++ b/tests/services/audioService.test.js
@@ -69,6 +69,75 @@ describe("audio service", () => {
     expect(contexts[0].close).toHaveBeenCalledOnce();
   });
 
+  it("stops the old track before a replacement player loads and plays another", async () => {
+    const { contexts, MockAudioContext } = createAudioContextHarness();
+    globalThis.window = { AudioContext: MockAudioContext };
+    const replacementResponse = Promise.withResolvers();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(createAudioResponse())
+      .mockReturnValueOnce(replacementResponse.promise);
+    const audioService = createAudioService();
+    const releaseOldPlayer = audioService.acquire();
+    await audioService.loadAudio("blob:first");
+    await audioService.play();
+    const context = contexts[0];
+    const oldSource = context.createBufferSource.mock.results[0].value;
+    const firstBuffer = oldSource.buffer;
+    const releaseNewPlayer = audioService.acquire();
+
+    try {
+      const replacementLoad = audioService.loadAudio("blob:second");
+      releaseOldPlayer();
+
+      expect(audioService.isPlaying()).toBe(false);
+      expect(audioService.getCurrentTime()).toBe(0);
+      expect(oldSource.stop).toHaveBeenCalledOnce();
+      expect(oldSource.disconnect).toHaveBeenCalledOnce();
+      expect(oldSource.onended).toBeNull();
+      expect(context.close).not.toHaveBeenCalled();
+
+      replacementResponse.resolve(createAudioResponse());
+      await replacementLoad;
+      await audioService.play();
+
+      expect(context.createBufferSource).toHaveBeenCalledTimes(2);
+      const newSource = context.createBufferSource.mock.results[1].value;
+      expect(newSource.buffer).not.toBe(firstBuffer);
+      expect(newSource.start).toHaveBeenCalledWith(0, 0);
+      expect(audioService.isPlaying()).toBe(true);
+    } finally {
+      releaseOldPlayer();
+      releaseNewPlayer();
+    }
+  });
+
+  it("keeps the previous track stopped if loading its replacement fails", async () => {
+    const { contexts, MockAudioContext } = createAudioContextHarness();
+    globalThis.window = { AudioContext: MockAudioContext };
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(createAudioResponse())
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+    const audioService = createAudioService();
+    const releasePlayer = audioService.acquire();
+
+    try {
+      await audioService.loadAudio("blob:first");
+      await audioService.play();
+      const oldSource = contexts[0].createBufferSource.mock.results[0].value;
+
+      await expect(audioService.loadAudio("blob:missing")).rejects.toThrow(
+        "Failed to fetch audio: 404",
+      );
+
+      expect(audioService.isPlaying()).toBe(false);
+      expect(oldSource.stop).toHaveBeenCalledOnce();
+    } finally {
+      releasePlayer();
+    }
+  });
+
   it("ignores a superseded audio load", async () => {
     const { MockAudioContext } = createAudioContextHarness();
     globalThis.window = { AudioContext: MockAudioContext };


### PR DESCRIPTION
Project imports now show the existing progress dialog while importing and refreshing the project list, with English, Japanese, and Simplified Chinese copy. The dialog closes before success or error feedback, and cancelling the folder picker leaves it closed.

Long-pressing another sound on Android could leave the previous track playing because replacement players share the audio service. Loading a replacement now stops the active source first, allowing the selected track to start from the beginning.

Mobile tab action sheets now use press feedback for unselected rows instead of hover styling. This prevents Android's lingering hover state from highlighting untouched items after opening or scrolling a sheet, while preserving the selected row color.

Validation:
- All 125 targeted project-import, progress-dialog, Sounds, and audio-playback tests passed, including new import-lifecycle and track-replacement regressions.
- All 92 targeted app, sidebar, and action-sheet tests passed.
- Lint, formatting checks, and `git diff --check` passed.
- On the Vivo phone, verified four actual long presses switch audio sources correctly, and verified the import dialog through the real handler with a simulated import.
- Verified all four tab sheets retain normal row colors despite hover, and actual touch press feedback clears after release and reopening.
