### PR TITLE
Prevent sound waveform blinking and redundant redraws

### DIFF
--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -11,6 +11,7 @@ import {
   toggleTagFilterPopoverOption,
 } from "../../internal/ui/tagFilterPopover.handlers.js";
 import { dispatchResourceViewBackgroundClick } from "../../internal/ui/resourcePages/resourceViewBackground.js";
+import { getRetainedRenderedItemCount } from "../../internal/ui/resourcePages/progressivePlaceholders.js";
 
 const PROGRESSIVE_INITIAL_ITEM_COUNT = 8;
 const PROGRESSIVE_BATCH_ITEM_COUNT = 24;
@@ -491,7 +492,18 @@ const syncProgressiveRenderState = (deps) => {
   const nextRenderedItemCount = currentSignature
     ? Math.min(
         totalItemCount,
-        Math.max(currentRenderedItemCount, progressiveInitialItemCount),
+        Math.max(
+          progressiveInitialItemCount,
+          getRetainedRenderedItemCount({
+            previousItemIds: JSON.parse(currentSignature).flatMap(
+              ([, itemIds]) => itemIds,
+            ),
+            nextItemIds: groups.flatMap((group) =>
+              (group.children ?? []).map((item) => item.id),
+            ),
+            renderedItemCount: currentRenderedItemCount,
+          }),
+        ),
       )
     : Math.min(totalItemCount, progressiveInitialItemCount);
   store.setProgressiveRenderedItemCount({
@@ -536,10 +548,15 @@ const syncSoundWaveformHydrationState = (deps) => {
   }
 
   cancelSoundWaveformRenderFrame(store);
+  const nextRenderedItemCount = getRetainedRenderedItemCount({
+    previousItemIds: currentSignature ? JSON.parse(currentSignature) : [],
+    nextItemIds: getSoundWaveformItemIds(groups),
+    renderedItemCount: store.selectSoundWaveformRenderedItemCount(),
+  });
   store.setSoundWaveformRenderSignature({ signature: nextSignature });
-  store.setSoundWaveformRenderedItemCount({ itemCount: 0 });
+  store.setSoundWaveformRenderedItemCount({ itemCount: nextRenderedItemCount });
 
-  if (totalItemCount > 0) {
+  if (nextRenderedItemCount < totalItemCount) {
     scheduleSoundWaveformHydration(deps);
   }
 

--- a/src/components/mediaResourcesView/mediaResourcesView.handlers.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.handlers.js
@@ -11,7 +11,6 @@ import {
   toggleTagFilterPopoverOption,
 } from "../../internal/ui/tagFilterPopover.handlers.js";
 import { dispatchResourceViewBackgroundClick } from "../../internal/ui/resourcePages/resourceViewBackground.js";
-import { getRetainedRenderedItemCount } from "../../internal/ui/resourcePages/progressivePlaceholders.js";
 
 const PROGRESSIVE_INITIAL_ITEM_COUNT = 8;
 const PROGRESSIVE_BATCH_ITEM_COUNT = 24;
@@ -274,14 +273,6 @@ const getSoundWaveformItemIds = (groups = []) => {
   return itemIds;
 };
 
-const getSoundWaveformRenderSignature = (groups = []) => {
-  return JSON.stringify(getSoundWaveformItemIds(groups));
-};
-
-const countSoundWaveformItems = (groups = []) => {
-  return getSoundWaveformItemIds(groups).length;
-};
-
 const cancelProgressiveRenderFrame = (store) => {
   const frameId = store.selectProgressiveFrameId();
   if (frameId === undefined) {
@@ -297,8 +288,8 @@ const canManageSoundWaveformHydration = (store) => {
     typeof store.selectSoundWaveformFrameId === "function" &&
     typeof store.clearSoundWaveformFrameId === "function" &&
     typeof store.setSoundWaveformFrameId === "function" &&
-    typeof store.selectSoundWaveformRenderedItemCount === "function" &&
-    typeof store.setSoundWaveformRenderedItemCount === "function" &&
+    typeof store.selectSoundWaveformRenderedItemIds === "function" &&
+    typeof store.setSoundWaveformRenderedItemIds === "function" &&
     typeof store.selectSoundWaveformRenderSignature === "function" &&
     typeof store.setSoundWaveformRenderSignature === "function"
   );
@@ -415,33 +406,34 @@ const scheduleSoundWaveformHydration = (deps) => {
     return;
   }
 
-  const totalItemCount = countSoundWaveformItems(props.groups);
-  if (store.selectSoundWaveformRenderedItemCount() >= totalItemCount) {
+  const itemIds = getSoundWaveformItemIds(props.groups);
+  const renderedIds = new Set(store.selectSoundWaveformRenderedItemIds());
+  if (itemIds.every((id) => renderedIds.has(id))) {
     return;
   }
 
   const hydrateNextBatch = () => {
     store.clearSoundWaveformFrameId();
 
-    const nextTotalItemCount = countSoundWaveformItems(deps.props.groups);
-    const nextRenderedItemCount = Math.min(
-      nextTotalItemCount,
-      store.selectSoundWaveformRenderedItemCount() +
-        SOUND_WAVEFORM_BATCH_ITEM_COUNT,
-    );
+    const nextItemIds = getSoundWaveformItemIds(deps.props.groups);
+    const nextRenderedIds = new Set(store.selectSoundWaveformRenderedItemIds());
+    const pendingIds = nextItemIds.filter((id) => !nextRenderedIds.has(id));
+    pendingIds
+      .slice(0, SOUND_WAVEFORM_BATCH_ITEM_COUNT)
+      .forEach((id) => nextRenderedIds.add(id));
 
-    store.setSoundWaveformRenderedItemCount({
-      itemCount: nextRenderedItemCount,
+    store.setSoundWaveformRenderedItemIds({
+      itemIds: nextItemIds.filter((id) => nextRenderedIds.has(id)),
     });
     render();
 
-    if (nextRenderedItemCount < nextTotalItemCount) {
+    if (pendingIds.length > SOUND_WAVEFORM_BATCH_ITEM_COUNT) {
       scheduleSoundWaveformHydration(deps);
     }
   };
 
   if (typeof globalThis.requestAnimationFrame !== "function") {
-    store.setSoundWaveformRenderedItemCount({ itemCount: totalItemCount });
+    store.setSoundWaveformRenderedItemIds({ itemIds });
     render();
     return;
   }
@@ -492,18 +484,7 @@ const syncProgressiveRenderState = (deps) => {
   const nextRenderedItemCount = currentSignature
     ? Math.min(
         totalItemCount,
-        Math.max(
-          progressiveInitialItemCount,
-          getRetainedRenderedItemCount({
-            previousItemIds: JSON.parse(currentSignature).flatMap(
-              ([, itemIds]) => itemIds,
-            ),
-            nextItemIds: groups.flatMap((group) =>
-              (group.children ?? []).map((item) => item.id),
-            ),
-            renderedItemCount: currentRenderedItemCount,
-          }),
-        ),
+        Math.max(progressiveInitialItemCount, currentRenderedItemCount),
       )
     : Math.min(totalItemCount, progressiveInitialItemCount);
   store.setProgressiveRenderedItemCount({
@@ -524,40 +505,36 @@ const syncSoundWaveformHydrationState = (deps) => {
   }
 
   const groups = props.groups ?? [];
-  const totalItemCount = countSoundWaveformItems(groups);
+  const itemIds = getSoundWaveformItemIds(groups);
+  const nextSignature = JSON.stringify(itemIds);
+  const currentSignature = store.selectSoundWaveformRenderSignature();
   const lazySoundWaveformsEnabled = isLazySoundWaveformsEnabled(props);
 
   if (!lazySoundWaveformsEnabled) {
     const didChange =
-      store.selectSoundWaveformRenderSignature() !== "" ||
-      store.selectSoundWaveformRenderedItemCount() !== totalItemCount;
+      currentSignature !== "" ||
+      JSON.stringify(store.selectSoundWaveformRenderedItemIds()) !==
+        nextSignature;
     cancelSoundWaveformRenderFrame(store);
     store.setSoundWaveformRenderSignature({ signature: "" });
-    store.setSoundWaveformRenderedItemCount({ itemCount: totalItemCount });
+    store.setSoundWaveformRenderedItemIds({ itemIds });
     return didChange;
   }
 
-  const nextSignature = getSoundWaveformRenderSignature(groups);
-  const currentSignature = store.selectSoundWaveformRenderSignature();
-
   if (nextSignature === currentSignature) {
-    if (store.selectSoundWaveformRenderedItemCount() < totalItemCount) {
-      scheduleSoundWaveformHydration(deps);
-    }
+    scheduleSoundWaveformHydration(deps);
     return false;
   }
 
-  cancelSoundWaveformRenderFrame(store);
-  const nextRenderedItemCount = getRetainedRenderedItemCount({
-    previousItemIds: currentSignature ? JSON.parse(currentSignature) : [],
-    nextItemIds: getSoundWaveformItemIds(groups),
-    renderedItemCount: store.selectSoundWaveformRenderedItemCount(),
-  });
+  const renderedIds = new Set(store.selectSoundWaveformRenderedItemIds());
+  const retainedIds = itemIds.filter((id) => renderedIds.has(id));
   store.setSoundWaveformRenderSignature({ signature: nextSignature });
-  store.setSoundWaveformRenderedItemCount({ itemCount: nextRenderedItemCount });
+  store.setSoundWaveformRenderedItemIds({ itemIds: retainedIds });
 
-  if (nextRenderedItemCount < totalItemCount) {
+  if (retainedIds.length < itemIds.length) {
     scheduleSoundWaveformHydration(deps);
+  } else {
+    cancelSoundWaveformRenderFrame(store);
   }
 
   return true;

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -1,5 +1,8 @@
 import { buildResourceOverflowMenuItems } from "../../internal/ui/resourcePages/resourceOverflowMenu.js";
-import { buildProgressivePlaceholderChildren } from "../../internal/ui/resourcePages/progressivePlaceholders.js";
+import {
+  buildProgressivePlaceholderChildren,
+  getRetainedRenderedItemCount,
+} from "../../internal/ui/resourcePages/progressivePlaceholders.js";
 import {
   buildTagFilterPopoverViewData,
   clearTagFilterPopoverTagIds,
@@ -381,13 +384,35 @@ export const selectViewData = ({ state, props, i18n }) => {
     ? DEFAULT_EAGER_IMAGE_CARD_COUNT
     : Number.POSITIVE_INFINITY;
   let remainingSoundWaveformCount = lazySoundWaveforms
-    ? state.soundWaveformRenderedItemCount
+    ? getRetainedRenderedItemCount({
+        previousItemIds: state.soundWaveformRenderSignature
+          ? JSON.parse(state.soundWaveformRenderSignature)
+          : [],
+        nextItemIds: sourceGroups.flatMap((group) =>
+          (group.children ?? [])
+            .filter(
+              (item) => item.cardKind === "sound" && item.waveformDataFileId,
+            )
+            .map((item) => item.id),
+        ),
+        renderedItemCount: state.soundWaveformRenderedItemCount,
+      })
     : Number.POSITIVE_INFINITY;
   let remainingProgressiveItemCount = progressiveRenderEnabled
-    ? state.progressiveRenderedItemCount
+    ? getRetainedRenderedItemCount({
+        previousItemIds: state.progressiveRenderSignature
+          ? JSON.parse(state.progressiveRenderSignature).flatMap(
+              ([, itemIds]) => itemIds,
+            )
+          : [],
+        nextItemIds: sourceGroups.flatMap((group) =>
+          (group.children ?? []).map((item) => item.id),
+        ),
+        renderedItemCount: state.progressiveRenderedItemCount,
+      })
     : Number.POSITIVE_INFINITY;
 
-  const groups = sourceGroups.map((group) => {
+  const groups = sourceGroups.map((group, groupIndex) => {
     const isCollapsed = state.collapsedIds.includes(group.id);
     const children = isCollapsed ? [] : (group.children ?? []);
     const hasVisibleChildren = children.length > 0;
@@ -419,7 +444,7 @@ export const selectViewData = ({ state, props, i18n }) => {
       showEmptyUpload: !hasVisibleChildren && !hasChildFolders,
       headerBackgroundColor: group.id === props.selectedFolderId ? "mu" : "bg",
       progressiveContentMinHeight: 0,
-      children: progressiveChildren.children.map((item) => {
+      children: progressiveChildren.children.map((item, itemIndex) => {
         const isSelected = item.id === props.selectedItemId;
         const defaultBorderColor = resolveDefaultBorderColor();
         const isInteractive = item.isInteractive !== false;
@@ -470,6 +495,14 @@ export const selectViewData = ({ state, props, i18n }) => {
 
         return {
           ...item,
+          // FE uses element IDs as DOM keys. Keep sound canvases tied to their
+          // resource rather than their changing position in the list.
+          refKey:
+            item.cardKind === "sound"
+              ? Array.from(item.id, (character) =>
+                  character.codePointAt(0).toString(16),
+                ).join("x")
+              : `${groupIndex}x${itemIndex}`,
           domItemId: isInteractive ? item.id : "",
           cursor: isInteractive ? "pointer" : "default",
           itemContainerStyle: useFullWidthCard

--- a/src/components/mediaResourcesView/mediaResourcesView.store.js
+++ b/src/components/mediaResourcesView/mediaResourcesView.store.js
@@ -1,8 +1,5 @@
 import { buildResourceOverflowMenuItems } from "../../internal/ui/resourcePages/resourceOverflowMenu.js";
-import {
-  buildProgressivePlaceholderChildren,
-  getRetainedRenderedItemCount,
-} from "../../internal/ui/resourcePages/progressivePlaceholders.js";
+import { buildProgressivePlaceholderChildren } from "../../internal/ui/resourcePages/progressivePlaceholders.js";
 import {
   buildTagFilterPopoverViewData,
   clearTagFilterPopoverTagIds,
@@ -113,7 +110,7 @@ export const createInitialState = ({ props } = {}) => ({
   ),
   progressiveRenderSignature: "",
   progressiveFrameId: undefined,
-  soundWaveformRenderedItemCount: 0,
+  soundWaveformRenderedItemIds: [],
   soundWaveformRenderSignature: "",
   soundWaveformFrameId: undefined,
   syncRenderFrameId: undefined,
@@ -188,15 +185,15 @@ export const clearProgressiveFrameId = ({ state }) => {
 
 export const selectProgressiveFrameId = ({ state }) => state.progressiveFrameId;
 
-export const setSoundWaveformRenderedItemCount = (
+export const setSoundWaveformRenderedItemIds = (
   { state },
-  { itemCount } = {},
+  { itemIds } = {},
 ) => {
-  state.soundWaveformRenderedItemCount = itemCount ?? 0;
+  state.soundWaveformRenderedItemIds = itemIds ?? [];
 };
 
-export const selectSoundWaveformRenderedItemCount = ({ state }) =>
-  state.soundWaveformRenderedItemCount;
+export const selectSoundWaveformRenderedItemIds = ({ state }) =>
+  state.soundWaveformRenderedItemIds;
 
 export const setSoundWaveformRenderSignature = (
   { state },
@@ -383,33 +380,9 @@ export const selectViewData = ({ state, props, i18n }) => {
   let remainingEagerImageCardCount = lazyImageCards
     ? DEFAULT_EAGER_IMAGE_CARD_COUNT
     : Number.POSITIVE_INFINITY;
-  let remainingSoundWaveformCount = lazySoundWaveforms
-    ? getRetainedRenderedItemCount({
-        previousItemIds: state.soundWaveformRenderSignature
-          ? JSON.parse(state.soundWaveformRenderSignature)
-          : [],
-        nextItemIds: sourceGroups.flatMap((group) =>
-          (group.children ?? [])
-            .filter(
-              (item) => item.cardKind === "sound" && item.waveformDataFileId,
-            )
-            .map((item) => item.id),
-        ),
-        renderedItemCount: state.soundWaveformRenderedItemCount,
-      })
-    : Number.POSITIVE_INFINITY;
+  const renderedSoundWaveformIds = new Set(state.soundWaveformRenderedItemIds);
   let remainingProgressiveItemCount = progressiveRenderEnabled
-    ? getRetainedRenderedItemCount({
-        previousItemIds: state.progressiveRenderSignature
-          ? JSON.parse(state.progressiveRenderSignature).flatMap(
-              ([, itemIds]) => itemIds,
-            )
-          : [],
-        nextItemIds: sourceGroups.flatMap((group) =>
-          (group.children ?? []).map((item) => item.id),
-        ),
-        renderedItemCount: state.progressiveRenderedItemCount,
-      })
+    ? state.progressiveRenderedItemCount
     : Number.POSITIVE_INFINITY;
 
   const groups = sourceGroups.map((group, groupIndex) => {
@@ -422,15 +395,22 @@ export const selectViewData = ({ state, props, i18n }) => {
       remainingProgressiveItemCount,
       groupId: group.id,
       placeholderItemCount: children.length,
-      createPlaceholder: ({ item, absoluteIndex, groupId }) => ({
-        id: `${item.id ?? `${groupId}-${absoluteIndex}`}-placeholder`,
-        domItemId: "",
-        sourceItemId: item.id,
-        cardKind: item.cardKind,
-        previewAspectRatio: item.previewAspectRatio,
-        isPlaceholder: true,
-        isInteractive: false,
-      }),
+      createPlaceholder: ({ item, absoluteIndex, groupId }) => {
+        // Keep a hydrated sound's card when it moves beyond the card batch,
+        // without enabling intervening cards or waveforms.
+        if (lazySoundWaveforms && renderedSoundWaveformIds.has(item.id)) {
+          return item;
+        }
+        return {
+          id: `${item.id ?? `${groupId}-${absoluteIndex}`}-placeholder`,
+          domItemId: "",
+          sourceItemId: item.id,
+          cardKind: item.cardKind,
+          previewAspectRatio: item.previewAspectRatio,
+          isPlaceholder: true,
+          isInteractive: false,
+        };
+      },
     });
 
     remainingProgressiveItemCount =
@@ -455,21 +435,13 @@ export const selectViewData = ({ state, props, i18n }) => {
         const hasSoundWaveform =
           item.cardKind === "sound" && Boolean(item.waveformDataFileId);
         const shouldRenderWaveform =
-          hasSoundWaveform && remainingSoundWaveformCount > 0;
+          hasSoundWaveform &&
+          (!lazySoundWaveforms || renderedSoundWaveformIds.has(item.id));
 
         if (canRenderImagePreview) {
           remainingEagerImageCardCount = Math.max(
             0,
             remainingEagerImageCardCount - 1,
-          );
-        }
-        if (
-          hasSoundWaveform &&
-          remainingSoundWaveformCount !== Number.POSITIVE_INFINITY
-        ) {
-          remainingSoundWaveformCount = Math.max(
-            0,
-            remainingSoundWaveformCount - 1,
           );
         }
         const useFullWidthCard =

--- a/src/components/mediaResourcesView/mediaResourcesView.view.yaml
+++ b/src/components/mediaResourcesView/mediaResourcesView.view.yaml
@@ -162,7 +162,7 @@ template:
                               - 'rtgl-grid w=f pt=md pb=sm mb=lg g=md cols="${cardGridColumns}" style="min-width: 0; min-height: ${group.progressiveContentMinHeight}px; align-content: start; align-items: start;"':
                                   - $if group.hasChildren:
                                       - $for item, itemIndex in group.children:
-                                          - rtgl-view#itemRef${gIndex}x${itemIndex} key=${item.id} data-item-id=${item.domItemId} data-resource-view-item=true cur=${item.cursor} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md style="${item.itemContainerStyle}":
+                                          - rtgl-view#itemRef${item.refKey} data-item-id=${item.domItemId} data-resource-view-item=true cur=${item.cursor} bw=xs bc=${item.itemBorderColor} h-bc=${item.itemHoverBorderColor} br=md style="${item.itemContainerStyle}":
                                               - $if item.isPlaceholder:
                                                   - 'rtgl-view br=md w=${item.placeholderCardWidth} overflow=hidden style="max-width: 100%; box-sizing: border-box;"':
                                                       - $if item.useFullWidthPlaceholder:
@@ -224,14 +224,14 @@ template:
                                                       - rtgl-view w=f p=md:
                                                           - rtgl-text s=xs c=mu-fg ellipsis w=f: ${item.name}
                                                 $elif item.cardKind == 'sound':
-                                                  - 'rtgl-view br=md pos=rel w=${item.mediaCardWidth} overflow=hidden style="${item.mediaCardStyle}"':
+                                                  - 'rtgl-view#soundCardRef${item.refKey} br=md pos=rel w=${item.mediaCardWidth} overflow=hidden style="${item.mediaCardStyle}"':
                                                       - $if item.useFullWidthMediaPreview:
-                                                          - 'rtgl-view w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
+                                                          - 'rtgl-view#soundPreviewRef${item.refKey} w=f style="aspect-ratio: ${item.previewAspectRatio}; overflow: hidden;"':
                                                               - $if item.isProcessing:
                                                                   - rtgl-view w=f h=f bw=xs bc=bo av=c ah=c:
                                                                       - rtgl-text s=sm c=mu-fg: Processing...
                                                                 $elif item.shouldRenderWaveform:
-                                                                  - rvn-waveform-visualizer key=${item.waveformDataFileId}-${item.mediaCardWidth}x16x9 waveformDataFileId=${item.waveformDataFileId} w=f h=f: null
+                                                                  - rvn-waveform-visualizer#waveformRef${item.refKey} waveformDataFileId=${item.waveformDataFileId} w=f h=f: null
                                                                 $elif item.waveformDataFileId:
                                                                   - rtgl-view w=f h=f bw=xs bc=bo bgc=mu: null
                                                                 $else:
@@ -241,7 +241,7 @@ template:
                                                           - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo av=c ah=c:
                                                               - rtgl-text s=sm c=mu-fg: Processing...
                                                         $elif item.shouldRenderWaveform:
-                                                          - rvn-waveform-visualizer key=${item.waveformDataFileId}-${item.mediaCardWidth}x${mediaHeight} waveformDataFileId=${item.waveformDataFileId} w=f h=${mediaHeight}: null
+                                                          - rvn-waveform-visualizer#waveformRef${item.refKey} waveformDataFileId=${item.waveformDataFileId} w=f h=${mediaHeight}: null
                                                         $elif item.waveformDataFileId:
                                                           - rtgl-view w=f h=${mediaHeight} bw=xs bc=bo bgc=mu: null
                                                         $else:

--- a/src/components/waveformVisualizer/waveformVisualizer.handlers.js
+++ b/src/components/waveformVisualizer/waveformVisualizer.handlers.js
@@ -50,7 +50,9 @@ export const handleBeforeMount = (deps) => {
   return () => {
     cancelAnimationFrame(animationFrameId);
     resizeObserver?.disconnect();
-    store.resetWaveform();
+    // Keyed DOM moves disconnect this instance briefly. Keep completed data
+    // and its canvas, but prevent an unfinished request from rendering later.
+    store.cancelWaveformLoad();
   };
 };
 

--- a/src/components/waveformVisualizer/waveformVisualizer.handlers.js
+++ b/src/components/waveformVisualizer/waveformVisualizer.handlers.js
@@ -50,23 +50,37 @@ export const handleBeforeMount = (deps) => {
   return () => {
     cancelAnimationFrame(animationFrameId);
     resizeObserver?.disconnect();
+    store.resetWaveform();
   };
 };
 
-export const handleAfterMount = async (deps) => {
-  const { props: attrs, refs, store, render, projectService } = deps;
+const loadWaveform = async (deps, fileId) => {
+  const { refs, store, render, projectService } = deps;
+  const { loadedFileId, loadingFileId } = store.selectWaveformLoad();
 
-  if (!attrs.waveformDataFileId) {
+  if (!fileId) {
+    if (loadedFileId || loadingFileId) {
+      store.resetWaveform();
+      render();
+    }
     return;
   }
 
-  try {
-    const waveformData = await projectService.downloadMetadata(
-      attrs.waveformDataFileId,
-    );
+  if (fileId === loadedFileId || fileId === loadingFileId) {
+    return;
+  }
 
-    store.setWaveformData({ data: waveformData });
-    store.setLoading({ isLoading: false });
+  store.startWaveformLoad({ fileId });
+  const { version } = store.selectWaveformLoad();
+  render();
+
+  try {
+    const waveformData = await projectService.downloadMetadata(fileId);
+    if (store.selectWaveformLoad().version !== version) {
+      return;
+    }
+
+    store.finishWaveformLoad({ fileId, data: waveformData });
     render();
     const { width, height } = store.selectRenderedSize();
     renderWaveformCanvas({
@@ -76,38 +90,22 @@ export const handleAfterMount = async (deps) => {
       height,
     });
   } catch {
-    store.setLoading({ isLoading: false });
+    if (store.selectWaveformLoad().version !== version) {
+      return;
+    }
+    store.finishWaveformLoad({ fileId, data: undefined });
     render();
   }
 };
 
-export const handleOnUpdate = async (deps, payload) => {
-  const { refs, store, render, projectService } = deps;
-  const { newProps: attrs } = payload;
+export const handleAfterMount = (deps) => {
+  return loadWaveform(deps, deps.props.waveformDataFileId);
+};
 
-  if (!attrs?.waveformDataFileId) {
-    return;
-  }
-
-  store.setLoading({ isLoading: true });
-
-  try {
-    const waveformData = await projectService.downloadMetadata(
-      attrs.waveformDataFileId,
-    );
-
-    store.setWaveformData({ data: waveformData });
-    store.setLoading({ isLoading: false });
-    render();
-    const { width, height } = store.selectRenderedSize();
-    renderWaveformCanvas({
-      canvas: refs.waveformCanvas,
-      waveformData,
-      width,
-      height,
-    });
-  } catch {
-    store.setLoading({ isLoading: false });
+export const handleOnUpdate = (deps, { oldProps, newProps }) => {
+  const { render } = deps;
+  if (oldProps.w !== newProps.w || oldProps.h !== newProps.h) {
     render();
   }
+  return loadWaveform(deps, newProps.waveformDataFileId);
 };

--- a/src/components/waveformVisualizer/waveformVisualizer.store.js
+++ b/src/components/waveformVisualizer/waveformVisualizer.store.js
@@ -36,6 +36,12 @@ export const resetWaveform = ({ state }) => {
   state.isLoading = false;
 };
 
+export const cancelWaveformLoad = ({ state }) => {
+  state.loadVersion += 1;
+  state.loadingFileId = undefined;
+  state.isLoading = false;
+};
+
 export const selectWaveformLoad = ({ state }) => ({
   loadedFileId: state.loadedFileId,
   loadingFileId: state.loadingFileId,

--- a/src/components/waveformVisualizer/waveformVisualizer.store.js
+++ b/src/components/waveformVisualizer/waveformVisualizer.store.js
@@ -1,22 +1,46 @@
 export const createInitialState = () => ({
-  waveformData: null,
+  waveformData: undefined,
   isLoading: true,
+  loadedFileId: undefined,
+  loadingFileId: undefined,
+  loadVersion: 0,
   renderedWidth: 0,
   renderedHeight: 0,
 });
 
-export const setLoading = ({ state }, { isLoading } = {}) => {
-  state.isLoading = isLoading;
+export const startWaveformLoad = ({ state }, { fileId }) => {
+  state.loadVersion += 1;
+  state.loadingFileId = fileId;
+  state.loadedFileId = undefined;
+  state.waveformData = undefined;
+  state.isLoading = true;
 };
 
-export const setWaveformData = ({ state }, { data } = {}) => {
+export const finishWaveformLoad = ({ state }, { fileId, data }) => {
   // Validate waveform data structure
   if (data && !data.amplitudes) {
     throw new Error("Invalid waveform data: missing amplitudes field");
   }
 
   state.waveformData = data;
+  state.loadedFileId = data ? fileId : undefined;
+  state.loadingFileId = undefined;
+  state.isLoading = false;
 };
+
+export const resetWaveform = ({ state }) => {
+  state.loadVersion += 1;
+  state.waveformData = undefined;
+  state.loadedFileId = undefined;
+  state.loadingFileId = undefined;
+  state.isLoading = false;
+};
+
+export const selectWaveformLoad = ({ state }) => ({
+  loadedFileId: state.loadedFileId,
+  loadingFileId: state.loadingFileId,
+  version: state.loadVersion,
+});
 
 export const setRenderedSize = ({ state }, { width, height } = {}) => {
   state.renderedWidth = width;

--- a/src/internal/ui/resourcePages/progressivePlaceholders.js
+++ b/src/internal/ui/resourcePages/progressivePlaceholders.js
@@ -1,20 +1,5 @@
 export const DEFAULT_PROGRESSIVE_PLACEHOLDER_ITEM_COUNT = 12;
 
-export const getRetainedRenderedItemCount = ({
-  previousItemIds,
-  nextItemIds,
-  renderedItemCount,
-}) => {
-  const renderedIds = new Set(previousItemIds.slice(0, renderedItemCount));
-  let nextCount = Math.min(renderedItemCount, nextItemIds.length);
-  nextItemIds.forEach((itemId, index) => {
-    if (renderedIds.has(itemId)) {
-      nextCount = Math.max(nextCount, index + 1);
-    }
-  });
-  return nextCount;
-};
-
 const clampNonNegativeInteger = (value, fallback = 0) => {
   const numericValue = Number(value);
   if (!Number.isFinite(numericValue) || numericValue < 0) {

--- a/src/internal/ui/resourcePages/progressivePlaceholders.js
+++ b/src/internal/ui/resourcePages/progressivePlaceholders.js
@@ -1,5 +1,20 @@
 export const DEFAULT_PROGRESSIVE_PLACEHOLDER_ITEM_COUNT = 12;
 
+export const getRetainedRenderedItemCount = ({
+  previousItemIds,
+  nextItemIds,
+  renderedItemCount,
+}) => {
+  const renderedIds = new Set(previousItemIds.slice(0, renderedItemCount));
+  let nextCount = Math.min(renderedItemCount, nextItemIds.length);
+  nextItemIds.forEach((itemId, index) => {
+    if (renderedIds.has(itemId)) {
+      nextCount = Math.max(nextCount, index + 1);
+    }
+  });
+  return nextCount;
+};
+
 const clampNonNegativeInteger = (value, fallback = 0) => {
   const numericValue = Number(value);
   if (!Number.isFinite(numericValue) || numericValue < 0) {

--- a/tests/mediaResourcesView/mediaResourcesView.handlers.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.handlers.test.js
@@ -342,7 +342,7 @@ describe("mediaResourcesView.handlers", () => {
     );
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
 
-    let renderedItemCount = 0;
+    let renderedItemIds = [];
     let renderSignature = "";
     let frameId;
     const render = vi.fn();
@@ -395,9 +395,9 @@ describe("mediaResourcesView.handlers", () => {
           clearSoundWaveformFrameId: () => {
             frameId = undefined;
           },
-          selectSoundWaveformRenderedItemCount: () => renderedItemCount,
-          setSoundWaveformRenderedItemCount: ({ itemCount }) => {
-            renderedItemCount = itemCount;
+          selectSoundWaveformRenderedItemIds: () => renderedItemIds,
+          setSoundWaveformRenderedItemIds: ({ itemIds }) => {
+            renderedItemIds = itemIds;
           },
           selectSoundWaveformRenderSignature: () => renderSignature,
           setSoundWaveformRenderSignature: ({ signature }) => {
@@ -407,17 +407,22 @@ describe("mediaResourcesView.handlers", () => {
         render,
       });
 
-      expect(renderedItemCount).toBe(0);
+      expect(renderedItemIds).toEqual([]);
       expect(render).not.toHaveBeenCalled();
 
       for (let frameIndex = 0; frameIndex < 7; frameIndex += 1) {
         frameCallbacks.shift()();
-        expect(renderedItemCount).toBe(0);
+        expect(renderedItemIds).toEqual([]);
         expect(render).not.toHaveBeenCalled();
       }
 
       frameCallbacks.shift()();
-      expect(renderedItemCount).toBe(4);
+      expect(renderedItemIds).toEqual([
+        "sound-1",
+        "sound-2",
+        "sound-3",
+        "sound-4",
+      ]);
       expect(render).toHaveBeenCalledTimes(1);
     } finally {
       vi.unstubAllGlobals();

--- a/tests/mediaResourcesView/mediaResourcesView.hydration.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.hydration.test.js
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
 import { h } from "snabbdom/build/h.js";
 import { init } from "snabbdom/build/init.js";
 import { attributesModule } from "snabbdom/build/modules/attributes.js";
 import { propsModule } from "snabbdom/build/modules/props.js";
 import { parseView } from "../../node_modules/@rettangoli/fe/src/parser.js";
+import createComponent from "../../node_modules/@rettangoli/fe/src/createComponent.js";
 import { parse } from "../../node_modules/@rettangoli/fe/node_modules/jempl/src/index.js";
 import { loadViewTemplate } from "../support/renderView.js";
 import {
@@ -12,6 +15,8 @@ import {
   handleOnUpdate,
 } from "../../src/components/mediaResourcesView/mediaResourcesView.handlers.js";
 import * as mediaStore from "../../src/components/mediaResourcesView/mediaResourcesView.store.js";
+import * as waveformStore from "../../src/components/waveformVisualizer/waveformVisualizer.store.js";
+import * as waveformHandlers from "../../src/components/waveformVisualizer/waveformVisualizer.handlers.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -21,7 +26,11 @@ const sound = (id) => ({
   waveformDataFileId: `waveform-${id}`,
 });
 
-const createHydratedSounds = () => {
+const createHydratedSounds = ({
+  itemCount = 5,
+  framesToHydrate = 16,
+  props: extraProps = {},
+} = {}) => {
   let frameId = 0;
   const frames = new Map();
   vi.stubGlobal("requestAnimationFrame", (callback) => {
@@ -40,12 +49,13 @@ const createHydratedSounds = () => {
     groups: [
       {
         id: "folder-1",
-        children: Array.from({ length: 5 }, (_, index) =>
+        children: Array.from({ length: itemCount }, (_, index) =>
           sound(`sound-${index}`),
         ),
       },
     ],
   };
+  Object.assign(props, extraProps);
   const state = mediaStore.createInitialState({ props });
   const store = Object.fromEntries(
     Object.entries(mediaStore).map(([name, fn]) => [
@@ -55,7 +65,7 @@ const createHydratedSounds = () => {
   );
   const deps = { props, store, render: vi.fn() };
   const cleanup = handleBeforeMount(deps);
-  for (let index = 0; index < 16; index++) advanceFrame();
+  for (let index = 0; index < framesToHydrate; index++) advanceFrame();
   return { deps, advanceFrame, cleanup };
 };
 
@@ -70,70 +80,137 @@ const expectWaveformsVisible = (deps, ids) => {
   });
 };
 
+const mountSounds = (deps) => {
+  const dom = new JSDOM("<body><div id='root'></div></body>");
+  for (const name of ["document", "window", "HTMLElement", "CustomEvent"]) {
+    vi.stubGlobal(name, name === "window" ? dom.window : dom.window[name]);
+  }
+  vi.stubGlobal(
+    "CSSStyleSheet",
+    class {
+      replaceSync() {}
+    },
+  );
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+  dom.window.HTMLElement.prototype.getBoundingClientRect = () => ({
+    width: 120,
+    height: 60,
+  });
+  const context = {
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    createLinearGradient: () => ({ addColorStop() {} }),
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+  };
+  dom.window.HTMLCanvasElement.prototype.getContext = () => context;
+  const downloadMetadata = vi.fn(async () => ({ amplitudes: [64, 255] }));
+  const loadWaveformYaml = (suffix) =>
+    yaml.load(
+      readFileSync(
+        new URL(
+          `../../src/components/waveformVisualizer/waveformVisualizer.${suffix}.yaml`,
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    );
+  const view = loadWaveformYaml("view");
+  view.template = parse(view.template);
+  dom.window.customElements.define(
+    "rvn-waveform-visualizer",
+    createComponent(
+      {
+        view,
+        schema: loadWaveformYaml("schema"),
+        handlers: waveformHandlers,
+        store: waveformStore,
+      },
+      { projectService: { downloadMetadata } },
+    ),
+  );
+  const template = parse(
+    loadViewTemplate(
+      "src/components/mediaResourcesView/mediaResourcesView.view.yaml",
+    ),
+  );
+  const patch = init([attributesModule, propsModule]);
+  let tree = dom.window.document.querySelector("#root");
+  const render = () => {
+    tree = patch(
+      tree,
+      parseView({
+        h,
+        template,
+        viewData: deps.store.selectViewData(),
+        wireEventListeners: false,
+      }),
+    );
+  };
+  deps.render.mockImplementation(render);
+  return {
+    render,
+    downloadMetadata,
+    context,
+    findWaveform: (id) =>
+      tree.elm.querySelector(`[data-item-id='${id}'] rvn-waveform-visualizer`),
+    close: () => dom.window.close(),
+  };
+};
+
 describe("media resource waveform hydration", () => {
   it.each([false, true])(
-    "retains waveform canvas elements after insertion and resizing (mobile=%s)",
-    (mobileLayout) => {
-      const { deps, cleanup } = createHydratedSounds();
+    "retains loaded waveforms through real FE lifecycle moves, insertion and resizing (mobile=%s)",
+    async (mobileLayout) => {
+      const { deps, advanceFrame, cleanup } = createHydratedSounds();
       deps.props.mobileLayout = mobileLayout;
-      const dom = new JSDOM("<body><div id='root'></div></body>");
-      vi.stubGlobal("document", dom.window.document);
-      dom.window.customElements.define(
-        "rvn-waveform-visualizer",
-        class extends dom.window.HTMLElement {
-          constructor() {
-            super();
-            this.attachShadow({ mode: "open" }).append(
-              dom.window.document.createElement("canvas"),
-            );
-          }
-        },
-      );
-      const template = parse(
-        loadViewTemplate(
-          "src/components/mediaResourcesView/mediaResourcesView.view.yaml",
-        ),
-      );
-      const patch = init([attributesModule, propsModule]);
-      let tree = dom.window.document.querySelector("#root");
-      const render = () => {
-        tree = patch(
-          tree,
-          parseView({
-            h,
-            template,
-            viewData: deps.store.selectViewData(),
-            wireEventListeners: false,
-          }),
-        );
-      };
-      const findWaveform = (id) =>
-        tree.elm.querySelector(
-          `[data-item-id='${id}'] rvn-waveform-visualizer`,
-        );
+      const { render, findWaveform, downloadMetadata, context, close } =
+        mountSounds(deps);
       try {
         render();
+        await Promise.resolve();
+        advanceFrame();
+        expect(downloadMetadata).toHaveBeenCalledTimes(5);
         const originals = deps.props.groups[0].children.map((item) => {
           const waveform = findWaveform(item.id);
+          expect(waveform.shadowRoot.querySelector("canvas")).not.toBeNull();
           return {
             id: item.id,
             waveform,
             canvas: waveform.shadowRoot.querySelector("canvas"),
           };
         });
+        // A regression must be visible even while replacement requests hang.
+        downloadMetadata.mockImplementation(() => new Promise(() => {}));
+        context.clearRect.mockClear();
+        deps.props.groups[0].children.reverse();
+        render();
+        handleOnUpdate(deps);
+        render();
         deps.props.groups[0].children.unshift(sound("new-sound"));
         render();
         handleOnUpdate(deps);
         render();
         deps.store.setZoomLevel({ zoomLevel: 2 });
         render();
+        advanceFrame();
         originals.forEach(({ id, waveform, canvas }) => {
           expect(findWaveform(id)).toBe(waveform);
           expect(waveform.shadowRoot.querySelector("canvas")).toBe(canvas);
         });
+        expect(downloadMetadata).toHaveBeenCalledTimes(5);
+        expect(context.clearRect).not.toHaveBeenCalled();
       } finally {
         cleanup();
-        dom.window.close();
+        close();
       }
     },
   );
@@ -150,6 +227,11 @@ describe("media resource waveform hydration", () => {
       expectWaveformsVisible(deps, existingIds);
       handleOnUpdate(deps);
       expectWaveformsVisible(deps, existingIds);
+      const addedItem = () =>
+        deps.store
+          .selectViewData()
+          .groups[0].children.find((item) => item.id === "new-sound");
+      expect(addedItem().shouldRenderWaveform).toBe(false);
       for (let frame = 0; frame < 8; frame++) {
         advanceFrame();
         expectWaveformsVisible(deps, existingIds);
@@ -158,6 +240,109 @@ describe("media resource waveform hydration", () => {
       cleanup();
     },
   );
+
+  it("keeps 96 deferred waveforms deferred when a hydrated sound moves to the end", async () => {
+    const { deps, advanceFrame, cleanup } = createHydratedSounds({
+      itemCount: 100,
+      framesToHydrate: 8,
+      props: { progressiveHydrationDelayFrameCount: 16 },
+    });
+    const { render, findWaveform, downloadMetadata, close } = mountSounds(deps);
+    const enabledIds = () =>
+      deps.store
+        .selectViewData()
+        .groups.flatMap((group) =>
+          group.children
+            .filter((item) => item.shouldRenderWaveform)
+            .map((item) => item.id),
+        );
+    try {
+      render();
+      await Promise.resolve();
+      expect(downloadMetadata).toHaveBeenCalledTimes(4);
+      const waveform = findWaveform("sound-0");
+      const canvas = waveform.shadowRoot.querySelector("canvas");
+      expect(canvas).not.toBeNull();
+
+      const items = deps.props.groups[0].children;
+      items.push(items.shift());
+      render();
+      expect(enabledIds()).toEqual([
+        "sound-1",
+        "sound-2",
+        "sound-3",
+        "sound-0",
+      ]);
+      handleOnUpdate(deps);
+      render();
+      for (let frame = 0; frame < 7; frame++) {
+        advanceFrame();
+        expect(enabledIds()).toEqual([
+          "sound-1",
+          "sound-2",
+          "sound-3",
+          "sound-0",
+        ]);
+        expect(downloadMetadata).toHaveBeenCalledTimes(4);
+        expect(findWaveform("sound-0")).toBe(waveform);
+        expect(waveform.shadowRoot.querySelector("canvas")).toBe(canvas);
+      }
+      expect(deps.store.selectProgressiveRenderedItemCount()).toBe(8);
+      expect(
+        deps.store.selectViewData().groups[0].children[50].isPlaceholder,
+      ).toBe(true);
+      advanceFrame();
+      await Promise.resolve();
+      expect(enabledIds()).toEqual([
+        "sound-1",
+        "sound-2",
+        "sound-3",
+        "sound-4",
+        "sound-5",
+        "sound-6",
+        "sound-7",
+        "sound-0",
+      ]);
+      expect(downloadMetadata).toHaveBeenCalledTimes(8);
+      expect(waveform.shadowRoot.querySelector("canvas")).toBe(canvas);
+    } finally {
+      cleanup();
+      close();
+    }
+  });
+
+  it("uses the latest pending identities without restarting an active batch delay", () => {
+    const { deps, advanceFrame, cleanup } = createHydratedSounds({
+      itemCount: 12,
+      framesToHydrate: 8,
+    });
+    try {
+      for (let frame = 0; frame < 7; frame++) {
+        deps.props.groups[0].children.reverse();
+        handleOnUpdate(deps);
+        advanceFrame();
+        expect(deps.store.selectSoundWaveformRenderedItemIds()).toHaveLength(4);
+      }
+      const items = deps.props.groups[0].children;
+      deps.props.groups[0].children = items.filter(
+        (item) => !["sound-0", "sound-11"].includes(item.id),
+      );
+      deps.props.groups[0].children.unshift(sound("new-sound"));
+      handleOnUpdate(deps);
+      advanceFrame();
+      expect(deps.store.selectSoundWaveformRenderedItemIds()).toEqual([
+        "new-sound",
+        "sound-10",
+        "sound-9",
+        "sound-8",
+        "sound-3",
+        "sound-2",
+        "sound-1",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
 
   it("keeps the initial paint delay for newly appended waveforms", () => {
     const { deps, advanceFrame, cleanup } = createHydratedSounds();

--- a/tests/mediaResourcesView/mediaResourcesView.hydration.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.hydration.test.js
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import { h } from "snabbdom/build/h.js";
+import { init } from "snabbdom/build/init.js";
+import { attributesModule } from "snabbdom/build/modules/attributes.js";
+import { propsModule } from "snabbdom/build/modules/props.js";
+import { parseView } from "../../node_modules/@rettangoli/fe/src/parser.js";
+import { parse } from "../../node_modules/@rettangoli/fe/node_modules/jempl/src/index.js";
+import { loadViewTemplate } from "../support/renderView.js";
+import {
+  handleBeforeMount,
+  handleOnUpdate,
+} from "../../src/components/mediaResourcesView/mediaResourcesView.handlers.js";
+import * as mediaStore from "../../src/components/mediaResourcesView/mediaResourcesView.store.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+const sound = (id) => ({
+  id,
+  cardKind: "sound",
+  waveformDataFileId: `waveform-${id}`,
+});
+
+const createHydratedSounds = () => {
+  let frameId = 0;
+  const frames = new Map();
+  vi.stubGlobal("requestAnimationFrame", (callback) => {
+    frames.set(++frameId, callback);
+    return frameId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id) => frames.delete(id));
+  const advanceFrame = () => {
+    const callbacks = [...frames.values()];
+    frames.clear();
+    callbacks.forEach((callback) => callback());
+  };
+  const props = {
+    progressiveRender: true,
+    lazySoundWaveforms: true,
+    groups: [
+      {
+        id: "folder-1",
+        children: Array.from({ length: 5 }, (_, index) =>
+          sound(`sound-${index}`),
+        ),
+      },
+    ],
+  };
+  const state = mediaStore.createInitialState({ props });
+  const store = Object.fromEntries(
+    Object.entries(mediaStore).map(([name, fn]) => [
+      name,
+      (payload) => fn({ state, props }, payload),
+    ]),
+  );
+  const deps = { props, store, render: vi.fn() };
+  const cleanup = handleBeforeMount(deps);
+  for (let index = 0; index < 16; index++) advanceFrame();
+  return { deps, advanceFrame, cleanup };
+};
+
+const expectWaveformsVisible = (deps, ids) => {
+  const items = deps.store
+    .selectViewData()
+    .groups.flatMap((group) => group.children);
+  ids.forEach((id) => {
+    expect(items.find((item) => item.id === id)).toMatchObject({
+      shouldRenderWaveform: true,
+    });
+  });
+};
+
+describe("media resource waveform hydration", () => {
+  it.each([false, true])(
+    "retains waveform canvas elements after insertion and resizing (mobile=%s)",
+    (mobileLayout) => {
+      const { deps, cleanup } = createHydratedSounds();
+      deps.props.mobileLayout = mobileLayout;
+      const dom = new JSDOM("<body><div id='root'></div></body>");
+      vi.stubGlobal("document", dom.window.document);
+      dom.window.customElements.define(
+        "rvn-waveform-visualizer",
+        class extends dom.window.HTMLElement {
+          constructor() {
+            super();
+            this.attachShadow({ mode: "open" }).append(
+              dom.window.document.createElement("canvas"),
+            );
+          }
+        },
+      );
+      const template = parse(
+        loadViewTemplate(
+          "src/components/mediaResourcesView/mediaResourcesView.view.yaml",
+        ),
+      );
+      const patch = init([attributesModule, propsModule]);
+      let tree = dom.window.document.querySelector("#root");
+      const render = () => {
+        tree = patch(
+          tree,
+          parseView({
+            h,
+            template,
+            viewData: deps.store.selectViewData(),
+            wireEventListeners: false,
+          }),
+        );
+      };
+      const findWaveform = (id) =>
+        tree.elm.querySelector(
+          `[data-item-id='${id}'] rvn-waveform-visualizer`,
+        );
+      try {
+        render();
+        const originals = deps.props.groups[0].children.map((item) => {
+          const waveform = findWaveform(item.id);
+          return {
+            id: item.id,
+            waveform,
+            canvas: waveform.shadowRoot.querySelector("canvas"),
+          };
+        });
+        deps.props.groups[0].children.unshift(sound("new-sound"));
+        render();
+        handleOnUpdate(deps);
+        render();
+        deps.store.setZoomLevel({ zoomLevel: 2 });
+        render();
+        originals.forEach(({ id, waveform, canvas }) => {
+          expect(findWaveform(id)).toBe(waveform);
+          expect(waveform.shadowRoot.querySelector("canvas")).toBe(canvas);
+        });
+      } finally {
+        cleanup();
+        dom.window.close();
+      }
+    },
+  );
+
+  it.each([0, 2, 5])(
+    "preserves existing waveforms when adding a sound at index %s",
+    (index) => {
+      const { deps, advanceFrame, cleanup } = createHydratedSounds();
+      const existingIds = deps.props.groups[0].children.map((item) => item.id);
+      expectWaveformsVisible(deps, existingIds);
+
+      deps.props.groups[0].children.splice(index, 0, sound("new-sound"));
+      // FE renders new props before calling handleOnUpdate.
+      expectWaveformsVisible(deps, existingIds);
+      handleOnUpdate(deps);
+      expectWaveformsVisible(deps, existingIds);
+      for (let frame = 0; frame < 8; frame++) {
+        advanceFrame();
+        expectWaveformsVisible(deps, existingIds);
+      }
+      expectWaveformsVisible(deps, [...existingIds, "new-sound"]);
+      cleanup();
+    },
+  );
+
+  it("keeps the initial paint delay for newly appended waveforms", () => {
+    const { deps, advanceFrame, cleanup } = createHydratedSounds();
+    deps.props.groups[0].children.push(sound("new-sound"));
+    handleOnUpdate(deps);
+    for (let frame = 0; frame < 7; frame++) {
+      advanceFrame();
+      expect(
+        deps.store.selectViewData().groups[0].children.at(-1)
+          .shouldRenderWaveform,
+      ).toBe(false);
+    }
+    advanceFrame();
+    expectWaveformsVisible(deps, ["new-sound"]);
+    cleanup();
+  });
+
+  it("preserves waveforms when the list is reordered or an item is removed", () => {
+    const { deps, advanceFrame, cleanup } = createHydratedSounds();
+    deps.props.groups[0].children.reverse();
+    deps.props.groups[0].children.splice(2, 1);
+    const remainingIds = deps.props.groups[0].children.map((item) => item.id);
+    expectWaveformsVisible(deps, remainingIds);
+    handleOnUpdate(deps);
+    advanceFrame();
+    expectWaveformsVisible(deps, remainingIds);
+    cleanup();
+  });
+
+  it("does not restart hydration for selection or waveform-data changes", () => {
+    const { deps, advanceFrame, cleanup } = createHydratedSounds();
+    deps.render.mockClear();
+    deps.props.selectedItemId = "sound-1";
+    deps.props.groups[0].children[1].waveformDataFileId =
+      "replacement-waveform";
+    handleOnUpdate(deps);
+    advanceFrame();
+    expectWaveformsVisible(
+      deps,
+      deps.props.groups[0].children.map((item) => item.id),
+    );
+    expect(deps.render).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/tests/mediaResourcesView/mediaResourcesView.store.test.js
+++ b/tests/mediaResourcesView/mediaResourcesView.store.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createInitialState,
   selectViewData,
-  setSoundWaveformRenderedItemCount,
+  setSoundWaveformRenderedItemIds,
 } from "../../src/components/mediaResourcesView/mediaResourcesView.store.js";
 import { MOBILE_RESOURCE_SCROLL_BOTTOM_PADDING } from "../../src/internal/ui/resourcePages/mobileResourcePage.js";
 
@@ -294,10 +294,10 @@ describe("mediaResourcesView.store", () => {
       ),
     ).toEqual([false, false]);
 
-    setSoundWaveformRenderedItemCount(
+    setSoundWaveformRenderedItemIds(
       { state },
       {
-        itemCount: 1,
+        itemIds: ["sound-1"],
       },
     );
     const hydratedViewData = selectViewData({ state, props });

--- a/tests/waveformVisualizer/waveformVisualizer.handlers.test.js
+++ b/tests/waveformVisualizer/waveformVisualizer.handlers.test.js
@@ -51,7 +51,7 @@ describe("waveformVisualizer.handlers", () => {
         selectRenderedSize: () => renderedSize,
         selectWaveformData: () => undefined,
         setRenderedSize,
-        resetWaveform: vi.fn(),
+        cancelWaveformLoad: vi.fn(),
       },
     });
 
@@ -262,6 +262,32 @@ describe("waveformVisualizer.handlers", () => {
 
     expect(deps.render).toHaveBeenCalledTimes(renderCount);
     expect(context.clearRect).not.toHaveBeenCalled();
+  });
+
+  it("retries an interrupted load after reconnecting and ignores the old result", async () => {
+    const resolveLoads = [];
+    const downloadMetadata = vi.fn(
+      () => new Promise((resolve) => resolveLoads.push(resolve)),
+    );
+    const { deps, context } = createWaveform(downloadMetadata);
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+    globalThis.cancelAnimationFrame = vi.fn();
+    const cleanup = handleBeforeMount(deps);
+    const firstLoad = handleAfterMount(deps);
+    cleanup();
+    const reconnectedCleanup = handleBeforeMount(deps);
+    const secondLoad = handleAfterMount(deps);
+    expect(downloadMetadata).toHaveBeenCalledTimes(2);
+
+    resolveLoads[0]({ amplitudes: [100] });
+    await firstLoad;
+    expect(deps.store.selectWaveformData()).toBeUndefined();
+    expect(context.clearRect).not.toHaveBeenCalled();
+    resolveLoads[1]({ amplitudes: [200] });
+    await secondLoad;
+    expect(deps.store.selectWaveformData()).toEqual({ amplitudes: [200] });
+    expect(context.clearRect).toHaveBeenCalledOnce();
+    reconnectedCleanup();
   });
 
   it("downsamples the complete waveform into the canvas width", () => {

--- a/tests/waveformVisualizer/waveformVisualizer.handlers.test.js
+++ b/tests/waveformVisualizer/waveformVisualizer.handlers.test.js
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleBeforeMount,
+  handleAfterMount,
+  handleOnUpdate,
   renderWaveformCanvas,
 } from "../../src/components/waveformVisualizer/waveformVisualizer.handlers.js";
+import * as waveformStore from "../../src/components/waveformVisualizer/waveformVisualizer.store.js";
 
 const originalResizeObserver = globalThis.ResizeObserver;
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
@@ -48,6 +51,7 @@ describe("waveformVisualizer.handlers", () => {
         selectRenderedSize: () => renderedSize,
         selectWaveformData: () => undefined,
         setRenderedSize,
+        resetWaveform: vi.fn(),
       },
     });
 
@@ -72,6 +76,192 @@ describe("waveformVisualizer.handlers", () => {
     cleanup();
     expect(globalThis.cancelAnimationFrame).toHaveBeenCalledWith(7);
     expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  const createWaveform = (
+    downloadMetadata = vi.fn(async () => ({ amplitudes: [64, 255] })),
+  ) => {
+    const props = { waveformDataFileId: "waveform-1", w: "f", h: "f" };
+    const state = waveformStore.createInitialState();
+    const store = Object.fromEntries(
+      Object.entries(waveformStore).map(([name, fn]) => [
+        name,
+        (payload) => fn({ state, props }, payload),
+      ]),
+    );
+    const context = {
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      createLinearGradient: () => ({ addColorStop: vi.fn() }),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+    };
+    const canvas = { getContext: () => context };
+    const refs = {};
+    const render = vi.fn(() => {
+      refs.waveformCanvas = store.selectWaveformData() ? canvas : undefined;
+    });
+    store.setRenderedSize({ width: 120, height: 60 });
+    const deps = {
+      props,
+      store,
+      refs,
+      render,
+      projectService: { downloadMetadata },
+    };
+    const update = (changes) => {
+      const oldProps = { ...props };
+      Object.assign(props, changes);
+      return handleOnUpdate(deps, { oldProps, newProps: { ...props } });
+    };
+    return { deps, update, context, downloadMetadata };
+  };
+
+  it("reuses loaded waveform data and pixels across unrelated updates", async () => {
+    const { deps, update, context, downloadMetadata } = createWaveform();
+    await handleAfterMount(deps);
+    const renderCount = deps.render.mock.calls.length;
+
+    await update({});
+    await update({ selected: true });
+    await update({ selected: false });
+
+    expect(downloadMetadata).toHaveBeenCalledExactlyOnceWith("waveform-1");
+    expect(context.clearRect).toHaveBeenCalledOnce();
+    expect(deps.render).toHaveBeenCalledTimes(renderCount);
+  });
+
+  it("redraws resized waveforms without downloading their data again", async () => {
+    const { deps, update, context, downloadMetadata } = createWaveform();
+    let notifyResize;
+    let runFrame;
+    globalThis.requestAnimationFrame = vi.fn((callback) => {
+      runFrame = callback;
+      return 1;
+    });
+    globalThis.cancelAnimationFrame = vi.fn();
+    globalThis.ResizeObserver = class {
+      constructor(callback) {
+        notifyResize = callback;
+      }
+      observe() {}
+      disconnect() {}
+    };
+    deps.refs.waveformContainer = {
+      getBoundingClientRect: () => ({ width: 120, height: 60 }),
+    };
+    const cleanup = handleBeforeMount(deps);
+    runFrame();
+    await handleAfterMount(deps);
+
+    await update({ w: "240" });
+    notifyResize([{ contentRect: { width: 120.2, height: 60.2 } }]);
+    expect(context.clearRect).toHaveBeenCalledOnce();
+    notifyResize([{ contentRect: { width: 240, height: 120 } }]);
+    expect(context.clearRect).toHaveBeenCalledTimes(2);
+    expect(context.clearRect).toHaveBeenLastCalledWith(0, 0, 240, 120);
+    expect(downloadMetadata).toHaveBeenCalledOnce();
+    cleanup();
+  });
+
+  it("shares an in-flight data load across repeated updates", async () => {
+    let resolveData;
+    const downloadMetadata = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveData = resolve;
+        }),
+    );
+    const { deps, update, context } = createWaveform(downloadMetadata);
+    const mounted = handleAfterMount(deps);
+    await update({});
+    await update({ h: "100" });
+    expect(downloadMetadata).toHaveBeenCalledOnce();
+
+    resolveData({ amplitudes: [255] });
+    await mounted;
+    expect(context.clearRect).toHaveBeenCalledOnce();
+  });
+
+  it("ignores an older data load after switching waveform IDs", async () => {
+    const resolvers = new Map();
+    const downloadMetadata = vi.fn(
+      (id) =>
+        new Promise((resolve) => {
+          resolvers.set(id, resolve);
+        }),
+    );
+    const { deps, update, context } = createWaveform(downloadMetadata);
+    const first = handleAfterMount(deps);
+    const second = update({ waveformDataFileId: "waveform-2" });
+    resolvers.get("waveform-2")({ amplitudes: [200] });
+    await second;
+    resolvers.get("waveform-1")({ amplitudes: [100] });
+    await first;
+
+    expect(deps.store.selectWaveformData()).toEqual({ amplitudes: [200] });
+    expect(deps.store.selectWaveformLoad().loadedFileId).toBe("waveform-2");
+    expect(context.clearRect).toHaveBeenCalledOnce();
+  });
+
+  it("clears a removed waveform and ignores its unfinished load", async () => {
+    let resolveData;
+    const { deps, update, context } = createWaveform(
+      vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveData = resolve;
+          }),
+      ),
+    );
+    const mounted = handleAfterMount(deps);
+    await update({ waveformDataFileId: undefined });
+    const renderCount = deps.render.mock.calls.length;
+    resolveData({ amplitudes: [255] });
+    await mounted;
+
+    expect(deps.store.selectWaveformData()).toBeUndefined();
+    expect(deps.render).toHaveBeenCalledTimes(renderCount);
+    expect(context.clearRect).not.toHaveBeenCalled();
+  });
+
+  it("allows a failed data load to retry on the next update", async () => {
+    const downloadMetadata = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Unavailable"))
+      .mockResolvedValue({ amplitudes: [255] });
+    const { deps, update, context } = createWaveform(downloadMetadata);
+    await handleAfterMount(deps);
+    await update({});
+
+    expect(downloadMetadata).toHaveBeenCalledTimes(2);
+    expect(deps.store.selectWaveformLoad().loadedFileId).toBe("waveform-1");
+    expect(context.clearRect).toHaveBeenCalledOnce();
+  });
+
+  it("does not render an unfinished load after unmounting", async () => {
+    let resolveData;
+    const { deps, context } = createWaveform(
+      vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveData = resolve;
+          }),
+      ),
+    );
+    globalThis.requestAnimationFrame = vi.fn(() => 1);
+    globalThis.cancelAnimationFrame = vi.fn();
+    const cleanup = handleBeforeMount(deps);
+    const mounted = handleAfterMount(deps);
+    cleanup();
+    const renderCount = deps.render.mock.calls.length;
+    resolveData({ amplitudes: [255] });
+    await mounted;
+
+    expect(deps.render).toHaveBeenCalledTimes(renderCount);
+    expect(context.clearRect).not.toHaveBeenCalled();
   });
 
   it("downsamples the complete waveform into the canvas width", () => {

--- a/vt/specs/project/sounds.yaml
+++ b/vt/specs/project/sounds.yaml
@@ -91,11 +91,11 @@ steps:
   - action: wait
     ms: 500
   - action: waitFor
-    selector: "#groupview #itemRef0x0[data-item-id]:not([data-item-id=''])"
+    selector: "#groupview [data-resource-view-item='true'][data-item-id]:not([data-item-id=''])"
     state: visible
     timeoutMs: 10000
   - action: select
-    selector: "#groupview #itemRef0x0[data-item-id]:not([data-item-id=''])"
+    selector: "#groupview [data-resource-view-item='true'][data-item-id]:not([data-item-id=''])"
     steps:
       - action: click
   - action: waitFor


### PR DESCRIPTION
Adding or reordering sounds could make existing waveforms blink: list changes reset hydration, position-based card IDs reassigned canvases, and transient DOM disconnects discarded completed waveform data. Unchanged prop updates also downloaded metadata again.

Give sound cards and preview containers stable resource IDs, reuse loaded or in-flight data, and redraw only when waveform data or measured dimensions change. Keep completed data and canvases across same-instance DOM moves while invalidating unfinished requests on disconnect.

Track hydrated sound IDs separately from the progressive card budget. Moving a hydrated sound to the end preserves that card without enabling intervening waveforms. New waveforms load in batches of four every eight frames, and list changes retain the active batch delay.

Validation:

- 446 tests passed across waveform visualizers, media resources, sounds, images, resource pages, and BGM/sound-effect/voice components.
- Regression tests use the actual FE waveform component on desktop and mobile to verify canvas retention and no metadata reloads during DOM moves. Interrupted loads retry on reconnect and ignore stale results.
- A 100-sound regression test preserves the four hydrated waveforms after moving one to the end, keeps 96 deferred, and starts only four additional metadata loads in the next batch.
- Refreshed the Vivo from the existing Android dev server. All 11 existing canvases survived reordering, appending, prepending, and selection changes with zero redraws. Resizing redrew each canvas once. Temporary UI changes were restored afterward.
- Lint, changed-test formatting, and diff checks passed.
- Updated the Sounds visual-test selectors for stable card IDs; the full visual-test suite was not run.
