### PR TITLE
Align legacy BGM editor identity with engine compatibility fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "jszip": "3.10.1",
         "lexical": "0.22.0",
         "nanoid": "5.1.11",
-        "route-engine-js": "1.46.0",
+        "route-engine-js": "1.46.1",
         "route-graphics": "1.43.0",
         "rxjs": "7.8.2",
         "snabbdom": "3.6.3",
@@ -907,7 +907,7 @@
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
-    "route-engine-js": ["route-engine-js@1.46.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1", "unicode-segmenter": "^0.17.0" } }, "sha512-CSm8luIgm8sTJDdLh7qLpdMUquokphQBxxd8BJMiK+0yIzkdXJPZQwxDNkTmNW46mcSI22QkAW3CwfYO2trt1w=="],
+    "route-engine-js": ["route-engine-js@1.46.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.1.1", "js-yaml": "^4.1.0", "puty": "^0.1.1", "unicode-segmenter": "^0.17.0" } }, "sha512-G/XNXD5GZPkQxGnZuuldLMjLNpxbfYkfkfXbNX6NmRtrG9lh11y429VKo70OdXe7aPMQkTxpOuigSvTf3LMGYg=="],
 
     "route-graphics": ["route-graphics@1.43.0", "", { "dependencies": { "@pixi/unsafe-eval": "^7.4.3", "@wasm-audio-decoders/ogg-vorbis": "^0.1.20", "gsap": "3.15.0", "hotkeys-js": "^4.0.0-beta.7", "js-yaml": "^4.1.0", "ogg-opus-decoder": "^1.7.3", "pixi.js": "8.9.2", "playwright": "1.57.0" }, "bin": { "route-graphics": "bin/route-graphics.js" } }, "sha512-hA1XDDwWmxiJAkbER8LkU+vDa6wa8Vo4IDRP7fxwa4SvW2lkcMlKxuO70l9qJk+8p+QLql03RW0iBTrqaHvhug=="],
 

--- a/docs/platform/08-id-generation.md
+++ b/docs/platform/08-id-generation.md
@@ -107,14 +107,16 @@ volume changes can retain playback. Opening legacy single-sound BGM in the
 editor uses that same resource ID for its local clip, matching route-engine's
 legacy runtime fallback. This does not rewrite stored project data on open.
 
-Older editor conversions used `default` for a single BGM clip. Opening that
-form also uses the resource ID in the local draft, matching the engine's alias
-and keeping later insertions distinct. Other explicit IDs are preserved,
-including `default` in multi-clip channels. Repeated insertions of a resource
-within one channel receive `-2`, `-3`, and later suffixes to keep occurrences
-distinct. Resource IDs remain unescaped in authored data; the engine escapes
-them when constructing namespaced render IDs. Voice and SFX keep their
-separate occurrence-ID rules.
+Existing explicit IDs are preserved, including `default` in single-clip
+channels. That ID may come from an older editor conversion or identify a
+surviving occurrence after other clips were removed; the editor cannot infer
+which. The engine resolves legacy playback compatibility at runtime without
+rewriting authored IDs.
+
+Repeated insertions receive `-2`, `-3`, and later suffixes when their IDs
+collide with existing clips. Resource IDs remain unescaped in authored data;
+the engine escapes them when constructing namespaced render IDs. Voice and SFX
+keep their separate occurrence-ID rules.
 
 ## Generator Injection Rule
 

--- a/docs/platform/08-id-generation.md
+++ b/docs/platform/08-id-generation.md
@@ -107,7 +107,10 @@ volume changes can retain playback. Opening legacy single-sound BGM in the
 editor uses that same resource ID for its local clip, matching route-engine's
 legacy runtime fallback. This does not rewrite stored project data on open.
 
