### PR TITLE
Fix scene editor preview overflow, voice removal, and mobile loading

### DIFF
--- a/src/components/commandLineVoice/commandLineVoice.handlers.js
+++ b/src/components/commandLineVoice/commandLineVoice.handlers.js
@@ -408,20 +408,8 @@ export const handleAudioPlayerClose = (deps) => {
 
 export const handleSubmitClick = (deps, payload) => {
   payload._event.stopPropagation();
-  const { appService, dispatchEvent, store, i18n } = deps;
-  const copy = selectCommandLineCopy(i18n);
+  const { dispatchEvent, store } = deps;
   const voice = store.selectVoicePayload();
-
-  if (voice.sounds.length === 0) {
-    showAlert(appService, {
-      message: localizeCommandLineText(
-        "Select a voice audio file first.",
-        copy,
-      ),
-      title: localizeCommandLineText("Warning", copy),
-    });
-    return;
-  }
 
   dispatchEvent(
     new CustomEvent("submit", {

--- a/src/internal/ui/sceneEditor/lineViewModels.js
+++ b/src/internal/ui/sceneEditor/lineViewModels.js
@@ -291,30 +291,6 @@ const buildDialogueSpeakerPreview = (characterId, characterLookups) => {
   return characterLookups.flatCharacterById.get(characterId)?.fileId;
 };
 
-const resolveDialogueModeLabel = (repositoryState, line) => {
-  const lineActions = normalizeLineActions(line.actions || {});
-  const dialogue = lineActions?.dialogue;
-  if (!dialogue) {
-    return undefined;
-  }
-
-  if (dialogue.mode === "nvl") {
-    return "NVL";
-  }
-
-  if (dialogue.mode === "adv") {
-    return "ADV";
-  }
-
-  const layoutId = dialogue.ui?.resourceId ?? dialogue.gui?.resourceId;
-  const layoutType = repositoryState?.layouts?.items?.[layoutId]?.layoutType;
-  if (layoutType === "dialogue-nvl") {
-    return "NVL";
-  }
-
-  return "ADV";
-};
-
 const toStableDomRefSuffix = (value = "") => {
   return Array.from(String(value)).reduce((result, char) => {
     if (/^[a-zA-Z0-9]$/.test(char)) {
@@ -387,7 +363,6 @@ const buildSceneDocumentLineViewModels = ({
         !!changes.setNextLineConfig || !!lineActions?.setNextLineConfig,
       setNextLineConfigChangeType: changes.setNextLineConfig?.changeType,
       hasDialogueLayout: !!changes.dialogue,
-      dialogueModeLabel: resolveDialogueModeLabel(repositoryState, line),
       dialogueChangeType: changes.dialogue?.changeType,
       hasControl: !!changes.control,
       controlChangeType: changes.control?.changeType,

--- a/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
+++ b/src/pages/sceneEditorLexical/sceneEditorLexical.view.yaml
@@ -258,5 +258,9 @@ template:
       - $if previewVisible:
           - rvn-vn-preview#vnPreview scene-id="${previewSceneId}" section-id="${previewSectionId}" line-id="${previewLineId}": null
       - $if isScenePageLoading:
-          - 'rtgl-view pos=abs edge=f z=1000 bgc=bg av=c ah=c style="pointer-events: auto;"':
-              - rtgl-text s=sm c=mu-fg: ${loadingSceneLabel}
+          - $if isTouchMode:
+              - 'rtgl-view#scenePageLoading pos=fix bgc=bg av=c ah=c role=status style="z-index: 1101; left: 0; right: 0; top: 0; bottom: ${mobileSceneEditorBottomInset}; pointer-events: auto;"':
+                  - rtgl-text s=sm c=mu-fg: ${loadingSceneLabel}
+            $else:
+              - 'rtgl-view#scenePageLoading pos=abs edge=f z=1000 bgc=bg av=c ah=c role=status style="pointer-events: auto;"':
+                  - rtgl-text s=sm c=mu-fg: ${loadingSceneLabel}

--- a/src/primitives/lexicalSceneDocumentEditor.js
+++ b/src/primitives/lexicalSceneDocumentEditor.js
@@ -605,7 +605,7 @@ const STYLES = `
     right: 0;
     width: max-content;
     max-width: none;
-    justify-content: flex-start;
+    justify-content: flex-end;
     padding-left: 0;
     padding-right: 0;
   }
@@ -613,6 +613,7 @@ const STYLES = `
   .gutter-right .gutter-row[data-constrained="true"] {
     width: var(--line-right-gutter-width);
     max-width: var(--line-right-gutter-width);
+    overflow: hidden;
   }
 
   .gutter-row[data-selected="true"] .line-number {
@@ -656,7 +657,7 @@ const STYLES = `
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: flex-start;
-    justify-content: flex-start;
+    justify-content: flex-end;
     gap: 8px;
     min-width: 0;
     width: max-content;
@@ -671,7 +672,6 @@ const STYLES = `
 
   .gutter-right .gutter-row[data-constrained="true"] .preview-items {
     display: flex;
-    flex-wrap: wrap;
     width: 100%;
     max-width: 100%;
   }
@@ -679,7 +679,8 @@ const STYLES = `
   .preview-item {
     display: inline-flex;
     align-items: flex-start;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
     gap: 6px;
     min-width: 0;
     max-width: 100%;
@@ -690,6 +691,19 @@ const STYLES = `
     align-items: center;
     gap: 4px;
     min-height: 16px;
+  }
+
+  .preview-overflow {
+    flex: 0 0 auto;
+    color: var(--muted-foreground);
+    font-size: 12px;
+    line-height: 24px;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  .preview-item[hidden], .preview-overflow[hidden] {
+    display: none;
   }
 
   .preview-item[data-overlay="true"] {
@@ -761,7 +775,8 @@ const STYLES = `
 
   .preview-image-stack {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
     align-items: center;
     gap: 4px;
     min-width: 0;
@@ -822,12 +837,6 @@ const STYLES = `
     justify-content: center;
     color: var(--foreground);
     pointer-events: none;
-  }
-
-  .preview-dialogue-label {
-    color: var(--muted-foreground);
-    font-size: 12px;
-    line-height: 1;
   }
 
   .surface[data-mode="block"] .editor {
@@ -8005,7 +8014,6 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
       screenTransition: Boolean(lineDecoration.screenTransition),
       sectionTransition: Boolean(lineDecoration.sectionTransition),
       hasDialogueLayout: Boolean(lineDecoration.hasDialogueLayout),
-      dialogueModeLabel: lineDecoration.dialogueModeLabel || "",
       dialogueChangeType: lineDecoration.dialogueChangeType,
       hasControl: Boolean(lineDecoration.hasControl),
       controlChangeType: lineDecoration.controlChangeType,
@@ -8060,15 +8068,44 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
     rightRow.removeAttribute("data-constrained");
 
     const previewItems = rightRow.firstElementChild;
+    const overflow = previewItems.querySelector(".preview-overflow");
+    const items = Array.from(previewItems.children).filter(
+      (item) => item !== overflow,
+    );
+    items.forEach((item) => {
+      item.hidden = false;
+    });
+    overflow.hidden = true;
+
+    const previewRect = previewItems.getBoundingClientRect();
     const measuredNaturalWidth = Math.max(
-      Math.ceil(previewItems?.getBoundingClientRect?.().width ?? 0),
-      Math.ceil(previewItems?.scrollWidth ?? 0),
+      Math.ceil(previewRect.width),
+      Math.ceil(previewItems.scrollWidth),
     );
     const isConstrained = measuredNaturalWidth > maxRightGutterWidth;
     const lineRightGutterWidth = Math.min(
       maxRightGutterWidth,
       Math.max(DEFAULT_RIGHT_GUTTER_WIDTH, measuredNaturalWidth),
     );
+
+    if (isConstrained) {
+      const gap = Number.parseFloat(getComputedStyle(previewItems).columnGap);
+      const itemRightEdges = items.map(
+        (item) => item.getBoundingClientRect().right - previewRect.left,
+      );
+      overflow.textContent = `+${items.length}`;
+      overflow.hidden = false;
+      const overflowWidth = Math.ceil(overflow.getBoundingClientRect().width);
+      const availableWidth = lineRightGutterWidth - overflowWidth - gap;
+      const firstHiddenIndex = itemRightEdges.findIndex(
+        (rightEdge) => rightEdge > availableWidth,
+      );
+      const hiddenItems = items.slice(firstHiddenIndex);
+      hiddenItems.forEach((item) => {
+        item.hidden = true;
+      });
+      overflow.textContent = `+${hiddenItems.length}`;
+    }
 
     rightRow.dataset.constrained = String(isConstrained);
     rightRow.style.setProperty(
@@ -8770,10 +8807,6 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           deleteDisplay: "mark",
         }),
       );
-      const label = document.createElement("div");
-      label.className = "preview-dialogue-label";
-      label.textContent = lineDecoration.dialogueModeLabel || "ADV";
-      item.append(label);
       container.append(item);
     }
 
@@ -8852,6 +8885,14 @@ export class LexicalSceneDocumentEditorElement extends HTMLElement {
           isDelete: lineDecoration.setNextLineConfigChangeType === "delete",
         }),
       );
+    }
+
+    if (container.childNodes.length > 0) {
+      const overflow = document.createElement("span");
+      overflow.className = "preview-overflow";
+      overflow.hidden = true;
+      overflow.setAttribute("aria-hidden", "true");
+      container.append(overflow);
     }
 
     return container;

--- a/tests/commandLineVoice/commandLineVoice.handlers.test.js
+++ b/tests/commandLineVoice/commandLineVoice.handlers.test.js
@@ -258,7 +258,7 @@ describe("commandLineVoice.handlers", () => {
     expect(render).not.toHaveBeenCalled();
   });
 
-  it("removes a Voice clip from its context menu", async () => {
+  it("submits an empty channel after removing the last Voice clip", async () => {
     const state = voiceStore.createInitialState();
     const store = createStore(state);
     const render = vi.fn();
@@ -266,6 +266,8 @@ describe("commandLineVoice.handlers", () => {
     const showDropdownMenu = vi.fn().mockResolvedValue({
       item: { key: "remove" },
     });
+    const showAlert = vi.fn();
+    const dispatchEvent = vi.fn();
 
     await handleSoundContextMenu(
       {
@@ -293,6 +295,21 @@ describe("commandLineVoice.handlers", () => {
     });
     expect(state.voice.sounds).toEqual([]);
     expect(render).toHaveBeenCalledTimes(2);
+
+    handleSubmitClick(
+      { appService: { showAlert }, dispatchEvent, i18n, store },
+      { _event: { stopPropagation: vi.fn() } },
+    );
+    expect(showAlert).not.toHaveBeenCalled();
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+    expect(dispatchEvent.mock.calls[0][0].detail).toEqual({
+      voice: {
+        sounds: [],
+        interruption: "immediate",
+        loop: false,
+        volume: 100,
+      },
+    });
   });
 
   it("connects a Voice clip and shifts every following clip", async () => {

--- a/tests/sceneEditor/lexicalLinePreview.test.js
+++ b/tests/sceneEditor/lexicalLinePreview.test.js
@@ -8,12 +8,14 @@ const installDomGlobals = () => {
     document: globalThis.document,
     HTMLElement: globalThis.HTMLElement,
     Node: globalThis.Node,
+    getComputedStyle: globalThis.getComputedStyle,
   };
 
   globalThis.window = dom.window;
   globalThis.document = dom.window.document;
   globalThis.HTMLElement = dom.window.HTMLElement;
   globalThis.Node = dom.window.Node;
+  globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
 
   return () => {
     for (const [name, value] of Object.entries(previousGlobals)) {
@@ -189,40 +191,103 @@ describe("lexical scene document editor line previews", () => {
     }
   });
 
-  it("renders deleted dialogue previews as dialogue icons with a centered x mark", async () => {
-    const restoreDomGlobals = installDomGlobals();
+  it.each(["ADV", "NVL"])(
+    "renders deleted dialogue as an icon with an x mark and no %s label",
+    async (dialogueModeLabel) => {
+      const restoreDomGlobals = installDomGlobals();
 
+      try {
+        const { LexicalSceneDocumentEditorElement } = await import(
+          "../../src/primitives/lexicalSceneDocumentEditor.js"
+        );
+        const editorPrototype = LexicalSceneDocumentEditorElement.prototype;
+        const previewItems = editorPrototype.createPreviewItems.call(
+          editorPrototype,
+          {
+            hasDialogueLayout: true,
+            dialogueChangeType: "delete",
+            dialogueModeLabel,
+          },
+        );
+
+        expect(
+          previewItems.querySelector(".preview-delete-overlay"),
+        ).toBeNull();
+        expect(previewItems.textContent).toBe("");
+        expect(
+          previewItems.querySelector(".preview-icon-delete-mark"),
+        ).not.toBeNull();
+        expect(
+          previewItems.querySelector(".preview-dialogue-item"),
+        ).not.toBeNull();
+        expect(
+          Array.from(previewItems.querySelectorAll("rtgl-svg")).map((icon) =>
+            icon.getAttribute("svg"),
+          ),
+        ).toEqual(["dialogue", "x"]);
+        expect(
+          Array.from(previewItems.querySelectorAll("rtgl-svg")).map((icon) =>
+            icon.getAttribute("wh"),
+          ),
+        ).toEqual(["24", "20"]);
+      } finally {
+        restoreDomGlobals();
+      }
+    },
+  );
+
+  it("summarizes only previews that do not fit and restores them when the gutter grows", async () => {
+    const restoreDomGlobals = installDomGlobals();
     try {
       const { LexicalSceneDocumentEditorElement } = await import(
         "../../src/primitives/lexicalSceneDocumentEditor.js"
       );
-      const editorPrototype = LexicalSceneDocumentEditorElement.prototype;
-      const previewItems = editorPrototype.createPreviewItems.call(
-        editorPrototype,
-        {
-          hasDialogueLayout: true,
-          dialogueChangeType: "delete",
-          dialogueModeLabel: "ADV",
-        },
-      );
+      const editor = LexicalSceneDocumentEditorElement.prototype;
+      const previews = editor.createPreviewItems({
+        hasDialogueLayout: true,
+        hasControl: true,
+        hasVoice: true,
+        hasSfx: true,
+        hasChoices: true,
+        hasInput: true,
+      });
+      const items = [...previews.querySelectorAll(":scope > .preview-item")];
+      const overflow = previews.querySelector(".preview-overflow");
+      overflow.getBoundingClientRect = () => ({ width: 16 });
+      previews.style.columnGap = "8px";
+      previews.getBoundingClientRect = () => ({ left: 100, width: 184 });
+      items.forEach((item, index) => {
+        item.getBoundingClientRect = () => ({ right: 124 + index * 32 });
+      });
+      const row = document.createElement("div");
+      row.append(previews);
+      const line = document.createElement("p");
 
-      expect(previewItems.querySelector(".preview-delete-overlay")).toBeNull();
-      expect(
-        previewItems.querySelector(".preview-icon-delete-mark"),
-      ).not.toBeNull();
-      expect(
-        previewItems.querySelector(".preview-dialogue-item"),
-      ).not.toBeNull();
-      expect(
-        Array.from(previewItems.querySelectorAll("rtgl-svg")).map((icon) =>
-          icon.getAttribute("svg"),
-        ),
-      ).toEqual(["dialogue", "x"]);
-      expect(
-        Array.from(previewItems.querySelectorAll("rtgl-svg")).map((icon) =>
-          icon.getAttribute("wh"),
-        ),
-      ).toEqual(["24", "20"]);
+      editor.syncLineRightGutterWidth(line, row, 100);
+      expect(items.map((item) => item.hidden)).toEqual([
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+      ]);
+      expect(overflow.hidden).toBe(false);
+      expect(overflow.textContent).toBe("+4");
+      expect(line.style.paddingRight).toBe("100px");
+
+      editor.syncLineRightGutterWidth(line, row, 24);
+      expect(items.every((item) => item.hidden)).toBe(true);
+      expect(overflow.textContent).toBe("+6");
+
+      editor.syncLineRightGutterWidth(line, row, 200);
+      expect(items.every((item) => !item.hidden)).toBe(true);
+      expect(overflow.hidden).toBe(true);
+      expect(line.style.paddingRight).toBe("184px");
+
+      editor.syncLineRightGutterWidth(line, row, 100);
+      expect(items.filter((item) => !item.hidden)).toHaveLength(2);
+      expect(overflow.textContent).toBe("+4");
     } finally {
       restoreDomGlobals();
     }

--- a/vt/specs/project/scenes.yaml
+++ b/vt/specs/project/scenes.yaml
@@ -280,6 +280,9 @@ steps:
   - action: assert
     type: url
     value: /project/scene-editor
+  - action: assert
+    type: hidden
+    selector: "rvn-lexical-scene-document-editor .preview-dialogue-label"
   - action: wait
     ms: 1600
   - action: waitFor


### PR DESCRIPTION
Scene editor previews now stay on one line instead of wrapping into neighboring lines. The icons and compact `+N` overflow count align to the right, and dialogue previews show only the icon without ADV/NVL text.

This also lets users submit an empty Voice channel after removing the last clip, clearing that line's voice audio. On mobile, the centered “Loading scene...” overlay now appears above the editor instead of being hidden behind it.

Validation:
- All 342 scene editor, Voice, and system-actions handler tests passed.
- Lint, formatting, and diff checks passed.
- Verified overflow at multiple viewport widths, voice removal, and loading-overlay visibility in the Vivo WebView using the Android dev server.
- The broader system-actions test run previously found four failures in unchanged confirmation-dialog tests whose mocks omit required store selectors. Those files are outside this change. The full visual test suite was not run.
