### PR TITLE
Improve web export loading and start experience

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -21,6 +21,8 @@ import { resolveBundleAssetMimeType } from "../src/internal/bundleRuntimeAssets.
 import { createBundleRangeReader as createPackageBinRangeReader } from "../src/deps/services/shared/projectExportService.js";
 import { installPlayerAudioUnlock } from "./playerAudioUnlock.js";
 import { waitForPlayerStart } from "./playerStartGate.js";
+import { updatePlayerLoadingProgress } from "./playerLoadingProgress.js";
+import { createPlayerStartupEffects } from "./playerStartupEffects.js";
 
 const MAX_DIAGNOSTIC_EVENTS = 24;
 const MAX_DIAGNOSTIC_TEXT_LENGTH = 12_000;
@@ -474,11 +476,20 @@ const createBundleAssetLoader = ({ bundleReader, routeGraphics }) => {
       );
     },
 
-    async ensureAssetsLoaded(assetIds = []) {
+    async ensureAssetsLoaded(assetIds = [], onProgress) {
       const uniqueAssetIds = Array.from(
         new Set(assetIds.filter((assetId) => bundleReader.hasAsset(assetId))),
       );
-      await Promise.all(uniqueAssetIds.map(loadAsset));
+      let loaded = 0;
+      const total = uniqueAssetIds.length;
+      onProgress?.({ loaded, total });
+      await Promise.all(
+        uniqueAssetIds.map(async (assetId) => {
+          await loadAsset(assetId);
+          loaded += 1;
+          onProgress?.({ loaded, total });
+        }),
+      );
     },
   };
 };
@@ -607,7 +618,10 @@ const createRuntimePersistence = ({ namespace }) => {
   return createHostPersistence();
 };
 
-const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
+const prepareEngine = async (
+  { jsonData, bundleReader, bundleMetadata },
+  { onStepComplete, onAssetProgress, waitForStart },
+) => {
   recordDiagnosticStep("Preparing graphics runtime", {
     assetCount: Object.keys(bundleReader.manifest?.assets ?? {}).length,
     atlasCount: Object.keys(bundleReader.manifest?.atlases ?? {}).length,
@@ -615,11 +629,11 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
   const plugins = await loadGraphicsEnginePlugins().catch((error) => {
     throw createRuntimeError("Failed to load graphics engine plugins.", error);
   });
+  onStepComplete();
   const namespace = createBundleNamespace(bundleMetadata);
 
   // Create dedicated ticker for auto mode
   const ticker = new Ticker();
-  ticker.start();
 
   const routeGraphics = createRouteGraphics();
   let engine;
@@ -711,14 +725,18 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
     }
   };
 
-  const renderEngineState = (renderState) => {
+  const prepareRenderState = (renderState) => {
     const audioRenderState = prepareRenderStateAudioChannelsForGraphics({
       renderState,
       presentationState: engine?.selectPresentationState?.(),
     });
-    latestPreparedRenderState = prepareRenderStateKeyboardForGraphics({
+    return prepareRenderStateKeyboardForGraphics({
       renderState: audioRenderState,
     });
+  };
+
+  const renderEngineState = (renderState) => {
+    latestPreparedRenderState = prepareRenderState(renderState);
     const missingAssetIds = bundleAssetLoader.collectMissingAssetIds(
       latestPreparedRenderState,
     );
@@ -784,6 +802,7 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
       namespace,
     });
   });
+  onStepComplete();
 
   const handlePersistenceError = (error) => {
     const runtimeError = createRuntimeError(
@@ -864,6 +883,7 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
         height: screenHeight,
       });
     });
+  onStepComplete();
 
   installPlayerAudioUnlock({
     resumeAudio: () => routeGraphics.resumeAudio(),
@@ -871,7 +891,12 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
 
   canvasContainer?.appendChild(routeGraphics.canvas);
 
-  engine = createRouteEngine({ handlePendingEffects: effectsHandler });
+  const startupEffects = waitForStart
+    ? createPlayerStartupEffects({ getEngine: () => engine, effectsHandler })
+    : undefined;
+  engine = createRouteEngine({
+    handlePendingEffects: startupEffects ?? effectsHandler,
+  });
   const preloadSaveSlotImagesResult = await preloadRuntimeSaveSlotImages(
     routeGraphics,
     saveSlots,
@@ -881,6 +906,7 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
       error,
     );
   });
+  onStepComplete();
 
   if (preloadSaveSlotImagesResult.failed > 0) {
     console.warn(
@@ -888,7 +914,7 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
     );
   }
 
