### PR TITLE
Fix Android background audio and scene editor navigation

### DIFF
--- a/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
+++ b/android/routevn/app/src/main/java/com/routevn/creator/MainActivity.java
@@ -165,6 +165,7 @@ public class MainActivity extends Activity {
     }
 
     private WebView webView;
+    private boolean appResumed = false;
     private long splashStartedAt;
     private boolean splashDismissRequested = false;
     private boolean splashReady = false;
@@ -700,6 +701,35 @@ public class MainActivity extends Activity {
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+        appResumed = true;
+        if (webView != null) {
+            webView.onResume();
+            notifyAudioLifecycle();
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        appResumed = false;
+        notifyAudioLifecycle();
+        if (webView != null) {
+            webView.onPause();
+        }
+        super.onPause();
+    }
+
+    private void notifyAudioLifecycle() {
+        if (webView != null) {
+            webView.evaluateJavascript(
+                "window.routeVNSetAppActive?.(" + appResumed + ")",
+                null
+            );
+        }
+    }
+
+    @Override
     protected void onDestroy() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             unregisterBackInvokedCallback();
@@ -749,6 +779,12 @@ public class MainActivity extends Activity {
     }
 
     private final class RouteVNWebViewClient extends WebViewClient {
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
+            notifyAudioLifecycle();
+        }
+
         @Override
         public WebResourceResponse shouldInterceptRequest(
             WebView view,

--- a/docs/keyboard-navigation-shortcuts.md
+++ b/docs/keyboard-navigation-shortcuts.md
@@ -143,6 +143,11 @@ Implementation:
 
 The Scene Editor has block mode for line-level navigation and text mode for
 editing the selected line.
+Block navigation continues one line at a time across section boundaries,
+including repeated keys while keyboard focus transfers to the selected section.
+Inactive sections do not handle block shortcuts or reclaim keyboard focus.
+When the selected block moves outside the viewport, it is revealed immediately
+without a smooth-scroll animation. Text-mode scrolling is unchanged.
 
 | Shortcut           | Mode  | Action                                                  |
 | ------------------ | ----- | ------------------------------------------------------- |

--- a/src/deps/clients/android/audioRuntime.js
+++ b/src/deps/clients/android/audioRuntime.js
@@ -1,0 +1,155 @@
+export const createAndroidAudioRuntime = ({
+  windowTarget = globalThis.window,
+  documentTarget = globalThis.document,
+} = {}) => {
+  const contexts = new Set();
+  const timers = new Set();
+  let nativeActive = true;
+  let active = !documentTarget.hidden;
+  let hiddenAt = active ? undefined : windowTarget.performance.now();
+  let hiddenDuration = 0;
+  let graphicsContext;
+
+  const nowMs = () =>
+    (hiddenAt ?? windowTarget.performance.now()) - hiddenDuration;
+
+  const reportError = (error) => {
+    console.error("[Android audio] Failed to update playback lifecycle", error);
+  };
+
+  const scheduleTimer = (timer) => {
+    if (!active) return;
+    timer.nativeId = windowTarget.setTimeout(
+      () => {
+        timer.nativeId = undefined;
+        if (!active || !timers.has(timer)) return;
+        if (timer.intervalMs === undefined) {
+          timers.delete(timer);
+        } else {
+          timer.deadline = nowMs() + timer.intervalMs;
+          scheduleTimer(timer);
+        }
+        timer.callback();
+      },
+      Math.max(0, timer.deadline - nowMs()),
+    );
+  };
+
+  const createTimer = (callback, delayMs = 0, intervalMs) => {
+    const timer = {
+      callback,
+      deadline: nowMs() + Math.max(0, delayMs),
+      intervalMs,
+    };
+    timers.add(timer);
+    scheduleTimer(timer);
+    return timer;
+  };
+
+  const clearTimer = (timer) => {
+    if (!timers.delete(timer)) return;
+    windowTarget.clearTimeout(timer.nativeId);
+  };
+
+  const updateActivity = () => {
+    const nextActive = nativeActive && !documentTarget.hidden;
+    if (nextActive === active) return;
+    active = nextActive;
+
+    if (!active) {
+      hiddenAt = windowTarget.performance.now();
+      for (const timer of timers) {
+        windowTarget.clearTimeout(timer.nativeId);
+        timer.nativeId = undefined;
+      }
+      for (const entry of contexts) {
+        if (entry.context.state === "running") {
+          entry.resumeOnForeground = true;
+          void entry.suspend().catch(reportError);
+        }
+      }
+      return;
+    }
+
+    hiddenDuration += windowTarget.performance.now() - hiddenAt;
+    hiddenAt = undefined;
+    for (const entry of contexts) {
+      if (entry.resumeOnForeground) {
+        entry.resumeOnForeground = false;
+        void entry.resume().catch(reportError);
+      }
+    }
+    for (const timer of timers) scheduleTimer(timer);
+  };
+
+  const setAppActive = (value) => {
+    nativeActive = value;
+    updateActivity();
+  };
+
+  const createAudioContext = () => {
+    const AudioContextConstructor =
+      windowTarget.AudioContext ?? windowTarget.webkitAudioContext;
+    const context = new AudioContextConstructor();
+    const entry = {
+      context,
+      resume: context.resume.bind(context),
+      suspend: context.suspend.bind(context),
+      resumeOnForeground: false,
+    };
+    const close = context.close.bind(context);
+    const handleStateChange = () => {
+      if (!active && context.state === "running") {
+        entry.resumeOnForeground = true;
+        void entry.suspend().catch(reportError);
+      }
+    };
+
+    // RouteGraphics can request a resume after a delayed asset finishes loading.
+    // Keep that request pending until the Activity and document are both visible.
+    context.resume = () => {
+      if (!active) {
+        entry.resumeOnForeground = true;
+        return Promise.resolve();
+      }
+      return entry.resume();
+    };
+    context.close = () => {
+      contexts.delete(entry);
+      context.removeEventListener("statechange", handleStateChange);
+      return close();
+    };
+    contexts.add(entry);
+    context.addEventListener("statechange", handleStateChange);
+    handleStateChange();
+    return context;
+  };
+
+  documentTarget.addEventListener("visibilitychange", updateActivity);
+  windowTarget.routeVNSetAppActive = setAppActive;
+
+  return {
+    createAudioContext,
+    graphicsRuntime: {
+      get context() {
+        graphicsContext ??= createAudioContext();
+        return graphicsContext;
+      },
+      nowMs,
+      setTimeout: (callback, delayMs) => createTimer(callback, delayMs),
+      clearTimeout: clearTimer,
+      setInterval: (callback, intervalMs) =>
+        createTimer(callback, intervalMs, intervalMs),
+      clearInterval: clearTimer,
+      queueMicrotask: (callback) => windowTarget.queueMicrotask(callback),
+    },
+    dispose: async () => {
+      documentTarget.removeEventListener("visibilitychange", updateActivity);
+      if (windowTarget.routeVNSetAppActive === setAppActive) {
+        delete windowTarget.routeVNSetAppActive;
+      }
+      for (const timer of timers) clearTimer(timer);
+      await Promise.all(Array.from(contexts, ({ context }) => context.close()));
+    },
+  };
+};

--- a/src/deps/services/audioService.js
+++ b/src/deps/services/audioService.js
@@ -1,7 +1,7 @@
 /**
  * Audio Service - handles audio playback using Web Audio API
  */
-export const createAudioService = () => {
+export const createAudioService = ({ createAudioContext } = {}) => {
   // Audio context and nodes
   let audioContext = null;
   let sourceNode = null;
@@ -113,7 +113,9 @@ export const createAudioService = () => {
 
       const AudioContextClass =
         window.AudioContext || window.webkitAudioContext;
-      audioContext = new AudioContextClass();
+      audioContext = createAudioContext
+        ? createAudioContext()
+        : new AudioContextClass();
 
       gainNode = audioContext.createGain();
       gainNode.connect(audioContext.destination);

--- a/src/internal/ui/sceneEditor/sectionOperations.js
+++ b/src/internal/ui/sceneEditor/sectionOperations.js
@@ -30,22 +30,6 @@ const updateSceneEditorSelectionPayload = (
   appService.setPayload(nextPayload);
 };
 
-const flattenRefs = (value) => {
-  if (!value) {
-    return [];
-  }
-
-  if (Array.isArray(value)) {
-    return value.flatMap((item) => flattenRefs(item));
-  }
-
-  if (typeof value === "object") {
-    return [value];
-  }
-
-  return [];
-};
-
 export const scrollSceneEditorSectionTabIntoView = (deps, sectionId) => {
   const { refs } = deps;
   const scheduleFrame =
@@ -54,26 +38,29 @@ export const scrollSceneEditorSectionTabIntoView = (deps, sectionId) => {
       : (callback) => setTimeout(callback, 0);
 
   scheduleFrame(() => {
-    const refElements = Object.values(refs || {}).flatMap((entry) =>
-      flattenRefs(entry),
-    );
-    const sectionRef = refElements.find(
-      (element) =>
-        element?.dataset?.sectionBlockId === sectionId ||
-        element?.dataset?.sectionId === sectionId,
-    );
-    const doc = typeof document !== "undefined" ? document : undefined;
-    const sectionElement =
-      sectionRef ||
-      doc?.querySelector?.('[data-section-block-id="' + sectionId + '"]') ||
-      Array.from(doc?.querySelectorAll?.("[data-section-id]") || []).find(
-        (element) => element.getAttribute("data-section-id") === sectionId,
-      );
+    const scrollContainer = refs.sceneEditorSectionsScroll;
+    if (!scrollContainer) {
+      return;
+    }
 
-    sectionElement?.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-      inline: "nearest",
+    const sectionElement = Array.from(
+      scrollContainer.querySelectorAll("[data-section-block-id]"),
+    ).find((element) => element.dataset.sectionBlockId === sectionId);
+    if (!sectionElement) {
+      return;
+    }
+
+    // Sticky headers move with the viewport; the section block keeps its
+    // original position. Align it directly, without the line scroll padding.
+    const sectionTop = sectionElement.getBoundingClientRect().top;
+    const containerTop = scrollContainer.getBoundingClientRect().top;
+    scrollContainer.scrollTo({
+      top:
+        scrollContainer.scrollTop +
+        sectionTop -
+        containerTop -
+        scrollContainer.clientTop,
+      behavior: "instant",
     });
   });
 };

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.handlers.js
@@ -2351,6 +2351,7 @@ export const handleSelectedLineChanged = (deps, payload) => {
         refs,
         adjacentSectionTarget.lineId,
         adjacentSectionTarget.sectionId,
+        { behavior: detail.mode === "block" ? "instant" : "auto" },
       );
       if (detail.mode === "text-editor") {
         focusLinesEditorLine(refs, {

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -177,7 +177,7 @@ template:
                       - rtgl-text: ${sectionsGraph}
                 $else:
                   - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
-                      - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px; scroll-padding-bottom: 48px; overscroll-behavior: contain;"':
+                      - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-padding-top: 40px; scroll-padding-bottom: 48px; overscroll-behavior: contain;"':
                           - $for section, sectionIndex in sectionEditorItems:
                               - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
                                   - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c h=40 bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0; box-sizing: border-box; width: calc(100% + var(--spacing-md)); margin-left: calc(var(--spacing-sm) * -1); padding-left: var(--spacing-md); padding-right: var(--spacing-sm);"':
@@ -204,7 +204,7 @@ template:
                               - rtgl-text: ${sectionsGraph}
                     $else:
                       - 'rtgl-view#sceneEditorLeftEditor d=v w=f h=1fg style="min-width: 0; min-height: 0;"':
-                          - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-behavior: smooth; scroll-padding-top: 40px;"':
+                          - 'rtgl-view#sceneEditorSectionsScroll w=f ph=sm pb=md sv h=1fg style="min-width: 0; scroll-padding-top: 40px;"':
                               - $for section, sectionIndex in sectionEditorItems:
                                   - 'rtgl-view#sectionBlock${sectionIndex} data-section-block-id=${section.id} data-section-id=${section.id} w=f mb=xl style="min-width: 0; scroll-margin-top: 0;"':
                                       - 'rtgl-view#sectionHeader${sectionIndex} data-section-id=${section.id} d=h av=c h=40 bgc=bg bwb=xs style="position: sticky; top: 0px; z-index: 5; min-width: 0; box-sizing: border-box; width: calc(100% + var(--spacing-md)); margin-left: calc(var(--spacing-sm) * -1); padding-left: var(--spacing-md); padding-right: var(--spacing-sm);"':

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -628,7 +628,7 @@ const STYLES = `
     width: 32px;
     color: var(--muted-foreground);
     font-size: var(--scene-document-editor-font-size);
-    font-weight: 600;
+    font-weight: 400;
     line-height: 1.5;
     text-align: right;
     margin-right: 2px;

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -1939,6 +1939,10 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   }
 
   focusContainer({ scrollLine = true } = {}) {
+    if (this.state.selectionActive === false) {
+      return;
+    }
+
     const selectedLineId = this.state.selectedLineId || this.state.lines[0]?.id;
     this.enterBlockMode({
       focusSurface: true,
@@ -2081,7 +2085,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     if (lineId) {
       this.state.selectedLineId = lineId;
       if (scrollLine) {
-        this.scrollLineIntoView({ lineId });
+        this.scrollLineIntoView({ lineId, behavior: "instant" });
       }
     }
 
@@ -2097,7 +2101,11 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     if (focusSurface) {
       requestAnimationFrame(() => {
-        if (!this.isConnected) {
+        if (
+          !this.isConnected ||
+          this.state.selectionActive === false ||
+          this.state.mode !== "block"
+        ) {
           return;
         }
 
@@ -2188,7 +2196,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
 
     this.state.selectedLineId = nextLineId;
     this.scheduleRender();
-    this.scrollLineIntoView({ lineId: nextLineId });
+    this.scrollLineIntoView({ lineId: nextLineId, behavior: "instant" });
     this.dispatchSelectedLineChanged(nextLineId, selectionDetail);
   }
 
@@ -3096,13 +3104,24 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       (activeElement === document.body ||
         activeElement === document.documentElement) &&
       (target === document.body || target === document.documentElement);
-    if (!isBodyKeyTarget) {
+    // Selection changes before the next frame transfers focus between sections.
+    // Route repeated arrows from the old surface to the selected section.
+    const isInactiveSectionKeyTarget = (event.composedPath?.() ?? []).some(
+      (element) =>
+        element instanceof LexicalSceneDocumentEditorElement &&
+        element !== this &&
+        element.selectionActive === false,
+    );
+    if (!isBodyKeyTarget && !isInactiveSectionKeyTarget) {
       return false;
     }
 
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation?.();
+    if (isInactiveSectionKeyTarget) {
+      this.refs.surface.focus({ preventScroll: true });
+    }
     this.moveBlockSelection(navigationDelta);
     return true;
   }
@@ -4625,7 +4644,7 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
   handleSurfaceKeyDown(event) {
     this.hideSelectionPopover();
 
-    if (this.state.mode !== "block") {
+    if (this.state.selectionActive === false || this.state.mode !== "block") {
       return false;
     }
 

--- a/src/setup.android.js
+++ b/src/setup.android.js
@@ -1,8 +1,10 @@
 import { createGlobalUI } from "@rettangoli/ui";
+import { configureAudioRuntime } from "route-graphics";
 
 import { createDb } from "./deps/clients/android/db.js";
 import { callAndroidBridge } from "./deps/clients/android/bridge.js";
 import { createAndroidFilePicker } from "./deps/clients/android/filePicker.js";
+import { createAndroidAudioRuntime } from "./deps/clients/android/audioRuntime.js";
 import AndroidRouter from "./deps/clients/android/router.js";
 import { createBrowserEventsClient } from "./deps/clients/browserEvents.js";
 
@@ -20,6 +22,9 @@ import { setAndroidDebugBuild } from "./internal/navigationTiming.js";
 import tauriConfig from "../src-tauri/tauri.conf.json";
 
 registerPrimitives();
+
+const androidAudioRuntime = createAndroidAudioRuntime();
+configureAudioRuntime(androidAudioRuntime.graphicsRuntime);
 
 let isAndroidDebugBuild = false;
 try {
@@ -49,7 +54,9 @@ const router = new AndroidRouter({ initialPath: "/projects" });
 const filePicker = createAndroidFilePicker();
 const globalUIElement = document.querySelector("rtgl-global-ui");
 const globalUI = createGlobalUI(globalUIElement);
-const audioService = createAudioService();
+const audioService = createAudioService({
+  createAudioContext: androidAudioRuntime.createAudioContext,
+});
 const browserEventsClient = createBrowserEventsClient();
 
 const appVersion = tauriConfig.version;

--- a/tests/android/audioRuntime.test.js
+++ b/tests/android/audioRuntime.test.js
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAndroidAudioRuntime } from "../../src/deps/clients/android/audioRuntime.js";
+import { createAudioService } from "../../src/deps/services/audioService.js";
+
+const runtimes = [];
+
+const createHarness = () => {
+  vi.useFakeTimers();
+  const documentTarget = new EventTarget();
+  documentTarget.hidden = false;
+  class AudioContext extends EventTarget {
+    state = "running";
+    destination = {};
+    elapsed = 0;
+    startedAt = Date.now();
+    get currentTime() {
+      return (
+        (this.elapsed +
+          (this.state === "running" ? Date.now() - this.startedAt : 0)) /
+        1000
+      );
+    }
+    suspend = vi.fn(async () => {
+      if (this.state === "running") this.elapsed += Date.now() - this.startedAt;
+      this.state = "suspended";
+      this.dispatchEvent(new Event("statechange"));
+    });
+    resume = vi.fn(async () => {
+      this.startedAt = Date.now();
+      this.state = "running";
+      this.dispatchEvent(new Event("statechange"));
+    });
+    close = vi.fn(async () => {
+      this.state = "closed";
+    });
+    createGain = () => ({ connect() {}, gain: { value: 1 } });
+    createBufferSource = vi.fn(() => ({
+      connect() {},
+      disconnect() {},
+      start: vi.fn(),
+      stop: vi.fn(),
+    }));
+    decodeAudioData = async () => ({ duration: 60 });
+  }
+  const windowTarget = {
+    AudioContext,
+    performance: { now: () => Date.now() },
+    setTimeout,
+    clearTimeout,
+    queueMicrotask,
+  };
+  const runtime = createAndroidAudioRuntime({ windowTarget, documentTarget });
+  runtimes.push(runtime);
+  const setHidden = (hidden) => {
+    documentTarget.hidden = hidden;
+    documentTarget.dispatchEvent(new Event("visibilitychange"));
+  };
+  return { runtime, windowTarget, setHidden };
+};
+
+afterEach(async () => {
+  for (const runtime of runtimes.splice(0)) await runtime.dispose();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Android audio lifecycle", () => {
+  it("freezes both preview and sound-player contexts until the app is visible", async () => {
+    const { runtime, windowTarget, setHidden } = createHarness();
+    const preview = runtime.graphicsRuntime.context;
+    const soundPlayer = runtime.createAudioContext();
+    await vi.advanceTimersByTimeAsync(300);
+
+    windowTarget.routeVNSetAppActive(false);
+    setHidden(true);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(preview.state).toBe("suspended");
+    expect(soundPlayer.state).toBe("suspended");
+    expect(preview.currentTime).toBe(0.3);
+    expect(soundPlayer.currentTime).toBe(0.3);
+    expect(preview.suspend).toHaveBeenCalledOnce();
+
+    windowTarget.routeVNSetAppActive(true);
+    expect(preview.state).toBe("suspended");
+    setHidden(false);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(preview.currentTime).toBe(0.5);
+    expect(soundPlayer.currentTime).toBe(0.5);
+  });
+
+  it("blocks delayed resume requests and contexts created in the background", async () => {
+    const { runtime, setHidden } = createHarness();
+    setHidden(true);
+    const context = runtime.createAudioContext();
+
+    await context.resume();
+    expect(context.state).toBe("suspended");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(context.currentTime).toBe(0);
+
+    setHidden(false);
+    expect(context.state).toBe("running");
+  });
+
+  it("suspends a previously pending resume if it completes after backgrounding", () => {
+    const { runtime, setHidden } = createHarness();
+    const context = runtime.createAudioContext();
+    setHidden(true);
+
+    context.state = "running";
+    context.dispatchEvent(new Event("statechange"));
+
+    expect(context.state).toBe("suspended");
+    expect(context.suspend).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves sound delays and intervals without replaying background time", async () => {
+    const { runtime, setHidden } = createHarness();
+    const clock = runtime.graphicsRuntime;
+    const startedAt = clock.nowMs();
+    const delayed = vi.fn();
+    const repeating = vi.fn();
+    const createdWhileHidden = vi.fn();
+    clock.setTimeout(delayed, 1000);
+    const interval = clock.setInterval(repeating, 200);
+    await vi.advanceTimersByTimeAsync(250);
+    setHidden(true);
+    clock.setTimeout(createdWhileHidden, 500);
+
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(clock.nowMs() - startedAt).toBe(250);
+    expect(delayed).not.toHaveBeenCalled();
+    expect(createdWhileHidden).not.toHaveBeenCalled();
+    expect(repeating).toHaveBeenCalledOnce();
+
+    setHidden(false);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(repeating).toHaveBeenCalledTimes(2);
+    clock.clearInterval(interval);
+    await vi.advanceTimersByTimeAsync(350);
+    expect(createdWhileHidden).toHaveBeenCalledOnce();
+    expect(delayed).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(delayed).toHaveBeenCalledOnce();
+    expect(repeating).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not resume a closed or already suspended context", async () => {
+    const { runtime, setHidden } = createHarness();
+    const closed = runtime.createAudioContext();
+    const suspended = runtime.createAudioContext();
+    await suspended.suspend();
+    setHidden(true);
+    await closed.close();
+    setHidden(false);
+
+    expect(closed.state).toBe("closed");
+    expect(suspended.state).toBe("suspended");
+  });
+
+  it("preserves sound-player position and keeps a user-paused track paused", async () => {
+    const { runtime, windowTarget, setHidden } = createHarness();
+    vi.stubGlobal("window", windowTarget);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(8),
+      })),
+    );
+    const service = createAudioService({
+      createAudioContext: runtime.createAudioContext,
+    });
+    const release = service.acquire();
+    try {
+      await service.loadAudio("blob:track-one");
+      await service.play();
+      await vi.advanceTimersByTimeAsync(500);
+      setHidden(true);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(service.getCurrentTime()).toBe(0.5);
+      setHidden(false);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(service.getCurrentTime()).toBe(1);
+
+      service.pause();
+      setHidden(true);
+      setHidden(false);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(service.isPlaying()).toBe(false);
+      expect(service.getCurrentTime()).toBe(1);
+    } finally {
+      release();
+    }
+  });
+
+  it("clears scheduled work and native hooks when disposed", async () => {
+    const { runtime, windowTarget, setHidden } = createHarness();
+    const context = runtime.createAudioContext();
+    const callback = vi.fn();
+    runtime.graphicsRuntime.setTimeout(callback, 100);
+    await runtime.dispose();
+    setHidden(true);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(context.state).toBe("closed");
+    expect(callback).not.toHaveBeenCalled();
+    expect(windowTarget.routeVNSetAppActive).toBeUndefined();
+  });
+});

--- a/tests/sceneEditor/lexicalLineEditing.test.js
+++ b/tests/sceneEditor/lexicalLineEditing.test.js
@@ -361,6 +361,169 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it.each([
+    ["ArrowDown", 1],
+    ["ArrowUp", -1],
+    ["j", 1],
+    ["k", -1],
+  ])(
+    "routes repeated %s to the selected section before focus transfers",
+    async (key, delta) => {
+      const restoreDomGlobals = installDomGlobals();
+      try {
+        const { LexicalSceneDocumentEditorElement } = await import(
+          "../../src/primitives/lexicalSceneDocumentEditor.js"
+        );
+        const activeEditor = Object.create(
+          LexicalSceneDocumentEditorElement.prototype,
+        );
+        const previousEditor = Object.create(
+          LexicalSceneDocumentEditorElement.prototype,
+        );
+        const previousSurface = document.createElement("div");
+        const nextSurface = document.createElement("div");
+        previousSurface.tabIndex = 0;
+        nextSurface.tabIndex = 0;
+        document.body.append(previousSurface, nextSurface);
+        previousSurface.focus();
+        previousEditor.state = { selectionActive: false, mode: "block" };
+        activeEditor.state = { selectionActive: true, mode: "block" };
+        activeEditor.refs = {
+          editor: document.createElement("div"),
+          surface: nextSurface,
+        };
+        activeEditor.getActiveElement = () => document.activeElement;
+        activeEditor.moveBlockSelection = vi.fn();
+        const event = new window.KeyboardEvent("keydown", {
+          key,
+          bubbles: true,
+          cancelable: true,
+        });
+        Object.defineProperty(event, "target", { value: previousSurface });
+        Object.defineProperty(event, "composedPath", {
+          value: () => [
+            previousSurface,
+            previousEditor,
+            document.body,
+            document,
+            window,
+          ],
+        });
+
+        activeEditor.handleWindowKeyDownCapture(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(activeEditor.moveBlockSelection).toHaveBeenCalledExactlyOnceWith(
+          delta,
+        );
+        expect(document.activeElement).toBe(nextSurface);
+      } finally {
+        restoreDomGlobals();
+      }
+    },
+  );
+
+  it("does not navigate an inactive surface from a cleared line selection", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      editorElement.state = {
+        selectionActive: false,
+        mode: "block",
+        selectedLineId: undefined,
+        lines: [{ id: "line-1" }, { id: "line-2" }],
+      };
+      editorElement.hideSelectionPopover = vi.fn();
+      editorElement.moveBlockSelection = vi.fn();
+      const event = new window.KeyboardEvent("keydown", {
+        key: "ArrowDown",
+        cancelable: true,
+      });
+
+      expect(editorElement.handleSurfaceKeyDown(event)).toBe(false);
+      expect(editorElement.moveBlockSelection).not.toHaveBeenCalled();
+      expect(editorElement.state.selectedLineId).toBeUndefined();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it("ignores a queued container focus request after its section becomes inactive", async () => {
+    const restoreDomGlobals = installDomGlobals();
+    try {
+      const { LexicalSceneDocumentEditorElement } = await import(
+        "../../src/primitives/lexicalSceneDocumentEditor.js"
+      );
+      const editorElement = Object.create(
+        LexicalSceneDocumentEditorElement.prototype,
+      );
+      editorElement.state = {
+        selectionActive: false,
+        selectedLineId: undefined,
+        lines: [{ id: "line-1" }],
+      };
+      editorElement.enterBlockMode = vi.fn();
+
+      editorElement.focusContainer();
+
+      expect(editorElement.enterBlockMode).not.toHaveBeenCalled();
+      expect(editorElement.state.selectedLineId).toBeUndefined();
+    } finally {
+      restoreDomGlobals();
+    }
+  });
+
+  it.each(["inactive", "text-editor"])(
+    "cancels pending block focus when the editor becomes %s",
+    async (nextState) => {
+      const restoreDomGlobals = installDomGlobals();
+      const frames = installAnimationFrameQueue();
+      try {
+        const { LexicalSceneDocumentEditorElement } = await import(
+          "../../src/primitives/lexicalSceneDocumentEditor.js"
+        );
+        const editorElement = Object.create(
+          LexicalSceneDocumentEditorElement.prototype,
+        );
+        Object.defineProperty(editorElement, "dataset", { value: {} });
+        Object.defineProperty(editorElement, "isConnected", { value: true });
+        editorElement.state = {
+          selectionActive: true,
+          mode: "block",
+          selectedLineId: "line-1",
+        };
+        editorElement.refs = {
+          editor: { dataset: {}, blur: vi.fn() },
+          surface: { dataset: {}, focus: vi.fn() },
+        };
+        editorElement.clearPendingTextInputFallback = vi.fn();
+        editorElement.clearSelectedReferenceNodeKey = vi.fn();
+        editorElement.scheduleRender = vi.fn();
+        editorElement.enterBlockMode({ lineId: "line-1", scrollLine: false });
+        if (nextState === "inactive") {
+          editorElement.state.selectionActive = false;
+        } else {
+          editorElement.state.mode = "text-editor";
+        }
+        frames.callbacks.forEach((callback) => callback());
+
+        expect(editorElement.refs.surface.focus).not.toHaveBeenCalled();
+        expect(editorElement.refs.editor.blur).not.toHaveBeenCalled();
+        expect(editorElement.state.mode).toBe(
+          nextState === "text-editor" ? "text-editor" : "block",
+        );
+      } finally {
+        frames.restore();
+        restoreDomGlobals();
+      }
+    },
+  );
+
   it("suppresses block-mode Space from the window capture path", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -765,6 +928,10 @@ describe("lexical scene document editor line editing", () => {
       expect(editorElement.state.mode).toBe("block");
       expect(editorNode.dataset.mode).toBe("block");
       expect(surfaceNode.dataset.mode).toBe("block");
+      expect(editorElement.scrollLineIntoView).toHaveBeenCalledWith({
+        lineId: "line-1",
+        behavior: "instant",
+      });
       expect(document.activeElement).toBe(surfaceNode);
       expect(editorElement.isEditorFocused).toBe(false);
     } finally {
@@ -836,6 +1003,54 @@ describe("lexical scene document editor line editing", () => {
     }
   });
 
+  it.each([
+    [1, "line-1", "line-2", "down"],
+    [-1, "line-2", "line-1", "up"],
+  ])(
+    "moves block selection by %s and reveals the line without scroll animation",
+    async (delta, selectedLineId, nextLineId, navigationDirection) => {
+      const restoreDomGlobals = installDomGlobals();
+      try {
+        const { LexicalSceneDocumentEditorElement } = await import(
+          "../../src/primitives/lexicalSceneDocumentEditor.js"
+        );
+        const editorElement = Object.create(
+          LexicalSceneDocumentEditorElement.prototype,
+        );
+        editorElement.state = {
+          mode: "block",
+          selectedLineId,
+          lines: [{ id: "line-1" }, { id: "line-2" }],
+        };
+        editorElement.scheduleRender = vi.fn();
+        editorElement.scrollLineIntoView = vi.fn();
+        editorElement.dispatchSelectedLineChanged = vi.fn();
+
+        editorElement.moveBlockSelection(delta);
+
+        expect(editorElement.state.selectedLineId).toBe(nextLineId);
+        expect(editorElement.scheduleRender).toHaveBeenCalledOnce();
+        expect(
+          editorElement.scrollLineIntoView,
+        ).toHaveBeenCalledExactlyOnceWith({
+          lineId: nextLineId,
+          behavior: "instant",
+        });
+        expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
+          nextLineId,
+          {
+            cursorPosition: undefined,
+            isCollapsed: false,
+            mode: "block",
+            navigationDirection,
+          },
+        );
+      } finally {
+        restoreDomGlobals();
+      }
+    },
+  );
+
   it("emits block navigation direction when moving down at the last line", async () => {
     const restoreDomGlobals = installDomGlobals();
 
@@ -861,6 +1076,7 @@ describe("lexical scene document editor line editing", () => {
       expect(editorElement.state.selectedLineId).toBe("line-2");
       expect(editorElement.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-2",
+        behavior: "instant",
       });
       expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
         "line-2",
@@ -965,6 +1181,7 @@ describe("lexical scene document editor line editing", () => {
       expect(editorElement.state.selectedLineId).toBe("line-1");
       expect(editorElement.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-1",
+        behavior: "instant",
       });
       expect(editorElement.dispatchSelectedLineChanged).toHaveBeenCalledWith(
         "line-1",

--- a/tests/sceneEditor/sceneEditorLexical.handlers.test.js
+++ b/tests/sceneEditor/sceneEditorLexical.handlers.test.js
@@ -2411,7 +2411,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     );
   });
 
-  it("moves block selection from the last line to the next section first line", () => {
+  it("moves block selection to the next section without scroll animation", () => {
     const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
@@ -2508,6 +2508,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       expect(deps.render).toHaveBeenCalledOnce();
       expect(nextSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-3",
+        behavior: "instant",
       });
       expect(nextSectionEditor.focusContainer).toHaveBeenCalled();
       expect(deps.subject.dispatch).toHaveBeenCalledWith(
@@ -2526,7 +2527,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
     }
   });
 
-  it("moves block selection from the first line to the previous section last line", () => {
+  it("moves block selection to the previous section without scroll animation", () => {
     const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
     globalThis.requestAnimationFrame = vi.fn((callback) => {
       callback();
@@ -2623,6 +2624,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       expect(deps.render).toHaveBeenCalledOnce();
       expect(previousSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-2",
+        behavior: "instant",
       });
       expect(previousSectionEditor.focusContainer).toHaveBeenCalled();
       expect(deps.subject.dispatch).toHaveBeenCalledWith(
@@ -2734,6 +2736,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       });
       expect(nextSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-3",
+        behavior: "auto",
       });
       expect(nextSectionEditor.focusLine).toHaveBeenCalledWith({
         sectionId: "section-2",
@@ -2936,6 +2939,7 @@ describe("sceneEditorLexical.handlers actions dialog", () => {
       });
       expect(previousSectionEditor.scrollLineIntoView).toHaveBeenCalledWith({
         lineId: "line-2",
+        behavior: "auto",
       });
       expect(previousSectionEditor.focusLine).toHaveBeenCalledWith({
         sectionId: "section-1",

--- a/tests/sceneEditor/sectionOperations.test.js
+++ b/tests/sceneEditor/sectionOperations.test.js
@@ -1,7 +1,78 @@
-import { describe, expect, it, vi } from "vitest";
-import { createSceneEditorSectionWithName } from "../../src/internal/ui/sceneEditor/sectionOperations.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSceneEditorSectionWithName,
+  scrollSceneEditorSectionTabIntoView,
+} from "../../src/internal/ui/sceneEditor/sectionOperations.js";
 
 describe("scene editor section operations", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([0, 1996, 3400])(
+    "jumps to the section beginning from scroll position %i, ignoring its sticky header",
+    (scrollTop) => {
+      vi.stubGlobal("requestAnimationFrame", (callback) => callback());
+      const section = {
+        dataset: { sectionBlockId: "section-2" },
+        getBoundingClientRect: () => ({ top: 200 + 1296 - scrollTop }),
+      };
+      const stickyHeader = {
+        dataset: { sectionId: "section-2" },
+        getBoundingClientRect: () => ({ top: 200 }),
+        scrollIntoView: vi.fn(),
+      };
+      const scrollContainer = {
+        scrollTop,
+        clientTop: 0,
+        getBoundingClientRect: () => ({ top: 200 }),
+        querySelectorAll: vi.fn(() => [section]),
+        scrollTo: vi.fn(),
+      };
+
+      scrollSceneEditorSectionTabIntoView(
+        {
+          refs: {
+            sceneEditorSectionsScroll: scrollContainer,
+            sectionHeader1: stickyHeader,
+          },
+        },
+        "section-2",
+      );
+
+      expect(scrollContainer.scrollTo).toHaveBeenCalledExactlyOnceWith({
+        top: 1296,
+        behavior: "instant",
+      });
+      expect(stickyHeader.scrollIntoView).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not jump to another matching ref when the section has been removed", () => {
+    vi.stubGlobal("requestAnimationFrame", (callback) => callback());
+    const overviewRow = {
+      dataset: { sectionId: "section-2" },
+      scrollIntoView: vi.fn(),
+    };
+    const scrollContainer = {
+      querySelectorAll: () => [],
+      scrollTo: vi.fn(),
+    };
+
+    scrollSceneEditorSectionTabIntoView(
+      {
+        refs: {
+          sceneEditorSectionsScroll: scrollContainer,
+          sectionOverviewRow1: overviewRow,
+        },
+      },
+      "section-2",
+    );
+
+    expect(scrollContainer.scrollTo).not.toHaveBeenCalled();
+    expect(overviewRow.scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it("does not select or scroll to a newly created section", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
Scene editor navigation could jump backward during repeated keyboard input or land partway through a section chosen from the sections list. Android audio also continued playing when the app was minimized.

- Route repeated Up/Down and j/k input to the selected section while focus transfers, and prevent inactive sections or stale callbacks from reclaiming focus.
- Jump instantly to the actual section container when selecting from the sections list. The old target could be a sticky header already pinned to the viewport. Remove smooth scrolling from the editor containers.
- Render line numbers at regular weight, including the selected line.
- Pause sound-player and scene-preview audio when Android leaves the foreground. Preserve playback position and pending audio timing, block delayed background resumes, and resume on return. Tracks paused by the user stay paused.

Validation:

- All 227 targeted editor, Android audio lifecycle, sound-player, and graphics tests passed.
- Lint, formatting, and diff checks passed; Android frontend and debug APK builds passed.
- Browser validation covered repeated cross-section keyboard navigation and real AudioContext/RouteGraphics background playback behavior.
- Installed on the Vivo and verified audio pauses at Home and resumes from the same position, repeated section jumps stay at the heading, and selected/unselected line numbers use regular weight.