-Explicit existing clip IDs are preserved. Repeated insertions of a resource
+Older editor conversions used `default` for a single BGM clip. Opening that
+form also uses the resource ID in the local draft, matching the engine's alias
+and keeping later insertions distinct. Other explicit IDs are preserved,
+including `default` in multi-clip channels. Repeated insertions of a resource
 within one channel receive `-2`, `-3`, and later suffixes to keep occurrences
 distinct. Resource IDs remain unescaped in authored data; the engine escapes
 them when constructing namespaced render IDs. Voice and SFX keep their

--- a/docs/platform/08-id-generation.md
+++ b/docs/platform/08-id-generation.md
@@ -100,6 +100,19 @@ Default rule:
 - do not add new readable prefixes to normal persisted domain ids unless there
   is a compatibility or protocol reason
 
+## BGM Playback Identity
+
+BGM clip IDs default to the sound resource ID so independently authored
+volume changes can retain playback. Opening legacy single-sound BGM in the
+editor uses that same resource ID for its local clip, matching route-engine's
+legacy runtime fallback. This does not rewrite stored project data on open.
+
+Explicit existing clip IDs are preserved. Repeated insertions of a resource
+within one channel receive `-2`, `-3`, and later suffixes to keep occurrences
+distinct. Resource IDs remain unescaped in authored data; the engine escapes
+them when constructing namespaced render IDs. Voice and SFX keep their
+separate occurrence-ID rules.
+
 ## Generator Injection Rule
 
 Some services accept an `idGenerator` callback instead of directly importing the

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jszip": "3.10.1",
     "lexical": "0.22.0",
     "nanoid": "5.1.11",