-  const startEngine = () => {
+  const initializeEngine = () => {
     recordDiagnosticStep("Starting route engine", { namespace });
     try {
       engine.init({
@@ -913,19 +939,57 @@ const prepareEngine = async ({ jsonData, bundleReader, bundleMetadata }) => {
     }
   };
 
+  if (waitForStart) {
+    initializeEngine();
+    const openingState = prepareRenderState(engine.selectRenderState());
+    await bundleAssetLoader.ensureAssetsLoaded(
+      bundleAssetLoader.collectMissingAssetIds(openingState),
+      onAssetProgress,
+    );
+  }
+
   return {
-    startEngine,
+    startEngine: () => {
+      if (startupEffects) {
+        startupEffects.start();
+      } else {
+        initializeEngine();
+      }
+      ticker.start();
+    },
     waitForFirstRender: () => firstRenderPromise,
   };
 };
 
 const bootstrap = async () => {
+  const loadingElement = document.getElementById("loading");
+  const startMode = document.body?.dataset.playerStart;
+  // Five setup steps occupy the first 20%; opening assets occupy the rest.
+  let completedSteps = 0;
+  const onStepComplete = () => {
+    completedSteps += 1;
+    updatePlayerLoadingProgress(loadingElement, {
+      loaded: completedSteps * 4,
+      total: 100,
+    });
+  };
+  const onAssetProgress = ({ loaded, total }) => {
+    updatePlayerLoadingProgress(loadingElement, {
+      loaded: 20 + (total === 0 ? 80 : (loaded / total) * 80),
+      total: 100,
+    });
+  };
   try {
     const preloadedData = await preloadBundleData();
-    const engineRuntime = await prepareEngine(preloadedData);
+    onStepComplete();
+    const engineRuntime = await prepareEngine(preloadedData, {
+      onStepComplete,
+      onAssetProgress,
+      waitForStart: startMode === "click",
+    });
     await waitForPlayerStart({
-      loadingElement: document.getElementById("loading"),
-      startMode: document.body?.dataset.playerStart,
+      loadingElement,
+      startMode,
     });
     engineRuntime.startEngine();
     await engineRuntime.waitForFirstRender();

--- a/scripts/playerLoadingProgress.js
+++ b/scripts/playerLoadingProgress.js
@@ -1,0 +1,13 @@
+export const updatePlayerLoadingProgress = (
+  loadingElement,
+  { loaded, total },
+) => {
+  const progress = loadingElement?.querySelector("#loading-progress");
+  // Native players have no loading UI; errors replace it with diagnostics.
+  if (!progress) return;
+
+  const percentage = total === 0 ? 100 : Math.floor((loaded / total) * 100);
+  progress.value = percentage;
+  loadingElement.querySelector("#loading-percentage").textContent =
+    `${percentage}%`;
+};

--- a/scripts/playerStartGate.js
+++ b/scripts/playerStartGate.js
@@ -6,17 +6,20 @@ export const waitForPlayerStart = async ({
     return;
   }
 
-  loadingElement.textContent = "Click to start";
+  const progress = loadingElement.querySelector(".loading-progress");
+  const startButton = loadingElement.querySelector("#loading-start");
+  const window = loadingElement.ownerDocument.defaultView;
+  startButton.textContent = window.matchMedia("(pointer: coarse)").matches
+    ? "Tap to start"
+    : "Click to start";
+  progress.inert = true;
+  progress.setAttribute("aria-hidden", "true");
+  startButton.disabled = false;
   loadingElement.classList.add("ready");
 
   await new Promise((resolve) => {
-    const handleClick = () => {
-      loadingElement.removeEventListener("click", handleClick);
-      resolve();
-    };
-
-    loadingElement.addEventListener("click", handleClick);
+    loadingElement.addEventListener("click", resolve, { once: true });
   });
 
-  loadingElement.classList.remove("ready");
+  startButton.disabled = true;
 };

--- a/scripts/playerStartupEffects.js
+++ b/scripts/playerStartupEffects.js
@@ -1,0 +1,52 @@
+// Resolve the opening scene once, without rendering, saving, or running timers
+// until the player starts. The normal effects handler owns playback afterward.
+export const createPlayerStartupEffects = ({ getEngine, effectsHandler }) => {
+  let waiting = true;
+  let pending = [];
+  let schedule;
+
+  const handleEffects = (effects) => {
+    if (!waiting) return effectsHandler(effects);
+
+    for (const effect of effects) {
+      if (effect.name !== "handleLineActions") {
+        pending.push(effect);
+      }
+    }
+    // Match the normal handler's latest-wins entered-line reconciliation.
+    const enteredLine = effects.findLast(
+      (effect) => effect.name === "handleLineActions",
+    );
+    if (enteredLine) getEngine().handleLineActions(enteredLine.payload);
+  };
+
+  handleEffects.reconcilePlaybackScheduleV1 = (nextSchedule) => {
+    if (waiting) {
+      schedule = nextSchedule;
+    } else {
+      effectsHandler.reconcilePlaybackScheduleV1(nextSchedule);
+    }
+  };
+  handleEffects.reset = () => {
+    pending = [];
+    schedule = undefined;
+    effectsHandler.reset();
+  };
+  handleEffects.dispose = () => {
+    pending = [];
+    schedule = undefined;
+    effectsHandler.dispose();
+  };
+  handleEffects.start = () => {
+    if (!waiting) return;
+    waiting = false;
+    const effects = pending;
+    pending = [];
+    if (schedule) effectsHandler.reconcilePlaybackScheduleV1(schedule);
+    schedule = undefined;
+    // An empty opening line still needs its first render.
+    effectsHandler([...effects, { name: "render" }]);
+  };
+
+  return handleEffects;
+};

--- a/scripts/test-export-bundle-pipeline.js
+++ b/scripts/test-export-bundle-pipeline.js
@@ -367,7 +367,9 @@ try {
   assert.ok(!indexHtml.includes("/@vite/client"));
   assert.ok(!indexHtml.includes("player-runtime-persistence-host.js"));
   assert.ok(indexHtml.includes('<body data-player-start="click">'));
-  assert.ok(indexHtml.includes('<div id="loading">Loading...</div>'));
+  assert.ok(indexHtml.includes('<span id="loading-label">Loading…</span>'));
+  assert.ok(indexHtml.includes('<progress id="loading-progress"'));
+  assert.ok(indexHtml.includes("disabled>Click to start</button>"));
   assert.ok(indexHtml.includes("#loading.ready"));
 
   const packageBin = await zip.file("package.bin").async("arraybuffer");

--- a/src/deps/services/shared/projectExportService.js
+++ b/src/deps/services/shared/projectExportService.js
@@ -69,16 +69,103 @@ const BUNDLE_PLAYER_INDEX_HTML_TEMPLATE = `<!doctype html>
         place-items: center;
         box-sizing: border-box;
         padding: 24px;
-        color: #fff;
-        background: __ROUTEVN_WEB_BACKGROUND_COLOR__;
-        font: 600 24px/1.2 sans-serif;
-        letter-spacing: 0.02em;
+        color: #f2f2f2;
+        background: #101010;
+        font: 400 20px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         z-index: 10;
         user-select: none;
+        transition: opacity 200ms ease, visibility 0s 200ms;
       }
 
       #loading.ready {
         cursor: pointer;
+      }
+
+      .loading-progress,
+      #loading-start {
+        grid-area: 1 / 1;
+        transition: opacity 160ms ease, visibility 0s 160ms;
+      }
+
+      .loading-progress {
+        width: min(220px, 66vw);
+        animation: loading-appear 160ms ease-out;
+      }
+
+      #loading.ready .loading-progress {
+        opacity: 0;
+        visibility: hidden;
+        animation: none;
+      }
+
+      #loading.ready #loading-start {
+        opacity: 1;
+        visibility: visible;
+        transition-delay: 80ms;
+      }
+
+      @keyframes loading-appear {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+
+      .loading-labels {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 14px;
+      }
+
+      #loading-percentage {
+        color: #d0d0d0;
+        font-size: 18px;
+        font-variant-numeric: tabular-nums;
+      }
+
+      #loading-progress {
+        appearance: none;
+        display: block;
+        width: 100%;
+        height: 2px;
+        border: 0;
+        background: #333;
+        color: #eee;
+      }
+
+      #loading-progress::-webkit-progress-bar {
+        background: #333;
+      }
+
+      #loading-progress::-webkit-progress-value {
+        background: #eee;
+        transition: width 150ms ease-out;
+      }
+
+      #loading-progress::-moz-progress-bar {
+        background: #eee;
+        transition: width 150ms ease-out;
+      }
+
+      #loading-start {
+        opacity: 0;
+        visibility: hidden;
+        border: 0;
+        padding: 12px 22px;
+        min-height: 48px;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        letter-spacing: 0.01em;
+        cursor: pointer;
+      }
+
+      #loading-start:hover {
+        color: #fff;
+      }
+
+      #loading-start:focus-visible {
+        outline: 1px solid #b8b8b8;
+        outline-offset: 4px;
       }
 
       #loading.error {
@@ -88,7 +175,27 @@ const BUNDLE_PLAYER_INDEX_HTML_TEMPLATE = `<!doctype html>
       }
 
       #loading.hidden {
-        display: none;
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #loading,
+        .loading-progress,
+        #loading-start,
+        #loading.ready #loading-start {
+          animation: none;
+          transition: none;
+        }
+
+        #loading-progress::-webkit-progress-value {
+          transition: none;
+        }
+
+        #loading-progress::-moz-progress-bar {
+          transition: none;
+        }
       }
 
       #loading .loading-error {
@@ -123,7 +230,16 @@ const BUNDLE_PLAYER_INDEX_HTML_TEMPLATE = `<!doctype html>
     </style>
   </head>
   <body data-player-start="click">
-    <div id="loading">Loading...</div>
+    <div id="loading">
+      <div class="loading-progress">
+        <div class="loading-labels">
+          <span id="loading-label">Loading…</span>
+          <span id="loading-percentage" aria-hidden="true">0%</span>
+        </div>
+        <progress id="loading-progress" max="100" value="0" aria-labelledby="loading-label"></progress>
+      </div>
+      <button id="loading-start" type="button" disabled>Click to start</button>
+    </div>
     <div id="canvas"></div>
   </body>
   <script>

--- a/static/bundle/index.html
+++ b/static/bundle/index.html
@@ -1,5 +1,7 @@
 <html>
   <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       html,
       body {
@@ -41,25 +43,158 @@
         inset: 0;
         display: grid;
         place-items: center;
-        color: #fff;
-        background: #000;
-        font: 600 24px/1.2 sans-serif;
-        letter-spacing: 0.02em;
+        color: #f2f2f2;
+        background: #101010;
+        font:
+          400 20px/1.4 -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
         z-index: 10;
         user-select: none;
+        transition:
+          opacity 200ms ease,
+          visibility 0s 200ms;
       }
 
       #loading.ready {
         cursor: pointer;
       }
 
+      .loading-progress,
+      #loading-start {
+        grid-area: 1 / 1;
+        transition:
+          opacity 160ms ease,
+          visibility 0s 160ms;
+      }
+
+      .loading-progress {
+        width: min(220px, 66vw);
+        animation: loading-appear 160ms ease-out;
+      }
+
+      #loading.ready .loading-progress {
+        opacity: 0;
+        visibility: hidden;
+        animation: none;
+      }
+
+      #loading.ready #loading-start {
+        opacity: 1;
+        visibility: visible;
+        transition-delay: 80ms;
+      }
+
+      @keyframes loading-appear {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+
+      .loading-labels {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 14px;
+      }
+
+      #loading-percentage {
+        color: #d0d0d0;
+        font-size: 18px;
+        font-variant-numeric: tabular-nums;
+      }
+
+      #loading-progress {
+        appearance: none;
+        display: block;
+        width: 100%;
+        height: 2px;
+        border: 0;
+        background: #333;
+        color: #eee;
+      }
+
+      #loading-progress::-webkit-progress-bar {
+        background: #333;
+      }
+
+      #loading-progress::-webkit-progress-value {
+        background: #eee;
+        transition: width 150ms ease-out;
+      }
+
+      #loading-progress::-moz-progress-bar {
+        background: #eee;
+        transition: width 150ms ease-out;
+      }
+
+      #loading-start {
+        opacity: 0;
+        visibility: hidden;
+        border: 0;
+        padding: 12px 22px;
+        min-height: 48px;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        letter-spacing: 0.01em;
+        cursor: pointer;
+      }
+
+      #loading-start:hover {
+        color: #fff;
+      }
+
+      #loading-start:focus-visible {
+        outline: 1px solid #b8b8b8;
+        outline-offset: 4px;
+      }
+
       #loading.hidden {
-        display: none;
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #loading,
+        .loading-progress,
+        #loading-start,
+        #loading.ready #loading-start {
+          animation: none;
+          transition: none;
+        }
+
+        #loading-progress::-webkit-progress-value {
+          transition: none;
+        }
+
+        #loading-progress::-moz-progress-bar {
+          transition: none;
+        }
       }
     </style>
   </head>
   <body data-player-start="click">
-    <div id="loading">Loading...</div>
+    <div id="loading">
+      <div class="loading-progress">
+        <div class="loading-labels">
+          <span id="loading-label">Loading…</span>
+          <span id="loading-percentage" aria-hidden="true">0%</span>
+        </div>
+        <progress
+          id="loading-progress"
+          max="100"
+          value="0"
+          aria-labelledby="loading-label"
+        ></progress>
+      </div>
+      <button id="loading-start" type="button" disabled>Click to start</button>
+    </div>
     <div id="canvas"></div>
   </body>
   <script src="./main.js" type="module"></script>

--- a/tests/services/playerLoadingProgress.test.js
+++ b/tests/services/playerLoadingProgress.test.js
@@ -1,0 +1,43 @@
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+import { updatePlayerLoadingProgress } from "../../scripts/playerLoadingProgress.js";
+import { BUNDLE_PLAYER_INDEX_HTML } from "../../src/deps/services/shared/projectExportService.js";
+
+describe("player loading progress", () => {
+  it("shows whole-number progress while keeping a single loading label", () => {
+    const dom = new JSDOM(BUNDLE_PLAYER_INDEX_HTML);
+    const loadingElement = dom.window.document.querySelector("#loading");
+
+    for (const [loaded, total, percentage] of [
+      [0, 3, 0],
+      [1, 3, 33],
+      [2, 3, 66],
+      [3, 3, 100],
+      [0, 0, 100],
+    ]) {
+      updatePlayerLoadingProgress(loadingElement, { loaded, total });
+      expect(loadingElement.querySelector("#loading-progress").value).toBe(
+        percentage,
+      );
+      expect(
+        loadingElement.querySelector("#loading-percentage").textContent,
+      ).toBe(`${percentage}%`);
+      expect(loadingElement.querySelector("#loading-label").textContent).toBe(
+        "Loading…",
+      );
+    }
+    dom.window.close();
+  });
+
+  it("does not create UI in native players or overwrite an error", () => {
+    const dom = new JSDOM('<div id="loading"></div>');
+    const loadingElement = dom.window.document.querySelector("#loading");
+
+    updatePlayerLoadingProgress(loadingElement, { loaded: 1, total: 2 });
+    expect(loadingElement.innerHTML).toBe("");
+    loadingElement.textContent = "Failed to load";
+    updatePlayerLoadingProgress(loadingElement, { loaded: 2, total: 2 });
+    expect(loadingElement.textContent).toBe("Failed to load");
+    dom.window.close();
+  });
+});

--- a/tests/services/playerStartGate.test.js
+++ b/tests/services/playerStartGate.test.js
@@ -1,11 +1,20 @@
 import { JSDOM } from "jsdom";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { waitForPlayerStart } from "../../scripts/playerStartGate.js";
+import { BUNDLE_PLAYER_INDEX_HTML } from "../../src/deps/services/shared/projectExportService.js";
+
+const createWebPlayer = (touch = false) => {
+  const dom = new JSDOM(BUNDLE_PLAYER_INDEX_HTML);
+  dom.window.matchMedia = vi.fn(() => ({ matches: touch }));
+  return dom;
+};
 
 describe("player start gate", () => {
   it("waits for a click before starting the web player", async () => {
-    const dom = new JSDOM('<div id="loading">Loading...</div>');
+    const dom = createWebPlayer();
     const loadingElement = dom.window.document.querySelector("#loading");
+    const startButton = loadingElement.querySelector("#loading-start");
+    const progress = loadingElement.querySelector(".loading-progress");
     let didStart = false;
 
     const startPromise = waitForPlayerStart({
@@ -17,14 +26,40 @@ describe("player start gate", () => {
 
     await Promise.resolve();
     expect(didStart).toBe(false);
-    expect(loadingElement.textContent).toBe("Click to start");
+    expect(startButton.textContent).toBe("Click to start");
+    expect(startButton.disabled).toBe(false);
+    expect(progress.inert).toBe(true);
+    expect(progress.getAttribute("aria-hidden")).toBe("true");
     expect(loadingElement.classList.contains("ready")).toBe(true);
 
+    startButton.click();
+    await startPromise;
+
+    expect(startButton.disabled).toBe(true);
+    expect(didStart).toBe(true);
+    expect(loadingElement.querySelector("#loading-label").textContent).toBe(
+      "Loading…",
+    );
+    expect(loadingElement.querySelector("#loading-progress").value).toBe(0);
+    expect(loadingElement.classList.contains("ready")).toBe(true);
+    dom.window.close();
+  });
+
+  it("uses the touch prompt and accepts a click anywhere on the ready surface", async () => {
+    const dom = createWebPlayer(true);
+    const loadingElement = dom.window.document.querySelector("#loading");
+    const startPromise = waitForPlayerStart({
+      loadingElement,
+      startMode: "click",
+    });
+
+    expect(loadingElement.querySelector("#loading-start").textContent).toBe(
+      "Tap to start",
+    );
     loadingElement.click();
     await startPromise;
 
-    expect(loadingElement.textContent).toBe("Click to start");
-    expect(loadingElement.classList.contains("ready")).toBe(false);
+    expect(loadingElement.classList.contains("ready")).toBe(true);
     dom.window.close();
   });
 

--- a/tests/services/playerStartup.test.js
+++ b/tests/services/playerStartup.test.js
@@ -1,0 +1,197 @@
+import { JSDOM } from "jsdom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUNDLE_PLAYER_INDEX_HTML } from "../../src/deps/services/shared/projectExportService.js";
+
+const runtime = vi.hoisted(() => ({
+  init: vi.fn(),
+  render: vi.fn(),
+  loadAssets: vi.fn(),
+  resumeAudio: vi.fn(),
+  tickerStart: vi.fn(),
+}));
+
+vi.mock("file-type", () => ({
+  fileTypeFromBuffer: async () => ({ mime: "image/png" }),
+}));
+vi.mock("pixi.js", () => ({
+  Ticker: class {
+    start = runtime.tickerStart;
+  },
+}));
+vi.mock("route-graphics", () => ({
+  default: () => ({
+    canvas: document.createElement("canvas"),
+    init: async () => {},
+    render: runtime.render,
+    loadAssets: runtime.loadAssets,
+    resumeAudio: runtime.resumeAudio,
+  }),
+}));
+vi.mock("route-engine-js", () => ({
+  default: ({ handlePendingEffects }) => ({
+    init: runtime.init.mockImplementation(() =>
+      handlePendingEffects([{ name: "handleLineActions" }]),
+    ),
+    handleLineActions: () => {},
+    selectRenderState: () => ({
+      elements: [
+        { src: "image-one" },
+        { src: "image-two" },
+        { src: "image-one" },
+      ],
+    }),
+    selectPresentationState: () => ({}),
+  }),
+  createIndexedDbPersistence: () => ({ load: async () => ({ saveSlots: {} }) }),
+  createEffectsHandler: ({ routeGraphics }) => {
+    const handler = () =>
+      routeGraphics.render({
+        elements: [
+          { src: "image-one" },
+          { src: "image-two" },
+          { src: "image-one" },
+        ],
+      });
+    handler.reset = vi.fn();
+    handler.dispose = vi.fn();
+    handler.reconcilePlaybackScheduleV1 = vi.fn();
+    handler.createRouteGraphicsEventHandler = () => () => {};
+    return handler;
+  },
+}));
+vi.mock("../../src/internal/audioRenderState.js", () => ({
+  prepareRenderStateAudioChannelsForGraphics: ({ renderState }) => renderState,
+}));
+vi.mock("../../src/internal/project/layout.js", () => ({
+  prepareRenderStateKeyboardForGraphics: ({ renderState }) => renderState,
+}));
+vi.mock("../../src/internal/runtime/graphicsEngineRuntime.js", () => ({
+  loadGraphicsEnginePlugins: async () => ({}),
+  preloadRuntimeSaveSlotImages: async () => ({ failed: 0 }),
+  createRuntimeEventContext: vi.fn(),
+  getRuntimeEventActions: vi.fn(),
+  prepareRuntimeInteractionExecution: vi.fn(),
+}));
+vi.mock(
+  "../../src/deps/services/shared/projectExportService.js",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    createBundleRangeReader: async () => ({
+      manifest: { assets: { "image-one": {}, "image-two": {} } },
+      readInstructions: async () => ({
+        projectData: { screen: { width: 1920, height: 1080 } },
+        bundleMetadata: {
+          project: { name: "Project One", namespace: "project-one" },
+        },
+      }),
+      hasAsset: (id) => id === "image-one" || id === "image-two",
+      readAsset: async () => ({
+        buffer: new Uint8Array([1]),
+        mime: "image/png",
+      }),
+    }),
+  }),
+);
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("exported player startup", () => {
+  let dom;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    dom = new JSDOM(BUNDLE_PLAYER_INDEX_HTML, { url: "https://example.test/" });
+    dom.window.matchMedia = () => ({ matches: false });
+    vi.stubGlobal("document", dom.window.document);
+    vi.stubGlobal("window", dom.window);
+    runtime.loadAssets.mockResolvedValue([]);
+    runtime.resumeAudio.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("loads unique opening assets before start, then renders without a second loading phase", async () => {
+    const first = deferred();
+    const second = deferred();
+    runtime.loadAssets.mockImplementation((assets) =>
+      Object.hasOwn(assets, "image-one") ? first.promise : second.promise,
+    );
+    const loading = document.querySelector("#loading");
+    const progress = document.querySelector("#loading-progress");
+    const boot = import("../../scripts/main.js");
+    await vi.waitFor(() => expect(runtime.loadAssets).toHaveBeenCalledTimes(2));
+
+    expect(progress.value).toBe(20);
+    expect(loading.classList.contains("ready")).toBe(false);
+    expect(loading.querySelector("#loading-start").disabled).toBe(true);
+    first.resolve([]);
+    await vi.waitFor(() => expect(progress.value).toBe(60));
+    expect(runtime.render).not.toHaveBeenCalled();
+    expect(loading.classList.contains("hidden")).toBe(false);
+
+    second.resolve([]);
+    await vi.waitFor(() =>
+      expect(loading.classList.contains("ready")).toBe(true),
+    );
+    expect(progress.value).toBe(100);
+    expect(runtime.render).not.toHaveBeenCalled();
+    expect(runtime.resumeAudio).not.toHaveBeenCalled();
+    expect(runtime.tickerStart).not.toHaveBeenCalled();
+    document
+      .querySelector("#loading-start")
+      .dispatchEvent(new dom.window.Event("pointerdown", { bubbles: true }));
+    expect(runtime.resumeAudio).toHaveBeenCalledOnce();
+    document.querySelector("#loading-start").click();
+    await boot;
+    expect(progress.value).toBe(100);
+    expect(runtime.init).toHaveBeenCalledOnce();
+    expect(runtime.loadAssets).toHaveBeenCalledTimes(2);
+    expect(runtime.render).toHaveBeenCalledOnce();
+    expect(runtime.tickerStart).toHaveBeenCalledOnce();
+    expect(loading.classList.contains("ready")).toBe(true);
+    expect(loading.classList.contains("hidden")).toBe(true);
+  });
+
+  it("shows a loading failure instead of leaving the progress screen stuck", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    runtime.loadAssets.mockRejectedValue(new Error("Asset unavailable"));
+    const boot = import("../../scripts/main.js");
+    const loading = document.querySelector("#loading");
+    await boot;
+
+    expect(loading.classList.contains("error")).toBe(true);
+    expect(loading.classList.contains("hidden")).toBe(false);
+    expect(loading.querySelector(".loading-error-title").textContent).toBe(
+      "Failed to load",
+    );
+    expect(runtime.render).not.toHaveBeenCalled();
+    expect(runtime.tickerStart).not.toHaveBeenCalled();
+    expect(loading.classList.contains("ready")).toBe(false);
+  });
+
+  it("keeps native startup automatic without adding a progress screen", async () => {
+    document.body.dataset.playerStart = "automatic";
+    document.querySelector("#loading").replaceChildren();
+    await import("../../scripts/main.js");
+
+    expect(runtime.init).toHaveBeenCalledOnce();
+    expect(runtime.render).toHaveBeenCalledOnce();
+    expect(document.querySelector("#loading-progress")).toBeNull();
+    expect(
+      document.querySelector("#loading").classList.contains("hidden"),
+    ).toBe(true);
+  });
+});

--- a/tests/services/playerStartupEffects.test.js
+++ b/tests/services/playerStartupEffects.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import createRouteEngine, { createEffectsHandler } from "route-engine-js";
+import { createPlayerStartupEffects } from "../../scripts/playerStartupEffects.js";
+
+const createPlayer = (actions = {}) => {
+  const projectData = {
+    screen: { width: 1280, height: 720 },
+    resources: {
+      images: { opening: { fileId: "image-one", width: 64, height: 32 } },
+      layouts: {},
+      sounds: {},
+      variables: {
+        visits: { type: "number", scope: "device", default: 0 },
+        roll: { type: "number", scope: "context", default: 0 },
+      },
+    },
+    story: {
+      initialSceneId: "scene-one",
+      scenes: {
+        "scene-one": {
+          initialSectionId: "section-one",
+          sections: {
+            "section-one": {
+              lines: [
+                { id: "line-one", actions },
+                { id: "line-two", actions: {} },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+  let engine;
+  const render = vi.fn();
+  const persist = vi.fn();
+  const callbacks = new Set();
+  const ticker = {
+    add: vi.fn((callback) => callbacks.add(callback)),
+    remove: vi.fn((callback) => callbacks.delete(callback)),
+  };
+  const randomSource = { nextUint32: vi.fn(() => 16) };
+  const effectsHandler = createEffectsHandler({
+    getEngine: () => engine,
+    routeGraphics: { render },
+    ticker,
+    persistence: { applyScopedDataUpdates: persist },
+  });
+  const startupEffects = createPlayerStartupEffects({
+    getEngine: () => engine,
+    effectsHandler,
+  });
+  engine = createRouteEngine({
+    handlePendingEffects: startupEffects,
+    randomSource,
+  });
+  engine.init({ initialState: { projectData } });
+  return { engine, startupEffects, render, persist, ticker, randomSource };
+};
+
+describe("player startup effects", () => {
+  it("handles only the latest entered-line effect in a batch", () => {
+    const handleLineActions = vi.fn();
+    const effectsHandler = vi.fn();
+    const startupEffects = createPlayerStartupEffects({
+      getEngine: () => ({ handleLineActions }),
+      effectsHandler,
+    });
+    startupEffects([
+      { name: "handleLineActions", payload: { marker: "older" } },
+      { name: "render" },
+      { name: "handleLineActions", payload: { marker: "newer" } },
+    ]);
+    expect(handleLineActions).toHaveBeenCalledExactlyOnceWith({
+      marker: "newer",
+    });
+    expect(effectsHandler).not.toHaveBeenCalled();
+  });
+
+  it("resolves opening assets once, deferring rendering, persistence, and timers until start", async () => {
+    const { engine, startupEffects, render, persist, ticker, randomSource } =
+      createPlayer({
+        background: { resourceId: "opening", resourceType: "image" },
+        random: {
+          distribution: { type: "integer", min: 1, max: 20 },
+          variableId: "roll",
+        },
+        updateVariable: {
+          id: "countVisit",
+          operations: [{ variableId: "visits", op: "increment", value: 1 }],
+        },
+        setNextLineConfig: {
+          auto: { enabled: true, trigger: "fromStart", delay: 1000 },
+        },
+      });
+
+    expect(JSON.stringify(engine.selectRenderState())).toContain("image-one");
+    await Promise.resolve();
+    expect(render).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+    expect(ticker.add).not.toHaveBeenCalled();
+    expect(randomSource.nextUint32).toHaveBeenCalledOnce();
+    const openingLine =
+      engine.selectSystemState().contexts[0].pointers.read.lineId;
+
+    startupEffects.start();
+    await vi.waitFor(() =>
+      expect(
+        persist.mock.calls
+          .flatMap(([updates]) => updates)
+          .filter((update) => update.path === "variables.visits"),
+      ).toEqual([
+        { scope: "device", path: "variables.visits", op: "set", value: 1 },
+      ]),
+    );
+    expect(render).toHaveBeenCalledOnce();
+    expect(ticker.add).toHaveBeenCalledOnce();
+    expect(randomSource.nextUint32).toHaveBeenCalledOnce();
+    expect(engine.selectSystemState().global.variables.visits).toBe(1);
+    expect(engine.selectSystemState().contexts[0].pointers.read.lineId).toBe(
+      openingLine,
+    );
+    startupEffects.start();
+    expect(render).toHaveBeenCalledOnce();
+    engine.dispose();
+  });
+
+  it("renders an empty opening line and forwards normal effects after start", () => {
+    const { engine, startupEffects, render } = createPlayer();
+    expect(render).not.toHaveBeenCalled();
+    startupEffects.start();
+    expect(render).toHaveBeenCalledOnce();
+    engine.handleInternalAction("markLineCompleted");
+    const renderCount = render.mock.calls.length;
+    engine.handleAction("nextLine");
+    expect(render.mock.calls.length).toBeGreaterThan(renderCount);
+    expect(engine.selectSystemState().contexts[0].pointers.read.lineId).toBe(
+      "line-two",
+    );
+    engine.dispose();
+  });
+});

--- a/tests/services/projectExportService.test.js
+++ b/tests/services/projectExportService.test.js
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { JSDOM } from "jsdom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BUNDLE_FORMAT_VERSION_V4,
@@ -85,14 +86,24 @@ describe("projectExportService", () => {
   it("keeps the loading and click-to-start surface only in the web player HTML", () => {
     for (const html of [BUNDLE_PLAYER_INDEX_HTML, webPlayerIndexHtml]) {
       expect(html).toContain('<body data-player-start="click">');
-      expect(html).toContain('<div id="loading">Loading...</div>');
+      expect(html).toContain('<span id="loading-label">Loading…</span>');
+      const dom = new JSDOM(html);
+      expect(
+        dom.window.document.querySelector("#loading-progress").tagName,
+      ).toBe("PROGRESS");
+      expect(dom.window.document.querySelector("#loading-progress").value).toBe(
+        0,
+      );
+      dom.window.close();
+      expect(html).toContain('id="loading-start"');
+      expect(html).toContain("disabled>Click to start</button>");
       expect(html).toContain("#loading.ready");
     }
 
     for (const html of [macosPlayerIndexHtml, windowsPlayerIndexHtml]) {
       expect(html).toContain('<body data-player-start="automatic">');
       expect(html).toContain('<div id="loading"></div>');
-      expect(html).not.toContain('<div id="loading">Loading...</div>');
+      expect(html).not.toContain('id="loading-progress"');
       expect(html).not.toContain("#loading.ready");
     }
   });


### PR DESCRIPTION
## Summary

- Replace the web player's heavy loading text with a brand-neutral hairline progress bar, percentage, and regular-weight 20px soft-white text.
- Add quick fade-in, loading-to-start crossfade, and scene reveal transitions, respecting reduced-motion preferences.
- Preload the opening scene before enabling Click to start / Tap to start. Keep rendering, persistence writes, and playback timers gated until the user starts; preserve keyboard activation and audio unlock.
- Report completed startup steps and unique opening-asset loads without simulated progress. Keep native players automatic and loading errors visible.

## Validation

- 27 focused player/export tests pass, including real-engine startup-effect coverage.
- Export pipeline and smoke tests pass.
- Lint, formatting, and diff checks pass.
- Player bundle and Creator frontend builds pass.
- Playwright checks cover the exported player on desktop and narrow screens, keyboard start, audio unlock, reduced motion, slow assets, and visible loading failures. No asset requests occurred after the start click in the tested opening scene.

The standalone exported player was checked with generated exports in the browser rather than the Creator-page VT harness. Export archives, generated bundles, and temporary preview files are excluded.