-    "route-engine-js": "1.46.0",
+    "route-engine-js": "1.46.1",
     "route-graphics": "1.43.0",
     "rxjs": "7.8.2",
     "snabbdom": "3.6.3",

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -106,6 +106,10 @@ const normalizeBgm = (bgm = {}) => {
 
   if (Array.isArray(bgm.sounds)) {
     normalizedBgm.sounds = normalizeSounds(bgm.sounds);
+    const [sound] = normalizedBgm.sounds;
+    if (normalizedBgm.sounds.length === 1 && sound.id === "default") {
+      sound.id = sound.resourceId;
+    }
   } else if (bgm.resourceId !== undefined) {
     normalizedBgm.sounds = normalizeSounds([
       {

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -22,7 +22,6 @@ import { isTouchUiConfig } from "../../internal/ui/resourcePages/mobileResourceP
 const DEFAULT_CHANNEL_VOLUME = 75;
 const DEFAULT_SOUND_VOLUME = 100;
 const DEFAULT_AUDIO_EFFECT_PLAYBACK_SPEED = 1;
-const LEGACY_SOUND_ID = "default";
 
 const normalizeVolume = (volume, fallback) => {
   const parsedVolume = Number(volume);
@@ -110,7 +109,7 @@ const normalizeBgm = (bgm = {}) => {
   } else if (bgm.resourceId !== undefined) {
     normalizedBgm.sounds = normalizeSounds([
       {
-        id: LEGACY_SOUND_ID,
+        id: bgm.resourceId,
         resourceId: bgm.resourceId,
         volume: DEFAULT_SOUND_VOLUME,
         startDelayMs: bgm.startDelayMs,

--- a/src/components/commandLineBgm/commandLineBgm.store.js
+++ b/src/components/commandLineBgm/commandLineBgm.store.js
@@ -106,10 +106,6 @@ const normalizeBgm = (bgm = {}) => {
 
   if (Array.isArray(bgm.sounds)) {
     normalizedBgm.sounds = normalizeSounds(bgm.sounds);
-    const [sound] = normalizedBgm.sounds;
-    if (normalizedBgm.sounds.length === 1 && sound.id === "default") {
-      sound.id = sound.resourceId;
-    }
   } else if (bgm.resourceId !== undefined) {
     normalizedBgm.sounds = normalizeSounds([
       {

--- a/tests/commandLineBgm/commandLineBgm.runtime.test.js
+++ b/tests/commandLineBgm/commandLineBgm.runtime.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import createRouteEngine from "route-engine-js";
+import {
+  createInitialState,
+  insertSound,
+  removeSound,
+  selectBgm,
+  setBgm,
+  updateChannel,
+} from "../../src/components/commandLineBgm/commandLineBgm.store.js";
+
+const renderCommands = (commands) => {
+  let engine;
+  engine = createRouteEngine({
+    handlePendingEffects(effects) {
+      for (const effect of effects) {
+        if (effect.name === "handleLineActions") {
+          engine.handleLineActions(effect.payload);
+        }
+      }
+    },
+  });
+  engine.init({
+    initialState: {
+      projectData: {
+        screen: { width: 640, height: 360 },
+        resources: {
+          sounds: { theme: { fileId: "theme.ogg" } },
+        },
+        story: {
+          initialSceneId: "scene",
+          scenes: {
+            scene: {
+              initialSectionId: "section",
+              sections: {
+                section: {
+                  lines: commands.map((bgm, index) => ({
+                    id: `line-${index}`,
+                    actions: { bgm },
+                  })),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  return commands.map((_, index) => {
+    if (index > 0) {
+      engine.handleAction("markLineCompleted", {});
+      engine.handleAction("nextLine", {});
+    }
+    const rendered = engine.selectRenderState();
+    engine.commitRenderState(rendered);
+    return rendered;
+  });
+};
+
+describe("BGM editor playback identity", () => {
+  it.each(["default", "theme"])(
+    "retains the surviving %s occurrence after removal, reopening, and a volume edit",
+    (survivorId) => {
+      const original = {
+        loop: true,
+        volume: 80,
+        sounds: [
+          { id: "default", resourceId: "theme", volume: 40, loop: false },
+          { id: "theme", resourceId: "theme", volume: 70, loop: false },
+        ],
+      };
+      const state = createInitialState();
+      setBgm({ state }, { bgm: original });
+      removeSound(
+        { state },
+        { soundId: survivorId === "default" ? "theme" : "default" },
+      );
+      const saved = structuredClone(selectBgm({ state }));
+      setBgm({ state }, { bgm: saved });
+      updateChannel({ state }, { values: { volume: 35 } });
+
+      // Play the edited command directly after the original two-clip command.
+      const [before, after] = renderCommands([original, selectBgm({ state })]);
+      const originalIndex = original.sounds.findIndex(
+        ({ id }) => id === survivorId,
+      );
+      const retained = after.audio[0].children[0];
+      expect(after.audio[0].children).toHaveLength(1);
+      expect(retained.id).toBe(before.audio[0].children[originalIndex].id);
+      expect(retained.volume).toBeCloseTo(
+        (35 * original.sounds[originalIndex].volume) / 100,
+      );
+      expect(selectBgm({ state }).sounds[0].id).toBe(survivorId);
+      expect(saved.sounds[0].id).toBe(survivorId);
+    },
+  );
+
+  it("retains a default clip when another copy is inserted", () => {
+    const original = { sounds: [{ id: "default", resourceId: "theme" }] };
+    const state = createInitialState();
+    setBgm({ state }, { bgm: original });
+    insertSound({ state }, { resourceId: "theme" });
+
+    const [before, after] = renderCommands([original, selectBgm({ state })]);
+    const [retained, inserted] = after.audio[0].children;
+    expect(retained.id).toBe(before.audio[0].children[0].id);
+    expect(inserted.id).not.toBe(retained.id);
+    expect(selectBgm({ state }).sounds.map(({ id }) => id)).toEqual([
+      "default",
+      "theme",
+    ]);
+  });
+
+  it("preserves legacy handoffs through an edited default clip", () => {
+    const legacy = { resourceId: "theme", volume: 80, loop: true };
+    const state = createInitialState();
+    setBgm(
+      { state },
+      { bgm: { sounds: [{ id: "default", resourceId: "theme" }] } },
+    );
+    updateChannel({ state }, { values: { volume: 35 } });
+
+    const rendered = renderCommands([legacy, selectBgm({ state }), legacy]);
+    expect(rendered.map(({ audio }) => audio[0].children[0].id)).toEqual([
+      "bgm:theme",
+      "bgm:theme",
+      "bgm:theme",
+    ]);
+  });
+});

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -582,7 +582,61 @@ describe("commandLineBgm.store", () => {
     expect(legacy).not.toHaveProperty("sounds");
   });
 
-  it.each(["default", "old-random-id", "theme-2"])(
+  it("opens a converted legacy clip with resource identity before inserting another copy", () => {
+    const original = Object.freeze({
+      volume: 80,
+      sounds: Object.freeze([
+        Object.freeze({
+          id: "default",
+          resourceId: "theme",
+          volume: 40,
+          pan: 0.2,
+          startDelayMs: 250,
+        }),
+      ]),
+    });
+    const state = createInitialState();
+    setRepositoryState({ state }, { sounds });
+    setBgm({ state }, { bgm: original });
+
+    expect(selectBgm({ state }).sounds[0]).toMatchObject({
+      id: "theme",
+      resourceId: "theme",
+      volume: 40,
+      pan: 0.2,
+      startDelayMs: 250,
+    });
+    insertSound({ state }, { resourceId: "theme" });
+    expect(selectBgm({ state }).sounds.map(({ id }) => id)).toEqual([
+      "theme",
+      "theme-2",
+    ]);
+    expect(original.sounds[0].id).toBe("default");
+    expect(original.sounds).toHaveLength(1);
+  });
+
+  it("preserves a default ID in a multi-clip channel without collisions", () => {
+    const state = createInitialState();
+    setBgm(
+      { state },
+      {
+        bgm: {
+          sounds: [
+            { id: "default", resourceId: "theme" },
+            { id: "theme", resourceId: "theme" },
+          ],
+        },
+      },
+    );
+    insertSound({ state }, { resourceId: "theme" });
+    expect(selectBgm({ state }).sounds.map(({ id }) => id)).toEqual([
+      "default",
+      "theme",
+      "theme-2",
+    ]);
+  });
+
+  it.each(["old-random-id", "theme-2"])(
     "does not reinterpret an explicit canonical ID: %s",
     (id) => {
       const state = createInitialState();

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -582,7 +582,7 @@ describe("commandLineBgm.store", () => {
     expect(legacy).not.toHaveProperty("sounds");
   });
 
-  it("opens a converted legacy clip with resource identity before inserting another copy", () => {
+  it("preserves a singleton default ID and its settings when inserting another copy", () => {
     const original = Object.freeze({
       volume: 80,
       sounds: Object.freeze([
@@ -600,7 +600,7 @@ describe("commandLineBgm.store", () => {
     setBgm({ state }, { bgm: original });
 
     expect(selectBgm({ state }).sounds[0]).toMatchObject({
-      id: "theme",
+      id: "default",
       resourceId: "theme",
       volume: 40,
       pan: 0.2,
@@ -608,8 +608,8 @@ describe("commandLineBgm.store", () => {
     });
     insertSound({ state }, { resourceId: "theme" });
     expect(selectBgm({ state }).sounds.map(({ id }) => id)).toEqual([
+      "default",
       "theme",
-      "theme-2",
     ]);
     expect(original.sounds[0].id).toBe("default");
     expect(original.sounds).toHaveLength(1);
@@ -636,7 +636,7 @@ describe("commandLineBgm.store", () => {
     ]);
   });
 
-  it.each(["old-random-id", "theme-2"])(
+  it.each(["default", "old-random-id", "theme-2"])(
     "does not reinterpret an explicit canonical ID: %s",
     (id) => {
       const state = createInitialState();

--- a/tests/commandLineBgm/commandLineBgm.store.test.js
+++ b/tests/commandLineBgm/commandLineBgm.store.test.js
@@ -524,7 +524,7 @@ describe("commandLineBgm.store", () => {
     expect(selectSelectedSoundId({ state })).toBeUndefined();
   });
 
-  it("migrates legacy single-sound BGM without losing its start delay", () => {
+  it("opens legacy single-sound BGM with resource identity and its start delay", () => {
     const state = createInitialState();
     setRepositoryState({ state }, { sounds });
     setBgm(
@@ -545,7 +545,7 @@ describe("commandLineBgm.store", () => {
       volume: 50,
       sounds: [
         {
-          id: "default",
+          id: "theme",
           resourceId: "theme",
           loop: false,
           volume: 100,
@@ -558,6 +558,43 @@ describe("commandLineBgm.store", () => {
       leftPercent: "4.0000",
       widthPercent: "96.0000",
     });
+  });
+
+  it("matches legacy edit identity to a new insertion without mutating the input", () => {
+    const legacy = Object.freeze({
+      resourceId: "theme",
+      loop: true,
+      volume: 80,
+    });
+    const edited = createInitialState();
+    setBgm({ state: edited }, { bgm: legacy });
+    edited.bgm.volume = 35;
+    setBgm({ state: edited }, { bgm: selectBgm({ state: edited }) });
+
+    const inserted = createInitialState();
+    insertSound({ state: inserted }, { resourceId: "theme" });
+
+    expect(selectBgm({ state: edited }).sounds[0].id).toBe(
+      selectBgm({ state: inserted }).sounds[0].id,
+    );
+    expect(selectBgm({ state: edited }).volume).toBe(35);
+    expect(legacy).toEqual({ resourceId: "theme", loop: true, volume: 80 });
+    expect(legacy).not.toHaveProperty("sounds");
+  });
+
+  it.each(["default", "old-random-id", "theme-2"])(
+    "does not reinterpret an explicit canonical ID: %s",
+    (id) => {
+      const state = createInitialState();
+      setBgm({ state }, { bgm: { sounds: [{ id, resourceId: "theme" }] } });
+      expect(selectBgm({ state }).sounds[0].id).toBe(id);
+    },
+  );
+
+  it("keeps raw resource IDs so the engine can escape them exactly once", () => {
+    const state = createInitialState();
+    setBgm({ state }, { bgm: { resourceId: "theme:mix%" } });
+    expect(selectBgm({ state }).sounds[0].id).toBe("theme:mix%");
   });
 
   it("positions canonical clips by their preserved absolute start delays", () => {


### PR DESCRIPTION
## Summary

Companion to https://github.com/RouteVN/route-engine/pull/347.

- Use the resource ID in local editor drafts for ID-less legacy BGM, matching the engine's runtime compatibility rule.
- Preserve existing explicit IDs, including singleton `default` clips. Their origin is ambiguous: an older conversion and a surviving occurrence after multi-clip removal must not be conflated.
- Keep duplicate insertions distinct without renaming existing clips.
- No migration, repository scan, or automatic project rewrite on open. Voice and SFX are unchanged.

## Engine dependency

Pins the published `route-engine-js` **1.46.1** in `package.json` and `bun.lock`. Runtime compatibility and collision resolution remain engine-owned; no local file dependency or post-render ID shim is used.

## Review fix

Removed the singleton `default -> resourceId` rewrite. It could select the wrong playing occurrence after a multi-clip removal and subsequent reopen/save. Added regression coverage against the published engine for either surviving clip, volume-only edits, new duplicate insertions, and legacy handoffs.

## Validation

- **170 focused audio, projection, player-startup, and scene-runtime tests passed** against engine 1.46.1.
- The new removal/reopen regression failed before the fix: expected `bgm:default`, received `bgm:theme`; it now passes.
- Frozen-input coverage confirms opening old forms does not mutate stored input.
- Playwright/Chromium with the actual client draft actions, published engine, and route-graphics: two audio sources started; removing the second clip, reopening, and changing volume stopped only source 2. Source 1 continued as `bgm:default`, with no new source start.
- `bun run test:export-bundle`, `node scripts/test-route-engine-project-data.js`, lint, formatting, and diff checks passed.

Existing unrelated untracked files were left untouched.
